### PR TITLE
[Search][Getting Started Chat] Suggested prompts

### DIFF
--- a/x-pack/solutions/search/plugins/search_getting_started/common/prompts.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/common/prompts.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface SuggestedPrompt {
+  id: string;
+  prompt: string;
+}
+
+export const DEFAULT_PROMPTS: SuggestedPrompt[] = [
+  {
+    id: 'chatbot_my_data',
+    prompt: 'I want to build a chatbot that answers questions from my data',
+  },
+  {
+    id: 'recommendations',
+    prompt: "Add 'you may like' recommendations to my app",
+  },
+  {
+    id: 'product_search',
+    prompt: 'Build product search with filters, autocomplete and facets',
+  },
+  {
+    id: 'geo_filters',
+    prompt: "Help me build 'near me' search with geo filters",
+  },
+  {
+    id: 'logs',
+    prompt: 'I need to search and analyze my applications logs',
+  },
+  {
+    id: 'docs_search',
+    prompt: 'Make my docs and wiki searchable',
+  },
+];

--- a/x-pack/solutions/search/plugins/search_getting_started/common/prompts.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/common/prompts.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
+
 export interface SuggestedPrompt {
   id: string;
   prompt: string;
@@ -13,26 +15,38 @@ export interface SuggestedPrompt {
 export const DEFAULT_PROMPTS: SuggestedPrompt[] = [
   {
     id: 'chatbot_my_data',
-    prompt: 'I want to build a chatbot that answers questions from my data',
+    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.chatbot_my_data', {
+      defaultMessage: 'I want to build a chatbot that answers questions from my data',
+    }),
   },
   {
     id: 'recommendations',
-    prompt: "Add 'you may like' recommendations to my app",
+    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.recommendations', {
+      defaultMessage: "Add 'you may like' recommendations to my app",
+    }),
   },
   {
     id: 'product_search',
-    prompt: 'Build product search with filters, autocomplete and facets',
+    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.product_search', {
+      defaultMessage: 'Build product search with filters, autocomplete and facets',
+    }),
   },
   {
     id: 'geo_filters',
-    prompt: "Help me build 'near me' search with geo filters",
+    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.geo_filters', {
+      defaultMessage: "Help me build 'near me' search with geo filters",
+    }),
   },
   {
     id: 'logs',
-    prompt: 'I need to search and analyze my applications logs',
+    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.logs', {
+      defaultMessage: 'I need to search and analyze my applications logs',
+    }),
   },
   {
     id: 'docs_search',
-    prompt: 'Make my docs and wiki searchable',
+    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.docs_search', {
+      defaultMessage: 'Make my docs and wiki searchable',
+    }),
   },
 ];

--- a/x-pack/solutions/search/plugins/search_getting_started/public/analytics/constants.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/analytics/constants.ts
@@ -11,4 +11,6 @@ export enum AnalyticsEvents {
   claudeCliPromptCopied = 'claude_cli_prompt_copied',
   codeExampleCopied = 'code_example_copied',
   languageSelected = 'language_selected',
+  startChat = 'start_chat_gs',
+  suggestedPrompt = 'gs_suggested_prompt',
 }

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_content.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_content.tsx
@@ -10,14 +10,22 @@ import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { ChatElasticsearchConnectionDetails } from './connection_details';
 import { ConversationPrompt } from './conversation_prompt';
