### PR TITLE
[8.19] [js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -12,7 +12,7 @@ import {
   FleetUnauthorizedError,
   type PackageClient,
 } from '@kbn/fleet-plugin/server';
-import { dump } from 'js-yaml';
+import { stringify } from 'yaml';
 import { PackageDataStreamTypes, Output } from '@kbn/fleet-plugin/common/types';
 import { transformOutputToFullPolicyOutput } from '@kbn/fleet-plugin/server/services/output_client';
 import { OBSERVABILITY_ONBOARDING_TELEMETRY_EVENT } from '../../../common/telemetry_events';
@@ -431,7 +431,7 @@ async function ensureInstalledIntegrations(
         pkgName,
         pkgVersion: '1.0.0', // Custom integrations are always installed as version `1.0.0`
         title: pkgName,
-        config: dump({
+        config: stringify({
           inputs: [
             {
               id: `filestream-${pkgName}`,

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -561,7 +561,7 @@ function generateAgentConfigTar(output: Output, installedIntegrations: Installed
       path: 'elastic-agent.yml',
       mode: 0o644,
       mtime: now,
-      data: dump({
+      data: stringify({
         outputs: {
           default: transformOutputToFullPolicyOutput(output, undefined, true),
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)](https://github.com/elastic/kibana/pull/252349)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-05-29T06:58:39Z","message":"[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)\n\nCloses #267871\n\n## Migration: js-yaml → yaml\n\nThis PR migrates 8 file(s) from `js-yaml` to `yaml` package for\n@elastic/obs-onboarding-team.\n\n### Changes\n- Replaced `js-yaml` imports with `yaml` package\n- Updated function calls: `load()` → `parse()`, `dump()` → `stringify()`\n- Mapped options:\n  - `noRefs: true` → `aliasDuplicateObjects: false`\n  - `skipInvalid: true` → `strict: false`\n  - `sortKeys` → `sortMapEntries`\n  - `JSON_SCHEMA` → `schema: 'core'`\n\n### Files Changed\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/online_boutique/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/otel_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts`\n- `src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts`\n\n### Testing\n- All relevant Jest tests pass\n- Snapshot tests updated to reflect new YAML output format\n\n---\n\n**Note:** This is part of a larger migration effort. Other teams' files\nare in separate PRs. These changes were generated using Cursor.","sha":"95273155871d61a1c674823af4f26ba4102a441e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0"],"title":"[js-yaml to yaml migration] @elastic/obs-onboarding-team","number":252349,"url":"https://github.com/elastic/kibana/pull/252349","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)\n\nCloses #267871\n\n## Migration: js-yaml → yaml\n\nThis PR migrates 8 file(s) from `js-yaml` to `yaml` package for\n@elastic/obs-onboarding-team.\n\n### Changes\n- Replaced `js-yaml` imports with `yaml` package\n- Updated function calls: `load()` → `parse()`, `dump()` → `stringify()`\n- Mapped options:\n  - `noRefs: true` → `aliasDuplicateObjects: false`\n  - `skipInvalid: true` → `strict: false`\n  - `sortKeys` → `sortMapEntries`\n  - `JSON_SCHEMA` → `schema: 'core'`\n\n### Files Changed\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/online_boutique/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/otel_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts`\n- `src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts`\n\n### Testing\n- All relevant Jest tests pass\n- Snapshot tests updated to reflect new YAML output format\n\n---\n\n**Note:** This is part of a larger migration effort. Other teams' files\nare in separate PRs. These changes were generated using Cursor.","sha":"95273155871d61a1c674823af4f26ba4102a441e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252349","number":252349,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/obs-onboarding-team (#252349)\n\nCloses #267871\n\n## Migration: js-yaml → yaml\n\nThis PR migrates 8 file(s) from `js-yaml` to `yaml` package for\n@elastic/obs-onboarding-team.\n\n### Changes\n- Replaced `js-yaml` imports with `yaml` package\n- Updated function calls: `load()` → `parse()`, `dump()` → `stringify()`\n- Mapped options:\n  - `noRefs: true` → `aliasDuplicateObjects: false`\n  - `skipInvalid: true` → `strict: false`\n  - `sortKeys` → `sortMapEntries`\n  - `JSON_SCHEMA` → `schema: 'core'`\n\n### Files Changed\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/online_boutique/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/demos/otel_demo/manifests.ts`\n-\n`src/platform/packages/shared/kbn-otel-demo/src/get_kubernetes_manifests.ts`\n- `src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/__tests__/generate_semconv.test.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/lib/generate_semconv.ts`\n-\n`src/platform/packages/shared/kbn-otel-semantic-conventions/src/sort_yaml.ts`\n-\n`x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts`\n\n### Testing\n- All relevant Jest tests pass\n- Snapshot tests updated to reflect new YAML output format\n\n---\n\n**Note:** This is part of a larger migration effort. Other teams' files\nare in separate PRs. These changes were generated using Cursor.","sha":"95273155871d61a1c674823af4f26ba4102a441e"}},{"url":"https://github.com/elastic/kibana/pull/271832","number":271832,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->