### PR TITLE
[9.3] [js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)

### DIFF
--- a/src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts
+++ b/src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import yaml from 'js-yaml';
+import { stringify } from 'yaml';
 
 const OTEL_DEMO_VERSION = '1.12.0';
 const NAMESPACE = 'otel-demo';
@@ -472,7 +472,7 @@ export function getKubernetesManifests(options: K8sManifestOptions): string {
     },
   });
 
-  return manifests.map((m) => yaml.dump(m)).join('---\n');
+  return manifests.map((m) => stringify(m)).join('---\n');
 }
 
 function createDeployment(opts: {

--- a/src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts
+++ b/src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts
@@ -9,7 +9,7 @@
 
 import type { ToolingLog } from '@kbn/tooling-log';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 import { pickBy, identity } from 'lodash';
 import { resolve } from 'path';
 
@@ -41,15 +41,12 @@ export const readKibanaConfig = (log: ToolingLog, configPath?: string): KibanaCo
   let serverConfigValues = {};
 
   if (fs.existsSync(configPathToUse)) {
-    const config = (yaml.load(fs.readFileSync(configPathToUse, 'utf8')) || {}) as Record<
-      string,
-      any
-    >;
+    const config = (parse(fs.readFileSync(configPathToUse, 'utf8')) || {}) as Record<string, any>;
     esConfigValues = config.elasticsearch || {};
     serverConfigValues = config.server || {};
   } else {
     log.warning(
-      `Config file not found at ${configPathToUse}. 
+      `Config file not found at ${configPathToUse}.
       Using environment variables or defaults for Elasticsearch credentials.`
     );
   }

--- a/src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts
+++ b/src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts
@@ -9,7 +9,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as yaml from 'js-yaml';
+import * as yaml from 'yaml';
 import { processSemconvYaml, extractFirstExample } from '../src/lib/generate_semconv';
 import type { ResolvedSemconvYaml, YamlGroup } from '../src/types/semconv_types';
 
@@ -30,7 +30,7 @@ describe('OpenTelemetry Semantic Conventions Processing', () => {
 
   const createYamlFile = (groups: YamlGroup[]) => {
     const yamlContent: ResolvedSemconvYaml = { groups };
-    fs.writeFileSync(tempYamlFile, yaml.dump(yamlContent), 'utf8');
+    fs.writeFileSync(tempYamlFile, yaml.stringify(yamlContent), 'utf8');
   };
 
   describe('Deterministic Ordering for PR Diffs', () => {
@@ -135,7 +135,7 @@ describe('OpenTelemetry Semantic Conventions Processing', () => {
     });
 
     it('handles missing groups property', () => {
-      fs.writeFileSync(tempYamlFile, yaml.dump({ notGroups: [] }), 'utf8');
+      fs.writeFileSync(tempYamlFile, yaml.stringify({ notGroups: [] }), 'utf8');
 
       expect(() => processSemconvYaml(tempYamlFile)).toThrow(
         /missing or invalid "groups" property/

--- a/src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts
+++ b/src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts
@@ -8,7 +8,7 @@
  */
 
 import * as fs from 'fs';
-import * as yaml from 'js-yaml';
+import * as yaml from 'yaml';
 import { getHardcodedMappings } from './hardcoded_mappings';
 import { sortObjectByKeys } from './sorting_utils';
 import type {
@@ -254,7 +254,7 @@ function processMetricGroups(
 function loadYamlFile(filePath: string): ResolvedSemconvYaml {
   try {
     const fileContent = fs.readFileSync(filePath, 'utf8');
-    const parsed = yaml.load(fileContent) as ResolvedSemconvYaml;
+    const parsed = yaml.parse(fileContent) as ResolvedSemconvYaml;
 
     if (!parsed || !parsed.groups || !Array.isArray(parsed.groups)) {
       throw new Error('Invalid YAML structure: missing or invalid "groups" property');

--- a/src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts
+++ b/src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts
@@ -8,7 +8,7 @@
  */
 
 import * as fs from 'fs';
-import * as yaml from 'js-yaml';
+import { parse, stringify } from 'yaml';
 
 interface YamlAttribute {
   name?: string;
@@ -61,7 +61,7 @@ export function sortYamlFile(inputFile: string, outputFile: string): void {
   try {
     // Read and parse the YAML file
     const yamlContent = fs.readFileSync(inputFile, 'utf8');
-    const data = yaml.load(yamlContent) as ResolvedSemconvYaml;
+    const data = parse(yamlContent) as ResolvedSemconvYaml;
 
     if (!data || !data.groups) {
       throw new Error('Invalid YAML structure: missing "groups" property');
@@ -74,11 +74,11 @@ export function sortYamlFile(inputFile: string, outputFile: string): void {
     };
 
     // Write the sorted YAML back to file
-    const sortedYaml = yaml.dump(sortedData, {
+    const sortedYaml = stringify(sortedData, {
       indent: 2,
       lineWidth: -1, // Disable line wrapping
-      noRefs: true, // Disable anchors/references
-      sortKeys: false, // We handle sorting manually for better control
+      aliasDuplicateObjects: false, // Disable anchors/references
+      sortMapEntries: false, // We handle sorting manually for better control
     });
 
     fs.writeFileSync(outputFile, sortedYaml, 'utf8');

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -614,7 +614,7 @@ function generateAgentConfigTar(output: Output, installedIntegrations: Installed
       path: 'elastic-agent.yml',
       mode: 0o644,
       mtime: now,
-      data: dump({
+      data: stringify({
         outputs: {
           default: transformOutputToFullPolicyOutput(output, undefined, true),
         },

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -12,7 +12,7 @@ import {
   FleetUnauthorizedError,
   type PackageClient,
 } from '@kbn/fleet-plugin/server';
-import { dump } from 'js-yaml';
+import { stringify } from 'yaml';
 import type { PackageDataStreamTypes, Output } from '@kbn/fleet-plugin/common/types';
 import { transformOutputToFullPolicyOutput } from '@kbn/fleet-plugin/server/services/output_client';
 import { OBSERVABILITY_ONBOARDING_TELEMETRY_EVENT } from '../../../common/telemetry_events';
@@ -484,7 +484,7 @@ async function ensureInstalledIntegrations(
         pkgName,
         pkgVersion: '1.0.0', // Custom integrations are always installed as version `1.0.0`
         title: pkgName,
-        config: dump({
+        config: stringify({
           inputs: [
             {
               id: `filestream-${pkgName}`,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)](https://github.com/elastic/kibana/pull/252349)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-05-29T06:58:39Z","message":"[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)\n\nCloses #267871\n\n## Migration: js-yaml → yaml\n\nThis PR migrates 8 file(s) from `js-yaml` to `yaml` package for\n@elastic/obs-onboarding-team.\n\n### Changes\n- Replaced `js-yaml` imports with `yaml` package\n- Updated function calls: `load()` → `parse()`, `dump()` → `stringify()`\n- Mapped options:\n  - `noRefs: true` → `aliasDuplicateObjects: false`\n  - `skipInvalid: true` → `strict: false`\n  - `sortKeys` → `sortMapEntries`\n  - `JSON_SCHEMA` → `schema: 'core'`\n\n### Files Changed\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/online_boutique/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/otel_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts`\n- `src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts`\n\n### Testing\n- All relevant Jest tests pass\n- Snapshot tests updated to reflect new YAML output format\n\n---\n\n**Note:** This is part of a larger migration effort. Other teams' files\nare in separate PRs. These changes were generated using Cursor.","sha":"95273155871d61a1c674823af4f26ba4102a441e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0"],"title":"[js-yaml to yaml migration] @elastic/obs-onboarding-team","number":252349,"url":"https://github.com/elastic/kibana/pull/252349","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)\n\nCloses #267871\n\n## Migration: js-yaml → yaml\n\nThis PR migrates 8 file(s) from `js-yaml` to `yaml` package for\n@elastic/obs-onboarding-team.\n\n### Changes\n- Replaced `js-yaml` imports with `yaml` package\n- Updated function calls: `load()` → `parse()`, `dump()` → `stringify()`\n- Mapped options:\n  - `noRefs: true` → `aliasDuplicateObjects: false`\n  - `skipInvalid: true` → `strict: false`\n  - `sortKeys` → `sortMapEntries`\n  - `JSON_SCHEMA` → `schema: 'core'`\n\n### Files Changed\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/online_boutique/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/otel_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts`\n- `src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts`\n\n### Testing\n- All relevant Jest tests pass\n- Snapshot tests updated to reflect new YAML output format\n\n---\n\n**Note:** This is part of a larger migration effort. Other teams' files\nare in separate PRs. These changes were generated using Cursor.","sha":"95273155871d61a1c674823af4f26ba4102a441e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252349","number":252349,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)\n\nCloses #267871\n\n## Migration: js-yaml → yaml\n\nThis PR migrates 8 file(s) from `js-yaml` to `yaml` package for\n@elastic/obs-onboarding-team.\n\n### Changes\n- Replaced `js-yaml` imports with `yaml` package\n- Updated function calls: `load()` → `parse()`, `dump()` → `stringify()`\n- Mapped options:\n  - `noRefs: true` → `aliasDuplicateObjects: false`\n  - `skipInvalid: true` → `strict: false`\n  - `sortKeys` → `sortMapEntries`\n  - `JSON_SCHEMA` → `schema: 'core'`\n\n### Files Changed\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/online_boutique/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/otel_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts`\n- `src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts`\n\n### Testing\n- All relevant Jest tests pass\n- Snapshot tests updated to reflect new YAML output format\n\n---\n\n**Note:** This is part of a larger migration effort. Other teams' files\nare in separate PRs. These changes were generated using Cursor.","sha":"95273155871d61a1c674823af4f26ba4102a441e"}},{"url":"https://github.com/elastic/kibana/pull/271832","number":271832,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->