### PR TITLE
[8.19] Remove js-sha256 dependency (#271339)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1216,7 +1216,6 @@
     "joi-to-json": "4.3.2",
     "jquery": "3.7.1",
     "js-search": "1.4.3",
-    "js-sha256": "0.11.1",
     "js-yaml": "4.1.1",
     "jsdom": "20.0.1",
     "json-schema-to-ts": "2.9.1",

--- a/renovate.json
+++ b/renovate.json
@@ -1785,7 +1785,6 @@
         "node-forge",
         "formik",
         "handlebars",
-        "js-sha256",
         "js-yaml",
         "magic-bytes.js",
         "minimist",

--- a/x-pack/platform/plugins/shared/cases/public/components/use_push_to_service/callout/helpers.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/use_push_to_service/callout/helpers.test.tsx
@@ -5,24 +5,23 @@
  * 2.0.
  */
 
-import { sha256 } from 'js-sha256';
 import { createCalloutId } from './helpers';
 
 describe('createCalloutId', () => {
   it('creates id correctly with one id', () => {
-    const digest = sha256('one');
+    const digest = encodeURIComponent('one');
     const id = createCalloutId(['one']);
     expect(id).toBe(digest);
   });
 
   it('creates id correctly with multiples ids', () => {
-    const digest = sha256('one|two|three');
+    const digest = encodeURIComponent('one|two|three');
     const id = createCalloutId(['one', 'two', 'three']);
     expect(id).toBe(digest);
   });
 
   it('creates id correctly with multiples ids and delimiter', () => {
-    const digest = sha256('one,two,three');
+    const digest = encodeURIComponent('one,two,three');
     const id = createCalloutId(['one', 'two', 'three'], ',');
     expect(id).toBe(digest);
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/use_push_to_service/callout/helpers.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/use_push_to_service/callout/helpers.tsx
@@ -5,7 +5,5 @@
  * 2.0.
  */
 
-import { sha256 } from 'js-sha256';
-
 export const createCalloutId = (ids: string[], delimiter: string = '|'): string =>
-  sha256(ids.join(delimiter));
+  encodeURIComponent(ids.join(delimiter));

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/executor.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/executor.ts
@@ -4,8 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { sha256 } from 'js-sha256';
 import { i18n } from '@kbn/i18n';
 import type { CoreSetup } from '@kbn/core/server';
 import { getEcsGroups } from '@kbn/alerting-rule-utils';
@@ -273,10 +271,6 @@ export function tryToParseAsDate(sortValue?: string | number | null): undefined 
   if (sortDate && !isNaN(sortDate)) {
     return new Date(sortDate).toISOString();
   }
-}
-
-export function getChecksum(params: OnlyEsQueryRuleParams) {
-  return sha256.create().update(JSON.stringify(params));
 }
 
 export function getInvalidComparatorError(comparator: string) {

--- a/x-pack/platform/test/cloud_integration/tests/fullstory.ts
+++ b/x-pack/platform/test/cloud_integration/tests/fullstory.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import fetch from 'node-fetch';
-import { sha256 } from 'js-sha256';
+import { createHash } from 'crypto';
 import { CLOUD_USER_ID } from '@kbn/cloud-integration-saml-provider-plugin/constants';
 import { FtrProviderContext } from '../ftr_provider_context';
 
@@ -50,7 +50,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       sessionUrl = sessionUrl!.replace('%3A', ':'); // undo encoding so comparisons work with API response
 
       // Check that the session was recorded in the FS API for the given user based on their hashed ID
-      const hashedUserId = sha256(CLOUD_USER_ID);
+      const hashedUserId = createHash('sha256').update(CLOUD_USER_ID).digest('hex');
       const fsSessions = await fetch(
         `https://www.fullstory.com/api/v1/sessions?uid=${hashedUserId}&limit=100`,
         {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { sha256 } from 'js-sha256';
+
 import type { Logger } from '@kbn/core/server';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { SavedObject } from '@kbn/core/server';
@@ -21,7 +21,7 @@ import type { TelemetryEventsSender } from '../../telemetry/sender';
 import { createMockTelemetryEventsSender } from '../../telemetry/__mocks__';
 
 import { MONITOR_UPDATE_CHANNEL, MONITOR_CURRENT_CHANNEL } from '../../telemetry/constants';
-
+import { createHash } from 'crypto';
 import {
   formatTelemetryEvent,
   formatTelemetryUpdateEvent,
@@ -94,7 +94,7 @@ describe('monitor upgrade telemetry helpers', () => {
     });
     expect(actual).toEqual({
       stackVersion,
-      configId: sha256.create().update(testConfig.id).hex(),
+      configId: createHash('sha256').update(testConfig.id).digest('hex'),
       locations: ['us_central', 'other'],
       locationsCount: 2,
       monitorNameLength: testConfig.attributes[ConfigKey.NAME].length,
@@ -132,7 +132,7 @@ describe('monitor upgrade telemetry helpers', () => {
       });
       expect(actual).toEqual({
         stackVersion,
-        configId: sha256.create().update(testConfig.id).hex(),
+        configId: createHash('sha256').update(testConfig.id).digest('hex'),
         locations: ['us_central', 'other'],
         locationsCount: 2,
         monitorNameLength: testConfig.attributes[ConfigKey.NAME].length,
@@ -159,7 +159,7 @@ describe('monitor upgrade telemetry helpers', () => {
     );
     expect(actual).toEqual({
       stackVersion,
-      configId: sha256.create().update(testConfig.id).hex(),
+      configId: createHash('sha256').update(testConfig.id).digest('hex'),
       locations: ['us_central', 'other'],
       locationsCount: 2,
       monitorNameLength: testConfig.attributes[ConfigKey.NAME].length,
@@ -185,7 +185,7 @@ describe('monitor upgrade telemetry helpers', () => {
     );
     expect(actual).toEqual({
       stackVersion,
-      configId: sha256.create().update(testConfig.id).hex(),
+      configId: createHash('sha256').update(testConfig.id).digest('hex'),
       locations: ['us_central', 'other'],
       locationsCount: 2,
       monitorNameLength: testConfig.attributes[ConfigKey.NAME].length,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { sha256 } from 'js-sha256';
 import type { Logger } from '@kbn/core/server';
 import { SavedObjectsUpdateResponse, SavedObject } from '@kbn/core/server';
+import { createHash } from 'crypto';
 import type { MonitorUpdateEvent } from '../../telemetry/types';
 
 import { TelemetryEventsSender } from '../../telemetry/sender';
@@ -102,7 +102,7 @@ export function formatTelemetryEvent({
             },
           }))
         : undefined,
-    configId: sha256.create().update(monitor.id).hex(),
+    configId: createHash('sha256').update(monitor.id).digest('hex'),
     revision: attributes[ConfigKey.REVISION],
   };
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_lookups_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_lookups_client.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { sha256 } from 'js-sha256';
+import { createHash } from 'crypto';
 import type { AuthenticatedUser, IScopedClusterClient, Logger } from '@kbn/core/server';
 import { retryTransientEsErrors } from '@kbn/index-adapter';
 import { LOOKUPS_INDEX_PREFIX } from '../../../../../common/siem_migrations/constants';
@@ -66,6 +66,6 @@ export class RuleMigrationsDataLookupsClient {
   }
 
   private generateDocumentHash(document: object): string {
-    return sha256.create().update(JSON.stringify(document)).hex(); // document need to be created in a deterministic way
+    return createHash('sha256').update(JSON.stringify(document)).digest('hex'); // document need to be created in a deterministic way
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_resources_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_resources_client.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { sha256 } from 'js-sha256';
+import { createHash } from 'crypto';
 import type {
   QueryDslQueryContainer,
   Duration,
@@ -137,7 +137,7 @@ export class RuleMigrationsDataResourcesClient extends RuleMigrationsDataBaseCli
 
   private createId(resource: CreateRuleMigrationResourceInput): string {
     const key = `${resource.migration_id}-${resource.type}-${resource.name}`;
-    return sha256.create().update(key).hex();
+    return createHash('sha256').update(key).digest('hex');
   }
 
   private getFilterQuery(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/helpers.ts
@@ -6,12 +6,12 @@
  */
 
 import moment from 'moment';
+import { createHash } from 'crypto';
 import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import type { PackagePolicy } from '@kbn/fleet-plugin/common/types/models/package_policy';
 import { merge, isPlainObject } from 'lodash';
 import { set } from '@kbn/safer-lodash-set';
 import type { Logger, LogMeta } from '@kbn/core/server';
-import { sha256 } from 'js-sha256';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { copyAllowlistedFields, filterList } from './filterlists';
 import type { PolicyConfig, PolicyData, SafeEndpointEvent } from '../../../common/endpoint/types';
@@ -347,7 +347,7 @@ export const newTelemetryLogger = (
 
 function obfuscateString(clusterId: string, toHash: string): string {
   const valueToObfuscate = toHash + clusterId;
-  return sha256.create().update(valueToObfuscate).hex();
+  return createHash('sha256').update(valueToObfuscate).digest('hex');
 }
 
 function isAllowlistK8sUsername(username: string) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/insights/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/insights/insights.ts
@@ -7,7 +7,7 @@
 
 import moment from 'moment';
 import type { KibanaRequest } from '@kbn/core/server';
-import { sha256 } from 'js-sha256';
+import { createHash } from 'crypto';
 
 interface AlertContext {
   alert_id: string;
@@ -52,8 +52,7 @@ export function getSessionIDfromKibanaRequest(clusterId: string, request: Kibana
 
 function getClusterHashSalt(clusterId: string, toHash: string): string {
   const concatValue = toHash + clusterId;
-  const sha = sha256.create().update(concatValue).hex();
-  return sha;
+  return createHash('sha256').update(concatValue).digest('hex');
 }
 
 export function createAlertStatusPayloads(

--- a/yarn.lock
+++ b/yarn.lock
@@ -23995,7 +23995,7 @@ js-search@1.4.3:
   resolved "https://registry.yarnpkg.com/js-search/-/js-search-1.4.3.tgz#23a86d7e064ca53a473930edc48615b6b1c1954a"
   integrity sha512-Sny5pf00kX1sM1KzvUC9nGYWXOvBfy30rmvZWeRktpg+esQKedIXrXNee/I2CAnsouCyaTjitZpRflDACx4toA==
 
-js-sha256@0.11.1, js-sha256@^0.11.1:
+js-sha256@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.1.tgz#712262e8fc9569d6f7f6eea72c0d8e5ccc7c976c"
   integrity sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remove js-sha256 dependency (#271339)](https://github.com/elastic/kibana/pull/271339)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T12:32:54Z","message":"Remove js-sha256 dependency (#271339)\n\n## Summary\n\nRemoves the `js-sha256` dependency in favor of native platform code.\n\nCherry-picked from the work on\nhttps://github.com/elastic/kibana/pull/241162","sha":"4da84e4e62251e2b133865b703ddc1a79766213b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","dependency-reduction","v9.5.0"],"title":"Remove js-sha256 dependency","number":271339,"url":"https://github.com/elastic/kibana/pull/271339","mergeCommit":{"message":"Remove js-sha256 dependency (#271339)\n\n## Summary\n\nRemoves the `js-sha256` dependency in favor of native platform code.\n\nCherry-picked from the work on\nhttps://github.com/elastic/kibana/pull/241162","sha":"4da84e4e62251e2b133865b703ddc1a79766213b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271339","number":271339,"mergeCommit":{"message":"Remove js-sha256 dependency (#271339)\n\n## Summary\n\nRemoves the `js-sha256` dependency in favor of native platform code.\n\nCherry-picked from the work on\nhttps://github.com/elastic/kibana/pull/241162","sha":"4da84e4e62251e2b133865b703ddc1a79766213b"}},{"url":"https://github.com/elastic/kibana/pull/271698","number":271698,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->