### PR TITLE
[CODEOWNERS] Move Fleet cloud_connector ownership from contextual-security-apps to cloud-services

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3330,8 +3330,10 @@ x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details
 
 ## Fleet plugin (co-owned with Fleet team)
 x-pack/platform/plugins/shared/fleet/public/components/cloud_security_posture @elastic/fleet @elastic/contextual-security-apps
-x-pack/platform/plugins/shared/fleet/public/components/cloud_connector @elastic/fleet @elastic/contextual-security-apps
-x-pack/platform/plugins/shared/fleet/common/services/cloud_connectors @elastic/fleet @elastic/contextual-security-apps
+x-pack/platform/plugins/shared/fleet/public/components/cloud_connector @elastic/fleet @elastic/cloud-services
+x-pack/platform/plugins/shared/fleet/common/services/cloud_connectors @elastic/fleet @elastic/cloud-services
+x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector @elastic/fleet @elastic/cloud-services
+x-pack/platform/plugins/shared/fleet/server/services/cloud_connectors @elastic/fleet @elastic/cloud-services
 x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/cloud_security_posture @elastic/fleet @elastic/contextual-security-apps
 x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/cloud_posture_third_party_support_callout.* @elastic/fleet @elastic/contextual-security-apps
 ## SessionView tests


### PR DESCRIPTION
## Summary
- Reassigns `@elastic/contextual-security-apps` co-ownership of Fleet's `cloud_connector` code to `@elastic/cloud-services`.
- Adds explicit co-ownership for the server-side `cloud_connector` route and services dirs (previously only inherited from the parent `fleet` rule).
- Context: [kibana#271195 (comment)](https://github.com/elastic/kibana/pull/271195#issuecomment-4553558725).

## Paths affected
| Path | Before | After |
| --- | --- | --- |
| `x-pack/platform/plugins/shared/fleet/public/components/cloud_connector` | `@elastic/fleet @elastic/contextual-security-apps` | `@elastic/fleet @elastic/cloud-services` |
| `x-pack/platform/plugins/shared/fleet/common/services/cloud_connectors` | `@elastic/fleet @elastic/contextual-security-apps` | `@elastic/fleet @elastic/cloud-services` |
| `x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector` | (inherited `@elastic/fleet`) | `@elastic/fleet @elastic/cloud-services` *(new)* |
| `x-pack/platform/plugins/shared/fleet/server/services/cloud_connectors` | (inherited `@elastic/fleet`) | `@elastic/fleet @elastic/cloud-services` *(new)* |

Other `cloud_security_posture` / `cloud_posture_third_party_support_callout` lines in the same block are intentionally left as-is.

## Test plan
- [ ] CI CODEOWNERS validation passes.
- [ ] Confirm a follow-up PR touching `fleet/public/components/cloud_connector/**` auto-requests review from `@elastic/cloud-services` (and not `@elastic/contextual-security-apps`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)