### PR TITLE
[One Workflow] Restore compact validation telemetry for generate_workflow

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/generate_workflow.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/generate_workflow.test.ts
@@ -21,8 +21,10 @@ jest.mock('@kbn/agent-builder-workflow-gen', () => ({
 const generateWorkflowMock = generateWorkflow as jest.MockedFunction<typeof generateWorkflow>;
 
 describe('generateWorkflowTool', () => {
+  const validateWorkflowMock = jest.fn().mockResolvedValue({ valid: true, diagnostics: [] });
+
   const workflowsManagement = {
-    management: { __mock: 'workflowsApi' },
+    management: { validateWorkflow: validateWorkflowMock },
   } as any;
 
   const aiTelemetryClient = {
@@ -73,6 +75,8 @@ describe('generateWorkflowTool', () => {
   beforeEach(() => {
     generateWorkflowMock.mockReset();
     aiTelemetryClient.reportEditResult.mockReset();
+    validateWorkflowMock.mockReset();
+    validateWorkflowMock.mockResolvedValue({ valid: true, diagnostics: [] });
   });
 
   it('creates a new workflow: adds diff attachment, adds workflow attachment, sends UI event, reports telemetry', async () => {
@@ -242,6 +246,76 @@ describe('generateWorkflowTool', () => {
     expect(generateWorkflowMock).not.toHaveBeenCalled();
     expect((out as { results: Array<{ type: string }> }).results[0].type).toBe(
       ToolResultType.error
+    );
+  });
+
+  it('passes a compact validation result to telemetry when the generated YAML is valid', async () => {
+    generateWorkflowMock.mockResolvedValueOnce({
+      workflow: generatedWorkflow,
+      response: 'created',
+    } as any);
+    validateWorkflowMock.mockResolvedValueOnce({ valid: true, diagnostics: [] });
+
+    const context = buildContext();
+    const tool = generateWorkflowTool({ workflowsManagement, aiTelemetryClient });
+    await tool.handler({ query: 'q' } as any, context);
+
+    expect(validateWorkflowMock).toHaveBeenCalledWith(
+      expect.stringContaining('name: foo'),
+      'default',
+      expect.objectContaining({ __mock: 'request' })
+    );
+    expect(aiTelemetryClient.reportEditResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editSuccess: true,
+        isCreation: true,
+        validation: { valid: true },
+      })
+    );
+  });
+
+  it('passes compact errors to telemetry when the generated YAML fails validation', async () => {
+    generateWorkflowMock.mockResolvedValueOnce({
+      workflow: generatedWorkflow,
+      response: 'created',
+    } as any);
+    validateWorkflowMock.mockResolvedValueOnce({
+      valid: false,
+      diagnostics: [
+        { severity: 'error', source: 'schema', message: 'missing field', path: ['steps', 0] },
+        { severity: 'warning', source: 'schema', message: 'soft warning' },
+        { severity: 'error', source: 'liquid', message: 'bad template' },
+      ],
+    });
+
+    const context = buildContext();
+    const tool = generateWorkflowTool({ workflowsManagement, aiTelemetryClient });
+    await tool.handler({ query: 'q' } as any, context);
+
+    expect(aiTelemetryClient.reportEditResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editSuccess: true,
+        validation: {
+          valid: false,
+          errors: ['[schema] missing field (at steps.0)', '[liquid] bad template'],
+        },
+      })
+    );
+  });
+
+  it('omits validation in telemetry when validateWorkflow throws', async () => {
+    generateWorkflowMock.mockResolvedValueOnce({
+      workflow: generatedWorkflow,
+      response: 'created',
+    } as any);
+    validateWorkflowMock.mockRejectedValueOnce(new Error('validator down'));
+
+    const context = buildContext();
+    const tool = generateWorkflowTool({ workflowsManagement, aiTelemetryClient });
+    await tool.handler({ query: 'q' } as any, context);
+
+    expect(aiTelemetryClient.reportEditResult).toHaveBeenCalledWith(
+      expect.objectContaining({ editSuccess: true, validation: undefined })
     );
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/generate_workflow.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/generate_workflow.ts
@@ -7,17 +7,46 @@
 
 import { v4 } from 'uuid';
 import { z } from '@kbn/zod/v4';
+import type { KibanaRequest } from '@kbn/core/server';
 import { platformCoreTools, ToolType } from '@kbn/agent-builder-common';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { generateWorkflow, type GenerateWorkflowEdit } from '@kbn/agent-builder-workflow-gen';
 import { cleanPrompt } from '@kbn/agent-builder-genai-utils/prompts';
 import { errorResult, otherResult } from '@kbn/agent-builder-genai-utils/tools/utils/results';
-import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type {
+  WorkflowsManagementApi,
+  WorkflowsServerPluginSetup,
+} from '@kbn/workflows-management-plugin/server';
 import { workflowIdSchema } from '@kbn/workflows-management-plugin/common/lib/workflow_id_schema';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import { stringifyWorkflowDefinition } from '@kbn/workflows-yaml';
 import type { WorkflowsAiTelemetryClient } from '../telemetry/workflows_ai_telemetry_client';
 import { emitWorkflowDiff, extractConversationId } from './utils/workflow_attachments';
+
+interface CompactValidation {
+  valid: boolean;
+  errors?: string[];
+}
+
+const runCompactValidation = async (
+  yaml: string,
+  api: WorkflowsManagementApi,
+  spaceId: string,
+  request: KibanaRequest
+): Promise<CompactValidation | undefined> => {
+  try {
+    const result = await api.validateWorkflow(yaml, spaceId, request);
+    if (result.valid) {
+      return { valid: true };
+    }
+    const errors = result.diagnostics
+      .filter((d) => d.severity === 'error')
+      .map((d) => `[${d.source}] ${d.message}${d.path ? ` (at ${d.path.join('.')})` : ''}`);
+    return { valid: false, errors };
+  } catch {
+    return undefined;
+  }
+};
 
 const generateWorkflowSchema = z.object({
   query: z
@@ -162,11 +191,14 @@ And you should **not**:
           toolId: platformCoreTools.generateWorkflow,
         });
 
+        const validation = await runCompactValidation(afterYaml, workflowsApi, spaceId, request);
+
         aiTelemetryClient.reportEditResult({
           toolId: platformCoreTools.generateWorkflow,
           conversationId: extractConversationId(toolContext),
           editSuccess: true,
           isCreation: !sourceAttachment,
+          validation,
         });
 
         return {


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/17641

Follow-up to #269351 — addresses [@yiannisnikolopoulos's review comment](https://github.com/elastic/kibana/pull/269351#pullrequestreview-4389261579).

## Summary

The old low-level edit tools (deleted in #269351) ran a compact validation pass against the resulting YAML and surfaced the outcome via `WorkflowsAiTelemetryClient.reportEditResult`, emitting:

- `validation_passed: boolean`
- `validation_error_count: number` (when invalid)
- `is_self_correction: boolean` (when a previously-failed conversation produced a valid YAML)

When `generate_workflow` became the single entry point, `reportEditResult` started being called without a `validation` field, so those telemetry fields are permanently undefined and we can't track generation-quality regressions over time.

This PR reintroduces the helper, calls `api.validateWorkflow` against the stringified generated YAML, and passes the result through to telemetry on the success path. The failure path (generation threw) still has no YAML to validate, so it keeps the existing behavior.

## Test plan

- [x] `generate_workflow.test.ts` unit suite (10 cases, including new coverage):
  - passes a compact validation result to telemetry when the generated YAML is valid
  - passes compact errors to telemetry when the generated YAML fails validation (error-only diagnostic flattening, drops warnings)
  - omits validation in telemetry when `validateWorkflow` throws
- [ ] Manual smoke check that the `workflows_ai_edit_result` event now carries `validation_passed` in dev tools (not required for merge, but worth confirming once on a deployed env).