### PR TITLE
[Scout] Create "Migrate tests to Scout" guide

### DIFF
--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -12,6 +12,7 @@ Scout is Kibana’s **modern UI and API test framework** built on [Playwright](h
 - [Best practices](./scout/best-practices.md) (see also [UI](./scout/ui-best-practices.md) and [API](./scout/api-best-practices.md) test best practices)
 - [UI testing](./scout/ui-testing.md)
 - [API testing](./scout/api-testing.md)
+- [Migrate tests to Scout](./scout/migrate-tests.md)
 
 ## Scout benefits [scout-main-features]
 

--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -95,7 +95,7 @@ Existing FTR tests continue to run, and teams can migrate them to Scout incremen
 
 #### Q: Should I migrate every FTR test to Scout? [scout-faq-migrate-ftr-to-scout]
 
-_It, depends_: [pick the right test type](./scout/best-practices.md#pick-the-right-test-type) before migrating a test.
+_It depends_: [pick the right test type](./scout/best-practices.md#pick-the-right-test-type) before migrating a test. For the full workflow (triage gates, pattern mapping, cleanup), see [Migrate tests to Scout](./scout/migrate-tests.md).
 
 #### Q: Does Scout support feature flags? [scout-faq-feature-flags]
 

--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -57,7 +57,7 @@ We welcome contributions to one of the Scout packages.
 | Is reusable but scoped to a solution  | In the solution Scout package (for example `@kbn/scout-security`, `@kbn/scout-oblt`, `@kbn/scout-search`) | Solution workflows and domain-specific helpers     |
 | Is specific to one plugin or package  | In your plugin or package’s `test/scout` directory                                                        | Components specific to your plugin or package only |
 
-## Need help?
+## Need help? [need-help]
 
 - **Internal (Elasticians)**: reach out to the AppEx QA team in the `#kibana-scout` Slack channel for guidance.
 

--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -95,7 +95,7 @@ Existing FTR tests continue to run, and teams can migrate them to Scout incremen
 
 #### Q: Should I migrate every FTR test to Scout? [scout-faq-migrate-ftr-to-scout]
 
-_It depends_: [pick the right test type](./scout/best-practices.md#pick-the-right-test-type) before migrating a test. For the full workflow (triage gates, pattern mapping, cleanup), see [Migrate tests to Scout](./scout/migrate-tests.md).
+_It depends_: [pick the right test type](./scout/best-practices.md#pick-the-right-test-type) before migrating a test. Refer to our [Migrate tests to Scout](./scout/migrate-tests.md) guide.
 
 #### Q: Does Scout support feature flags? [scout-faq-feature-flags]
 

--- a/docs/extend/scout/deployment-tags.md
+++ b/docs/extend/scout/deployment-tags.md
@@ -51,6 +51,21 @@ test.describe(
 
 This test will only run locally (stateful classic and serverless Security complete tier), and will be skipped by Elastic Cloud pipelines.
 
+## Pick the right tags [scout-deployment-tags-pick]
+
+Pick the narrowest scope that's still correct for the feature under test as every extra deployment target spins up an additional run:
+
+| The test covers…                                 | Use                                                                                                                  |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| A platform feature that works everywhere         | [`tags.deploymentAgnostic`](#scout-deployment-tags-deployment-agnostic)                                              |
+| A solution feature                               | `tags.stateful.<solution>` + `tags.serverless.<solution>` (use `.complete` when the solution has tiers)              |
+| Behavior specific to one serverless project tier | The explicit tier tag, e.g. `tags.serverless.security.essentials` or `tags.serverless.observability.logs_essentials` |
+| Behavior that only exists on stateful            | `tags.stateful.<solution>` alone                                                                                     |
+
+::::::{warning}
+Don't reach for `tags.deploymentAgnostic` from a solution module. It runs your test across every solution and is expensive — use explicit per-deployment tags instead. See the [`tags.deploymentAgnostic` note](#scout-deployment-tags-deployment-agnostic).
+::::::
+
 ## Common shortcuts [scout-deployment-tags-shortcuts]
 
 ### `tags.deploymentAgnostic` [scout-deployment-tags-deployment-agnostic]

--- a/docs/extend/scout/deployment-tags.md
+++ b/docs/extend/scout/deployment-tags.md
@@ -53,7 +53,7 @@ This test will only run locally (stateful classic and serverless Security comple
 
 ## Pick the right tags [scout-deployment-tags-pick]
 
-Pick the narrowest scope that's still correct for the feature under test as every extra deployment target spins up an additional run:
+Pick the narrowest scope that's still correct for the feature under test, as every extra deployment target spins up an additional run:
 
 | The test covers…                                 | Use                                                                                                                  |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -8,14 +8,14 @@ Some Kibana features are gated behind feature flags or experimental configuratio
 
 ## When to use runtime versus server-level flags [scout-feature-flags-when-to-use]
 
-|  | Runtime flags | Custom server configs |
-|---|---|---|
-| **API** | `apiServices.core.settings()` | `ScoutServerConfig` config set |
-| **Restart required** | No — applied while running | Yes — must be present at boot |
-| **Elastic Cloud (QA)** | Supported | Not supported — local only |
-| **CI cost** | Low — shares default servers | Higher — dedicated server instance |
-| **Toggle per suite** | Yes | No — fixed at server start |
-| **When to use** | **Preferred** for most flags | Settings required at boot (e.g., route registration) |
+|                        | Runtime flags                 | Custom server configs                                |
+| ---------------------- | ----------------------------- | ---------------------------------------------------- |
+| **API**                | `apiServices.core.settings()` | `ScoutServerConfig` config set                       |
+| **Restart required**   | No — applied while running    | Yes — must be present at boot                        |
+| **Elastic Cloud (QA)** | Supported                     | Not supported — local only                           |
+| **CI cost**            | Low — shares default servers  | Higher — dedicated server instance                   |
+| **Toggle per suite**   | Yes                           | No — fixed at server start                           |
+| **When to use**        | **Preferred** for most flags  | Settings required at boot (e.g., route registration) |
 
 For custom server configs, reach out to the AppEx QA team before creating one (see [below](#scout-feature-flags-custom-servers)).
 
@@ -89,7 +89,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
 
 When using `feature_flags.overrides`, the keys must match the feature flag IDs registered by the owning plugin. Overrides bypass variation and type validation, so ensure the values match what the consuming code expects.
 
-## Custom server configs (reach out to AppEx QA first) [scout-feature-flags-custom-servers]
+## Custom server configs [scout-feature-flags-custom-servers]
 
 Some settings — such as those used during the plugin `setup` lifecycle (e.g., HTTP route registration) — cannot be changed at runtime and must be present when Kibana starts. For these cases Scout supports **custom server configuration sets** that manage a local Kibana process.
 

--- a/docs/extend/scout/getting-started.md
+++ b/docs/extend/scout/getting-started.md
@@ -10,3 +10,4 @@ Start here to set up Scout in a plugin/package, run tests, and debug failures.
 - [Run Scout tests](./run-tests.md)
 - [Debug Scout test runs](./debugging.md)
 - [Best practices for Scout tests](./best-practices.md)
+- [Migrate tests to Scout](./migrate-tests.md)

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -14,7 +14,11 @@ Treat migration as a chance to revisit your tests and make them more robust, not
 
 ::::::::{step} Do your UI tests _really_ need to be UI tests?
 
-Many UI tests should be rewritten as API or component tests (see [Pick the right test type](./best-practices.md#pick-the-right-test-type)). <br><br>Whenever possible, prefer an **API test** over asserting on a rendered element. UI tests (the slowest, most expensive, and most brittle kind) should be reserved for full end-to-end user flows. Tests that only verify a component renders correctly belong as **RTL component tests**.
+We found that many UI tests should be rewritten as API or component tests (see [Pick the right test type](./best-practices.md#pick-the-right-test-type)).
+
+::::::{tip}
+Whenever possible, prefer an **API test** over asserting on a rendered element. UI tests (the slowest, most expensive, and most brittle kind) should be reserved for full end-to-end user flows. Tests that only verify a component renders correctly belong as **RTL component tests**.
+::::::
 
 ::::::::
 
@@ -40,7 +44,16 @@ Most FTR-era setups don't need a custom config in Scout:
 
 ::::::::{step} Be the driver: review and _understand_ your new tests
 
-We provide AI tooling to most of the toil out of migration, but **always review their AI-generated output manually**. _Understand_ the decisions the AI made for you as it will help you troubleshoot flaky tests down the road. <br><br> **Some helpful questions**: <br> • Did we lose or gain any test coverage with the migration?<br> • Should the new tests really be UI tests? Should they be made [parallel](./parallelism.md)?<br> • Are the [deployment tags](./deployment-tags.md) looking good? See [pick the right tags](./deployment-tags.md#scout-deployment-tags-pick).<br> • Is there any way tests can use Scout's default test servers config?
+We provide AI tooling to take most of the toil out of migration, but **always review the AI-generated output manually**. Understanding the decisions the AI made on your behalf will help you troubleshoot flaky tests down the road.
+
+::::::{tip}
+Some helpful questions to ask while reviewing:
+
+- Did we lose or gain any test coverage with the migration?
+- Should the new tests really be UI tests? Should they run in [parallel](./parallelism.md)?
+- Do the [deployment tags](./deployment-tags.md) look right? See [Pick the right tags](./deployment-tags.md#scout-deployment-tags-pick).
+- Can the tests reuse Scout's default test servers config?
+  ::::::
 
 ::::::::
 

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -61,7 +61,7 @@ Some helpful questions to ask while reviewing:
 
 ## Let your AI agent help [ai-assist]
 
-Agentic skills in Kibana can take most of the toil out of migration, but **always review their output manually**.
+Agentic skills in Kibana can take most of the toil out of migration. Your coding agent should pick up the skills below automatically. As always, **review the AI-generated output manually**.
 
 ### FTR → Scout
 

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -46,7 +46,7 @@ Agentic skills in Kibana can take most of the toil out of migration, but **alway
 
 ### FTR → Scout
 
-The [`scout-migrate-from-ftr`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-migrate-from-ftr/SKILL.md) skill analyzes your FTR tests and drafts a migration plan. Review it, and the skill executes the migration.
+The [`scout-migrate-from-ftr`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-migrate-from-ftr/SKILL.md) skill analyzes your FTR tests and drafts a **migration plan**. Review it, and the skill executes the migration.
 
 ### Cypress → Scout
 

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -32,9 +32,9 @@ Reach for a [custom server config](./feature-flags.md#scout-feature-flags-custom
 
 ::::::::
 
-::::::::{step} Where should your tests run?
+::::::::{step} Be the driver: review and _understand_ your new tests
 
-[Deployment tags](./deployment-tags.md) control where your tests run (e.g., local and Elastic Cloud pipelines, and serverless project tiers for serverless tests). Decide up front by [choosing the right deployment tags](./deployment-tags.md#scout-deployment-tags-pick).
+We provide AI tooling to most of the toil out of migration, but **always review their AI-generated output manually**. _Understand_ the decisions the AI made for you as it will help you troubleshoot flaky tests down the road. <br><br> **Some helpful questions**: <br> • Did we lose or gain any test coverage with the migration?<br> • Should the new tests really be UI tests? Should they be made [parallel](./parallelism.md)?<br> • Are the [deployment tags](./deployment-tags.md) looking good? See [pick the right tags](./deployment-tags.md#scout-deployment-tags-pick).<br> • Is there any way tests can use Scout's default test servers config?
 
 ::::::::
 
@@ -55,7 +55,3 @@ The [`cypress-to-scout-migration`](https://github.com/elastic/kibana/blob/main/.
 ### Best practices review
 
 Run the [`scout-best-practices-reviewer`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-best-practices-reviewer/SKILL.md) skill on the migrated tests to make sure they follow our [Scout best practices](./best-practices.md).
-
-## Questions?
-
-See [Need help?](../scout.md#need-help) to get in touch with the AppEx QA team. We're happy to provide guidance as you migrate.

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -20,15 +20,21 @@ Many UI tests should be rewritten as API or component tests (see [Pick the right
 
 ::::::::{step} Can your tests reuse Scout's _default_ servers config?
 
-Scout's `default` server configuration is shared across many suites in CI. A **custom server config** spins up a dedicated Kibana process for your suite, which adds CI cost and only runs in our local pipelines (no Elastic Cloud support).
+Scout's [`default` server configuration](https://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default) mirrors the Cloud (MKI/ECH) setup and is shared across many suites in CI.
 
+**Don't modify it:** changes apply only to local CI servers and are silently ignored when provisioning Cloud projects or deployments (your test will behave differently in the two environments).
+
+A **[custom server config](./feature-flags.md#scout-feature-flags-custom-servers)** is the alternative: it boots test servers with custom settings for your suite alone, overriding Kibana's server args. It adds CI cost and only runs in local pipelines (no Elastic Cloud support), so **stick with the default config whenever possible**.
+
+::::::{tip}
 Most FTR-era setups don't need a custom config in Scout:
 
-- **To enable a feature conditionally**: use runtime [feature flags](./feature-flags.md#scout-feature-flags-runtime) via `apiServices.core.settings()` (this works locally and on Cloud, no test servers restart needed).
-- **To ingest data**: load via `apiServices`, `kbnClient`, or `esArchiver` in `beforeAll` or a [global setup hook](./global-setup-hook.md).
-- **To set UI and advanced settings**: use the `uiSettings` [fixture](./fixtures.md).
+- **To enable a feature conditionally** (no Kibana restart needed): use [runtime feature flags](./feature-flags.md#scout-feature-flags-runtime) via `apiServices.core.settings()` in a test spec or [global setup hook](./global-setup-hook.md). Works locally and on Cloud.
+- **To ingest data**: load via `apiServices`, `kbnClient`, or `esArchiver` in `beforeAll`, or in a [global setup hook](./global-setup-hook.md).
+- **To set UI or advanced settings**: use the `uiSettings` [fixture](./fixtures.md).
 
-Reach for a [custom server config](./feature-flags.md#scout-feature-flags-custom-servers) only when a setting must be present at boot (for example, plugin-`setup`-time HTTP route registration).
+  Reach for a custom server config only when a setting must be present at Kibana boot (for example, registering HTTP routes at plugin-`setup` time).
+  ::::::
 
 ::::::::
 

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -1,0 +1,65 @@
+---
+navigation_title: Migrate tests
+---
+
+# Migrate tests to Scout [scout-migrate-tests]
+
+This guide covers migrating existing FTR and Cypress tests to [Scout](../scout.md).
+
+## Don't migrate blindly [dont-migrate-blindly]
+
+Treat migration as a chance to revist your tests and make them more robust, not a 1-to-1 port:
+
+:::::::::{stepper}
+
+::::::::{step} Do your tests _really_ need to be UI tests?
+
+Many UI tests should be rewritten as API or component tests (see [Pick the right test type](./best-practices.md#pick-the-right-test-type)). <br><br>Whenever possible, prefer an **API test** over asserting on a rendered element. UI tests (the slowest, most expensive, and most brittle kind) should be reserved for full end-to-end user flows. Tests that only verify a component renders correctly belong as **RTL component tests**.
+
+::::::::
+
+::::::::{step} Where should your tests run?
+
+[Deployment tags](./deployment-tags.md) control where your tests run (e.g., local and Elastic Cloud pipelines, and serverless project tiers for serverless tests). Decide up front by [choosing the right deployment tags](./deployment-tags.md#scout-deployment-tags-pick).
+
+::::::::
+
+::::::::{step} Can your tests reuse Scout's _default_ servers config?
+
+Scout's `default` server configuration is shared across many suites in CI. A **custom server config** spins up a dedicated Kibana process for your suite, which adds CI cost and only runs in our local pipelines (no Elastic Cloud support).
+
+Most FTR-era setups don't need a custom config in Scout:
+
+- **To enable a feature conditionally**: use runtime [feature flags](./feature-flags.md#scout-feature-flags-runtime) via `apiServices.core.settings()` (this works locally and on Cloud, no test servers restart needed).
+- **To ingest data**: load via `apiServices`, `kbnClient`, or `esArchiver` in `beforeAll` or a [global setup hook](./global-setup-hook.md).
+- **To set UI and advanced settings**: use the `uiSettings` fixture.
+
+Reach for a [custom server config](./feature-flags.md#scout-feature-flags-custom-servers) only when a setting must be present at boot (for example, plugin-`setup`-time HTTP route registration).
+
+::::::::
+
+:::::::::
+
+## Let your AI agent help [ai-assist]
+
+Agentic skills in Kibana can take most of the toil out of migration, but **always review their output manually**.
+
+### FTR → Scout
+
+The [`scout-migrate-from-ftr`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-migrate-from-ftr/SKILL.md) skill analyzes your FTR tests and drafts a migration plan. Review it, and the skill executes the migration.
+
+### Cypress → Scout skill
+
+The Security Engineering Productivity team maintains the **Cypress → Scout**: [`cypress-to-scout-migration`](https://github.com/elastic/kibana/blob/main/.agents/skills/cypress-to-scout-migration/SKILL.md) skill for porting Cypress to Scout.
+
+::::::{warning}
+Cypress gives each spec a clean environment, so many Cypress tests never clean up after themselves. Scout shares the deployment across specs, so leftover state leaks between tests. Audit every resource the source test creates — saved objects, indices, agents, UI settings — and clean it up explicitly.
+::::::
+
+### Best practices review
+
+Run the [`scout-best-practices-reviewer`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-best-practices-reviewer/SKILL.md) skill on the migrated tests to make sure they follow our [Scout best practices](./best-practices.md).
+
+## Questions?
+
+See [Need help?](../scout.md#need-help) to get in touch with the AppEx QA team. We're happy to provide guidance as you migrate.

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -8,7 +8,7 @@ This guide covers migrating existing FTR and Cypress tests to [Scout](../scout.m
 
 ## Don't migrate blindly [dont-migrate-blindly]
 
-Treat migration as a chance to revist your tests and make them more robust, not a 1-to-1 port:
+Treat migration as a chance to revisit your tests and make them more robust, not a 1-to-1 port:
 
 :::::::::{stepper}
 
@@ -48,9 +48,9 @@ Agentic skills in Kibana can take most of the toil out of migration, but **alway
 
 The [`scout-migrate-from-ftr`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-migrate-from-ftr/SKILL.md) skill analyzes your FTR tests and drafts a migration plan. Review it, and the skill executes the migration.
 
-### Cypress → Scout skill
+### Cypress → Scout
 
-The Security Engineering Productivity team maintains the **Cypress → Scout**: [`cypress-to-scout-migration`](https://github.com/elastic/kibana/blob/main/.agents/skills/cypress-to-scout-migration/SKILL.md) skill for porting Cypress to Scout.
+The [`cypress-to-scout-migration`](https://github.com/elastic/kibana/blob/main/.agents/skills/cypress-to-scout-migration/SKILL.md) skill, maintained by the Security Engineering Productivity team, ports Cypress tests to Scout.
 
 ::::::{warning}
 Cypress gives each spec a clean environment, so many Cypress tests never clean up after themselves. Scout shares the deployment across specs, so leftover state leaks between tests. Audit every resource the source test creates — saved objects, indices, agents, UI settings — and clean it up explicitly.

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -13,12 +13,9 @@ Treat migration as a chance to revisit your tests and make them more robust, not
 :::::::::{stepper}
 
 ::::::::{step} Do your UI tests _really_ need to be UI tests?
+UI tests (the slowest, most expensive, and most brittle kind) should be reserved for full end-to-end user flows.<br><br> • UI tests that assert **backend behavior** (is a given feature available for the user? Is the table rendering the right number of items?) should be rewritten as **API tests**. <br> • Tests that only verify a **component** renders correctly belong as **RTL component tests**.
 
-We found that many UI tests should be rewritten as API or component tests (see [Pick the right test type](./best-practices.md#pick-the-right-test-type)).
-
-::::::{tip}
-Whenever possible, prefer an **API test** over asserting on a rendered element. UI tests (the slowest, most expensive, and most brittle kind) should be reserved for full end-to-end user flows. Tests that only verify a component renders correctly belong as **RTL component tests**.
-::::::
+See [Pick the right test type](./best-practices.md#pick-the-right-test-type) for complete guidance.
 
 ::::::::
 

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -66,8 +66,8 @@ The [`scout-migrate-from-ftr`](https://github.com/elastic/kibana/blob/main/.agen
 
 ### Cypress → Scout
 
-The [`cypress-to-scout-migration`](https://github.com/elastic/kibana/blob/main/.agents/skills/cypress-to-scout-migration/SKILL.md) skill, maintained by the Security Engineering Productivity team, ports Cypress tests to Scout.
+The [`cypress-to-scout-migration`](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration) skill, maintained by the Security Engineering Productivity team, ports Cypress tests to Scout. Redirect questions to the team in [#security-solution-scout](https://elastic.slack.com/archives/C0A1DD686RH).
 
 ### Best practices review
 
-Run the [`scout-best-practices-reviewer`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-best-practices-reviewer/SKILL.md) skill on the migrated tests to make sure they follow our [Scout best practices](./best-practices.md).
+Run the [`scout-best-practices-reviewer`](https://github.com/elastic/kibana/blob/main/.agents/skills/scout-best-practices-reviewer/SKILL.md) skill on the migrated tests to make sure they follow our [Scout best practices](./best-practices.md). The Security solution created their own version of the skill [here](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer).

--- a/docs/extend/scout/migrate-tests.md
+++ b/docs/extend/scout/migrate-tests.md
@@ -12,15 +12,9 @@ Treat migration as a chance to revisit your tests and make them more robust, not
 
 :::::::::{stepper}
 
-::::::::{step} Do your tests _really_ need to be UI tests?
+::::::::{step} Do your UI tests _really_ need to be UI tests?
 
 Many UI tests should be rewritten as API or component tests (see [Pick the right test type](./best-practices.md#pick-the-right-test-type)). <br><br>Whenever possible, prefer an **API test** over asserting on a rendered element. UI tests (the slowest, most expensive, and most brittle kind) should be reserved for full end-to-end user flows. Tests that only verify a component renders correctly belong as **RTL component tests**.
-
-::::::::
-
-::::::::{step} Where should your tests run?
-
-[Deployment tags](./deployment-tags.md) control where your tests run (e.g., local and Elastic Cloud pipelines, and serverless project tiers for serverless tests). Decide up front by [choosing the right deployment tags](./deployment-tags.md#scout-deployment-tags-pick).
 
 ::::::::
 
@@ -32,9 +26,15 @@ Most FTR-era setups don't need a custom config in Scout:
 
 - **To enable a feature conditionally**: use runtime [feature flags](./feature-flags.md#scout-feature-flags-runtime) via `apiServices.core.settings()` (this works locally and on Cloud, no test servers restart needed).
 - **To ingest data**: load via `apiServices`, `kbnClient`, or `esArchiver` in `beforeAll` or a [global setup hook](./global-setup-hook.md).
-- **To set UI and advanced settings**: use the `uiSettings` fixture.
+- **To set UI and advanced settings**: use the `uiSettings` [fixture](./fixtures.md).
 
 Reach for a [custom server config](./feature-flags.md#scout-feature-flags-custom-servers) only when a setting must be present at boot (for example, plugin-`setup`-time HTTP route registration).
+
+::::::::
+
+::::::::{step} Where should your tests run?
+
+[Deployment tags](./deployment-tags.md) control where your tests run (e.g., local and Elastic Cloud pipelines, and serverless project tiers for serverless tests). Decide up front by [choosing the right deployment tags](./deployment-tags.md#scout-deployment-tags-pick).
 
 ::::::::
 
@@ -51,10 +51,6 @@ The [`scout-migrate-from-ftr`](https://github.com/elastic/kibana/blob/main/.agen
 ### Cypress → Scout
 
 The [`cypress-to-scout-migration`](https://github.com/elastic/kibana/blob/main/.agents/skills/cypress-to-scout-migration/SKILL.md) skill, maintained by the Security Engineering Productivity team, ports Cypress tests to Scout.
-
-::::::{warning}
-Cypress gives each spec a clean environment, so many Cypress tests never clean up after themselves. Scout shares the deployment across specs, so leftover state leaks between tests. Audit every resource the source test creates — saved objects, indices, agents, UI settings — and clean it up explicitly.
-::::::
 
 ### Best practices review
 

--- a/docs/extend/toc.yml
+++ b/docs/extend/toc.yml
@@ -61,6 +61,7 @@ toc:
           - file: scout/run-tests.md
           - file: scout/debugging.md
           - file: scout/best-practices.md
+          - file: scout/migrate-tests.md
       - file: scout/core-concepts.md
         children:
           - file: scout/fixtures.md


### PR DESCRIPTION
This PR adds a new "Migrate tests to Scout" guide to help teams migrate with confidence to Scout. 

The guide includes these sections:

- Don't migrate blindly ("be the driver!")
- Let your AI agent help (skills available for agentic migration - but mention to check their output!)

Find the new guide under **Contribute to Kibana** > **Testing Framework** > **Getting Started** > **Migrate tests**.