### PR TITLE
[9.4] [Home] Hide inaccessible Stack Management link (#271528)

### DIFF
--- a/src/platform/plugins/shared/home/public/application/components/manage_data/__snapshots__/manage_data.test.tsx.snap
+++ b/src/platform/plugins/shared/home/public/application/components/manage_data/__snapshots__/manage_data.test.tsx.snap
@@ -134,21 +134,6 @@ exports[`ManageData render 1`] = `
             />
           </EuiButtonEmpty>
         </EuiFlexItem>
-        <EuiFlexItem
-          grow={false}
-        >
-          <EuiButtonEmpty
-            data-test-subj="homeManage"
-            flush="both"
-            href=""
-            iconType="gear"
-          >
-            <MemoizedFormattedMessage
-              defaultMessage="Stack Management"
-              id="home.manageData.stackManagementButtonLabel"
-            />
-          </EuiButtonEmpty>
-        </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx
@@ -8,9 +8,13 @@
  */
 
 import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EuiProvider } from '@elastic/eui';
 import { ManageData } from './manage_data';
 import { shallowWithIntl } from '@kbn/test-jest-helpers';
-import type { ApplicationStart } from '@kbn/core/public';
+import { AppStatus, type ApplicationStart, type PublicAppInfo } from '@kbn/core/public';
+import { BehaviorSubject } from 'rxjs';
 import type { FeatureCatalogueEntry } from '../../../services';
 
 jest.mock('../app_navigation_handler', () => {
@@ -30,13 +34,39 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const applicationStartMock = {
-  capabilities: { navLinks: { management: true, dev_tools: true } },
-} as unknown as ApplicationStart;
+const createApplicationStartMock = ({
+  isManagementEnabled,
+  isDevToolsEnabled,
+  managementAppStatus = AppStatus.accessible,
+}: {
+  isManagementEnabled: boolean;
+  isDevToolsEnabled: boolean;
+  managementAppStatus?: AppStatus;
+}) =>
+  ({
+    capabilities: { navLinks: { management: isManagementEnabled, dev_tools: isDevToolsEnabled } },
+    applications$: new BehaviorSubject(
+      new Map<string, PublicAppInfo>([
+        ['management', { status: managementAppStatus } as PublicAppInfo],
+      ])
+    ),
+  } as unknown as ApplicationStart);
 
-const applicationStartMockRestricted = {
-  capabilities: { navLinks: { management: false, dev_tools: false } },
-} as unknown as ApplicationStart;
+const applicationStartMock = createApplicationStartMock({
+  isManagementEnabled: true,
+  isDevToolsEnabled: true,
+});
+
+const applicationStartMockRestricted = createApplicationStartMock({
+  isManagementEnabled: false,
+  isDevToolsEnabled: false,
+});
+
+const applicationStartMockWithInaccessibleManagement = createApplicationStartMock({
+  isManagementEnabled: true,
+  isDevToolsEnabled: true,
+  managementAppStatus: AppStatus.inaccessible,
+});
 
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 
@@ -112,5 +142,68 @@ describe('ManageData', () => {
       />
     );
     expect(component).toMatchSnapshot();
+  });
+
+  test('renders dev tools link when capability is enabled', () => {
+    render(
+      <EuiProvider>
+        <I18nProvider>
+          <ManageData
+            addBasePath={addBasePathMock}
+            application={applicationStartMock}
+            features={mockFeatures}
+          />
+        </I18nProvider>
+      </EuiProvider>
+    );
+    expect(screen.getByTestId('homeDevTools')).toBeInTheDocument();
+  });
+
+  test('renders stack management link when management app is accessible', async () => {
+    render(
+      <EuiProvider>
+        <I18nProvider>
+          <ManageData
+            addBasePath={addBasePathMock}
+            application={applicationStartMock}
+            features={mockFeatures}
+          />
+        </I18nProvider>
+      </EuiProvider>
+    );
+
+    expect(await screen.findByTestId('homeManage')).toBeInTheDocument();
+  });
+
+  test('does not render dev tools link when capability is disabled', () => {
+    render(
+      <EuiProvider>
+        <I18nProvider>
+          <ManageData
+            addBasePath={addBasePathMock}
+            application={applicationStartMockRestricted}
+            features={mockFeatures}
+          />
+        </I18nProvider>
+      </EuiProvider>
+    );
+    expect(screen.queryByTestId('homeDevTools')).not.toBeInTheDocument();
+  });
+
+  test('does not render stack management link when management app is inaccessible', async () => {
+    render(
+      <EuiProvider>
+        <I18nProvider>
+          <ManageData
+            addBasePath={addBasePathMock}
+            application={applicationStartMockWithInaccessibleManagement}
+            features={mockFeatures}
+          />
+        </I18nProvider>
+      </EuiProvider>
+    );
+
+    expect(screen.getByTestId('homeDevTools')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('homeManage')).not.toBeInTheDocument());
   });
 });

--- a/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx
@@ -15,11 +15,14 @@ import { EuiButtonEmpty, EuiFlexGroup, EuiSpacer, EuiTitle, EuiFlexItem } from '
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { METRIC_TYPE } from '@kbn/analytics';
-import type { ApplicationStart } from '@kbn/core/public';
+import { AppStatus, type ApplicationStart } from '@kbn/core/public';
+import useObservable from 'react-use/lib/useObservable';
 import type { FeatureCatalogueEntry } from '../../../services';
 import { createAppNavigationHandler } from '../app_navigation_handler';
 import { Synopsis } from '../synopsis';
 import { getServices } from '../../kibana_services';
+
+const MANAGEMENT_APP_ID = 'management';
 
 interface Props {
   addBasePath: (path: string) => string;
@@ -34,11 +37,15 @@ export const ManageData: FC<Props> = ({ addBasePath, application, features }) =>
   const managementHref = share.url.locators
     .get('MANAGEMENT_APP_LOCATOR')
     ?.useUrl({ sectionId: '' });
+  const { management: isManagementEnabled, dev_tools: isDevToolsEnabled } =
+    application.capabilities.navLinks;
+  const applications = useObservable(application.applications$);
+  const managementApp = applications?.get(MANAGEMENT_APP_ID);
+  const isManagementAppAccessible = Boolean(
+    isManagementEnabled && managementApp?.status === AppStatus.accessible
+  );
 
   if (features.length) {
-    const { management: isManagementEnabled, dev_tools: isDevToolsEnabled } =
-      application.capabilities.navLinks;
-
     return (
       <KibanaPageTemplate.Section
         bottomBorder
@@ -55,7 +62,7 @@ export const ManageData: FC<Props> = ({ addBasePath, application, features }) =>
             </EuiTitle>
           </EuiFlexItem>
 
-          {isDevToolsEnabled || isManagementEnabled ? (
+          {isDevToolsEnabled || isManagementAppAccessible ? (
             <EuiFlexItem grow={false}>
               <EuiFlexGroup alignItems="center" responsive={false} wrap>
                 {/* Check if both the Dev Tools UI and the Console UI are enabled. */}
@@ -75,7 +82,7 @@ export const ManageData: FC<Props> = ({ addBasePath, application, features }) =>
                   </EuiFlexItem>
                 ) : null}
 
-                {isManagementEnabled ? (
+                {isManagementAppAccessible ? (
                   <EuiFlexItem grow={false}>
                     <EuiButtonEmpty
                       data-test-subj="homeManage"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Home] Hide inaccessible Stack Management link (#271528)](https://github.com/elastic/kibana/pull/271528)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-05-27T20:29:25Z","message":"[Home] Hide inaccessible Stack Management link (#271528)\n\nCloses #239725\n\n## Summary\n- Hides the Stack Management shortcut on the Home Management section\nwhen the registered Management app is marked inaccessible.\n- Preserves the Dev Tools shortcut for users who only have Dev Tools\nprivileges.\n- Note: this touches `src/platform/plugins/shared/home`, owned by\n`@elastic/appex-sharedux`, so that team should review the Home UI\nchange.\n\n## Root Cause\n- The Management app marks itself `AppStatus.inaccessible` when the\ncurrent user has no enabled Management apps, but Home only checked\n`capabilities.navLinks.management` before rendering the Stack Management\nshortcut.\n\n## Fix\n- Home now derives Stack Management shortcut visibility from both the\nManagement nav-link capability and the registered app status from\n`application.applications# Backport

This will backport the following commits from `main` to `9.4`:
{{{{raw}}}} - [[Home] Hide inaccessible Stack Management link (#271528)](https://github.com/elastic/kibana/pull/271528){{{{/raw}}}}

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT .\n- Adds regression coverage for accessible Management and Dev\nTools-only/inaccessible Management states.\n\n## Screenshots\n\n### Before\n<img width=\"2532\" height=\"666\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ab6405e2-95eb-4a0c-ad68-6b78abc16cfa\"\n/>\n\n### After\n<img width=\"1481\" height=\"435\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fa81716d-f08e-464c-85f1-e50582e60241\"\n/>\n\n## Test Plan\n- Local UI repro/check:\n1. Start Kibana locally with security enabled and sign in as a user that\ncan create roles.\n2. Create a role with only Kibana feature privilege `Dev Tools: All` and\nno Management privileges. For example, create a role with `kibana: [{\nspaces: [\"*\"], base: [], feature: { dev_tools: [\"all\"] } }]`.\n  3. Assign only that role to a test user and sign in as that user.\n4. Open Home. Verify `Dev Tools` is visible in the Management section\nand `Stack Management` is not visible.\n5. Optionally navigate directly to `/app/management` to confirm the\nManagement app is inaccessible for that role.\n- `node scripts/jest\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`\n- `node scripts/eslint\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/home/tsconfig.json`\n- `node scripts/check_changes.ts`\n\nAssisted with Cursor using GPT-5.5\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ea4519c11a957e25a2f98eff4247ced1b617bc5c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Dev Tools","Feature:Home","Feature:Kibana Management","Team:Kibana Management","release_note:skip","Team:SharedUX","backport:all-open","reviewer:claude","v9.5.0","reviewer:codex"],"title":"[Home] Hide inaccessible Stack Management link","number":271528,"url":"https://github.com/elastic/kibana/pull/271528","mergeCommit":{"message":"[Home] Hide inaccessible Stack Management link (#271528)\n\nCloses #239725\n\n## Summary\n- Hides the Stack Management shortcut on the Home Management section\nwhen the registered Management app is marked inaccessible.\n- Preserves the Dev Tools shortcut for users who only have Dev Tools\nprivileges.\n- Note: this touches `src/platform/plugins/shared/home`, owned by\n`@elastic/appex-sharedux`, so that team should review the Home UI\nchange.\n\n## Root Cause\n- The Management app marks itself `AppStatus.inaccessible` when the\ncurrent user has no enabled Management apps, but Home only checked\n`capabilities.navLinks.management` before rendering the Stack Management\nshortcut.\n\n## Fix\n- Home now derives Stack Management shortcut visibility from both the\nManagement nav-link capability and the registered app status from\n`application.applications# Backport

This will backport the following commits from `main` to `9.4`:
{{{{raw}}}} - [[Home] Hide inaccessible Stack Management link (#271528)](https://github.com/elastic/kibana/pull/271528){{{{/raw}}}}

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT .\n- Adds regression coverage for accessible Management and Dev\nTools-only/inaccessible Management states.\n\n## Screenshots\n\n### Before\n<img width=\"2532\" height=\"666\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ab6405e2-95eb-4a0c-ad68-6b78abc16cfa\"\n/>\n\n### After\n<img width=\"1481\" height=\"435\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fa81716d-f08e-464c-85f1-e50582e60241\"\n/>\n\n## Test Plan\n- Local UI repro/check:\n1. Start Kibana locally with security enabled and sign in as a user that\ncan create roles.\n2. Create a role with only Kibana feature privilege `Dev Tools: All` and\nno Management privileges. For example, create a role with `kibana: [{\nspaces: [\"*\"], base: [], feature: { dev_tools: [\"all\"] } }]`.\n  3. Assign only that role to a test user and sign in as that user.\n4. Open Home. Verify `Dev Tools` is visible in the Management section\nand `Stack Management` is not visible.\n5. Optionally navigate directly to `/app/management` to confirm the\nManagement app is inaccessible for that role.\n- `node scripts/jest\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`\n- `node scripts/eslint\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/home/tsconfig.json`\n- `node scripts/check_changes.ts`\n\nAssisted with Cursor using GPT-5.5\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ea4519c11a957e25a2f98eff4247ced1b617bc5c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271528","number":271528,"mergeCommit":{"message":"[Home] Hide inaccessible Stack Management link (#271528)\n\nCloses #239725\n\n## Summary\n- Hides the Stack Management shortcut on the Home Management section\nwhen the registered Management app is marked inaccessible.\n- Preserves the Dev Tools shortcut for users who only have Dev Tools\nprivileges.\n- Note: this touches `src/platform/plugins/shared/home`, owned by\n`@elastic/appex-sharedux`, so that team should review the Home UI\nchange.\n\n## Root Cause\n- The Management app marks itself `AppStatus.inaccessible` when the\ncurrent user has no enabled Management apps, but Home only checked\n`capabilities.navLinks.management` before rendering the Stack Management\nshortcut.\n\n## Fix\n- Home now derives Stack Management shortcut visibility from both the\nManagement nav-link capability and the registered app status from\n`application.applications# Backport

This will backport the following commits from `main` to `9.4`:
{{{{raw}}}} - [[Home] Hide inaccessible Stack Management link (#271528)](https://github.com/elastic/kibana/pull/271528){{{{/raw}}}}

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT .\n- Adds regression coverage for accessible Management and Dev\nTools-only/inaccessible Management states.\n\n## Screenshots\n\n### Before\n<img width=\"2532\" height=\"666\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ab6405e2-95eb-4a0c-ad68-6b78abc16cfa\"\n/>\n\n### After\n<img width=\"1481\" height=\"435\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fa81716d-f08e-464c-85f1-e50582e60241\"\n/>\n\n## Test Plan\n- Local UI repro/check:\n1. Start Kibana locally with security enabled and sign in as a user that\ncan create roles.\n2. Create a role with only Kibana feature privilege `Dev Tools: All` and\nno Management privileges. For example, create a role with `kibana: [{\nspaces: [\"*\"], base: [], feature: { dev_tools: [\"all\"] } }]`.\n  3. Assign only that role to a test user and sign in as that user.\n4. Open Home. Verify `Dev Tools` is visible in the Management section\nand `Stack Management` is not visible.\n5. Optionally navigate directly to `/app/management` to confirm the\nManagement app is inaccessible for that role.\n- `node scripts/jest\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`\n- `node scripts/eslint\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx\nsrc/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`\n- `node scripts/type_check --project\nsrc/platform/plugins/shared/home/tsconfig.json`\n- `node scripts/check_changes.ts`\n\nAssisted with Cursor using GPT-5.5\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ea4519c11a957e25a2f98eff4247ced1b617bc5c"}}]}] BACKPORT-->