### PR TITLE
[One Workflow] Update liquidjs to version 10.26.0 and add sha256 and hmac_sha256 filters (#269989)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1415,7 +1415,7 @@
     "langchain": "1.2.30",
     "langsmith": "0.7.1",
     "launchdarkly-js-client-sdk": "3.9.0",
-    "liquidjs": "10.25.6",
+    "liquidjs": "10.26.0",
     "lodash": "4.18.1",
     "lru-cache": "11.3.5",
     "lz-string": "1.5.0",

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.test.ts
@@ -155,6 +155,41 @@ describe('WorkflowTemplatingEngine', () => {
     });
   });
 
+  describe('sha256 filter', () => {
+    it('should return the SHA-256 hex digest (Shopify reference vector)', () => {
+      const template = '{{ text | sha256 }}';
+      const context = { text: 'Polyjuice' };
+      const result = templatingEngine.render(template, context);
+      expect(result).toBe('44ac1d7a2936e30a5de07082fd65d6fe9b1fb658a1a98bfe65bc5959beac5dd0');
+    });
+
+    it('should coerce null and undefined to empty string', () => {
+      const template = '{{ value | sha256 }}';
+      expect(templatingEngine.render(template, { value: null })).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      );
+      expect(templatingEngine.render(template, { value: undefined })).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      );
+    });
+  });
+
+  describe('hmac_sha256 filter', () => {
+    it('should return the HMAC-SHA256 hex digest (Shopify reference vector)', () => {
+      const template = '{{ text | hmac_sha256: key }}';
+      const context = { text: 'Polyjuice', key: 'Polina' };
+      const result = templatingEngine.render(template, context);
+      expect(result).toBe('8e0d5d65cff1242a4af66c8f4a32854fd5fb80edcc8aabe9b302b29c7c71dc20');
+    });
+
+    it('should stringify numeric secret keys', () => {
+      const template = '{{ text | hmac_sha256: key }}';
+      const context = { text: 'test', key: 12345 };
+      const result = templatingEngine.render(template, context);
+      expect(result).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
   describe('base64_encode filter with Buffer support', () => {
     it('should base64 encode a plain string', () => {
       const template = '{{ text | base64_encode }}';

--- a/src/platform/plugins/shared/workflows_management/common/lib/liquid_parse_cache.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/liquid_parse_cache.test.ts
@@ -32,6 +32,19 @@ describe('getLiquidInstance', () => {
     expect(result).toBeDefined();
   });
 
+  it('parses templates using built-in sha256 and hmac_sha256 filters', () => {
+    const engine = getLiquidInstance();
+    const shaTemplate = engine.parse('{{ val | sha256 }}');
+    expect(engine.renderSync(shaTemplate, { val: 'Polyjuice' })).toBe(
+      '44ac1d7a2936e30a5de07082fd65d6fe9b1fb658a1a98bfe65bc5959beac5dd0'
+    );
+
+    const hmacTemplate = engine.parse('{{ val | hmac_sha256: key }}');
+    expect(engine.renderSync(hmacTemplate, { val: 'Polyjuice', key: 'Polina' })).toBe(
+      '8e0d5d65cff1242a4af66c8f4a32854fd5fb80edcc8aabe9b302b29c7c71dc20'
+    );
+  });
+
   describe('json_parse filter behavior', () => {
     it('parses valid JSON strings', () => {
       const engine = getLiquidInstance();

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.test.ts
@@ -40,6 +40,8 @@ describe('liquid_completions', () => {
       expect(filterNames).toContain('minus');
       expect(filterNames).toContain('base64_encode');
       expect(filterNames).toContain('base64_decode');
+      expect(filterNames).toContain('sha256');
+      expect(filterNames).toContain('hmac_sha256');
     });
 
     it('should have proper structure for each filter', () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.ts
@@ -194,6 +194,13 @@ export const LIQUID_FILTERS = [
       '{{ products | has_exp: "item", "item.price > 100" }} => true if any product has price > 100',
   },
   {
+    name: 'hmac_sha256',
+    description: 'Returns the HMAC-SHA256 hex digest of a string using the given secret key',
+    insertText: 'hmac_sha256: "${1:secret}"',
+    example:
+      '{{ "Polyjuice" | hmac_sha256: "Polina" }} => "8e0d5d65cff1242a4af66c8f4a32854fd5fb80edcc8aabe9b302b29c7c71dc20"',
+  },
+  {
     name: 'join',
     description: 'Combines the items in an array into a single string',
     insertText: 'join: "${1:separator}"',
@@ -346,6 +353,13 @@ export const LIQUID_FILTERS = [
     description: 'Removes all whitespace from the end of a string',
     insertText: 'rstrip',
     example: '{{ "hello   " | rstrip }} => "hello"',
+  },
+  {
+    name: 'sha256',
+    description: 'Returns the SHA-256 hex digest of a string',
+    insertText: 'sha256',
+    example:
+      '{{ "Polyjuice" | sha256 }} => "44ac1d7a2936e30a5de07082fd65d6fe9b1fb658a1a98bfe65bc5959beac5dd0"',
   },
   {
     name: 'shift',

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_providers/unified_hover_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_providers/unified_hover_provider.ts
@@ -555,13 +555,13 @@ export class UnifiedHoverProvider implements monaco.languages.HoverProvider {
 
       if (templateInfo.filters.length > 0 && templateInfo.isOnFilter) {
         evaluatedPath = templateInfo.expression;
-        value = evaluateExpression({
+        value = await evaluateExpression({
           expression: templateInfo.expression,
           context: evalContext,
         });
       } else {
         evaluatedPath = templateInfo.pathUpToCursor.join('.');
-        value = evaluateExpression({
+        value = await evaluateExpression({
           expression: evaluatedPath,
           context: evalContext,
         });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.test.ts
@@ -49,94 +49,97 @@ describe('evaluateExpression', () => {
   };
 
   describe('simple path resolution', () => {
-    it('should resolve top-level context properties', () => {
-      expect(evaluateExpression({ expression: 'inputs', context: mockContext })).toEqual({
+    it('should resolve top-level context properties', async () => {
+      expect(await evaluateExpression({ expression: 'inputs', context: mockContext })).toEqual({
         userId: 'user-123',
         greeting: 'hello',
       });
 
-      expect(evaluateExpression({ expression: 'consts', context: mockContext })).toEqual({
+      expect(await evaluateExpression({ expression: 'consts', context: mockContext })).toEqual({
         indexName: 'test-index',
         apiUrl: 'https://api.example.com',
       });
     });
 
-    it('should resolve nested paths', () => {
-      expect(evaluateExpression({ expression: 'inputs.userId', context: mockContext })).toBe(
+    it('should resolve nested paths', async () => {
+      expect(await evaluateExpression({ expression: 'inputs.userId', context: mockContext })).toBe(
         'user-123'
       );
 
-      expect(evaluateExpression({ expression: 'consts.indexName', context: mockContext })).toBe(
-        'test-index'
-      );
+      expect(
+        await evaluateExpression({ expression: 'consts.indexName', context: mockContext })
+      ).toBe('test-index');
 
       expect(
-        evaluateExpression({
+        await evaluateExpression({
           expression: 'steps.search_data.output.hits.total',
           context: mockContext,
         })
       ).toBe(5);
     });
 
-    it('should resolve array access', () => {
+    it('should resolve array access', async () => {
       expect(
-        evaluateExpression({
+        await evaluateExpression({
           expression: 'steps.search_data.output.hits.hits[0]._source.name',
           context: mockContext,
         })
       ).toBe('Item 1');
 
       expect(
-        evaluateExpression({
+        await evaluateExpression({
           expression: 'steps.search_data.output.hits.hits[1]._source.value',
           context: mockContext,
         })
       ).toBe(200);
     });
 
-    it('should return undefined for non-existent paths', () => {
+    it('should return undefined for non-existent paths', async () => {
       expect(
-        evaluateExpression({ expression: 'nonexistent.path', context: mockContext })
+        await evaluateExpression({ expression: 'nonexistent.path', context: mockContext })
       ).toBeUndefined();
     });
   });
 
   describe('filter support', () => {
-    it('should apply string filters', () => {
+    it('should apply string filters', async () => {
       expect(
-        evaluateExpression({ expression: 'inputs.greeting | upcase', context: mockContext })
+        await evaluateExpression({ expression: 'inputs.greeting | upcase', context: mockContext })
       ).toBe('HELLO');
 
       expect(
-        evaluateExpression({ expression: 'inputs.greeting | capitalize', context: mockContext })
+        await evaluateExpression({
+          expression: 'inputs.greeting | capitalize',
+          context: mockContext,
+        })
       ).toBe('Hello');
     });
 
-    it('should apply number filters', () => {
+    it('should apply number filters', async () => {
       expect(
-        evaluateExpression({
+        await evaluateExpression({
           expression: 'steps.search_data.output.hits.total | plus: 10',
           context: mockContext,
         })
       ).toBe(15);
 
       expect(
-        evaluateExpression({
+        await evaluateExpression({
           expression: 'steps.search_data.output.hits.total | times: 2',
           context: mockContext,
         })
       ).toBe(10);
     });
 
-    it('should apply array filters', () => {
-      const result = evaluateExpression({
+    it('should apply array filters', async () => {
+      const result = await evaluateExpression({
         expression: 'steps.search_data.output.hits.hits | first',
         context: mockContext,
       });
 
       expect(result).toEqual({ _source: { name: 'Item 1', value: 100 } });
 
-      const size = evaluateExpression({
+      const size = await evaluateExpression({
         expression: 'steps.search_data.output.hits.hits | size',
         context: mockContext,
       });
@@ -144,8 +147,8 @@ describe('evaluateExpression', () => {
       expect(size).toBe(3);
     });
 
-    it('should apply json filter (stringify)', () => {
-      const result = evaluateExpression({
+    it('should apply json filter (stringify)', async () => {
+      const result = await evaluateExpression({
         expression: 'inputs | json',
         context: mockContext,
       });
@@ -157,7 +160,7 @@ describe('evaluateExpression', () => {
       expect(result).toContain('"hello"');
     });
 
-    it('should apply json_parse filter', () => {
+    it('should apply json_parse filter', async () => {
       const contextWithJson: ExecutionContext = {
         ...mockContext,
         inputs: {
@@ -166,7 +169,7 @@ describe('evaluateExpression', () => {
         },
       };
 
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'inputs.jsonString | json_parse',
         context: contextWithJson,
       });
@@ -174,8 +177,8 @@ describe('evaluateExpression', () => {
       expect(result).toEqual({ key: 'value', number: 42 });
     });
 
-    it('should chain multiple filters', () => {
-      const result = evaluateExpression({
+    it('should chain multiple filters', async () => {
+      const result = await evaluateExpression({
         expression: 'inputs.greeting | upcase | append: " WORLD"',
         context: mockContext,
       });
@@ -183,18 +186,34 @@ describe('evaluateExpression', () => {
       expect(result).toBe('HELLO WORLD');
     });
 
-    it('should handle map filter on arrays', () => {
-      const result = evaluateExpression({
+    it('should handle map filter on arrays', async () => {
+      const result = await evaluateExpression({
         expression: 'steps.search_data.output.hits.hits | map: "_source" | map: "name"',
         context: mockContext,
       });
 
       expect(result).toEqual(['Item 1', 'Item 2', 'Item 3']);
     });
+
+    it('should apply sha256 and hmac_sha256 filters (Shopify reference vectors)', async () => {
+      expect(
+        await evaluateExpression({
+          expression: '"Polyjuice" | sha256',
+          context: mockContext,
+        })
+      ).toBe('44ac1d7a2936e30a5de07082fd65d6fe9b1fb658a1a98bfe65bc5959beac5dd0');
+
+      expect(
+        await evaluateExpression({
+          expression: '"Polyjuice" | hmac_sha256: "Polina"',
+          context: mockContext,
+        })
+      ).toBe('8e0d5d65cff1242a4af66c8f4a32854fd5fb80edcc8aabe9b302b29c7c71dc20');
+    });
   });
 
   describe('foreach.item support', () => {
-    it('should resolve foreach.item when foreach step exists', () => {
+    it('should resolve foreach.item when foreach step exists', async () => {
       const contextWithForeach: ExecutionContext = {
         ...mockContext,
         steps: {
@@ -215,7 +234,7 @@ describe('evaluateExpression', () => {
         },
       };
 
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'foreach.item._source.name',
         context: contextWithForeach,
       });
@@ -223,7 +242,7 @@ describe('evaluateExpression', () => {
       expect(result).toBe('Park 1');
     });
 
-    it('should resolve foreach.item._source when foreach step exists', () => {
+    it('should resolve foreach.item._source when foreach step exists', async () => {
       const contextWithForeach: ExecutionContext = {
         ...mockContext,
         steps: {
@@ -243,7 +262,7 @@ describe('evaluateExpression', () => {
         },
       };
 
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'foreach.item._source',
         context: contextWithForeach,
       });
@@ -251,7 +270,7 @@ describe('evaluateExpression', () => {
       expect(result).toEqual({ name: 'Park 1', location: 'NY' });
     });
 
-    it('should resolve foreach.index and foreach.total', () => {
+    it('should resolve foreach.index and foreach.total', async () => {
       const contextWithForeach: ExecutionContext = {
         ...mockContext,
         steps: {
@@ -268,17 +287,17 @@ describe('evaluateExpression', () => {
         },
       };
 
-      expect(evaluateExpression({ expression: 'foreach.index', context: contextWithForeach })).toBe(
-        0
-      );
+      expect(
+        await evaluateExpression({ expression: 'foreach.index', context: contextWithForeach })
+      ).toBe(0);
 
-      expect(evaluateExpression({ expression: 'foreach.total', context: contextWithForeach })).toBe(
-        3
-      );
+      expect(
+        await evaluateExpression({ expression: 'foreach.total', context: contextWithForeach })
+      ).toBe(3);
     });
 
-    it('should return undefined for foreach.item when no foreach step exists', () => {
-      const result = evaluateExpression({
+    it('should return undefined for foreach.item when no foreach step exists', async () => {
+      const result = await evaluateExpression({
         expression: 'foreach.item',
         context: mockContext,
       });
@@ -286,7 +305,7 @@ describe('evaluateExpression', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should apply filters to foreach.item', () => {
+    it('should apply filters to foreach.item', async () => {
       const contextWithForeach: ExecutionContext = {
         ...mockContext,
         steps: {
@@ -303,7 +322,7 @@ describe('evaluateExpression', () => {
         },
       };
 
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'foreach.item._source.name | upcase',
         context: contextWithForeach,
       });
@@ -313,10 +332,10 @@ describe('evaluateExpression', () => {
   });
 
   describe('error handling', () => {
-    it('should handle invalid filter with strictFilters', () => {
+    it('should handle invalid filter with strictFilters', async () => {
       // With strictFilters: true, unknown filters should throw an error
       // The error is caught and we fallback to path resolution
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'inputs.userId | unknown_filter',
         context: mockContext,
       });
@@ -325,9 +344,9 @@ describe('evaluateExpression', () => {
       expect(result).toBe('user-123');
     });
 
-    it('should fallback to path resolution when liquid evaluation fails', () => {
+    it('should fallback to path resolution when liquid evaluation fails', async () => {
       // Even with a syntax error, it should try fallback path resolution
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'inputs.userId',
         context: mockContext,
       });
@@ -337,8 +356,8 @@ describe('evaluateExpression', () => {
   });
 
   describe('bracket notation', () => {
-    it('should resolve numeric array index', () => {
-      const result = evaluateExpression({
+    it('should resolve numeric array index', async () => {
+      const result = await evaluateExpression({
         expression: 'steps.search_data.output.hits.hits[0]._source.name',
         context: mockContext,
       });
@@ -346,7 +365,7 @@ describe('evaluateExpression', () => {
       expect(result).toBe('Item 1');
     });
 
-    it('should resolve string key with dots in bracket notation', () => {
+    it('should resolve string key with dots in bracket notation', async () => {
       const contextWithDottedKeys: ExecutionContext = {
         ...mockContext,
         inputs: {
@@ -358,7 +377,7 @@ describe('evaluateExpression', () => {
         },
       };
 
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: "inputs.fields['exception.message']",
         context: contextWithDottedKeys,
       });
@@ -366,7 +385,7 @@ describe('evaluateExpression', () => {
       expect(result).toBe('Error occurred');
     });
 
-    it('should resolve bracket notation in middle of path', () => {
+    it('should resolve bracket notation in middle of path', async () => {
       const contextWithArrays: ExecutionContext = {
         ...mockContext,
         steps: {
@@ -379,7 +398,7 @@ describe('evaluateExpression', () => {
         },
       };
 
-      const result = evaluateExpression({
+      const result = await evaluateExpression({
         expression: 'steps.formatMessage.output[0].result',
         context: contextWithArrays,
       });
@@ -389,7 +408,7 @@ describe('evaluateExpression', () => {
   });
 
   describe('complex real-world scenarios', () => {
-    it('should handle foreach with json filter', () => {
+    it('should handle foreach with json filter', async () => {
       const contextWithForeach: ExecutionContext = {
         ...mockContext,
         steps: {
@@ -419,7 +438,7 @@ describe('evaluateExpression', () => {
       };
 
       // Simulate the foreach expression itself
-      const foreachArray = evaluateExpression({
+      const foreachArray = await evaluateExpression({
         expression: 'steps.search_park_data.output.hits.hits',
         context: contextWithForeach,
       });
@@ -427,7 +446,7 @@ describe('evaluateExpression', () => {
       expect(foreachArray).toHaveLength(2);
 
       // Simulate accessing item within foreach
-      const itemName = evaluateExpression({
+      const itemName = await evaluateExpression({
         expression: 'foreach.item._source.name',
         context: contextWithForeach,
       });
@@ -435,8 +454,8 @@ describe('evaluateExpression', () => {
       expect(itemName).toBe('Central Park');
     });
 
-    it('should handle deeply nested path with filters', () => {
-      const result = evaluateExpression({
+    it('should handle deeply nested path with filters', async () => {
+      const result = await evaluateExpression({
         expression: 'steps.search_data.output.hits.hits[0]._source.name | upcase',
         context: mockContext,
       });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/template_expression/evaluate_expression.ts
@@ -50,8 +50,12 @@ export interface EvaluateExpressionOptions {
  * Evaluate a template expression with filters using LiquidJS
  * This handles both simple paths and expressions with filters like "| json"
  * Also handles foreach.item by finding the current foreach step context
+ *
+ * Uses async evalValue so browser builds can run Web Crypto filters (sha256, hmac_sha256).
  */
-export function evaluateExpression(options: EvaluateExpressionOptions): JsonValue | undefined {
+export async function evaluateExpression(
+  options: EvaluateExpressionOptions
+): Promise<JsonValue | undefined> {
   const { expression, context, currentStepId } = options;
   try {
     // Build enhanced context with foreach if needed
@@ -59,7 +63,7 @@ export function evaluateExpression(options: EvaluateExpressionOptions): JsonValu
 
     // Use LiquidJS to evaluate the expression
     // This handles filters automatically (e.g., "steps.search.output | json")
-    const result = liquidEngine.evalValueSync(expression, enhancedContext);
+    const result = await liquidEngine.evalValue(expression, enhancedContext);
     return result as JsonValue;
   } catch (error) {
     // If liquid evaluation fails, try simple path resolution as fallback

--- a/yarn.lock
+++ b/yarn.lock
@@ -26526,10 +26526,10 @@ linkify-it@^5.0.0:
   dependencies:
     uc.micro "^2.0.0"
 
-liquidjs@10.25.6:
-  version "10.25.6"
-  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-10.25.6.tgz#dddf7ee43cd3c7a2d7768063937bf14e77079afb"
-  integrity sha512-h5ki5HS1PiL9/NmLw3iUcTF1jQswKJd8KLEXNrtSf8XHF0v3c5+d+8llz3N9I5IUdc5rsOuVLb9AVnqvqqscPg==
+liquidjs@10.26.0:
+  version "10.26.0"
+  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-10.26.0.tgz#76c9a0a2834b296ef3882366bae6f5b89b1f106a"
+  integrity sha512-Ub9FFNOLB9tdH/gB2MKkeU7x9NifoVidxAam6YWU7LUcy7Glumi6q5C3tDpWOEpeNaT8Cdwdb1axEdlvLSoyaQ==
   dependencies:
     commander "^10.0.0"
 


### PR DESCRIPTION
## Summary

Adopts Shopify-compatible `sha256` and `hmac_sha256` Liquid filters for Workflows by upgrading [liquidjs to
10.26.0](https://github.com/harttle/liquidjs/releases/tag/v10.26.0) ([harttle/liquidjs#889](https://github.com/harttle/liquidjs/pull/889)). Filter behavior comes from liquidjs core—no custom server-side implementations.

- **Execution (server):** Built-in filters work via `createWorkflowLiquidEngine()` with existing `renderSync` / `evalValueSync` (Node `crypto`).
- **Editor autocomplete:** Added `sha256` and `hmac_sha256` entries with Shopify reference examples.
- **Hover preview (browser):** Switched `evaluateExpression` to async `evalValue` so crypto filters resolve correctly in the browser bundle (Web Crypto is async-only). Hover only shows evaluated filter output when viewing an execution on the **Executions** tab and hovering on the filter segment inside `{{ }}`.

## Changes

| Area | Change |
|------|--------|
| `package.json` / `yarn.lock` | `liquidjs` `10.25.7` → `10.26.0` | | `liquid_completions.ts` | Autocomplete for `sha256`, `hmac_sha256` | | `templating_engine.test.ts` | Server tests (Shopify reference vectors) |
| `liquid_parse_cache.test.ts` | Parse/validation tests for built-in crypto filters |
| `evaluate_expression.ts` | `evalValueSync` → `await evalValue` for browser crypto |
| `unified_hover_provider.ts` | `await evaluateExpression(...)` | | `evaluate_expression.test.ts` | Async tests + crypto filter coverage |

**Not changed:** `templating_engine.ts`, `liquid_parse_cache.ts` — no `registerFilter` stubs needed for built-in filters.

## Examples:

```yaml
name: Crypto filters
enabled: true
triggers:
  - type: manual
    inputs:
      - name: message
        type: string
        default: "hello world"

consts:
  secret: "secret"

steps:
  - name: hmac_sha256
    type: console
    with:
      message: "{{ inputs.message | hmac_sha256: consts.secret }}"

  - name: sha256
    type: console
    with:
      message: "{{ inputs.message | sha256 }}"

```