### PR TITLE
[SigEvents][Discovery]: Remove verdicts

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/discovery.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/discovery.yaml
@@ -58,8 +58,8 @@ consts:
   SEVERITY_HIGH: 51
   SEVERITY_MEDIUM: 25
   UNHANDLED_RULES_MAX: 500
-  VERDICT_ACKNOWLEDGED: "acknowledged"
-  VERDICT_PROMOTED: "promoted"
+  STATUS_ACKNOWLEDGED: "acknowledged"
+  STATUS_PROMOTED: "promoted"
 
 steps:
   # Copy workflow.spaceId into variables so ES body Liquid expressions can reference it.
@@ -280,7 +280,7 @@ steps:
 
   # -----------------------------------------------------------------------
   # Step 3: Unhandled detection docs → correlation agent → index discoveries.
-  # -----------------------------------------------------------------------
+  # -----------------------------------------------------------------------      
   - name: get_active_unhandled_rules
     type: elasticsearch.request
     with:
@@ -405,7 +405,7 @@ steps:
       continue: true
 
   - name: get_active_events
-    # No verdict filter — ES filters BEFORE collapse; post-filtered in compute_active_events_context.
+    # No status filter — ES filters BEFORE collapse; post-filtered in compute_active_events_context.
     type: elasticsearch.request
     with:
       method: POST
@@ -421,7 +421,7 @@ steps:
           includes:
             - discovery_slug
             - title
-            - verdict
+            - status
         query:
           bool:
             filter:
@@ -436,8 +436,8 @@ steps:
   - name: compute_active_events_context
     type: data.set
     with:
-      promoted_events: "${{ steps.get_active_events.output.hits.hits | where: '_source.verdict', 'promoted' | map: '_source' | default: [] }}"
-      acknowledged_events: "${{ steps.get_active_events.output.hits.hits | where: '_source.verdict', 'acknowledged' | map: '_source' | default: [] }}"
+      promoted_events: "${{ steps.get_active_events.output.hits.hits | where: '_source.status', 'promoted' | map: '_source' | default: [] }}"
+      acknowledged_events: "${{ steps.get_active_events.output.hits.hits | where: '_source.status', 'acknowledged' | map: '_source' | default: [] }}"
 
   - name: run_investigator_agent
     # TODO: agent-id and connector-id are config fields and are NOT rendered through Liquid by the
@@ -630,7 +630,7 @@ steps:
           is_not_group: "${{ foreach.item.grouped_discovery_ids == null or foreach.item.grouped_discovery_ids.size == 0 }}"
 
       - name: get_active_event_for_slug
-        # No verdict filter — post-filtered in compute_active_event_for_slug.
+        # No status filter — post-filtered in compute_active_event_for_slug.
         type: elasticsearch.request
         with:
           method: POST
@@ -644,7 +644,7 @@ steps:
                   order: desc
             _source:
               includes:
-                - verdict
+                - status
             query:
               bool:
                 filter:
@@ -660,9 +660,9 @@ steps:
         with:
           has_active_event: >-
             ${{ steps.get_active_event_for_slug.output.hits.total.value > 0
-            and steps.get_active_event_for_slug.output.hits.hits[0]._source.verdict == consts.VERDICT_PROMOTED
+            and steps.get_active_event_for_slug.output.hits.hits[0]._source.status == consts.STATUS_PROMOTED
             or steps.get_active_event_for_slug.output.hits.total.value > 0
-            and steps.get_active_event_for_slug.output.hits.hits[0]._source.verdict == consts.VERDICT_ACKNOWLEDGED }}
+            and steps.get_active_event_for_slug.output.hits.hits[0]._source.status == consts.STATUS_ACKNOWLEDGED }}
 
       - name: check_recent_finding
         if: "${{ foreach.item.detections != null and foreach.item.detections.size > 0 }}"

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/discovery.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/discovery.yaml
@@ -312,10 +312,9 @@ steps:
     type: data.set
     with:
       # active_rule_uuids: rules whose latest doc is kind:detection — fed to investigator batch.
-      # catchall_rule_uuids: detection OR quiet latest — fed to the catchall handled stamper so
-      #   quiet-latest rules also receive a kind:handled stamp after investigation.
       active_rule_uuids: "${{ steps.get_active_unhandled_rules.output.hits.hits | where: '_source.kind', 'detection' | map: '_source' | map: 'rule_uuid' | default: [] }}"
-      catchall_rule_uuids: "${{ steps.get_active_unhandled_rules.output.hits.hits | reject: '_source.kind', 'handled' | map: '_source' | map: 'rule_uuid' | default: [] }}"
+      # quiet_rule_uuids: rules whose latest doc is kind:quiet — not investigated, but stamped handled.
+      quiet_rule_uuids: "${{ steps.get_active_unhandled_rules.output.hits.hits | where: '_source.kind', 'quiet' | map: '_source' | map: 'rule_uuid' | default: [] }}"
 
   - name: get_detected_window
     # if guard: terms with an empty array causes an ES parsing_exception.
@@ -363,6 +362,14 @@ steps:
                     gte: '{{ inputs.detectionLookback }}'
     on-failure:
       continue: true
+
+  - name: compute_stamp_rule_uuids
+    # Rules to mark handled this cycle: the investigated batch plus quiet (recovered) rules,
+    # so recovered rules aren't left looking unprocessed. Active rules beyond the
+    # detectionBatchMax cap are excluded so they survive for the next cycle.
+    type: data.set
+    with:
+      stamp_rule_uuids: "${{ steps.get_detected_window.output.hits.hits | map: '_source' | map: 'rule_uuid' | compact | concat: steps.compute_active_unhandled_rule_uuids.output.quiet_rule_uuids | uniq | default: [] }}"
 
   - name: exit_idle
     type: workflow.output
@@ -925,12 +932,9 @@ steps:
               continue: true
 
   - name: get_unhandled_state_docs
-    # Use catchall_rule_uuids (detection OR quiet latest) so quiet-latest rules
-    # also get a kind:handled stamp. active_rule_uuids would exclude them.
-    # Gate on agent success: if the agent failed, skip handled stamping so detections
-    # are not silently consumed — they will be retried on the next discovery cycle.
+    # Skip handled-stamping if the agent failed, so its detections are retried next cycle.
     if: >-
