### PR TITLE
[9.3] [Synthetics] Wait for active space before fetching cross-space monitor in flyout !! (#270936)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import * as reduxHooks from 'react-redux';
 import { render } from '../../../../utils/testing/rtl_helpers';
 import { fireEvent } from '@testing-library/react';
 import { MonitorDetailFlyout } from './monitor_detail_flyout';
@@ -15,6 +16,7 @@ import * as statusByLocation from '../../../../hooks/use_status_by_location';
 import * as monitorDetailLocator from '../../../../hooks/use_monitor_detail_locator';
 import { TagsList } from '@kbn/observability-shared-plugin/public';
 import { useFetcher } from '@kbn/observability-shared-plugin/public';
+import { getMonitorAction } from '../../../../state';
 
 jest.mock('@kbn/observability-shared-plugin/public');
 
@@ -132,6 +134,49 @@ describe('Monitor Detail Flyout', () => {
     );
 
     expect(getByRole('progressbar'));
+  });
+
+  it('does not dispatch getMonitorAction before the active space resolves', () => {
+    // Simulate `useKibanaSpace` (which is the only `useFetcher` consumer in
+    // this component) still loading — `space` is undefined across renders.
+    // Previously the flyout would dispatch `getMonitorAction.get` without
+    // `spaceId`, hit the active space, and 404 for cross-space monitors.
+    // The retry that fires once `space` resolves was then silently dropped
+    // by the `takeLeading` saga while the first call was still in flight,
+    // leaving the 404 in Redux state forever.
+    const previousFetcherImpl = useFetcherMock.getMockImplementation();
+    useFetcherMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      refetch: jest.fn(),
+    });
+
+    const mockDispatch = jest.fn();
+    jest.spyOn(reduxHooks, 'useDispatch').mockReturnValue(mockDispatch);
+
+    try {
+      render(
+        <MonitorDetailFlyout
+          configId="cross-space-monitor"
+          id="cross-space-monitor"
+          location="US East"
+          locationId="us-east"
+          spaces={['team-a']}
+          onClose={jest.fn()}
+          onEnabledChange={jest.fn()}
+          onLocationChange={jest.fn()}
+        />
+      );
+
+      const getMonitorCalls = mockDispatch.mock.calls.filter(
+        ([action]) => action?.type === getMonitorAction.get.type
+      );
+      expect(getMonitorCalls).toHaveLength(0);
+    } finally {
+      if (previousFetcherImpl) {
+        useFetcherMock.mockImplementation(previousFetcherImpl);
+      }
+    }
   });
 
   it('renders details for fetch success', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -268,13 +268,21 @@ export function MonitorDetailFlyout(props: Props) {
   const { spaceId: crossSpaceId } = getMonitorSpaceToAppend(space, spaces);
 
   useEffect(() => {
+    // `useKibanaSpace` resolves asynchronously, so `space` is undefined on
+    // the first render. `getMonitorSpaceToAppend` short-circuits to `{}` in
+    // that case, which means an early dispatch would fetch the SO from the
+    // active space and 404 for cross-space monitors. The follow-up dispatch
+    // (after `space` resolves) is silently dropped by the `takeLeading`
+    // saga while the first request is still in flight, leaving the 404 in
+    // Redux state forever. Wait for the active space before dispatching.
+    if (!space) return;
     dispatch(
       getMonitorAction.get({
         monitorId: configId,
         ...(crossSpaceId ? { spaceId: crossSpaceId } : {}),
       })
     );
-  }, [configId, crossSpaceId, dispatch, upsertSuccess]);
+  }, [configId, crossSpaceId, dispatch, space, upsertSuccess]);
 
   const [isActionsPopoverOpen, setIsActionsPopoverOpen] = useState(false);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[Synthetics] Wait for active space before fetching cross-space monitor in flyout !! (#270936)](https://github.com/elastic/kibana/pull/270936)

## Conflicts

- `monitor_detail_flyout.tsx` — the upstream diff was rebased on top of `if (isRemote) return;` and `isRemote` in the effect's dependency array, which landed via [#265748](https://github.com/elastic/kibana/pull/265748) (not yet backported to 9.3). The space guard is the only change this PR is meant to ship, so the resolution keeps `if (!space) return;` and adds `space` to the dependency array without pulling in the unrelated `isRemote` early return.
- `monitor_detail_flyout.test.tsx` — the import line was conflicting with later changes that brought in `useEsSearch` and `OBSERVABILITY_MONITOR_ATTACHMENT_TYPE_ID` (not in 9.3). Only the `getMonitorAction` import — required by the new jest case — was added.

### Made with [backport](https://github.com/sorenlouv/backport)

Made with [Cursor](https://cursor.com)