### PR TITLE
[9.4] [Synthetics] Preserve spaceId for cross-space monitor sub-pages (#265748)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -154,7 +154,11 @@ export const MonitorDetailsPanel = ({
           <>
             <EuiDescriptionListTitle>{LOCATIONS_LABEL}</EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
-              <LocationsStatus configId={configId} monitorLocations={monitor.locations} />
+              <LocationsStatus
+                configId={configId}
+                monitorLocations={monitor.locations}
+                spaces={monitor[ConfigKey.KIBANA_SPACES]}
+              />
             </EuiDescriptionListDescription>
           </>
         )}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/error_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/error_details_link.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_location';
 import { useSyntheticsSettingsContext } from '../../../contexts';
 import { getErrorDetailsUrl } from '../../monitor_details/monitor_errors/errors_list';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 export const ErrorDetailsLink = ({
   stateId,
@@ -67,12 +68,14 @@ export const useErrorDetailsLink = ({
   locationId?: string;
 }) => {
   const { basePath } = useSyntheticsSettingsContext();
+  const spaceId = useUrlSpaceId();
 
   return getErrorDetailsUrl({
     basePath,
     configId,
     stateId,
     locationId,
+    spaceId,
   });
 };
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
@@ -12,6 +12,7 @@ import type { CommonProps } from '@elastic/eui/src/components/common';
 
 import { useSyntheticsSettingsContext } from '../../../contexts';
 import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_location';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 export const StepDetailsLinkIcon = ({
   stepIndex,
@@ -31,8 +32,10 @@ export const StepDetailsLinkIcon = ({
 }) => {
   const { basePath } = useSyntheticsSettingsContext();
   const selectedLocation = useSelectedLocation({ refetchMonitorEnabled: false });
+  const spaceId = useUrlSpaceId();
 
-  const stepDetailsLink = `${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}`;
+  const spaceIdQuery = spaceId ? `&spaceId=${spaceId}` : '';
+  const stepDetailsLink = `${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}${spaceIdQuery}`;
 
   if (asButton) {
     return (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/test_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/test_details_link.tsx
@@ -11,6 +11,10 @@ import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_lo
 import type { Ping } from '../../../../../../common/runtime_types';
 import { useSyntheticsSettingsContext } from '../../../contexts';
 import { useDateFormat } from '../../../../../hooks/use_date_format';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
+import { getTestRunDetailLink, getTestRunDetailRelativeLink } from './test_run_urls';
+
+export { getTestRunDetailLink, getTestRunDetailRelativeLink };
 
 export const TestDetailsLink = ({
   isBrowserMonitor,
@@ -24,6 +28,7 @@ export const TestDetailsLink = ({
   const { euiTheme } = useEuiTheme();
   const { basePath } = useSyntheticsSettingsContext();
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
   const formatter = useDateFormat();
   const timestampText = (
@@ -40,6 +45,7 @@ export const TestDetailsLink = ({
         checkGroup: ping.monitor.check_group,
         monitorId: ping?.config_id ?? '',
         locationId: selectedLocation?.id,
+        spaceId,
       })}
     >
       {timestampText}
@@ -47,31 +53,4 @@ export const TestDetailsLink = ({
   ) : (
     timestampText
   );
-};
-
-export const getTestRunDetailLink = ({
-  monitorId,
-  basePath,
-  checkGroup,
-  locationId,
-}: {
-  monitorId: string;
-  checkGroup: string;
-  basePath: string;
-  locationId?: string;
-}) => {
-  const testRunUrl = `/monitor/${monitorId}/test-run/${checkGroup}?locationId=${locationId}`;
-  return `${basePath}/app/synthetics${testRunUrl}`;
-};
-
-export const getTestRunDetailRelativeLink = ({
-  monitorId,
-  checkGroup,
-  locationId,
-}: {
-  monitorId: string;
-  checkGroup: string;
-  locationId?: string;
-}) => {
-  return `/monitor/${monitorId}/test-run/${checkGroup}?locationId=${locationId}`;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/test_run_urls.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/test_run_urls.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getTestRunDetailLink, getTestRunDetailRelativeLink } from './test_run_urls';
+
+describe('getTestRunDetailRelativeLink', () => {
+  it('builds a relative URL with locationId only when no spaceId is provided', () => {
+    expect(
+      getTestRunDetailRelativeLink({
+        monitorId: 'mon-1',
+        checkGroup: 'cg-1',
+        locationId: 'loc-1',
+      })
+    ).toBe('/monitor/mon-1/test-run/cg-1?locationId=loc-1');
+  });
+
+  it('appends spaceId when provided', () => {
+    expect(
+      getTestRunDetailRelativeLink({
+        monitorId: 'mon-1',
+        checkGroup: 'cg-1',
+        locationId: 'loc-1',
+        spaceId: 'team-a',
+      })
+    ).toBe('/monitor/mon-1/test-run/cg-1?locationId=loc-1&spaceId=team-a');
+  });
+
+  it('omits spaceId when it is an empty string', () => {
+    expect(
+      getTestRunDetailRelativeLink({
+        monitorId: 'mon-1',
+        checkGroup: 'cg-1',
+        locationId: 'loc-1',
+        spaceId: '',
+      })
+    ).toBe('/monitor/mon-1/test-run/cg-1?locationId=loc-1');
+  });
+
+  it('omits locationId when it is undefined', () => {
+    expect(
+      getTestRunDetailRelativeLink({
+        monitorId: 'mon-1',
+        checkGroup: 'cg-1',
+      })
+    ).toBe('/monitor/mon-1/test-run/cg-1');
+  });
+
+  it('omits locationId but keeps spaceId when locationId is undefined', () => {
+    expect(
+      getTestRunDetailRelativeLink({
+        monitorId: 'mon-1',
+        checkGroup: 'cg-1',
+        spaceId: 'team-a',
+      })
+    ).toBe('/monitor/mon-1/test-run/cg-1?spaceId=team-a');
+  });
+});
+
+describe('getTestRunDetailLink', () => {
+  it('prefixes basePath and reuses the relative link, including spaceId', () => {
+    expect(
+      getTestRunDetailLink({
+        basePath: '/s/foo',
+        monitorId: 'mon-1',
+        checkGroup: 'cg-1',
+        locationId: 'loc-1',
+        spaceId: 'team-a',
+      })
+    ).toBe('/s/foo/app/synthetics/monitor/mon-1/test-run/cg-1?locationId=loc-1&spaceId=team-a');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/test_run_urls.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/links/test_run_urls.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const getTestRunDetailRelativeLink = ({
+  monitorId,
+  checkGroup,
+  locationId,
+  spaceId,
+}: {
+  monitorId: string;
+  checkGroup: string;
+  locationId?: string;
+  spaceId?: string;
+}) => {
+  const params = new URLSearchParams();
+  if (locationId) params.set('locationId', locationId);
+  if (spaceId) params.set('spaceId', spaceId);
+  const search = params.toString();
+  return `/monitor/${monitorId}/test-run/${checkGroup}${search ? `?${search}` : ''}`;
+};
+
+export const getTestRunDetailLink = ({
+  monitorId,
+  basePath,
+  checkGroup,
+  locationId,
+  spaceId,
+}: {
+  monitorId: string;
+  checkGroup: string;
+  basePath: string;
+  locationId?: string;
+  spaceId?: string;
+}) => {
+  return `${basePath}/app/synthetics${getTestRunDetailRelativeLink({
+    monitorId,
+    checkGroup,
+    locationId,
+    spaceId,
+  })}`;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/failed_tests_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/failed_tests_list.tsx
@@ -16,6 +16,7 @@ import { useDateFormat } from '../../../../../hooks/use_date_format';
 import { getTestRunDetailRelativeLink } from '../../common/links/test_details_link';
 import { useSyntheticsSettingsContext } from '../../../contexts';
 import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_location';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 export const FailedTestsList = ({
   failedTests,
@@ -37,6 +38,7 @@ export const FailedTestsList = ({
 
   const history = useHistory();
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
   const formatter = useDateFormat();
 
@@ -48,10 +50,11 @@ export const FailedTestsList = ({
       name: TIMESTAMP_LABEL,
       sortable: true,
       render: (value: string, item: Ping) => {
+        const spaceIdQuery = spaceId ? `?spaceId=${spaceId}` : '';
         return (
           <EuiLink
             data-test-subj="failed-test-link"
-            href={`${basePath}/app/synthetics/monitor/${monitorId}/test-run/${item.monitor.check_group}`}
+            href={`${basePath}/app/synthetics/monitor/${monitorId}/test-run/${item.monitor.check_group}${spaceIdQuery}`}
           >
             {formatter(value)}
           </EuiLink>
@@ -84,6 +87,7 @@ export const FailedTestsList = ({
               monitorId,
               checkGroup: item.monitor.check_group,
               locationId: selectedLocation?.id,
+              spaceId,
             })
           );
         },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_details_breadcrumbs.ts
@@ -11,6 +11,7 @@ import { useTestRunDetailsBreadcrumbs } from '../../test_run_details/hooks/use_t
 import { useSelectedMonitor } from '../../monitor_details/hooks/use_selected_monitor';
 import { ConfigKey } from '../../../../../../common/runtime_types';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 export const useErrorDetailsBreadcrumbs = (
   extraCrumbs?: Array<{ text: string; href?: string }>
@@ -21,13 +22,15 @@ export const useErrorDetailsBreadcrumbs = (
   const { monitor } = useSelectedMonitor();
 
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
+  const spaceIdQuery = spaceId ? `&spaceId=${spaceId}` : '';
   const errorsBreadcrumbs = [
     {
       text: ERRORS_CRUMB,
       href: `${appPath}/monitor/${monitor?.[ConfigKey.CONFIG_ID]}/errors?locationId=${
         selectedLocation?.id
-      }`,
+      }${spaceIdQuery}`,
     },
     ...(extraCrumbs ?? []),
   ];

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -10,6 +10,7 @@ import { useHistory } from 'react-router-dom';
 import { EuiLink, EuiIcon } from '@elastic/eui';
 import { InPortal } from 'react-reverse-portal';
 import { useSelectedLocation } from '../monitor_details/hooks/use_selected_location';
+import { useUrlSpaceId } from '../../hooks/use_url_space_id';
 import { MonitorDetailsLinkPortalNode } from './portals';
 
 interface Props {
@@ -38,6 +39,7 @@ export const MonitorDetailsLinkPortal = ({ name, configId, locationId, updateUrl
 
 const MonitorDetailsLinkWithLocation = ({ name, configId, locationId, updateUrl }: Props) => {
   const selectedLocation = useSelectedLocation({ updateUrl });
+  const spaceId = useUrlSpaceId();
 
   let locId = locationId;
 
@@ -47,17 +49,34 @@ const MonitorDetailsLinkWithLocation = ({ name, configId, locationId, updateUrl 
 
   const history = useHistory();
   const href = history.createHref({
-    pathname: locId ? `monitor/${configId}?locationId=${locId}` : `monitor/${configId}`,
+    pathname: `monitor/${configId}`,
+    search: buildSearch({ locationId: locId, spaceId }),
   });
   return <MonitorLink href={href} name={name} />;
 };
 
 const MonitorDetailsLink = ({ name, configId }: Props) => {
+  const spaceId = useUrlSpaceId();
   const history = useHistory();
   const href = history.createHref({
     pathname: `monitor/${configId}`,
+    search: buildSearch({ spaceId }),
   });
   return <MonitorLink href={href} name={name} />;
+};
+
+const buildSearch = ({
+  locationId,
+  spaceId,
+}: {
+  locationId?: string;
+  spaceId?: string;
+}): string | undefined => {
+  const params = new URLSearchParams();
+  if (locationId) params.set('locationId', locationId);
+  if (spaceId) params.set('spaceId', spaceId);
+  const qs = params.toString();
+  return qs ? `?${qs}` : undefined;
 };
 
 const MonitorLink = ({ href, name }: { href: string; name: string }) => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/error_details_url.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/error_details_url.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getErrorDetailsUrl } from './error_details_url';
+
+describe('getErrorDetailsUrl', () => {
+  it('builds a URL without spaceId when none is provided', () => {
+    expect(
+      getErrorDetailsUrl({
+        basePath: '',
+        configId: 'cfg-1',
+        stateId: 'state-1',
+        locationId: 'loc-1',
+      })
+    ).toBe('/app/synthetics/monitor/cfg-1/errors/state-1?locationId=loc-1');
+  });
+
+  it('appends spaceId when provided', () => {
+    expect(
+      getErrorDetailsUrl({
+        basePath: '/s/foo',
+        configId: 'cfg-1',
+        stateId: 'state-1',
+        locationId: 'loc-1',
+        spaceId: 'team-a',
+      })
+    ).toBe('/s/foo/app/synthetics/monitor/cfg-1/errors/state-1?locationId=loc-1&spaceId=team-a');
+  });
+
+  it('omits locationId when it is undefined', () => {
+    expect(
+      getErrorDetailsUrl({
+        basePath: '',
+        configId: 'cfg-1',
+        stateId: 'state-1',
+      })
+    ).toBe('/app/synthetics/monitor/cfg-1/errors/state-1');
+  });
+
+  it('omits locationId but keeps spaceId when locationId is undefined', () => {
+    expect(
+      getErrorDetailsUrl({
+        basePath: '',
+        configId: 'cfg-1',
+        stateId: 'state-1',
+        spaceId: 'team-a',
+      })
+    ).toBe('/app/synthetics/monitor/cfg-1/errors/state-1?spaceId=team-a');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/error_details_url.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/error_details_url.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const getErrorDetailsUrl = ({
+  basePath,
+  configId,
+  stateId,
+  locationId,
+  spaceId,
+}: {
+  stateId: string;
+  basePath: string;
+  configId: string;
+  locationId?: string;
+  spaceId?: string;
+}) => {
+  const params = new URLSearchParams();
+  if (locationId) params.set('locationId', locationId);
+  if (spaceId) params.set('spaceId', spaceId);
+  const search = params.toString();
+  return `${basePath}/app/synthetics/monitor/${configId}/errors/${stateId}${
+    search ? `?${search}` : ''
+  }`;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/errors_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/errors_list.tsx
@@ -26,6 +26,10 @@ import { useErrorFailedStep } from '../hooks/use_error_failed_step';
 import { formatTestDuration } from '../../../utils/monitor_test_result/test_time_formats';
 import { useDateFormat } from '../../../../../hooks/use_date_format';
 import { useMonitorLatestPing } from '../hooks/use_monitor_latest_ping';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
+import { getErrorDetailsUrl } from './error_details_url';
+
+export { getErrorDetailsUrl };
 
 function isErrorActive(lastError: PingState, currentError: PingState, latestPing?: Ping) {
   return (
@@ -65,6 +69,7 @@ export const ErrorsList = ({
 
   const formatter = useDateFormat();
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
   const { latestPing } = useMonitorLatestPing({
     monitorId: configId,
@@ -177,11 +182,12 @@ export const ErrorsList = ({
   const getRowProps = (item: Ping) => {
     const { state } = item;
     if (state?.id) {
+      const spaceIdQuery = spaceId ? `&spaceId=${encodeURIComponent(spaceId)}` : '';
       return {
         'data-test-subj': `row-${state.id}`,
         onClick: (evt: MouseEvent) => {
           history.push(
-            `/monitor/${configId}/errors/${state.id}?locationId=${selectedLocation?.id}`
+            `/monitor/${configId}/errors/${state.id}?locationId=${selectedLocation?.id}${spaceIdQuery}`
           );
         },
       };
@@ -209,20 +215,6 @@ export const ErrorsList = ({
       />
     </div>
   );
-};
-
-export const getErrorDetailsUrl = ({
-  basePath,
-  configId,
-  stateId,
-  locationId,
-}: {
-  stateId: string;
-  basePath: string;
-  configId: string;
-  locationId?: string;
-}) => {
-  return `${basePath}/app/synthetics/monitor/${configId}/errors/${stateId}?locationId=${locationId}`;
 };
 
 const ERRORS_LIST_LABEL = i18n.translate('xpack.synthetics.errorsList.label', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -43,6 +43,7 @@ import { useJourneySteps } from '../hooks/use_journey_steps';
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { useMonitorLatestPing } from '../hooks/use_monitor_latest_ping';
 import { useDateFormat } from '../../../../../hooks/use_date_format';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 export const LastTestRun = () => {
   const { latestPing, loading: pingsLoading } = useMonitorLatestPing();
@@ -84,6 +85,7 @@ export const LastTestRunComponent = ({
 
   const selectedLocation = useSelectedLocation();
   const { basePath } = useSyntheticsSettingsContext();
+  const spaceId = useUrlSpaceId();
 
   return (
     <EuiPanel hasShadow={false} hasBorder css={{ minHeight: 356 }}>
@@ -112,6 +114,7 @@ export const LastTestRunComponent = ({
                 configId: monitor?.[ConfigKey.CONFIG_ID]!,
                 locationId: selectedLocation!.id,
                 stateId: latestPing.state?.id!,
+                spaceId,
               })}
             >
               {i18n.translate('xpack.synthetics.monitorDetails.summary.viewErrorDetails', {
@@ -152,6 +155,7 @@ const PanelHeader = ({
   const { basePath } = useSyntheticsSettingsContext();
 
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
   const { monitorId } = useParams<{ monitorId: string }>();
 
@@ -214,6 +218,7 @@ const PanelHeader = ({
                 monitorId,
                 checkGroup: latestPing?.monitor.check_group,
                 locationId: selectedLocation?.id,
+                spaceId,
               })}
             >
               {i18n.translate('xpack.synthetics.monitorDetails.summary.viewTestRun', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/locations_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/locations_status.tsx
@@ -12,11 +12,20 @@ import { useStatusByLocation } from '../../../hooks/use_status_by_location';
 export const LocationsStatus = ({
   configId,
   monitorLocations,
+  spaces,
 }: {
   configId: string;
   monitorLocations?: EncryptedSyntheticsSavedMonitor['locations'];
+  spaces?: string[];
 }) => {
   const { locations, loading } = useStatusByLocation({ configId, monitorLocations });
 
-  return <LocationStatusBadges configId={configId} locations={locations} loading={loading} />;
+  return (
+    <LocationStatusBadges
+      configId={configId}
+      locations={locations}
+      loading={loading}
+      spaces={spaces}
+    />
+  );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
@@ -51,6 +51,7 @@ import { useSelectedLocation } from '../hooks/use_selected_location';
 import { useMonitorPings } from '../hooks/use_monitor_pings';
 import { JourneyLastScreenshot } from '../../common/screenshot/journey_last_screenshot';
 import { useSyntheticsRefreshContext, useSyntheticsSettingsContext } from '../../../contexts';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 type SortableField = 'timestamp' | 'monitor.status' | 'monitor.duration.us';
 
@@ -93,6 +94,7 @@ export const TestRunsTable = ({
   const pingsError = useSelector(selectPingsError);
   const { monitor } = useSelectedMonitor();
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
   const isTabletOrGreater = useIsWithinMinBreakpoint('s');
 
   const isBrowserMonitor = monitor?.[ConfigKey.MONITOR_TYPE] === MonitorTypeEnum.BROWSER;
@@ -162,6 +164,7 @@ export const TestRunsTable = ({
             isBrowserMonitor={isBrowserMonitor}
             basePath={basePath}
             locationId={selectedLocation?.id}
+            spaceId={spaceId}
           />
         ),
       },
@@ -279,6 +282,7 @@ export const TestRunsTable = ({
               monitorId,
               checkGroup: item.monitor.check_group,
               locationId: selectedLocation?.id,
+              spaceId,
             })
           );
         }
@@ -329,11 +333,13 @@ export const MobileRowDetails = ({
   isBrowserMonitor,
   basePath,
   locationId,
+  spaceId,
 }: {
   ping: Ping;
   isBrowserMonitor: boolean;
   basePath: string;
   locationId?: string;
+  spaceId?: string;
 }) => {
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
@@ -364,6 +370,7 @@ export const MobileRowDetails = ({
                 configId: ping.config_id,
                 locationId,
                 stateId: ping?.state?.id!,
+                spaceId,
               })}
             >
               {i18n.translate('xpack.synthetics.monitorDetails.summary.viewErrorDetails', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -32,6 +32,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useKibanaSpace } from '../../../../../../hooks/use_kibana_space';
 import type { ClientPluginsStart } from '../../../../../../plugin';
 import { useMonitorDetail } from '../../../../hooks/use_monitor_detail';
+import { getMonitorSpaceToAppend } from '../../../../hooks/use_edit_monitor_locator';
 import { useMonitorDetailLocator } from '../../../../hooks/use_monitor_detail_locator';
 import type { LocationsStatus } from '../../../../hooks/use_status_by_location';
 import { useStatusByLocation } from '../../../../hooks/use_status_by_location';
@@ -265,14 +266,16 @@ export function MonitorDetailFlyout(props: Props) {
 
   const { space } = useKibanaSpace();
 
+  const { spaceId: crossSpaceId } = getMonitorSpaceToAppend(space, spaces);
+
   useEffect(() => {
     dispatch(
       getMonitorAction.get({
         monitorId: configId,
-        ...(space && spaces?.length && !spaces?.includes(space?.id) ? { spaceId: spaces[0] } : {}),
+        ...(crossSpaceId ? { spaceId: crossSpaceId } : {}),
       })
     );
-  }, [configId, dispatch, space, space?.id, spaces, upsertSuccess]);
+  }, [configId, crossSpaceId, dispatch, upsertSuccess]);
 
   const [isActionsPopoverOpen, setIsActionsPopoverOpen] = useState(false);
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_detail_page.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_detail_page.ts
@@ -10,6 +10,7 @@ import { useMemo } from 'react';
 import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_location';
 import { useSyntheticsSettingsContext } from '../../../contexts';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 
 export const useStepDetailPage = () => {
   const {
@@ -25,6 +26,7 @@ export const useStepDetailPage = () => {
   const stepIndex = Number(stepIndexString);
 
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
   const { data: journey, stepEnds } = useJourneySteps(checkGroupId);
 
@@ -44,6 +46,7 @@ export const useStepDetailPage = () => {
       checkGroupId,
       stepIndex: stepNo,
       locationId: selectedLocation?.id,
+      spaceId,
     });
 
   return {
@@ -70,6 +73,7 @@ export const useStepDetailLink = ({
   }>();
 
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
 
   if (!checkGroupId) {
     return '';
@@ -81,6 +85,7 @@ export const useStepDetailLink = ({
     monitorId,
     checkGroupId,
     locationId: selectedLocation?.id,
+    spaceId,
   });
 };
 
@@ -90,12 +95,15 @@ const getStepDetailLink = ({
   basePath,
   monitorId,
   locationId,
+  spaceId,
 }: {
   checkGroupId: string;
   locationId?: string;
   stepIndex: number | string;
   basePath: string;
   monitorId: string;
+  spaceId?: string;
 }) => {
-  return `${basePath}/app/synthetics/monitor/${monitorId}/test-run/${checkGroupId}/step/${stepIndex}?locationId=${locationId}`;
+  const spaceIdQuery = spaceId ? `&spaceId=${spaceId}` : '';
+  return `${basePath}/app/synthetics/monitor/${monitorId}/test-run/${checkGroupId}/step/${stepIndex}?locationId=${locationId}${spaceIdQuery}`;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_page_nav.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_page_nav.tsx
@@ -23,6 +23,7 @@ import { getTestRunDetailLink } from '../common/links/test_details_link';
 import { useStepDetailLink } from './hooks/use_step_detail_page';
 import { useJourneySteps } from '../monitor_details/hooks/use_journey_steps';
 import { useDateFormat } from '../../../../hooks/use_date_format';
+import { useUrlSpaceId } from '../../hooks/use_url_space_id';
 
 export const StepRunDate = () => {
   return (
@@ -43,6 +44,7 @@ export const StepPageNavigation = ({ testRunPage }: { testRunPage?: boolean }) =
   const formatter = useDateFormat();
   const { basePath } = useSyntheticsSettingsContext();
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
   const startedAt = formatter(data?.details?.timestamp);
 
   const { stepIndex, monitorId } = useParams<{ stepIndex: string; monitorId: string }>();
@@ -64,6 +66,7 @@ export const StepPageNavigation = ({ testRunPage }: { testRunPage?: boolean }) =
         monitorId,
         locationId: selectedLocation?.id,
         checkGroup: data?.details?.previous?.checkGroup,
+        spaceId,
       });
     }
     if (data?.details?.next?.checkGroup) {
@@ -72,6 +75,7 @@ export const StepPageNavigation = ({ testRunPage }: { testRunPage?: boolean }) =
         monitorId,
         locationId: selectedLocation?.id,
         checkGroup: data?.details?.next?.checkGroup,
+        spaceId,
       });
     }
   }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_result_header.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_result_header.tsx
@@ -18,6 +18,7 @@ import { i18n } from '@kbn/i18n';
 import * as React from 'react';
 import { getTestRunDetailLink } from '../common/links/test_details_link';
 import { useLocations } from '../../hooks';
+import { useUrlSpaceId } from '../../hooks/use_url_space_id';
 import { useSyntheticsSettingsContext } from '../../contexts';
 import type { JourneyStep, Ping } from '../../../../../common/runtime_types';
 import { formatDuration } from '../../utils/formatting';
@@ -40,6 +41,7 @@ export function TestResultHeader({
   configId,
 }: Props) {
   const { basePath } = useSyntheticsSettingsContext();
+  const spaceId = useUrlSpaceId();
   let duration = 0;
   if (summaryDocs && summaryDocs.length > 0) {
     summaryDocs.forEach((sDoc) => {
@@ -100,6 +102,7 @@ export function TestResultHeader({
               monitorId: configId,
               checkGroup: checkGroupId,
               locationId: getLocationByLabel(summaryDoc?.observer?.geo?.name!)?.id,
+              spaceId,
             })}
           >
             {VIEW_DETAILS}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
@@ -9,6 +9,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_location';
 import { useSelectedMonitor } from '../../monitor_details/hooks/use_selected_monitor';
 import { useBreadcrumbs } from '../../../hooks/use_breadcrumbs';
+import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 import { ConfigKey } from '../../../../../../common/runtime_types';
 import { MONITOR_ROUTE, MONITORS_ROUTE } from '../../../../../../common/constants';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
@@ -21,6 +22,12 @@ export const useTestRunDetailsBreadcrumbs = (
 
   const { monitor } = useSelectedMonitor();
   const selectedLocation = useSelectedLocation();
+  const spaceId = useUrlSpaceId();
+
+  const monitorHrefParams = new URLSearchParams();
+  if (selectedLocation?.id) monitorHrefParams.set('locationId', selectedLocation.id);
+  if (spaceId) monitorHrefParams.set('spaceId', spaceId);
+  const monitorHrefSearch = monitorHrefParams.toString();
 
   useBreadcrumbs([
     {
@@ -34,7 +41,7 @@ export const useTestRunDetailsBreadcrumbs = (
             href: `${appPath}${MONITOR_ROUTE.replace(
               ':monitorId',
               monitor?.[ConfigKey.CONFIG_ID] ?? ''
-            )}?locationId=${selectedLocation?.id ?? ''}`,
+            )}${monitorHrefSearch ? `?${monitorHrefSearch}` : ''}`,
           },
         ]
       : []),

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/index.ts
@@ -19,3 +19,4 @@ export * from './use_fleet_permissions';
 export * from './use_monitor_enable_handler';
 export * from './use_edit_monitor_locator';
 export * from './use_monitor_detail_locator';
+export * from './use_url_space_id';

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_url_space_id.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_url_space_id.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useKibanaSpace } from '../../../hooks/use_kibana_space';
+import { useGetUrlParams } from './use_url_params';
+import { useUrlSpaceId } from './use_url_space_id';
+
+jest.mock('../../../hooks/use_kibana_space', () => ({
+  useKibanaSpace: jest.fn(),
+}));
+
+jest.mock('./use_url_params', () => ({
+  useGetUrlParams: jest.fn(),
+}));
+
+describe('useUrlSpaceId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the spaceId when it differs from the active space', () => {
+    (useKibanaSpace as jest.Mock).mockReturnValue({ space: { id: 'default' } });
+    (useGetUrlParams as jest.Mock).mockReturnValue({ spaceId: 'team-a' });
+
+    const { result } = renderHook(() => useUrlSpaceId());
+
+    expect(result.current).toBe('team-a');
+  });
+
+  it('returns undefined when spaceId matches the active space', () => {
+    (useKibanaSpace as jest.Mock).mockReturnValue({ space: { id: 'team-a' } });
+    (useGetUrlParams as jest.Mock).mockReturnValue({ spaceId: 'team-a' });
+
+    const { result } = renderHook(() => useUrlSpaceId());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when spaceId is missing from the URL', () => {
+    (useKibanaSpace as jest.Mock).mockReturnValue({ space: { id: 'default' } });
+    (useGetUrlParams as jest.Mock).mockReturnValue({});
+
+    const { result } = renderHook(() => useUrlSpaceId());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the spaceId when the active space is not yet resolved', () => {
+    (useKibanaSpace as jest.Mock).mockReturnValue({ space: undefined });
+    (useGetUrlParams as jest.Mock).mockReturnValue({ spaceId: 'team-a' });
+
+    const { result } = renderHook(() => useUrlSpaceId());
+
+    expect(result.current).toBe('team-a');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_url_space_id.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_url_space_id.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibanaSpace } from '../../../hooks/use_kibana_space';
+import { useGetUrlParams } from './use_url_params';
+
+/**
+ * Returns the `spaceId` URL query param when the user is viewing a monitor that
+ * belongs to a different space than the active one. Used to thread cross-space
+ * context through navigation links inside the monitor detail/sub-route pages.
+ *
+ * Returns `undefined` when no cross-space context is in effect, so callers can
+ * spread it into URL builders without producing an empty `?spaceId=` segment.
+ */
+export const useUrlSpaceId = (): string | undefined => {
+  const { space } = useKibanaSpace();
+  const { spaceId } = useGetUrlParams();
+
+  return spaceId && spaceId !== space?.id ? spaceId : undefined;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/utils/api_service/api_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/utils/api_service/api_service.ts
@@ -73,11 +73,26 @@ class ApiService {
   }
 
   private parseApiUrl(apiUrl: string, spaceId?: string) {
-    if (spaceId && spaceId !== 'default' && spaceId !== '*') {
+    // `*` is the all-spaces marker used by saved object `namespaces`; it is not
+    // a real space ID we can route to, so callers should fall back to the
+    // active space rather than rewriting the URL.
+    if (spaceId && spaceId !== '*') {
       const basePath = kibanaService.coreSetup.http.basePath;
+      // `addSpaceIdToPath` already produces a basePath-only URL (no `/s/<id>`
+      // segment) for the default space, so it works for both default and
+      // named spaces. Returning here lets us drop the basePath prefix Kibana
+      // would otherwise add for the active space, which would mis-route a
+      // cross-space request.
       return addSpaceIdToPath(basePath.serverBasePath, spaceId, apiUrl);
     }
     return apiUrl;
+  }
+
+  private shouldSkipBasePath(spaceId?: string) {
+    // Only opt out of the http client's basePath logic when we have actually
+    // rewritten the URL ourselves (i.e. `parseApiUrl` produced a fully
+    // qualified path including the basePath).
+    return Boolean(spaceId && spaceId !== '*');
   }
 
   public async get<T>(
@@ -92,7 +107,7 @@ class ApiService {
       query: queryParams,
       version,
       ...(options ?? {}),
-      ...(spaceId ? { prependBasePath: false } : {}),
+      ...(this.shouldSkipBasePath(spaceId) ? { prependBasePath: false } : {}),
     });
 
     this.addInspectorRequest?.({
@@ -112,7 +127,7 @@ class ApiService {
       body: JSON.stringify(data),
       query: queryParams,
       version,
-      ...(spaceId ? { prependBasePath: false } : {}),
+      ...(this.shouldSkipBasePath(spaceId) ? { prependBasePath: false } : {}),
     });
 
     this.addInspectorRequest?.({
@@ -139,7 +154,7 @@ class ApiService {
       query: queryParams,
       version,
       ...(options ?? {}),
-      ...(spaceId ? { prependBasePath: false } : {}),
+      ...(this.shouldSkipBasePath(spaceId) ? { prependBasePath: false } : {}),
     });
 
     return this.parseResponse(response, apiUrl, decodeType);
@@ -154,7 +169,7 @@ class ApiService {
       body: JSON.stringify(data),
       version,
       ...(options ?? {}),
-      ...(spaceId ? { prependBasePath: false } : {}),
+      ...(this.shouldSkipBasePath(spaceId) ? { prependBasePath: false } : {}),
     });
 
     if (response instanceof Error) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Synthetics] Preserve spaceId for cross-space monitor sub-pages (#265748)](https://github.com/elastic/kibana/pull/265748)

The original auto-backport failed (https://github.com/elastic/kibana/pull/265748#issuecomment) on 8.19, 9.3 and 9.4. 8.19 (#270567) and 9.3 (#270568) are tracked separately; this PR covers 9.4. Prerequisite #265647 is already on 9.4 via #265715.

## Conflicts

Same shape as the 8.19 (#270567) and 9.3 (#270568) sibling backports. Resolved manually:

- **`monitor_detail_flyout.tsx`**: Heavy upstream divergence (main was refactored into a remote/tabbed layout that 9.4 doesn't have). Reset to 9.4 base and ported only the PR-specific deltas:
  - Imported `getMonitorSpaceToAppend` from `use_edit_monitor_locator`.
  - Computed `crossSpaceId` and threaded it into the `getMonitorAction.get` dispatch (replacing the previous inline `space && spaces?.length && !spaces?.includes(space?.id) ? { spaceId: spaces[0] } : {}` check).
  - **Skipped** the "hide error callout when overview metadata is present" polish — on 9.4 the flyout body is gated on `monitorObject`, so hiding the callout would leave an empty flyout. The dispatch fix alone removes the underlying 404. The accompanying new test case was dropped for the same reason.
- **`errors_list.tsx`**: Kept 9.4 base and added the new helper-file re-export (`getErrorDetailsUrl` from `./error_details_url`), the `useUrlSpaceId` hook usage, and `&spaceId=...` suffix on the inline `history.push` URL. Skipped the unrelated upstream per-row `item.config_id` / `observer?.name` fallback logic that isn't on 9.4.
- **`last_test_run.tsx`**: Kept 9.4's null-assertion style for `monitor?.[CONFIG_ID]!` / `selectedLocation!.id` / `latestPing.state?.id!` (9.4 typing requires it); added `spaceId` to the `getErrorDetailsUrl` call.
- **`monitor_details_panel.tsx`**: Main introduced a `savedMonitor` variable because its `SelectedSyntheticsMonitor` union now includes a `RemoteSyntheticsMonitor` branch that lacks `spaces`. 9.4 doesn't have that union (the `monitor` prop is `SyntheticsMonitorWithId | EncryptedSyntheticsSavedMonitor`), so read `monitor[ConfigKey.KIBANA_SPACES]` directly (same as the 8.19 backport).
- **`flyout_panels.tsx`** (rename/delete): file doesn't exist on 9.4 and no caller references it → dropped.
- **`error_details_url.ts`** (rename/delete): kept the file at the new `monitor_details/monitor_errors/` location (the rename target).

All other files auto-merged cleanly.

## Validation

- `node scripts/type_check --project x-pack/solutions/observability/plugins/synthetics/tsconfig.json` — passes.
- `node scripts/jest` on the 4 added/changed test files (`monitor_detail_flyout.test.tsx`, `test_run_urls.test.ts`, `error_details_url.test.ts`, `use_url_space_id.test.ts`) — 21/21 pass.
- `node scripts/eslint --fix` on all staged files — clean.

## Test plan

Cross-space repro checklist from the parent PR, re-run on 9.4 against a monitor that lives in a non-active space:

1. Open the cross-space monitor detail page from the Monitors list → URL contains `?spaceId=<other-space>`, page loads (no 404).
2. Location badges on the detail page and overview flyout body → preserve `spaceId`.
3. "View test run" / Test runs table rows / Errors rows → preserve `spaceId`.
4. Error details breadcrumb back to Monitor → preserves `spaceId`.
5. Test run details → Step → Previous/Next check → preserve `spaceId`.
6. Edit monitor → "Back to monitor" breadcrumb → preserves `spaceId`.
7. Overview flyout's monitor-details fetch no longer 404s for cross-space monitors (`apiService.parseApiUrl` fix).

### Made with [backport](https://github.com/sorenlouv/backport)


Made with [Cursor](https://cursor.com)