-import { ChatColumnsGrid, ChatContentSeparator } from './styles';
+import { SuggestedPrompts } from './suggested_prompts';
+import { ChatColumnsGrid, ChatContentSeparator, PromptsContainer } from './styles';
 import { GettingStartedAgentPrompt } from './agent_prompt';
 
 export const GettingStartedChatContent = () => {
   return (
     <EuiFlexGrid data-test-subj="gettingStartedChatContent" columns={2} css={ChatColumnsGrid}>
       <EuiFlexItem css={ChatContentSeparator}>
-        <ConversationPrompt />
+        <EuiFlexGroup direction="column" gutterSize="m" css={PromptsContainer}>
+          <EuiFlexItem grow={false}>
+            <ConversationPrompt />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <SuggestedPrompts />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiFlexGroup direction="column" gutterSize="l">

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -5,94 +5,72 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { EuiButtonIcon, EuiToolTip, keys } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
-import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { ConversationInputShell } from '@kbn/agent-builder-plugin/public';
-import { useKibana } from '../../hooks/use_kibana';
 
-import {
-  NewConversationTextArea,
-  NewConversationSendButton,
-  NewConversationContainer,
-} from './styles';
+import { NewConversationTextArea, NewConversationSendButton } from './styles';
+import { useOpenAgentBuilder } from '../../hooks/use_open_agent_builder';
 
 export const ConversationPrompt = () => {
-  const {
-    services: { application },
-  } = useKibana();
+  const openAgentBuilder = useOpenAgentBuilder();
   const [initialMessage, setInitialMessage] = useState<string>('');
-  const openConversation = useCallback(() => {
+  const openConversation = () => {
     if (initialMessage.trim().length === 0) return;
-    application.navigateToApp(AGENT_BUILDER_APP_ID, {
-      path: `/agents/${agentBuilderDefaultAgentId}/conversations/new`,
-      state: {
-        initialMessage,
-        entryPointSource: 'search_getting_started',
-      },
-    });
-  }, [application, initialMessage]);
-  const onInputKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key === keys.ENTER && !event.shiftKey) {
-        event.preventDefault();
-        openConversation();
-      }
-    },
-    [openConversation]
-  );
+    openAgentBuilder(initialMessage);
+  };
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === keys.ENTER && !event.shiftKey) {
+      event.preventDefault();
+      openConversation();
+    }
+  };
 
   return (
-    <div css={NewConversationContainer}>
-      <ConversationInputShell>
-        <textarea
-          css={NewConversationTextArea}
-          name="searchGettingStartedChatPromptInput"
-          data-test-subj="searchGettingStartedChatPromptInput"
-          placeholder={i18n.translate(
-            'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
-            { defaultMessage: 'How can I help you get started today?' }
-          )}
-          aria-label={i18n.translate(
-            'xpack.search.gettingStarted.chat.conversationPrompt.input.aria',
+    <ConversationInputShell>
+      <textarea
+        css={NewConversationTextArea}
+        name="searchGettingStartedChatPromptInput"
+        data-test-subj="searchGettingStartedChatPromptInput"
+        placeholder={i18n.translate(
+          'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
+          { defaultMessage: 'How can I help you get started today?' }
+        )}
+        aria-label={i18n.translate(
+          'xpack.search.gettingStarted.chat.conversationPrompt.input.aria',
+          {
+            defaultMessage: 'Ask the AI assistant a question to get started',
+          }
+        )}
+        rows={3}
+        value={initialMessage}
+        onChange={(e) => setInitialMessage(e.currentTarget.value)}
+        onKeyDown={onInputKeyDown}
+      />
+      <div css={NewConversationSendButton}>
+        <EuiToolTip
+          content={i18n.translate(
+            'xpack.search.gettingStarted.chat.conversationPrompt.send.tooltip',
             {
-              defaultMessage: 'Ask the AI assistant a question to get started',
+              defaultMessage: 'Open the AI assistant chat',
             }
           )}
-          rows={3}
-          value={initialMessage}
-          onChange={(e) => setInitialMessage(e.currentTarget.value)}
-          onKeyDown={onInputKeyDown}
-        />
-        <div css={NewConversationSendButton}>
-          <EuiToolTip
-            content={i18n.translate(
-              'xpack.search.gettingStarted.chat.conversationPrompt.send.tooltip',
-              {
-                defaultMessage: 'Open the AI assistant chat',
-              }
-            )}
-            disableScreenReaderOutput
-          >
-            <EuiButtonIcon
-              iconType="kqlFunction"
-              display="fill"
-              size="m"
-              disabled={initialMessage.trim().length === 0}
-              onClick={openConversation}
-              aria-label={i18n.translate(
-                'xpack.search.gettingStarted.chat.conversationPrompt.send',
-                {
-                  defaultMessage: 'Open the AI assistant chat',
-                }
-              )}
-              data-test-subj="searchGettingStartedChatPromptSend"
-            />
-          </EuiToolTip>
-        </div>
-      </ConversationInputShell>
-    </div>
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="kqlFunction"
+            display="fill"
+            size="m"
+            disabled={initialMessage.trim().length === 0}
+            onClick={openConversation}
+            aria-label={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
+              defaultMessage: 'Open the AI assistant chat',
+            })}
+            data-test-subj="searchGettingStartedChatPromptSend"
+          />
+        </EuiToolTip>
+      </div>
+    </ConversationInputShell>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -10,19 +10,24 @@ import { EuiButtonIcon, EuiToolTip, keys } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ConversationInputShell } from '@kbn/agent-builder-plugin/public';
 
