### PR TITLE
[Security Solution] Fix rule snooze/unsnooze change history logging

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.test.ts
@@ -58,6 +58,15 @@ const context = {
 } as unknown as RulesClientContext;
 
 describe('validate snooze params and body', () => {
+  beforeEach(() => {
+    savedObjectsMock.update = jest.fn().mockResolvedValue({
+      id: '123',
+      type: 'alert',
+      attributes: { snoozeSchedule: [] },
+      references: [],
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -232,7 +241,12 @@ describe('snoozeRule change tracking', () => {
   beforeEach(() => {
     getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry);
     unsecuredSavedObjectsClient.get.mockResolvedValue(existingRuleSO);
-    unsecuredSavedObjectsClient.update.mockResolvedValue(updatedRuleSO);
+    unsecuredSavedObjectsClient.update.mockResolvedValue({
+      id: 'rule-1',
+      type: 'alert',
+      attributes: { snoozeSchedule: updatedRuleSO.attributes.snoozeSchedule },
+      references: [],
+    });
     setRuleType();
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.ts
@@ -121,7 +121,9 @@ async function snoozeWithOCC<Params extends RuleParams = never>(
   });
 
   await logRuleChanges({
-    ruleSOs: [updatedRuleRaw] as Array<SavedObject<RawRule>>,
+    ruleSOs: [
+      { ...updatedRuleRaw, attributes: { ...attributes, ...updatedRuleRaw.attributes } },
+    ] as Array<SavedObject<RawRule>>,
     rulesClientContext: context,
     changesContext: {
       action: RuleChangeTrackingAction.ruleSnooze,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.ts
@@ -122,8 +122,12 @@ async function snoozeWithOCC<Params extends RuleParams = never>(
 
   await logRuleChanges({
     ruleSOs: [
-      { ...updatedRuleRaw, attributes: { ...attributes, ...updatedRuleRaw.attributes } },
-    ] as Array<SavedObject<RawRule>>,
+      {
+        ...updatedRuleRaw,
+        attributes: { ...attributes, ...updatedRuleRaw.attributes },
+        references: updatedRuleRaw.references ?? [],
+      },
+    ],
     rulesClientContext: context,
     changesContext: {
       action: RuleChangeTrackingAction.ruleSnooze,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze/snooze_rule.ts
@@ -7,7 +7,6 @@
 
 import Boom from '@hapi/boom';
 import { withSpan } from '@kbn/apm-utils';
-import type { SavedObject } from '@kbn/core/server';
 import { RuleChangeTrackingAction } from '@kbn/alerting-types';
 import { ruleSnoozeScheduleSchema } from '../../../../../common/routes/rule/request';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.test.ts
@@ -70,6 +70,15 @@ const context = {
 } as unknown as RulesClientContext;
 
 describe('validate unsnooze params', () => {
+  beforeEach(() => {
+    savedObjectsMock.update = jest.fn().mockResolvedValue({
+      id: '123',
+      type: 'alert',
+      attributes: { snoozeSchedule: [] },
+      references: [],
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -212,7 +221,12 @@ describe('unsnoozeRule change tracking', () => {
   beforeEach(() => {
     getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry);
     unsecuredSavedObjectsClient.get.mockResolvedValue(existingRuleSO);
-    unsecuredSavedObjectsClient.update.mockResolvedValue(updatedRuleSO);
+    unsecuredSavedObjectsClient.update.mockResolvedValue({
+      id: 'rule-1',
+      type: 'alert',
+      attributes: { snoozeSchedule: updatedRuleSO.attributes.snoozeSchedule },
+      references: [],
+    });
     setRuleType();
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.ts
@@ -100,8 +100,12 @@ async function unsnoozeWithOCC(context: RulesClientContext, { id, scheduleIds }:
 
   await logRuleChanges({
     ruleSOs: [
-      { ...updatedRuleRaw, attributes: { ...attributes, ...updatedRuleRaw.attributes } },
-    ] as Array<SavedObject<RawRule>>,
+      {
+        ...updatedRuleRaw,
+        attributes: { ...attributes, ...updatedRuleRaw.attributes },
+        references: updatedRuleRaw.references ?? [],
+      },
+    ],
     rulesClientContext: context,
     changesContext: {
       action: RuleChangeTrackingAction.ruleUnsnooze,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.ts
@@ -99,7 +99,9 @@ async function unsnoozeWithOCC(context: RulesClientContext, { id, scheduleIds }:
   });
 
   await logRuleChanges({
-    ruleSOs: [updatedRuleRaw] as Array<SavedObject<RawRule>>,
+    ruleSOs: [
+      { ...updatedRuleRaw, attributes: { ...attributes, ...updatedRuleRaw.attributes } },
+    ] as Array<SavedObject<RawRule>>,
     rulesClientContext: context,
     changesContext: {
       action: RuleChangeTrackingAction.ruleUnsnooze,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze/unsnooze_rule.ts
@@ -7,9 +7,7 @@
 
 import Boom from '@hapi/boom';
 import { withSpan } from '@kbn/apm-utils';
-import type { SavedObject } from '@kbn/core/server';
 import { RuleChangeTrackingAction } from '@kbn/alerting-types';
-import type { RawRule } from '../../../../types';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
 import { getRuleSavedObject } from '../../../../rules_client/lib';


### PR DESCRIPTION
**Epic:** https://github.com/elastic/security-team/issues/12367 (internal)
**Follow-up to: https://github.com/elastic/kibana/pull/267350**
**Related to: https://github.com/elastic/kibana/pull/269617**

## Summary

Fixed rule change tracking instrumentation for RulesClient snooze and unsnooze methods.

## Details

`snoozeRule` and `unsnoozeRule` in `RulesClient` perform an OCC (optimistic concurrency control) update that only modifies snooze-related attributes. The saved object returned by that update contains only the updated partial attributes, not the complete rule document. Passing that partial object to `logRuleChanges` caused the change history record to be missing required rule fields, breaking change tracking for snooze and unsnooze actions.

The fix merges the original pre-update `attributes` with `updatedRuleRaw.attributes` so that `logRuleChanges` always receives a complete rule document.

Issues were discovered during e2e testing of the UI in https://github.com/elastic/kibana/pull/269617.

- `snooze_rule.ts`: Merge original `attributes` with `updatedRuleRaw.attributes` before passing the saved object to `logRuleChanges`.
- `unsnooze_rule.ts`: Same fix.
- `snooze_rule.test.ts`, `unsnooze_rule.test.ts`: Add test cases that verify `logRuleChanges` is called with the fully merged attributes.