### PR TITLE
Fix the UI plugins tree from filtering out missing runtime dependencies

### DIFF
--- a/src/core/packages/plugins/server-internal/src/plugins_system.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.test.ts
@@ -33,12 +33,14 @@ function createPlugin(
   {
     required = [],
     optional = [],
+    runtime = [],
     server = true,
     ui = true,
     type = PluginType.standard,
   }: {
     required?: string[];
     optional?: string[];
+    runtime?: string[];
     server?: boolean;
     ui?: boolean;
     type?: PluginType;
@@ -54,7 +56,7 @@ function createPlugin(
       type,
       requiredPlugins: required,
       optionalPlugins: optional,
-      runtimePluginDependencies: [],
+      runtimePluginDependencies: runtime,
       requiredBundles: [],
       server,
       ui,
@@ -551,6 +553,26 @@ test('`uiPlugins` returns only ui plugin dependencies', async () => {
   const plugin = pluginsSystem.uiPlugins().get('ui-plugin')!;
   expect(plugin.requiredPlugins).toEqual(['req-ui']);
   expect(plugin.optionalPlugins).toEqual(['opt-ui']);
+});
+
+test('`uiPlugins` filters out missing plugin dependencies', async () => {
+  const plugins = [
+    createPlugin('ui-plugin', {
+      optional: ['available', 'missing'],
+      runtime: ['available', 'missing'],
+      ui: true,
+      server: false,
+    }),
+    createPlugin('available', { ui: true, server: false }),
+  ];
+
+  plugins.forEach((plugin) => {
+    pluginsSystem.addPlugin(plugin);
+  });
+
+  const plugin = pluginsSystem.uiPlugins().get('ui-plugin')!;
+  expect(plugin.optionalPlugins).toEqual(['available']);
+  expect(plugin.runtimePluginDependencies).toEqual(['available', 'missing']);
 });
 
 test('can start without plugins', async () => {

--- a/src/core/packages/plugins/server-internal/src/plugins_system.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.ts
@@ -290,8 +290,7 @@ export class PluginsSystem<T extends PluginType> {
             configPath: plugin.manifest.configPath,
             requiredPlugins: plugin.manifest.requiredPlugins.filter(filterUiPlugins),
             optionalPlugins: plugin.manifest.optionalPlugins.filter(filterUiPlugins),
-            runtimePluginDependencies:
-              plugin.manifest.runtimePluginDependencies.filter(filterUiPlugins),
+            runtimePluginDependencies: plugin.manifest.runtimePluginDependencies,
             requiredBundles: plugin.manifest.requiredBundles,
             enabledOnAnonymousPages: plugin.manifest.enabledOnAnonymousPages,
           },


### PR DESCRIPTION
## Summary

The [expected](https://github.com/elastic/kibana/blob/f15ba40d3d24050bb5b3603b7735a00a970258cb/src/core/packages/plugins/browser-internal/src/plugin_contract_resolver.ts#L146-L162) behavior of the plugin contract resolver is to allow missing runtime dependencies. But when the runtime dependencies were introduced in #167113, the missing dependencies were filtered out similarly to the optional ones. This bug causes runtime errors when the plugin is being disabled in the configuration.

Resolves #270457.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->