-import { NewConversationTextArea, NewConversationSendButton } from './styles';
+import { AnalyticsEvents } from '../../analytics/constants';
+import { useUsageTracker } from '../../contexts/usage_tracker_context';
 import { useOpenAgentBuilder } from '../../hooks/use_open_agent_builder';
+import { NewConversationTextArea, NewConversationSendButton } from './styles';
 
 export const ConversationPrompt = () => {
   const openAgentBuilder = useOpenAgentBuilder();
+  const usageTracker = useUsageTracker();
   const [initialMessage, setInitialMessage] = useState<string>('');
   const openConversation = () => {
     if (initialMessage.trim().length === 0) return;
+    usageTracker.click(AnalyticsEvents.startChat);
     openAgentBuilder(initialMessage);
   };
   const onInputKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === keys.ENTER && !event.shiftKey) {
       event.preventDefault();
+
       openConversation();
     }
   };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
@@ -43,10 +43,29 @@ export const NewConversationSendButton = css({
   justifyContent: 'flex-end',
 });
 
-export const NewConversationContainer = ({ euiTheme }: UseEuiTheme) =>
+export const PromptsContainer = ({ euiTheme }: UseEuiTheme) =>
   css({
     paddingRight: euiTheme.size.l,
+    containerType: 'inline-size',
   });
