### PR TITLE
[Embeddable] embeddable schema cache

### DIFF
--- a/src/platform/plugins/shared/embeddable/server/embeddable_transforms/registry.ts
+++ b/src/platform/plugins/shared/embeddable/server/embeddable_transforms/registry.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ObjectType } from '@kbn/config-schema';
+import type { ObjectType, Type } from '@kbn/config-schema';
 import type { getDrilldownRegistry } from '../drilldowns/registry';
 import type { EmbeddableServerDefinition } from './types';
 
@@ -15,6 +15,20 @@ export function getEmbeddableServerRegistry(
   drilldownRegistry: ReturnType<typeof getDrilldownRegistry>
 ) {
   const registry: { [key: string]: EmbeddableServerDefinition<any, any> } = {};
+  const schemaCache: Record<string, Type<object>> = {};
+
+  function getCachedSchema(type: string) {
+    if (schemaCache[type]) {
+      return schemaCache[type];
+    }
+
+    const { getSchema } = registry[type] ?? {};
+    if (!getSchema) return;
+    const schema = getSchema(drilldownRegistry.getSchema);
+    if (!schema) return;
+    schemaCache[type] = schema;
+    return schema;
+  }
 
   return {
     registerEmbeddableServerDefinition: (
@@ -30,7 +44,7 @@ export function getEmbeddableServerRegistry(
     getAllEmbeddableSchemas: () => {
       const schemas: { [key: string]: { schema: ObjectType; title: string } } = {};
       Object.entries(registry).forEach(([type, definition]) => {
-        const schema = definition?.getSchema?.(drilldownRegistry.getSchema);
+        const schema = getCachedSchema(type);
         if (schema) {
           schemas[type] = {
             schema: schema as ObjectType,
@@ -41,10 +55,11 @@ export function getEmbeddableServerRegistry(
       return schemas;
     },
     getEmbeddableTransforms: (type: string) => {
-      const { getTransforms, getSchema, throwOnUnmappedPanel } = registry[type] ?? {};
+      const { getTransforms, throwOnUnmappedPanel } = registry[type] ?? {};
+      const schema = getCachedSchema(type);
       return {
         ...getTransforms?.(drilldownRegistry.transforms),
-        ...(getSchema ? { schema: getSchema(drilldownRegistry.getSchema) } : {}),
+        ...(schema ? { schema } : {}),
         ...(typeof throwOnUnmappedPanel === 'boolean' ? { throwOnUnmappedPanel } : {}),
       };
     },

--- a/src/platform/plugins/shared/embeddable/server/embeddable_transforms/registry.ts
+++ b/src/platform/plugins/shared/embeddable/server/embeddable_transforms/registry.ts
@@ -15,7 +15,7 @@ export function getEmbeddableServerRegistry(
   drilldownRegistry: ReturnType<typeof getDrilldownRegistry>
 ) {
   const registry: { [key: string]: EmbeddableServerDefinition<any, any> } = {};
-  const schemaCache: Record<string, Type<object>> = {};
+  const schemaCache: Record<string, Type<object> | undefined> = {};
 
   function getCachedSchema(type: string) {
     if (schemaCache[type]) {
@@ -23,9 +23,7 @@ export function getEmbeddableServerRegistry(
     }
 
     const { getSchema } = registry[type] ?? {};
-    if (!getSchema) return;
-    const schema = getSchema(drilldownRegistry.getSchema);
-    if (!schema) return;
+    const schema = getSchema?.(drilldownRegistry.getSchema);
     schemaCache[type] = schema;
     return schema;
   }


### PR DESCRIPTION
Dashboard transforms call `getTransforms` for each panel in the dashboard. The current implementation of this function builds the embeddable schema on each call. This can put a lot of CPU and memory pressure on the Kibana server for large dashboards. Instead, embeddable schemas should only be created once. 

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->