### PR TITLE
[9.3] [Console] Mark invalid request-line methods as errors (#270479)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/console_errors_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/console_errors_provider.ts
@@ -32,13 +32,15 @@ export const setupConsoleErrorsProvider = (workerProxyService: ConsoleWorkerProx
     monaco.editor.setModelMarkers(
       model,
       CONSOLE_LANG_ID,
-      errors.map(({ offset, text }) => {
+      errors.map(({ offset, endOffset, text }) => {
         const { column, lineNumber } = model.getPositionAt(offset);
+        const endPosition =
+          endOffset !== undefined ? model.getPositionAt(endOffset) : { column, lineNumber };
         return {
           startLineNumber: lineNumber,
           startColumn: column,
-          endLineNumber: lineNumber,
-          endColumn: column,
+          endLineNumber: endPosition.lineNumber,
+          endColumn: endPosition.column,
           message: text,
           severity: monaco.MarkerSeverity.Error,
         };

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.js
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.js
@@ -25,8 +25,20 @@ export const createParser = () => {
     },
     text,
     errors,
-    addError = function (text) {
-      errors.push({ text: text, offset: at });
+    addError = function (text, offset = at, endOffset) {
+      const errorAnnotation = { text: text, offset: offset };
+      if (endOffset !== undefined) {
+        errorAnnotation.endOffset = endOffset;
+      }
+      errors.push(errorAnnotation);
+    },
+    hasErrorCoveringOffset = function (offset) {
+      return errors.some(
+        (errorAnnotation) =>
+          errorAnnotation.endOffset !== undefined &&
+          errorAnnotation.offset <= offset &&
+          offset <= errorAnnotation.endOffset
+      );
     },
     requests,
     requestStartOffset,
@@ -46,11 +58,12 @@ export const createParser = () => {
       lastRequest.endOffset = requestEndOffset;
       requests.push(lastRequest);
     },
-    error = function (m) {
+    error = function (m, errorAt = at, errorEndAt) {
       throw {
         name: 'SyntaxError',
         message: m,
-        at: at,
+        at: errorAt,
+        endAt: errorEndAt,
         text: text,
       };
     },
@@ -88,6 +101,16 @@ export const createParser = () => {
     },
     peek = function (offset) {
       return text.charAt(at + offset);
+    },
+    isRequestLineSeparator = function (character) {
+      return character === ' ' || character === '\t' || character === '\n' || character === '\r';
+    },
+    readCurrentLineTokenEndOffset = function (startOffset) {
+      let tokenEndOffset = startOffset;
+      while (tokenEndOffset < text.length && !isRequestLineSeparator(text[tokenEndOffset])) {
+        tokenEndOffset++;
+      }
+      return tokenEndOffset;
     },
     number = function () {
       let number,
@@ -230,6 +253,18 @@ export const createParser = () => {
       }
       error('Unexpected \'' + ch + '\'');
     },
+    // After consuming method letters, the next character must separate the
+    // method from the URL/body: horizontal whitespace, a line break, or
+    // end-of-input. Anything else is part of an invalid method token.
+    methodBoundary = function () {
+      if (ch && !isRequestLineSeparator(ch)) {
+        error(
+          'Expected one of GET/POST/PUT/DELETE/HEAD/PATCH',
+          requestStartOffset ?? at,
+          readCurrentLineTokenEndOffset(at)
+        );
+      }
+    },
     // parses and returns the method
     method = function () {
     const upperCaseChar = ch.toUpperCase();
@@ -238,12 +273,14 @@ export const createParser = () => {
           nextOneOf(['G', 'g']);
           nextOneOf(['E', 'e']);
           nextOneOf(['T', 't']);
+          methodBoundary();
           return 'GET';
         case 'H':
           nextOneOf(['H', 'h']);
           nextOneOf(['E', 'e']);
           nextOneOf(['A', 'a']);
           nextOneOf(['D', 'd']);
+          methodBoundary();
           return 'HEAD';
         case 'D':
           nextOneOf(['D', 'd']);
@@ -252,6 +289,7 @@ export const createParser = () => {
           nextOneOf(['E', 'e']);
           nextOneOf(['T', 't']);
           nextOneOf(['E', 'e']);
+          methodBoundary();
           return 'DELETE';
         case 'P':
           nextOneOf(['P', 'p']);
@@ -262,15 +300,18 @@ export const createParser = () => {
               nextOneOf(['T', 't']);
               nextOneOf(['C', 'c']);
               nextOneOf(['H', 'h']);
+              methodBoundary();
               return 'PATCH';
             case 'U':
               nextOneOf(['U', 'u']);
               nextOneOf(['T', 't']);
+              methodBoundary();
               return 'PUT';
             case 'O':
               nextOneOf(['O', 'o']);
               nextOneOf(['S', 's']);
               nextOneOf(['T', 't']);
+              methodBoundary();
               return 'POST';
             default:
               error('Unexpected \'' + ch + '\'');
@@ -414,10 +455,15 @@ export const createParser = () => {
           request();
           white();
         } catch (e) {
-          addError(e.message);
+          addError(e.message, e.at, e.endAt);
           // snap
           const remainingText = text.substr(at);
-          const nextMethodIndex = remainingText.search(/^\s*(POST|HEAD|GET|PUT|DELETE|PATCH)\b/mi);
+          // Match the verb without a trailing `\b` so that lines starting with
+          // a valid method prefix but continuing with identifier characters
+          // (`GETT`, `POSTS`, `PUThjjkjoj`) are picked up as recovery anchors;
+          // `method()` then re-throws at the boundary and an error annotation
+          // is recorded for each such line.
+          const nextMethodIndex = remainingText.search(/^\s*(POST|HEAD|GET|PUT|DELETE|PATCH)/mi);
           const nextCommentLine = remainingText.search(/^\s*(#|\/\*|\/\/).*$/m);
           if (nextMethodIndex === -1 && nextCommentLine === -1) {
             // If there are no comments or other requests after the error, there is no point in parsing more so we stop here
@@ -441,7 +487,9 @@ export const createParser = () => {
     multi_request();
     white();
     if (ch) {
-      addError('Syntax error');
+      if (!hasErrorCoveringOffset(at)) {
+        addError('Syntax error');
+      }
     }
 
     result = { errors, requests };

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts
@@ -140,6 +140,99 @@ describe('console parser', () => {
     });
   });
 
+  describe('request-line method boundary', () => {
+    // The first token of a request line must have one canonical method
+    // interpretation. A valid method prefix followed by non-whitespace
+    // characters (e.g. `GETT`, `POSTS`, `PUThjjkjoj`) must not be silently
+    // accepted as the matching method with a malformed url tail.
+    const methodBoundaryError = 'Expected one of GET/POST/PUT/DELETE/HEAD/PATCH';
+
+    it('rejects a valid method prefix followed by extra letters (`GETT _search`)', () => {
+      const { errors } = parser('GETT _search') as ConsoleParserResult;
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+    });
+
+    it('rejects a valid method prefix followed by an `S` suffix (`POSTS _search`)', () => {
+      const { errors } = parser('POSTS _search') as ConsoleParserResult;
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+    });
+
+    it('rejects a method with arbitrary trailing characters (`PUThjjkjoj /my-index`)', () => {
+      const { errors } = parser('PUThjjkjoj /my-index') as ConsoleParserResult;
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+    });
+
+    it('recovers and continues parsing the next request after an invalid method line', () => {
+      const input = 'GETT _search\nPOST _bulk';
+      const { requests, errors } = parser(input) as ConsoleParserResult;
+      // First request is invalid: errors are recorded
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+      // Second request is parsed correctly
+      const validRequest = requests.find(
+        (r) => r.endOffset !== undefined && r.endOffset >= 'GETT _search\n'.length
+      );
+      expect(validRequest).toBeDefined();
+    });
+
+    it('marks every consecutive invalid-method-prefix line, not only the first', () => {
+      const input = 'PUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\nGET _ok';
+      const { requests, errors } = parser(input) as ConsoleParserResult;
+      // Each of the three invalid-prefix lines must produce its own marker
+      // so users see them all, not only the first one.
+      const boundaryErrors = errors.filter((e) => e.text === methodBoundaryError);
+      expect(boundaryErrors.length).toBe(3);
+      // The final valid request must also be captured despite the preceding
+      // boundary errors.
+      const validRequest = requests.find(
+        (r) =>
+          r.startOffset === 'PUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\n'.length &&
+          r.endOffset !== undefined
+      );
+      expect(validRequest).toBeDefined();
+    });
+
+    // The boundary is "next character separates the method from the URL/body".
+    // These tables lock in which inputs are accepted vs rejected.
+    it.each([
+      ['GET_index', 'underscore'],
+      ['GET2 _x', 'digit'],
+      ['GETSomething', 'letter'],
+      ['HEADX _x', 'letter'],
+      ['DELETEX _x', 'letter'],
+      ['PATCHX _x', 'letter'],
+      ['GET/_search', 'slash'],
+      ['GET?q=1', 'question mark'],
+      ['GET-foo', 'dash'],
+      ['GET*', 'star'],
+    ])('rejects invalid method boundary: %s (%s)', (input) => {
+      const { errors } = parser(input) as ConsoleParserResult;
+      expect(errors.length).toBe(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+      expect(errors[0].offset).toBe(0);
+      expect(errors[0].endOffset).toBe(input.split(/[ \t\r\n]/)[0].length);
+    });
+
+    it.each([
+      ['GET _search', 'space'],
+      ['GET\t_search', 'tab'],
+      ['GET', 'end-of-input'],
+    ])('accepts request-line separator after method: %s (%s)', (input) => {
+      const { errors, requests } = parser(input) as ConsoleParserResult;
+      expect(errors.filter((e) => e.text === methodBoundaryError)).toEqual([]);
+      expect(requests.length).toBe(1);
+    });
+
+    it('does not falsely flag a method whose url contains identifier chars (`GET _index_internal`)', () => {
+      const { errors, requests } = parser('GET _index_internal') as ConsoleParserResult;
+      expect(errors).toEqual([]);
+      expect(requests.length).toBe(1);
+    });
+  });
+
   describe('CRLF line endings (Windows)', () => {
     it('parses a single request with CRLF line endings without errors', () => {
       const input = 'GET _search\r\n';

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/types.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/types.ts
@@ -9,6 +9,7 @@
 
 export interface ErrorAnnotation {
   offset: number;
+  endOffset?: number;
   text: string;
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Console] Mark invalid request-line methods as errors (#270479)](https://github.com/elastic/kibana/pull/270479)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-05-26T22:20:25Z","message":"[Console] Mark invalid request-line methods as errors (#270479)\n\nCloses #219253\n\n## Summary\n\nRequest lines starting with a valid HTTP method prefix followed by extra\ncharacters (e.g. `PUThjjkjoj /my-index`, `GETT _search`, `POSTS _bulk`)\nwere silently accepted by the Console Monaco parser — the prefix was\nconsumed as the method and the tail treated as the URL, so no marker was\nemitted. Each such line is now marked.\n\n## Root cause\n\nIn\n`src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts`:\n\n1. `method()` greedily consumed the longest matching prefix without\nchecking that the next character was a token boundary, so `PUThjjkjoj`\nparsed as method `PUT` + URL `hjjkjoj /my-index`.\n2. `multiRequest()` recovery used\n`/^\\s*(POST|HEAD|GET|PUT|DELETE|PATCH)\\b/im`. With `\\b`, consecutive\ninvalid-prefix lines were skipped over, so only the first one in a run\ncould ever be marked.\n\n## Fix\n\n- Add `methodBoundary()` after each matched verb; it errors with\n`Expected one of GET/POST/PUT/DELETE/HEAD/PATCH` when the next character\nis not a request-line separator (horizontal whitespace, line break, or\nend-of-input). This rejects `GETT`, `POSTS`, `PUThjjkjoj`, `GET_index`,\n`GET2`, and punctuation-glued lines such as `GET/_search`, `GET?q=1`,\n`GET-foo`, `GET*`.\n- Store an explicit `offset..endOffset` range for method-boundary errors\nand pass it through the Monaco marker provider, so the full invalid\nmethod token is underlined consistently (`GETT`, `PUThjjkjoj`,\n`GET-foo`, etc.).\n- Drop `\\b` from the recovery anchor regex so each invalid-prefix line\nis revisited by `request()` and gets its own error annotation.\n\n## Before / After\n\nInput used in both states:\n\n```\nPUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\nGET _search\n```\n\n### Before\n\n<img width=\"700\" height=\"220\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f0ebe2c3-9967-42f7-8e0e-922ec945db52\"\n/>\n\nAll three invalid-prefix lines silently accepted, no markers.\n\n### After\n\n<img width=\"700\" height=\"200\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cb86d7da-5334-4e31-8693-40b98626f374\"\n/>\n<img width=\"700\" height=\"320\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e55102f-949d-45c2-8aa4-75e63bda9de2\"\n/>\n\nThree squigglies, one per invalid-prefix line, spanning the full invalid\nmethod token. Hover shows `Expected one of\nGET/POST/PUT/DELETE/HEAD/PATCH`. `GET _search` still parses cleanly.\n\n## Test plan\n\n- `node scripts/jest\n--config=src/platform/packages/shared/kbn-monaco/jest.config.js\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts`\n— 52/52 pass, including `it.each` tables that lock in valid request-line\nseparators (`GET _search`, `GET\\t_search`, `GET`) and invalid method\nboundaries (`GET_index`, `GET2 _x`, `GETSomething`, `HEADX`, `DELETEX`,\n`PATCHX`, `GET/_search`, `GET?q=1`, `GET-foo`, `GET*`), plus full-token\nerror ranges and the consecutive-invalid-prefix run.\n- `node scripts/check_changes.ts` — green.\n- Manual on a build of this branch: each invalid input alone produces\none marker; `GET _search`, `get _search`, and `GET` (existing\nmissing-URL marker only) unchanged.\n\n## Release note\n\nMarks invalid HTTP methods (e.g. `GETT`, `POSTS`) as errors in the Dev\nTools Console.\n\nAssisted with Cursor using Claude Opus 4.7\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"af47bddae4c614675bfc9f4cf2b43a39bc080987","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","reviewer:claude","v9.5.0","v9.4.2"],"title":"[Console] Mark invalid request-line methods as errors","number":270479,"url":"https://github.com/elastic/kibana/pull/270479","mergeCommit":{"message":"[Console] Mark invalid request-line methods as errors (#270479)\n\nCloses #219253\n\n## Summary\n\nRequest lines starting with a valid HTTP method prefix followed by extra\ncharacters (e.g. `PUThjjkjoj /my-index`, `GETT _search`, `POSTS _bulk`)\nwere silently accepted by the Console Monaco parser — the prefix was\nconsumed as the method and the tail treated as the URL, so no marker was\nemitted. Each such line is now marked.\n\n## Root cause\n\nIn\n`src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts`:\n\n1. `method()` greedily consumed the longest matching prefix without\nchecking that the next character was a token boundary, so `PUThjjkjoj`\nparsed as method `PUT` + URL `hjjkjoj /my-index`.\n2. `multiRequest()` recovery used\n`/^\\s*(POST|HEAD|GET|PUT|DELETE|PATCH)\\b/im`. With `\\b`, consecutive\ninvalid-prefix lines were skipped over, so only the first one in a run\ncould ever be marked.\n\n## Fix\n\n- Add `methodBoundary()` after each matched verb; it errors with\n`Expected one of GET/POST/PUT/DELETE/HEAD/PATCH` when the next character\nis not a request-line separator (horizontal whitespace, line break, or\nend-of-input). This rejects `GETT`, `POSTS`, `PUThjjkjoj`, `GET_index`,\n`GET2`, and punctuation-glued lines such as `GET/_search`, `GET?q=1`,\n`GET-foo`, `GET*`.\n- Store an explicit `offset..endOffset` range for method-boundary errors\nand pass it through the Monaco marker provider, so the full invalid\nmethod token is underlined consistently (`GETT`, `PUThjjkjoj`,\n`GET-foo`, etc.).\n- Drop `\\b` from the recovery anchor regex so each invalid-prefix line\nis revisited by `request()` and gets its own error annotation.\n\n## Before / After\n\nInput used in both states:\n\n```\nPUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\nGET _search\n```\n\n### Before\n\n<img width=\"700\" height=\"220\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f0ebe2c3-9967-42f7-8e0e-922ec945db52\"\n/>\n\nAll three invalid-prefix lines silently accepted, no markers.\n\n### After\n\n<img width=\"700\" height=\"200\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cb86d7da-5334-4e31-8693-40b98626f374\"\n/>\n<img width=\"700\" height=\"320\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e55102f-949d-45c2-8aa4-75e63bda9de2\"\n/>\n\nThree squigglies, one per invalid-prefix line, spanning the full invalid\nmethod token. Hover shows `Expected one of\nGET/POST/PUT/DELETE/HEAD/PATCH`. `GET _search` still parses cleanly.\n\n## Test plan\n\n- `node scripts/jest\n--config=src/platform/packages/shared/kbn-monaco/jest.config.js\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts`\n— 52/52 pass, including `it.each` tables that lock in valid request-line\nseparators (`GET _search`, `GET\\t_search`, `GET`) and invalid method\nboundaries (`GET_index`, `GET2 _x`, `GETSomething`, `HEADX`, `DELETEX`,\n`PATCHX`, `GET/_search`, `GET?q=1`, `GET-foo`, `GET*`), plus full-token\nerror ranges and the consecutive-invalid-prefix run.\n- `node scripts/check_changes.ts` — green.\n- Manual on a build of this branch: each invalid input alone produces\none marker; `GET _search`, `get _search`, and `GET` (existing\nmissing-URL marker only) unchanged.\n\n## Release note\n\nMarks invalid HTTP methods (e.g. `GETT`, `POSTS`) as errors in the Dev\nTools Console.\n\nAssisted with Cursor using Claude Opus 4.7\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"af47bddae4c614675bfc9f4cf2b43a39bc080987"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270479","number":270479,"mergeCommit":{"message":"[Console] Mark invalid request-line methods as errors (#270479)\n\nCloses #219253\n\n## Summary\n\nRequest lines starting with a valid HTTP method prefix followed by extra\ncharacters (e.g. `PUThjjkjoj /my-index`, `GETT _search`, `POSTS _bulk`)\nwere silently accepted by the Console Monaco parser — the prefix was\nconsumed as the method and the tail treated as the URL, so no marker was\nemitted. Each such line is now marked.\n\n## Root cause\n\nIn\n`src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts`:\n\n1. `method()` greedily consumed the longest matching prefix without\nchecking that the next character was a token boundary, so `PUThjjkjoj`\nparsed as method `PUT` + URL `hjjkjoj /my-index`.\n2. `multiRequest()` recovery used\n`/^\\s*(POST|HEAD|GET|PUT|DELETE|PATCH)\\b/im`. With `\\b`, consecutive\ninvalid-prefix lines were skipped over, so only the first one in a run\ncould ever be marked.\n\n## Fix\n\n- Add `methodBoundary()` after each matched verb; it errors with\n`Expected one of GET/POST/PUT/DELETE/HEAD/PATCH` when the next character\nis not a request-line separator (horizontal whitespace, line break, or\nend-of-input). This rejects `GETT`, `POSTS`, `PUThjjkjoj`, `GET_index`,\n`GET2`, and punctuation-glued lines such as `GET/_search`, `GET?q=1`,\n`GET-foo`, `GET*`.\n- Store an explicit `offset..endOffset` range for method-boundary errors\nand pass it through the Monaco marker provider, so the full invalid\nmethod token is underlined consistently (`GETT`, `PUThjjkjoj`,\n`GET-foo`, etc.).\n- Drop `\\b` from the recovery anchor regex so each invalid-prefix line\nis revisited by `request()` and gets its own error annotation.\n\n## Before / After\n\nInput used in both states:\n\n```\nPUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\nGET _search\n```\n\n### Before\n\n<img width=\"700\" height=\"220\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f0ebe2c3-9967-42f7-8e0e-922ec945db52\"\n/>\n\nAll three invalid-prefix lines silently accepted, no markers.\n\n### After\n\n<img width=\"700\" height=\"200\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cb86d7da-5334-4e31-8693-40b98626f374\"\n/>\n<img width=\"700\" height=\"320\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e55102f-949d-45c2-8aa4-75e63bda9de2\"\n/>\n\nThree squigglies, one per invalid-prefix line, spanning the full invalid\nmethod token. Hover shows `Expected one of\nGET/POST/PUT/DELETE/HEAD/PATCH`. `GET _search` still parses cleanly.\n\n## Test plan\n\n- `node scripts/jest\n--config=src/platform/packages/shared/kbn-monaco/jest.config.js\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts`\n— 52/52 pass, including `it.each` tables that lock in valid request-line\nseparators (`GET _search`, `GET\\t_search`, `GET`) and invalid method\nboundaries (`GET_index`, `GET2 _x`, `GETSomething`, `HEADX`, `DELETEX`,\n`PATCHX`, `GET/_search`, `GET?q=1`, `GET-foo`, `GET*`), plus full-token\nerror ranges and the consecutive-invalid-prefix run.\n- `node scripts/check_changes.ts` — green.\n- Manual on a build of this branch: each invalid input alone produces\none marker; `GET _search`, `get _search`, and `GET` (existing\nmissing-URL marker only) unchanged.\n\n## Release note\n\nMarks invalid HTTP methods (e.g. `GETT`, `POSTS`) as errors in the Dev\nTools Console.\n\nAssisted with Cursor using Claude Opus 4.7\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"af47bddae4c614675bfc9f4cf2b43a39bc080987"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/271358","number":271358,"state":"MERGED","mergeCommit":{"sha":"81215ecabcc3fccdbee6f611dd90361456579a61","message":"[9.4] [Console] Mark invalid request-line methods as errors (#270479) (#271358)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Console] Mark invalid request-line methods as errors\n(#270479)](https://github.com/elastic/kibana/pull/270479)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}}]}] BACKPORT-->