### PR TITLE
[9.3] [Custom Threshold rule] Fix viewInAppUrl to use rule's lookback window instead of hardcoded 20-minute range (#271149)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/custom_threshold_rule/get_view_in_app_url.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/custom_threshold_rule/get_view_in_app_url.test.ts
@@ -75,6 +75,42 @@ describe('getViewInAppUrl', () => {
     );
   });
 
+  it('should extend the time range with the lookback window', () => {
+    const mockDateNow = jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date('2026-01-01T00:00:00.000Z').valueOf());
+
+    const args: GetViewInAppUrlArgs = {
+      logsLocator,
+      startedAt,
+      endedAt,
+      timeSize: 7,
+      timeUnit: 'd',
+    };
+
+    expect(getViewInAppUrl(args)).toBe('mockedGetRedirectUrl');
+    expect(logsLocator.getRedirectUrl).toHaveBeenCalledWith(
+      {
+        dataset: undefined,
+        dataViewSpec: undefined,
+        timeRange: {
+          // startedAt - 7d * 20 = 2023-12-07 - 140d = 2023-07-20
+          from: '2023-07-20T16:30:15.403Z',
+          // endedAt + 7d * 20 = 2023-12-07 + 140d = 2024-04-25
+          to: '2024-04-25T20:30:15.403Z',
+        },
+        filters: [],
+        query: {
+          query: '',
+          language: 'kuery',
+        },
+      },
+      {}
+    );
+
+    mockDateNow.mockRestore();
+  });
+
   it('should call getRedirectUrl with only count filter', () => {
     const args: GetViewInAppUrlArgs = {
       metrics: [

--- a/x-pack/solutions/observability/plugins/observability/common/custom_threshold_rule/get_view_in_app_url.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/custom_threshold_rule/get_view_in_app_url.ts
@@ -13,7 +13,7 @@ import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { isEmpty } from 'lodash';
 import { getGroupFilters } from './helpers/get_group';
 import type { SearchConfigurationWithExtractedReferenceType } from './types';
-import type { CustomThresholdExpressionMetric } from './types';
+import type { BaseMetricExpressionParams, CustomThresholdExpressionMetric } from './types';
 import type { Group } from '../typings';
 export interface GetViewInAppUrlArgs {
   searchConfiguration?: SearchConfigurationWithExtractedReferenceType;
@@ -24,6 +24,8 @@ export interface GetViewInAppUrlArgs {
   metrics?: CustomThresholdExpressionMetric[];
   startedAt?: string;
   spaceId?: string;
+  timeSize?: BaseMetricExpressionParams['timeSize'];
+  timeUnit?: BaseMetricExpressionParams['timeUnit'];
 }
 
 export const getViewInAppLocatorParams = ({
@@ -33,11 +35,19 @@ export const getViewInAppLocatorParams = ({
   metrics = [],
   searchConfiguration,
   startedAt = new Date().toISOString(),
+  timeSize,
+  timeUnit,
 }: GetViewInAppUrlArgs) => {
   const searchConfigurationQuery = searchConfiguration?.query.query;
   const searchConfigurationFilters = searchConfiguration?.filter || [];
   const groupFilters = getGroupFilters(groups);
-  const timeRange: TimeRange | undefined = getPaddedAlertTimeRange(startedAt, endedAt);
+  const lookBackWindow =
+    timeSize !== undefined && timeUnit ? { size: timeSize, unit: timeUnit } : undefined;
+  const timeRange: TimeRange | undefined = getPaddedAlertTimeRange(
+    startedAt,
+    endedAt,
+    lookBackWindow
+  );
   timeRange.to = endedAt ? timeRange.to : 'now';
 
   const query = {
@@ -72,26 +82,10 @@ export const getViewInAppLocatorParams = ({
   };
 };
 
-export const getViewInAppUrl = ({
-  dataViewId,
-  endedAt,
-  groups,
-  logsLocator,
-  metrics = [],
-  searchConfiguration,
-  startedAt = new Date().toISOString(),
-  spaceId,
-}: GetViewInAppUrlArgs) => {
+export const getViewInAppUrl = ({ logsLocator, spaceId, ...rest }: GetViewInAppUrlArgs) => {
   if (!logsLocator) return '';
 
-  const params = getViewInAppLocatorParams({
-    dataViewId,
-    endedAt,
-    groups,
-    metrics,
-    searchConfiguration,
-    startedAt,
-  });
+  const params = getViewInAppLocatorParams(rest);
 
   return logsLocator.getRedirectUrl(params, { spaceId });
 };

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/hooks/use_discover_url/get_rule_data/custom_threshold_rule.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/hooks/use_discover_url/get_rule_data/custom_threshold_rule.ts
@@ -16,9 +16,19 @@ import {
 } from '@kbn/es-query';
 import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { getViewInAppLocatorParams } from '../../../../../../common/custom_threshold_rule/get_view_in_app_url';
+import type { BaseMetricExpressionParams } from '../../../../../../common/custom_threshold_rule/types';
+
+const TIME_UNIT_CHARS: ReadonlyArray<BaseMetricExpressionParams['timeUnit']> = ['s', 'm', 'h', 'd'];
+
+const isTimeUnitChar = (
+  timeUnit: string | undefined
+): timeUnit is BaseMetricExpressionParams['timeUnit'] =>
+  TIME_UNIT_CHARS.includes(timeUnit as BaseMetricExpressionParams['timeUnit']);
 
 export const getCustomThresholdRuleData = ({ rule }: { rule: Rule }) => {
   const ruleParams = rule.params as CustomThresholdParams;
+  const firstCriterion = ruleParams.criteria[0];
+  const timeUnit = isTimeUnitChar(firstCriterion?.timeUnit) ? firstCriterion.timeUnit : undefined;
   const { index } = ruleParams.searchConfiguration;
   let dataViewId: string | undefined;
   if (typeof index === 'string') {
@@ -53,6 +63,8 @@ export const getCustomThresholdRuleData = ({ rule }: { rule: Rule }) => {
           query: ruleParams.searchConfiguration.query,
           filter: ruleParams.searchConfiguration.filter,
         },
+        timeSize: firstCriterion?.timeSize,
+        timeUnit,
       }),
       filters,
     },

--- a/x-pack/solutions/observability/plugins/observability/public/rules/format_custom_threshold_alert.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/rules/format_custom_threshold_alert.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALERT_REASON, ALERT_RULE_PARAMETERS, ALERT_START } from '@kbn/rule-data-utils';
+import { formatCustomThresholdAlert } from './format_custom_threshold_alert';
+import { Aggregators } from '../../common/custom_threshold_rule/types';
+
+jest.mock('../../common/custom_threshold_rule/get_view_in_app_url', () => ({
+  getViewInAppUrl: jest.fn(() => 'mockedUrl'),
+}));
+
+const { getViewInAppUrl } = jest.requireMock(
+  '../../common/custom_threshold_rule/get_view_in_app_url'
+);
+
+describe('formatCustomThresholdAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const baseCriterion = {
+    metrics: [{ name: 'A', aggType: Aggregators.COUNT }],
+    timeSize: 7,
+    timeUnit: 'd',
+    comparator: '>',
+    threshold: [0],
+  };
+
+  it('normalizes criteria from a single object to an array', () => {
+    const fields = {
+      [ALERT_RULE_PARAMETERS]: {
+        criteria: baseCriterion,
+        searchConfiguration: { index: 'test-index', query: { query: '', language: 'kuery' } },
+      },
+      [ALERT_REASON]: 'test reason',
+      [ALERT_START]: '2023-12-07T16:30:15.403Z',
+    };
+
+    formatCustomThresholdAlert(fields);
+
+    expect(getViewInAppUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: baseCriterion.metrics,
+        timeSize: 7,
+        timeUnit: 'd',
+      })
+    );
+  });
+
+  it('handles criteria as an array (normal case)', () => {
+    const fields = {
+      [ALERT_RULE_PARAMETERS]: {
+        criteria: [baseCriterion],
+        searchConfiguration: { index: 'test-index', query: { query: '', language: 'kuery' } },
+      },
+      [ALERT_REASON]: 'test reason',
+      [ALERT_START]: '2023-12-07T16:30:15.403Z',
+    };
+
+    formatCustomThresholdAlert(fields);
+
+    expect(getViewInAppUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: baseCriterion.metrics,
+        timeSize: 7,
+        timeUnit: 'd',
+      })
+    );
+  });
+
+  it('handles missing criteria gracefully', () => {
+    const fields = {
+      [ALERT_RULE_PARAMETERS]: {
+        searchConfiguration: { index: 'test-index', query: { query: '', language: 'kuery' } },
+      },
+      [ALERT_REASON]: 'test reason',
+      [ALERT_START]: '2023-12-07T16:30:15.403Z',
+    };
+
+    formatCustomThresholdAlert(fields);
+
+    expect(getViewInAppUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: [],
+        timeSize: undefined,
+        timeUnit: undefined,
+      })
+    );
+  });
+
+  it('does not pass timeSize/timeUnit for multi-criteria rules', () => {
+    const fields = {
+      [ALERT_RULE_PARAMETERS]: {
+        criteria: [baseCriterion, { ...baseCriterion, timeSize: 1, timeUnit: 'h' }],
+        searchConfiguration: { index: 'test-index', query: { query: '', language: 'kuery' } },
+      },
+      [ALERT_REASON]: 'test reason',
+      [ALERT_START]: '2023-12-07T16:30:15.403Z',
+    };
+
+    formatCustomThresholdAlert(fields);
+
+    expect(getViewInAppUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: [],
+        timeSize: undefined,
+        timeUnit: undefined,
+      })
+    );
+  });
+
+  it('returns reason from fields or falls back to "-"', () => {
+    const fields = {
+      [ALERT_RULE_PARAMETERS]: { criteria: [], searchConfiguration: {} },
+    };
+
+    const result = formatCustomThresholdAlert(fields);
+
+    expect(result.reason).toBe('-');
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/rules/format_custom_threshold_alert.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/rules/format_custom_threshold_alert.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ALERT_GROUP_FIELD,
+  ALERT_GROUP_VALUE,
+  ALERT_REASON,
+  ALERT_RULE_PARAMETERS,
+  ALERT_START,
+} from '@kbn/rule-data-utils';
+import type { LocatorPublic } from '@kbn/share-plugin/common';
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import type {
+  CustomThresholdExpressionMetric,
+  SearchConfigurationWithExtractedReferenceType,
+} from '../../common/custom_threshold_rule/types';
+import type { MetricExpression } from '../components/custom_threshold/types';
+import { getViewInAppUrl } from '../../common/custom_threshold_rule/get_view_in_app_url';
+import { getGroups } from '../../common/custom_threshold_rule/helpers/get_group';
+
+const getDataViewId = (searchConfiguration?: SearchConfigurationWithExtractedReferenceType) =>
+  typeof searchConfiguration?.index === 'string'
+    ? searchConfiguration.index
+    : searchConfiguration?.index?.title;
+
+export const formatCustomThresholdAlert = (
+  fields: Record<string, unknown>,
+  logsLocator?: LocatorPublic<DiscoverAppLocatorParams>
+) => {
+  const groups = getGroups(
+    fields[ALERT_GROUP_FIELD] as string[] | undefined,
+    fields[ALERT_GROUP_VALUE] as string[] | undefined
+  );
+  const ruleParams = fields[ALERT_RULE_PARAMETERS] as
+    | { searchConfiguration?: SearchConfigurationWithExtractedReferenceType; criteria?: unknown }
+    | undefined;
+  const searchConfiguration = ruleParams?.searchConfiguration;
+  const criteriaRaw = ruleParams?.criteria;
+  const criteria = (
+    Array.isArray(criteriaRaw) ? criteriaRaw : criteriaRaw ? [criteriaRaw] : []
+  ) as MetricExpression[];
+  const singleCriterion = criteria.length === 1 ? criteria[0] : undefined;
+  const metrics: CustomThresholdExpressionMetric[] = singleCriterion?.metrics ?? [];
+
+  const dataViewId = getDataViewId(searchConfiguration);
+
+  return {
+    reason: (fields[ALERT_REASON] as string) ?? '-',
+    link: getViewInAppUrl({
+      dataViewId,
+      groups,
+      logsLocator,
+      metrics,
+      searchConfiguration,
+      startedAt: fields[ALERT_START] as string,
+      timeSize: singleCriterion?.timeSize,
+      timeUnit: singleCriterion?.timeUnit,
+    }),
+    hasBasePath: true,
+  };
+};

--- a/x-pack/solutions/observability/plugins/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/rules/register_observability_rule_types.ts
@@ -7,29 +7,18 @@
 
 import { lazy } from 'react';
 import { i18n } from '@kbn/i18n';
-import {
-  ALERT_GROUP_FIELD,
-  ALERT_GROUP_VALUE,
-  ALERT_REASON,
-  ALERT_RULE_PARAMETERS,
-  ALERT_START,
-  OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
-} from '@kbn/rule-data-utils';
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/rule-data-utils';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type {
   CustomMetricExpressionParams,
-  CustomThresholdExpressionMetric,
   CustomThresholdSearchSourceFields,
-  SearchConfigurationWithExtractedReferenceType,
 } from '../../common/custom_threshold_rule/types';
