### PR TITLE
[9.4] feat(obs-onboarding-team): replace title props and wrap EuiButtonIcon with EuiToolTip (#271496)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/content/import_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/content/import_flyout.tsx
@@ -28,6 +28,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTitle,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -149,7 +150,7 @@ export function ImportContentPackFlyout({
               <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
                 <EuiFlexGroup alignItems="center" gutterSize="m">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="package" />
+                    <EuiIcon type="package" aria-hidden={true} />
                   </EuiFlexItem>
 
                   <EuiFlexItem grow={false}>
@@ -158,19 +159,29 @@ export function ImportContentPackFlyout({
                 </EuiFlexGroup>
 
                 <EuiFlexItem grow={false}>
-                  <EuiButtonIcon
-                    aria-label={i18n.translate('xpack.streams.importContentPackFlyout.closeIcon', {
+                  <EuiToolTip
+                    content={i18n.translate('xpack.streams.importContentPackFlyout.closeIcon', {
                       defaultMessage: 'Close',
                     })}
-                    iconType="cross"
-                    color="danger"
-                    onClick={() => {
-                      setFile(undefined);
-                      setManifest(undefined);
-                      setContentPackObjects(undefined);
-                      setIncludedObjects({ objects: { all: {} } });
-                    }}
-                  />
+                    disableScreenReaderOutput
+                  >
+                    <EuiButtonIcon
+                      aria-label={i18n.translate(
+                        'xpack.streams.importContentPackFlyout.closeIcon',
+                        {
+                          defaultMessage: 'Close',
+                        }
+                      )}
+                      iconType="cross"
+                      color="danger"
+                      onClick={() => {
+                        setFile(undefined);
+                        setManifest(undefined);
+                        setContentPackObjects(undefined);
+                        setIncludedObjects({ objects: { all: {} } });
+                      }}
+                    />
+                  </EuiToolTip>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPanel>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/content/objects_list/tree.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/content/objects_list/tree.tsx
@@ -15,6 +15,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { ContentPackStream } from '@kbn/content-packs-schema';
 import {
@@ -116,7 +117,10 @@ export function StreamTree({
               </EuiLink>
             )}
             <EuiText color="subdued" size="s">
-              {selectedCount}/{Object.values(rows).length} selected
+              {selectedCount}/{Object.values(rows).length}{' '}
+              {i18n.translate('xpack.streams.streamTree.selectedTextLabel', {
+                defaultMessage: 'selected',
+              })}
             </EuiText>
           </EuiFlexGroup>
         </EuiFlexItem>
@@ -138,39 +142,53 @@ export function StreamTree({
               {item.parent ? (
                 item.expanded ? (
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      aria-label={i18n.translate('xpack.streams.contentPack.tree.collapse', {
+                    <EuiToolTip
+                      content={i18n.translate('xpack.streams.contentPack.tree.collapse', {
                         defaultMessage: 'Collapse',
                       })}
-                      iconType="chevronSingleDown"
-                      color="text"
-                      onClick={() => {
-                        setRows((prevRows) => {
-                          const updated = { ...prevRows };
-                          updated[item.name].expanded = false;
-                          onSelectionChange(updated);
-                          return updated;
-                        });
-                      }}
-                    />
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        aria-label={i18n.translate('xpack.streams.contentPack.tree.collapse', {
+                          defaultMessage: 'Collapse',
+                        })}
+                        iconType="chevronSingleDown"
+                        color="text"
+                        onClick={() => {
+                          setRows((prevRows) => {
+                            const updated = { ...prevRows };
+                            updated[item.name].expanded = false;
+                            onSelectionChange(updated);
+                            return updated;
+                          });
+                        }}
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 ) : (
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      aria-label={i18n.translate('xpack.streams.contentPack.tree.expand', {
+                    <EuiToolTip
+                      content={i18n.translate('xpack.streams.contentPack.tree.expand', {
                         defaultMessage: 'Expand',
                       })}
-                      iconType="chevronSingleRight"
-                      color="text"
-                      onClick={() => {
-                        setRows((prevRows) => {
-                          const updated = { ...prevRows };
-                          updated[item.name].expanded = true;
-                          onSelectionChange(updated);
-                          return updated;
-                        });
-                      }}
-                    />
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        aria-label={i18n.translate('xpack.streams.contentPack.tree.expand', {
+                          defaultMessage: 'Expand',
+                        })}
+                        iconType="chevronSingleRight"
+                        color="text"
+                        onClick={() => {
+                          setRows((prevRows) => {
+                            const updated = { ...prevRows };
+                            updated[item.name].expanded = true;
+                            onSelectionChange(updated);
+                            return updated;
+                          });
+                        }}
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 )
               ) : (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/request_preview_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/request_preview_flyout/index.tsx
@@ -20,6 +20,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -59,14 +60,16 @@ export const RequestPreviewFlyout = ({
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              aria-label={downloadAriaLabel}
-              display="base"
-              size="m"
-              download="streams-request.txt"
-              href={`data:text/plain;charset=utf-8,${encodeURIComponent(codeContent)}`}
-              iconType="download"
-            />
+            <EuiToolTip content={downloadAriaLabel} disableScreenReaderOutput>
+              <EuiButtonIcon
+                aria-label={downloadAriaLabel}
+                display="base"
+                size="m"
+                download="streams-request.txt"
+                href={`data:text/plain;charset=utf-8,${encodeURIComponent(codeContent)}`}
+                iconType="download"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/field_actions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/field_actions.tsx
@@ -6,7 +6,13 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiButtonIcon, EuiContextMenu, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiContextMenu,
+  EuiPopover,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useBoolean } from '@kbn/react-hooks';
 import { toMountPoint } from '@kbn/react-kibana-mount';
@@ -214,15 +220,23 @@ export const FieldActionsCell = ({ field }: { field: SchemaField }) => {
     <EuiPopover
       id={contextMenuPopoverId}
       button={
-        <EuiButtonIcon
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.streams.streamDetailSchemaEditorFieldsTableActionsTriggerButton',
             { defaultMessage: 'Open actions menu' }
           )}
-          data-test-subj="streamsAppActionsButton"
-          iconType="boxesVertical"
-          onClick={toggle}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailSchemaEditorFieldsTableActionsTriggerButton',
+              { defaultMessage: 'Open actions menu' }
+            )}
+            data-test-subj="streamsAppActionsButton"
+            iconType="boxesVertical"
+            onClick={toggle}
+          />
+        </EuiToolTip>
       }
       isOpen={popoverIsOpen}
       closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/shared/preview_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/shared/preview_table.tsx
@@ -13,13 +13,14 @@ import type {
   EuiDataGridToolbarProps,
 } from '@elastic/eui';
 import {
+  EuiButtonEmpty,
   EuiButtonIcon,
   EuiDataGrid,
   EuiFlexGroup,
   EuiFlexItem,
-  useEuiTheme,
+  EuiToolTip,
   euiScreenReaderOnly,
-  EuiButtonEmpty,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -60,22 +61,30 @@ function RowSelectionButton({ rowIndex }: { rowIndex: number }) {
   const { selectedRowIndex, onRowSelected } = useRowSelection();
 
   return (
-    <EuiButtonIcon
-      onClick={() => {
-        if (onRowSelected) {
-          onRowSelected(rowIndex);
-        }
-      }}
-      aria-label={i18n.translate(
-        'xpack.streams.resultPanel.euiDataGrid.preview.selectRowAriaLabel',
-        {
-          defaultMessage: 'Select row {rowIndex}',
-          values: { rowIndex: rowIndex + 1 },
-        }
-      )}
-      iconType={selectedRowIndex === rowIndex ? 'minimize' : 'expand'}
-      color={selectedRowIndex === rowIndex ? 'primary' : 'text'}
-    />
+    <EuiToolTip
+      content={i18n.translate('xpack.streams.resultPanel.euiDataGrid.preview.selectRowAriaLabel', {
+        defaultMessage: 'Select row {rowIndex}',
+        values: { rowIndex: rowIndex + 1 },
+      })}
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        onClick={() => {
+          if (onRowSelected) {
+            onRowSelected(rowIndex);
+          }
+        }}
+        aria-label={i18n.translate(
+          'xpack.streams.resultPanel.euiDataGrid.preview.selectRowAriaLabel',
+          {
+            defaultMessage: 'Select row {rowIndex}',
+            values: { rowIndex: rowIndex + 1 },
+          }
+        )}
+        iconType={selectedRowIndex === rowIndex ? 'minimize' : 'expand'}
+        color={selectedRowIndex === rowIndex ? 'primary' : 'text'}
+      />
+    </EuiToolTip>
   );
 }
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/create_step_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/create_step_button.tsx
@@ -6,13 +6,14 @@
  */
 
 import {
-  EuiPopover,
-  EuiContextMenuPanel,
-  EuiContextMenuItem,
-  useGeneratedHtmlId,
   EuiButton,
-  EuiIcon,
   EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiIcon,
+  EuiPopover,
+  EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React from 'react';
 import useToggle from 'react-use/lib/useToggle';
@@ -118,20 +119,30 @@ export const CreateStepButton: React.FC<AddStepProps> = ({
   );
 
   const inlineButton = (
-    <EuiButtonIcon
-      data-test-subj="streamsAppStreamDetailEnrichmentCreateStepButtonInline"
-      data-stream-type={streamType}
-      size="xs"
-      iconType="plusCircle"
-      onClick={togglePopover}
-      disabled={!canAddStep}
-      aria-label={i18n.translate(
+    <EuiToolTip
+      content={i18n.translate(
         'xpack.streams.streamDetailView.managementTab.enrichment.createStepButtonInlineAriaLabel',
         {
           defaultMessage: 'Create nested step',
         }
       )}
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        data-test-subj="streamsAppStreamDetailEnrichmentCreateStepButtonInline"
+        data-stream-type={streamType}
+        size="xs"
+        iconType="plusCircle"
+        onClick={togglePopover}
+        disabled={!canAddStep}
+        aria-label={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.createStepButtonInlineAriaLabel',
+          {
+            defaultMessage: 'Create nested step',
+          }
+        )}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/concat/concat_from_builder.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/concat/concat_from_builder.tsx
@@ -18,6 +18,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiSuperSelect,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FieldNameWithIcon } from '@kbn/react-field';
@@ -143,7 +144,7 @@ const FromBuilderItem = ({
                   defaultMessage: 'Drag Handle',
                 })}
               >
-                <EuiIcon type="dragVertical" />
+                <EuiIcon type="dragVertical" aria-hidden={true} />
               </EuiPanel>
             </EuiFlexItem>
           )}
@@ -155,15 +156,22 @@ const FromBuilderItem = ({
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="trash"
-              color="danger"
-              size="m"
-              aria-label={i18n.translate('xpack.streams.fromBuilderItem.removeLabel', {
+            <EuiToolTip
+              content={i18n.translate('xpack.streams.fromBuilderItem.removeLabel', {
                 defaultMessage: 'Remove',
               })}
-              onClick={() => onRemove(index)}
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                iconType="trash"
+                color="danger"
+                size="m"
+                aria-label={i18n.translate('xpack.streams.fromBuilderItem.removeLabel', {
+                  defaultMessage: 'Remove',
+                })}
+                onClick={() => onRemove(index)}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/grok/grok_patterns_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/grok/grok_patterns_editor.tsx
@@ -9,14 +9,15 @@ import React from 'react';
 import { useFormContext, useFieldArray } from 'react-hook-form';
 import type { DragDropContextProps, EuiButtonEmptyProps } from '@elastic/eui';
 import {
-  EuiFormRow,
-  EuiPanel,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiDraggable,
   EuiFlexGroup,
-  EuiIcon,
-  EuiButtonIcon,
   EuiFlexItem,
+  EuiFormRow,
+  EuiIcon,
+  EuiPanel,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -179,7 +180,7 @@ const DraggablePatternInput = ({
                   { defaultMessage: 'Drag Handle' }
                 )}
               >
-                <EuiIcon type="dragVertical" />
+                <EuiIcon type="dragVertical" aria-hidden={true} />
               </EuiPanel>
             </EuiFlexItem>
             <EuiFlexItem style={{ minWidth: 0 }}>
@@ -191,16 +192,24 @@ const DraggablePatternInput = ({
               />
             </EuiFlexItem>
             {onRemove && (
-              <EuiButtonIcon
-                data-test-subj="streamsAppDraggablePatternInputButton"
-                iconType="minusCircle"
-                color="danger"
-                onClick={onRemove}
-                aria-label={i18n.translate(
+              <EuiToolTip
+                content={i18n.translate(
                   'xpack.streams.streamDetailView.managementTab.enrichment.processor.grokEditor.removePattern',
                   { defaultMessage: 'Remove grok pattern' }
                 )}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  data-test-subj="streamsAppDraggablePatternInputButton"
+                  iconType="minusCircle"
+                  color="danger"
+                  onClick={onRemove}
+                  aria-label={i18n.translate(
+                    'xpack.streams.streamDetailView.managementTab.enrichment.processor.grokEditor.removePattern',
+                    { defaultMessage: 'Remove grok pattern' }
+                  )}
+                />
+              </EuiToolTip>
             )}
           </EuiFlexGroup>
         </EuiFormRow>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
@@ -19,6 +19,7 @@ import {
   EuiSpacer,
   EuiSuperSelect,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useController, useFieldArray, useFormContext } from 'react-hook-form';
@@ -276,17 +277,25 @@ const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) =
         />
       </EuiFormRow>
       <div css={{ alignSelf: 'center' }}>
-        <EuiButtonIcon
-          iconType="trash"
-          color="danger"
-          onClick={onRemove}
-          disabled={!canRemove}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractRemoveExtraction',
             { defaultMessage: 'Remove extraction' }
           )}
-          data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="trash"
+            color="danger"
+            onClick={onRemove}
+            disabled={!canRemove}
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractRemoveExtraction',
+              { defaultMessage: 'Remove extraction' }
+            )}
+            data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
+          />
+        </EuiToolTip>
       </div>
     </>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/network_direction/internal_networks_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/network_direction/internal_networks_selector.tsx
@@ -15,6 +15,7 @@ import {
   EuiFormRow,
   EuiSpacer,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { Fragment, useState, type ReactNode } from 'react';
@@ -49,16 +50,24 @@ const InternalNetworksFieldInput = ({ index, onRemove }: InternalNetworksFieldIn
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          iconType="trash"
-          color="danger"
-          size="m"
-          onClick={() => onRemove(index)}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.streams.streamDetailView.managementTab.enrichment.processor.networkDirectionsSelectorInternalNetworksRemoveButton',
             { defaultMessage: 'Remove' }
           )}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="trash"
+            color="danger"
+            size="m"
+            onClick={() => onRemove(index)}
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.networkDirectionsSelectorInternalNetworksRemoveButton',
+              { defaultMessage: 'Remove' }
+            )}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   );
@@ -88,16 +97,24 @@ const InternalNetworksContent = () => {
             <InternalNetworksFieldInput index={index} onRemove={handleRemove} />
           </EuiFlexItem>
         ))}
-        <EuiButtonIcon
-          iconType="plus"
-          display="base"
-          color="text"
-          onClick={handleAdd}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.streams.streamDetailView.managementTab.enrichment.processor.networkDirectionsSelectorInternalNetworksAddButton',
             { defaultMessage: 'Add' }
           )}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="plus"
+            display="base"
+            color="text"
+            onClick={handleAdd}
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.networkDirectionsSelectorInternalNetworksAddButton',
+              { defaultMessage: 'Add' }
+            )}
+          />
+        </EuiToolTip>
       </EuiFlexGroup>
     </EuiFormRow>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/redact/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/redact/index.tsx
@@ -9,16 +9,17 @@ import React, { useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
-  EuiSpacer,
-  EuiFieldText,
-  EuiFormRow,
+  EuiButtonEmpty,
+  EuiButtonIcon,
   EuiCode,
+  EuiComboBox,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonIcon,
-  EuiButtonEmpty,
-  EuiComboBox,
+  EuiFormRow,
+  EuiSpacer,
   EuiText,
+  EuiToolTip,
   type EuiComboBoxOptionOption,
 } from '@elastic/eui';
 import { useController, useFieldArray, useFormContext } from 'react-hook-form';
@@ -272,16 +273,24 @@ const PatternField = ({ index, onRemove, canRemove }: PatternFieldProps) => {
       </EuiFlexItem>
       {canRemove && (
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="trash"
-            color="danger"
-            onClick={onRemove}
-            aria-label={i18n.translate(
+          <EuiToolTip
+            content={i18n.translate(
               'xpack.streams.streamDetailView.managementTab.enrichment.processor.redactRemovePattern',
               { defaultMessage: 'Remove pattern' }
             )}
-            data-test-subj={`streamsAppRedactRemovePatternButton-${index}`}
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              iconType="trash"
+              color="danger"
+              onClick={onRemove}
+              aria-label={i18n.translate(
+                'xpack.streams.streamDetailView.managementTab.enrichment.processor.redactRemovePattern',
+                { defaultMessage: 'Remove pattern' }
+              )}
+              data-test-subj={`streamsAppRedactRemovePatternButton-${index}`}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       )}
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
@@ -10,6 +10,7 @@ import {
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiPopover,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -309,20 +310,30 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
   ];
 
   const button = (
-    <EuiButtonIcon
-      aria-label={i18n.translate(
+    <EuiToolTip
+      content={i18n.translate(
         'xpack.streams.streamDetailView.managementTab.enrichment.stepContextMenuButtonAriaLabel',
         {
           defaultMessage: 'Step context menu',
         }
       )}
-      data-test-subj="streamsAppStreamDetailEnrichmentStepContextMenuButton"
-      data-stream-type={streamType}
-      disabled={!!stepUnderEdit}
-      size="xs"
-      iconType="boxesVertical"
-      onClick={togglePopover}
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        aria-label={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.stepContextMenuButtonAriaLabel',
+          {
+            defaultMessage: 'Step context menu',
+          }
+        )}
+        data-test-subj="streamsAppStreamDetailEnrichmentStepContextMenuButton"
+        data-stream-type={streamType}
+        disabled={!!stepUnderEdit}
+        size="xs"
+        iconType="boxesVertical"
+        onClick={togglePopover}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/where/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/where/index.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiSpacer,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -159,16 +160,26 @@ export const WhereBlock = (props: StepConfigurationProps) => {
                       margin-left: -${euiTheme.size.xxs};
                     `}
                   >
-                    <EuiButtonIcon
-                      iconType={isExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
-                      onClick={toggle}
-                      aria-label={i18n.translate(
+                    <EuiToolTip
+                      content={i18n.translate(
                         'xpack.streams.streamDetailView.managementTab.enrichment.toggleNestedStepsButtonAriaLabel',
                         {
                           defaultMessage: 'Toggle nested steps',
                         }
                       )}
-                    />
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        iconType={isExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
+                        onClick={toggle}
+                        aria-label={i18n.translate(
+                          'xpack.streams.streamDetailView.managementTab.enrichment.toggleNestedStepsButtonAriaLabel',
+                          {
+                            defaultMessage: 'Toggle nested steps',
+                          }
+                        )}
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 ) : null}
                 <EuiFlexItem

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/idle_routing_stream_entry.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/idle_routing_stream_entry.tsx
@@ -148,15 +148,22 @@ export function IdleRoutingStreamEntry({
                 <VerticalRule />
               </>
             )}
-            <EuiButtonIcon
-              data-test-subj={`routingRuleEditButton-${routingRule.destination}`}
-              iconType="pencil"
-              disabled={!isEditingEnabled}
-              onClick={() => onEditClick(routingRule.id)}
-              aria-label={i18n.translate('xpack.streams.streamDetailRouting.edit', {
+            <EuiToolTip
+              content={i18n.translate('xpack.streams.streamDetailRouting.edit', {
                 defaultMessage: 'Edit',
               })}
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                data-test-subj={`routingRuleEditButton-${routingRule.destination}`}
+                iconType="pencil"
+                disabled={!isEditingEnabled}
+                onClick={() => onEditClick(routingRule.id)}
+                aria-label={i18n.translate('xpack.streams.streamDetailRouting.edit', {
+                  defaultMessage: 'Edit',
+                })}
+              />
+            </EuiToolTip>
           </EuiFlexGroup>
         </EuiFlexGroup>
         <EuiFlexItem

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/query_stream_entry.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/query_stream_entry.tsx
@@ -7,18 +7,19 @@
 
 import React, { useCallback } from 'react';
 import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiText,
-  EuiButtonIcon,
-  EuiPanel,
-  useEuiTheme,
   EuiLink,
+  EuiPanel,
   EuiSkeletonText,
-  EuiCodeBlock,
-  EuiCallOut,
-  EuiButtonEmpty,
   EuiSpacer,
+  EuiText,
+  EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/css';
@@ -113,14 +114,24 @@ export function IdleQueryStreamEntry({ streamName, onEdit }: IdleQueryStreamEntr
             <QueryStreamBadge />
             {onEdit && (
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType="pencil"
-                  aria-label={i18n.translate('xpack.streams.queryStreamEntry.editButtonAriaLabel', {
+                <EuiToolTip
+                  content={i18n.translate('xpack.streams.queryStreamEntry.editButtonAriaLabel', {
                     defaultMessage: 'Edit query stream',
                   })}
-                  data-test-subj={`streamsAppQueryStreamEditButton-${streamName}`}
-                  onClick={() => onEdit(streamName)}
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    iconType="pencil"
+                    aria-label={i18n.translate(
+                      'xpack.streams.queryStreamEntry.editButtonAriaLabel',
+                      {
+                        defaultMessage: 'Edit query stream',
+                      }
+                    )}
+                    data-test-subj={`streamsAppQueryStreamEditButton-${streamName}`}
+                    onClick={() => onEdit(streamName)}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             )}
           </EuiFlexGroup>
@@ -287,6 +298,7 @@ export function EditingQueryStreamEntry({
     return (
       <EuiPanel hasShadow={false} hasBorder paddingSize="m">
         <EuiCallOut
+          announceOnMount
           title={i18n.translate('xpack.streams.editingQueryStreamEntry.fetchError', {
             defaultMessage: 'Unable to load query stream details',
           })}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/review_suggestions_form/refinement_popover.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/review_suggestions_form/refinement_popover.tsx
@@ -7,16 +7,17 @@
 
 import React, { useState, useCallback, useRef } from 'react';
 import {
-  EuiPopover,
-  EuiButtonIcon,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPopover,
   EuiText,
-  useEuiTheme,
-  useEuiFontSize,
-  useGeneratedHtmlId,
+  EuiToolTip,
   keys,
+  useEuiFontSize,
+  useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -223,14 +224,16 @@ export const RefinementPopover = ({
                     onClose={() => setIsConnectorPopoverOpen(false)}
                     aria-label={connectorPickerAriaLabel}
                     button={
-                      <EuiButtonIcon
-                        data-test-subj="streamsAppRefinementPickConnectorButton"
-                        onClick={() => setIsConnectorPopoverOpen((prev) => !prev)}
-                        color="text"
-                        size="s"
-                        iconType="controlsHorizontal"
-                        aria-label={connectorPickerAriaLabel}
-                      />
+                      <EuiToolTip content={connectorPickerAriaLabel} disableScreenReaderOutput>
+                        <EuiButtonIcon
+                          data-test-subj="streamsAppRefinementPickConnectorButton"
+                          onClick={() => setIsConnectorPopoverOpen((prev) => !prev)}
+                          color="text"
+                          size="s"
+                          iconType="controlsHorizontal"
+                          aria-label={connectorPickerAriaLabel}
+                        />
+                      </EuiToolTip>
                     }
                   />
                 </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/review_suggestions_form/suggested_stream_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/review_suggestions_form/suggested_stream_panel.tsx
@@ -6,17 +6,18 @@
  */
 
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiTitle,
   EuiButton,
   EuiButtonEmpty,
-  EuiSpacer,
-  EuiText,
-  EuiIcon,
-  EuiLoadingSpinner,
   EuiButtonIcon,
   EuiCheckbox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -179,7 +180,7 @@ export function SuggestedStreamPanel({
           </EuiFlexItem>
         ) : matchRate.value !== undefined ? (
           <>
-            <EuiIcon type="check" color="success" size="s" />
+            <EuiIcon type="check" color="success" size="s" aria-hidden={true} />
             <EuiText size="s" color="success">
               {matchRate.value}
             </EuiText>
@@ -188,14 +189,21 @@ export function SuggestedStreamPanel({
         <EuiFlexItem grow={false}>
           <VerticalRule />
         </EuiFlexItem>
-        <EuiButtonIcon
-          iconType="pencil"
-          onClick={() => onEdit(index, currentSuggestion)}
-          aria-label={i18n.translate('xpack.streams.streamDetailRouting.edit', {
+        <EuiToolTip
+          content={i18n.translate('xpack.streams.streamDetailRouting.edit', {
             defaultMessage: 'Edit',
           })}
-          data-test-subj={`suggestionEditButton-${currentSuggestion.name}`}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="pencil"
+            onClick={() => onEdit(index, currentSuggestion)}
+            aria-label={i18n.translate('xpack.streams.streamDetailRouting.edit', {
+              defaultMessage: 'Edit',
+            })}
+            data-test-subj={`suggestionEditButton-${currentSuggestion.name}`}
+          />
+        </EuiToolTip>
       </EuiFlexGroup>
       <EuiSpacer size="s" />
       <div data-test-subj={`suggestionConditionPanel-${currentSuggestion.name}`}>

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_apm/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_apm/index.tsx
@@ -23,6 +23,7 @@ import {
   EuiSpacer,
   EuiSteps,
   EuiText,
+  EuiToolTip,
   copyToClipboard,
   useEuiTheme,
 } from '@elastic/eui';
@@ -346,15 +347,22 @@ function ConfigureSDKInstructions({
             {value}
           </EuiText>
           {value && (
-            <EuiButtonIcon
-              data-test-subj="apmConfigurationValueColumnButton"
-              aria-label={i18n.translate('xpack.observability_onboarding.otelApm.copyIconText', {
+            <EuiToolTip
+              content={i18n.translate('xpack.observability_onboarding.otelApm.copyIconText', {
                 defaultMessage: 'Copy to clipboard',
               })}
-              color="text"
-              iconType="copy"
-              onClick={() => copyToClipboard(value)}
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                data-test-subj="apmConfigurationValueColumnButton"
+                aria-label={i18n.translate('xpack.observability_onboarding.otelApm.copyIconText', {
+                  defaultMessage: 'Copy to clipboard',
+                })}
+                color="text"
+                iconType="copy"
+                onClick={() => copyToClipboard(value)}
+              />
+            </EuiToolTip>
           )}
         </>
       ),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [feat(obs-onboarding-team): replace title props and wrap EuiButtonIcon with EuiToolTip (#271496)](https://github.com/elastic/kibana/pull/271496)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Weronika Olejniczak","email":"32842468+weronikaolejniczak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-28T15:05:43Z","message":"feat(obs-onboarding-team): replace title props and wrap EuiButtonIcon with EuiToolTip (#271496)\n\nRelates to https://github.com/elastic/eui/issues/9566\n\n> [!IMPORTANT]\n> These changes **should be carefully tested visually by each code\nowner.** Wrapping with `EuiToolTip` instead of passing `title` leads to\nanother DOM node and can potentially break the layout. In such cases, I\nwould appreciate committing appropriate fixes to this PR directly, I\ncannot possibly setup and run all Kibana functionalities to fix every\nregression.\n\nThis PR:\n\n- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same\nas `aria-label`, any `title` passed to `EuiButtonIcon` is removed,\n- changes several `title` cases (not truncation related) to use\n`EuiToolTip` instead (if applicable).","sha":"30d0e4affe81f36a00cd755a177767953904e852","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","EUI","backport:version","v9.5.0","v9.4.2"],"title":"feat(obs-onboarding-team): replace title props and wrap EuiButtonIcon with EuiToolTip","number":271496,"url":"https://github.com/elastic/kibana/pull/271496","mergeCommit":{"message":"feat(obs-onboarding-team): replace title props and wrap EuiButtonIcon with EuiToolTip (#271496)\n\nRelates to https://github.com/elastic/eui/issues/9566\n\n> [!IMPORTANT]\n> These changes **should be carefully tested visually by each code\nowner.** Wrapping with `EuiToolTip` instead of passing `title` leads to\nanother DOM node and can potentially break the layout. In such cases, I\nwould appreciate committing appropriate fixes to this PR directly, I\ncannot possibly setup and run all Kibana functionalities to fix every\nregression.\n\nThis PR:\n\n- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same\nas `aria-label`, any `title` passed to `EuiButtonIcon` is removed,\n- changes several `title` cases (not truncation related) to use\n`EuiToolTip` instead (if applicable).","sha":"30d0e4affe81f36a00cd755a177767953904e852"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271496","number":271496,"mergeCommit":{"message":"feat(obs-onboarding-team): replace title props and wrap EuiButtonIcon with EuiToolTip (#271496)\n\nRelates to https://github.com/elastic/eui/issues/9566\n\n> [!IMPORTANT]\n> These changes **should be carefully tested visually by each code\nowner.** Wrapping with `EuiToolTip` instead of passing `title` leads to\nanother DOM node and can potentially break the layout. In such cases, I\nwould appreciate committing appropriate fixes to this PR directly, I\ncannot possibly setup and run all Kibana functionalities to fix every\nregression.\n\nThis PR:\n\n- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same\nas `aria-label`, any `title` passed to `EuiButtonIcon` is removed,\n- changes several `title` cases (not truncation related) to use\n`EuiToolTip` instead (if applicable).","sha":"30d0e4affe81f36a00cd755a177767953904e852"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->