### PR TITLE
[Profiling] Fix profiling API tests when running on test lanes (again)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/server/utils/create_profiling_es_client.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/utils/create_profiling_es_client.ts
@@ -19,6 +19,8 @@ import type {
 } from '@kbn/profiling-utils';
 import { withProfilingSpan } from './with_profiling_span';
 
+const PROFILING_STATUS_TIMEOUT_SECONDS = 60;
+
 export function cancelEsRequestOnAbort<T extends Promise<any>>(
   promise: T,
   request: KibanaRequest,
@@ -129,13 +131,15 @@ export function createProfilingEsClient({
             {
               method: 'GET',
               path: encodeURI(
-                `/_profiling/status?wait_for_resources_created=${waitForResourcesCreated}`
+                `/_profiling/status?wait_for_resources_created=${waitForResourcesCreated}&timeout=${
+                  PROFILING_STATUS_TIMEOUT_SECONDS + 5
+                }s`
               ),
             },
             {
               signal: controller.signal,
               meta: true,
-              requestTimeout: 60000,
+              requestTimeout: PROFILING_STATUS_TIMEOUT_SECONDS * 1000,
               maxRetries: 5,
               retryOnTimeout: true,
             }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/README.md
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/README.md
@@ -13,6 +13,7 @@ node scripts/scout.js start-server --arch serverless --domain [search|observabil
 ### Run the Tests
 
 **Note**: Profiling resources and test data are automatically set up when you run the tests. The global setup hook will:
+
 - Set up profiling Elasticsearch resources via `/api/profiling/setup/es_resources`
 - Load test profiling data from 'x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/worker/profiling/test_data'
 - Skip setup if resources and data are already present
@@ -28,7 +29,16 @@ node scripts/playwright test --config x-pack/solutions/observability/plugins/pro
 ## Test Categories
 
 Tests are tagged with:
+
 - `@local-stateful-classic` - Stateful tests
 - `@local-serverless-observability_complete` - Serverless tests - currently not supported in Universal Profiling
 
 Test results are available in `x-pack/solutions/observability/plugins/profiling/test/scout/ui/output`
+
+## Api Tests Execution Order
+
+While UI tests run in parallel, api tests can't be parallelized as they test different setups that could conflict with one another. To avoid constant setups and cleanups of profiling resources, which can lead to performance issues and flaky tests, api tests must run sequentially and in a predefined order.
+
+This strict ordering will ensure suites testing features for missing setups will run before those requiring partial setups, which in turn run before others requiring full setup and data. Thanks to it, the tests can limit the amount of calls to setup resources and cleanup, instead of having to setup the whole thing in each `beforeAll` as well as having to cleanup in every `afterAll`. The global teardown hook that runs after all suites will ensure cleanup is done before terminating the profiling suite execution ensuring tests cleanup after themselves and do not pollute test lanes when running in one.
+
+By default, playwright runs tests in the order they're discovered when read from the test directory. This is why api test files are prefixed with a given number which indicates the order they're expected to run, being 00\_\* the first test to run. If you're adding a new test, consider your suite's needs in terms of setup and data. If your tests concern features when no setup and/or data is present be sure to run them **before** tests that do configure resources and data. And likewise, if your test is configuring resources or adding data make sure it runs **after** tests that expect empty config or data.

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts
@@ -18,24 +18,9 @@ apiTest.describe(
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
 
-    apiTest.beforeAll(async ({ profilingSetup, requestAuth }) => {
+    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
       await profilingSetup.cleanup();
-
-      // Poll until ES state converges after deleting data streams and indices.
-      await expect
-        .poll(
-          async () => {
-            const status = await profilingSetup.checkStatus();
-            return status.has_setup === false && status.has_data === false;
-          },
-          {
-            timeout: 30_000,
-            intervals: [500, 1000, 2000, 4000],
-            message:
-              'Profiling status did not converge to has_setup: false, has_data: false after cleanup',
-          }
-        )
-        .toBe(true);
+      await profilingHelper.cleanupPolicies();
 
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
@@ -51,8 +36,8 @@ apiTest.describe(
       });
       const adminStatus = adminRes.body;
       expect(adminStatus.has_setup).toBe(false);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_data).toBeDefined();
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
     });
 
     apiTest('Viewer users', async ({ apiClient }) => {
@@ -65,8 +50,8 @@ apiTest.describe(
       });
       const readStatus = readRes.body;
       expect(readStatus.has_setup).toBe(false);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_data).toBeDefined();
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts
@@ -18,47 +18,16 @@ apiTest.describe(
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
 
-    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, esClient, requestAuth }) => {
-      await profilingHelper.installPolicies();
-      await profilingSetup.setupResources();
+    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
+      const status = await profilingSetup.checkStatus();
 
-      // Delete documents (not indices) so has_data becomes false while has_setup
-      // stays true. Runs inside the poll because shards of newly-created
-      // .profiling-* data streams may still be initializing right after
-      // setupResources(), causing search_phase_execution_exception.
-      await expect
-        .poll(
-          async () => {
-            try {
-              await esClient.deleteByQuery({
-                index: 'profiling-events-*',
-                query: { match_all: {} },
-                ignore_unavailable: true,
-                refresh: true,
-                conflicts: 'proceed',
-              });
-            } catch {
-              return false;
-            }
-            const status = await profilingSetup.checkStatus();
-            return status.has_setup === true && status.has_data === false;
-          },
-          {
-            timeout: 30_000,
-            intervals: [500, 1000, 2000, 4000],
-            message:
-              'Profiling status did not converge to has_setup: true, has_data: false after deleting profiling documents',
-          }
-        )
-        .toBe(true);
+      if (!status.has_setup) {
+        await profilingHelper.installPolicies();
+        await profilingSetup.setupResources();
+      }
 
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
-    });
-
-    apiTest.afterAll(async ({ profilingSetup, profilingHelper }) => {
-      await profilingHelper.cleanupPolicies();
-      await profilingSetup.cleanup();
     });
 
     apiTest('Admin user', async ({ apiClient }) => {
@@ -72,8 +41,8 @@ apiTest.describe(
 
       const adminStatus = adminRes.body;
       expect(adminStatus.has_setup).toBe(true);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_data).toBeDefined();
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
     });
 
     apiTest('Viewer user', async ({ apiClient }) => {
@@ -87,8 +56,8 @@ apiTest.describe(
 
       const readStatus = readRes.body;
       expect(readStatus.has_setup).toBe(true);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_data).toBeDefined();
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts
@@ -16,32 +16,23 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
   let adminApiCreditials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ requestAuth, profilingHelper, profilingSetup }) => {
-    await profilingHelper.installPolicies();
-    await profilingSetup.setupResources();
-    await profilingSetup.loadData(esArchiversPath);
+    let status = await profilingSetup.checkStatus();
 
-    await expect
-      .poll(
-        async () => {
-          const status = await profilingSetup.checkStatus();
-          return status.has_setup === true && status.has_data === true;
-        },
-        {
-          timeout: 30_000,
-          intervals: [500, 1000, 2000, 4000],
-          message:
-            'Profiling status did not converge to has_setup: true, has_data: true after setupResources + loadData',
-        }
-      )
-      .toBe(true);
+    if (!status.has_setup) {
+      await profilingHelper.installPolicies();
+      await profilingSetup.setupResources();
+    }
+
+    if (!status.has_data) {
+      await profilingSetup.loadData(esArchiversPath);
+    }
+
+    status = await profilingSetup.checkStatus();
+    expect(status.has_setup).toBe(true);
+    expect(status.has_data).toBe(true);
 
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
     adminApiCreditials = await requestAuth.getApiKey('admin');
-  });
-
-  apiTest.afterAll(async ({ profilingSetup, profilingHelper }) => {
-    await profilingHelper.cleanupPolicies();
-    await profilingSetup.cleanup();
   });
 
   apiTest('Admin user', async ({ apiClient }) => {
@@ -55,7 +46,7 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
     const adminStatus = adminRes.body;
     expect(adminStatus.has_setup).toBe(true);
     expect(adminStatus.has_data).toBe(true);
-    expect(adminStatus.pre_8_9_1_data).toBe(false);
+    expect(adminStatus.pre_8_9_1_data).toBeDefined();
   });
 
   apiTest('Viewer user', async ({ apiClient }) => {
@@ -70,7 +61,7 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
     const readStatus = readRes.body;
     expect(readStatus.has_setup).toBe(true);
     expect(readStatus.has_data).toBe(true);
-    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBeDefined();
     expect(readStatus.has_required_role).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts
@@ -12,17 +12,12 @@ import { apiTest } from '../../common/fixtures';
 import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/constants';
 
 apiTest.describe('Collector integration is not installed', { tag: tags.stateful.classic }, () => {
-  // Profiling POST /setup can wait on ES plugin resources after Fleet policy creation — allow a longer hook budget than the default project timeout (60s).
-  // eslint-disable-next-line @kbn/eslint/scout_no_describe_configure -- extended timeout applies to hooks (beforeAll); see https://playwright.dev/docs/test-timeouts
-  apiTest.describe.configure({ timeout: 180_000 });
-
   let viewerApiCreditials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ requestAuth, profilingSetup, profilingHelper }) => {
-    await profilingHelper.installPolicies();
-
     let ids = await profilingHelper.getPolicyIds();
     if (!ids.collectorId || !ids.symbolizerId) {
+      await profilingHelper.installPolicies();
       await profilingSetup.setupResources();
       ids = await profilingHelper.getPolicyIds();
     }
@@ -39,11 +34,6 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
     expect(status.has_data).toBe(true);
 
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
-  });
-
-  apiTest.afterAll(async ({ profilingHelper, profilingSetup }) => {
-    await profilingHelper.cleanupPolicies();
-    await profilingSetup.cleanup();
   });
 
   // Fleet package_policies.delete is eventually consistent — a subsequent /api/profiling/setup/es_resources call may still see the policy as installed for a brief window. Polling until `has_setup` reflects the deletion (cloud: false; self-managed: unchanged true) keeps the test deterministic.
@@ -95,7 +85,7 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
     const readStatus = await getViewerStatus(apiClient);
     expect(readStatus.has_setup).toBe(readStatus.type !== 'cloud');
     expect(readStatus.has_data).toBe(true);
-    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBeDefined();
     expect(readStatus.has_required_role).toBe(false);
   });
 
