### PR TITLE
[ES|QL] Shorter placeholder for inline editor or small space

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -372,18 +372,16 @@ export function QuickSearchVisor({
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={false} css={styles.closeButtonWrapper}>
-        <EuiToolTip content={closeButtonAriaLabel} disableScreenReaderOutput>
-          <EuiButtonIcon
-            color="text"
-            display="base"
-            size="s"
-            iconSize="m"
-            onClick={onToggleVisor}
-            iconType="cross"
-            aria-label={closeButtonAriaLabel}
-            css={styles.closeButton}
-          />
-        </EuiToolTip>
+        <EuiButtonIcon
+          color="text"
+          display="base"
+          size="s"
+          iconSize="m"
+          onClick={onToggleVisor}
+          iconType="cross"
+          aria-label={closeButtonAriaLabel}
+          css={styles.closeButton}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -39,6 +39,8 @@ export interface QuickSearchVisorProps {
   query: string;
   // Handling smaller space for the visor
   isSpaceReduced?: boolean;
+  // Whether the editor is rendered inline (controls placeholder length)
+  isInline?: boolean;
   // Whether the visor is visible
   isVisible: boolean;
   // Callback when the query is updated and submitted
@@ -52,8 +54,16 @@ export const searchPlaceholder = i18n.translate('esqlEditor.visor.searchPlacehol
   defaultMessage: 'Filter your data using KQL',
 });
 
+const searchPlaceholderShort = i18n.translate('esqlEditor.visor.searchPlaceholderShort', {
+  defaultMessage: 'Filter using KQL',
+});
+
 const nlPlaceholder = i18n.translate('esqlEditor.visor.nlPlaceholder', {
   defaultMessage: 'Describe the query you want in plain language',
+});
+
+const nlPlaceholderShort = i18n.translate('esqlEditor.visor.nlPlaceholderShort', {
+  defaultMessage: 'Describe in plain language',
 });
 
 const closeButtonAriaLabel = i18n.translate('esqlEditor.visor.closeButtonAriaLabel', {
@@ -67,6 +77,7 @@ const techPreviewTooltip = i18n.translate('esqlEditor.visor.techPreviewTooltip',
 export function QuickSearchVisor({
   query,
   isSpaceReduced,
+  isInline,
   isVisible,
   onUpdateAndSubmitQuery,
   onToggleVisor,
@@ -76,6 +87,7 @@ export function QuickSearchVisor({
   const { kql, core, data } = kibana.services;
   const isNlToEsqlEnabled = useNlToEsqlCheck();
   const euiThemeContext = useEuiTheme();
+  const useShortPlaceholder = useMemo(() => isInline || isSpaceReduced, [isInline, isSpaceReduced]);
   const [selectedSources, setSelectedSources] = useState<EuiComboBoxOptionOption[]>([]);
   const [searchValue, setSearchValue] = useState('');
   const [visorMode, setVisorMode] = useState<VisorMode>(VisorMode.KQL);
@@ -327,7 +339,7 @@ export function QuickSearchVisor({
                       language: 'kuery',
                     }}
                     disableAutoFocus={false}
-                    placeholder={searchPlaceholder}
+                    placeholder={useShortPlaceholder ? searchPlaceholderShort : searchPlaceholder}
                     onChange={(newQuery) => {
                       onKqlValueChange(newQuery.query as string);
                     }}
@@ -348,7 +360,7 @@ export function QuickSearchVisor({
               ) : (
                 <NLInput
                   value={nlValue}
-                  placeholder={nlPlaceholder}
+                  placeholder={useShortPlaceholder ? nlPlaceholderShort : nlPlaceholder}
                   disabled={!isVisible || isNlLoading}
                   onChange={setNlValue}
                   onSubmit={onNlSubmit}

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIconTip,
+  EuiToolTip,
   useEuiTheme,
   type EuiComboBoxOptionOption,
 } from '@elastic/eui';

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -372,16 +372,18 @@ export function QuickSearchVisor({
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={false} css={styles.closeButtonWrapper}>
-        <EuiButtonIcon
-          color="text"
-          display="base"
-          size="s"
-          iconSize="m"
-          onClick={onToggleVisor}
-          iconType="cross"
-          aria-label={closeButtonAriaLabel}
-          css={styles.closeButton}
-        />
+        <EuiToolTip content={closeButtonAriaLabel} disableScreenReaderOutput>
+          <EuiButtonIcon
+            color="text"
+            display="base"
+            size="s"
+            iconSize="m"
+            onClick={onToggleVisor}
+            iconType="cross"
+            aria-label={closeButtonAriaLabel}
+            css={styles.closeButton}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -902,6 +902,7 @@ const ESQLEditorInternal = function ESQLEditor({
       {!hideQuickSearch && (
         <QuickSearchVisor
           query={code}
+          isInline={Boolean(editorIsInline)}
           isSpaceReduced={Boolean(editorIsInline) || measuredEditorWidth < BREAKPOINT_WIDTH}
           isVisible={isVisorOpen}
           onUpdateAndSubmitQuery={(newQuery) =>


### PR DESCRIPTION
## Summary

When the editor is inline, the visor placeholders do not look very nice. I am shortening them in these cases.

