### PR TITLE
[kbn-es] Stop already-started containers on serverless cluster startup failure

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
@@ -1048,6 +1048,35 @@ describe('runServerlessCluster()', () => {
     });
     expect(waitForSecurityIndexMock).not.toHaveBeenCalled();
   });
+
+  test('should stop already-started containers when UIAM container fails to become healthy', async () => {
+    const runningContainerIds = ['es01-id', 'es02-id', 'es03-id'];
+    mockFs({
+      [baseEsPath]: {},
+    });
+    // ES node starts (and other async docker calls) succeed
+    execa.mockImplementation(() => Promise.resolve({ stdout: '' }));
+    // Cleanup queries running containers synchronously then kills them
+    execa.commandSync.mockImplementation(() => ({
+      stdout: runningContainerIds.join('\n'),
+    }));
+    // Simulate the recurring CI failure: UIAM healthcheck times out
+    const uiamError = new Error('The "uiam" container failed to start within the expected time');
+    runUiamContainerMock.mockRejectedValueOnce(uiamError);
+
+    await expect(
+      runServerlessCluster(log, { projectType, basePath: baseEsPath, uiam: true })
+    ).rejects.toThrow(uiamError);
+
+    // Cleanup must have been triggered: enumerate via docker ps, then docker kill
+    const commands: string[] = execa.commandSync.mock.calls.map((call: unknown[]) =>
+      String(call[0])
+    );
+    expect(commands.some((c: string) => c.startsWith('docker ps'))).toBe(true);
+    expect(commands.some((c: string) => c === `docker kill ${runningContainerIds.join(' ')}`)).toBe(
+      true
+    );
+  });
 });
 
 describe('stopServerlessCluster()', () => {

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -1013,27 +1013,42 @@ export async function runServerlessCluster(log: ToolingLog, options: ServerlessO
   const portCmd = resolvePort(options);
 
   log.info('[runServerlessCluster] Starting ES nodes...');
-  // This is where nodes are started
-  const nodeNames = await Promise.all(
-    SERVERLESS_NODES.map(async (node, i) => {
-      await runServerlessEsNode(log, {
-        ...node,
-        image: esServerlessImage,
-        params: node.params.concat(
-          resolveEsArgs(DEFAULT_SERVERLESS_ESARGS.concat(node.esArgs ?? []), options),
-          i === 0 ? portCmd : [],
-          volumeCmd
-        ),
-      });
-      return node.name;
-    }).concat(
-      options.uiam
-        ? getUiamContainers({ includeOAuth: options.uiamOAuth }).map((container) =>
-            runUiamContainer(log, container)
-          )
-        : []
-    )
-  );
+  // This is where nodes are started. If any container start (ES or UIAM) fails,
+  // stop any containers that did start so they don't hold ports (e.g. 9220) and
+  // poison subsequent jest-integration configs on the same CI agent.
+  let nodeNames: string[];
+  try {
+    nodeNames = await Promise.all(
+      SERVERLESS_NODES.map(async (node, i) => {
+        await runServerlessEsNode(log, {
+          ...node,
+          image: esServerlessImage,
+          params: node.params.concat(
+            resolveEsArgs(DEFAULT_SERVERLESS_ESARGS.concat(node.esArgs ?? []), options),
+            i === 0 ? portCmd : [],
+            volumeCmd
+          ),
+        });
+        return node.name;
+      }).concat(
+        options.uiam
+          ? getUiamContainers({ includeOAuth: options.uiamOAuth }).map((container) =>
+              runUiamContainer(log, container)
+            )
+          : []
+      )
+    );
+  } catch (error) {
+    log.warning(
+      `[runServerlessCluster] Container startup failed (${elapsed()}); stopping any started containers`
+    );
+    try {
+      teardownServerlessClusterSync(log, options);
+    } catch (cleanupError) {
+      log.warning(`[runServerlessCluster] Cleanup failed: ${cleanupError.message}`);
+    }
+    throw error;
+  }
   log.info(`[runServerlessCluster] All ES nodes started (${elapsed()})`);
 
   log.success(`Serverless ES cluster running.


### PR DESCRIPTION
## Summary

When `runServerlessCluster` in `@kbn/es` fails mid-way — most commonly because the `uiam` healthcheck times out while the ES nodes (`es01`/`es02`/`es03`) have already started successfully — the previously-started Docker containers are left behind. `es01` keeps holding host port `127.0.0.1:9220:9220`. The next jest-integration config scheduled on the same CI agent then tries to start its own `kbn-test-es-server` cluster on port 9220 and dies with:

```
fatal exception while booting Elasticsearch
org.elasticsearch.http.BindHttpException: Failed to bind to 127.0.0.1:9220
Caused by: java.net.BindException: Address already in use
```

Because the failure happens in `beforeAll`, Jest reports every `it()` in the next config's spec as failed, and `kbn-failed-tests-notifier` files one issue per `it()`.

## What this PR changes

`runServerlessCluster` now wraps the parallel container start in a `try/catch`. On any failure (ES node or UIAM), the existing `teardownServerlessClusterSync` helper is called to stop any containers that did start, then the original error is rethrown. Cleanup errors are caught and logged but never mask the underlying cause.

The fix is targeted at the documented failure path. It does **not** make UIAM more reliable — when uiam-cosmosdb/uiam containers are slow to start, the `project_routing_serverless_cps.test.ts` suite still fails. It just stops that failure from cascading into unrelated configs.

## Evidence of the underlying pattern

- May 2026 occurrence: 8 issues filed against `kbn-change-history` from one job in [kibana-on-merge build 98314](https://buildkite.com/elastic/kibana-on-merge/builds/98314#019e5fb0-a1d0-466e-ace8-00a3d961d20b) — #265906, #271136–#271142. ES Docker container from `core/server/integration_tests/elasticsearch` shard=1/8 (uiam timeout) left port 9220 held.
- April 2026 occurrence: same root cause in [build 95610](https://buildkite.com/elastic/kibana-on-merge/builds/95610) — sibling cascade hit `saved_objects/migrations/group4`, `zdt_2`, and `kbn-change-history`.
- The underlying `uiam`-timeout flake has filed its own pile of issues going back to build 88892, including #254425–#254434 (open).
- Similar pattern recognized in 2024 — #180651, closed with a partial fix at the test-author level. This PR addresses the framework-level gap.

## Test plan

- [x] Added unit test in [`docker.test.ts`](src/platform/packages/shared/kbn-es/src/utils/docker.test.ts) — mocks UIAM rejection while ES nodes resolve, asserts that `docker ps` enumeration and `docker kill` are invoked, and that the original UIAM error is rethrown.
- [x] Existing tests pass (the 3 pre-existing snapshot failures on `verifyDockerInstalled` / `maybeCreateDockerNetwork` are unrelated to this change).
- [x] Typecheck and lint clean on `kbn-es`.

CI signal will be the real-world proof: if downstream `BindException`-on-9220 issues stop appearing on `kibana-on-merge` while the upstream UIAM-timeout issues continue to appear in isolation, the fix is working.