### PR TITLE
[WIP] [alerting_v2] POC: alerting_v2.create_alert workflow step

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/episodes_table_cell_renderers.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/episodes_table_cell_renderers.tsx
@@ -97,7 +97,17 @@ export const EpisodeRuleCell = ({
   }
 
   if (!rule) {
-    return <>{ruleId}</>;
+    const eventRuleName = row.flattened['rule.name'] as string | undefined;
+    return (
+      <EuiText
+        size="s"
+        css={css`
+          font-weight: ${euiTheme.font.weight.semiBold};
+        `}
+      >
+        {eventRuleName ?? ruleId}
+      </EuiText>
+    );
   }
   const ruleName = (
     <EuiText

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
@@ -28,6 +28,7 @@ export interface AlertEpisode {
   'episode.id': string;
   'episode.status': AlertEpisodeStatus;
   'rule.id': string;
+  'rule.name'?: string | null;
   group_hash: string;
   first_timestamp: string;
   last_timestamp: string;
@@ -57,6 +58,7 @@ export const ALERT_EPISODE_FIELDS = [
   'episode.id',
   'episode.status',
   'rule.id',
+  'rule.name',
   'group_hash',
   'first_timestamp',
   'last_timestamp',
@@ -139,7 +141,7 @@ export const addEpisodeAggregation = (query: ComposerQuery) => {
   // prettier-ignore
   query
     .pipe`EVAL extracted_data = JSON_EXTRACT(_source, "data")`
-    .pipe`INLINE STATS first_timestamp = MIN(@timestamp), last_timestamp = MAX(@timestamp), triggered_at = MIN(@timestamp) WHERE \`episode.status\` == "active", episode_data = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}", severity = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL BY episode.id`
+    .pipe`INLINE STATS first_timestamp = MIN(@timestamp), last_timestamp = MAX(@timestamp), triggered_at = MIN(@timestamp) WHERE \`episode.status\` == "active", episode_data = LAST(extracted_data, @timestamp) WHERE extracted_data != "{}", severity = LAST(severity, @timestamp) WHERE status == "breached" AND severity IS NOT NULL, \`rule.name\` = LAST(\`rule.name\`, @timestamp) BY episode.id`
     .pipe`EVAL duration = DATE_DIFF("ms", first_timestamp, last_timestamp)`
     .pipe`WHERE @timestamp == last_timestamp`;
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/create_alert_event_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/create_alert_event_data_schema.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+
+const alertEventSeveritySchema = z.enum(['info', 'low', 'medium', 'high', 'critical']);
+
+/**
+ * Mirrors alertEpisodeStatusSchema from alert_events.ts.
+ * All four lifecycle states can be set explicitly by external callers.
+ * When omitted, status defaults to active.
+ */
+const externalAlertStatusSchema = z.enum(['active', 'inactive', 'pending', 'recovering']);
+
+const RESERVED_SOURCE_PREFIX = 'elastic.';
+
+export const createAlertEventDataSchema = z.object({
+  source: z
+    .string()
+    .min(1)
+    .refine((v) => !v.startsWith(RESERVED_SOURCE_PREFIX), {
+      message:
+        'source cannot start with "elastic." — this prefix is reserved for Elastic-produced events.',
+    }),
+  fingerprint: z.string().min(1),
+  rule_id: z.string().min(1).optional(),
+  rule_name: z.string().optional(),
+  alert_url: z.string().optional(),
+  alert_status: externalAlertStatusSchema.optional(),
+  data: z.record(z.string(), z.any()).optional(),
+  timestamp: z.string().optional(),
+  severity: alertEventSeveritySchema.optional(),
+});
+
+export const createAlertEventResponseSchema = z.object({
+  id: z.string(),
+});
+
+export type CreateAlertEventData = z.infer<typeof createAlertEventDataSchema>;
+export type CreateAlertEventResponse = z.infer<typeof createAlertEventResponseSchema>;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/lib/workflow_extensions/steps/create_alert_event_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/lib/workflow_extensions/steps/create_alert_event_step.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { StepCategory } from '@kbn/workflows';
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { z } from '@kbn/zod/v4';
+
+const inputSchema = z.object({
+  source: z
+    .string()
+    .describe(
+      'Source system identifier (e.g. "prometheus", "datadog"). Prefix "elastic." is reserved.'
+    ),
+  fingerprint: z.string().describe('Stable grouping key for this alert series (e.g. alertname, dedup_key)'),
+  rule_id: z
+    .string()
+    .optional()
+    .describe('Rule/monitor/check ID in the source system; defaults to source'),
+  rule_name: z.string().optional().describe('Human-readable rule name; falls back to rule_id or source'),
+  alert_url: z
+    .string()
+    .optional()
+    .describe('URL to view this alert in its origin system'),
+  alert_status: z
+    .enum(['active', 'inactive', 'pending', 'recovering'])
+    .optional()
+    .describe('Explicit lifecycle override; defaults to active'),
+  data: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Alert payload — arbitrary k/v metadata'),
+  timestamp: z.string().optional().describe('ISO-8601 override for @timestamp'),
+  severity: z
+    .string()
+    .optional()
+    .describe('Severity level: info | low | medium | high | critical'),
+});
+
+const outputSchema = z.object({
+  group_hash: z.string().describe('Stable series key for this alert; use in action URLs'),
+});
+
+const configSchema = z.object({});
+
+export const createAlertEventStepDefinition = createPublicStepDefinition({
+  id: 'alerting_v2.create_alert',
+  category: StepCategory.Kibana,
+  label: i18n.translate('alertingV2.workflowStep.createAlert.label', {
+    defaultMessage: 'Create V2 Alert',
+  }),
+  description: i18n.translate('alertingV2.workflowStep.createAlert.description', {
+    defaultMessage:
+      'Push an alert event directly into the Elastic v2 alerting system without a backing rule.',
+  }),
+    documentation: {
+      details: i18n.translate('alertingV2.workflowStep.createAlert.documentation.details', {
+        defaultMessage: `The {stepId} step writes a pre-normalized alert event into the v2 alerting system via {apiPath}. Use it to bridge external monitoring tools (Prometheus, PagerDuty, CloudWatch) into Elastic's alerting episode lifecycle.
+
+Use a stable {fingerprint} to group events into the same alert series. The server manages episode lifecycle automatically: same fingerprint while active continues the episode; after recovery, same fingerprint opens a new episode. Set {alertStatus} to signal recovery when the source system has no end timestamp.`,
+        values: {
+          stepId: '`alerting_v2.create_alert`',
+          apiPath: '`POST /api/alerting/v2/alerts`',
+          fingerprint: '`fingerprint`',
+          alertStatus: '`alert_status`',
+        },
+      }),
+      examples: [
+        `## Fire an alert from Prometheus
+\`\`\`yaml
+- name: push-alert
+  type: alerting_v2.create_alert
+  with:
+    source: "prometheus"
+    fingerprint: "\${{ trigger.labels.alertname }}-\${{ trigger.labels.instance }}"
+    rule_id: "\${{ trigger.labels.alertname }}"
+    alert_url: "\${{ trigger.generatorURL }}"
+    timestamp: "\${{ trigger.startsAt }}"
+    data:
+      summary: "\${{ trigger.annotations.summary }}"
+\`\`\``,
+
+        `## Resolve a previously fired alert
+\`\`\`yaml
+- name: resolve-alert
+  type: alerting_v2.create_alert
+  with:
+    source: "prometheus"
+    fingerprint: "\${{ trigger.labels.alertname }}-\${{ trigger.labels.instance }}"
+    rule_id: "\${{ trigger.labels.alertname }}"
+    alert_status: "inactive"
+    timestamp: "\${{ trigger.endsAt }}"
+\`\`\``,
+      ],
+    },
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/bell').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+  inputSchema,
+  outputSchema,
+  configSchema,
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
@@ -120,10 +120,11 @@ export function EpisodeDetailsPage() {
 
   const showRuleDependentUi = isRuleLoaded(ruleState);
 
+  const eventRuleName = episode?.['rule.name'] as string | undefined;
   const episodeBreadcrumbTitle =
     showRuleDependentUi && ruleState.rule.metadata.name
       ? ruleState.rule.metadata.name
-      : i18n.EPISODE_DETAILS_BREADCRUMB_FALLBACK;
+      : eventRuleName ?? i18n.EPISODE_DETAILS_BREADCRUMB_FALLBACK;
 
   useBreadcrumbs('episode_details', { ruleName: episodeBreadcrumbTitle });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -26,20 +26,22 @@ export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
       | WHERE type IS NULL OR type == ${alertEventType}
       | EVAL
           rule_id = COALESCE(rule.id, rule_id),
+          rule_name = rule.name,
           episode_id = COALESCE(episode.id, episode_id),
           episode_status = episode.status,
           data_json = CASE(type IS NOT NULL, JSON_EXTRACT(_source, "$.data"), NULL)
-      | DROP episode.id, rule.id, episode.status, _source
+      | DROP episode.id, rule.id, rule.name, episode.status, _source
       | INLINE STATS last_fired = max(last_series_event_timestamp) WHERE action_type == "fire" OR action_type == "suppress" OR action_type == "unmatched" BY rule_id, group_hash
       | WHERE last_fired IS NULL OR last_fired < @timestamp
       | STATS
           last_event_timestamp = MAX(@timestamp) WHERE type IS NOT NULL,
           last_episode_status = LAST(episode_status, @timestamp) WHERE type IS NOT NULL,
           data_json = LAST(data_json, @timestamp) WHERE type IS NOT NULL,
-          severity = LAST(severity, @timestamp) WHERE type IS NOT NULL
+          severity = LAST(severity, @timestamp) WHERE type IS NOT NULL,
+          rule_name = LAST(rule_name, @timestamp) WHERE type IS NOT NULL
           BY rule_id, group_hash, episode_id
       | WHERE last_event_timestamp IS NOT NULL
-      | KEEP last_event_timestamp, rule_id, group_hash, episode_id, last_episode_status, data_json, severity
+      | KEEP last_event_timestamp, rule_id, rule_name, group_hash, episode_id, last_episode_status, data_json, severity
       | RENAME last_episode_status AS episode_status
       | SORT last_event_timestamp asc
       | LIMIT 10000`.toRequest();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_rules_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_rules_step.ts
@@ -46,6 +46,23 @@ export class FetchRulesStep implements DispatcherStep {
       });
     }
 
+    // For rule IDs not found as saved objects (external alerts), build synthetic
+    // Rule entries from the episode's event data so downstream steps (matchers,
+    // maintenance windows, groups) don't skip them.
+    const episodesByRuleId = Map.groupBy(dispatchable, (ep) => ep.rule_id);
+    for (const ruleId of uniqueRuleIds) {
+      if (!rules.has(ruleId)) {
+        const representative = episodesByRuleId.get(ruleId)?.[0];
+        rules.set(ruleId, {
+          id: ruleId,
+          spaceId: 'default',
+          name: representative?.rule_name ?? ruleId,
+          tags: [],
+          isExternal: true,
+        });
+      }
+    }
+
     return { type: 'continue', data: { rules } };
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/store_execution_history_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/store_execution_history_step.ts
@@ -137,10 +137,12 @@ export class StoreExecutionHistoryStep implements DispatcherStep {
 
     const refs: SavedObjectRef[] = [
       policyRef({ id: summary.policyId, spaceId: summary.spaceId }),
-      ...capped.map((id) => {
-        const rule = rules?.get(id);
-        return ruleRef({ id, spaceId: rule?.spaceId ?? summary.spaceId });
-      }),
+      ...capped
+        .filter((id) => !rules?.get(id)?.isExternal)
+        .map((id) => {
+          const rule = rules?.get(id);
+          return ruleRef({ id, spaceId: rule?.spaceId ?? summary.spaceId });
+        }),
     ];
 
     this.eventLogService.logEvent(
@@ -178,13 +180,14 @@ export class StoreExecutionHistoryStep implements DispatcherStep {
     rules: Map<RuleId, Rule> | undefined;
   }): void {
     const rule = rules?.get(ruleId);
+    const isExternal = rule?.isExternal === true;
     this.eventLogService.logEvent(
       buildEvent({
         timestamp,
         executionUuid,
         action: ACTION_POLICY_EVENT_ACTIONS.UNMATCHED,
         spaceId: rule?.spaceId ?? 'default',
-        savedObjects: [ruleRef({ id: ruleId, spaceId: rule?.spaceId })],
+        savedObjects: isExternal ? [] : [ruleRef({ id: ruleId, spaceId: rule?.spaceId })],
         dispatcherFields: {
           episode_count: episodeIds.size,
           episode_ids: Array.from(episodeIds),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/types.ts
@@ -23,6 +23,7 @@ export interface ActionPolicyDestination {
 export interface AlertEpisode {
   last_event_timestamp: string;
   rule_id: RuleId;
+  rule_name?: string;
   group_hash: string;
   episode_id: string;
   episode_status: AlertEpisodeStatus;
@@ -58,6 +59,8 @@ export interface Rule {
   spaceId: string;
   name: string;
   tags: string[];
+  /** True when the rule has no backing Kibana saved object (external alert source). */
+  isExternal?: boolean;
 }
 
 export interface ActionPolicy {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/build_alert_events.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/build_alert_events.ts
@@ -142,7 +142,7 @@ export function createAlertEventsBatchBuilder({
 
   // Timestamp when the alert event is written to the index.
   const wroteAt = new Date().toISOString();
-  const source = 'internal';
+  const source = { name: 'internal' };
   const groupingFields = ruleAttributes.grouping?.fields ?? [];
   let index = 0;
 
@@ -222,7 +222,7 @@ export function buildRecoveryAlertEvents({
         group_hash,
         data: {},
         status: 'recovered',
-        source: 'internal',
+        source: { name: 'internal' },
         type,
         space_id: spaceId,
       })
@@ -261,7 +261,7 @@ export function buildContinuedBreachAlertEvents({
     group_hash: groupHash,
     data: {},
     status: 'breached' as const,
-    source: 'internal',
+    source: { name: 'internal' },
     type,
     space_id: spaceId,
   }));
@@ -298,7 +298,7 @@ export function buildNoDataAlertEvents({
     group_hash: groupHash,
     data: {},
     status: 'no_data' as const,
-    source: 'internal',
+    source: { name: 'internal' },
     type,
     space_id: spaceId,
   }));
@@ -398,7 +398,7 @@ export function buildQueryRecoveryAlertEvents({
       group_hash: groupHash,
       data,
       status: 'recovered',
-      source: 'internal',
+      source: { name: 'internal' },
       type,
       space_id: spaceId,
     })

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/workflow_extensions/steps/create_alert_event_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/workflow_extensions/steps/create_alert_event_step.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart } from '@kbn/core/server';
+import { StepCategory } from '@kbn/workflows';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import { ALERTING_V2_ALERT_API_PATH } from '@kbn/alerting-v2-constants';
+
+const inputSchema = z.object({
+  source: z
+    .string()
+    .describe('Source system identifier (e.g. "prometheus", "datadog"). Prefix "elastic." is reserved.'),
+  fingerprint: z.string().describe('Stable grouping key for this alert series (e.g. alertname, dedup_key)'),
+  rule_id: z
+    .string()
+    .optional()
+    .describe('Rule/monitor/check ID in the source system; defaults to source'),
+  rule_name: z.string().optional().describe('Human-readable rule name; falls back to rule_id or source'),
+  alert_url: z.string().optional().describe('Link to this alert in its origin system'),
+  alert_status: z
+    .enum(['active', 'inactive', 'pending', 'recovering'])
+    .optional()
+    .describe('Explicit lifecycle override; defaults to active'),
+  data: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Alert payload — arbitrary k/v metadata'),
+  timestamp: z.string().optional().describe('ISO-8601 override for @timestamp'),
+  severity: z
+    .string()
+    .optional()
+    .describe('Severity level: info | low | medium | high | critical'),
+});
+
+const outputSchema = z.object({
+  group_hash: z.string().describe('Stable series key for this alert; use in action URLs'),
+});
+
+const configSchema = z.object({});
+
+export function createAlertEventStepDefinition(
+  getStartServices: () => Promise<[CoreStart, unknown, unknown]>
+) {
+  return createServerStepDefinition({
+    id: 'alerting_v2.create_alert',
+    category: StepCategory.Kibana,
+    label: i18n.translate('alertingV2.workflowStep.createAlert.label', {
+      defaultMessage: 'Create V2 Alert',
+    }),
+    description: i18n.translate('alertingV2.workflowStep.createAlert.description', {
+      defaultMessage:
+        'Push an alert event directly into the Elastic v2 alerting system without a backing rule.',
+    }),
+    documentation: {
+      details: i18n.translate('alertingV2.workflowStep.createAlert.documentation.details', {
+        defaultMessage: `The {stepId} step writes a pre-normalized alert event into the v2 alerting system via {apiPath}. Use it to bridge external monitoring tools (Prometheus, PagerDuty, CloudWatch) into Elastic's alerting episode lifecycle.
+
+Use a stable {fingerprint} to group events into the same alert series. The server manages episode lifecycle automatically: same fingerprint while active continues the episode; after recovery, same fingerprint opens a new episode. Set {alertStatus} to signal recovery when the source system has no end timestamp.`,
+        values: {
+          stepId: '`alerting_v2.create_alert`',
+          apiPath: '`POST /api/alerting/v2/alerts`',
+          fingerprint: '`fingerprint`',
+          alertStatus: '`alert_status`',
+        },
+      }),
+      examples: [
+        `## Fire an alert from Prometheus
+\`\`\`yaml
+- name: push-alert
+  type: alerting_v2.create_alert
+  with:
+    source: "prometheus"
+    fingerprint: "\${{ trigger.labels.alertname }}-\${{ trigger.labels.instance }}"
+    rule_id: "\${{ trigger.labels.alertname }}"
+    alert_url: "\${{ trigger.generatorURL }}"
+    timestamp: "\${{ trigger.startsAt }}"
+    data:
+      summary: "\${{ trigger.annotations.summary }}"
+\`\`\``,
+
+        `## Resolve a previously fired alert
+\`\`\`yaml
+- name: resolve-alert
+  type: alerting_v2.create_alert
+  with:
+    source: "prometheus"
+    fingerprint: "\${{ trigger.labels.alertname }}-\${{ trigger.labels.instance }}"
+    rule_id: "\${{ trigger.labels.alertname }}"
+    alert_status: "inactive"
+    timestamp: "\${{ trigger.endsAt }}"
+\`\`\``,
+      ],
+    },
+    inputSchema,
+    outputSchema,
+    configSchema,
+    handler: async (context) => {
+      const [coreStart] = await getStartServices();
+
+      const { protocol, hostname, port } = coreStart.http.getServerInfo();
+      const basePath = coreStart.http.basePath.serverBasePath;
+      const url = `${protocol}://${hostname}:${port}${basePath}${ALERTING_V2_ALERT_API_PATH}`;
+
+      const fakeRequest = context.contextManager.getFakeRequest();
+      const forwardHeaders: Record<string, string> = {
+        'content-type': 'application/json',
+        'kbn-xsrf': 'true',
+        'x-elastic-internal-origin': 'kibana',
+      };
+      for (const [key, value] of Object.entries(fakeRequest.headers)) {
+        const lowerKey = key.toLowerCase();
+        if (
+          value != null &&
+          !['host', 'content-length', 'transfer-encoding', 'content-type'].includes(lowerKey)
+        ) {
+          forwardHeaders[lowerKey] = Array.isArray(value) ? value[0] : String(value);
+        }
+      }
+
+      const input = context.input;
+
+      const body: Record<string, unknown> = {
+        source: input.source,
+        fingerprint: input.fingerprint,
+      };
+      if (input.rule_id != null) body.rule_id = input.rule_id;
+      if (input.rule_name != null) body.rule_name = input.rule_name;
+      if (input.alert_url != null) body.alert_url = input.alert_url;
+      if (input.alert_status != null) body.alert_status = input.alert_status;
+      if (input.data != null) body.data = input.data;
+      if (input.timestamp != null) body.timestamp = input.timestamp;
+      if (input.severity != null) body.severity = input.severity;
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: 'POST',
+          headers: forwardHeaders,
+          body: JSON.stringify(body),
+          signal: context.abortSignal,
+        });
+      } catch (err) {
+        context.logger.error(
+          `Network error posting to ${url} for source=${input.source} fingerprint=${input.fingerprint}`,
+          err instanceof Error ? err : undefined
+        );
+        return { error: err instanceof Error ? err : new Error(String(err)) };
+      }
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => '(unreadable)');
+        const msg = `POST ${url} returned ${response.status}: ${text}`;
+        context.logger.error(msg);
+        return { error: new Error(msg) };
+      }
+
+      const responseBody = (await response.json()) as { id: string };
+      const groupHash = responseBody.id;
+
+      context.logger.info(
+        `Created external alert via API: source=${input.source} fingerprint=${input.fingerprint} group_hash=${groupHash}`
+      );
+
+      return { output: { group_hash: groupHash } };
+    },
+  });
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_events/create_alert_event_route.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createHash, randomUUID } from 'crypto';
+import type { KibanaRequest, RouteSecurity } from '@kbn/core-http-server';
+import { inject, injectable } from 'inversify';
+import { Request } from '@kbn/core-di-server';
+import {
+  createAlertEventDataSchema,
+  createAlertEventResponseSchema,
+  errorResponseSchema,
+  type CreateAlertEventData,
+} from '@kbn/alerting-v2-schemas';
+import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
+import { ALERTING_V2_ALERT_API_PATH } from '../constants';
+import { BaseAlertingRoute } from '../base_alerting_route';
+import { AlertingRouteContext } from '../alerting_route_context';
+import { StorageServiceInternalToken } from '../../lib/services/storage_service/tokens';
+import type { StorageServiceContract } from '../../lib/services/storage_service/storage_service';
+import { RequestSpaceIdToken } from '../../lib/services/spaces_service/tokens';
+import {
+  ALERT_EVENTS_DATA_STREAM,
+  alertEventStatus,
+  alertEpisodeStatus,
+  alertEventType,
+} from '../../resources/datastreams/alert_events';
+import type { AlertEvent } from '../../resources/datastreams/alert_events';
+import type { QueryServiceContract } from '../../lib/services/query_service/query_service';
+import { QueryServiceInternalToken } from '../../lib/services/query_service/tokens';
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+@injectable()
+export class CreateAlertEventRoute extends BaseAlertingRoute {
+  static method = 'post' as const;
+  static path = `${ALERTING_V2_ALERT_API_PATH}`;
+  static security: RouteSecurity = {
+    authz: {
+      requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.alerts.write],
+    },
+  };
+  static routeOptions = {
+    summary: 'Create an alert event',
+    description:
+      'Creates an alert event directly without a backing rule. ' +
+      'Intended for external monitoring systems pushing pre-normalized alerts.',
+  } as const;
+  static schemas = {
+    request: {
+      body: createAlertEventDataSchema,
+    },
+    response: {
+      201: {
+        body: () => createAlertEventResponseSchema,
+        description: 'Indicates a successful call.',
+      },
+      400: {
+        body: () => errorResponseSchema,
+        description: 'Indicates an invalid schema or parameters.',
+      },
+    },
+  };
+
+  protected readonly routeName = 'create alert event';
+
+  constructor(
+    @inject(AlertingRouteContext) ctx: AlertingRouteContext,
+    @inject(Request) private readonly request: KibanaRequest<unknown, unknown, CreateAlertEventData>,
+    @inject(StorageServiceInternalToken) private readonly storageService: StorageServiceContract,
+    @inject(QueryServiceInternalToken) private readonly queryService: QueryServiceContract,
+    @inject(RequestSpaceIdToken) private readonly spaceId: string
+  ) {
+    super(ctx);
+  }
+
+  protected async execute() {
+    const body = this.request.body;
+    const source = body.source;
+    const fingerprint = body.fingerprint;
+    const inputRuleId = body.rule_id || undefined;
+    const inputRuleName = body.rule_name || undefined;
+    const alertUrl = body.alert_url || undefined;
+    const alertStatus = body.alert_status || undefined;
+    const data = body.data;
+    const timestamp = body.timestamp || undefined;
+    const severity = body.severity || undefined;
+
+    const ruleId = inputRuleId ? `${source}/${inputRuleId}` : source;
+    const ruleName = inputRuleName ?? inputRuleId ?? source;
+
+    // group_hash is stable per-series: sha256(derived_rule_id + ":" + fingerprint)
+    const groupHash = sha256(`${ruleId}:${fingerprint}`);
+
+    const episodeStatus = alertStatus ?? alertEpisodeStatus.active;
+
+    // Episode continuation: query latest event for this group_hash to decide
+    // whether to continue an existing episode or start a new one.
+    const episodeId = await this.resolveEpisodeId(groupHash, episodeStatus);
+
+    const atTimestamp = timestamp ?? new Date().toISOString();
+
+    // status: active/pending → breached; inactive/recovering → recovered
+    const status =
+      episodeStatus === alertEpisodeStatus.inactive || episodeStatus === alertEpisodeStatus.recovering
+        ? alertEventStatus.recovered
+        : alertEventStatus.breached;
+
+    // status_count must be >= 1 for pending/recovering states
+    const statusCount =
+      episodeStatus === alertEpisodeStatus.pending || episodeStatus === alertEpisodeStatus.recovering
+        ? 1
+        : undefined;
+
+    const doc: AlertEvent = {
+      '@timestamp': atTimestamp,
+      rule: { id: ruleId, name: ruleName, version: 1 },
+      group_hash: groupHash,
+      data: data ?? {},
+      status,
+      source: {
+        name: source,
+        ...(alertUrl != null ? { alert_url: alertUrl } : {}),
+      },
+      type: alertEventType.alert,
+      episode: {
+        id: episodeId,
+        status: episodeStatus,
+        ...(statusCount != null ? { status_count: statusCount } : {}),
+      },
+      space_id: this.spaceId,
+      ...(severity != null ? { severity } : {}),
+    };
+
+    await this.storageService.bulkIndexDocs({
+      index: ALERT_EVENTS_DATA_STREAM,
+      docs: [doc],
+    });
+
+    return this.ctx.response.created({ body: { id: groupHash } });
+  }
+
+  /**
+   * Resolve episode ID for this group_hash by querying latest state:
+   * - No prior event → new episode (UUID v4)
+   * - Prior episode is inactive and new status is non-inactive → new episode (re-open)
+   * - Otherwise → continue existing episode
+   */
+  private async resolveEpisodeId(
+    groupHash: string,
+    nextStatus: string
+  ): Promise<string> {
+    try {
+      const rows = await this.queryService.executeQueryRows<{
+        last_episode_id: string;
+        last_episode_status: string;
+      }>({
+        query: `FROM ${ALERT_EVENTS_DATA_STREAM}
+          | WHERE type == "alert" AND group_hash == "${groupHash}" AND episode.status IS NOT NULL
+          | STATS last_episode_id = LAST(episode.id, @timestamp),
+                  last_episode_status = LAST(episode.status, @timestamp)
+            BY group_hash
+          | KEEP last_episode_id, last_episode_status
+          | LIMIT 1`,
+      });
+
+      if (rows.length === 0 || !rows[0].last_episode_id) {
+        return randomUUID();
+      }
+
+      const { last_episode_id: lastEpisodeId, last_episode_status: lastEpisodeStatus } = rows[0];
+
+      const isNewLifecycle =
+        lastEpisodeStatus === alertEpisodeStatus.inactive &&
+        nextStatus !== alertEpisodeStatus.inactive;
+
+      return isNewLifecycle ? randomUUID() : lastEpisodeId;
+    } catch {
+      return randomUUID();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `alerting_v2.create_alert` Kibana Workflow step — the bridge between Kibana Workflows and the external alert ingestion API.

### What it does

Allows workflows to push external alerts into `POST /api/alerting/v2/alerts` with forwarded auth headers. The step maps workflow context fields to the flat API schema.

**Depends on:** #270769 (Create Alert Event API) — merge that first.

### Files

- `server/lib/workflow_extensions/steps/create_alert_event_step.ts` — server step definition, input schema, HTTP handler
- `public/lib/workflow_extensions/steps/create_alert_event_step.ts` — public step definition, editor schema, documentation

### Usage example

```yaml
steps:
  - id: ingest
    action: alerting_v2.create_alert
    input:
      source: "prometheus"
      fingerprint: "{{ foreach.item.fingerprint }}"
      rule_id: "{{ foreach.item.labels.alertname }}"
      rule_name: "prometheus/{{ foreach.item.labels.alertname }}"
      alert_status: "active"
      severity: "high"
```

### Issue

elastic/rna-program#733 (epic: elastic/rna-program#731)