-import type { MetricExpression } from '../components/custom_threshold/types';
-import { getViewInAppUrl } from '../../common/custom_threshold_rule/get_view_in_app_url';
-import { getGroups } from '../../common/custom_threshold_rule/helpers/get_group';
 import type { ObservabilityRuleTypeRegistry } from './create_observability_rule_type_registry';
 import { validateCustomThreshold } from '../components/custom_threshold/components/validation';
 import { getDescriptionFields } from './custom_threshold_description_fields';
+import { formatCustomThresholdAlert } from './format_custom_threshold_alert';
 
 const thresholdDefaultActionMessage = i18n.translate(
   'xpack.observability.customThreshold.rule.alerting.threshold.defaultActionMessage',
@@ -53,11 +42,6 @@ const thresholdDefaultRecoveryMessage = i18n.translate(
 `,
   }
 );
-
-const getDataViewId = (searchConfiguration?: SearchConfigurationWithExtractedReferenceType) =>
-  typeof searchConfiguration?.index === 'string'
-    ? searchConfiguration.index
-    : searchConfiguration?.index?.title;
 
 export const registerObservabilityRuleTypes = (
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry,
@@ -91,30 +75,7 @@ export const registerObservabilityRuleTypes = (
     defaultActionMessage: thresholdDefaultActionMessage,
     defaultRecoveryMessage: thresholdDefaultRecoveryMessage,
     requiresAppContext: false,
-    format: ({ fields }) => {
-      const groups = getGroups(fields[ALERT_GROUP_FIELD], fields[ALERT_GROUP_VALUE]);
-      const searchConfiguration = fields[ALERT_RULE_PARAMETERS]?.searchConfiguration as
-        | SearchConfigurationWithExtractedReferenceType
-        | undefined;
-      const criteria = fields[ALERT_RULE_PARAMETERS]?.criteria as MetricExpression[];
-      const metrics: CustomThresholdExpressionMetric[] =
-        criteria.length === 1 ? criteria[0].metrics : [];
-
-      const dataViewId = getDataViewId(searchConfiguration);
-
-      return {
-        reason: fields[ALERT_REASON] ?? '-',
-        link: getViewInAppUrl({
-          dataViewId,
-          groups,
-          logsLocator,
-          metrics,
-          searchConfiguration,
-          startedAt: fields[ALERT_START],
-        }),
-        hasBasePath: true,
-      };
-    },
+    format: ({ fields }) => formatCustomThresholdAlert(fields, logsLocator),
     alertDetailsAppSection: lazy(
       () =>
         import(

--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.test.ts
@@ -1730,6 +1730,8 @@ describe('The custom threshold alert type', () => {
               language: 'kuery',
             },
           },
+          timeSize: 1,
+          timeUnit: 'm',
         });
       });
 
@@ -1791,6 +1793,8 @@ describe('The custom threshold alert type', () => {
               language: 'kuery',
             },
           },
+          timeSize: 1,
+          timeUnit: 'm',
         });
       });
       test('includes reason message in the recovered alert context pulled from the last active alert ', async () => {

--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
@@ -301,6 +301,7 @@ export const createCustomThresholdExecutor = ({
           typeof params.searchConfiguration?.index === 'string'
             ? params.searchConfiguration?.index
             : params.searchConfiguration?.index?.title;
+        const singleCriterion = alertResults.length === 1 ? alertResults[0][group] : undefined;
         alertsClient.setAlertData({
           id: `${group}`,
           context: {
@@ -322,10 +323,12 @@ export const createCustomThresholdExecutor = ({
               dataViewId: dataViewIdTitle ?? dataViewId,
               groups,
               logsLocator,
-              metrics: alertResults.length === 1 ? alertResults[0][group].metrics : [],
+              metrics: singleCriterion?.metrics ?? [],
               searchConfiguration: params.searchConfiguration,
               startedAt: indexedStartedAt,
               spaceId,
+              timeSize: singleCriterion?.timeSize,
+              timeUnit: singleCriterion?.timeUnit,
             }),
             ...additionalContext,
           },
@@ -357,6 +360,8 @@ export const createCustomThresholdExecutor = ({
           metrics: params.criteria[0]?.metrics,
           searchConfiguration: params.searchConfiguration,
           startedAt: indexedStartedAt,
+          timeSize: params.criteria[0]?.timeSize,
+          timeUnit: params.criteria[0]?.timeUnit,
         }),
         reason: alertHits?.[ALERT_REASON],
         ...additionalContext,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Custom Threshold rule] Fix viewInAppUrl to use rule's lookback window instead of hardcoded 20-minute range (#271149)](https://github.com/elastic/kibana/pull/271149)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Anna Davydova","email":"ana.davydova@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T09:48:52Z","message":"[Custom Threshold rule] Fix viewInAppUrl to use rule's lookback window instead of hardcoded 20-minute range (#271149)\n\n## Summary\n\nFixes #271131 \n\n`{{context.viewInAppUrl}}` in Custom Threshold rule notifications\ngenerated a Discover link with a hardcoded ~20-minute time window\nregardless of the rule's actual lookback period. Users with longer\nwindows (e.g. 7 days) would click the link and see \"no results\" because\nthe data fell outside the narrow range.\n\n**Root cause:** `getViewInAppUrl` called\n`getPaddedAlertTimeRange(startedAt, endedAt)` without passing the\noptional `lookBackWindow` parameter. Without it, the utility always\nfalls back to a 20-minute buffer.\n\n**Fix:** Thread the criterion's `timeSize`/`timeUnit` through to\n`getPaddedAlertTimeRange` via the existing `lookBackWindow` argument.\nFor multi-criteria rules (where there's no single unambiguous window),\nthe fields are left undefined and the previous 20-minute default applies\n— consistent with how `metrics` is already handled.\n\n### Changes\n\n- **`get_view_in_app_url.ts`** — Added `timeSize`/`timeUnit` to\n`GetViewInAppUrlArgs`; builds the `lookBackWindow` and passes it to\n`getPaddedAlertTimeRange`. Simplified `getViewInAppUrl` to use\nrest/spread instead of re-listing every property. Uses `timeSize !==\nundefined` (not `timeSize &&`) so a theoretical `timeSize: 0` wouldn't\nbe silently ignored.\n- **`custom_threshold_executor.ts`** — Passes `timeSize`/`timeUnit` from\nthe evaluation result (active alert) or `params.criteria[0]` (recovered\nalert). Extracted `singleCriterion` to avoid repeating the\n`alertResults.length === 1` guard.\n- **`register_observability_rule_types.ts`** — Extracted\n`formatCustomThresholdAlert` as a named export for testability. Passes\n`timeSize`/`timeUnit` from the alert's rule parameters for the alert\nlist \"View in app\" link. Normalizes `criteria` from object → array to\nguard against ES flattened-field serialization inconsistencies.\n- **`custom_threshold_rule.ts`** (alert details) — Passes\n`timeSize`/`timeUnit` from `ruleParams.criteria[0]` for the \"Investigate\nin Discover\" link, with an `isTimeUnitChar` type guard to narrow the\nwider `string` type from `@kbn/response-ops-rule-params`.\n\n### Tests\n\n- **`get_view_in_app_url.test.ts`** — Added test case verifying that a\n7-day lookback extends the time range by 140 days (7 × 20) on each side.\nMocks `Date.now` for determinism.\n- **`custom_threshold_executor.test.ts`** — Updated active-alert and\nrecovered-alert assertions to expect the new `timeSize`/`timeUnit`\nfields.\n- **`format_custom_threshold_alert.test.ts`** (new) — Unit tests for the\nextracted `formatCustomThresholdAlert` function covering: criteria as a\nbare object (normalization), criteria as an array (happy path), missing\ncriteria, multi-criteria (no timeSize/timeUnit forwarded), and reason\nfallback.\n\n## Test plan\n\n- [ ] `node scripts/jest ...get_view_in_app_url.test.ts` passes\n- [ ] `node scripts/jest ...custom_threshold_executor.test.ts` passes\n- [ ] `node scripts/jest ...format_custom_threshold_alert.test.ts`\npasses\n- [ ] `node scripts/type_check --project\n.../observability/tsconfig.json` passes\n- [ ] Manual: rule with 7-day window fires → viewInAppUrl contains\nextended time range → Discover shows results\n- [ ] Manual: recovered alert also has correct time range\n- [ ] Manual: multi-criteria rule still produces a working link (falls\nback to 20-min default)\n\nMade with Cursor.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d66a887820a49f3d6c88d4e3b8bf04b2fe8776ff","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","author:actionable-obs","v9.5.0"],"title":"[Custom Threshold rule] Fix viewInAppUrl to use rule's lookback window instead of hardcoded 20-minute range","number":271149,"url":"https://github.com/elastic/kibana/pull/271149","mergeCommit":{"message":"[Custom Threshold rule] Fix viewInAppUrl to use rule's lookback window instead of hardcoded 20-minute range (#271149)\n\n## Summary\n\nFixes #271131 \n\n`{{context.viewInAppUrl}}` in Custom Threshold rule notifications\ngenerated a Discover link with a hardcoded ~20-minute time window\nregardless of the rule's actual lookback period. Users with longer\nwindows (e.g. 7 days) would click the link and see \"no results\" because\nthe data fell outside the narrow range.\n\n**Root cause:** `getViewInAppUrl` called\n`getPaddedAlertTimeRange(startedAt, endedAt)` without passing the\noptional `lookBackWindow` parameter. Without it, the utility always\nfalls back to a 20-minute buffer.\n\n**Fix:** Thread the criterion's `timeSize`/`timeUnit` through to\n`getPaddedAlertTimeRange` via the existing `lookBackWindow` argument.\nFor multi-criteria rules (where there's no single unambiguous window),\nthe fields are left undefined and the previous 20-minute default applies\n— consistent with how `metrics` is already handled.\n\n### Changes\n\n- **`get_view_in_app_url.ts`** — Added `timeSize`/`timeUnit` to\n`GetViewInAppUrlArgs`; builds the `lookBackWindow` and passes it to\n`getPaddedAlertTimeRange`. Simplified `getViewInAppUrl` to use\nrest/spread instead of re-listing every property. Uses `timeSize !==\nundefined` (not `timeSize &&`) so a theoretical `timeSize: 0` wouldn't\nbe silently ignored.\n- **`custom_threshold_executor.ts`** — Passes `timeSize`/`timeUnit` from\nthe evaluation result (active alert) or `params.criteria[0]` (recovered\nalert). Extracted `singleCriterion` to avoid repeating the\n`alertResults.length === 1` guard.\n- **`register_observability_rule_types.ts`** — Extracted\n`formatCustomThresholdAlert` as a named export for testability. Passes\n`timeSize`/`timeUnit` from the alert's rule parameters for the alert\nlist \"View in app\" link. Normalizes `criteria` from object → array to\nguard against ES flattened-field serialization inconsistencies.\n- **`custom_threshold_rule.ts`** (alert details) — Passes\n`timeSize`/`timeUnit` from `ruleParams.criteria[0]` for the \"Investigate\nin Discover\" link, with an `isTimeUnitChar` type guard to narrow the\nwider `string` type from `@kbn/response-ops-rule-params`.\n\n### Tests\n\n- **`get_view_in_app_url.test.ts`** — Added test case verifying that a\n7-day lookback extends the time range by 140 days (7 × 20) on each side.\nMocks `Date.now` for determinism.\n- **`custom_threshold_executor.test.ts`** — Updated active-alert and\nrecovered-alert assertions to expect the new `timeSize`/`timeUnit`\nfields.\n- **`format_custom_threshold_alert.test.ts`** (new) — Unit tests for the\nextracted `formatCustomThresholdAlert` function covering: criteria as a\nbare object (normalization), criteria as an array (happy path), missing\ncriteria, multi-criteria (no timeSize/timeUnit forwarded), and reason\nfallback.\n\n## Test plan\n\n- [ ] `node scripts/jest ...get_view_in_app_url.test.ts` passes\n- [ ] `node scripts/jest ...custom_threshold_executor.test.ts` passes\n- [ ] `node scripts/jest ...format_custom_threshold_alert.test.ts`\npasses\n- [ ] `node scripts/type_check --project\n.../observability/tsconfig.json` passes\n- [ ] Manual: rule with 7-day window fires → viewInAppUrl contains\nextended time range → Discover shows results\n- [ ] Manual: recovered alert also has correct time range\n- [ ] Manual: multi-criteria rule still produces a working link (falls\nback to 20-min default)\n\nMade with Cursor.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d66a887820a49f3d6c88d4e3b8bf04b2fe8776ff"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271149","number":271149,"mergeCommit":{"message":"[Custom Threshold rule] Fix viewInAppUrl to use rule's lookback window instead of hardcoded 20-minute range (#271149)\n\n## Summary\n\nFixes #271131 \n\n`{{context.viewInAppUrl}}` in Custom Threshold rule notifications\ngenerated a Discover link with a hardcoded ~20-minute time window\nregardless of the rule's actual lookback period. Users with longer\nwindows (e.g. 7 days) would click the link and see \"no results\" because\nthe data fell outside the narrow range.\n\n**Root cause:** `getViewInAppUrl` called\n`getPaddedAlertTimeRange(startedAt, endedAt)` without passing the\noptional `lookBackWindow` parameter. Without it, the utility always\nfalls back to a 20-minute buffer.\n\n**Fix:** Thread the criterion's `timeSize`/`timeUnit` through to\n`getPaddedAlertTimeRange` via the existing `lookBackWindow` argument.\nFor multi-criteria rules (where there's no single unambiguous window),\nthe fields are left undefined and the previous 20-minute default applies\n— consistent with how `metrics` is already handled.\n\n### Changes\n\n- **`get_view_in_app_url.ts`** — Added `timeSize`/`timeUnit` to\n`GetViewInAppUrlArgs`; builds the `lookBackWindow` and passes it to\n`getPaddedAlertTimeRange`. Simplified `getViewInAppUrl` to use\nrest/spread instead of re-listing every property. Uses `timeSize !==\nundefined` (not `timeSize &&`) so a theoretical `timeSize: 0` wouldn't\nbe silently ignored.\n- **`custom_threshold_executor.ts`** — Passes `timeSize`/`timeUnit` from\nthe evaluation result (active alert) or `params.criteria[0]` (recovered\nalert). Extracted `singleCriterion` to avoid repeating the\n`alertResults.length === 1` guard.\n- **`register_observability_rule_types.ts`** — Extracted\n`formatCustomThresholdAlert` as a named export for testability. Passes\n`timeSize`/`timeUnit` from the alert's rule parameters for the alert\nlist \"View in app\" link. Normalizes `criteria` from object → array to\nguard against ES flattened-field serialization inconsistencies.\n- **`custom_threshold_rule.ts`** (alert details) — Passes\n`timeSize`/`timeUnit` from `ruleParams.criteria[0]` for the \"Investigate\nin Discover\" link, with an `isTimeUnitChar` type guard to narrow the\nwider `string` type from `@kbn/response-ops-rule-params`.\n\n### Tests\n\n- **`get_view_in_app_url.test.ts`** — Added test case verifying that a\n7-day lookback extends the time range by 140 days (7 × 20) on each side.\nMocks `Date.now` for determinism.\n- **`custom_threshold_executor.test.ts`** — Updated active-alert and\nrecovered-alert assertions to expect the new `timeSize`/`timeUnit`\nfields.\n- **`format_custom_threshold_alert.test.ts`** (new) — Unit tests for the\nextracted `formatCustomThresholdAlert` function covering: criteria as a\nbare object (normalization), criteria as an array (happy path), missing\ncriteria, multi-criteria (no timeSize/timeUnit forwarded), and reason\nfallback.\n\n## Test plan\n\n- [ ] `node scripts/jest ...get_view_in_app_url.test.ts` passes\n- [ ] `node scripts/jest ...custom_threshold_executor.test.ts` passes\n- [ ] `node scripts/jest ...format_custom_threshold_alert.test.ts`\npasses\n- [ ] `node scripts/type_check --project\n.../observability/tsconfig.json` passes\n- [ ] Manual: rule with 7-day window fires → viewInAppUrl contains\nextended time range → Discover shows results\n- [ ] Manual: recovered alert also has correct time range\n- [ ] Manual: multi-criteria rule still produces a working link (falls\nback to 20-min default)\n\nMade with Cursor.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d66a887820a49f3d6c88d4e3b8bf04b2fe8776ff"}},{"url":"https://github.com/elastic/kibana/pull/271665","number":271665,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->