### PR TITLE
[One workflow](fix): suppress workflow flush errors during shutdown

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/persistence_loop.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/persistence_loop.test.ts
@@ -69,6 +69,22 @@ describe('persistenceLoop', () => {
     await expect(loopPromise).resolves.toBeUndefined();
   });
 
+  it('passes the task abort signal to workflow log flushes', async () => {
+    const abortController = new AbortController();
+    const params = makeParams({ status: ExecutionStatus.RUNNING });
+
+    const loopPromise = persistenceLoop(params, abortController.signal);
+
+    expect(params.workflowLogger.flushEvents).toHaveBeenCalledWith({
+      signal: params.taskAbortController.signal,
+    });
+
+    abortController.abort();
+    jest.advanceTimersByTime(500);
+
+    await expect(loopPromise).resolves.toBeUndefined();
+  });
+
   it('does not cause an unhandled rejection when abort fires during flushState', async () => {
     // This is the core regression test for the crash:
     // If persistenceAbortController.abort() fires while `await flushState()` is running

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/persistence_loop.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/persistence_loop.ts
@@ -59,7 +59,9 @@ export async function persistenceLoop(
       return;
     }
 
-    await flushState(params);
+    await flushState(params, {
+      workflowLogFlushSignal: params.taskAbortController.signal,
+    });
 
     try {
       const waitSpan = apm.startSpan('persistence wait', 'workflow', 'wait');


### PR DESCRIPTION
## Summary

- Pass the Task Manager abort signal into periodic workflow persistence flushes so shutdown-time event indexing failures use the existing best-effort path.
- Add regression coverage that workflow log flushes receive the abort signal.

## References

Closes elastic/security-team#17646