### PR TITLE
[CSP] Un-skip benchmark v2 API integration test (stale skip from #243499)

### DIFF
--- a/x-pack/solutions/security/test/api_integration/apis/cloud_security_posture/benchmark/v2.ts
+++ b/x-pack/solutions/security/test/api_integration/apis/cloud_security_posture/benchmark/v2.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  // TODO: see https://github.com/elastic/kibana/pull/243499
-  describe.skip('GET /internal/cloud_security_posture/benchmark', () => {
+  describe('GET /internal/cloud_security_posture/benchmark', () => {
     let agentPolicyId: string;
     let agentPolicyId2: string;
     let agentPolicyId3: string;
@@ -24,6 +23,12 @@ export default function ({ getService }: FtrProviderContext) {
     beforeEach(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+
+      await supertest
+        .post(`/api/fleet/setup`)
+        .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
+        .set('kbn-xsrf', 'xxxx')
+        .expect(200);
 
       const { body: agentPolicyResponse } = await supertest
         .post(`/api/fleet/agent_policies`)


### PR DESCRIPTION
## Summary

Un-skips `x-pack/solutions/security/test/api_integration/apis/cloud_security_posture/benchmark/v2.ts`.

This test was temporarily skipped in November 2025 while a bug in `@kbn/cleanup-before-exit` was fixed ([#243499](https://github.com/elastic/kibana/pull/243499)). The fix was merged the same day and has been live for 6+ months. All other suites skipped in that batch have been re-enabled; this one was overlooked.

Tracking issue: #244717

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/GUIDELINE.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Identify risks

- Low. Only un-skipping a previously passing test. The underlying infrastructure bug (`@kbn/cleanup-before-exit` passing `undefined` exit code) was fixed months ago.
