### PR TITLE
[Sig Events] Add Discovery navigation to global search

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -180,7 +180,7 @@ pageLoadAssetSize:
   stackAlerts: 31499
   stackConnectors: 85421
   streams: 32595
-  streamsApp: 25375
+  streamsApp: 29825
   synthetics: 31571
   telemetry: 25755
   telemetryManagementSection: 5522

--- a/src/platform/packages/shared/deeplinks/observability/deep_links.ts
+++ b/src/platform/packages/shared/deeplinks/observability/deep_links.ts
@@ -98,7 +98,16 @@ export type UptimeLinkId = 'Certificates';
 
 export type ProfilingLinkId = 'stacktraces' | 'flamegraphs' | 'functions';
 
-export type StreamsLinkId = 'overview';
+export const significantEventsDeepLinkIds = [
+  'significantEventsDiscovery',
+  'significantEventsKnowledgeIndicators',
+  'significantEventsEvents',
+  'significantEventsRules',
+] as const;
+
+export type SigEventsLinkId = (typeof significantEventsDeepLinkIds)[number];
+
+export type StreamsLinkId = 'overview' | SigEventsLinkId;
 
 export type LinkId =
   | LogsLinkId

--- a/src/platform/packages/shared/deeplinks/observability/index.ts
+++ b/src/platform/packages/shared/deeplinks/observability/index.ts
@@ -19,5 +19,6 @@ export {
   INGEST_HUB_APP_ID,
   ONBOARDING_APP_ID,
 } from './constants';
-export type { AppId, DeepLinkId } from './deep_links';
+export { significantEventsDeepLinkIds } from './deep_links';
+export type { AppId, DeepLinkId, SigEventsLinkId, StreamsLinkId } from './deep_links';
 export * from './locators';

--- a/x-pack/platform/plugins/shared/streams_app/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/plugin.tsx
@@ -15,6 +15,7 @@ import {
   type PluginInitializerContext,
 } from '@kbn/core/public';
 import type { Logger } from '@kbn/logging';
+import { significantEventsDeepLinkIds, type SigEventsLinkId } from '@kbn/deeplinks-observability';
 import { OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS_DISCOVERY } from '@kbn/management-settings-ids';
 import { DataStreamsStatsService } from '@kbn/dataset-quality-plugin/public';
 import { dynamic } from '@kbn/shared-ux-utility';
@@ -38,15 +39,6 @@ import {
 } from './discover_features';
 import { StreamsTelemetryService } from './telemetry/service';
 import { StreamsAppLocatorDefinition } from '../common/locators';
