### PR TITLE
[Fleet] Fix missing reserved index pattern guard in streaming install path

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { KibanaSavedObjectType } from '../../../../types';
+import { createArchiveIteratorFromMap } from '../../archive/archive_iterator';
+import { appContextService } from '../../../app_context';
+import { createAppContextStartContractMock } from '../../../../mocks';
+
+import { installKibanaAssetsWithStreaming } from './install_with_streaming';
+
+jest.mock('./saved_objects', () => ({
+  getSpaceAwareSaveobjectsClients: jest.fn(),
+}));
+
+jest.mock('./install', () => ({
+  ...jest.requireActual('./install'),
+  installManagedIndexPattern: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../packages/install', () => ({
+  ...jest.requireActual('../../packages/install'),
+  saveKibanaAssetsRefs: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { getSpaceAwareSaveobjectsClients } = jest.requireMock('./saved_objects');
+
+const makeArchiveBuffer = (id: string, soType: string) =>
+  Buffer.from(JSON.stringify({ id, type: soType, attributes: { title: id } }));
+
+describe('installKibanaAssetsWithStreaming', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let soClientWithSpace: ReturnType<typeof savedObjectsClientMock.create>;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    soClientWithSpace = savedObjectsClientMock.create();
+    soClientWithSpace.bulkCreate.mockResolvedValue({ saved_objects: [] });
+
+    getSpaceAwareSaveobjectsClients.mockReturnValue({
+      savedObjectClientWithSpace: soClientWithSpace,
+      savedObjectsImporter: { import: jest.fn().mockResolvedValue({ errors: [] }) },
+      savedObjectTagAssignmentService: jest.fn(),
+      savedObjectTagClient: jest.fn(),
+    });
+
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  it('should not include reserved index patterns (metrics-*, logs-*) in returned assetRefs', async () => {
+    const assetsMap = new Map([
+      [
+        'test-package-1.0.0/kibana/index_pattern/metrics-star.json',
+        makeArchiveBuffer('metrics-*', 'index-pattern'),
+      ],
+      [
+        'test-package-1.0.0/kibana/index_pattern/logs-star.json',
+        makeArchiveBuffer('logs-*', 'index-pattern'),
+      ],
+      [
+        'test-package-1.0.0/kibana/dashboard/my-dashboard.json',
+        makeArchiveBuffer('my-dashboard', 'dashboard'),
+      ],
+    ]);
+
+    const refs = await installKibanaAssetsWithStreaming({
+      spaceId: 'default',
+      packageInstallContext: {
+        archiveIterator: createArchiveIteratorFromMap(assetsMap),
+        paths: [...assetsMap.keys()],
+        packageInfo: {
+          title: 'Test',
+          name: 'test-package',
+          version: '1.0.0',
+          description: 'test',
+          type: 'integration',
+          categories: [],
+          format_version: '1.0.0',
+          release: 'ga',
+          conditions: {},
+          owner: { github: 'elastic/fleet' },
+        } as any,
+      },
+      savedObjectsClient: soClient,
+      pkgName: 'test-package',
+    });
+
+    const refIds = refs.map((r) => r.id);
+    expect(refIds).not.toContain('metrics-*');
+    expect(refIds).not.toContain('logs-*');
+    expect(refIds).toContain('my-dashboard');
+  });
+
+  it('should return empty refs when archive contains only reserved index patterns', async () => {
+    const assetsMap = new Map([
+      [
+        'test-package-1.0.0/kibana/index_pattern/metrics-star.json',
+        makeArchiveBuffer('metrics-*', 'index-pattern'),
+      ],
+      [
+        'test-package-1.0.0/kibana/index_pattern/logs-star.json',
+        makeArchiveBuffer('logs-*', 'index-pattern'),
+      ],
+    ]);
+
+    const refs = await installKibanaAssetsWithStreaming({
+      spaceId: 'default',
+      packageInstallContext: {
+        archiveIterator: createArchiveIteratorFromMap(assetsMap),
+        paths: [...assetsMap.keys()],
+        packageInfo: {
+          title: 'Test',
+          name: 'test-package',
+          version: '1.0.0',
+          description: 'test',
+          type: 'integration',
+          categories: [],
+          format_version: '1.0.0',
+          release: 'ga',
+          conditions: {},
+          owner: { github: 'elastic/fleet' },
+        } as any,
+      },
+      savedObjectsClient: soClient,
+      pkgName: 'test-package',
+    });
+
+    expect(refs).toEqual([]);
+    expect(soClientWithSpace.bulkCreate).not.toBeCalled();
+  });
+
+  it('should include non-reserved index patterns in returned assetRefs', async () => {
+    const assetsMap = new Map([
+      [
+        'test-package-1.0.0/kibana/index_pattern/custom-index-pattern.json',
+        makeArchiveBuffer('custom-index-pattern', 'index-pattern'),
+      ],
+    ]);
+
+    const refs = await installKibanaAssetsWithStreaming({
+      spaceId: 'default',
+      packageInstallContext: {
+        archiveIterator: createArchiveIteratorFromMap(assetsMap),
+        paths: [...assetsMap.keys()],
+        packageInfo: {
+          title: 'Test',
+          name: 'test-package',
+          version: '1.0.0',
+          description: 'test',
+          type: 'integration',
+          categories: [],
+          format_version: '1.0.0',
+          release: 'ga',
+          conditions: {},
+          owner: { github: 'elastic/fleet' },
+        } as any,
+      },
+      savedObjectsClient: soClient,
+      pkgName: 'test-package',
+    });
+
+    expect(refs).toEqual([
+      { id: 'custom-index-pattern', type: KibanaSavedObjectType.indexPattern },
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.ts
@@ -19,6 +19,8 @@ import { appContextService } from '../../../app_context';
 
 import { saveKibanaAssetsRefs } from '../../packages/install';
 
+import { indexPatternTypes } from '../index_pattern/install';
+
 import type { ArchiveAsset } from './install';
 import {
   KibanaSavedObjectTypeMapping,
@@ -79,6 +81,13 @@ export async function installKibanaAssetsWithStreaming({
     if (
       soType === KibanaSavedObjectType.sloTemplate &&
       !appContextService.getExperimentalFeatures().enableSloTemplates
+    ) {
+      return;
+    }
+
+    if (
+      soType === KibanaSavedObjectType.indexPattern &&
+      indexPatternTypes.some((pattern) => `${pattern}-*` === savedObject.id)
     ) {
       return;
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.test.ts
@@ -412,6 +412,10 @@ describe('cleanUpUnusedKibanaAssetsStep', () => {
     appContextService.start(createAppContextStartContractMock());
   });
 
+  afterEach(() => {
+    mockedDeleteKibanaAssets.mockReset();
+  });
+
   it('should not clean up assets if they all present in the new package', async () => {
     const installedAssets = [{ type: KibanaSavedObjectType.dashboard, id: 'dashboard-1' }];
     await cleanUpUnusedKibanaAssetsStep({
@@ -453,5 +457,52 @@ describe('cleanUpUnusedKibanaAssetsStep', () => {
       packageSpecConditions: { kibana: { version: 'x.y.z' } },
       logger: expect.anything(),
     });
+  });
+
+  it('should never delete reserved Fleet index patterns (metrics-*, logs-*) even if absent from new package', async () => {
+    const previousAssets = [
+      { type: KibanaSavedObjectType.dashboard, id: 'dashboard-to-remove' },
+      { type: KibanaSavedObjectType.indexPattern, id: 'metrics-*' },
+      { type: KibanaSavedObjectType.indexPattern, id: 'logs-*' },
+    ];
+
+    await cleanUpUnusedKibanaAssetsStep({
+      ...installationContext,
+      installedPkg: {
+        ...mockInstalledPackageSo,
+        attributes: {
+          ...mockInstalledPackageSo.attributes,
+          installed_kibana: previousAssets,
+        },
+      },
+      installedKibanaAssetsRefs: [],
+    });
+
+    expect(mockedDeleteKibanaAssets).toBeCalledWith(
+      expect.objectContaining({
+        installedObjects: [{ type: KibanaSavedObjectType.dashboard, id: 'dashboard-to-remove' }],
+      })
+    );
+  });
+
+  it('should not call deleteKibanaAssets at all when only reserved index patterns would be removed', async () => {
+    const previousAssets = [
+      { type: KibanaSavedObjectType.indexPattern, id: 'metrics-*' },
+      { type: KibanaSavedObjectType.indexPattern, id: 'logs-*' },
+    ];
+
+    await cleanUpUnusedKibanaAssetsStep({
+      ...installationContext,
+      installedPkg: {
+        ...mockInstalledPackageSo,
+        attributes: {
+          ...mockInstalledPackageSo.attributes,
+          installed_kibana: previousAssets,
+        },
+      },
+      installedKibanaAssetsRefs: [],
+    });
+
+    expect(mockedDeleteKibanaAssets).not.toBeCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
@@ -14,6 +14,7 @@ import { deleteKibanaAssets } from '../../remove';
 import type { KibanaAssetReference } from '../../../../../../common/types';
 import { INSTALL_STATES, KibanaSavedObjectType } from '../../../../../../common/types';
 import { installKibanaAssetsWithStreaming } from '../../../kibana/assets/install_with_streaming';
+import { indexPatternTypes } from '../../../kibana/index_pattern/install';
 
 export async function stepInstallKibanaAssets(context: InstallContext) {
   const { savedObjectsClient, logger, installedPkg, packageInstallContext, spaceId } = context;
@@ -125,12 +126,18 @@ export async function cleanUpUnusedKibanaAssetsStep(context: InstallContext) {
   const nextAssetRefKeys = new Set(
     installedKibanaAssetsRefs.map((asset: KibanaAssetReference) => `${asset.id}-${asset.type}`)
   );
-  // Do not remove alerting rules or alerting rule templates (they are managed separately)
+  const reservedIndexPatternIds = new Set(indexPatternTypes.map((pattern) => `${pattern}-*`));
+
+  // Do not remove alerting rules, alerting rule templates, or reserved Fleet index patterns
   const assetsToRemove = previousAssetRefs.filter(
     (existingAsset) =>
       !nextAssetRefKeys.has(`${existingAsset.id}-${existingAsset.type}`) &&
       existingAsset.type !== KibanaSavedObjectType.alert &&
-      existingAsset.type !== KibanaSavedObjectType.alertingRuleTemplate
+      existingAsset.type !== KibanaSavedObjectType.alertingRuleTemplate &&
+      !(
+        existingAsset.type === KibanaSavedObjectType.indexPattern &&
+        reservedIndexPatternIds.has(existingAsset.id)
+      )
   );
 
   if (assetsToRemove.length === 0) {


### PR DESCRIPTION
# Summary

Closes https://github.com/elastic/ingest-dev/issues/7887

`AutoInstallContentPackagesTask` (introduced in 9.2) could permanently delete user-created `metrics-*` and `logs-*` data views from all Kibana spaces on every content package upgrade cycle. The regular install path already filtered these
reserved IDs via `removeReservedIndexPatterns` in `install.ts`, but the streaming path (`install_with_streaming.ts`) had no equivalent guard — so if a content package shipped a `metrics-*` index-pattern asset, the streaming path would record that ID in `installed_kibana`. On the next upgrade where the new version dropped the asset, `cleanUpUnusedKibanaAssetsStep` would delete the stale reference using an unscoped client, silently wiping the data view from every space.

  This PR adds two guards: (1) the streaming path now skips reserved index-pattern IDs before recording them as
  `installed_kibana refs`, and (2) `cleanUpUnusedKibanaAssetsStep` now explicitly excludes `logs-*` and `metrics-*` from cleanup as a defensive backstop for any IDs already incorrectly recorded in prior installs.

  ## Testing

There is no easy way to trigger this manually without a content package that ships a metrics-* or logs-* index-pattern asset. The fix is covered by unit tests. To verify the guard is in place, the behavior to check after a streaming content package install is that {id: 'metrics-*', type: 'index-pattern'} and {id: 'logs-*', type: 'index-pattern'} do not appear in the package's installed_kibana attribute in the epm-packages saved object.

  ## Checklist

  - [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
  - [ ] [Documentation ](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)was added for features that require explanation or tutorials
  - [x] [Unit or functional tests ](https://www.elastic.co/guide/en/kibana/master/development-tests.html)were updated or added to match the most common scenarios
  - [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
  [ list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
  - [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the
  breaking-change committee. The release_note:breaking label should be applied in these situations.
  - [ ] [Flaky Test Runner ](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)was used on any tests changed
  - [ ] The PR description includes the appropriate Release Notes section, and the correct release_note:* label is
  applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
  - [ ] Review the [backport guidelines ](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)and apply applicable backport:* labels.

  ## Identify risks

  Low. The streaming path change only skips assets whose ID exactly matches logs-* or metrics-* — no other assets are
  affected. The cleanUpUnusedKibanaAssetsStep change extends an existing filtering pattern (already used for alert and
  alertingRuleTemplate) to cover these two IDs. Non-reserved index patterns continue to be installed and cleaned up
  normally.

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->