### PR TITLE
[9.4] [discover] move loadIfNeeded in index file, remove unloading on finish (#271144)

### DIFF
--- a/src/platform/test/functional/apps/discover/ccs_compatibility/index.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/index.ts
@@ -10,7 +10,6 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
   const config = getService('config');
   const isCcsTest = config.get('esTestCluster.ccs');
@@ -18,12 +17,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/ccs_compatible', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_data_view_editor'));

--- a/src/platform/test/functional/apps/discover/context_awareness/_telemetry.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/_telemetry.ts
@@ -28,7 +28,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const monacoEditor = getService('monacoEditor');
   const ebtUIHelper = getService('kibana_ebt_ui');
   const retry = getService('retry');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dashboardAddPanel = getService('dashboardAddPanel');
   const toasts = getService('toasts');
@@ -36,9 +35,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('telemetry', () => {
     describe('context', () => {
       before(async () => {
-        await esArchiver.loadIfNeeded(
-          'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-        );
         await kibanaServer.importExport.load(
           'src/platform/test/functional/fixtures/kbn_archiver/discover'
         );
@@ -133,9 +129,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('contextual profiles', () => {
       before(async () => {
-        await esArchiver.loadIfNeeded(
-          'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-        );
         await kibanaServer.importExport.load(
           'src/platform/test/functional/fixtures/kbn_archiver/discover'
         );

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_app_menu.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_app_menu.ts
@@ -18,22 +18,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'discover',
     'header',
   ]);
-  const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
 
   describe('extension getAppMenu', () => {
-    before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-    });
-
-    after(async () => {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-    });
-
     it('should render the main actions and the action from root profile', async () => {
       const state = kbnRison.encode({
         dataSource: { type: 'esql' },

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_default_ad_hoc_data_views.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_default_ad_hoc_data_views.ts
@@ -85,6 +85,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await esArchiver.load(
           'src/platform/test/functional/fixtures/es_archiver/discover/context_awareness'
         );
+        // `logstash_functional` is loaded once at the suite level (see `../index.ts`),
+        // so reload it here after the "no data page" test unloaded it.
+        await esArchiver.loadIfNeeded(
+          'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+        );
         await kibanaServer.importExport.load(
           'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
         );
@@ -112,6 +117,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show the no data page when no ES data is available', async () => {
         await esArchiver.unload(
           'src/platform/test/functional/fixtures/es_archiver/discover/context_awareness'
+        );
+        // Also unload the suite-level archive so Discover truly sees no ES data.
+        await esArchiver.unload(
+          'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
         );
         await common.navigateToActualUrl('discover', undefined, {
           ensureCurrentUrl: false,

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_pagination_config.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_pagination_config.ts
@@ -15,7 +15,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const dataViews = getService('dataViews');
   const dataGrid = getService('dataGrid');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
   const resetTimeFrame = {
@@ -30,19 +29,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('extension getPaginationConfig', () => {
     before(async () => {
-      // To load more than 500 records
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.update({
         'timepicker:timeDefaults': `{ "from": "${currentTimeFrame.from}", "to": "${currentTimeFrame.to}"}`,
       });
     });
 
     after(async () => {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.update({
         'timepicker:timeDefaults': `{ "from": "${resetTimeFrame.from}", "to": "${resetTimeFrame.to}"}`,
       });

--- a/src/platform/test/functional/apps/discover/context_awareness/index.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/index.ts
@@ -22,6 +22,9 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await esArchiver.load(
         'src/platform/test/functional/fixtures/es_archiver/discover/context_awareness'
       );
+      await esArchiver.loadIfNeeded(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
       );

--- a/src/platform/test/functional/apps/discover/embeddable/_esql_embeddable.ts
+++ b/src/platform/test/functional/apps/discover/embeddable/_esql_embeddable.ts
@@ -15,7 +15,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dashboardAddPanel = getService('dashboardAddPanel');
   const dashboardPanelActions = getService('dashboardPanelActions');
   const filterBar = getService('filterBar');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const globalNav = getService('globalNav');
   const testSubjects = getService('testSubjects');
@@ -28,9 +27,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover ES|QL embeddable', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/embeddable/_new_panel_embeddable.ts
+++ b/src/platform/test/functional/apps/discover/embeddable/_new_panel_embeddable.ts
@@ -14,7 +14,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dashboardAddPanel = getService('dashboardAddPanel');
   const filterBar = getService('filterBar');
   const queryBar = getService('queryBar');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const globalNav = getService('globalNav');
@@ -27,12 +26,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('add new discover panel embeddable', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-      );
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana'

--- a/src/platform/test/functional/apps/discover/embeddable/index.ts
+++ b/src/platform/test/functional/apps/discover/embeddable/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/embeddable', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_saved_search_embeddable'));

--- a/src/platform/test/functional/apps/discover/embeddable/multiple_data_views.ts
+++ b/src/platform/test/functional/apps/discover/embeddable/multiple_data_views.ts
@@ -12,19 +12,12 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dashboardExpect = getService('dashboardExpect');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const { dashboard } = getPageObjects(['dashboard']);
 
   describe('discover session multiple data views', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-      );
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana'

--- a/src/platform/test/functional/apps/discover/esql_1/_esql_columns.ts
+++ b/src/platform/test/functional/apps/discover/esql_1/_esql_columns.ts
@@ -17,7 +17,6 @@ const SAVED_SEARCH_TRANSFORMATIONAL_INITIAL_COLUMNS = 'transformationalInitialCo
 const SAVED_SEARCH_TRANSFORMATIONAL_CUSTOM_COLUMNS = 'transformationalCustomColumns';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
   const dataGrid = getService('dataGrid');
@@ -42,9 +41,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/esql_1/_esql_formatting.ts
+++ b/src/platform/test/functional/apps/discover/esql_1/_esql_formatting.ts
@@ -41,9 +41,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await esArchiver.load(
         'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
       );

--- a/src/platform/test/functional/apps/discover/esql_1/index.ts
+++ b/src/platform/test/functional/apps/discover/esql_1/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/esql_1', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group1/_discover.ts
+++ b/src/platform/test/functional/apps/discover/group1/_discover.ts
@@ -15,7 +15,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const log = getService('log');
   const retry = getService('retry');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const queryBar = getService('queryBar');
   const inspector = getService('inspector');
@@ -37,10 +36,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      // and load a set of makelogs data
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/group1/_discover_accessibility.ts
+++ b/src/platform/test/functional/apps/discover/group1/_discover_accessibility.ts
@@ -15,7 +15,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const find = getService('find');
   const testSubjects = getService('testSubjects');
@@ -37,10 +36,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      // and load a set of makelogs data
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/group1/_discover_histogram.ts
+++ b/src/platform/test/functional/apps/discover/group1/_discover_histogram.ts
@@ -35,9 +35,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover histogram', function describeIndexTests() {
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await esArchiver.load(
         'src/platform/test/functional/fixtures/es_archiver/long_window_logstash'
       );

--- a/src/platform/test/functional/apps/discover/group1/_discover_histogram_breakdown.ts
+++ b/src/platform/test/functional/apps/discover/group1/_discover_histogram_breakdown.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const filterBar = getService('filterBar');
   const { common, discover, header, timePicker, unifiedFieldList } = getPageObjects([
@@ -24,9 +23,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover unified histogram breakdown', function describeIndexTests() {
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group1/_doc_accessibility.ts
+++ b/src/platform/test/functional/apps/discover/group1/_doc_accessibility.ts
@@ -14,7 +14,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const find = getService('find');
   const testSubjects = getService('testSubjects');
@@ -30,10 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      // and load a set of makelogs data
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();

--- a/src/platform/test/functional/apps/discover/group1/_errors.ts
+++ b/src/platform/test/functional/apps/discover/group1/_errors.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const { common, header, discover, timePicker } = getPageObjects([
@@ -23,9 +22,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('errors', function describeIndexTests() {
     before(async function () {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/invalid_scripted_field'

--- a/src/platform/test/functional/apps/discover/group1/index.ts
+++ b/src/platform/test/functional/apps/discover/group1/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group1', function () {
     before(async function () {
       await browser.setWindowSize(1300, 1000);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group11/_time_field_column.ts
+++ b/src/platform/test/functional/apps/discover/group11/_time_field_column.ts
@@ -25,7 +25,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'unifiedFieldList',
     'header',
   ]);
-  const esArchiver = getService('esArchiver');
   const retry = getService('retry');
   const kibanaServer = getService('kibanaServer');
   const dashboardAddPanel = getService('dashboardAddPanel');
@@ -41,9 +40,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover time field column', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
@@ -52,9 +48,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.uiSettings.replace({});

--- a/src/platform/test/functional/apps/discover/group11/_unsaved_changes_modal.ts
+++ b/src/platform/test/functional/apps/discover/group11/_unsaved_changes_modal.ts
@@ -10,7 +10,6 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const appsMenu = getService('appsMenu');
@@ -29,9 +28,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover unsaved changes modal', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group11/index.ts
+++ b/src/platform/test/functional/apps/discover/group11/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group11', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group12/_unsaved_changes_notification_indicator.ts
+++ b/src/platform/test/functional/apps/discover/group12/_unsaved_changes_notification_indicator.ts
@@ -15,7 +15,6 @@ const SAVED_SEARCH_WITH_FILTERS_NAME = 'test saved search with filters';
 const SAVED_SEARCH_ESQL = 'test saved search ES|QL';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const dataGrid = getService('dataGrid');
@@ -37,9 +36,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover unsaved changes notification indicator', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group12/_view_mode_toggle.ts
+++ b/src/platform/test/functional/apps/discover/group12/_view_mode_toggle.ts
@@ -17,7 +17,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'timePicker',
     'header',
   ]);
-  const esArchiver = getService('esArchiver');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const queryBar = getService('queryBar');
@@ -30,9 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover view mode toggle', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
@@ -45,9 +41,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.uiSettings.replace({});

--- a/src/platform/test/functional/apps/discover/group12/index.ts
+++ b/src/platform/test/functional/apps/discover/group12/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group12', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover data grid tests', function describeDiscoverDataGrid() {
-    const esArchiver = getService('esArchiver');
     const { common, timePicker, unifiedFieldList } = getPageObjects([
       'common',
       'timePicker',
@@ -30,9 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid_context.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid_context.ts
@@ -37,7 +37,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'discover:rowHeightOption': 0, // single line
   };
   const kibanaServer = getService('kibanaServer');
-  const esArchiver = getService('esArchiver');
   const dashboardAddPanel = getService('dashboardAddPanel');
   const browser = getService('browser');
   const security = getService('security');
@@ -48,9 +47,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await kibanaServer.uiSettings.update(defaultSettings);

--- a/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid_copy_to_clipboard.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid_copy_to_clipboard.ts
@@ -13,7 +13,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataGrid = getService('dataGrid');
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const browser = getService('browser');
   const toasts = getService('toasts');
@@ -30,9 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();

--- a/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid_doc_navigation.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid1/_data_grid_doc_navigation.ts
@@ -15,7 +15,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataGrid = getService('dataGrid');
   const testSubjects = getService('testSubjects');
   const { common, discover, timePicker } = getPageObjects(['common', 'discover', 'timePicker']);
-  const esArchiver = getService('esArchiver');
   const retry = getService('retry');
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
@@ -24,9 +23,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover data grid doc link', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid1/index.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid1/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group2/data_grid1', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_data.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_data.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const queryBar = getService('queryBar');
   const { common, discover, timePicker, unifiedFieldList } = getPageObjects([
@@ -32,9 +31,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await kibanaServer.uiSettings.update(defaultSettings);

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
@@ -20,7 +20,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'unifiedFieldList',
     'header',
   ]);
-  const esArchiver = getService('esArchiver');
   const log = getService('log');
   const retry = getService('retry');
   const dashboardAddPanel = getService('dashboardAddPanel');
@@ -73,9 +72,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover data grid field tokens', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
@@ -84,9 +80,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_footer.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_footer.ts
@@ -32,9 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('time field with date type', function () {
       before(async () => {
         await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-        await esArchiver.loadIfNeeded(
-          'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-        );
         await kibanaServer.importExport.load(
           'src/platform/test/functional/fixtures/kbn_archiver/discover'
         );
@@ -43,9 +40,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       after(async () => {
         await kibanaServer.importExport.unload(
           'src/platform/test/functional/fixtures/kbn_archiver/discover'
-        );
-        await esArchiver.unload(
-          'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
         );
         await kibanaServer.savedObjects.cleanStandardList();
         await kibanaServer.uiSettings.replace({});

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_in_table_search.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_in_table_search.ts
@@ -14,7 +14,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const retry = getService('retry');
@@ -35,9 +34,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await browser.setWindowSize(1200, 2000);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_new_line.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_new_line.ts
@@ -17,7 +17,6 @@ const VALUE_WITHOUT_NEW_LINES = VALUE_WITH_NEW_LINES.replaceAll('\n', ' ');
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const es = getService('es');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const dataViews = getService('dataViews');
@@ -34,9 +33,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await browser.setWindowSize(1200, 2000);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/index.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group2/data_grid2', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_column_widths.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_column_widths.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const dashboardAddPanel = getService('dashboardAddPanel');
@@ -37,9 +36,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover data grid column widths', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_density.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_density.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const { common, discover, timePicker } = getPageObjects(['common', 'discover', 'timePicker']);
@@ -23,9 +22,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await browser.setWindowSize(1200, 2000);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_pagination.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_pagination.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const { appMenu, common, discover, header, timePicker, dashboard } = getPageObjects([
@@ -37,9 +36,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await browser.setWindowSize(1200, 2000);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_row_height.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_row_height.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const testSubjects = getService('testSubjects');
@@ -24,9 +23,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await browser.setWindowSize(1200, 2000);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_row_selection.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_row_selection.ts
@@ -13,7 +13,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataGrid = getService('dataGrid');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const retry = getService('retry');
   const security = getService('security');
@@ -36,9 +35,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover data grid row selection', function describeIndexTests() {
     before(async function () {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
@@ -56,9 +52,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_sample_size.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_sample_size.ts
@@ -20,7 +20,6 @@ const SAVED_SEARCH_NAME = 'With sample size';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const testSubjects = getService('testSubjects');
@@ -44,9 +43,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover data grid sample size', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/index.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group2/data_grid3', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group3/_default_columns.ts
+++ b/src/platform/test/functional/apps/discover/group3/_default_columns.ts
@@ -30,9 +30,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover default columns', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await esArchiver.load(
         'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_logs_tsdb'
       );
@@ -53,9 +50,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await esArchiver.unload(
         'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_logs_tsdb'

--- a/src/platform/test/functional/apps/discover/group3/_drag_drop.ts
+++ b/src/platform/test/functional/apps/discover/group3/_drag_drop.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const { common, discover, timePicker, header, unifiedFieldList } = getPageObjects([
     'common',
@@ -22,12 +21,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   ]);
 
   describe('discover drag and drop', function describeIndexTests() {
-    before(async function () {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-    });
-
     beforeEach(async () => {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'

--- a/src/platform/test/functional/apps/discover/group3/_request_counts.ts
+++ b/src/platform/test/functional/apps/discover/group3/_request_counts.ts
@@ -29,9 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover request counts', function describeIndexTests() {
     before(async function () {
       await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/long_window_logstash'
       );
       await kibanaServer.importExport.load(

--- a/src/platform/test/functional/apps/discover/group3/index.ts
+++ b/src/platform/test/functional/apps/discover/group3/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group3', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group4/_adhoc_data_views.ts
+++ b/src/platform/test/functional/apps/discover/group4/_adhoc_data_views.ts
@@ -13,7 +13,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataGrid = getService('dataGrid');
   const toasts = getService('toasts');
-  const esArchiver = getService('esArchiver');
   const filterBar = getService('filterBar');
   const fieldEditor = getService('fieldEditor');
   const dashboardAddPanel = getService('dashboardAddPanel');
@@ -48,9 +47,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
 
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await common.navigateToApp('discover');
@@ -58,7 +54,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/logstash_functional');
     });
 
     it('should navigate back correctly from to surrounding and single views', async () => {

--- a/src/platform/test/functional/apps/discover/group4/_chart_hidden.ts
+++ b/src/platform/test/functional/apps/discover/group4/_chart_hidden.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
   const { common, discover, header, timePicker, dashboard } = getPageObjects([
@@ -36,10 +35,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
 
-      // and load a set of makelogs data
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await common.navigateToApp('discover');
       await timePicker.setDefaultAbsoluteRange();

--- a/src/platform/test/functional/apps/discover/group4/_data_view_edit.ts
+++ b/src/platform/test/functional/apps/discover/group4/_data_view_edit.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
   const es = getService('es');
@@ -32,9 +31,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
 
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await common.navigateToApp('discover');
@@ -43,7 +39,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/logstash_functional');
       await es.transport.request({
         path: '/data-view-index-000001',
         method: 'DELETE',

--- a/src/platform/test/functional/apps/discover/group4/_discover_fields_api.ts
+++ b/src/platform/test/functional/apps/discover/group4/_discover_fields_api.ts
@@ -13,7 +13,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
   const retry = getService('retry');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dataGrid = getService('dataGrid');
   const { common, discover, timePicker, unifiedFieldList } = getPageObjects([
@@ -33,9 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.savedObjects.clean({ types: ['search', 'index-pattern'] });
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/group4/_document_comparison.ts
+++ b/src/platform/test/functional/apps/discover/group4/_document_comparison.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const { common, discover, timePicker, unifiedFieldList } = getPageObjects([
     'common',
     'discover',
@@ -30,18 +29,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
     });
 
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.savedObjects.cleanStandardList();

--- a/src/platform/test/functional/apps/discover/group4/_field_list_new_fields.ts
+++ b/src/platform/test/functional/apps/discover/group4/_field_list_new_fields.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
   const es = getService('es');
@@ -31,9 +30,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
 
       await common.navigateToApp('discover');
       await timePicker.setCommonlyUsedTime('This_week');
@@ -41,7 +37,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/logstash_functional');
       await es.transport.request({
         path: '/my-index-000001',
         method: 'DELETE',

--- a/src/platform/test/functional/apps/discover/group4/index.ts
+++ b/src/platform/test/functional/apps/discover/group4/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group4', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group5/index.ts
+++ b/src/platform/test/functional/apps/discover/group5/index.ts
@@ -24,6 +24,9 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       );
     });
 
+    // `_no_data` is intentionally first: it expects a clean ES/Kibana state.
+    // Running it after other tests leaves residual managed/default data views
+    // (e.g. "All logs") that prevent Discover from rendering the no-data page.
     loadTestFile(require.resolve('./_no_data'));
     loadTestFile(require.resolve('./_filter_editor'));
     loadTestFile(require.resolve('./_field_data_with_fields_api'));

--- a/src/platform/test/functional/apps/discover/group6/_sidebar.ts
+++ b/src/platform/test/functional/apps/discover/group6/_sidebar.ts
@@ -50,12 +50,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   describe('discover sidebar', function describeIndexTests() {
-    before(async function () {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-    });
-
     beforeEach(async () => {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'

--- a/src/platform/test/functional/apps/discover/group6/_sidebar_field_stats.ts
+++ b/src/platform/test/functional/apps/discover/group6/_sidebar_field_stats.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const { common, discover, timePicker, header, unifiedFieldList } = getPageObjects([
     'common',
@@ -27,9 +26,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover sidebar field stats popover', function describeIndexTests() {
     before(async function () {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group6/index.ts
+++ b/src/platform/test/functional/apps/discover/group6/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group6', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group7/_new_search.ts
+++ b/src/platform/test/functional/apps/discover/group7/_new_search.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const { common, discover, timePicker, header } = getPageObjects([
     'common',
     'discover',
@@ -32,9 +31,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await common.navigateToApp('discover');
       await timePicker.setDefaultAbsoluteRange();
@@ -43,9 +39,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.savedObjects.cleanStandardList();

--- a/src/platform/test/functional/apps/discover/group7/_request_cancellation.ts
+++ b/src/platform/test/functional/apps/discover/group7/_request_cancellation.ts
@@ -13,7 +13,6 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const filterBar = getService('filterBar');
   const testSubjects = getService('testSubjects');
@@ -29,18 +28,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
     });
 
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
       await timePicker.resetDefaultAbsoluteRangeViaUiSettings();

--- a/src/platform/test/functional/apps/discover/group7/_runtime_fields_editor.ts
+++ b/src/platform/test/functional/apps/discover/group7/_runtime_fields_editor.ts
@@ -14,7 +14,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const kibanaServer = getService('kibanaServer');
-  const esArchiver = getService('esArchiver');
   const fieldEditor = getService('fieldEditor');
   const security = getService('security');
   const dataGrid = getService('dataGrid');
@@ -43,9 +42,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover integration with runtime fields editor', function describeIndexTests() {
     before(async function () {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group7/_search_on_page_load.ts
+++ b/src/platform/test/functional/apps/discover/group7/_search_on_page_load.ts
@@ -56,10 +56,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
 
-      // and load a set of data
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await esArchiver.load('src/platform/test/functional/fixtures/es_archiver/date_nested');
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/date_nested.json'
@@ -77,9 +73,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/kbn_archiver/date_nested'
       );
       await esArchiver.unload('src/platform/test/functional/fixtures/es_archiver/date_nested');
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/src/platform/test/functional/apps/discover/group7/index.ts
+++ b/src/platform/test/functional/apps/discover/group7/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group7', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group8/_default_route.ts
+++ b/src/platform/test/functional/apps/discover/group8/_default_route.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const { discover, timePicker, header } = getPageObjects(['discover', 'timePicker', 'header']);
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
@@ -28,9 +27,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
     });
@@ -38,9 +34,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.savedObjects.cleanStandardList();

--- a/src/platform/test/functional/apps/discover/group8/_flyouts.ts
+++ b/src/platform/test/functional/apps/discover/group8/_flyouts.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const { common, discover, timePicker, header } = getPageObjects([
     'common',
     'discover',
@@ -30,9 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
     });
@@ -49,9 +45,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.savedObjects.cleanStandardList();

--- a/src/platform/test/functional/apps/discover/group8/_sidenav_link.ts
+++ b/src/platform/test/functional/apps/discover/group8/_sidenav_link.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const { discover, timePicker, header, common } = getPageObjects([
     'discover',
     'timePicker',
@@ -33,9 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
     });
@@ -43,9 +39,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.savedObjects.cleanStandardList();

--- a/src/platform/test/functional/apps/discover/group8/index.ts
+++ b/src/platform/test/functional/apps/discover/group8/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group8', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const { common, discover, timePicker, header, unifiedFieldList } = getPageObjects([
     'common',
@@ -29,9 +28,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover doc viewer', function describeIndexTests() {
     before(async function () {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await browser.setWindowSize(1600, 1200);
     });
 

--- a/src/platform/test/functional/apps/discover/group9/_doc_viewer_pinning.ts
+++ b/src/platform/test/functional/apps/discover/group9/_doc_viewer_pinning.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const esql = getService('esql');
   const kibanaServer = getService('kibanaServer');
   const { common, discover, timePicker, unifiedFieldList } = getPageObjects([
@@ -108,9 +107,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('discover doc viewer pinning', function describeIndexTests() {
     before(async function () {
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
@@ -122,9 +118,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.unload(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
+++ b/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const monacoEditor = getService('monacoEditor');
@@ -31,9 +30,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('discover panels toggle', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );

--- a/src/platform/test/functional/apps/discover/group9/index.ts
+++ b/src/platform/test/functional/apps/discover/group9/index.ts
@@ -16,10 +16,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   describe('discover/group9', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
+      await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
     });

--- a/src/platform/test/functional/apps/discover/observability/embeddable/_saved_search_embeddable.ts
+++ b/src/platform/test/functional/apps/discover/observability/embeddable/_saved_search_embeddable.ts
@@ -30,9 +30,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana'
       );
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.replace({
         defaultIndex: '0bf35f60-3dc9-11e8-8660-4d65aa086b3c',
       });
@@ -50,9 +47,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await common.unsetTime();
       await esArchiver.unload(
         'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/src/platform/test/functional/apps/discover/observability/index.ts
+++ b/src/platform/test/functional/apps/discover/observability/index.ts
@@ -9,8 +9,9 @@
 
 import type { FtrProviderContext } from '../ftr_provider_context';
 
-export default function ({ getPageObjects, loadTestFile }: FtrProviderContext) {
+export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
   const { spaceSettings } = getPageObjects(['common', 'spaceSettings']);
+  const esArchiver = getService('esArchiver');
 
   describe('discover/observability', () => {
     before(async () => {
@@ -18,6 +19,9 @@ export default function ({ getPageObjects, loadTestFile }: FtrProviderContext) {
         spaceName: 'default',
         solution: 'oblt',
       });
+      await esArchiver.loadIfNeeded(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+      );
     });
 
     after(async () => {

--- a/src/platform/test/functional/apps/discover/observability/logs/_get_pagination_config.ts
+++ b/src/platform/test/functional/apps/discover/observability/logs/_get_pagination_config.ts
@@ -15,7 +15,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const dataViews = getService('dataViews');
   const dataGrid = getService('dataGrid');
-  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
   const currentTimeFrame = {
@@ -25,19 +24,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('extension getPaginationConfig', () => {
     before(async () => {
-      // To load more than 500 records
-      await esArchiver.loadIfNeeded(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await kibanaServer.uiSettings.update({
         'timepicker:timeDefaults': `{ "from": "${currentTimeFrame.from}", "to": "${currentTimeFrame.to}"}`,
       });
     });
 
     after(async () => {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
       await PageObjects.common.unsetTime();
     });
 

--- a/src/platform/test/functional/apps/discover/query_mode/index.ts
+++ b/src/platform/test/functional/apps/discover/query_mode/index.ts
@@ -20,12 +20,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await browser.setWindowSize(1600, 1200);
     });
 
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-    });
-
     loadTestFile(require.resolve('./_default_query_mode'));
   });
 }

--- a/src/platform/test/functional/apps/discover/query_mode_esql_default/index.ts
+++ b/src/platform/test/functional/apps/discover/query_mode_esql_default/index.ts
@@ -20,12 +20,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await browser.setWindowSize(1600, 1200);
     });
 
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-    });
-
     loadTestFile(require.resolve('./_default_query_mode'));
   });
 }

--- a/src/platform/test/functional/apps/discover/tabs/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_restorable_state'));
     loadTestFile(require.resolve('./_on_tab_change'));
     loadTestFile(require.resolve('./_controls'));

--- a/src/platform/test/functional/apps/discover/tabs4/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs4/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_new_tab'));
     loadTestFile(require.resolve('./_no_data'));
     loadTestFile(require.resolve('./_duplication'));

--- a/src/platform/test/functional/apps/discover/tabs5/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs5/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_save_and_load'));
     loadTestFile(require.resolve('./_inspector'));
   });

--- a/src/platform/test/functional/apps/discover/tabs6/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs6/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_sharing'));
     loadTestFile(require.resolve('./_recently_closed_tabs'));
   });

--- a/src/platform/test/functional/apps/discover/tabs7/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs7/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_unsaved_changes'));
     loadTestFile(require.resolve('./_data_view_editing'));
   });

--- a/src/platform/test/functional/apps/discover/tabs8/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs8/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_deprecated_saved_objects_api'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[discover] move loadIfNeeded in index file, remove unloading on finish (#271144)](https://github.com/elastic/kibana/pull/271144)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-26T14:56:01Z","message":"[discover] move loadIfNeeded in index file, remove unloading on finish (#271144)\n\n## Summary\n\nDoing the same changes over each discover FTR config to cut CI runtime:\n\n- Add one `await esArchiver.loadIfNeeded('X')` in the index file's\n`before` hook.\n- Delete the per-child `loadIfNeeded('X')` calls.\n- Delete any `esArchiver.unload('X')` in the index after hook and in\nchildren.\n\nSince we stop servers after FTR config is finished we are losing quite\nsome time unloading the data.\n\nSome numbers:\n\n- `loadIfNeeded` calls eliminated per CI run: 43 \n- `esArchiver.unload(...)` calls removed: **57**\n- Total esArchiver ops eliminated per CI run: ~99","sha":"1dad2b30e66a61b584e24f93ebfef0ac7eae9ef3","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open"],"title":"[discover] move loadIfNeeded in index file, remove unloading on finish","number":271144,"url":"https://github.com/elastic/kibana/pull/271144","mergeCommit":{"message":"[discover] move loadIfNeeded in index file, remove unloading on finish (#271144)\n\n## Summary\n\nDoing the same changes over each discover FTR config to cut CI runtime:\n\n- Add one `await esArchiver.loadIfNeeded('X')` in the index file's\n`before` hook.\n- Delete the per-child `loadIfNeeded('X')` calls.\n- Delete any `esArchiver.unload('X')` in the index after hook and in\nchildren.\n\nSince we stop servers after FTR config is finished we are losing quite\nsome time unloading the data.\n\nSome numbers:\n\n- `loadIfNeeded` calls eliminated per CI run: 43 \n- `esArchiver.unload(...)` calls removed: **57**\n- Total esArchiver ops eliminated per CI run: ~99","sha":"1dad2b30e66a61b584e24f93ebfef0ac7eae9ef3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->