### PR TITLE
[Entity Analytics] Passing internalEsClient to prebuilt watchlist setup

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/prebuilt_install.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/prebuilt_install.ts
@@ -47,6 +47,7 @@ export const installPrebuiltWatchlistsRoute = (
             namespace,
             soClient,
             esClient: core.elasticsearch.client.asCurrentUser,
+            internalEsClient: core.elasticsearch.client.asInternalUser,
             logger,
           });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.ts
@@ -203,6 +203,7 @@ export const installPrebuiltWatchlists = async ({
     const watchlistClient = new WatchlistConfigClientClass({
       soClient,
       esClient,
+      internalEsClient: esClient,
       namespace,
       logger,
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/269513

## Summary

Investigating this flaky test: https://github.com/elastic/kibana/issues/269513 where running migrations from the FTR was receiving a 500 response rather than a 200, the response body logged was 

```
ERROR Failed to run migrations: body: {"message":"internalEsClient is required to create a watchlist index","full_error":"{}","status_code":500}, status: 500
```

which comes from trying to install prebuilt watchlists during the migration https://github.com/elastic/kibana/blob/f88486e1385180df59a1a1d9e47183af949098c2/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/index.ts#L72 

It looks like there were a couple of places where the internal ES client wasn't passed to the watchlist client when [this PR](https://github.com/elastic/kibana/pull/265966) was merged.



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->