-      ${{ steps.compute_active_unhandled_rule_uuids.output.catchall_rule_uuids.size > 0
+      ${{ steps.compute_stamp_rule_uuids.output.stamp_rule_uuids.size > 0
       and steps.run_investigator_agent.error == null }}
     type: elasticsearch.request
     with:
@@ -951,7 +955,7 @@ steps:
                     - '{{ consts.KIND_DETECTION }}'
                     - '{{ consts.KIND_QUIET }}'
               - terms:
-                  rule_uuid: "${{ steps.compute_active_unhandled_rule_uuids.output.catchall_rule_uuids }}"
+                  rule_uuid: "${{ steps.compute_stamp_rule_uuids.output.stamp_rule_uuids }}"
               - range:
                   "@timestamp":
                     gte: '{{ inputs.detectionLookback }}'

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/index.ts
@@ -38,7 +38,7 @@ export const SIGEVENTS_DETECTION_WORKFLOW = {
 export const SIGEVENTS_DISCOVERY_WORKFLOW = {
   id: SIGEVENTS_DISCOVERY_WORKFLOW_ID,
   pluginId: 'streams',
-  version: 1,
+  version: 2,
   yaml: DISCOVERY_YAML,
   management: SIGEVENTS_WORKFLOW_MANAGEMENT,
 } as const satisfies ManagedWorkflowDefinition;
@@ -54,7 +54,7 @@ export const SIGEVENTS_ORCHESTRATOR_WORKFLOW = {
 export const SIGEVENTS_TRIAGE_WORKFLOW = {
   id: SIGEVENTS_TRIAGE_WORKFLOW_ID,
   pluginId: 'streams',
-  version: 1,
+  version: 2,
   yaml: TRIAGE_YAML,
   management: SIGEVENTS_WORKFLOW_MANAGEMENT,
 } as const satisfies ManagedWorkflowDefinition;

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/triage.yaml
@@ -30,12 +30,12 @@ triggers:
         type: string
         default: "now-7d"
         required: false
-        description: "Lookback window for active discoveries and reviewed verdict IDs. Should match .significant_events-discoveries retention."
+        description: "Lookback window for active discoveries and reviewed discovery IDs. Should match .significant_events-discoveries retention."
       - name: knowledgeBaseLookback
         type: string
         default: "now-7d"
         required: false
-        description: "Lookback window for knowledge base calibration examples (promoted + demoted verdicts). Wider = more examples, larger context."
+        description: "Lookback window for knowledge base calibration examples (promoted + demoted significant events). Wider = more examples, larger context."
       - name: discoveryBatchMax
         type: number
         default: 5
@@ -58,10 +58,9 @@ consts:
   SEVERITY_CRITICAL: 76
   SEVERITY_HIGH: 51
   SEVERITY_MEDIUM: 25
-  VERDICTS_INDEX: ".significant_events-verdicts"
-  VERDICT_ACKNOWLEDGED: "acknowledged"
-  VERDICT_DEMOTED: "demoted"
-  VERDICT_PROMOTED: "promoted"
+  STATUS_ACKNOWLEDGED: "acknowledged"
+  STATUS_DEMOTED: "demoted"
+  STATUS_PROMOTED: "promoted"
 steps:
   # Copy workflow.spaceId into variables so ES body Liquid expressions can reference it.
   - name: set_space_vars
@@ -107,7 +106,7 @@ steps:
   # Re-review: evidence-based (detection state changed) + 5m fallback (stale safety net).
   # -----------------------------------------------------------------------
   - name: get_all_event_docs
-    # No verdict filter — post-filtered in compute_promoted_context and compute_active_event_ids.
+    # No status filter — post-filtered in compute_promoted_context and compute_active_event_ids.
     type: elasticsearch.request
     with:
       method: POST
@@ -124,7 +123,7 @@ steps:
             - discovery_slug
             - event_id
             - title
-            - verdict
+            - status
         query:
           bool:
             filter:
@@ -137,8 +136,8 @@ steps:
   - name: compute_promoted_context
     type: data.set
     with:
-      promoted_events: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.verdict', 'promoted' | map: '_source' | default: [] }}"
-      acknowledged_events: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.verdict', 'acknowledged' | map: '_source' | default: [] }}"
+      promoted_events: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.status', 'promoted' | map: '_source' | default: [] }}"
+      acknowledged_events: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.status', 'acknowledged' | map: '_source' | default: [] }}"
 
   - name: get_latest_detection_ts
     # Latest evidence marker: if newer than an event's @timestamp, evidence changed.
@@ -167,7 +166,7 @@ steps:
       continue: true
 
   - name: get_promoted_with_cleared_signal
-    # No verdict filter — post-filtered in compute_cleared_signal_events.
+    # No status filter — post-filtered in compute_cleared_signal_events.
     type: elasticsearch.request
     if: "${{ steps.compute_cleared_slugs.output.slugs.size > 0 }}"
     with:
@@ -185,7 +184,7 @@ steps:
             - discovery_id
             - discovery_slug
             - title
-            - verdict
+            - status
             - summary
             - root_cause
             - impact
@@ -208,25 +207,25 @@ steps:
   - name: compute_cleared_signal_events
     type: data.set
     with:
-      cleared_promoted: "${{ steps.get_promoted_with_cleared_signal.output.hits.hits | where: '_source.verdict', 'promoted' | default: [] }}"
-      cleared_acknowledged: "${{ steps.get_promoted_with_cleared_signal.output.hits.hits | where: '_source.verdict', 'acknowledged' | default: [] }}"
+      cleared_promoted: "${{ steps.get_promoted_with_cleared_signal.output.hits.hits | where: '_source.status', 'promoted' | default: [] }}"
+      cleared_acknowledged: "${{ steps.get_promoted_with_cleared_signal.output.hits.hits | where: '_source.status', 'acknowledged' | default: [] }}"
 
   - name: compute_active_event_ids
     type: data.set
     with:
-      promoted_ids: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.verdict', 'promoted' | map: '_source.event_id' | default: [] }}"
-      acknowledged_ids: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.verdict', 'acknowledged' | map: '_source.event_id' | default: [] }}"
+      promoted_ids: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.status', 'promoted' | map: '_source.event_id' | default: [] }}"
+      acknowledged_ids: "${{ steps.get_all_event_docs.output.hits.hits | where: '_source.status', 'acknowledged' | map: '_source.event_id' | default: [] }}"
 
   # -----------------------------------------------------------------------
   # Step 1: Find unreviewed discoveries.
   # -----------------------------------------------------------------------
 
   - name: get_reviewed_ids
-    # Per-ID exclusion avoids missing recurrences when another slug has a newer verdict.
+    # Per-ID exclusion avoids missing recurrences when another slug has a newer event.
     type: elasticsearch.request
     with:
       method: POST
-      path: '/{{ consts.VERDICTS_INDEX }}/_search?ignore_unavailable=true'
+      path: '/{{ consts.EVENTS_INDEX }}/_search?ignore_unavailable=true'
       body:
         size: 0
         query:
@@ -243,7 +242,7 @@ steps:
               field: discovery_slug
               size: "${{ consts.REVIEWED_IDS_MAX }}"
             aggs:
-              latest_verdict_ts:
+              latest_status_ts:
                 max:
                   field: "@timestamp"
           reviewed_ids:
@@ -263,7 +262,7 @@ steps:
     type: data.set
     with:
       flag: "${{ steps.compute_reviewed_ids.output.reviewed_discovery_ids.size > 0 }}"
-
+      
   - name: get_unreviewed_discoveries
     # Guards against empty-array terms queries (ES rejects terms: [] at parse time).
     # Four branches cover the cross-product of (has_reviewed_ids) × (has_cleared_slugs).
@@ -685,7 +684,7 @@ steps:
             - discovery_id
             - discovery_slug
             - title
-            - verdict
+            - status
             - summary
             - root_cause
             - impact
@@ -778,19 +777,19 @@ steps:
       active_evidence: "${{ steps.get_detection_evidence.output.hits.hits | where: '_source.kind', 'detection' | default: [] }}"
 
   # -----------------------------------------------------------------------
-  # Step 3: Knowledge base — promoted + demoted verdicts for judge calibration.
+  # Step 3: Knowledge base — promoted + demoted events for judge calibration.
   # -----------------------------------------------------------------------
   - name: get_knowledge_base
-    # acknowledged/grouped verdicts excluded — promoted/demoted pattern data is
-    # what calibrates the judge; older promoted/demoted verdicts for a slug are
-    # exactly the desired signal even if the latest verdict is acknowledged.
-    # evidences excluded from KB — the judge calibrates from verdict/criticality/title;
+    # acknowledged/grouped events excluded — promoted/demoted pattern data is
+    # what calibrates the judge; older promoted/demoted events for a slug are
+    # exactly the desired signal even if the latest status is acknowledged.
+    # evidences excluded from KB — the judge calibrates from status/criticality/title;
     # full evidence payloads add ~50KB per entry for no calibration gain.
     # Slug-scoped should omitted — terms with an empty array causes an ES parse error.
     type: elasticsearch.request
     with:
       method: POST
-      path: '/{{ consts.VERDICTS_INDEX }}/_search?ignore_unavailable=true'
+      path: '/{{ consts.EVENTS_INDEX }}/_search?ignore_unavailable=true'
       body:
         size: '${{ consts.KB_BATCH_MAX }}'
         sort:
@@ -802,17 +801,17 @@ steps:
           includes:
             - "@timestamp"
             - discovery_slug
-            - verdict
+            - status
             - criticality
             - title
-            - verdict_summary
+            - analysis_summary
         query:
           bool:
             filter:
               - term:
                   kibana.space_ids: "{{ variables.spaceId }}"
               - terms:
-                  verdict: ["promoted", "demoted"]
+                  status: ["promoted", "demoted"]
               - range:
                   "@timestamp":
                     gte: '{{ inputs.knowledgeBaseLookback }}'
@@ -848,7 +847,7 @@ steps:
 
         {{ steps.compute_active_detection_evidence.output.active_evidence | map: '_source' | json }}
 
-        ## Knowledge Base (recent promoted + demoted verdicts)
+        ## Knowledge Base (recent promoted + demoted events)
 
         {{ steps.get_knowledge_base.output.hits.hits | map: '_source' | json }}
 
@@ -874,7 +873,7 @@ steps:
       schema:
         type: object
         properties:
-          verdicts:
+          significant_events:
             type: array
             items:
               type: object
@@ -889,8 +888,8 @@ steps:
                   type: array
                   items:
                     type: string
-                  description: "For new group verdicts: populate with the discovery_ids of all grouped discoveries. For re-reviewed group verdicts: echo verbatim from the group discovery — do not add or modify entries."
-                verdict:
+                  description: "For new group events: populate with the discovery_ids of all grouped discoveries. For re-reviewed group events: echo verbatim from the group discovery — do not add or modify entries."
+                status:
                   type: string
                   enum: [acknowledged, demoted, promoted]
                 criticality:
@@ -905,8 +904,8 @@ steps:
                   type: array
                   items:
                     type: string
-                  description: "Top 3 operator action items. Required for promoted and acknowledged verdicts."
-                verdict_summary:
+                  description: "Top 3 operator action items. Required for promoted and acknowledged events."
+                analysis_summary:
                   type: string
                 assessment_note:
                   type: string
@@ -949,138 +948,48 @@ steps:
                       confirmed:
                         type: boolean
                   description: "Inherit all discovery evidences unchanged, then append one entry per tool call made during this evaluation."
-              required: [discovery_id, discovery_slug, verdict, criticality, confidence, verdict_summary, assessment_note, title, evidences]
-        required: [verdicts]
+              required: [discovery_id, discovery_slug, status, criticality, confidence, analysis_summary, assessment_note, title, evidences]
+        required: [significant_events]
     on-failure:
       continue: false
 
   # -----------------------------------------------------------------------
-  # Step 5: Process each verdict — write to events + verdicts indices.
+  # Step 5: Process each significant event — write to events index.
   # -----------------------------------------------------------------------
 
   # Eviction-safe snapshot — ai.agent outputs are evictable; data.set outputs are not.
   - name: check_judge_agent_output
     type: if
-    condition: "${{ steps.run_judge_agent.error == null and steps.run_judge_agent.output.structured_output.verdicts != null }}"
+    condition: "${{ steps.run_judge_agent.error == null and steps.run_judge_agent.output.structured_output.significant_events != null }}"
     steps:
-      - name: store_verdicts
+      - name: store_significant_events
         type: data.set
         with:
-          verdicts: "${{ steps.run_judge_agent.output.structured_output.verdicts }}"
+          significant_events: "${{ steps.run_judge_agent.output.structured_output.significant_events }}"
           conversation_id: "{{ steps.run_judge_agent.output.conversation_id }}"
 
-  - name: foreach_verdict
+  - name: foreach_significant_event
     type: foreach
     if: >-
-      ${{ steps.store_verdicts.output != null
-      and steps.store_verdicts.output.verdicts != null }}
-    foreach: "${{ steps.store_verdicts.output.verdicts }}"
+      ${{ steps.store_significant_events.output != null
+      and steps.store_significant_events.output.significant_events != null }}
+    foreach: "${{ steps.store_significant_events.output.significant_events }}"
     steps:
 
-      # Phase 1: Read state
-      - name: check_existing_event_doc
-        # No verdict filter — post-filtered in compute_verdict_meta.
-        type: elasticsearch.request
-        with:
-          method: POST
-          path: '/{{ consts.EVENTS_INDEX }}/_search?ignore_unavailable=true'
-          body:
-            size: 1
-            collapse:
-              field: event_id
-            _source:
-              includes:
-                - verdict
-                - event_id
-                - created_at
-                - previous_event_id
-                - discovery_id
-                - discovery_slug
-                - recommended_action
-                - verdict_id
-                - title
-                - summary
-                - root_cause
-                - dependency_edges
-                - infra_components
-                - cause_kis
-            sort:
-              - "@timestamp":
-                  order: desc
-            query:
-              bool:
-                filter:
-                  - term:
-                      kibana.space_ids: "{{ variables.spaceId }}"
-                  - term:
-                      discovery_slug: "${{ foreach.item.discovery_slug }}"
-        on-failure:
-          continue: true
-
-      - name: check_latest_verdict_doc
-        # Detect actual verdict transitions — avoids infinite writes when a discovery
-        # is consistently demoted ("not has_active_event" is insufficient for that).
-        type: elasticsearch.request
-        with:
-          method: POST
-          path: '/{{ consts.VERDICTS_INDEX }}/_search?ignore_unavailable=true'
-          body:
-            size: 1
-            sort:
-              - "@timestamp":
-                  order: desc
-            _source:
-              includes:
-                - verdict
-            query:
-              bool:
-                filter:
-                  - term:
-                      kibana.space_ids: "{{ variables.spaceId }}"
-                  - term:
-                      discovery_id: "${{ foreach.item.discovery_id }}"
-        on-failure:
-          continue: true
-
-      # Phase 2: Compute signals
-      - name: compute_verdict_meta
+      # Phase 1: Compute signals
+      - name: compute_significant_event_meta
         type: data.set
         with:
-          recommended_action: "{% if foreach.item.verdict == consts.VERDICT_DEMOTED %}monitor{% elsif foreach.item.verdict == consts.VERDICT_ACKNOWLEDGED and foreach.item.criticality < consts.SEVERITY_CRITICAL %}monitor{% elsif foreach.item.criticality >= consts.SEVERITY_CRITICAL %}escalate{% elsif foreach.item.criticality >= consts.SEVERITY_HIGH %}investigate{% else %}monitor{% endif %}"
+          recommended_action: "{% if foreach.item.status == consts.STATUS_DEMOTED %}monitor{% elsif foreach.item.status == consts.STATUS_ACKNOWLEDGED and foreach.item.criticality < consts.SEVERITY_CRITICAL %}monitor{% elsif foreach.item.criticality >= consts.SEVERITY_CRITICAL %}escalate{% elsif foreach.item.criticality >= consts.SEVERITY_HIGH %}investigate{% else %}monitor{% endif %}"
           impact: "{% if foreach.item.criticality >= consts.SEVERITY_CRITICAL %}critical{% elsif foreach.item.criticality >= consts.SEVERITY_HIGH %}high{% elsif foreach.item.criticality >= consts.SEVERITY_MEDIUM %}medium{% else %}low{% endif %}"
-          has_active_event: >-
-            ${{ steps.check_existing_event_doc.output.hits.total.value > 0
-            and steps.check_existing_event_doc.output.hits.hits[0]._source.verdict == consts.VERDICT_PROMOTED
-            or steps.check_existing_event_doc.output.hits.total.value > 0
-            and steps.check_existing_event_doc.output.hits.hits[0]._source.verdict == consts.VERDICT_ACKNOWLEDGED }}
 
-      - name: compute_changes
-        # verdict_changed compares the last verdict doc (not the event doc) so
-        # consistently-demoted discoveries don't generate redundant verdict writes.
-        type: data.set
-        with:
-          event_changed: >-
-            ${{ not steps.compute_verdict_meta.output.has_active_event
-            or steps.check_existing_event_doc.output.hits.hits[0]._source.verdict != foreach.item.verdict
-            or steps.check_existing_event_doc.output.hits.hits[0]._source.recommended_action != steps.compute_verdict_meta.output.recommended_action
-            or steps.check_existing_event_doc.output.hits.hits[0]._source.discovery_id != foreach.item.discovery_id
-            or steps.check_existing_event_doc.output.hits.hits[0]._source.verdict_id == null }}
-          verdict_changed: >-
-            ${{ steps.check_latest_verdict_doc.error != null
-            or steps.check_latest_verdict_doc.output.hits.total.value < 1
-            or steps.check_latest_verdict_doc.output.hits.hits[0]._source.verdict != foreach.item.verdict }}
-          has_event_doc: >-
-            ${{ steps.compute_verdict_meta.output.has_active_event
-            or steps.check_existing_event_doc.error != null }}
-
-      # Phase 3: Compute content
+      # Phase 2: Compute content
       - name: resolve_discovery_source
         # New discoveries: look up from pre-judge unreviewed_hits by slug.
-        # Re-reviews: slug not in unreviewed_hits — fall back to existing event doc
-        # (carries cause_kis, dependency_edges, infra_components from creation time).
+        # Re-reviews: slug not in unreviewed_hits — source from foreach item directly.
         type: data.set
         with:
-          src: "${{ steps.check_has_unreviewed.output.unreviewed_hits | default: [] | map: '_source' | where: 'discovery_slug', foreach.item.discovery_slug | first | default: steps.check_existing_event_doc.output.hits.hits[0]._source }}"
+          src: "${{ steps.check_has_unreviewed.output.unreviewed_hits | default: [] | map: '_source' | where: 'discovery_slug', foreach.item.discovery_slug | first }}"
 
       - name: compute_event_content
         type: data.set
@@ -1095,7 +1004,6 @@ steps:
           title: "{{ foreach.item.title | default: steps.resolve_discovery_source.output.src.title }}"
 
       - name: get_prior_event_doc
-        # Any verdict, including demoted — chains previous_event_id for new events.
         type: elasticsearch.request
         with:
           method: POST
@@ -1143,40 +1051,21 @@ steps:
         with:
           cleared: "${{ steps.check_discovery_cleared.error == null and steps.check_discovery_cleared.output.count > 0 }}"
 
-      - name: compute_write_gates
-        type: data.set
-        with:
-          needs_new_event: >-
-            ${{ not steps.compute_verdict_meta.output.has_active_event
-            and foreach.item.verdict != consts.VERDICT_DEMOTED
-            and not steps.compute_is_cleared.output.cleared }}
-          needs_revision: >-
-            ${{ steps.compute_changes.output.has_event_doc
-            and steps.compute_changes.output.verdict_changed }}
-
       - name: compute_event_write
-        # Unifies create and append paths: event_id, created_at, previous_event_id
-        # preserve existing values on the append path; content falls back to the prior doc.
         type: data.set
         with:
-          should_write: >-
-            ${{ steps.compute_write_gates.output.needs_new_event
-            or steps.compute_write_gates.output.needs_revision }}
-          event_id: "{% if steps.compute_verdict_meta.output.has_active_event %}{{ steps.check_existing_event_doc.output.hits.hits[0]._source.event_id }}{% else %}{{ steps.compute_event_content.output.discovery_id }}-event{% endif %}"
-          created_at: "{% if steps.compute_verdict_meta.output.has_active_event %}{{ steps.check_existing_event_doc.output.hits.hits[0]._source.created_at }}{% else %}{{ 'now' | date: '%Y-%m-%dT%H:%M:%S%:z' }}{% endif %}"
-          previous_event_id: "{% if steps.compute_verdict_meta.output.has_active_event %}{{ steps.check_existing_event_doc.output.hits.hits[0]._source.previous_event_id }}{% else %}{{ steps.get_prior_event_doc.output.hits.hits[0]._source.event_id }}{% endif %}"
-          title: "{{ steps.compute_event_content.output.title | default: steps.check_existing_event_doc.output.hits.hits[0]._source.title }}"
-          summary: "{{ steps.compute_event_content.output.summary | default: steps.check_existing_event_doc.output.hits.hits[0]._source.summary }}"
-          root_cause: "{{ steps.compute_event_content.output.root_cause | default: steps.check_existing_event_doc.output.hits.hits[0]._source.root_cause }}"
-          dependency_edges: "${{ steps.compute_event_content.output.dependency_edges | default: steps.check_existing_event_doc.output.hits.hits[0]._source.dependency_edges | default: [] }}"
-          infra_components: "${{ steps.compute_event_content.output.infra_components | default: steps.check_existing_event_doc.output.hits.hits[0]._source.infra_components | default: [] }}"
-          cause_kis: "${{ steps.compute_event_content.output.cause_kis | default: steps.check_existing_event_doc.output.hits.hits[0]._source.cause_kis }}"
-          discovery_slug: "{{ steps.compute_event_content.output.discovery_slug | default: steps.check_existing_event_doc.output.hits.hits[0]._source.discovery_slug }}"
-          discovery_id: "{{ steps.compute_event_content.output.discovery_id | default: steps.check_existing_event_doc.output.hits.hits[0]._source.discovery_id }}"
-          verdict_id: "{% if steps.compute_changes.output.event_changed %}{{ execution.id }}-{{ steps.compute_event_content.output.discovery_id }}{% else %}{{ steps.check_existing_event_doc.output.hits.hits[0]._source.verdict_id }}{% endif %}"
+          should_write: "${{ not steps.compute_is_cleared.output.cleared }}"
+          event_id: "{{ execution.id }}-{{ foreach.item.discovery_id }}"
+          created_at: '{{ "now" | date: "%Y-%m-%dT%H:%M:%S%:z" }}'
+          previous_event_id: "{{ steps.get_prior_event_doc.output.hits.hits[0]._source.event_id }}"
+          title: "{{ steps.compute_event_content.output.title }}"
+          summary: "{{ steps.compute_event_content.output.summary }}"
+          root_cause: "{{ steps.compute_event_content.output.root_cause }}"
+          discovery_slug: "{{ foreach.item.discovery_slug }}"
+          discovery_id: "{{ foreach.item.discovery_id }}"
 
-      # Phase 4: Write
-      - name: write_event_doc
+      # Phase 3: Write
+      - name: write_significant_event_doc
         type: elasticsearch.request
         if: "${{ steps.compute_event_write.output.should_write }}"
         with:
@@ -1187,64 +1076,30 @@ steps:
             kibana:
               space_ids:
                 - "{{ variables.spaceId }}"
-            cause_kis: "${{ steps.compute_event_write.output.cause_kis }}"
+            cause_kis: "${{ steps.compute_event_content.output.cause_kis }}"
             confidence: "${{ foreach.item.confidence }}"
             created_at: "{{ steps.compute_event_write.output.created_at }}"
             criticality: "${{ foreach.item.criticality }}"
-            dependency_edges: "${{ steps.compute_event_write.output.dependency_edges }}"
+            dependency_edges: "${{ steps.compute_event_content.output.dependency_edges }}"
             discovery_id: "{{ steps.compute_event_write.output.discovery_id }}"
             discovery_slug: "{{ steps.compute_event_write.output.discovery_slug }}"
             event_id: "{{ steps.compute_event_write.output.event_id }}"
             evidences: "${{ foreach.item.evidences | where: 'result', 'found' }}"
-            impact: "{{ steps.compute_verdict_meta.output.impact }}"
-            infra_components: "${{ steps.compute_event_write.output.infra_components }}"
+            impact: "{{ steps.compute_significant_event_meta.output.impact }}"
+            infra_components: "${{ steps.compute_event_content.output.infra_components }}"
             previous_event_id: "{{ steps.compute_event_write.output.previous_event_id }}"
             recommendations: "${{ foreach.item.recommendations | default: [] }}"
-            recommended_action: "{{ steps.compute_verdict_meta.output.recommended_action }}"
+            recommended_action: "{{ steps.compute_significant_event_meta.output.recommended_action }}"
             stream_names: "${{ foreach.item.evidences | map: 'stream_name' | compact | uniq }}"
             root_cause: "{{ steps.compute_event_write.output.root_cause }}"
             summary: "{{ steps.compute_event_write.output.summary }}"
             title: "{{ steps.compute_event_write.output.title }}"
-            verdict: "${{ foreach.item.verdict }}"
-            verdict_id: "{{ steps.compute_event_write.output.verdict_id }}"
+            status: "${{ foreach.item.status }}"
+            analysis_summary: "${{ foreach.item.analysis_summary }}"
+            assessment_note: "${{ foreach.item.assessment_note }}"
+            analysis_source: judge_agent
+            conversation_id: "{{ steps.store_significant_events.output.conversation_id }}"
+            grouped_discovery_ids: "${{ foreach.item.grouped_discovery_ids }}"
             workflow_execution_id: "{{ execution.id }}"
         on-failure:
           continue: true
-
-      - name: write_verdict_doc
-        # POST _doc — PUT _create/{id} unavailable on data streams.
-        type: elasticsearch.request
-        if: "${{ steps.compute_changes.output.verdict_changed }}"
-        with:
-          method: POST
-          path: '/{{ consts.VERDICTS_INDEX }}/_doc'
-          body:
-            "@timestamp": '{{ "now" | date: "%Y-%m-%dT%H:%M:%S%:z" }}'
-            kibana:
-              space_ids:
-                - "{{ variables.spaceId }}"
-            assessment_note: "${{ foreach.item.assessment_note }}"
-            cause_kis: "${{ steps.compute_event_content.output.cause_kis | default: [] }}"
-            confidence: "${{ foreach.item.confidence }}"
-            conversation_id: "{{ steps.store_verdicts.output.conversation_id }}"
-            criticality: "${{ foreach.item.criticality }}"
-            dependency_edges: "${{ steps.compute_event_content.output.dependency_edges }}"
-            discovery_id: "{{ steps.compute_event_content.output.discovery_id }}"
-            discovery_slug: "{{ steps.compute_event_content.output.discovery_slug }}"
-            evidences: "${{ foreach.item.evidences | where: 'result', 'found' }}"
-            grouped_discovery_ids: "${{ foreach.item.grouped_discovery_ids }}"
-            impact: "{{ steps.compute_verdict_meta.output.impact }}"
-            infra_components: "${{ steps.compute_event_content.output.infra_components }}"
-            recommendations: "${{ foreach.item.recommendations }}"
-            recommended_action: "{{ steps.compute_verdict_meta.output.recommended_action }}"
-            stream_names: "${{ foreach.item.evidences | map: 'stream_name' | compact | uniq }}"
-            root_cause: "{{ steps.compute_event_content.output.root_cause }}"
-            summary: "{{ steps.compute_event_content.output.summary }}"
-            title: "{{ steps.compute_event_content.output.title }}"
-            verdict: "${{ foreach.item.verdict }}"
-            verdict_id: "{{ execution.id }}-{{ steps.compute_event_content.output.discovery_id }}"
-            verdict_source: judge_discoveries
-            verdict_summary: "${{ foreach.item.verdict_summary }}"
-            workflow_execution_id: "{{ execution.id }}"
-        on-failure:
-          continue: false

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/sig_events/triage.yaml
@@ -947,6 +947,7 @@ steps:
                           - type: "null"
                       confirmed:
                         type: boolean
+                        enum: [true]
                   description: "Inherit all discovery evidences unchanged, then append one entry per tool call made during this evaluation."
               required: [discovery_id, discovery_slug, status, criticality, confidence, analysis_summary, assessment_note, title, evidences]
         required: [significant_events]
@@ -1102,4 +1103,4 @@ steps:
             grouped_discovery_ids: "${{ foreach.item.grouped_discovery_ids }}"
             workflow_execution_id: "{{ execution.id }}"
         on-failure:
-          continue: true
+          continue: false

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/sig_events/events/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/sig_events/events/index.ts
@@ -29,8 +29,7 @@ export const sigEventSchema = z.object({
   discovery_id: z.string().max(255).optional(),
   discovery_slug: z.string().max(255),
   previous_event_id: z.string().max(255).optional(),
-  verdict: sigEventStatusSchema,
-  verdict_id: z.string().max(255).optional(),
+  status: sigEventStatusSchema,
   workflow_execution_id: z.string().max(255).optional(),
   rule_names: z.array(z.string().max(255)).max(100).optional(),
   stream_names: z.array(z.string().max(255)).max(100),
@@ -47,9 +46,7 @@ export const sigEventSchema = z.object({
   cause_kis: z.array(causeKiSchema).optional(),
   evidences: z.array(evidenceSchema).optional(),
   grouped_into: z.string().max(255).optional(),
-  // TODO: rename once the data stream fields are renamed
-  // Audit fields merged from verdict docs
-  verdict_summary: z.string().max(MAX_TEXT_LENGTH).optional(),
+  analysis_summary: z.string().max(MAX_TEXT_LENGTH).optional(),
   assessment_note: z.string().max(MAX_TEXT_LENGTH).optional(),
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/instructions/investigator.md.text
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/instructions/investigator.md.text
@@ -11,7 +11,7 @@ Your scope is **the detections batch and nothing else**. Adjacent issues surface
 | **INPUT SCOPE** | The `detections` batch and supporting context (`open_discoveries`, `confirmed_significant_events`). Every rule you act on must appear in `detections`. |
 | **ACTIVE BATCH** | `## Active batch` contains all currently-firing rules. Run `search_knowledge_indicators` and all tool calls for every rule in this list. **Empty batch early exit**: if `## Active batch` is `[]` → return `{ "discoveries": [] }` immediately. No tool calls. |
 | **EARLY EXIT** | `detections` absent or empty → return `{ "discoveries": [] }` immediately. `open_discoveries` is supporting context, not a work item. |
-| **FORBIDDEN** | Creating a discovery for a rule not in `detections` — adjacent issues go in `summary` only. Writing `verdict`, `recommended_action`, or `recommendations`. Adding any field not in the Step 8 schema. Running `execute_esql` for a KI whose `rule.id` is not a `rule_uuid` in this discovery's `detections`. |
+| **FORBIDDEN** | Creating a discovery for a rule not in `detections` — adjacent issues go in `summary` only. Writing `status`, `recommended_action`, or `recommendations`. Adding any field not in the Step 8 schema. Running `execute_esql` for a KI whose `rule.id` is not a `rule_uuid` in this discovery's `detections`. |
 
 </scope>
 
@@ -258,7 +258,7 @@ Apply the correlation rules above. When uncertain, default to splitting.
 #### Step 7-pre: Coverage Absorption
 
 Build the set of covered rule UUIDs:
-1. `promoted_slugs` = discovery slugs from `confirmed_significant_events` where `verdict == "promoted"`.
+1. `promoted_slugs` = discovery slugs from `confirmed_significant_events` where `status == "promoted"`.
 2. `covered_uuids` = `rule_uuid` values from `open_discoveries` whose `discovery_slug` is in `promoted_slugs`.
 3. A detection `D` is covered when `D.rule_uuid` is in `covered_uuids`.
 

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/instructions/judge.md.text
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/instructions/judge.md.text
@@ -9,7 +9,7 @@ You receive only unreviewed discoveries. After evaluating each item individually
 | | Boundary |
 |---|---|
 | **INPUT SCOPE** | Unreviewed discoveries. Each discovery's `rule_names`/`stream_names` are fixed at discovery time and read-only. |
-| **EARLY EXIT** | `## Unreviewed Discoveries` absent or empty → return `{ "verdicts": [] }` immediately. No tool calls. |
+| **EARLY EXIT** | `## Unreviewed Discoveries` absent or empty → return `{ "significant_events": [] }` immediately. No tool calls. |
 | **FORBIDDEN** | Modifying `rule_names`/`stream_names`. Adjacent tool-call findings go in `assessment_note` only. Adding any field not in the Step 9 schema. |
 
 </scope>
@@ -23,7 +23,7 @@ You receive only unreviewed discoveries. After evaluating each item individually
    - `get_logs`-origin entries (`esql_query: null`) never trigger a `search_knowledge_indicators` call.
 2. **`cause_kis` read-only**: use entity names and stream mappings to scope tool calls. Never add, remove, or modify entries, and never add a `confirmed` field.
 3. **`dependency_edges`/`infra_components` read-only**: use for exposure assessment, criticality calibration, and recommendations. Never modify `exposure` values or add/remove entries. For group discoveries, echo all fields verbatim.
-4. **Verdict consistency**: active failures confirmed by tools → verdict must be `promoted`. A verdict contradicting your evidence is a critical error — fix the verdict.
+4. **Status consistency**: active failures confirmed by tools → status must be `promoted`. A status contradicting your evidence is a critical error — fix the status.
 5. **Freshness gate — hard stop**: if `collected_at` ≤10m AND `result: "found"` → stamp `confirmed: true` and move on. Do NOT call `execute_esql` for this entry.
 6. **`acknowledged` gate**: only reachable when the broad stream check (Step 5b) returned results AND no confirmed active errors AND `criticality < 76`. Otherwise use `promoted` or `demoted`.
 7. **Never emit `confirmed: false`**: omit the field entirely on unverified entries.
@@ -85,19 +85,19 @@ Read `@timestamp` from last row to first (oldest→newest). Assess: (a) is the p
 
 **Review approach**: read all hypotheses before reaching for any tool. For each one, check whether the claimed failure is still active, whether the evidence holds up, and whether it's actually worth paging someone. Prioritise based on signal strength (`p_value`, change type) and what you can confirm — not just what the hypothesis says.
 
-**Output target**: one `verdict` entry per discovery. Finalize all fields at Step 9.
+**Output target**: one `status` entry per discovery. Finalize all fields at Step 9.
 
 **Before any tool call — two required checkpoints for ALL items:**
 
 **Blind assessment (before reading discovery text):**
-For each item, read ONLY `detection_evidence` (`p_value`, `change_point_type`, `rules_activity`, `alert_count`). Write one line: `"<discovery_slug> | p_value | change_type | independent verdict: promoted/acknowledged/demoted | reason in ≤6 words"`. Do NOT read `root_cause` or `summary` yet. This is your anchor-free baseline.
+For each item, read ONLY `detection_evidence` (`p_value`, `change_point_type`, `rules_activity`, `alert_count`). Write one line: `"<discovery_slug> | p_value | change_type | independent status: promoted/acknowledged/demoted | reason in ≤6 words"`. Do NOT read `root_cause` or `summary` yet. This is your anchor-free baseline.
 
 **Compare and devil's advocate:**
 Now read the discovery's `root_cause` and `summary`. Note whether your independent assessment agrees or diverges. Then write one counter-argument:
 - Leaning promoted/acknowledged → `"Could be demoted because: ..."`
 - Leaning demoted → `"Could be promoted because: ..."`
 
-If your blind verdict diverges from what the evidence supports after reading the discovery, record the divergence in `assessment_note`. Your evidence-based read wins.
+If your blind assessment diverges from what the evidence supports after reading the discovery, record the divergence in `assessment_note`. Your evidence-based read wins.
 
 **Execution model — do not make any tool calls until the pre-evaluation checkpoints and Steps 1–3 are complete for ALL items:**
 1. **Read-only pass** — Steps 1–3 across all items. No tool calls.
@@ -107,7 +107,7 @@ If your blind verdict diverges from what the evidence supports after reading the
 ### Step 1: Classify Item Type
 
 - **new discovery**: `change_point_occurrence: "first"` or absent — fresh evaluation.
-- **recurrence**: `change_point_occurrence: "recurring"` — treat as fresh; do NOT anchor on prior verdict.
+- **recurrence**: `change_point_occurrence: "recurring"` — treat as fresh; do NOT anchor on prior status.
 
 ### Step 2: Per-Rule Evidence Check
 
@@ -122,7 +122,7 @@ A rule failing both checks should be noted in `assessment_note` as weakly suppor
 - `p_value < 0.05`: credible. `> 0.1`: weak — be skeptical of high criticality.
 - `dip` implies service down and warrants higher criticality than a `spike` at equal `p_value`. `stationary` implies no real change.
 - Empty `cause_kis` + empty `evidences` = no KI backing — reflect in criticality.
-- **KB skepticism**: if this `discovery_slug` appears in `knowledge_base` with ≥2 prior `demoted` verdicts and similar `root_cause` context — burden of proof shifts. Require ≥1 confirmed evidence entry to promote; default to `demoted` when evidence is unconfirmed or empty, regardless of `p_value`.
+- **KB skepticism**: if this `discovery_slug` appears in `knowledge_base` with ≥2 prior `demoted` statuses and similar `root_cause` context — burden of proof shifts. Require ≥1 confirmed evidence entry to promote; default to `demoted` when evidence is unconfirmed or empty, regardless of `p_value`.
 
 ### Step 4: Build and Dispatch Execute Plan
 
@@ -147,7 +147,7 @@ Complete Steps 1–3 for ALL items first, then dispatch simultaneously.
 - Already-stamped entries: no tool call needed. Evidence may be truncated to at most 2 entries per rule.
 - Re-verification: re-run as-is (`esql_query` is the post-modification snapshot). Cap at 2 calls.
 - Empty evidences fallback:
-  - Recurrence: check `knowledge_base` for prior verdict with `esql_query` values — re-run those directly.
+  - Recurrence: check `knowledge_base` for prior status with `esql_query` values — re-run those directly.
   - Otherwise: call `search_knowledge_indicators` and run the highest-severity matching query.
 - Recurrence with no error signal in confirmed entries → emit `demoted` immediately.
 - Discovery slug in `## Discoveries with Detections Cleared` + no confirmed entries → emit `demoted` immediately.
@@ -161,7 +161,7 @@ Complete Steps 1–3 for ALL items first, then dispatch simultaneously.
 - **Pre-fetched check**: if `## Pre-fetched Broad Stream Checks` is present, look up `stream_names` there. Found with count > 0 → `demoted`; found with 0 → `demoted`. Not listed → fall through to `get_logs`.
 - **Broad stream check**: when re-verification returns 0 or stale rows, make one broad `get_logs` call (no error keywords). Budget exhausted → proceed with `promoted`, note in `assessment_note`.
 
-| Broad call result | Errors in re-verification | Verdict |
+| Broad call result | Errors in re-verification | Status |
 |---|---|---|
 | Returns results | 0 or stale | Stream active, errors cleared → `demoted` |
 | Returns 0 | 0 or stale | Stream inactive → `demoted` |
@@ -188,14 +188,14 @@ Check whether any discoveries describe the **same operational event** under diff
 - Compare `rule_names` by what they MONITOR (service, endpoint, operation) — not by exact name.
 - **Same-batch dedup**: if two discoveries cover the same concern, demote the less comprehensive one.
   - `assessment_note`: "Duplicate of discovery X — same operational concern."
-  - `verdict_summary`: "Demoted: superseded by the more comprehensive [title] event, which covers the same failure under its [N] detection rules."
+  - `analysis_summary`: "Demoted: superseded by the more comprehensive [title] event, which covers the same failure under its [N] detection rules."
   - Do NOT rewrite `summary` (discovery-owned). Do NOT promote both.
 - **Confirmed event dedup**: if a new discovery describes the same event as an already-promoted significant event, do not promote both.
   - **Causal inference test**: could one service failure explain both `root_cause` fields?
   - Supporting signals (not gatekeeping): same `stream_names`; same service in both `root_cause`s; `cause_kis` names a service from the new `root_cause`.
   - **Rank comprehensiveness**: (a) non-empty `cause_kis` > empty; (b) specific error class + downstream target > generic symptom; (c) confirmed evidence > unconfirmed.
   - Incoming wins → emit `promoted`; `assessment_note`: "Supersedes [title] — more accurate root-cause identification; prior event may now be superseded."
-  - Existing wins → emit `demoted`; `verdict_summary`: "Demoted: superseded by [title], which identifies root cause at [service/component] level vs. this discovery's symptom-level observation."
+  - Existing wins → emit `demoted`; `analysis_summary`: "Demoted: superseded by [title], which identifies root cause at [service/component] level vs. this discovery's symptom-level observation."
   - Never emit `acknowledged` for duplicates.
 
 ### Step 8: Criticality Calibration
@@ -211,9 +211,9 @@ Check whether any discoveries describe the **same operational event** under diff
 
 <output_properties>
 
-Output: single JSON `{ "verdicts": [...] }`. No preamble, summary, or commentary.
+Output: single JSON `{ "significant_events": [...] }`. No preamble, summary, or commentary.
 
-| Verdict | When to use |
+| Status | When to use |
 |---------|-------------|
 | `promoted` | Real AND impactful — persistence > 10 min, `p_value < 0.01`, KI confirmation, or tools confirm active failures |
 | `acknowledged` | Real but not impactful enough — low-impact, transient, or expected behavior |
@@ -222,7 +222,7 @@ Output: single JSON `{ "verdicts": [...] }`. No preamble, summary, or commentary
 Emit only fields defined in this schema. Output discipline applies to all narrative fields.
 
 - `discovery_id`: echo verbatim.
-- `verdict`: per table above. Required.
+- `status`: per table above. Required.
 - `criticality`: integer 0–100 (76–100 critical, 51–75 major, 31–50 partial, 0–30 noise). Calibrate per Step 8. Required.
 - `recommendations`:
   - Required for `promoted`/`acknowledged` (top 3 max, priority order); optional for `demoted`.
@@ -245,8 +245,8 @@ Emit only fields defined in this schema. Output discipline applies to all narrat
   - Remove claims for streams with empty/error evidence.
   - Never add alert counts, rule names, or recurrence context.
 - `discovery_slug`, `rule_names`, `stream_names`: echo verbatim. Adjacent tool-call findings go in `assessment_note` only.
-- `verdict_summary`: 1 sentence — answers: "What should an on-call engineer know about this situation right now?" Anchor to ≥1 confirmed entry (KI name + row_count). Never repeat `summary`.
-- `assessment_note`: 1–2 sentences — answers: "What evidence did I check and what fields did I change?" Cite confirmed entry count first, then changed-field dispositions. Never restate verdict reasoning.
+- `analysis_summary`: 1 sentence — answers: "What should an on-call engineer know about this situation right now?" Anchor to ≥1 confirmed entry (KI name + row_count). Never repeat `summary`.
+- `assessment_note`: 1–2 sentences — answers: "What evidence did I check and what fields did I change?" Cite confirmed entry count first, then changed-field dispositions. Never restate status reasoning.
 - `evidences`:
   - Schema per entry: `rule_name`, `rule_uuid` (null for `get_logs`), `stream_name`, `result` (found/empty/error), `row_count`, `esql_query` (null for `get_logs`), `description`, `collected_at`, `confirmed` (true when standing; omit otherwise — never emit false).
   - Echo all inherited entries unchanged; append one entry per tool call.

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/significant_event_attachment_type.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/significant_event_attachment_type.test.ts
@@ -26,7 +26,7 @@ const event: SigEvent = {
   event_id: 'event-1',
   discovery_id: 'discovery-1',
   discovery_slug: 'payment-outage',
-  verdict: 'promoted',
+  status: 'promoted',
   workflow_execution_id: 'workflow-1',
   rule_names: ['Payment errors'],
   stream_names: ['logs.payment'],
@@ -89,7 +89,7 @@ describe('createSignificantEventAttachmentType', () => {
   });
 
   it('resolves the latest event by discovery slug', async () => {
-    const updatedEvent = { ...event, event_id: 'event-2', verdict: 'acknowledged' as const };
+    const updatedEvent = { ...event, event_id: 'event-2', status: 'acknowledged' as const };
     const type = createSignificantEventAttachmentType({
       logger: loggingSystemMock.createLogger(),
       getScopedClients: createGetScopedClients([event, updatedEvent]),
@@ -99,7 +99,7 @@ describe('createSignificantEventAttachmentType', () => {
   });
 
   it('reports stale when the latest event differs from the stored snapshot', async () => {
-    const updatedEvent = { ...event, event_id: 'event-2', verdict: 'acknowledged' as const };
+    const updatedEvent = { ...event, event_id: 'event-2', status: 'acknowledged' as const };
     const type = createSignificantEventAttachmentType({
       logger: loggingSystemMock.createLogger(),
       getScopedClients: createGetScopedClients([updatedEvent]),

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/significant_event_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/significant_event_attachment_type.ts
@@ -36,7 +36,7 @@ export const formatSignificantEventAsText = (event: SigEvent): string => {
     `Significant Event "${event.title}"`,
     `Event ID: ${event.event_id}`,
     `Discovery slug: ${event.discovery_slug}`,
-    `Status: ${event.verdict}`,
+    `Status: ${event.status}`,
     `Impact: ${event.impact}`,
     `Criticality: ${event.criticality}`,
     `Confidence: ${event.confidence}`,

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/significant_event_sml_type.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/significant_event_sml_type.test.ts
@@ -22,7 +22,7 @@ const event: SigEvent = {
   created_at: '2026-01-01T00:00:00.000Z',
   event_id: 'event-1',
   discovery_slug: 'payment-outage',
-  verdict: 'promoted',
+  status: 'promoted',
   stream_names: ['logs.payment'],
   title: 'Payment outage',
   summary: 'Payments are failing.',

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/significant_event_sml_type.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/significant_event_sml_type.ts
@@ -24,7 +24,7 @@ const eventToSmlContent = (event: SigEvent): string => {
     event.title,
     event.summary,
     event.root_cause,
-    `status: ${event.verdict}`,
+    `status: ${event.status}`,
     `impact: ${event.impact}`,
     `criticality: ${event.criticality}`,
     `confidence: ${event.confidence}`,

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_create/handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_create/handler.ts
@@ -36,7 +36,7 @@ export async function createEventToolHandler({
     created_at: now,
     event_id: eventId,
     discovery_slug: `agent-event-${eventId.slice(0, 8)}`,
-    verdict: eventInput.status ?? 'promoted',
+    status: eventInput.status ?? 'promoted',
     stream_names: eventInput.stream_names,
     title: eventInput.title,
     summary: eventInput.summary,

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_search/handler.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_search/handler.test.ts
@@ -28,7 +28,7 @@ describe('searchEventsToolHandler', () => {
       perPage: undefined,
       search: 'timeout',
       stream: ['logs.checkout'],
-      verdict: ['promoted'],
+      status: ['promoted'],
     });
     expect(result).toEqual({ events: [{ event_id: 'e1' }], page: 2, per_page: 10, total: 17 });
   });
@@ -53,7 +53,7 @@ describe('searchEventsToolHandler', () => {
       perPage: undefined,
       search: 'latency',
       stream: undefined,
-      verdict: ['promoted'],
+      status: ['promoted'],
     });
   });
 });

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_search/handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_search/handler.ts
@@ -26,7 +26,7 @@ export async function searchEventsToolHandler({
     perPage: params.per_page,
     search: params.query,
     stream: params.stream_name ? [params.stream_name] : undefined,
-    verdict: params.status,
+    status: params.status,
   });
 
   return {

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_status_update/handler.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_status_update/handler.test.ts
@@ -11,7 +11,7 @@ describe('updateEventStatusToolHandler', () => {
   it('creates a new event version when status changes', async () => {
     const eventClient = {
       findById: jest.fn().mockResolvedValue({
-        hits: [{ event_id: 'event-1', verdict: 'promoted' }],
+        hits: [{ event_id: 'event-1', status: 'promoted' }],
       }),
       bulkCreate: jest.fn().mockResolvedValue({}),
     };
@@ -24,7 +24,7 @@ describe('updateEventStatusToolHandler', () => {
 
     expect(eventClient.bulkCreate).toHaveBeenCalledTimes(1);
     expect(eventClient.bulkCreate).toHaveBeenCalledWith(
-      [expect.objectContaining({ verdict: 'acknowledged' })],
+      [expect.objectContaining({ status: 'acknowledged' })],
       { throwOnFail: true }
     );
     expect(result.event_id).not.toBe('event-1');
@@ -49,9 +49,7 @@ describe('updateEventStatusToolHandler', () => {
     expect(missing).toEqual({ event_id: 'event-1', updated: 0, ignored: 1, status: 'demoted' });
 
     const eventClientSame = {
-      findById: jest
-        .fn()
-        .mockResolvedValue({ hits: [{ event_id: 'event-1', verdict: 'demoted' }] }),
+      findById: jest.fn().mockResolvedValue({ hits: [{ event_id: 'event-1', status: 'demoted' }] }),
       bulkCreate: jest.fn(),
     };
     const same = await updateEventStatusToolHandler({

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_status_update/handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_status_update/handler.ts
@@ -21,7 +21,7 @@ export async function updateEventStatusToolHandler({
   const { hits } = await eventClient.findById(eventId);
   const latest = hits[hits.length - 1];
 
-  if (!latest || latest.verdict === status) {
+  if (!latest || latest.status === status) {
     return { event_id: eventId, updated: 0, ignored: 1, status };
   }
 
@@ -33,7 +33,7 @@ export async function updateEventStatusToolHandler({
     created_at: now,
     event_id: nextEventId,
     previous_event_id: latest.event_id,
-    verdict: status,
+    status,
   };
 
   await eventClient.bulkCreate([updatedEvent], { throwOnFail: true });

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_status_update/tool.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/event_status_update/tool.ts
@@ -24,7 +24,7 @@ export const STREAMS_EVENT_STATUS_UPDATE_TOOL_ID = platformStreamsSigEventsTools
 
 const eventStatusUpdateSchema = z.object({
   event_id: z.string().describe(
-    i18n.translate('xpack.streams.agentBuilder.tools.eventVerdictUpdate.schema.eventId', {
+    i18n.translate('xpack.streams.agentBuilder.tools.eventStatusUpdate.schema.eventId', {
       defaultMessage: 'Identifier of the significant event to update.',
     })
   ),

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
@@ -25,22 +25,8 @@ export const eventsMappings = {
     impact: mappings.keyword(),
     title: mappings.text(),
     summary: mappings.text(),
-    root_cause: mappings.text(),
-    analysis_summary: mappings.text(),
-    assessment_note: mappings.text(),
-    criticality: mappings.integer(),
-    confidence: mappings.integer(),
-    recommended_action: mappings.keyword(),
-    created_at: mappings.date({ format: 'strict_date_optional_time' }),
-    workflow_execution_id: mappings.keyword(),
-    conversation_id: mappings.keyword(),
-    analysis_source: mappings.keyword(),
-    grouped_discovery_ids: mappings.keyword(),
-    rule_names: mappings.keyword(),
   },
 } satisfies MappingsDefinition;
-// version: 5
-
 export type StoredEvent = GetFieldsOf<typeof eventsMappings>;
 export type { SigEvent };
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
@@ -21,7 +21,7 @@ export const eventsMappings = {
     discovery_slug: mappings.keyword(),
     previous_event_id: mappings.keyword(),
     stream_names: mappings.keyword(),
-    verdict: mappings.keyword(),
+    status: mappings.keyword(),
     impact: mappings.keyword(),
     title: mappings.text(),
     summary: mappings.text(),
@@ -33,7 +33,7 @@ export type { SigEvent };
 
 export const eventsDataStream: DataStreamDefinition<typeof eventsMappings, StoredEvent> = {
   name: EVENTS_DATA_STREAM,
-  version: 4,
+  version: 5,
   hidden: true,
   template: {
     priority: 500,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
@@ -25,8 +25,21 @@ export const eventsMappings = {
     impact: mappings.keyword(),
     title: mappings.text(),
     summary: mappings.text(),
+    root_cause: mappings.text(),
+    analysis_summary: mappings.text(),
+    assessment_note: mappings.text(),
+    criticality: mappings.integer(),
+    confidence: mappings.integer(),
+    recommended_action: mappings.keyword(),
+    created_at: mappings.date({ format: 'strict_date_optional_time' }),
+    workflow_execution_id: mappings.keyword(),
+    conversation_id: mappings.keyword(),
+    analysis_source: mappings.keyword(),
+    grouped_discovery_ids: mappings.keyword(),
+    rule_names: mappings.keyword(),
   },
 } satisfies MappingsDefinition;
+// version: 5
 
 export type StoredEvent = GetFieldsOf<typeof eventsMappings>;
 export type { SigEvent };

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.test.ts
@@ -15,7 +15,7 @@ const createEvent = (): SigEvent => ({
   created_at: '2026-01-01T00:00:00.000Z',
   event_id: 'event-1',
   discovery_slug: 'agent-event-1',
-  verdict: 'promoted',
+  status: 'promoted',
   stream_names: ['logs.test'],
   title: 'Test event',
   summary: 'Test summary',

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
@@ -35,7 +35,7 @@ import { enrichFromEvidences } from '../utils';
 export type EventDataStreamClient = IDataStreamClient<typeof eventsMappings, StoredEvent>;
 
 export interface EventsFilterOptions {
-  verdict?: string[];
+  status?: string[];
   stream?: string[];
   search?: string;
 }
@@ -53,7 +53,7 @@ export class EventClient {
 
   private buildWhere(options: EventsFilterOptions): ESQLAstExpression | undefined {
     let where: ESQLAstExpression | undefined;
-    where = inFilter({ where, field: 'verdict', values: options.verdict });
+    where = inFilter({ where, field: 'status', values: options.status });
     where = inFilter({ where, field: 'stream_names', values: options.stream });
 
     if (options.search) {

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
@@ -61,7 +61,7 @@ const eventsSearchRoute = createServerRoute({
       to: z.iso.datetime().optional(),
       page: z.coerce.number().int().min(1).optional(),
       perPage: z.coerce.number().int().min(1).max(1000).optional(),
-      verdict: z.union([z.string().max(50), z.array(z.string().max(50)).max(50)]).optional(),
+      status: z.union([z.string().max(50), z.array(z.string().max(50)).max(50)]).optional(),
       stream: z.union([z.string().max(255), z.array(z.string().max(255)).max(50)]).optional(),
       search: z.string().max(500).optional(),
     }),
@@ -76,11 +76,11 @@ const eventsSearchRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
-    const { verdict, stream, search, ...rest } = params.query;
+    const { status, stream, search, ...rest } = params.query;
 
     return getEventClient().findLatestPaginated({
       ...rest,
-      verdict: toArray(verdict),
+      status: toArray(status),
       stream: toArray(stream),
       search: search || undefined,
     });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment.test.tsx
@@ -23,7 +23,7 @@ const attachment: SignificantEventAttachment = {
     created_at: '2026-01-01T00:00:00.000Z',
     event_id: 'event-1',
     discovery_slug: 'payment-outage',
-    verdict: 'promoted',
+    status: 'promoted',
     stream_names: ['logs.payment'],
     title: 'Payment outage',
     summary: 'Payments are failing.',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment.tsx
@@ -92,8 +92,8 @@ const SignificantEventInlineContent = ({
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
             <EuiFlexItem grow={false}>
-              <EuiBadge color={getStatusColor(data.verdict)}>
-                {labels.status}: {data.verdict}
+              <EuiBadge color={getStatusColor(data.status)}>
+                {labels.status}: {data.status}
               </EuiBadge>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -161,7 +161,7 @@ export const significantEventAttachmentDefinition: AttachmentUIDefinition<Signif
     getIcon: () => 'warning',
     getHeader: ({ attachment }) => {
       const badges: HeaderBadge[] = [
-        { label: attachment.data.verdict, color: getStatusColor(attachment.data.verdict) },
+        { label: attachment.data.status, color: getStatusColor(attachment.data.status) },
         { label: attachment.data.impact, color: 'hollow' },
       ];
       return {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
@@ -69,8 +69,7 @@ const columns: Array<EuiBasicTableColumn<SigEvent>> = [
     render: (timestamp: string) => formatTimestamp(timestamp),
   },
   {
-    // TODO: rename field binding to 'status' once the data stream field is renamed
-    field: 'verdict',
+    field: 'status',
     name: i18n.translate('xpack.streams.sigEventsTab.statusColumn', {
       defaultMessage: 'Status',
     }),

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/lifecycle_timeline.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/lifecycle_timeline.tsx
@@ -99,13 +99,12 @@ const buildEventDescription = ({
   const description = i18n.translate('xpack.streams.lifecycle.eventDesc', {
     defaultMessage: 'Status: {status}, Criticality: {criticality}',
     values: {
-      // TODO: rename to event.status once the data stream field is renamed
-      status: event.verdict ?? '-',
+      status: event.status ?? '-',
       criticality: event.criticality != null ? String(event.criticality) : '-',
     },
   });
   const detail =
-    [event.verdict_summary, event.assessment_note].filter(Boolean).join(' — ') || undefined;
+    [event.analysis_summary, event.assessment_note].filter(Boolean).join(' — ') || undefined;
   return { description, detail };
 };
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
@@ -98,8 +98,7 @@ export const SigEventFlyout = ({ event, onClose }: SigEventFlyoutProps) => {
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
             <EuiFlexItem grow={false}>
-              {/* TODO: rename event.verdict to event.status once the data stream field is renamed */}
-              <EuiBadge color={getStatusColor(event.verdict)}>{event.verdict}</EuiBadge>
+              <EuiBadge color={getStatusColor(event.status)}>{event.status}</EuiBadge>
             </EuiFlexItem>
             {event.recommended_action && (
               <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
@@ -52,8 +52,7 @@ export const useFetchSigEvents = ({
             perPage: pagination.perPage,
             from: new Date(from).toISOString(),
             to: new Date(to).toISOString(),
-            // TODO: rename to status once the data stream field and API param are renamed
-            ...(status?.length ? { verdict: status } : {}),
+            ...(status?.length ? { status } : {}),
             ...(stream?.length ? { stream } : {}),
             ...(search ? { search } : {}),
           },


### PR DESCRIPTION
closes https://github.com/elastic/nightshift-program/issues/163

## Summary

Removes `verdict` from workflows and agents instructions

### How to test
- Run workflows via `<kibana-url>app/workflows/system-significant-events-orchestrator`
- Open the **Significant Events** tab: confirm the **Verdicts** tab is absent and that a re-investigated incident shows a **single** row (no duplicate live rows for one `discovery_slug`).
- Open a discovery's history flyout: confirm the full finding/clearance timeline still renders.
- Confirm `GET /internal/streams/{name}/sig_events/events` and `.../events/{id}/lifecycle` respond; the lifecycle body contains `{ detections, discoveries, events }` only (no `verdicts`).
- Confirm events carry `status` of `promoted` / `acknowledged` / `demoted` (demoted findings are now written too).

### Checklist

- [ ] Any text added follows EUI's writing guidelines, uses sentence case text and includes i18n support
- [ ] Unit or functional tests were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes
- [ ] Review the backport guidelines and apply applicable `backport:*` labels

### Identify risks

- **ES mapping rename (`verdict` → `status`)**: existing rollover indices retain `verdict`; new indices use `status`. The first triage cycle after deploy re-evaluates pre-migration discoveries (one-time burst — expected, no data loss).

---
🤖 Co-authored with AI assistance.
