### PR TITLE
[docs] Add security advisory notice to 8.19.16 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -128,6 +128,8 @@ include::upgrade-notes.asciidoc[]
 
 The 8.19.16 release includes the following fixes.
 
+IMPORTANT: The 8.19.16 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+
 [float]
 [[fixes-v8.19.16]]
 === Fixes


### PR DESCRIPTION
## Summary

Adds the standard `IMPORTANT` security advisory notice to the 8.19.16 release notes section, matching the existing 8.19.12 / 8.19.13 pattern.

```asciidoc
IMPORTANT: The 8.19.16 release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
```

The equivalent 9.x change (in MyST Markdown) is opened separately against `main`.

## Test plan

- [ ] Docs preview renders the IMPORTANT admonition immediately under the 8.19.16 intro line and above the `Fixes` subsection.

Made with [Cursor](https://cursor.com)