### PR TITLE
[Core][Logging] Include Node roots in OTEL gRPC TLS CAs

### DIFF
--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_tls.test.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_tls.test.ts
@@ -10,7 +10,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import type { PeerCertificate } from 'tls';
+import { rootCertificates, type PeerCertificate } from 'tls';
 
 import {
   buildGrpcVerifyOptions,
@@ -137,13 +137,17 @@ describe('buildGrpcVerifyOptions', () => {
 });
 
 describe('toGrpcRootCerts', () => {
-  it('returns null when no CA is configured', () => {
-    expect(toGrpcRootCerts({ verificationMode: 'full' })).toBeNull();
+  it("returns Node's built-in roots when no CA is configured", () => {
+    expect(toGrpcRootCerts({ verificationMode: 'full' }).toString()).toEqual(
+      rootCertificates.join('\n')
+    );
   });
 
   it('returns a single buffer for one CA', () => {
     const b = Buffer.from('ca');
-    expect(toGrpcRootCerts({ verificationMode: 'full', ca: b })).toEqual(b);
+    expect(toGrpcRootCerts({ verificationMode: 'full', ca: b }).toString()).toEqual(
+      `ca\n${rootCertificates.join('\n')}`
+    );
   });
 
   it('concatenates multiple CAs', () => {
@@ -151,6 +155,6 @@ describe('toGrpcRootCerts', () => {
       verificationMode: 'full',
       ca: [Buffer.from('a'), Buffer.from('b')],
     });
-    expect(merged?.toString()).toBe('a\nb');
+    expect(merged?.toString()).toEqual(`a\nb\n${rootCertificates.join('\n')}`);
   });
 });

--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_tls.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_tls.ts
@@ -9,7 +9,7 @@
 
 import { readFileSync } from 'fs';
 import type { AgentOptions as HttpsAgentOptions } from 'https';
-import type { PeerCertificate } from 'tls';
+import { rootCertificates, type PeerCertificate } from 'tls';
 import type { OtelAppenderTlsConfig } from '@kbn/core-logging-server';
 
 /** Compatible with `@grpc/grpc-js` `VerifyOptions` passed to `credentials.createSsl`. */
@@ -118,11 +118,16 @@ export const buildHttpsAgentTlsOptions = (resolved: ResolvedOtelTls): HttpsAgent
   return opts;
 };
 
-export const toGrpcRootCerts = (resolved: ResolvedOtelTls): Buffer | null => {
+export const toGrpcRootCerts = (resolved: ResolvedOtelTls): Buffer => {
+  const systemRoots = Buffer.from(rootCertificates.join('\n'));
+  // Use Node's built-in roots only if no custom CAs are configured
   if (resolved.ca === undefined) {
-    return null;
+    return systemRoots;
   }
-  return Array.isArray(resolved.ca) ? concatCaBuffers(resolved.ca) : resolved.ca;
+
+  const customCa = Array.isArray(resolved.ca) ? concatCaBuffers(resolved.ca) : resolved.ca;
+  // Append to Node's built-in roots so intermediate CAs can be verified
+  return Buffer.concat([customCa, Buffer.from('\n'), systemRoots]);
 };
 
 export const buildGrpcVerifyOptions = (resolved: ResolvedOtelTls): OtelGrpcVerifyOptions => {


### PR DESCRIPTION
## Summary
- fix OTEL gRPC TLS root certificate handling by always including Node's built-in root certificates in the CA bundle passed to gRPC
- keep custom CA support by concatenating configured CAs with Node roots
- update unit tests for `toGrpcRootCerts` to validate the new behavior

Resolves #271621.

## Context
- Upstream gRPC issue: https://github.com/grpc/grpc-node/issues/3059
- This is an interim Kibana-side fix while upstream behavior is being discussed.

## Test plan
- [x] `node scripts/check_changes.ts`
- [x] Unit tests updated in `otel_tls.test.ts`
