### PR TITLE
[9.4] [Search][Content Connectors] Fix management app shown to users without capability (#271709)

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/plugin.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
+import { managementPluginMock } from '@kbn/management-plugin/public/mocks';
+import type { FeatureCatalogueSolution } from '@kbn/home-plugin/public';
+import type { ManagementApp } from '@kbn/management-plugin/public';
+
+import { SearchConnectorsPlugin } from './plugin';
+import type { ClientConfigType } from '../common/types/config';
+import { PLUGIN_ID } from '../common/constants';
+import type {
+  SearchConnectorsPluginStart,
+  SearchConnectorsPluginSetupDependencies,
+  SearchConnectorsPluginStartDependencies,
+} from './types';
+
+const securitySolution: FeatureCatalogueSolution = {
+  id: 'securitySolution',
+  title: 'Security',
+  description: '',
+  icon: 'logoSecurity',
+  path: '/app/security',
+  order: 300,
+};
+
+const observabilitySolution: FeatureCatalogueSolution = {
+  id: 'observability',
+  title: 'Observability',
+  description: '',
+  icon: 'logoObservability',
+  path: '/app/observability',
+  order: 200,
+};
+
+const otherSolution: FeatureCatalogueSolution = {
+  id: 'kibana',
+  title: 'Analytics',
+  description: '',
+  icon: 'logoKibana',
+  path: '/app/home',
+  order: 400,
+};
+
+const createPlugin = (config: ClientConfigType) => {
+  const initializerContext = coreMock.createPluginInitializerContext(config);
+  return new SearchConnectorsPlugin(initializerContext);
+};
+
+const createSetupDependencies = () => {
+  const managementSetup = managementPluginMock.createSetupContract();
+  const registeredApp = {
+    enabled: true,
+    disable: jest.fn(),
+    enable: jest.fn(),
+  } as unknown as ManagementApp;
+  (managementSetup.sections.section.data.registerApp as jest.Mock).mockReturnValue(registeredApp);
+  return { managementSetup, registeredApp };
+};
+
+const createStartDependencies = (
+  solutions: FeatureCatalogueSolution[]
+): SearchConnectorsPluginStartDependencies => {
+  const home = {
+    featureCatalogue: {
+      getSolutions: jest.fn(() => solutions),
+    },
+  };
+  return { home } as unknown as SearchConnectorsPluginStartDependencies;
+};
+
+type PluginCoreSetup = CoreSetup<
+  SearchConnectorsPluginStartDependencies,
+  SearchConnectorsPluginStart
+>;
+
+const setupPlugin = ({ uiEnabled }: { uiEnabled: boolean }) => {
+  const plugin = createPlugin({ ui: { enabled: uiEnabled } });
+  const coreSetup = coreMock.createSetup() as unknown as PluginCoreSetup;
+  const { managementSetup, registeredApp } = createSetupDependencies();
+  plugin.setup(coreSetup, {
+    management: managementSetup,
+  } as unknown as SearchConnectorsPluginSetupDependencies);
+  return { plugin, coreSetup, managementSetup, registeredApp };
+};
+
+describe('SearchConnectorsPlugin (public)', () => {
+  describe('setup()', () => {
+    it('registers the Content Connectors management app synchronously, before getStartServices resolves', () => {
+      const plugin = createPlugin({ ui: { enabled: true } });
+      const coreSetup = coreMock.createSetup() as unknown as PluginCoreSetup;
+      const { managementSetup } = createSetupDependencies();
+      const getStartServices = jest.spyOn(coreSetup, 'getStartServices');
+
+      plugin.setup(coreSetup, {
+        management: managementSetup,
+      } as unknown as SearchConnectorsPluginSetupDependencies);
+
+      expect(managementSetup.sections.section.data.registerApp).toHaveBeenCalledTimes(1);
+      expect(managementSetup.sections.section.data.registerApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: PLUGIN_ID,
+          order: 8,
+          keywords: ['content connectors', 'search'],
+          mount: expect.any(Function),
+        })
+      );
+      expect(getStartServices).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('start()', () => {
+    it('keeps the management app enabled when config is enabled and a supported solution is registered', () => {
+      const { plugin, registeredApp } = setupPlugin({ uiEnabled: true });
+
+      plugin.start(coreMock.createStart(), createStartDependencies([securitySolution]));
+
+      expect(registeredApp.disable).not.toHaveBeenCalled();
+    });
+
+    it('keeps the management app enabled when observability solution is registered', () => {
+      const { plugin, registeredApp } = setupPlugin({ uiEnabled: true });
+
+      plugin.start(coreMock.createStart(), createStartDependencies([observabilitySolution]));
+
+      expect(registeredApp.disable).not.toHaveBeenCalled();
+    });
+
+    it('disables the management app when no security or observability solution is registered', () => {
+      const { plugin, registeredApp } = setupPlugin({ uiEnabled: true });
+
+      plugin.start(coreMock.createStart(), createStartDependencies([otherSolution]));
+
+      expect(registeredApp.disable).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the management app when no solutions are registered at all', () => {
+      const { plugin, registeredApp } = setupPlugin({ uiEnabled: true });
+
+      plugin.start(coreMock.createStart(), createStartDependencies([]));
+
+      expect(registeredApp.disable).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the management app when config.ui.enabled is false even if a supported solution is registered', () => {
+      const { plugin, registeredApp } = setupPlugin({ uiEnabled: false });
+
+      plugin.start(coreMock.createStart(), createStartDependencies([securitySolution]));
+
+      expect(registeredApp.disable).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/content_connectors/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/plugin.ts
@@ -7,7 +7,7 @@
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import { docLinks } from '@kbn/search-connectors/constants/doc_links';
-import type { ManagementAppMountParams } from '@kbn/management-plugin/public';
+import type { ManagementApp, ManagementAppMountParams } from '@kbn/management-plugin/public';
 import type { FeatureCatalogueSolution } from '@kbn/home-plugin/public';
 import { type ClientConfigType } from '../common/types/config';
 import { getConnectorFullTypes, getConnectorTypes } from '../common/lib/connector_types';
@@ -31,6 +31,7 @@ export class SearchConnectorsPlugin
 {
   private readonly kibanaVersion: string;
   private readonly config: ClientConfigType;
+  private contentConnectorsApp?: ManagementApp;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.kibanaVersion = initializerContext.env.packageInfo.version;
@@ -45,34 +46,29 @@ export class SearchConnectorsPlugin
     const connectorTypes = getConnectorTypes(core.http.staticAssets);
     const kibanaVersion = this.kibanaVersion;
 
-    core.getStartServices().then(([coreStart, pluginsStartDeps, pluginStart]) => {
-      const hasAnyContentConnectorsSolutions = pluginsStartDeps.home.featureCatalogue
-        .getSolutions()
-        .some(({ id }: FeatureCatalogueSolution) =>
-          ['securitySolution', 'observability'].includes(id)
+    // Register the management app synchronously in setup so the management plugin's
+    // start-phase capability sweep can disable it for users without the
+    // `management.data.content_connectors` capability. Solution/config gating is
+    // applied later in start() via this.contentConnectorsApp.disable().
+    this.contentConnectorsApp = management.sections.section.data.registerApp({
+      id: PLUGIN_ID,
+      title: PLUGIN_NAME,
+      order: 8,
+      keywords: ['content connectors', 'search'],
+      async mount(params: ManagementAppMountParams) {
+        const [coreStart, pluginsStartDeps, pluginStart] = await core.getStartServices();
+        const { renderApp } = await import('./app');
+
+        const connectorsDefinitions = getConnectorFullTypes(core.http.staticAssets);
+        return renderApp(
+          coreStart,
+          pluginsStartDeps,
+          pluginStart,
+          params,
+          connectorsDefinitions,
+          kibanaVersion
         );
-
-      if (this.config.ui.enabled && hasAnyContentConnectorsSolutions) {
-        management.sections.section.data.registerApp({
-          id: PLUGIN_ID,
-          title: PLUGIN_NAME,
-          order: 8,
-          keywords: ['content connectors', 'search'],
-          async mount(params: ManagementAppMountParams) {
-            const { renderApp } = await import('./app');
-
-            const connectorsDefinitions = getConnectorFullTypes(core.http.staticAssets);
-            return renderApp(
-              coreStart,
-              pluginsStartDeps,
-              pluginStart,
-              params,
-              connectorsDefinitions,
-              kibanaVersion
-            );
-          },
-        });
-      }
+      },
     });
 
     return {
@@ -87,6 +83,16 @@ export class SearchConnectorsPlugin
     const { http } = core;
     docLinks.setDocLinks(core.docLinks.links);
     const connectorTypes = getConnectorFullTypes(http.staticAssets);
+
+    const hasAnyContentConnectorsSolutions = services.home.featureCatalogue
+      .getSolutions()
+      .some(({ id }: FeatureCatalogueSolution) =>
+        ['securitySolution', 'observability'].includes(id)
+      );
+
+    if (!this.config.ui.enabled || !hasAnyContentConnectorsSolutions) {
+      this.contentConnectorsApp?.disable();
+    }
 
     return {
       getConnectorTypes: () => connectorTypes,

--- a/x-pack/platform/test/functional/apps/api_keys/feature_controls/api_keys_security.ts
+++ b/x-pack/platform/test/functional/apps/api_keys/feature_controls/api_keys_security.ts
@@ -43,7 +43,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(sectionIds).to.contain('kibana');
 
         const dataSection = sections.find((section) => section.sectionId === 'data');
-        expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+        expect(dataSection?.sectionLinks).to.eql(['data_quality']);
       });
     });
 

--- a/x-pack/platform/test/functional/apps/cross_cluster_replication/feature_controls/ccr_security.ts
+++ b/x-pack/platform/test/functional/apps/cross_cluster_replication/feature_controls/ccr_security.ts
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/index_lifecycle_management/feature_controls/ilm_security.ts
+++ b/x-pack/platform/test/functional/apps/index_lifecycle_management/feature_controls/ilm_security.ts
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/index_management/feature_controls/index_management_security.ts
+++ b/x-pack/platform/test/functional/apps/index_management/feature_controls/index_management_security.ts
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/ingest_pipelines/feature_controls/ingest_pipelines_security.ts
+++ b/x-pack/platform/test/functional/apps/ingest_pipelines/feature_controls/ingest_pipelines_security.ts
@@ -51,7 +51,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/license_management/feature_controls/license_management_security.ts
+++ b/x-pack/platform/test/functional/apps/license_management/feature_controls/license_management_security.ts
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/logstash/feature_controls/logstash_security.ts
+++ b/x-pack/platform/test/functional/apps/logstash/feature_controls/logstash_security.ts
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/management/feature_controls/management_security.ts
+++ b/x-pack/platform/test/functional/apps/management/feature_controls/management_security.ts
@@ -68,7 +68,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         // Order of the sections in Stack Management might change in the future
         // so we need to find the sections by their id
         const dataSection = sections.find((section) => section.sectionId === 'data');
-        expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+        expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         const insightsAndAlertingSection = sections.find(
           (section) => section.sectionId === 'insightsAndAlerting'
         );

--- a/x-pack/platform/test/functional/apps/remote_clusters/feature_controls/remote_clusters_security.ts
+++ b/x-pack/platform/test/functional/apps/remote_clusters/feature_controls/remote_clusters_security.ts
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/transform/feature_controls/transform_security.ts
+++ b/x-pack/platform/test/functional/apps/transform/feature_controls/transform_security.ts
@@ -52,7 +52,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(sectionIds).to.contain('kibana');
 
           const dataSection = sections.find((section) => section.sectionId === 'data');
-          expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+          expect(dataSection?.sectionLinks).to.eql(['data_quality']);
         });
       });
     });

--- a/x-pack/platform/test/functional/apps/upgrade_assistant/feature_controls/upgrade_assistant_security.ts
+++ b/x-pack/platform/test/functional/apps/upgrade_assistant/feature_controls/upgrade_assistant_security.ts
@@ -43,7 +43,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(sectionIds).to.contain('kibana');
 
         const dataSection = sections.find((section) => section.sectionId === 'data');
-        expect(dataSection?.sectionLinks).to.eql(['data_quality', 'content_connectors']);
+        expect(dataSection?.sectionLinks).to.eql(['data_quality']);
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Search][Content Connectors] Fix management app shown to users without capability (#271709)](https://github.com/elastic/kibana/pull/271709)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan-Kazlouski-elastic","email":"jan.kazlouski@elastic.co"},"sourceCommit":{"committedDate":"2026-05-29T15:40:44Z","message":"[Search][Content Connectors] Fix management app shown to users without capability (#271709)\n\n## Closes https://github.com/elastic/search-team/issues/11985\n\n## Summary\n\nThe Content Connectors entry under Stack Management was registered\ninside a\n`core.getStartServices().then(...)` callback in `setup()`, so\nregistration\nhappened after `management.start()` had already run its per-app\ncapability\nsweep (`management_sections_service.ts` start()). The app stayed\n`enabled: true` regardless of the user's\n`capabilities.management.data.content_connectors` value — e.g. a role\nwith\nonly \"Observability > APM and User Experience: Read\" still saw the\n\"Content Connectors\" entry in the Stack Management sidebar (it then\n403'd\non navigation, which was the original support ticket).\n\nFix mirrors the pattern in\n\n`x-pack/platform/plugins/private/cross_cluster_replication/public/plugin.ts`:\n\n- Register the management app synchronously in `setup()` and keep the\n  returned `ManagementApp`, so the management plugin's start-phase\ncapability sweep correctly disables it for users without the capability.\n- In `start()`, additionally disable the app when\n`xpack.contentConnectors.ui.enabled` is `false` or no `securitySolution`\n  / `observability` solution is registered (existing gating, preserved).\n- The mount callback now resolves `getStartServices()` / `renderApp`\n  lazily, only when the user navigates.\n\nAdds `public/plugin.test.ts` covering synchronous setup-time\nregistration\nand the start-time disable matrix.\n\n### How to test\n\n1. Start ES + Kibana from this branch.\n2. Create role `apm_reader` with only Observability → APM and User\n   Experience: Read. Assign to a new user.\n3. Log in as that user → Stack Management. **\"Content Connectors\" should\n   no longer appear in the sidebar.**\n4. Log in as `elastic` (or any role granting the `content_connectors`\nElasticsearch feature capability) → \"Content Connectors\" still appears.\n\nBefore:\n<img width=\"1893\" height=\"857\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7a937839-6178-4993-86aa-cc6ec08226dc\"\n/>\nAfter:\n<img width=\"1891\" height=\"784\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bd0bd7eb-6cdd-4a1c-86cc-c24a2ed8eb3b\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n— no user-facing text added; existing strings unchanged.\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials — bug fix\nto existing behavior, no new feature to document.\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios — adds\n`x-pack/platform/plugins/shared/content_connectors/public/plugin.test.ts`\ncovering (a) synchronous registration in `setup()` without touching\n`getStartServices`, and (b) the start-time disable matrix across\n`config.ui.enabled`, no solutions, security solution, observability\nsolution, and unrelated solution.\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n— no configuration key changed.\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\npublic-only plugin change, no HTTP API surface affected.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed — new test is deterministic and lifecycle-only\n(no async timing/UI rendering), so flaky test runner was not triggered.\nHappy to run it if a reviewer requests.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n— `release_note:fix` applied.\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels. — bug present since the plugin\nfile was introduced in #213509 (April 2025); `backport:prev-minor`\napplied to cover the current released minor in addition to `main`. Bump\nto `backport:all-open` if Support has pressure on older 9.x lines.\n\n### Identify risks\n\n- Risk: registering the app unconditionally at setup() means it now\nexists\n  in Stack Management's app list even on deployments where no\nsecurity/observability solution is present. Mitigation: `start()` calls\n  `contentConnectorsApp.disable()` for those deployments, matching the\n  previous behavior. Covered by tests.\n- Risk: serverless project types could see new behavior. Mitigation: the\nconditional gate (`config.ui.enabled &&\nhasAnyContentConnectorsSolutions`)\n  is unchanged in semantics, only relocated to `start()`.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"af8adb204e36fa54532551b756bc64a42d382704","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.5.0","v9.3.5","v9.4.1"],"title":"[Search][Content Connectors] Fix management app shown to users without capability","number":271709,"url":"https://github.com/elastic/kibana/pull/271709","mergeCommit":{"message":"[Search][Content Connectors] Fix management app shown to users without capability (#271709)\n\n## Closes https://github.com/elastic/search-team/issues/11985\n\n## Summary\n\nThe Content Connectors entry under Stack Management was registered\ninside a\n`core.getStartServices().then(...)` callback in `setup()`, so\nregistration\nhappened after `management.start()` had already run its per-app\ncapability\nsweep (`management_sections_service.ts` start()). The app stayed\n`enabled: true` regardless of the user's\n`capabilities.management.data.content_connectors` value — e.g. a role\nwith\nonly \"Observability > APM and User Experience: Read\" still saw the\n\"Content Connectors\" entry in the Stack Management sidebar (it then\n403'd\non navigation, which was the original support ticket).\n\nFix mirrors the pattern in\n\n`x-pack/platform/plugins/private/cross_cluster_replication/public/plugin.ts`:\n\n- Register the management app synchronously in `setup()` and keep the\n  returned `ManagementApp`, so the management plugin's start-phase\ncapability sweep correctly disables it for users without the capability.\n- In `start()`, additionally disable the app when\n`xpack.contentConnectors.ui.enabled` is `false` or no `securitySolution`\n  / `observability` solution is registered (existing gating, preserved).\n- The mount callback now resolves `getStartServices()` / `renderApp`\n  lazily, only when the user navigates.\n\nAdds `public/plugin.test.ts` covering synchronous setup-time\nregistration\nand the start-time disable matrix.\n\n### How to test\n\n1. Start ES + Kibana from this branch.\n2. Create role `apm_reader` with only Observability → APM and User\n   Experience: Read. Assign to a new user.\n3. Log in as that user → Stack Management. **\"Content Connectors\" should\n   no longer appear in the sidebar.**\n4. Log in as `elastic` (or any role granting the `content_connectors`\nElasticsearch feature capability) → \"Content Connectors\" still appears.\n\nBefore:\n<img width=\"1893\" height=\"857\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7a937839-6178-4993-86aa-cc6ec08226dc\"\n/>\nAfter:\n<img width=\"1891\" height=\"784\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bd0bd7eb-6cdd-4a1c-86cc-c24a2ed8eb3b\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n— no user-facing text added; existing strings unchanged.\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials — bug fix\nto existing behavior, no new feature to document.\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios — adds\n`x-pack/platform/plugins/shared/content_connectors/public/plugin.test.ts`\ncovering (a) synchronous registration in `setup()` without touching\n`getStartServices`, and (b) the start-time disable matrix across\n`config.ui.enabled`, no solutions, security solution, observability\nsolution, and unrelated solution.\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n— no configuration key changed.\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\npublic-only plugin change, no HTTP API surface affected.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed — new test is deterministic and lifecycle-only\n(no async timing/UI rendering), so flaky test runner was not triggered.\nHappy to run it if a reviewer requests.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n— `release_note:fix` applied.\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels. — bug present since the plugin\nfile was introduced in #213509 (April 2025); `backport:prev-minor`\napplied to cover the current released minor in addition to `main`. Bump\nto `backport:all-open` if Support has pressure on older 9.x lines.\n\n### Identify risks\n\n- Risk: registering the app unconditionally at setup() means it now\nexists\n  in Stack Management's app list even on deployments where no\nsecurity/observability solution is present. Mitigation: `start()` calls\n  `contentConnectorsApp.disable()` for those deployments, matching the\n  previous behavior. Covered by tests.\n- Risk: serverless project types could see new behavior. Mitigation: the\nconditional gate (`config.ui.enabled &&\nhasAnyContentConnectorsSolutions`)\n  is unchanged in semantics, only relocated to `start()`.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"af8adb204e36fa54532551b756bc64a42d382704"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271709","number":271709,"mergeCommit":{"message":"[Search][Content Connectors] Fix management app shown to users without capability (#271709)\n\n## Closes https://github.com/elastic/search-team/issues/11985\n\n## Summary\n\nThe Content Connectors entry under Stack Management was registered\ninside a\n`core.getStartServices().then(...)` callback in `setup()`, so\nregistration\nhappened after `management.start()` had already run its per-app\ncapability\nsweep (`management_sections_service.ts` start()). The app stayed\n`enabled: true` regardless of the user's\n`capabilities.management.data.content_connectors` value — e.g. a role\nwith\nonly \"Observability > APM and User Experience: Read\" still saw the\n\"Content Connectors\" entry in the Stack Management sidebar (it then\n403'd\non navigation, which was the original support ticket).\n\nFix mirrors the pattern in\n\n`x-pack/platform/plugins/private/cross_cluster_replication/public/plugin.ts`:\n\n- Register the management app synchronously in `setup()` and keep the\n  returned `ManagementApp`, so the management plugin's start-phase\ncapability sweep correctly disables it for users without the capability.\n- In `start()`, additionally disable the app when\n`xpack.contentConnectors.ui.enabled` is `false` or no `securitySolution`\n  / `observability` solution is registered (existing gating, preserved).\n- The mount callback now resolves `getStartServices()` / `renderApp`\n  lazily, only when the user navigates.\n\nAdds `public/plugin.test.ts` covering synchronous setup-time\nregistration\nand the start-time disable matrix.\n\n### How to test\n\n1. Start ES + Kibana from this branch.\n2. Create role `apm_reader` with only Observability → APM and User\n   Experience: Read. Assign to a new user.\n3. Log in as that user → Stack Management. **\"Content Connectors\" should\n   no longer appear in the sidebar.**\n4. Log in as `elastic` (or any role granting the `content_connectors`\nElasticsearch feature capability) → \"Content Connectors\" still appears.\n\nBefore:\n<img width=\"1893\" height=\"857\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7a937839-6178-4993-86aa-cc6ec08226dc\"\n/>\nAfter:\n<img width=\"1891\" height=\"784\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bd0bd7eb-6cdd-4a1c-86cc-c24a2ed8eb3b\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n— no user-facing text added; existing strings unchanged.\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials — bug fix\nto existing behavior, no new feature to document.\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios — adds\n`x-pack/platform/plugins/shared/content_connectors/public/plugin.test.ts`\ncovering (a) synchronous registration in `setup()` without touching\n`getStartServices`, and (b) the start-time disable matrix across\n`config.ui.enabled`, no solutions, security solution, observability\nsolution, and unrelated solution.\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n— no configuration key changed.\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\npublic-only plugin change, no HTTP API surface affected.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed — new test is deterministic and lifecycle-only\n(no async timing/UI rendering), so flaky test runner was not triggered.\nHappy to run it if a reviewer requests.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n— `release_note:fix` applied.\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels. — bug present since the plugin\nfile was introduced in #213509 (April 2025); `backport:prev-minor`\napplied to cover the current released minor in addition to `main`. Bump\nto `backport:all-open` if Support has pressure on older 9.x lines.\n\n### Identify risks\n\n- Risk: registering the app unconditionally at setup() means it now\nexists\n  in Stack Management's app list even on deployments where no\nsecurity/observability solution is present. Mitigation: `start()` calls\n  `contentConnectorsApp.disable()` for those deployments, matching the\n  previous behavior. Covered by tests.\n- Risk: serverless project types could see new behavior. Mitigation: the\nconditional gate (`config.ui.enabled &&\nhasAnyContentConnectorsSolutions`)\n  is unchanged in semantics, only relocated to `start()`.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"af8adb204e36fa54532551b756bc64a42d382704"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->