### PR TITLE
[9.3] [Profiling] Fix profiling API tests when running on test lanes (again) (#271733)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/server/utils/create_profiling_es_client.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/utils/create_profiling_es_client.ts
@@ -19,6 +19,8 @@ import type {
 } from '@kbn/profiling-utils';
 import { withProfilingSpan } from './with_profiling_span';
 
+const PROFILING_STATUS_TIMEOUT_SECONDS = 60;
+
 export function cancelEsRequestOnAbort<T extends Promise<any>>(
   promise: T,
   request: KibanaRequest,
@@ -129,13 +131,15 @@ export function createProfilingEsClient({
             {
               method: 'GET',
               path: encodeURI(
-                `/_profiling/status?wait_for_resources_created=${waitForResourcesCreated}`
+                `/_profiling/status?wait_for_resources_created=${waitForResourcesCreated}&timeout=${
+                  PROFILING_STATUS_TIMEOUT_SECONDS + 5
+                }s`
               ),
             },
             {
               signal: controller.signal,
               meta: true,
-              requestTimeout: 60000,
+              requestTimeout: PROFILING_STATUS_TIMEOUT_SECONDS * 1000,
               maxRetries: 5,
               retryOnTimeout: true,
             }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/README.md
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/README.md
@@ -13,6 +13,7 @@ node scripts/scout.js start-server --arch serverless --domain [search|observabil
 ### Run the Tests
 
 **Note**: Profiling resources and test data are automatically set up when you run the tests. The global setup hook will:
+
 - Set up profiling Elasticsearch resources via `/api/profiling/setup/es_resources`
 - Load test profiling data from 'x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/worker/profiling/test_data'
 - Skip setup if resources and data are already present
@@ -28,7 +29,16 @@ npx playwright test --config x-pack/solutions/observability/plugins/profiling/te
 ## Test Categories
 
 Tests are tagged with:
+
 - `@local-stateful-classic` - Stateful tests
 - `@local-serverless-observability_complete` - Serverless tests - currently not supported in Universal Profiling
 
 Test results are available in `x-pack/solutions/observability/plugins/profiling/test/scout/ui/output`
+
+## Api Tests Execution Order
+
+While UI tests run in parallel, api tests can't be parallelized as they test different setups that could conflict with one another. To avoid constant setups and cleanups of profiling resources, which can lead to performance issues and flaky tests, api tests must run sequentially and in a predefined order.
+
+This strict ordering will ensure suites testing features for missing setups will run before those requiring partial setups, which in turn run before others requiring full setup and data. Thanks to it, the tests can limit the amount of calls to setup resources and cleanup, instead of having to setup the whole thing in each `beforeAll` as well as having to cleanup in every `afterAll`. The global teardown hook that runs after all suites will ensure cleanup is done before terminating the profiling suite execution ensuring tests cleanup after themselves and do not pollute test lanes when running in one.
+
+By default, playwright runs tests in the order they're discovered when read from the test directory. This is why api test files are prefixed with a given number which indicates the order they're expected to run, being 00\_\* the first test to run. If you're adding a new test, consider your suite's needs in terms of setup and data. If your tests concern features when no setup and/or data is present be sure to run them **before** tests that do configure resources and data. And likewise, if your test is configuring resources or adding data make sure it runs **after** tests that expect empty config or data.

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts
@@ -12,25 +12,21 @@ import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
 apiTest.describe(
-  'APM integration not installed but setup completed',
+  'Profiling is not setup and no data is loaded',
   { tag: tags.stateful.classic },
   () => {
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
-    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
-      // Ensure the agent policy that the cloud setup attaches the profiler_collector and
-      // profiler_symbolizer package policies to exists. Without this, setupResources()
-      // returns 500 when this spec runs ahead of (or independently of) has_no_setup.spec.
-      await profilingHelper.installPolicies();
 
-      if (!(await profilingSetup.checkStatus()).has_setup) {
-        await profilingSetup.setupResources();
-      }
+    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
+      await profilingSetup.cleanup();
+      await profilingHelper.cleanupPolicies();
+
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
     });
 
-    apiTest('Admin user', async ({ apiClient }) => {
+    apiTest('Admin users', async ({ apiClient }) => {
       const adminRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...adminApiCreditials.apiKeyHeader,
@@ -38,14 +34,13 @@ apiTest.describe(
           'kbn-xsrf': 'reporting',
         },
       });
-
       const adminStatus = adminRes.body;
-      expect(adminStatus.has_setup).toBe(true);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_setup).toBe(false);
+      expect(adminStatus.has_data).toBeDefined();
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
     });
 
-    apiTest('Viewer user', async ({ apiClient }) => {
+    apiTest('Viewer users', async ({ apiClient }) => {
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...viewerApiCreditials.apiKeyHeader,
@@ -53,11 +48,10 @@ apiTest.describe(
           'kbn-xsrf': 'reporting',
         },
       });
-
       const readStatus = readRes.body;
-      expect(readStatus.has_setup).toBe(true);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_setup).toBe(false);
+      expect(readStatus.has_data).toBeDefined();
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts
@@ -11,22 +11,26 @@ import { tags } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
-// Failing: See https://github.com/elastic/kibana/issues/268400
-apiTest.describe.skip(
-  'Profiling is not setup and no data is loaded',
+apiTest.describe(
+  'APM integration not installed but setup completed',
   { tag: tags.stateful.classic },
   () => {
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
+
     apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
-      await profilingHelper.cleanupPolicies();
-      await profilingHelper.installPolicies();
-      await profilingSetup.cleanup();
+      const status = await profilingSetup.checkStatus();
+
+      if (!status.has_setup) {
+        await profilingHelper.installPolicies();
+        await profilingSetup.setupResources();
+      }
+
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
     });
 
-    apiTest('Admin users', async ({ apiClient }) => {
+    apiTest('Admin user', async ({ apiClient }) => {
       const adminRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...adminApiCreditials.apiKeyHeader,
@@ -34,13 +38,14 @@ apiTest.describe.skip(
           'kbn-xsrf': 'reporting',
         },
       });
+
       const adminStatus = adminRes.body;
-      expect(adminStatus.has_setup).toBe(false);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_setup).toBe(true);
+      expect(adminStatus.has_data).toBeDefined();
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
     });
 
-    apiTest('Viewer users', async ({ apiClient }) => {
+    apiTest('Viewer user', async ({ apiClient }) => {
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...viewerApiCreditials.apiKeyHeader,
@@ -48,10 +53,11 @@ apiTest.describe.skip(
           'kbn-xsrf': 'reporting',
         },
       });
+
       const readStatus = readRes.body;
-      expect(readStatus.has_setup).toBe(false);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_setup).toBe(true);
+      expect(readStatus.has_data).toBeDefined();
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts
@@ -14,17 +14,23 @@ import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/cons
 apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.classic }, () => {
   let viewerApiCreditials: RoleApiCredentials;
   let adminApiCreditials: RoleApiCredentials;
-  apiTest.beforeAll(async ({ requestAuth, profilingHelper, profilingSetup }) => {
-    // Make this spec self-sufficient instead of relying on has_no_setup.spec running first:
-    // ensure the cloud agent policy exists and profiling resources are set up before
-    // attempting to load data.
-    await profilingHelper.installPolicies();
 
-    if (!(await profilingSetup.checkStatus()).has_setup) {
+  apiTest.beforeAll(async ({ requestAuth, profilingHelper, profilingSetup }) => {
+    let status = await profilingSetup.checkStatus();
+
+    if (!status.has_setup) {
+      await profilingHelper.installPolicies();
       await profilingSetup.setupResources();
     }
 
-    await profilingSetup.loadData(esArchiversPath);
+    if (!status.has_data) {
+      await profilingSetup.loadData(esArchiversPath);
+    }
+
+    status = await profilingSetup.checkStatus();
+    expect(status.has_setup).toBe(true);
+    expect(status.has_data).toBe(true);
+
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
     adminApiCreditials = await requestAuth.getApiKey('admin');
   });
@@ -40,7 +46,7 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
     const adminStatus = adminRes.body;
     expect(adminStatus.has_setup).toBe(true);
     expect(adminStatus.has_data).toBe(true);
-    expect(adminStatus.pre_8_9_1_data).toBe(false);
+    expect(adminStatus.pre_8_9_1_data).toBeDefined();
   });
 
   apiTest('Viewer user', async ({ apiClient }) => {
@@ -55,7 +61,7 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
     const readStatus = readRes.body;
     expect(readStatus.has_setup).toBe(true);
     expect(readStatus.has_data).toBe(true);
-    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBeDefined();
     expect(readStatus.has_required_role).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts
@@ -9,16 +9,31 @@ import { expect } from '@kbn/scout-oblt/api';
 import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { tags } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
-import { esResourcesEndpoint } from '../../common/fixtures/constants';
+import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/constants';
 
 apiTest.describe('Collector integration is not installed', { tag: tags.stateful.classic }, () => {
   let viewerApiCreditials: RoleApiCredentials;
-  apiTest.beforeAll(async ({ requestAuth, profilingSetup }) => {
-    await profilingSetup.cleanup();
+
+  apiTest.beforeAll(async ({ requestAuth, profilingSetup, profilingHelper }) => {
+    let ids = await profilingHelper.getPolicyIds();
+    if (!ids.collectorId || !ids.symbolizerId) {
+      await profilingHelper.installPolicies();
+      await profilingSetup.setupResources();
+      ids = await profilingHelper.getPolicyIds();
+    }
+
+    expect(ids.collectorId).toBeDefined();
+    expect(ids.symbolizerId).toBeDefined();
+
+    // Same fixture as has_setup_with_data: ensure profiling* has documents so we assert has_data like has_setup — indexed data remains after Fleet policy deletion.
+    let status = await profilingSetup.checkStatus();
+    if (!status.has_data) {
+      await profilingSetup.loadData(esArchiversPath);
+      status = await profilingSetup.checkStatus();
+    }
+    expect(status.has_data).toBe(true);
+
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
-  });
-  apiTest.afterAll(async ({ profilingHelper }) => {
-    profilingHelper.cleanupPolicies();
   });
 
   apiTest('collector integration missing', async ({ profilingHelper, apiServices, apiClient }) => {
@@ -44,8 +59,8 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
     });
     const readStatus = readRes.body;
     expect(readStatus.has_setup).toBe(false);
-    expect(readStatus.has_data).toBe(false);
-    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_data).toBe(true);
+    expect(readStatus.pre_8_9_1_data).toBeDefined();
     expect(readStatus.has_required_role).toBe(false);
   });
 
@@ -69,8 +84,8 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
       });
       const adminStatus = adminRes.body;
       expect(adminStatus.has_setup).toBe(false);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_data).toBe(true);
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
 
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
@@ -79,8 +94,8 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
       });
       const readStatus = readRes.body;
       expect(readStatus.has_setup).toBe(false);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_data).toBe(true);
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     }
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Profiling] Fix profiling API tests when running on test lanes (again) (#271733)](https://github.com/elastic/kibana/pull/271733)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-29T08:00:57Z","message":"[Profiling] Fix profiling API tests when running on test lanes (again) (#271733)\n\n## Summary\n\nThis PR is the result of investigating and trying to fix the latest\nflakiness issues for profiling API suites as reported in this [issue\ncomment](https://github.com/elastic/kibana/issues/248929#issuecomment-4563292721)\n\nThe error message we're dealing with this time is\n```\nKbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Error while setting up Universal Profiling\"}\n```\nWhich at first glance looked awfully similar to the errors #270623 was\ntargeting which read\n```\nKbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Error while setting up Universal Profiling\",\"attributes\":{\"cause\":\"Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found\",\"name\":\"Error\"}}\n```\n\nBut looking more carefully at both messages, we can notice the error now\ndoesn't have an explicit cause, while before it complained about `Saved\nobject [fleet-agent-policies/policy-elastic-agent-on-cloud] not found`\nWhile these are good news as at least we know #270623 did fix something,\nbut the current issue merits deeper investigation\n\n## The Symptom: ES returning a 408 response\n\n### Background\n\nThe Universal Profiling setup flow in Kibana ends with a call to\n`GET /_profiling/status?wait_for_resources_created=true`. This is a\nlong-polling\nendpoint: when `wait_for_resources_created=true`, ES holds the\nconnection open and\nwatches for cluster state changes, responding only once all profiling\nresources\n(index templates, ILM policies, data streams) are confirmed created — or\nwhen it\ntimes out.\n\n### Why Kibana sees a 408\n\nThe problem is a **race between two timeouts** that Kibana was losing\nevery time.\n\n**ES side:**\n\n[`RestGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/rest/RestGetStatusAction.java)\nparses the request and sets the server-side wait budget:\n\n```java\nrestRequest.paramAsTime(\"timeout\", TimeValue.THIRTY_SECONDS)\n```\n\nThe default server-side timeout is **30 seconds** when no `timeout=`\nquery parameter\nis provided.\n\n[`TransportGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java)\nuses this value to register a `ClusterStateObserver` that waits up to\nthat timeout\nfor `resolver::isResourcesCreated` to become true. When the timeout\nelapses and\nresources still aren't ready, the `onTimeout` callback fires:\n\n```java\n@Override\npublic void onTimeout(TimeValue timeout) {\n    resolver.execute(clusterService.state(), ActionListener.wrap(response -> {\n        response.setTimedOut(true);\n        listener.onResponse(response);\n    }, listener::onFailure));\n}\n```\n\nES then sends back a **completed HTTP response** with status code 408,\nvia this\nmapping in\n\n[`GetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetStatusAction.java):\n\n```java\npublic RestStatus status() {\n    return timedOut ? RestStatus.REQUEST_TIMEOUT : RestStatus.OK;\n}\n```\n\nThe response body contains\n`{ profiling: { enabled: true }, resource_management: { enabled: true },\nresources: { created: false } }`\n— the current partial status at timeout.\n\n**Kibana side:** The call was configured with `requestTimeout: 60_000` —\na 60-second\nclient-side budget. Since ES's default server timeout is 30s and\nKibana's was 60s,\n**ES always won the race**: it responded with a 408 at ~30s, well before\nKibana's\n60s client timeout ever fired.\n\n### Why that 408 was not retried\n\nA 408 response is a **completed HTTP exchange** from the transport's\nperspective.\nThe `@elastic/transport` client only auto-retries on `TimeoutError`\n(client-side\ntimeout before any response arrives) and HTTP 502/503/504. The existing\noptions\n`retryOnTimeout: true` and `maxRetries: 5` are both gated on a\nclient-side\n`TimeoutError` — they never triggered because Kibana received a valid\nHTTP response\n(just with status 408). The 408 was surfaced as a `ResponseError` and\nreturned to\nthe user as a failure with no retry attempt.\n\n### The fix\n\nBy appending `&timeout=65s` to the request path, we explicitly tell ES\nto wait\n**65 seconds** server-side before giving up. Kibana's `requestTimeout:\n60_000` now\nwins the race — it fires 5 seconds before ES would return a 408. The\nresulting\nclient-side `TimeoutError` is exactly what `retryOnTimeout: true` +\n`maxRetries: 5`\nwas already designed to handle: up to 6 attempts, each with a fresh 60s\nbudget,\nwith bounded exponential backoff between retries. No code path that\npreviously\nobserved a 60s per-attempt budget is affected.\n\nThis not only affects test runs, but it will also correct this behaviour\nin the actual profiling UI. In case ES is slow to respond the request\nwill keep retrying for longer than 30s (as it was always intended)\ninstead of failing and showing an error in the UI after 30s.\n\nThe code for this fix is in e8fe7a24896c3d028ec4982c1eb128732fd87887. \n\n### Is the error gone?\n\nWhile the problem described was an actual oversight we had in Kibana,\nthis error is a symptom rather than the cause. After implementing this\nchange we were no longer experiencing 408s but a new problem came\naround. Tests weren't failing mid run anymore but now the default test\nruntime timeout of 60s was being hit. My first instinct was bumping the\ntimeout up, but even 180s wasn't enough. At this point it was clear the\n408s coming from ES were just the way the issue was surfacing, while the\nreal problem was why was ES taking so long to complete the profiling\nsetup process\n\n## The Root Cause: Profiling is constantly setup and cleaned up\n\n### Background\n\nThe API suites have different requirements when it comes to profiling\nresources and/or data existing or not during test execution. Because\nwe're also verifying how the system behaves when setup or data is\nmissing as well as when everything is already wired up, we can't have a\nsingle global setup hook that pre-loads everything and leaves profiling\nsetup and data ingested.\n\nThis is also the reason why these suites aren't parallel and instead run\nsequentially. We can't ran suites concurrently because test requirements\nwould conflict with one another. But, even so they run sequentially,\neach test was being treated as a completely independent unit. What this\nmeans is each test was setting up (or cleaning up) all the resources it\nrequired as well as completely cleaning up after each one. This\nsituation lead to elasticsearch being continuously bombarded with\nrequest to setup resources quickly followed by requests to delete those\nsame resources it just created, repeated for each suite in the profiling\nconfig. Depending on how much work ES is dealing with and the state it\nwas left in by other tests in the lane it could lead to the situation\nobserved above where it starts to become overwhelmed and the setup call\nwould take too long.\n\n### The Fix\n\nThanks to test running sequentially, we can optimise the execution\nprocess by carefully controlling the order in which each suite runs. If\nwe can ensure suites expecting empty resources and/or data run first and\nthen are followed by suites that do fully setup and load data, we can\nreduce the amount of times we're loading and offloading resources,\nreducing the impact tests have on ES. While ideally each test would be\n100% independent from the rest, this is not the environment tests will\nbe running on specially on CI with tests lanes. Test shouldn't make the\nassumption that they're running on new and clean environments, so this\nPR adapts these suites to be resilient to polluted and overloaded\nenvironments.\n\nBy default, playwright runs test in the same order they're discovered\nfrom the test dir, aka, alphabetically. To ensure tests remain ordered\nas we expect them to be going forward, each test file is now prefixed by\na number. The first test to run is prefixed 00_* With this in mind, I've\nmodified and ordered each suite to try to reduce the number of setup and\ncleanup calls. While each tests will still make sure the environment is\nin the state it's expect in a `beforeAll` hook, each setup call is now\nguarded. This way, if resource or data already exist we won't try to set\nthem up again. Also, I've removed the `afterAll` hooks that were\ncleaning up everything profiling-related after each suite ran. If test\n02 creates the ES resources, test 03 can reuse those instead of having\nto create them all over again. And becase each test still checks if\neverything they expect is in place, they remain independent of each\nother if they need to.\n\nFor instance, if test 02 was skipped or removed it wouldn't cause test\n03 to then break as 03 is capable of setting up the environment as it\nexpects it to be. Each suite maintains it's capability to set itself up\nfor success while also gaining the ability to reuse pre-existing\nresources and data data other tests might have already created before\nthem","sha":"86bd4c5817c49814e938cd3a59f9d0acefcbce55","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"[Profiling] Fix profiling API tests when running on test lanes (again)","number":271733,"url":"https://github.com/elastic/kibana/pull/271733","mergeCommit":{"message":"[Profiling] Fix profiling API tests when running on test lanes (again) (#271733)\n\n## Summary\n\nThis PR is the result of investigating and trying to fix the latest\nflakiness issues for profiling API suites as reported in this [issue\ncomment](https://github.com/elastic/kibana/issues/248929#issuecomment-4563292721)\n\nThe error message we're dealing with this time is\n```\nKbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Error while setting up Universal Profiling\"}\n```\nWhich at first glance looked awfully similar to the errors #270623 was\ntargeting which read\n```\nKbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Error while setting up Universal Profiling\",\"attributes\":{\"cause\":\"Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found\",\"name\":\"Error\"}}\n```\n\nBut looking more carefully at both messages, we can notice the error now\ndoesn't have an explicit cause, while before it complained about `Saved\nobject [fleet-agent-policies/policy-elastic-agent-on-cloud] not found`\nWhile these are good news as at least we know #270623 did fix something,\nbut the current issue merits deeper investigation\n\n## The Symptom: ES returning a 408 response\n\n### Background\n\nThe Universal Profiling setup flow in Kibana ends with a call to\n`GET /_profiling/status?wait_for_resources_created=true`. This is a\nlong-polling\nendpoint: when `wait_for_resources_created=true`, ES holds the\nconnection open and\nwatches for cluster state changes, responding only once all profiling\nresources\n(index templates, ILM policies, data streams) are confirmed created — or\nwhen it\ntimes out.\n\n### Why Kibana sees a 408\n\nThe problem is a **race between two timeouts** that Kibana was losing\nevery time.\n\n**ES side:**\n\n[`RestGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/rest/RestGetStatusAction.java)\nparses the request and sets the server-side wait budget:\n\n```java\nrestRequest.paramAsTime(\"timeout\", TimeValue.THIRTY_SECONDS)\n```\n\nThe default server-side timeout is **30 seconds** when no `timeout=`\nquery parameter\nis provided.\n\n[`TransportGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java)\nuses this value to register a `ClusterStateObserver` that waits up to\nthat timeout\nfor `resolver::isResourcesCreated` to become true. When the timeout\nelapses and\nresources still aren't ready, the `onTimeout` callback fires:\n\n```java\n@Override\npublic void onTimeout(TimeValue timeout) {\n    resolver.execute(clusterService.state(), ActionListener.wrap(response -> {\n        response.setTimedOut(true);\n        listener.onResponse(response);\n    }, listener::onFailure));\n}\n```\n\nES then sends back a **completed HTTP response** with status code 408,\nvia this\nmapping in\n\n[`GetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetStatusAction.java):\n\n```java\npublic RestStatus status() {\n    return timedOut ? RestStatus.REQUEST_TIMEOUT : RestStatus.OK;\n}\n```\n\nThe response body contains\n`{ profiling: { enabled: true }, resource_management: { enabled: true },\nresources: { created: false } }`\n— the current partial status at timeout.\n\n**Kibana side:** The call was configured with `requestTimeout: 60_000` —\na 60-second\nclient-side budget. Since ES's default server timeout is 30s and\nKibana's was 60s,\n**ES always won the race**: it responded with a 408 at ~30s, well before\nKibana's\n60s client timeout ever fired.\n\n### Why that 408 was not retried\n\nA 408 response is a **completed HTTP exchange** from the transport's\nperspective.\nThe `@elastic/transport` client only auto-retries on `TimeoutError`\n(client-side\ntimeout before any response arrives) and HTTP 502/503/504. The existing\noptions\n`retryOnTimeout: true` and `maxRetries: 5` are both gated on a\nclient-side\n`TimeoutError` — they never triggered because Kibana received a valid\nHTTP response\n(just with status 408). The 408 was surfaced as a `ResponseError` and\nreturned to\nthe user as a failure with no retry attempt.\n\n### The fix\n\nBy appending `&timeout=65s` to the request path, we explicitly tell ES\nto wait\n**65 seconds** server-side before giving up. Kibana's `requestTimeout:\n60_000` now\nwins the race — it fires 5 seconds before ES would return a 408. The\nresulting\nclient-side `TimeoutError` is exactly what `retryOnTimeout: true` +\n`maxRetries: 5`\nwas already designed to handle: up to 6 attempts, each with a fresh 60s\nbudget,\nwith bounded exponential backoff between retries. No code path that\npreviously\nobserved a 60s per-attempt budget is affected.\n\nThis not only affects test runs, but it will also correct this behaviour\nin the actual profiling UI. In case ES is slow to respond the request\nwill keep retrying for longer than 30s (as it was always intended)\ninstead of failing and showing an error in the UI after 30s.\n\nThe code for this fix is in e8fe7a24896c3d028ec4982c1eb128732fd87887. \n\n### Is the error gone?\n\nWhile the problem described was an actual oversight we had in Kibana,\nthis error is a symptom rather than the cause. After implementing this\nchange we were no longer experiencing 408s but a new problem came\naround. Tests weren't failing mid run anymore but now the default test\nruntime timeout of 60s was being hit. My first instinct was bumping the\ntimeout up, but even 180s wasn't enough. At this point it was clear the\n408s coming from ES were just the way the issue was surfacing, while the\nreal problem was why was ES taking so long to complete the profiling\nsetup process\n\n## The Root Cause: Profiling is constantly setup and cleaned up\n\n### Background\n\nThe API suites have different requirements when it comes to profiling\nresources and/or data existing or not during test execution. Because\nwe're also verifying how the system behaves when setup or data is\nmissing as well as when everything is already wired up, we can't have a\nsingle global setup hook that pre-loads everything and leaves profiling\nsetup and data ingested.\n\nThis is also the reason why these suites aren't parallel and instead run\nsequentially. We can't ran suites concurrently because test requirements\nwould conflict with one another. But, even so they run sequentially,\neach test was being treated as a completely independent unit. What this\nmeans is each test was setting up (or cleaning up) all the resources it\nrequired as well as completely cleaning up after each one. This\nsituation lead to elasticsearch being continuously bombarded with\nrequest to setup resources quickly followed by requests to delete those\nsame resources it just created, repeated for each suite in the profiling\nconfig. Depending on how much work ES is dealing with and the state it\nwas left in by other tests in the lane it could lead to the situation\nobserved above where it starts to become overwhelmed and the setup call\nwould take too long.\n\n### The Fix\n\nThanks to test running sequentially, we can optimise the execution\nprocess by carefully controlling the order in which each suite runs. If\nwe can ensure suites expecting empty resources and/or data run first and\nthen are followed by suites that do fully setup and load data, we can\nreduce the amount of times we're loading and offloading resources,\nreducing the impact tests have on ES. While ideally each test would be\n100% independent from the rest, this is not the environment tests will\nbe running on specially on CI with tests lanes. Test shouldn't make the\nassumption that they're running on new and clean environments, so this\nPR adapts these suites to be resilient to polluted and overloaded\nenvironments.\n\nBy default, playwright runs test in the same order they're discovered\nfrom the test dir, aka, alphabetically. To ensure tests remain ordered\nas we expect them to be going forward, each test file is now prefixed by\na number. The first test to run is prefixed 00_* With this in mind, I've\nmodified and ordered each suite to try to reduce the number of setup and\ncleanup calls. While each tests will still make sure the environment is\nin the state it's expect in a `beforeAll` hook, each setup call is now\nguarded. This way, if resource or data already exist we won't try to set\nthem up again. Also, I've removed the `afterAll` hooks that were\ncleaning up everything profiling-related after each suite ran. If test\n02 creates the ES resources, test 03 can reuse those instead of having\nto create them all over again. And becase each test still checks if\neverything they expect is in place, they remain independent of each\nother if they need to.\n\nFor instance, if test 02 was skipped or removed it wouldn't cause test\n03 to then break as 03 is capable of setting up the environment as it\nexpects it to be. Each suite maintains it's capability to set itself up\nfor success while also gaining the ability to reuse pre-existing\nresources and data data other tests might have already created before\nthem","sha":"86bd4c5817c49814e938cd3a59f9d0acefcbce55"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271733","number":271733,"mergeCommit":{"message":"[Profiling] Fix profiling API tests when running on test lanes (again) (#271733)\n\n## Summary\n\nThis PR is the result of investigating and trying to fix the latest\nflakiness issues for profiling API suites as reported in this [issue\ncomment](https://github.com/elastic/kibana/issues/248929#issuecomment-4563292721)\n\nThe error message we're dealing with this time is\n```\nKbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Error while setting up Universal Profiling\"}\n```\nWhich at first glance looked awfully similar to the errors #270623 was\ntargeting which read\n```\nKbnClientRequesterError: [POST http://localhost:5620/api/profiling/setup/es_resources] 500 Internal Server Error -- {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Error while setting up Universal Profiling\",\"attributes\":{\"cause\":\"Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found\",\"name\":\"Error\"}}\n```\n\nBut looking more carefully at both messages, we can notice the error now\ndoesn't have an explicit cause, while before it complained about `Saved\nobject [fleet-agent-policies/policy-elastic-agent-on-cloud] not found`\nWhile these are good news as at least we know #270623 did fix something,\nbut the current issue merits deeper investigation\n\n## The Symptom: ES returning a 408 response\n\n### Background\n\nThe Universal Profiling setup flow in Kibana ends with a call to\n`GET /_profiling/status?wait_for_resources_created=true`. This is a\nlong-polling\nendpoint: when `wait_for_resources_created=true`, ES holds the\nconnection open and\nwatches for cluster state changes, responding only once all profiling\nresources\n(index templates, ILM policies, data streams) are confirmed created — or\nwhen it\ntimes out.\n\n### Why Kibana sees a 408\n\nThe problem is a **race between two timeouts** that Kibana was losing\nevery time.\n\n**ES side:**\n\n[`RestGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/rest/RestGetStatusAction.java)\nparses the request and sets the server-side wait budget:\n\n```java\nrestRequest.paramAsTime(\"timeout\", TimeValue.THIRTY_SECONDS)\n```\n\nThe default server-side timeout is **30 seconds** when no `timeout=`\nquery parameter\nis provided.\n\n[`TransportGetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java)\nuses this value to register a `ClusterStateObserver` that waits up to\nthat timeout\nfor `resolver::isResourcesCreated` to become true. When the timeout\nelapses and\nresources still aren't ready, the `onTimeout` callback fires:\n\n```java\n@Override\npublic void onTimeout(TimeValue timeout) {\n    resolver.execute(clusterService.state(), ActionListener.wrap(response -> {\n        response.setTimedOut(true);\n        listener.onResponse(response);\n    }, listener::onFailure));\n}\n```\n\nES then sends back a **completed HTTP response** with status code 408,\nvia this\nmapping in\n\n[`GetStatusAction.java`](https://github.com/elastic/elasticsearch/blob/1823a1f7dba79df95db4013c323c7afb219e4489/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetStatusAction.java):\n\n```java\npublic RestStatus status() {\n    return timedOut ? RestStatus.REQUEST_TIMEOUT : RestStatus.OK;\n}\n```\n\nThe response body contains\n`{ profiling: { enabled: true }, resource_management: { enabled: true },\nresources: { created: false } }`\n— the current partial status at timeout.\n\n**Kibana side:** The call was configured with `requestTimeout: 60_000` —\na 60-second\nclient-side budget. Since ES's default server timeout is 30s and\nKibana's was 60s,\n**ES always won the race**: it responded with a 408 at ~30s, well before\nKibana's\n60s client timeout ever fired.\n\n### Why that 408 was not retried\n\nA 408 response is a **completed HTTP exchange** from the transport's\nperspective.\nThe `@elastic/transport` client only auto-retries on `TimeoutError`\n(client-side\ntimeout before any response arrives) and HTTP 502/503/504. The existing\noptions\n`retryOnTimeout: true` and `maxRetries: 5` are both gated on a\nclient-side\n`TimeoutError` — they never triggered because Kibana received a valid\nHTTP response\n(just with status 408). The 408 was surfaced as a `ResponseError` and\nreturned to\nthe user as a failure with no retry attempt.\n\n### The fix\n\nBy appending `&timeout=65s` to the request path, we explicitly tell ES\nto wait\n**65 seconds** server-side before giving up. Kibana's `requestTimeout:\n60_000` now\nwins the race — it fires 5 seconds before ES would return a 408. The\nresulting\nclient-side `TimeoutError` is exactly what `retryOnTimeout: true` +\n`maxRetries: 5`\nwas already designed to handle: up to 6 attempts, each with a fresh 60s\nbudget,\nwith bounded exponential backoff between retries. No code path that\npreviously\nobserved a 60s per-attempt budget is affected.\n\nThis not only affects test runs, but it will also correct this behaviour\nin the actual profiling UI. In case ES is slow to respond the request\nwill keep retrying for longer than 30s (as it was always intended)\ninstead of failing and showing an error in the UI after 30s.\n\nThe code for this fix is in e8fe7a24896c3d028ec4982c1eb128732fd87887. \n\n### Is the error gone?\n\nWhile the problem described was an actual oversight we had in Kibana,\nthis error is a symptom rather than the cause. After implementing this\nchange we were no longer experiencing 408s but a new problem came\naround. Tests weren't failing mid run anymore but now the default test\nruntime timeout of 60s was being hit. My first instinct was bumping the\ntimeout up, but even 180s wasn't enough. At this point it was clear the\n408s coming from ES were just the way the issue was surfacing, while the\nreal problem was why was ES taking so long to complete the profiling\nsetup process\n\n## The Root Cause: Profiling is constantly setup and cleaned up\n\n### Background\n\nThe API suites have different requirements when it comes to profiling\nresources and/or data existing or not during test execution. Because\nwe're also verifying how the system behaves when setup or data is\nmissing as well as when everything is already wired up, we can't have a\nsingle global setup hook that pre-loads everything and leaves profiling\nsetup and data ingested.\n\nThis is also the reason why these suites aren't parallel and instead run\nsequentially. We can't ran suites concurrently because test requirements\nwould conflict with one another. But, even so they run sequentially,\neach test was being treated as a completely independent unit. What this\nmeans is each test was setting up (or cleaning up) all the resources it\nrequired as well as completely cleaning up after each one. This\nsituation lead to elasticsearch being continuously bombarded with\nrequest to setup resources quickly followed by requests to delete those\nsame resources it just created, repeated for each suite in the profiling\nconfig. Depending on how much work ES is dealing with and the state it\nwas left in by other tests in the lane it could lead to the situation\nobserved above where it starts to become overwhelmed and the setup call\nwould take too long.\n\n### The Fix\n\nThanks to test running sequentially, we can optimise the execution\nprocess by carefully controlling the order in which each suite runs. If\nwe can ensure suites expecting empty resources and/or data run first and\nthen are followed by suites that do fully setup and load data, we can\nreduce the amount of times we're loading and offloading resources,\nreducing the impact tests have on ES. While ideally each test would be\n100% independent from the rest, this is not the environment tests will\nbe running on specially on CI with tests lanes. Test shouldn't make the\nassumption that they're running on new and clean environments, so this\nPR adapts these suites to be resilient to polluted and overloaded\nenvironments.\n\nBy default, playwright runs test in the same order they're discovered\nfrom the test dir, aka, alphabetically. To ensure tests remain ordered\nas we expect them to be going forward, each test file is now prefixed by\na number. The first test to run is prefixed 00_* With this in mind, I've\nmodified and ordered each suite to try to reduce the number of setup and\ncleanup calls. While each tests will still make sure the environment is\nin the state it's expect in a `beforeAll` hook, each setup call is now\nguarded. This way, if resource or data already exist we won't try to set\nthem up again. Also, I've removed the `afterAll` hooks that were\ncleaning up everything profiling-related after each suite ran. If test\n02 creates the ES resources, test 03 can reuse those instead of having\nto create them all over again. And becase each test still checks if\neverything they expect is in place, they remain independent of each\nother if they need to.\n\nFor instance, if test 02 was skipped or removed it wouldn't cause test\n03 to then break as 03 is capable of setting up the environment as it\nexpects it to be. Each suite maintains it's capability to set itself up\nfor success while also gaining the ability to reuse pre-existing\nresources and data data other tests might have already created before\nthem","sha":"86bd4c5817c49814e938cd3a59f9d0acefcbce55"}}]}] BACKPORT-->