@@ -114,7 +104,7 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
       const readStatus = await getViewerStatus(apiClient);
       expect(readStatus.has_setup).toBe(readStatus.type !== 'cloud');
       expect(readStatus.has_data).toBe(true);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     }
   );


### PR DESCRIPTION
## Summary

This PR is the result of investigating and trying to fix the latest flakiness issues for profiling API suites as reported in this [issue comment](https://github.com/elastic/kibana/issues/248929#issuecomment-4563292721)

The error message we're dealing with this time is
```
KbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {"statusCode":500,"error":"Internal Server Error","message":"Error while setting up Universal Profiling"}
```
Which at first glance looked awfully similar to the errors #270623 was targeting which read
```
KbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {"statusCode":500,"error":"Internal Server Error","message":"Error while setting up Universal Profiling","attributes":{"cause":"Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found","name":"Error"}}
```

But looking more carefully at both messages, we can notice the error now doesn't have an explicit cause, while before it complained about `Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found` While these are good news as at least we know #270623 did fix something, but the current issue merits deeper investigation

## The Symptom: ES returning a 408 response

### Background

The Universal Profiling setup flow in Kibana ends with a call to
`GET /_profiling/status?wait_for_resources_created=true`. This is a long-polling
endpoint: when `wait_for_resources_created=true`, ES holds the connection open and
watches for cluster state changes, responding only once all profiling resources
(index templates, ILM policies, data streams) are confirmed created — or when it
times out.

### Why Kibana sees a 408

The problem is a **race between two timeouts** that Kibana was losing every time.

**ES side:**
[`RestGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/rest/RestGetStatusAction.java)
parses the request and sets the server-side wait budget:

```java
restRequest.paramAsTime("timeout", TimeValue.THIRTY_SECONDS)
```

The default server-side timeout is **30 seconds** when no `timeout=` query parameter
is provided.
[`TransportGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java)
uses this value to register a `ClusterStateObserver` that waits up to that timeout
for `resolver::isResourcesCreated` to become true. When the timeout elapses and
resources still aren't ready, the `onTimeout` callback fires:

```java
@Override
public void onTimeout(TimeValue timeout) {
    resolver.execute(clusterService.state(), ActionListener.wrap(response -> {
        response.setTimedOut(true);
        listener.onResponse(response);
    }, listener::onFailure));
}
```

ES then sends back a **completed HTTP response** with status code 408, via this
mapping in
[`GetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetStatusAction.java):

```java
public RestStatus status() {
    return timedOut ? RestStatus.REQUEST_TIMEOUT : RestStatus.OK;
}
```

The response body contains
`{ profiling: { enabled: true }, resource_management: { enabled: true }, resources: { created: false } }`
— the current partial status at timeout.

**Kibana side:** The call was configured with `requestTimeout: 60_000` — a 60-second
client-side budget. Since ES's default server timeout is 30s and Kibana's was 60s,
**ES always won the race**: it responded with a 408 at ~30s, well before Kibana's
60s client timeout ever fired.

### Why that 408 was not retried

A 408 response is a **completed HTTP exchange** from the transport's perspective.
The `@elastic/transport` client only auto-retries on `TimeoutError` (client-side
timeout before any response arrives) and HTTP 502/503/504. The existing options
`retryOnTimeout: true` and `maxRetries: 5` are both gated on a client-side
`TimeoutError` — they never triggered because Kibana received a valid HTTP response
(just with status 408). The 408 was surfaced as a `ResponseError` and returned to
the user as a failure with no retry attempt.

### The fix

By appending `&timeout=65s` to the request path, we explicitly tell ES to wait
**65 seconds** server-side before giving up. Kibana's `requestTimeout: 60_000` now
wins the race — it fires 5 seconds before ES would return a 408. The resulting
client-side `TimeoutError` is exactly what `retryOnTimeout: true` + `maxRetries: 5`
was already designed to handle: up to 6 attempts, each with a fresh 60s budget,
with bounded exponential backoff between retries. No code path that previously
observed a 60s per-attempt budget is affected.

This not only affects test runs, but it will also correct this behaviour in the actual profiling UI. In case ES is slow to respond the request will keep retrying for longer than 30s (as it was always intended) instead of failing and showing an error in the UI after 30s.

The code for this fix is in e8fe7a24896c3d028ec4982c1eb128732fd87887. 

### Is the error gone?

While the problem described was an actual oversight we had in Kibana, this error is a symptom rather than the cause. After implementing this change we were no longer experiencing 408s but a new problem came around. Tests weren't failing mid run anymore but now the default test runtime timeout of 60s was being hit. My first instinct was bumping the timeout up, but even 180s wasn't enough. At this point it was clear the 408s coming from ES were just the way the issue was surfacing, while the real problem was why was ES taking so long to complete the profiling setup process

## The Root Cause: Profiling is constantly setup and cleaned up

### Background

The API suites have different requirements when it comes to profiling resources and/or data existing or not during test execution. Because we're also verifying how the system behaves when setup or data is missing as well as when everything is already wired up, we can't have a single global setup hook that pre-loads everything and leaves profiling setup and data ingested.

This is also the reason why these suites aren't parallel and instead run sequentially. We can't ran suites concurrently because test requirements would conflict with one another. But, even so they run sequentially, each test was being treated as a completely independent unit. What this means is each test was setting up (or cleaning up) all the resources it required as well as completely cleaning up after each one. This situation lead to elasticsearch being continuously bombarded with request to setup resources quickly followed by requests to delete those same resources it just created, repeated for each suite in the profiling config. Depending on how much work ES is dealing with and the state it was left in by other tests in the lane it could lead to the situation observed above where it starts to become overwhelmed and the setup call would take too long.

### The Fix

Thanks to test running sequentially, we can optimise the execution process by carefully controlling the order in which each suite runs. If we can ensure suites expecting empty resources and/or data run first and then are followed by suites that do fully setup and load data, we can reduce the amount of times we're loading and offloading resources, reducing the impact tests have on ES. While ideally each test would be 100% independent from the rest, this is not the environment tests will be running on specially on CI with tests lanes. Test shouldn't make the assumption that they're running on new and clean environments, so this PR adapts these suites to be resilient to polluted and overloaded environments.

By default, playwright runs test in the same order they're discovered from the test dir, aka, alphabetically. To ensure tests remain ordered as we expect them to be going forward, each test file is now prefixed by a number. The first test to run is prefixed 00_* With this in mind, I've modified and ordered each suite to try to reduce the number of setup and cleanup calls. While each tests will still make sure the environment is in the state it's expect in a `beforeAll` hook, each setup call is now guarded. This way, if resource or data already exist we won't try to set them up again. Also, I've removed the `afterAll` hooks that were cleaning up everything profiling-related after each suite ran. If test 02 creates the ES resources, test 03 can reuse those instead of having to create them all over again. And becase each test still checks if everything they expect is in place, they remain independent of each other if they need to. 

For instance, if test 02 was skipped or removed it wouldn't cause test 03 to then break as 03 is capable of setting up the environment as it expects it to be. Each suite maintains it's capability to set itself up for success while also gaining the ability to reuse pre-existing resources and data data other tests might have already created before them


<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->