### PR TITLE
[One Workflow](fix): `scheduleWorkflowTriggers` prevent scheduling if the workflow is disabled or invalid

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.test.ts
@@ -1143,6 +1143,64 @@ steps:
       );
     });
 
+    it('does not schedule triggers when workflow is disabled', async () => {
+      const mockTaskScheduler = {
+        scheduleWorkflowTask: jest.fn().mockResolvedValue(undefined),
+      };
+      service.setTaskScheduler(mockTaskScheduler as any);
+
+      const mockRequest = {
+        auth: {
+          credentials: { username: 'test-user' },
+        },
+      } as any;
+
+      const workflowCommand = {
+        yaml: `
+name: disabled scheduled workflow
+enabled: false
+triggers:
+  - type: 'scheduled'
+    with:
+      every: '5m'
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+      };
+
+      mockEsClient.index.mockResolvedValue({ _id: 'new-workflow-id' } as any);
+
+      await service.createWorkflow(workflowCommand, 'default', mockRequest);
+
+      expect(mockTaskScheduler.scheduleWorkflowTask).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule triggers when workflow is invalid', async () => {
+      const mockTaskScheduler = {
+        scheduleWorkflowTask: jest.fn().mockResolvedValue(undefined),
+      };
+      service.setTaskScheduler(mockTaskScheduler as any);
+
+      const mockRequest = {
+        auth: {
+          credentials: { username: 'test-user' },
+        },
+      } as any;
+
+      const workflowCommand = {
+        yaml: 'name: invalid workflow\nenabled: true\ntriggers:\n  - type: invalid-trigger-type',
+      };
+
+      mockEsClient.index.mockResolvedValue({ _id: 'new-workflow-id' } as any);
+
+      await service.createWorkflow(workflowCommand, 'default', mockRequest);
+
+      expect(mockTaskScheduler.scheduleWorkflowTask).not.toHaveBeenCalled();
+    });
+
     it('should create workflow with custom ID when provided', async () => {
       const mockRequest = {
         auth: {
@@ -1793,6 +1851,41 @@ steps:
       await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
 
       expect(mockTaskScheduler.scheduleWorkflowTask).toHaveBeenCalled();
+    });
+
+    it('does not schedule triggers when workflow is disabled', async () => {
+      const mockTaskScheduler = {
+        scheduleWorkflowTask: jest.fn().mockResolvedValue(undefined),
+      };
+      service.setTaskScheduler(mockTaskScheduler as any);
+
+      mockEsClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ create: { _id: 'workflow-1', status: 201 } }],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: disabled scheduled workflow
+enabled: false
+triggers:
+  - type: 'scheduled'
+    with:
+      every: '5m'
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+      ];
+
+      await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      expect(mockTaskScheduler.scheduleWorkflowTask).not.toHaveBeenCalled();
     });
 
     it('should log warning when trigger scheduling fails without affecting result', async () => {

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -337,11 +337,13 @@ export class WorkflowsService {
   private async scheduleWorkflowTriggers(
     workflowId: string,
     definition: WorkflowYaml | undefined,
+    enabled: boolean,
+    valid: boolean,
     spaceId: string,
     request: KibanaRequest
   ): Promise<void> {
     const { taskScheduler } = this;
-    if (!taskScheduler || !definition?.triggers) {
+    if (!taskScheduler || !definition?.triggers || !enabled || !valid) {
       return;
     }
 
@@ -419,7 +421,14 @@ export class WorkflowsService {
       document: workflowData,
     });
 
-    await this.scheduleWorkflowTriggers(id, definition, spaceId, request);
+    await this.scheduleWorkflowTriggers(
+      id,
+      definition,
+      workflowData.enabled,
+      workflowData.valid,
+      spaceId,
+      request
+    );
 
     return this.transformStorageDocumentToWorkflowDto(id, workflowData);
   }
@@ -562,7 +571,14 @@ export class WorkflowsService {
 
     await Promise.allSettled(
       workflowsToSchedule.map((vw) =>
-        this.scheduleWorkflowTriggers(vw.id, vw.definition, spaceId, request)
+        this.scheduleWorkflowTriggers(
+          vw.id,
+          vw.definition,
+          vw.workflowData.enabled,
+          vw.workflowData.valid,
+          spaceId,
+          request
+        )
       )
     );
 


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/security-team/issues/17601

Fixes a bug where creating a workflow with `enabled: false` and a `scheduled` trigger still registered a Task Manager task. The update path already respected `enabled` via `syncSchedulerAfterSave`; create and bulk create did not.

## Changes

- Gate `scheduleWorkflowTriggers` on `enabled` and `valid`, matching `syncSchedulerAfterSave`
- Pass `workflowData.enabled` / `workflowData.valid` from `createWorkflow` and `bulkCreateWorkflows`
- Add unit tests for disabled and invalid workflows on create

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



