### PR TITLE
[SharedUX] Adjust side nav spacing

### DIFF
--- a/src/platform/kbn-ui/side-navigation/src/components/nested_secondary_menu/header.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/nested_secondary_menu/header.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import type { FC } from 'react';
-import { EuiButtonIcon, EuiTitle, useEuiTheme } from '@elastic/eui';
+import { EuiButtonIcon, EuiTitle, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 
@@ -31,21 +31,28 @@ export const Header: FC<HeaderProps> = ({ title, 'aria-describedby': ariaDescrib
     background: ${euiTheme.colors.backgroundBasePlain};
     border-radius: ${euiTheme.border.radius.medium};
     display: flex;
-    gap: ${euiTheme.size.s};
+    gap: ${euiTheme.size.xs};
     ${headerStyle}
   `;
 
   return (
     <div css={titleStyle}>
-      <EuiButtonIcon
-        aria-describedby={ariaDescribedBy}
-        aria-label={i18n.translate('kbnUI.sideNavigation.goBackButtonIconAriaLabel', {
+      <EuiToolTip
+        content={i18n.translate('kbnUI.sideNavigation.goBackButtonIconAriaLabel', {
           defaultMessage: 'Go back',
         })}
-        color="text"
-        iconType="chevronSingleLeft"
-        onClick={goBack}
-      />
+        disableScreenReaderOutput
+      >
+        <EuiButtonIcon
+          aria-describedby={ariaDescribedBy}
+          aria-label={i18n.translate('kbnUI.sideNavigation.goBackButtonIconAriaLabel', {
+            defaultMessage: 'Go back',
+          })}
+          color="text"
+          iconType="chevronSingleLeft"
+          onClick={goBack}
+        />
+      </EuiToolTip>
       {title && (
         <EuiTitle size="xs">
           <h4>{title}</h4>

--- a/src/platform/kbn-ui/side-navigation/src/components/secondary_menu/section.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/secondary_menu/section.tsx
@@ -64,7 +64,6 @@ export const SecondaryMenuSectionComponent = ({
     display: flex;
     flex-direction: column;
     width: 100%;
-    gap: ${euiTheme.size.xxs};
   `;
 
   return (

--- a/src/platform/kbn-ui/side-navigation/src/hooks/use_menu_header_style.ts
+++ b/src/platform/kbn-ui/side-navigation/src/hooks/use_menu_header_style.ts
@@ -25,7 +25,7 @@ export function useMenuHeaderStyle() {
     position: sticky;
     top: 0;
     z-index: calc(${euiTheme.levels.content} + 1);
-    padding: ${euiTheme.size.base} var(--horizontal-padding) ${euiTheme.size.xs}
+    padding: ${euiTheme.size.base} var(--horizontal-padding) ${euiTheme.size.xxs}
       var(--horizontal-padding);
     margin: 0 1px;
     min-height: var(--secondary-menu-header-height);

--- a/src/platform/kbn-ui/side-navigation/src/hooks/use_scroll.ts
+++ b/src/platform/kbn-ui/side-navigation/src/hooks/use_scroll.ts
@@ -19,7 +19,7 @@ import { css } from '@emotion/react';
 export const useScroll = (withMask: boolean = false) => {
   const scrollStyles = css`
     ${useEuiOverflowScroll('y', withMask)}
-    --secondary-menu-header-height: 44px;
+    --secondary-menu-header-height: 42px;
     scroll-padding-top: var(--secondary-menu-header-height);
   `;
 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana-team/issues/3411

## Summary

Adjusted side nav spacing:

- Header section bottom padding: 4px to 2px
- Gap between secondary items: 2px to 0px
- Gap between chevron back and section title: 8px to 4px to match icon and title gap

### Testing

| Before | After |
| --- | --- |
| <img width="343" height="533" alt="Screenshot 2026-05-28 at 11 28 28" src="https://github.com/user-attachments/assets/c912ee46-bfbd-4993-b335-5a88f96c79be" /> | <img width="343" height="490" alt="Screenshot 2026-05-28 at 11 26 06" src="https://github.com/user-attachments/assets/592b6a82-c006-4221-ae6e-b861fa2433d6" /> |
| <img width="355" height="186" alt="Screenshot 2026-05-28 at 11 27 27" src="https://github.com/user-attachments/assets/cafc2a32-73e6-4150-9137-a36e72d08c8c" /> | <img width="362" height="198" alt="Screenshot 2026-05-28 at 11 26 23" src="https://github.com/user-attachments/assets/29fe4e4f-90b7-4b19-a42c-286e4324317f" /> |
|  <img width="359" height="264" alt="Screenshot 2026-05-28 at 11 27 08" src="https://github.com/user-attachments/assets/06e1cf05-d6e8-40fa-a4c1-65e75b420bf8" /> | <img width="357" height="256" alt="Screenshot 2026-05-28 at 11 26 32" src="https://github.com/user-attachments/assets/61fa1a5b-774c-48a3-8cf0-48faacabb5a2" /> |
