### PR TITLE
[9.4] feat(kibana-esql): replace title props and wrap EuiButtonIcon with EuiToolTip (#271484)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/esql_starred_queries_service.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/esql_starred_queries_service.test.tsx
@@ -161,8 +161,9 @@ describe('EsqlStarredQueriesService', () => {
 
     await service.addStarredQuery(query);
     const buttonWithTooltip = service.renderStarredButton(query);
-    const button = buttonWithTooltip.props.children.props.children;
-    expect(button.props.title).toEqual('Remove ES|QL query from Starred');
+    const tooltip = buttonWithTooltip.props.children.props.children;
+    const button = tooltip.props.children;
+    expect(tooltip.props.content).toEqual('Remove ES|QL query from Starred');
     expect(button.props.iconType).toEqual('starFill');
   });
 
@@ -176,8 +177,9 @@ describe('EsqlStarredQueriesService', () => {
 
     await service.addStarredQuery(query);
     const buttonWithTooltip = service.renderStarredButton(query);
-    const button = buttonWithTooltip.props.children.props.children;
-    expect(button.props.title).toEqual('Remove ES|QL query from Starred');
+    const tooltip = buttonWithTooltip.props.children.props.children;
+    const button = tooltip.props.children;
+    expect(tooltip.props.content).toEqual('Remove ES|QL query from Starred');
     button.props.onClick();
 
     expect(service.discardModalVisibility$.value).toEqual(true);
@@ -194,7 +196,7 @@ describe('EsqlStarredQueriesService', () => {
 
     await service.addStarredQuery(query);
     const buttonWithTooltip = service.renderStarredButton(query);
-    const button = buttonWithTooltip.props.children.props.children;
+    const button = buttonWithTooltip.props.children.props.children.props.children;
     button.props.onClick();
 
     expect(service.discardModalVisibility$.value).toEqual(false);

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/esql_starred_queries_service.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/esql_starred_queries_service.tsx
@@ -13,7 +13,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { CoreStart } from '@kbn/core/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FavoritesClient, StardustWrapper } from '@kbn/content-management-favorites-public';
 import { FAVORITES_LIMIT as ESQL_STARRED_QUERIES_LIMIT } from '@kbn/content-management-favorites-common';
 import { type QueryHistoryItem, getTrimmedQuery } from '../history_local_storage';
@@ -206,8 +206,8 @@ export class EsqlStarredQueriesService {
       >
         {/* show startdust effect only after starring the query and not on the initial load */}
         <StardustWrapper active={isStarred && trimmedQueryString === this.queryToAdd}>
-          <EuiButtonIcon
-            title={
+          <EuiToolTip
+            content={
               isStarred
                 ? i18n.translate('esqlEditor.query.querieshistory.removeFavoriteTitle', {
                     defaultMessage: 'Remove ES|QL query from Starred',
@@ -216,35 +216,39 @@ export class EsqlStarredQueriesService {
                     defaultMessage: 'Add ES|QL query to Starred',
                   })
             }
-            className={!isStarred ? 'cm-favorite-button--empty' : ''}
-            aria-label={
-              isStarred
-                ? i18n.translate('esqlEditor.query.querieshistory.removeFavoriteTitle', {
-                    defaultMessage: 'Remove ES|QL query from Starred',
-                  })
-                : i18n.translate('esqlEditor.query.querieshistory.addFavoriteTitle', {
-                    defaultMessage: 'Add ES|QL query to Starred',
-                  })
-            }
-            iconType={isStarred ? 'starFill' : 'star'}
-            disabled={!isStarred && this.checkIfStarredQueriesLimitReached()}
-            onClick={async () => {
-              this.queryToEdit = trimmedQueryString;
-              if (isStarred) {
-                // show the discard modal only if the user has not dismissed it
-                if (!this.storage.get(STARRED_QUERIES_DISCARD_KEY)) {
-                  this.discardModalVisibility$.next(true);
-                } else {
-                  await this.removeStarredQuery(item.queryString);
-                }
-              } else {
-                this.queryToAdd = trimmedQueryString;
-                await this.addStarredQuery(item);
-                this.queryToAdd = '';
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              className={!isStarred ? 'cm-favorite-button--empty' : ''}
+              aria-label={
+                isStarred
+                  ? i18n.translate('esqlEditor.query.querieshistory.removeFavoriteTitle', {
+                      defaultMessage: 'Remove ES|QL query from Starred',
+                    })
+                  : i18n.translate('esqlEditor.query.querieshistory.addFavoriteTitle', {
+                      defaultMessage: 'Add ES|QL query to Starred',
+                    })
               }
-            }}
-            data-test-subj="ESQLFavoriteButton"
-          />
+              iconType={isStarred ? 'starFill' : 'star'}
+              disabled={!isStarred && this.checkIfStarredQueriesLimitReached()}
+              onClick={async () => {
+                this.queryToEdit = trimmedQueryString;
+                if (isStarred) {
+                  // show the discard modal only if the user has not dismissed it
+                  if (!this.storage.get(STARRED_QUERIES_DISCARD_KEY)) {
+                    this.discardModalVisibility$.next(true);
+                  } else {
+                    await this.removeStarredQuery(item.queryString);
+                  }
+                } else {
+                  this.queryToAdd = trimmedQueryString;
+                  await this.addStarredQuery(item);
+                  this.queryToAdd = '';
+                }
+              }}
+              data-test-subj="ESQLFavoriteButton"
+            />
+          </EuiToolTip>
         </StardustWrapper>
       </TooltipWrapper>
     );

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
@@ -317,17 +317,24 @@ export function QueryList({
                   })}
                 >
                   {(copy) => (
-                    <EuiButtonIcon
-                      iconType="copy"
-                      iconSize="m"
-                      onClick={copy}
-                      css={css`
-                        cursor: pointer;
-                      `}
-                      aria-label={i18n.translate('esqlEditor.query.esqlQueriesCopy', {
+                    <EuiToolTip
+                      content={i18n.translate('esqlEditor.query.esqlQueriesCopy', {
                         defaultMessage: 'Copy query to clipboard',
                       })}
-                    />
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        iconType="copy"
+                        iconSize="m"
+                        onClick={copy}
+                        css={css`
+                          cursor: pointer;
+                        `}
+                        aria-label={i18n.translate('esqlEditor.query.esqlQueriesCopy', {
+                          defaultMessage: 'Copy query to clipboard',
+                        })}
+                      />
+                    </EuiToolTip>
                   )}
                 </EuiCopy>
               </EuiFlexItem>
@@ -419,12 +426,8 @@ export function QueryColumn({
   return (
     <>
       {isExpandable && (
-        <EuiButtonIcon
-          onClick={() => {
-            setIsRowExpanded(!isRowExpanded);
-          }}
-          data-test-subj="ESQLEditor-queryList-queryString-expanded"
-          aria-label={
+        <EuiToolTip
+          content={
             isRowExpanded
               ? i18n.translate('esqlEditor.query.collapseLabel', {
                   defaultMessage: 'Collapse',
@@ -433,13 +436,30 @@ export function QueryColumn({
                   defaultMessage: 'Expand',
                 })
           }
-          iconType={isRowExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
-          size="xs"
-          color="text"
-          css={css`
-            flex-shrink: 0;
-          `}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            onClick={() => {
+              setIsRowExpanded(!isRowExpanded);
+            }}
+            data-test-subj="ESQLEditor-queryList-queryString-expanded"
+            aria-label={
+              isRowExpanded
+                ? i18n.translate('esqlEditor.query.collapseLabel', {
+                    defaultMessage: 'Collapse',
+                  })
+                : i18n.translate('esqlEditor.query.expandLabel', {
+                    defaultMessage: 'Expand',
+                  })
+            }
+            iconType={isRowExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
+            size="xs"
+            color="text"
+            css={css`
+              flex-shrink: 0;
+            `}
+          />
+        </EuiToolTip>
       )}
       <span
         css={css`

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -13,8 +13,8 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIconTip,
-  useEuiTheme,
   type EuiComboBoxOptionOption,
+  useEuiTheme,
 } from '@elastic/eui';
 import { getIndexPatternFromESQLQuery, getESQLAdHocDataview } from '@kbn/esql-utils';
 import type { DataView } from '@kbn/data-views-plugin/common';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [feat(kibana-esql): replace title props and wrap EuiButtonIcon with EuiToolTip (#271484)](https://github.com/elastic/kibana/pull/271484)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Weronika Olejniczak","email":"32842468+weronikaolejniczak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-29T08:55:14Z","message":"feat(kibana-esql): replace title props and wrap EuiButtonIcon with EuiToolTip (#271484)\n\nRelates to https://github.com/elastic/eui/issues/9566\n\n> [!IMPORTANT]\n> These changes **should be carefully tested visually by each code\nowner.** Wrapping with `EuiToolTip` instead of passing `title` leads to\nanother DOM node and can potentially break the layout. In such cases, I\nwould appreciate committing appropriate fixes to this PR directly, I\ncannot possibly setup and run all Kibana functionalities to fix every\nregression.\n\nThis PR:\n\n- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same\nas `aria-label`, any `title` passed to `EuiButtonIcon` is removed,\n- changes several `title` cases (not truncation related) to use\n`EuiToolTip` instead (if applicable).\n\n---------\n\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"e772ff3a16afd2a97fcf90c9b3a12837a0808f3d","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","EUI","backport:version","v9.5.0","v9.4.2"],"title":"feat(kibana-esql): replace title props and wrap EuiButtonIcon with EuiToolTip","number":271484,"url":"https://github.com/elastic/kibana/pull/271484","mergeCommit":{"message":"feat(kibana-esql): replace title props and wrap EuiButtonIcon with EuiToolTip (#271484)\n\nRelates to https://github.com/elastic/eui/issues/9566\n\n> [!IMPORTANT]\n> These changes **should be carefully tested visually by each code\nowner.** Wrapping with `EuiToolTip` instead of passing `title` leads to\nanother DOM node and can potentially break the layout. In such cases, I\nwould appreciate committing appropriate fixes to this PR directly, I\ncannot possibly setup and run all Kibana functionalities to fix every\nregression.\n\nThis PR:\n\n- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same\nas `aria-label`, any `title` passed to `EuiButtonIcon` is removed,\n- changes several `title` cases (not truncation related) to use\n`EuiToolTip` instead (if applicable).\n\n---------\n\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"e772ff3a16afd2a97fcf90c9b3a12837a0808f3d"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271484","number":271484,"mergeCommit":{"message":"feat(kibana-esql): replace title props and wrap EuiButtonIcon with EuiToolTip (#271484)\n\nRelates to https://github.com/elastic/eui/issues/9566\n\n> [!IMPORTANT]\n> These changes **should be carefully tested visually by each code\nowner.** Wrapping with `EuiToolTip` instead of passing `title` leads to\nanother DOM node and can potentially break the layout. In such cases, I\nwould appreciate committing appropriate fixes to this PR directly, I\ncannot possibly setup and run all Kibana functionalities to fix every\nregression.\n\nThis PR:\n\n- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same\nas `aria-label`, any `title` passed to `EuiButtonIcon` is removed,\n- changes several `title` cases (not truncation related) to use\n`EuiToolTip` instead (if applicable).\n\n---------\n\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"e772ff3a16afd2a97fcf90c9b3a12837a0808f3d"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->