-
-const significantEventsDeepLinkIds = [
-  'significantEventsDiscovery',
-  'significantEventsKnowledgeIndicators',
-  'significantEventsEvents',
-  'significantEventsRules',
-] as const;
-
-type SigEventsDeepLinkId = (typeof significantEventsDeepLinkIds)[number];
 
 const StreamsApplication = dynamic(() =>
   import('./application').then((mod) => ({ default: mod.StreamsApplication }))
@@ -122,7 +114,7 @@ export class StreamsAppPlugin
       order: 10000,
       deepLinks: [
         {
-          id: 'significantEventsDiscovery' satisfies SigEventsDeepLinkId,
+          id: 'significantEventsDiscovery' satisfies SigEventsLinkId,
           title: i18n.translate('xpack.streams.significantEventsDiscovery.deepLinkTitle', {
             defaultMessage: 'Significant Events',
           }),
@@ -131,7 +123,7 @@ export class StreamsAppPlugin
           keywords: ['significant events', 'sig events', 'discovery'],
         },
         {
-          id: 'significantEventsKnowledgeIndicators' satisfies SigEventsDeepLinkId,
+          id: 'significantEventsKnowledgeIndicators' satisfies SigEventsLinkId,
           title: i18n.translate('xpack.streams.significantEventsDiscovery.kiDeepLinkTitle', {
             defaultMessage: 'Significant Events / KIs',
           }),
@@ -147,7 +139,7 @@ export class StreamsAppPlugin
           ],
         },
         {
-          id: 'significantEventsEvents' satisfies SigEventsDeepLinkId,
+          id: 'significantEventsEvents' satisfies SigEventsLinkId,
           title: i18n.translate('xpack.streams.significantEventsDiscovery.eventsDeepLinkTitle', {
             defaultMessage: 'Significant Events / Events',
           }),
@@ -156,7 +148,7 @@ export class StreamsAppPlugin
           keywords: ['events', 'significant events', 'sig events', 'sig events events'],
         },
         {
-          id: 'significantEventsRules' satisfies SigEventsDeepLinkId,
+          id: 'significantEventsRules' satisfies SigEventsLinkId,
           title: i18n.translate('xpack.streams.significantEventsDiscovery.rulesDeepLinkTitle', {
             defaultMessage: 'Significant Events / Rules',
           }),
@@ -183,7 +175,7 @@ export class StreamsAppPlugin
                 return {
                   visibleIn: ['sideNav', 'globalSearch'],
                   deepLinks: (app.deepLinks ?? []).map((link) => {
-                    if (significantEventsDeepLinkIds.includes(link.id as SigEventsDeepLinkId)) {
+                    if (significantEventsDeepLinkIds.includes(link.id as SigEventsLinkId)) {
                       return {
                         ...link,
                         visibleIn: isSignificantEventsDiscoveryEnabled ? ['globalSearch'] : [],

--- a/x-pack/platform/plugins/shared/streams_app/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/plugin.tsx
@@ -15,11 +15,12 @@ import {
   type PluginInitializerContext,
 } from '@kbn/core/public';
 import type { Logger } from '@kbn/logging';
+import { OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS_DISCOVERY } from '@kbn/management-settings-ids';
 import { DataStreamsStatsService } from '@kbn/dataset-quality-plugin/public';
 import { dynamic } from '@kbn/shared-ux-utility';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { from, map, switchMap } from 'rxjs';
+import { combineLatest, from, map, switchMap } from 'rxjs';
 import { css } from '@emotion/css';
 import ReactDOM from 'react-dom';
 import type {
@@ -37,6 +38,15 @@ import {
 } from './discover_features';
 import { StreamsTelemetryService } from './telemetry/service';
 import { StreamsAppLocatorDefinition } from '../common/locators';
+
+const significantEventsDeepLinkIds = [
+  'significantEventsDiscovery',
+  'significantEventsKnowledgeIndicators',
+  'significantEventsEvents',
+  'significantEventsRules',
+] as const;
+
+type SigEventsDeepLinkId = (typeof significantEventsDeepLinkIds)[number];
 
 const StreamsApplication = dynamic(() =>
   import('./application').then((mod) => ({ default: mod.StreamsApplication }))
@@ -110,19 +120,78 @@ export class StreamsAppPlugin
       appRoute: '/app/streams',
       category: DEFAULT_APP_CATEGORIES.management,
       order: 10000,
+      deepLinks: [
+        {
+          id: 'significantEventsDiscovery' satisfies SigEventsDeepLinkId,
+          title: i18n.translate('xpack.streams.significantEventsDiscovery.deepLinkTitle', {
+            defaultMessage: 'Significant Events',
+          }),
+          path: '/_discovery',
+          visibleIn: [],
+          keywords: ['significant events', 'sig events', 'discovery'],
+        },
+        {
+          id: 'significantEventsKnowledgeIndicators' satisfies SigEventsDeepLinkId,
+          title: i18n.translate('xpack.streams.significantEventsDiscovery.kiDeepLinkTitle', {
+            defaultMessage: 'Significant Events / KIs',
+          }),
+          path: '/_discovery/knowledge_indicators',
+          visibleIn: [],
+          keywords: [
+            'knowledge indicators',
+            'ki',
+            'kis',
+            'significant events',
+            'sig events',
+            'sig events kis',
+          ],
+        },
+        {
+          id: 'significantEventsEvents' satisfies SigEventsDeepLinkId,
+          title: i18n.translate('xpack.streams.significantEventsDiscovery.eventsDeepLinkTitle', {
+            defaultMessage: 'Significant Events / Events',
+          }),
+          path: '/_discovery/significant_events',
+          visibleIn: [],
+          keywords: ['events', 'significant events', 'sig events', 'sig events events'],
+        },
+        {
+          id: 'significantEventsRules' satisfies SigEventsDeepLinkId,
+          title: i18n.translate('xpack.streams.significantEventsDiscovery.rulesDeepLinkTitle', {
+            defaultMessage: 'Significant Events / Rules',
+          }),
+          path: '/_discovery/queries',
+          visibleIn: [],
+          keywords: ['rules', 'queries', 'significant events', 'sig events', 'sig events rules'],
+        },
+      ],
       updater$: from(startServicesPromise).pipe(
-        switchMap(([_, pluginsStart]) =>
-          pluginsStart.streams.navigationStatus$.pipe(
-            map(({ status }): AppUpdater => {
+        switchMap(([coreStart, pluginsStart]) =>
+          combineLatest([
+            pluginsStart.streams.navigationStatus$,
+            coreStart.uiSettings.get$(OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS_DISCOVERY),
+          ]).pipe(
+            map(([{ status }, isSignificantEventsDiscoveryEnabled]): AppUpdater => {
               return (app) => {
                 if (status !== 'enabled') {
                   return {
                     visibleIn: [],
+                    deepLinks: (app.deepLinks ?? []).map((link) => ({ ...link, visibleIn: [] })),
                   };
                 }
 
                 return {
                   visibleIn: ['sideNav', 'globalSearch'],
+                  deepLinks: (app.deepLinks ?? []).map((link) => {
+                    if (significantEventsDeepLinkIds.includes(link.id as SigEventsDeepLinkId)) {
+                      return {
+                        ...link,
+                        visibleIn: isSignificantEventsDiscoveryEnabled ? ['globalSearch'] : [],
+                      };
+                    }
+
+                    return link;
+                  }),
                 };
               };
             })


### PR DESCRIPTION
Adds core nav items of Sig Events Discovery (root, KIs, Rules and Events) to the Kibana's global search gated behind the `observability:streamsEnableSignificantEventsDiscovery` flag.