### PR TITLE
[8.19] [core/http] Fix FIPS-mode cookie sealing (Deriving bits failed) (#268045)

### DIFF
--- a/src/core/packages/http/server-internal/src/cookie_session_storage.ts
+++ b/src/core/packages/http/server-internal/src/cookie_session_storage.ts
@@ -142,6 +142,24 @@ export async function createCookieSessionStorageFactory<T extends object>(
           definition.isSameSite = 'None;Partitioned';
         }
       },
+      // Override @hapi/iron's defaults so cookie sealing works under FIPS-mode OpenSSL.
+      // Iron's default is iterations=1, which OpenSSL's FIPS provider rejects with
+      // "Deriving bits failed". 1000 is the SP 800-132 minimum and is sufficient given
+      // encryptionKey is already required to be a 32+ char high-entropy value.
+      iron: {
+        encryption: {
+          saltBits: 256,
+          algorithm: 'aes-256-cbc',
+          iterations: 1000,
+          minPasswordlength: 32,
+        },
+        integrity: {
+          saltBits: 256,
+          algorithm: 'sha256',
+          iterations: 1000,
+          minPasswordlength: 32,
+        },
+      },
     },
     validate: async (req: Request, session: T | T[]) => {
       const result = cookieOptions.validate(session);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[core/http] Fix FIPS-mode cookie sealing (Deriving bits failed) (#268045)](https://github.com/elastic/kibana/pull/268045)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryan","email":"ryan.godfrey@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T12:08:56Z","message":"[core/http] Fix FIPS-mode cookie sealing (Deriving bits failed) (#268045)\n\n> [!IMPORTANT]\n> this is a backwards-incompatible change. Existing sessions will be\nterminated following an upgrade to a version which includes this change\n\n\n## Summary\n\nIn FIPS mode, login succeeds at the auth layer but the very next\nresponse (the post-login redirect that sets the `sid` cookie) fails\nwith:\n\n```\nFailed to encode cookie (sid) value: Deriving bits failed\n```\n\n…and the user is bounced back to the login page.\n\nRoot cause: `@hapi/iron`'s PBKDF2 defaults are `iterations: 1`, which\nOpenSSL's FIPS provider rejects (`SP 800-132` requires ≥ 1000\niterations). This PR plumbs a custom `iron` config through the\nauth-cookie strategy in `cookie_session_storage.ts`, setting iterations\nto **1000** for both encryption and integrity blocks.\n\n## Why 1000\n\n- `SP 800-132` minimum for FIPS-approved PBKDF2 — clears the OpenSSL\nFIPS check.\n- Iron caps PBKDF2's load to one call per seal/unseal, so cookie work\nhappens once at login + once per authenticated request. 1000 iterations\nis ~1 ms; bumping higher would add user-visible latency to every\nauthenticated request without buying real security here.\n- The iteration count's job is to slow down brute force on weak\npasswords. Kibana already requires `xpack.security.encryptionKey` to be\n≥ 32 characters, so the input is already high-entropy random material.\n\n## Risk / impact\n\n- **Cookie format changes.** Existing `sid` cookies in user browsers\nwill fail to decrypt after upgrade, forcing a single re-login. No data\nloss; worth a release note.\n- The `iron` field is officially typed on `StateOptions` from\n`@hapi/statehood` and forwarded to `Iron.seal`/`Iron.unseal`, so this is\na supported usage path.\n- No behavior change for non-FIPS deployments beyond the cookie-format\nreset.\n\n## How it was found\n\nReproduced locally against the 9.3.4 staging FIPS build\n(`elasticsearch-cloud-ess-fips` + `kibana-cloud-fips`):\n1. Without the fix: login → redirect → `Deriving bits failed` → bounce\nto login page.\n2. Verified the failing call path by tracing\n`@hapi/statehood/lib/index.js:486 → prepareValue → Iron.seal` (default\n`iterations: 1`).\n3. Confirmed `iterations: 1000` clears OpenSSL FIPS rejection in\nisolation against bundled Node, and that `iron` propagates correctly\nthrough `@hapi/cookie`'s `.unknown()` schema → `server.state()` →\nstatehood → iron.\n4. Patched the running Kibana container with this exact change; login\nthen completes successfully.\n\n## Test plan\n\n- [ ] CI green\n- [ ] Manual: bring up a FIPS-mode Kibana + ES, log in as `elastic`,\nconfirm no `Deriving bits failed` and that the session persists across\npage refreshes\n- [ ] Manual: non-FIPS deployment — verify login still works and\nexisting sessions are reset cleanly (one expected re-login on first\ndeploy)\n\nCo-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"ae93a37d9485fac407709c634409c12c1c69714f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","Feature:FIPS","ci:build-docker-fips","v9.5.0"],"title":"[core/http] Fix FIPS-mode cookie sealing (Deriving bits failed)","number":268045,"url":"https://github.com/elastic/kibana/pull/268045","mergeCommit":{"message":"[core/http] Fix FIPS-mode cookie sealing (Deriving bits failed) (#268045)\n\n> [!IMPORTANT]\n> this is a backwards-incompatible change. Existing sessions will be\nterminated following an upgrade to a version which includes this change\n\n\n## Summary\n\nIn FIPS mode, login succeeds at the auth layer but the very next\nresponse (the post-login redirect that sets the `sid` cookie) fails\nwith:\n\n```\nFailed to encode cookie (sid) value: Deriving bits failed\n```\n\n…and the user is bounced back to the login page.\n\nRoot cause: `@hapi/iron`'s PBKDF2 defaults are `iterations: 1`, which\nOpenSSL's FIPS provider rejects (`SP 800-132` requires ≥ 1000\niterations). This PR plumbs a custom `iron` config through the\nauth-cookie strategy in `cookie_session_storage.ts`, setting iterations\nto **1000** for both encryption and integrity blocks.\n\n## Why 1000\n\n- `SP 800-132` minimum for FIPS-approved PBKDF2 — clears the OpenSSL\nFIPS check.\n- Iron caps PBKDF2's load to one call per seal/unseal, so cookie work\nhappens once at login + once per authenticated request. 1000 iterations\nis ~1 ms; bumping higher would add user-visible latency to every\nauthenticated request without buying real security here.\n- The iteration count's job is to slow down brute force on weak\npasswords. Kibana already requires `xpack.security.encryptionKey` to be\n≥ 32 characters, so the input is already high-entropy random material.\n\n## Risk / impact\n\n- **Cookie format changes.** Existing `sid` cookies in user browsers\nwill fail to decrypt after upgrade, forcing a single re-login. No data\nloss; worth a release note.\n- The `iron` field is officially typed on `StateOptions` from\n`@hapi/statehood` and forwarded to `Iron.seal`/`Iron.unseal`, so this is\na supported usage path.\n- No behavior change for non-FIPS deployments beyond the cookie-format\nreset.\n\n## How it was found\n\nReproduced locally against the 9.3.4 staging FIPS build\n(`elasticsearch-cloud-ess-fips` + `kibana-cloud-fips`):\n1. Without the fix: login → redirect → `Deriving bits failed` → bounce\nto login page.\n2. Verified the failing call path by tracing\n`@hapi/statehood/lib/index.js:486 → prepareValue → Iron.seal` (default\n`iterations: 1`).\n3. Confirmed `iterations: 1000` clears OpenSSL FIPS rejection in\nisolation against bundled Node, and that `iron` propagates correctly\nthrough `@hapi/cookie`'s `.unknown()` schema → `server.state()` →\nstatehood → iron.\n4. Patched the running Kibana container with this exact change; login\nthen completes successfully.\n\n## Test plan\n\n- [ ] CI green\n- [ ] Manual: bring up a FIPS-mode Kibana + ES, log in as `elastic`,\nconfirm no `Deriving bits failed` and that the session persists across\npage refreshes\n- [ ] Manual: non-FIPS deployment — verify login still works and\nexisting sessions are reset cleanly (one expected re-login on first\ndeploy)\n\nCo-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"ae93a37d9485fac407709c634409c12c1c69714f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268045","number":268045,"mergeCommit":{"message":"[core/http] Fix FIPS-mode cookie sealing (Deriving bits failed) (#268045)\n\n> [!IMPORTANT]\n> this is a backwards-incompatible change. Existing sessions will be\nterminated following an upgrade to a version which includes this change\n\n\n## Summary\n\nIn FIPS mode, login succeeds at the auth layer but the very next\nresponse (the post-login redirect that sets the `sid` cookie) fails\nwith:\n\n```\nFailed to encode cookie (sid) value: Deriving bits failed\n```\n\n…and the user is bounced back to the login page.\n\nRoot cause: `@hapi/iron`'s PBKDF2 defaults are `iterations: 1`, which\nOpenSSL's FIPS provider rejects (`SP 800-132` requires ≥ 1000\niterations). This PR plumbs a custom `iron` config through the\nauth-cookie strategy in `cookie_session_storage.ts`, setting iterations\nto **1000** for both encryption and integrity blocks.\n\n## Why 1000\n\n- `SP 800-132` minimum for FIPS-approved PBKDF2 — clears the OpenSSL\nFIPS check.\n- Iron caps PBKDF2's load to one call per seal/unseal, so cookie work\nhappens once at login + once per authenticated request. 1000 iterations\nis ~1 ms; bumping higher would add user-visible latency to every\nauthenticated request without buying real security here.\n- The iteration count's job is to slow down brute force on weak\npasswords. Kibana already requires `xpack.security.encryptionKey` to be\n≥ 32 characters, so the input is already high-entropy random material.\n\n## Risk / impact\n\n- **Cookie format changes.** Existing `sid` cookies in user browsers\nwill fail to decrypt after upgrade, forcing a single re-login. No data\nloss; worth a release note.\n- The `iron` field is officially typed on `StateOptions` from\n`@hapi/statehood` and forwarded to `Iron.seal`/`Iron.unseal`, so this is\na supported usage path.\n- No behavior change for non-FIPS deployments beyond the cookie-format\nreset.\n\n## How it was found\n\nReproduced locally against the 9.3.4 staging FIPS build\n(`elasticsearch-cloud-ess-fips` + `kibana-cloud-fips`):\n1. Without the fix: login → redirect → `Deriving bits failed` → bounce\nto login page.\n2. Verified the failing call path by tracing\n`@hapi/statehood/lib/index.js:486 → prepareValue → Iron.seal` (default\n`iterations: 1`).\n3. Confirmed `iterations: 1000` clears OpenSSL FIPS rejection in\nisolation against bundled Node, and that `iron` propagates correctly\nthrough `@hapi/cookie`'s `.unknown()` schema → `server.state()` →\nstatehood → iron.\n4. Patched the running Kibana container with this exact change; login\nthen completes successfully.\n\n## Test plan\n\n- [ ] CI green\n- [ ] Manual: bring up a FIPS-mode Kibana + ES, log in as `elastic`,\nconfirm no `Deriving bits failed` and that the session persists across\npage refreshes\n- [ ] Manual: non-FIPS deployment — verify login still works and\nexisting sessions are reset cleanly (one expected re-login on first\ndeploy)\n\nCo-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"ae93a37d9485fac407709c634409c12c1c69714f"}},{"url":"https://github.com/elastic/kibana/pull/271693","number":271693,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/271694","number":271694,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->