### PR TITLE
[9.3] Bump fast-xml-builder to 1.2.0 (#270595)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -21449,11 +21449,12 @@ fast-uri@^3.0.1:
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast-xml-builder@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz#50188e1452a5fa095f415d3e63dcac0a1dbcbf11"
-  integrity sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
+  integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
   dependencies:
-    path-expression-matcher "^1.1.3"
+    path-expression-matcher "^1.5.0"
+    xml-naming "^0.1.0"
 
 fast-xml-parser@5.4.1, fast-xml-parser@5.5.7, fast-xml-parser@^5.5.1:
   version "5.5.7"
@@ -28424,10 +28425,10 @@ path-exists@^5.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
   integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
-path-expression-matcher@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz#8bf7c629dc1b114e42b633c071f06d14625b4e0d"
-  integrity sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==
+path-expression-matcher@^1.1.3, path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -35493,6 +35494,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml-naming@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
+  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
 
 xml-parser-xo@^4.1.5:
   version "4.1.5"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Bump fast-xml-builder to 1.2.0 (#270595)](https://github.com/elastic/kibana/pull/270595)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T08:17:27Z","message":"Bump fast-xml-builder to 1.2.0 (#270595)\n\n## Summary\n\nRelocks `fast-xml-builder` from `1.1.5` to `1.2.0` by removing the stale\nlockfile entry. The `^1.1.4` constraint declared by\n`fast-xml-parser@5.5.7` is satisfied by the new version; no changes to\n`package.json` dependencies were required.\n\nAlso brings in updated transitive deps: `path-expression-matcher@1.5.0`\nand `xml-naming@0.1.0` (new dep of `fast-xml-builder@1.2.0`).\n\n## Test plan\n\n- [ ] Verify `yarn.lock` resolves `fast-xml-builder` to `1.2.0`\n- [ ] CI green\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b293383e76b6e1924b2c2ecdfeafc68a3a2526f1","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.5.0"],"title":"Bump fast-xml-builder to 1.2.0","number":270595,"url":"https://github.com/elastic/kibana/pull/270595","mergeCommit":{"message":"Bump fast-xml-builder to 1.2.0 (#270595)\n\n## Summary\n\nRelocks `fast-xml-builder` from `1.1.5` to `1.2.0` by removing the stale\nlockfile entry. The `^1.1.4` constraint declared by\n`fast-xml-parser@5.5.7` is satisfied by the new version; no changes to\n`package.json` dependencies were required.\n\nAlso brings in updated transitive deps: `path-expression-matcher@1.5.0`\nand `xml-naming@0.1.0` (new dep of `fast-xml-builder@1.2.0`).\n\n## Test plan\n\n- [ ] Verify `yarn.lock` resolves `fast-xml-builder` to `1.2.0`\n- [ ] CI green\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b293383e76b6e1924b2c2ecdfeafc68a3a2526f1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270595","number":270595,"mergeCommit":{"message":"Bump fast-xml-builder to 1.2.0 (#270595)\n\n## Summary\n\nRelocks `fast-xml-builder` from `1.1.5` to `1.2.0` by removing the stale\nlockfile entry. The `^1.1.4` constraint declared by\n`fast-xml-parser@5.5.7` is satisfied by the new version; no changes to\n`package.json` dependencies were required.\n\nAlso brings in updated transitive deps: `path-expression-matcher@1.5.0`\nand `xml-naming@0.1.0` (new dep of `fast-xml-builder@1.2.0`).\n\n## Test plan\n\n- [ ] Verify `yarn.lock` resolves `fast-xml-builder` to `1.2.0`\n- [ ] CI green\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b293383e76b6e1924b2c2ecdfeafc68a3a2526f1"}},{"url":"https://github.com/elastic/kibana/pull/271636","number":271636,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->