### PR TITLE
[9.3] [Console] Fix method suggestion order (#270787)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -281,6 +281,24 @@ describe('Editor actions provider', () => {
       );
     });
 
+    it('orders method suggestions with GET first and DELETE last using sortText', async () => {
+      // Monaco sorts completion items by sortText, falling back to label. Without
+      // an explicit sortText, alphabetical sorting puts DELETE first (#259251).
+      mockGetParsedRequests.mockResolvedValue([]);
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        mockModel,
+        mockPosition,
+        mockContext
+      );
+      const sortedByMonaco = [...(completionItems?.suggestions ?? [])].sort((a, b) =>
+        String(a.sortText ?? a.label).localeCompare(String(b.sortText ?? b.label))
+      );
+      const orderedLabels = sortedByMonaco.map((s) => s.label);
+      expect(orderedLabels[0]).toBe('GET');
+      expect(orderedLabels[orderedLabels.length - 1]).toBe('DELETE');
+      expect(orderedLabels).toEqual(['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'DELETE']);
+    });
+
     it('returns completion items for url path if method already typed in', async () => {
       // mock a parsed request that only has a method
       mockGetParsedRequests.mockResolvedValue([

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -59,21 +59,27 @@ const filterTermsWithoutName = (terms: ResultTerm[]): ResultTerm[] =>
   terms.filter((term) => term.name !== undefined && term.name !== '');
 
 /*
- * This function returns an array of completion items for the request method
+ * This function returns an array of completion items for the request method.
+ *
+ * The order is deliberate: Monaco sorts completion items by `sortText` and
+ * falls back to alphabetical label sorting, which would otherwise put DELETE
+ * first (#259251). GET is the safest verb to accept by default and DELETE
+ * the most destructive, so we pin GET first and DELETE last.
  */
-const autocompleteMethods = ['GET', 'PUT', 'POST', 'DELETE', 'HEAD', 'PATCH'];
+const autocompleteMethods = ['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'DELETE'];
 export const getMethodCompletionItems = (
   model: monaco.editor.ITextModel,
   position: monaco.Position
 ): monaco.languages.CompletionItem[] => {
   // get the word before suggestions to replace when selecting a suggestion from the list
   const wordUntilPosition = model.getWordUntilPosition(position);
-  return autocompleteMethods.map((method) => ({
+  return autocompleteMethods.map((method, index) => ({
     label: method,
     insertText: method,
     detail: i18nTexts.method,
     // only used to configure the icon
     kind: monaco.languages.CompletionItemKind.Constant,
+    sortText: String(index),
     range: {
       // replace the whole word with the suggestion
       startColumn: wordUntilPosition.startColumn,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Console] Fix method suggestion order (#270787)](https://github.com/elastic/kibana/pull/270787)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-05-26T13:22:04Z","message":"[Console] Fix method suggestion order (#270787)\n\nCloses #259251\n\n## Summary\n\n- Pins Console HTTP method completion ordering with explicit `sortText`\nvalues so Monaco does not fall back to alphabetical label sorting.\n- Keeps the existing method set unchanged while ordering `GET` first and\n`DELETE` last.\n\n## Root Cause\n\n- Monaco uses `sortText` for completion ordering and falls back to the\nitem label when `sortText` is missing, which can put `DELETE` before\nsafer/default verbs.\n\n## Fix\n\n- Assign stable `sortText` values to method completion items based on\nthe intended canonical order.\n- Add a focused unit test that sorts method suggestions the same way and\nverifies `GET` is first and `DELETE` is last.\n\n## Before\n<img width=\"723\" height=\"466\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/faf244b2-4207-483b-acbc-32b148441b18\"\n/>\n\n## After\n<img width=\"725\" height=\"437\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/782c0c60-6052-4c28-80bc-f45403fa1383\"\n/>\n\n## Test Plan\n\n- `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts`\n— passed.\n- `node scripts/check_changes.ts` — passed.\n\n## Release Note\n\n- Fixes Console autocomplete so `GET` is shown before `DELETE` when\nsuggesting HTTP methods on an empty request line.\n\nAssisted with Cursor using GPT-5.5\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"8849fcf6623fc7d917db93caba0c18d5e8f16b34","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","reviewer:claude","v9.5.0","reviewer:codex"],"title":"[Console] Fix method suggestion order","number":270787,"url":"https://github.com/elastic/kibana/pull/270787","mergeCommit":{"message":"[Console] Fix method suggestion order (#270787)\n\nCloses #259251\n\n## Summary\n\n- Pins Console HTTP method completion ordering with explicit `sortText`\nvalues so Monaco does not fall back to alphabetical label sorting.\n- Keeps the existing method set unchanged while ordering `GET` first and\n`DELETE` last.\n\n## Root Cause\n\n- Monaco uses `sortText` for completion ordering and falls back to the\nitem label when `sortText` is missing, which can put `DELETE` before\nsafer/default verbs.\n\n## Fix\n\n- Assign stable `sortText` values to method completion items based on\nthe intended canonical order.\n- Add a focused unit test that sorts method suggestions the same way and\nverifies `GET` is first and `DELETE` is last.\n\n## Before\n<img width=\"723\" height=\"466\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/faf244b2-4207-483b-acbc-32b148441b18\"\n/>\n\n## After\n<img width=\"725\" height=\"437\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/782c0c60-6052-4c28-80bc-f45403fa1383\"\n/>\n\n## Test Plan\n\n- `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts`\n— passed.\n- `node scripts/check_changes.ts` — passed.\n\n## Release Note\n\n- Fixes Console autocomplete so `GET` is shown before `DELETE` when\nsuggesting HTTP methods on an empty request line.\n\nAssisted with Cursor using GPT-5.5\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"8849fcf6623fc7d917db93caba0c18d5e8f16b34"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270787","number":270787,"mergeCommit":{"message":"[Console] Fix method suggestion order (#270787)\n\nCloses #259251\n\n## Summary\n\n- Pins Console HTTP method completion ordering with explicit `sortText`\nvalues so Monaco does not fall back to alphabetical label sorting.\n- Keeps the existing method set unchanged while ordering `GET` first and\n`DELETE` last.\n\n## Root Cause\n\n- Monaco uses `sortText` for completion ordering and falls back to the\nitem label when `sortText` is missing, which can put `DELETE` before\nsafer/default verbs.\n\n## Fix\n\n- Assign stable `sortText` values to method completion items based on\nthe intended canonical order.\n- Add a focused unit test that sorts method suggestions the same way and\nverifies `GET` is first and `DELETE` is last.\n\n## Before\n<img width=\"723\" height=\"466\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/faf244b2-4207-483b-acbc-32b148441b18\"\n/>\n\n## After\n<img width=\"725\" height=\"437\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/782c0c60-6052-4c28-80bc-f45403fa1383\"\n/>\n\n## Test Plan\n\n- `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts`\n— passed.\n- `node scripts/check_changes.ts` — passed.\n\n## Release Note\n\n- Fixes Console autocomplete so `GET` is shown before `DELETE` when\nsuggesting HTTP methods on an empty request line.\n\nAssisted with Cursor using GPT-5.5\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"8849fcf6623fc7d917db93caba0c18d5e8f16b34"}}]}] BACKPORT-->