### PR TITLE
Revert "[Fleet] Filter OPAMP agents out of agent table"

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
@@ -177,7 +177,7 @@ describe('useFetchAgentsData', () => {
       },
     });
     expect(result?.current.kuery).toEqual(
-      '(status:online or (status:error or status:degraded) or status:orphaned or (status:updating or status:unenrolling or status:enrolling) or status:offline) and NOT type:OPAMP'
+      'status:online or (status:error or status:degraded) or status:orphaned or (status:updating or status:unenrolling or status:enrolling) or status:offline'
     );
 
     expect(result?.current.page).toEqual({ index: 0, size: 20 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -18,56 +18,54 @@ describe('getKuery', () => {
   const inactiveStatuses = ['unhealthy', 'offline', 'inactive', 'unenrolled'];
 
   it('should return a kuery with base search', () => {
-    expect(getKuery({ search })).toEqual('(base search) and NOT type:OPAMP');
+    expect(getKuery({ search })).toEqual('base search');
   });
 
   it('should return a kuery with selected tags', () => {
     expect(getKuery({ selectedTags })).toEqual(
-      '(fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and NOT type:OPAMP'
+      'fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")'
     );
   });
   it('should return a kuery for no tags if selected', () => {
-    expect(getKuery({ selectedTags: noTags })).toEqual(
-      '(((NOT fleet-agents.tags : (*)))) and NOT type:OPAMP'
-    );
+    expect(getKuery({ selectedTags: noTags })).toEqual('((NOT fleet-agents.tags : (*)))');
   });
   it('should return a kuery for no tags and other tags when multiple are selected', () => {
     expect(getKuery({ selectedTags: [...noTags, ...selectedTags] })).toEqual(
-      '(((NOT fleet-agents.tags : (*)) or fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3"))) and NOT type:OPAMP'
+      '((NOT fleet-agents.tags : (*)) or fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3"))'
     );
   });
 
   it('should return a kuery with selected agent policies', () => {
     expect(getKuery({ selectedAgentPolicies })).toEqual(
-      '(fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")) and NOT type:OPAMP'
+      'fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")'
     );
   });
 
   it('should return a kuery with selected agent ids', () => {
     expect(getKuery({ selectedAgentIds })).toEqual(
-      '(fleet-agents.agent.id : ("agent_id1" or "agent_id2")) and NOT type:OPAMP'
+      'fleet-agents.agent.id : ("agent_id1" or "agent_id2")'
     );
   });
 
   it('should return a kuery with healthy selected status', () => {
     expect(getKuery({ selectedStatus: healthyStatuses })).toEqual(
-      '(status:online or (status:updating or status:unenrolling or status:enrolling)) and NOT type:OPAMP'
+      'status:online or (status:updating or status:unenrolling or status:enrolling)'
     );
   });
 
   it('should return a kuery with unhealthy selected status', () => {
     expect(getKuery({ selectedStatus: inactiveStatuses })).toEqual(
-      '((status:error or status:degraded) or status:offline or status:inactive or status:unenrolled) and NOT type:OPAMP'
+      '(status:error or status:degraded) or status:offline or status:inactive or status:unenrolled'
     );
   });
 
   it('should return a kuery with a combination of previous kueries', () => {
     expect(getKuery({ search, selectedTags, selectedStatus })).toEqual(
-      '(((base search) and fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and (status:online or (status:error or status:degraded))) and NOT type:OPAMP'
+      '((base search) and fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and (status:online or (status:error or status:degraded))'
     );
   });
 
-  it('should exclude OpAMP agents even when no filters are passed', () => {
-    expect(getKuery({})).toEqual('NOT type:OPAMP');
+  it('should return empty string if nothing is passed', () => {
+    expect(getKuery({})).toEqual('');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -6,7 +6,6 @@
  */
 import { i18n } from '@kbn/i18n';
 
-import { AGENT_TYPE_OPAMP } from '../../../../../../../common/constants';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { AGENTS_PREFIX } from '../../../../constants';
 
@@ -102,13 +101,5 @@ export const getKuery = ({
       kueryBuilder = kueryStatus;
     }
   }
-  const excludeOpamp = `NOT type:${AGENT_TYPE_OPAMP}`;
-  const trimmed = kueryBuilder.trim();
-  if (trimmed) {
-    kueryBuilder = `(${trimmed}) and ${excludeOpamp}`;
-  } else {
-    kueryBuilder = excludeOpamp;
-  }
-
-  return kueryBuilder;
+  return kueryBuilder.trim();
 };


### PR DESCRIPTION
## Description

Reverts elastic/kibana#270258

The change was not behind the otel UI feature flag, and we are going to keep otel collector in the agent list table