### PR TITLE
[9.3] [Fleet] Fix missing reserved index pattern guard in streaming install path

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { KibanaSavedObjectType } from '../../../../types';
+import { createArchiveIteratorFromMap } from '../../archive/archive_iterator';
+import { appContextService } from '../../../app_context';
+import { createAppContextStartContractMock } from '../../../../mocks';
+
+import { installKibanaAssetsWithStreaming } from './install_with_streaming';
+
+jest.mock('./saved_objects', () => ({
+  getSpaceAwareSaveobjectsClients: jest.fn(),
+}));
+
+jest.mock('./install', () => ({
+  ...jest.requireActual('./install'),
+  installManagedIndexPattern: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../packages/install', () => ({
+  ...jest.requireActual('../../packages/install'),
+  saveKibanaAssetsRefs: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { getSpaceAwareSaveobjectsClients } = jest.requireMock('./saved_objects');
+
+const makeArchiveBuffer = (id: string, soType: string) =>
+  Buffer.from(JSON.stringify({ id, type: soType, attributes: { title: id } }));
+
+describe('installKibanaAssetsWithStreaming', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let soClientWithSpace: ReturnType<typeof savedObjectsClientMock.create>;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    soClientWithSpace = savedObjectsClientMock.create();
+    soClientWithSpace.bulkCreate.mockResolvedValue({ saved_objects: [] });
+
+    getSpaceAwareSaveobjectsClients.mockReturnValue({
+      savedObjectClientWithSpace: soClientWithSpace,
+      savedObjectsImporter: { import: jest.fn().mockResolvedValue({ errors: [] }) },
+      savedObjectTagAssignmentService: jest.fn(),
+      savedObjectTagClient: jest.fn(),
+    });
+
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  it('should not include reserved index patterns (metrics-*, logs-*) in returned assetRefs', async () => {
+    const assetsMap = new Map([
+      [
+        'test-package-1.0.0/kibana/index_pattern/metrics-star.json',
+        makeArchiveBuffer('metrics-*', 'index-pattern'),
+      ],
+      [
+        'test-package-1.0.0/kibana/index_pattern/logs-star.json',
+        makeArchiveBuffer('logs-*', 'index-pattern'),
+      ],
+      [
+        'test-package-1.0.0/kibana/dashboard/my-dashboard.json',
+        makeArchiveBuffer('my-dashboard', 'dashboard'),
+      ],
+    ]);
+
+    const refs = await installKibanaAssetsWithStreaming({
+      spaceId: 'default',
+      packageInstallContext: {
+        archiveIterator: createArchiveIteratorFromMap(assetsMap),
+        paths: [...assetsMap.keys()],
+        packageInfo: {
+          title: 'Test',
+          name: 'test-package',
+          version: '1.0.0',
+          description: 'test',
+          type: 'integration',
+          categories: [],
+          format_version: '1.0.0',
+          release: 'ga',
+          conditions: {},
+          owner: { github: 'elastic/fleet' },
+        } as any,
+      },
+      savedObjectsClient: soClient,
+      pkgName: 'test-package',
+    });
+
+    const refIds = refs.map((r) => r.id);
+    expect(refIds).not.toContain('metrics-*');
+    expect(refIds).not.toContain('logs-*');
+    expect(refIds).toContain('my-dashboard');
+  });
+
+  it('should return empty refs when archive contains only reserved index patterns', async () => {
+    const assetsMap = new Map([
+      [
+        'test-package-1.0.0/kibana/index_pattern/metrics-star.json',
+        makeArchiveBuffer('metrics-*', 'index-pattern'),
+      ],
+      [
+        'test-package-1.0.0/kibana/index_pattern/logs-star.json',
+        makeArchiveBuffer('logs-*', 'index-pattern'),
+      ],
+    ]);
+
+    const refs = await installKibanaAssetsWithStreaming({
+      spaceId: 'default',
+      packageInstallContext: {
+        archiveIterator: createArchiveIteratorFromMap(assetsMap),
+        paths: [...assetsMap.keys()],
+        packageInfo: {
+          title: 'Test',
+          name: 'test-package',
+          version: '1.0.0',
+          description: 'test',
+          type: 'integration',
+          categories: [],
+          format_version: '1.0.0',
+          release: 'ga',
+          conditions: {},
+          owner: { github: 'elastic/fleet' },
+        } as any,
+      },
+      savedObjectsClient: soClient,
+      pkgName: 'test-package',
+    });
+
+    expect(refs).toEqual([]);
+    expect(soClientWithSpace.bulkCreate).not.toBeCalled();
+  });
+
+  it('should include non-reserved index patterns in returned assetRefs', async () => {
+    const assetsMap = new Map([
+      [
+        'test-package-1.0.0/kibana/index_pattern/custom-index-pattern.json',
+        makeArchiveBuffer('custom-index-pattern', 'index-pattern'),
+      ],
+    ]);
+
+    const refs = await installKibanaAssetsWithStreaming({
+      spaceId: 'default',
+      packageInstallContext: {
+        archiveIterator: createArchiveIteratorFromMap(assetsMap),
+        paths: [...assetsMap.keys()],
+        packageInfo: {
+          title: 'Test',
+          name: 'test-package',
+          version: '1.0.0',
+          description: 'test',
+          type: 'integration',
+          categories: [],
+          format_version: '1.0.0',
+          release: 'ga',
+          conditions: {},
+          owner: { github: 'elastic/fleet' },
+        } as any,
+      },
+      savedObjectsClient: soClient,
+      pkgName: 'test-package',
+    });
+
+    expect(refs).toEqual([
+      { id: 'custom-index-pattern', type: KibanaSavedObjectType.indexPattern },
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.ts
@@ -28,6 +28,7 @@ import {
   toAssetReference,
 } from './install';
 import { getSpaceAwareSaveobjectsClients } from './saved_objects';
+import { indexPatternTypes } from '../index_pattern/install';
 
 interface InstallKibanaAssetsWithStreamingArgs {
   pkgName: string;
@@ -72,6 +73,13 @@ export async function installKibanaAssetsWithStreaming({
     if (
       soType === KibanaSavedObjectType.alertingRuleTemplate &&
       !appContextService.getExperimentalFeatures().enableAgentStatusAlerting
+    ) {
+      return;
+    }
+
+    if (
+      soType === KibanaSavedObjectType.indexPattern &&
+      indexPatternTypes.some((pattern) => `${pattern}-*` === savedObject.id)
     ) {
       return;
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.test.ts
@@ -412,6 +412,10 @@ describe('cleanUpUnusedKibanaAssetsStep', () => {
     appContextService.start(createAppContextStartContractMock());
   });
 
+  afterEach(() => {
+    mockedDeleteKibanaAssets.mockReset();
+  });
+
   it('should not clean up assets if they all present in the new package', async () => {
     const installedAssets = [{ type: KibanaSavedObjectType.dashboard, id: 'dashboard-1' }];
     await cleanUpUnusedKibanaAssetsStep({
@@ -453,5 +457,52 @@ describe('cleanUpUnusedKibanaAssetsStep', () => {
       packageSpecConditions: { kibana: { version: 'x.y.z' } },
       logger: expect.anything(),
     });
+  });
+
+  it('should never delete reserved Fleet index patterns (metrics-*, logs-*) even if absent from new package', async () => {
+    const previousAssets = [
+      { type: KibanaSavedObjectType.dashboard, id: 'dashboard-to-remove' },
+      { type: KibanaSavedObjectType.indexPattern, id: 'metrics-*' },
+      { type: KibanaSavedObjectType.indexPattern, id: 'logs-*' },
+    ];
+
+    await cleanUpUnusedKibanaAssetsStep({
+      ...installationContext,
+      installedPkg: {
+        ...mockInstalledPackageSo,
+        attributes: {
+          ...mockInstalledPackageSo.attributes,
+          installed_kibana: previousAssets,
+        },
+      },
+      installedKibanaAssetsRefs: [],
+    });
+
+    expect(mockedDeleteKibanaAssets).toBeCalledWith(
+      expect.objectContaining({
+        installedObjects: [{ type: KibanaSavedObjectType.dashboard, id: 'dashboard-to-remove' }],
+      })
+    );
+  });
+
+  it('should not call deleteKibanaAssets at all when only reserved index patterns would be removed', async () => {
+    const previousAssets = [
+      { type: KibanaSavedObjectType.indexPattern, id: 'metrics-*' },
+      { type: KibanaSavedObjectType.indexPattern, id: 'logs-*' },
+    ];
+
+    await cleanUpUnusedKibanaAssetsStep({
+      ...installationContext,
+      installedPkg: {
+        ...mockInstalledPackageSo,
+        attributes: {
+          ...mockInstalledPackageSo.attributes,
+          installed_kibana: previousAssets,
+        },
+      },
+      installedKibanaAssetsRefs: [],
+    });
+
+    expect(mockedDeleteKibanaAssets).not.toBeCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
@@ -14,6 +14,7 @@ import { deleteKibanaAssets } from '../../remove';
 import type { KibanaAssetReference } from '../../../../../../common/types';
 import { INSTALL_STATES, KibanaSavedObjectType } from '../../../../../../common/types';
 import { installKibanaAssetsWithStreaming } from '../../../kibana/assets/install_with_streaming';
+import { indexPatternTypes } from '../../../kibana/index_pattern/install';
 
 export async function stepInstallKibanaAssets(context: InstallContext) {
   const { savedObjectsClient, logger, installedPkg, packageInstallContext, spaceId } = context;
@@ -123,8 +124,16 @@ export async function cleanUpUnusedKibanaAssetsStep(context: InstallContext) {
   const nextAssetRefKeys = new Set(
     installedKibanaAssetsRefs.map((asset: KibanaAssetReference) => `${asset.id}-${asset.type}`)
   );
+  const reservedIndexPatternIds = new Set(indexPatternTypes.map((pattern) => `${pattern}-*`));
+
+  // Do not remove reserved Fleet index patterns
   const assetsToRemove = previousAssetRefs.filter(
-    (existingAsset) => !nextAssetRefKeys.has(`${existingAsset.id}-${existingAsset.type}`)
+    (existingAsset) =>
+      !nextAssetRefKeys.has(`${existingAsset.id}-${existingAsset.type}`) &&
+      !(
+        existingAsset.type === KibanaSavedObjectType.indexPattern &&
+        reservedIndexPatternIds.has(existingAsset.id)
+      )
   );
 
   if (assetsToRemove.length === 0) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `fix-index-pattern-guard` to `9.3`:
- [[Fleet] Fix missing reserved index pattern guard in streaming install path (#271749)](https://github.com/elastic/kibana/pull/271749)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":0,"url":"https://github.com/elastic/kibana/pull/0","title":"[Fleet] Fix missing reserved index pattern guard in streaming install path"},"sourceBranch":"fix-index-pattern-guard","suggestedTargetBranches":["9.3"],"sourceCommit":{"sha":"262f92d0ca53"}}] BACKPORT-->