### PR TITLE
[Agents] Restore symlinks when starting Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
     "PreToolUse": [
       {
@@ -17,6 +18,21 @@
             "type": "command",
             "if": "Bash(gh *)",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/strip-review-event.mjs"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rm -f $(pwd)/.claude/CLAUDE.md && ln -sf ../AGENTS.md $(pwd)/.claude/CLAUDE.md"
+          },
+          {
+            "type": "command",
+            "command": "rm -f $(pwd)/.claude/skills && ln -sf ../.agents/skills $(pwd)/.claude/skills"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Not all contributors have `core.symlinks = true` in their gitconfig:

```
[core]
	symlinks = true
```

For those people, Claude Code doesn't work out of the box as it cannot locate the `AGENTS.md` and the skills directory.

This PR adds `.claude/settings.json` to configure Claude Code's behavior when starting a session in this repository. The configuration registers two `SessionStart` hooks that ensure the required symlinks are created when the user starts Claude Code:

- `.claude/CLAUDE.md` -> `../AGENTS.md` - lets Claude Code read the repository's agent documentation
- `.claude/skills` -> `../.agents/skills` - lets Claude Code discover the repository's custom skills

## How to test

Start a Claude Code session in the repository and verify:
- `.claude/CLAUDE.md` is a symlink pointing to `AGENTS.md`
- `.claude/skills` is a symlink pointing to `.agents/skills`
