### PR TITLE
[POC] [ResponseOps] change index connector to support documents as strings

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/es_index/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/es_index/schemas/v1.ts
@@ -21,13 +21,15 @@ export const ConfigSchema = lazySchema(() =>
 
 export const SecretsSchema = lazySchema(() => z.object({}).strict().default({}));
 
+const documentSchema = z.union([z.string(), z.record(z.string(), z.any())]);
+
 // see: https://www.elastic.co/guide/en/elasticsearch/reference/current/actions-index.html
 // - timeout not added here, as this seems to be a generic thing we want to do
 //   eventually: https://github.com/elastic/kibana/projects/26#card-24087404
 export const ParamsSchema = lazySchema(() =>
   z
     .object({
-      documents: z.array(z.record(z.string(), z.any())),
+      documents: z.array(documentSchema),
       indexOverride: z
         .string()
         .nullable()

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/es_index/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/es_index/index.ts
@@ -35,6 +35,8 @@ import type {
   ConnectorTypeSecretsType,
 } from '@kbn/connector-schemas/es_index';
 
+import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
+
 export type ESIndexConnectorType = ConnectorType<
   ConnectorTypeConfigType,
   ConnectorTypeSecretsType,
@@ -87,13 +89,24 @@ async function executor(
 
   const bulkBody = [];
   for (const document of params.documents) {
+    let jsonDocument: Record<string, unknown>;
+    if (typeof document === 'string') {
+      try {
+        jsonDocument = JSON.parse(document);
+      } catch (err) {
+        return wrapErr(`error parsing document: ${err.message}`, actionId, logger, true);
+      }
+    } else {
+      jsonDocument = document;
+    }
+
     const timeField = config.executionTimeField == null ? '' : config.executionTimeField.trim();
     if (timeField !== '') {
-      document[timeField] = new Date();
+      jsonDocument[timeField] = new Date();
     }
 
     bulkBody.push({ index: { op_type: 'create' } });
-    bulkBody.push(document);
+    bulkBody.push(jsonDocument);
   }
 
   const bulkParams = {
@@ -162,7 +175,8 @@ function renderParameterTemplates(
 function wrapErr(
   errMessage: string,
   actionId: string,
-  logger: Logger
+  logger: Logger,
+  isUserError: boolean = false
 ): ConnectorTypeExecutorResult<unknown> {
   const message = i18n.translate('xpack.stackConnectors.esIndex.errorIndexingErrorMessage', {
     defaultMessage: 'error indexing documents',
@@ -173,5 +187,6 @@ function wrapErr(
     actionId,
     message,
     serviceMessage: errMessage,
+    ...(isUserError ? { errorSource: TaskErrorSource.USER } : {}),
   };
 }


### PR DESCRIPTION
towards https://github.com/elastic/kibana/issues/203949 
towards https://github.com/elastic/response-ops-team/issues/557

This branch is exploring changing the `documents` parameter of the `.index` connector from

    array of JSON objects

to

    array of (JSON object | string)

This allows us to support the original parameter type, but also support a version that will allow usage of mustache lambdas within the document.

I tested by creating a rule in DevTools; the relevant detail here is `"documents": ["{{{.}}}"]`, which would be invalid today, but with this change will write the expanded context variables as the document to index.

This rule expects an index connector named `index` (not required!), and you should specify the index name in the connector.  I used `test`.

After the alert goes off, add a dataview for that `test` index to check the data produced.

Note this rule runs off of the event log, requires no set up, will always have a single alarm active.

<details><summary>DevTools invocation</summary>

```
POST kbn:/api/alerting/rule
{
  "params": {
    "aggType": "count",
    "esQuery": "{ \"query\": { \"match_all\": {}}}",
    "groupBy": "all",
    "index": [ ".kibana-event-log*" ],
    "searchType": "esQuery",
    "size": 100,
    "termSize": 5,
    "threshold": [1000],
    "thresholdComparator": "<",
    "timeField": "@timestamp",
    "timeWindowSize": 5,
    "timeWindowUnit": "m"
  },
  "schedule": {"interval": "10s"},
  "consumer": "stackAlerts",
  "name": "test indexing strings",
  "notifyWhen": null,
  "enabled": true,
  "rule_type_id": ".es-query",
  "actions": [
    {
      "group": "query matched",
      "id": "index",
      "params": {
        "documents": ["{{{.}}}"]
      },
      "frequency": {
        "notify_when": "onActiveAlert",
        "throttle": null,
        "summary": false
      }
    }
  ],
  "alert_delay": { "active": 1}
}
```

</details>