+
+export const SuggestedPromptsGrid = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, 1fr)',
+    gap: euiTheme.size.m,
+    [`@container (max-width: ${euiTheme.breakpoint.s}px)`]: {
+      gridTemplateColumns: 'repeat(2, 1fr)',
+    },
+  });
+
+export const SuggestedPromptText = css({
+  display: '-webkit-box',
+  WebkitLineClamp: 3,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+  wordBreak: 'break-word',
+});
 
 export const ChatColumnsGrid = ({ euiTheme }: UseEuiTheme) =>
   css({

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompt_card.test.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompt_card.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { SuggestedPromptCard } from './suggested_prompt_card';
+
+const PROMPT = {
+  id: 'chatbot_my_data',
+  prompt: 'I want to build a chatbot that answers questions from my data',
+};
+
+const wrap = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiThemeProvider>{ui}</EuiThemeProvider>
+    </I18nProvider>
+  );
+
+describe('SuggestedPromptCard', () => {
+  it('renders with the data-test-subj derived from the prompt id', () => {
+    wrap(<SuggestedPromptCard prompt={PROMPT} onClick={jest.fn()} />);
+    expect(
+      screen.getByTestId(`searchGettingStartedSuggestedPrompt-${PROMPT.id}`)
+    ).toBeInTheDocument();
+  });
+
+  it('displays the prompt text', () => {
+    wrap(<SuggestedPromptCard prompt={PROMPT} onClick={jest.fn()} />);
+    expect(screen.getByText(PROMPT.prompt)).toBeInTheDocument();
+  });
+
+  it('calls onClick with the full prompt object when clicked', () => {
+    const onClick = jest.fn();
+    wrap(<SuggestedPromptCard prompt={PROMPT} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId(`searchGettingStartedSuggestedPrompt-${PROMPT.id}`));
+    expect(onClick).toHaveBeenCalledWith(PROMPT);
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompt_card.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompt_card.tsx
@@ -27,7 +27,7 @@ export const SuggestedPromptCard = ({ prompt, onClick }: SuggestedPromptCardProp
       data-test-subj={`searchGettingStartedSuggestedPrompt-${prompt.id}`}
       aria-label={prompt.prompt}
     >
-      <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+      <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiIcon type="sparkles" size="m" aria-hidden={true} color="subdued" />
         </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompt_card.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompt_card.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiText } from '@elastic/eui';
+
+import { type SuggestedPrompt } from '../../../common/prompts';
+import { SuggestedPromptText } from './styles';
+
+interface SuggestedPromptCardProps {
+  prompt: SuggestedPrompt;
+  onClick: (prompt: SuggestedPrompt) => void;
+}
+
+export const SuggestedPromptCard = ({ prompt, onClick }: SuggestedPromptCardProps) => {
+  return (
+    <EuiPanel
+      color="subdued"
+      paddingSize="m"
+      hasBorder
+      hasShadow={false}
+      onClick={() => onClick(prompt)}
+      data-test-subj={`searchGettingStartedSuggestedPrompt-${prompt.id}`}
+      aria-label={prompt.prompt}
+    >
+      <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="sparkles" size="m" aria-hidden={true} color="subdued" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="xs" color="subdued">
+            <p css={SuggestedPromptText}>{prompt.prompt}</p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompts.test.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompts.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { DEFAULT_PROMPTS } from '../../../common/prompts';
+import { SuggestedPrompts } from './suggested_prompts';
+import { useSuggestedPrompts } from '../../hooks/use_suggested_prompts';
+import { useOpenAgentBuilder } from '../../hooks/use_open_agent_builder';
+
+jest.mock('../../hooks/use_suggested_prompts');
+jest.mock('../../hooks/use_open_agent_builder');
+
+const mockUseSuggestedPrompts = useSuggestedPrompts as jest.Mock;
+const mockUseOpenAgentBuilder = useOpenAgentBuilder as jest.Mock;
+
+const FIXED_PROMPTS = DEFAULT_PROMPTS.slice(0, 4);
+
+const wrap = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiThemeProvider>{ui}</EuiThemeProvider>
+    </I18nProvider>
+  );
+
+describe('SuggestedPrompts', () => {
+  const mockOpenAgentBuilder = jest.fn();
+
+  beforeEach(() => {
+    mockOpenAgentBuilder.mockClear();
+    mockUseSuggestedPrompts.mockReturnValue(FIXED_PROMPTS);
+    mockUseOpenAgentBuilder.mockReturnValue(mockOpenAgentBuilder);
+  });
+
+  it('renders the wrapper with the correct data-test-subj', () => {
+    wrap(<SuggestedPrompts />);
+    expect(screen.getByTestId('searchGettingStartedSuggestedPrompts')).toBeInTheDocument();
+  });
+
+  it('renders one card per prompt returned by useSuggestedPrompts', () => {
+    wrap(<SuggestedPrompts />);
+    FIXED_PROMPTS.forEach(({ id }) => {
+      expect(screen.getByTestId(`searchGettingStartedSuggestedPrompt-${id}`)).toBeInTheDocument();
+    });
+  });
+
+  it('calls openAgentBuilder with the prompt text when a card is clicked', () => {
+    wrap(<SuggestedPrompts />);
+    fireEvent.click(
+      screen.getByTestId(`searchGettingStartedSuggestedPrompt-${FIXED_PROMPTS[1].id}`)
+    );
+    expect(mockOpenAgentBuilder).toHaveBeenCalledWith(FIXED_PROMPTS[1].prompt);
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompts.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompts.tsx
@@ -8,16 +8,24 @@
 import React from 'react';
 
 import { type SuggestedPrompt } from '../../../common/prompts';
+import { AnalyticsEvents } from '../../analytics/constants';
 import { useSuggestedPrompts } from '../../hooks/use_suggested_prompts';
 import { useOpenAgentBuilder } from '../../hooks/use_open_agent_builder';
+import { useUsageTracker } from '../../contexts/usage_tracker_context';
 import { SuggestedPromptsGrid } from './styles';
 import { SuggestedPromptCard } from './suggested_prompt_card';
 
 export const SuggestedPrompts = () => {
   const prompts = useSuggestedPrompts();
   const openAgentBuilder = useOpenAgentBuilder();
+  const usageTracker = useUsageTracker();
 
   const handlePromptClick = (prompt: SuggestedPrompt) => {
+    usageTracker.click([
+      AnalyticsEvents.startChat,
+      AnalyticsEvents.suggestedPrompt,
+      `${AnalyticsEvents.suggestedPrompt}-${prompt.id}`,
+    ]);
     openAgentBuilder(prompt.prompt);
   };
 

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompts.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/suggested_prompts.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { type SuggestedPrompt } from '../../../common/prompts';
+import { useSuggestedPrompts } from '../../hooks/use_suggested_prompts';
+import { useOpenAgentBuilder } from '../../hooks/use_open_agent_builder';
+import { SuggestedPromptsGrid } from './styles';
+import { SuggestedPromptCard } from './suggested_prompt_card';
+
+export const SuggestedPrompts = () => {
+  const prompts = useSuggestedPrompts();
+  const openAgentBuilder = useOpenAgentBuilder();
+
+  const handlePromptClick = (prompt: SuggestedPrompt) => {
+    openAgentBuilder(prompt.prompt);
+  };
+
+  return (
+    <div css={SuggestedPromptsGrid} data-test-subj="searchGettingStartedSuggestedPrompts">
+      {prompts.map((prompt) => (
+        <SuggestedPromptCard key={prompt.id} prompt={prompt} onClick={handlePromptClick} />
+      ))}
+    </div>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_open_agent_builder.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_open_agent_builder.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { useOpenAgentBuilder } from './use_open_agent_builder';
+import { useKibana } from './use_kibana';
+
+jest.mock('./use_kibana');
+
+const mockNavigateToApp = jest.fn();
+const mockUseKibana = useKibana as jest.Mock;
+
+beforeEach(() => {
+  mockNavigateToApp.mockClear();
+  mockUseKibana.mockReturnValue({
+    services: { application: { navigateToApp: mockNavigateToApp } },
+  });
+});
+
+describe('useOpenAgentBuilder', () => {
+  it('navigates to the agent builder app', () => {
+    const { result } = renderHook(() => useOpenAgentBuilder());
+    result.current('hello');
+    expect(mockNavigateToApp).toHaveBeenCalledWith(AGENT_BUILDER_APP_ID, expect.anything());
+  });
+
+  it('navigates to the new conversation path for the default agent', () => {
+    const { result } = renderHook(() => useOpenAgentBuilder());
+    result.current('hello');
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        path: `/agents/${agentBuilderDefaultAgentId}/conversations/new`,
+      })
+    );
+  });
+
+  it('passes initialMessage in navigation state', () => {
+    const { result } = renderHook(() => useOpenAgentBuilder());
+    result.current('Help me build search');
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        state: expect.objectContaining({ initialMessage: 'Help me build search' }),
+      })
+    );
+  });
+
+  it('uses search_getting_started as the default entryPointSource', () => {
+    const { result } = renderHook(() => useOpenAgentBuilder());
+    result.current('anything');
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        state: expect.objectContaining({ entryPointSource: 'search_getting_started' }),
+      })
+    );
+  });
+
+  it('passes a custom source as entryPointSource', () => {
+    const { result } = renderHook(() => useOpenAgentBuilder());
+    result.current('anything', 'my_custom_source');
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        state: expect.objectContaining({ entryPointSource: 'my_custom_source' }),
+      })
+    );
+  });
+
+  it('defaults initialMessage to an empty string when not provided', () => {
+    const { result } = renderHook(() => useOpenAgentBuilder());
+    result.current();
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        state: expect.objectContaining({ initialMessage: '' }),
+      })
+    );
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_open_agent_builder.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_open_agent_builder.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { useKibana } from './use_kibana';
+
+export const useOpenAgentBuilder = () => {
+  const {
+    services: { application },
+  } = useKibana();
+
+  const openAgentBuilder = useCallback(
+    (initialMessage: string = '', source: string = 'search_getting_started') => {
+      application.navigateToApp(AGENT_BUILDER_APP_ID, {
+        path: `/agents/${agentBuilderDefaultAgentId}/conversations/new`,
+        state: {
+          initialMessage,
+          entryPointSource: source,
+        },
+      });
+    },
+    [application]
+  );
+  return openAgentBuilder;
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_suggested_prompts.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_suggested_prompts.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { DEFAULT_PROMPTS } from '../../common/prompts';
+import { selectSuggestedPrompts, useSuggestedPrompts } from './use_suggested_prompts';
+
+describe('selectSuggestedPrompts', () => {
+  it('returns the requested number of prompts', () => {
+    expect(selectSuggestedPrompts(DEFAULT_PROMPTS, 4)).toHaveLength(4);
+  });
+
+  it('returns all prompts when count exceeds the list length', () => {
+    expect(selectSuggestedPrompts(DEFAULT_PROMPTS, 100)).toHaveLength(DEFAULT_PROMPTS.length);
+  });
+
+  it('returns only prompts that exist in the source list', () => {
+    const selected = selectSuggestedPrompts(DEFAULT_PROMPTS, 4);
+    selected.forEach((p) => {
+      expect(DEFAULT_PROMPTS).toContainEqual(p);
+    });
+  });
+
+  it('returns no duplicates', () => {
+    const selected = selectSuggestedPrompts(DEFAULT_PROMPTS, DEFAULT_PROMPTS.length);
+    const ids = selected.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('returns an empty array when given an empty list', () => {
+    expect(selectSuggestedPrompts([], 4)).toHaveLength(0);
+  });
+});
+
+describe('useSuggestedPrompts', () => {
+  it('returns exactly 4 prompts', () => {
+    const { result } = renderHook(() => useSuggestedPrompts());
+    expect(result.current).toHaveLength(4);
+  });
+
+  it('returns prompts that are all valid SuggestedPrompt objects', () => {
+    const { result } = renderHook(() => useSuggestedPrompts());
+    result.current.forEach((p) => {
+      expect(p).toHaveProperty('id');
+      expect(p).toHaveProperty('prompt');
+    });
+  });
+
+  it('returns a stable list across re-renders', () => {
+    const { result, rerender } = renderHook(() => useSuggestedPrompts());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_suggested_prompts.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_suggested_prompts.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState } from 'react';
+import { shuffle } from 'lodash';
+import { DEFAULT_PROMPTS, type SuggestedPrompt } from '../../common/prompts';
+
+const DISPLAYED_PROMPT_COUNT = 4;
+
+export const selectSuggestedPrompts = (
+  prompts: SuggestedPrompt[],
+  count: number = DISPLAYED_PROMPT_COUNT
+): SuggestedPrompt[] => shuffle(prompts).slice(0, count);
+
+export const useSuggestedPrompts = (): SuggestedPrompt[] => {
+  const [prompts] = useState<SuggestedPrompt[]>(() => selectSuggestedPrompts(DEFAULT_PROMPTS));
+  return prompts;
+};


### PR DESCRIPTION
## Summary

Introduced suggested prompts for the getting started chat page.

### Testing

1. Run Kibana with serverless elasticsearch & eis enabled
2. Enabled the feature flag in kibana.dev.yaml:
```yaml
feature_flags.overrides:
  searchSolution.gettingStartedChatEnabled: true
```

### Screenshots
<img width="1617" height="979" alt="image" src="https://github.com/user-attachments/assets/01138cc8-eb5a-4595-b0a4-30ea84608800" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
