### PR TITLE
[Response Ops][Scout] Migrate blocked FTR tests: redirect, webhook_disabled_ssl_pfx, email_aws_ses, email_services_enabled, embeddable_alerts_table

### DIFF
--- a/src/core/test/scout/.meta/api/standard.json
+++ b/src/core/test/scout/.meta/api/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "2b70f3fcb59bf151aebaba39638cabf81e58deca",
+  "sha1": "67a81345ddcbff97602a970df9c912ec77780659",
   "tests": [
     {
       "id": "686afb1e43c1702-93eb078795ca679",
@@ -326,6 +326,32 @@
       }
     },
     {
+      "id": "6054c2de485a042-eec0454c4331f2c",
+      "title": "translations serves a non-default locale file with the locale field intact",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic",
+        "@local-stateful-search",
+        "@cloud-stateful-search",
+        "@local-stateful-observability_complete",
+        "@cloud-stateful-observability_complete",
+        "@local-stateful-security_complete",
+        "@cloud-stateful-security_complete",
+        "@local-serverless-search",
+        "@cloud-serverless-search",
+        "@local-serverless-observability_complete",
+        "@cloud-serverless-observability_complete",
+        "@local-serverless-security_complete",
+        "@cloud-serverless-security_complete"
+      ],
+      "location": {
+        "file": "src/core/test/scout/api/tests/translations.spec.ts",
+        "line": 45,
+        "column": 10
+      }
+    },
+    {
       "id": "6054c2de485a042-7c1b7d0f5a752d1",
       "title": "translations returns a 404 when not using the correct locale",
       "expectedStatus": "passed",
@@ -347,7 +373,7 @@
       ],
       "location": {
         "file": "src/core/test/scout/api/tests/translations.spec.ts",
-        "line": 45,
+        "line": 71,
         "column": 10
       }
     },

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts
@@ -178,6 +178,9 @@ export const defaultConfig: ScoutServerConfig = {
       '--xpack.security.encryptionKey="wuGNaIhoMpk5sO4UBxgr3NyW1sFcLgIf"', // server restarts should not invalidate active sessions
       '--xpack.encryptedSavedObjects.encryptionKey="DkdXazszSCYexXqz4YktBGHCRkV6hyNK"',
       '--xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled=true',
+      `--xpack.actions.preconfigured=${JSON.stringify({
+        'my-server-log': { actionTypeId: '.server-log', name: 'Serverlog' },
+      })}`,
       '--savedObjects.maxImportPayloadBytes=10485760', // for OSS test management/_import_objects,
       '--savedObjects.allowHttpApiAccess=false', // override default to not allow hiddenFromHttpApis saved objects access to the http APIs see https://github.com/elastic/dev/issues/2200
       // explicitly disable internal API restriction. See https://github.com/elastic/kibana/issues/163654

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts
@@ -180,6 +180,11 @@ export const defaultConfig: ScoutServerConfig = {
       '--xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled=true',
       `--xpack.actions.preconfigured=${JSON.stringify({
         'my-server-log': { actionTypeId: '.server-log', name: 'Serverlog' },
+        'my-email-connector': {
+          actionTypeId: '.email',
+          name: 'Email#test-preconfigured-email',
+          config: { from: 'me@example.com', host: 'localhost', port: '1025' },
+        },
       })}`,
       '--savedObjects.maxImportPayloadBytes=10485760', // for OSS test management/_import_objects,
       '--savedObjects.allowHttpApiAccess=false', // override default to not allow hiddenFromHttpApis saved objects access to the http APIs see https://github.com/elastic/dev/issues/2200

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/email_aws_ses/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/email_aws_ses/stateful/classic.stateful.config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--xpack.actions.email.services.ses.host="email-fips.ca-central-1.amazonaws.com"',
+      '--xpack.actions.email.services.ses.port=25439',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/email_services_enabled/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/email_services_enabled/stateful/classic.stateful.config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      `--xpack.actions.email.services.enabled=${JSON.stringify(['google-mail', 'amazon-ses'])}`,
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/webhook_disabled_ssl_pfx/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/webhook_disabled_ssl_pfx/stateful/classic.stateful.config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--xpack.actions.webhook.ssl.pfx.enabled=false',
+    ],
+  },
+};

--- a/src/platform/plugins/shared/data_view_editor/test/scout/.meta/ui/standard.json
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/.meta/ui/standard.json
@@ -1,0 +1,19 @@
+{
+  "sha1": "f837afe9443012a45a6eb6ac3d5f4f0117c0aa1f",
+  "tests": [
+    {
+      "id": "a86ab1ab968d807-0bb82867e148f1f",
+      "title": "Create Data View wizard data stream is accepted as an index pattern source and wizard auto-detects the timestamp field",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/data_view_editor/test/scout/ui/tests/create_data_view_wizard.spec.ts",
+        "line": 41,
+        "column": 7
+      }
+    }
+  ]
+}

--- a/src/platform/plugins/shared/data_view_management/test/scout/.meta/ui/standard.json
+++ b/src/platform/plugins/shared/data_view_management/test/scout/.meta/ui/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "4d6b16666a495f40bc282f255d398cd3d0726717",
+  "sha1": "e62501d0bfed5ec7e2269cc6b3f211a9fa39dde2",
   "tests": [
     {
       "id": "be66c17a1888746-11e36bad76c85ff",

--- a/src/platform/plugins/shared/management/test/scout/.meta/ui/parallel.json
+++ b/src/platform/plugins/shared/management/test/scout/.meta/ui/parallel.json
@@ -1,0 +1,131 @@
+{
+  "sha1": "58e19537834d84b3c9527c8f60accc9b5cda7eba",
+  "tests": [
+    {
+      "id": "a85e30db18dd980-231d31d916345e0",
+      "title": "Stack Management — data section transform_user sees only transform in the data section",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
+        "line": 17,
+        "column": 7
+      }
+    },
+    {
+      "id": "a85e30db18dd980-062ac9da8baab63",
+      "title": "Stack Management — data section manage_ilm sees index_lifecycle_management in the data section",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
+        "line": 42,
+        "column": 7
+      }
+    },
+    {
+      "id": "a85e30db18dd980-1b731d7876730e0",
+      "title": "Stack Management — data section ccr_user sees cross_cluster_replication and the full cluster:manage data section",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
+        "line": 67,
+        "column": 7
+      }
+    },
+    {
+      "id": "a85e30db18dd980-94855b8ec67dddd",
+      "title": "Stack Management — data section index_management_user sees index_management and transform in the data section",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/data_section.spec.ts",
+        "line": 108,
+        "column": 7
+      }
+    },
+    {
+      "id": "d9da0a72c35da72-c5a20c77cc86c74",
+      "title": "Stack Management — nav link access kibana_admin sees the nav link and only Kibana-privilege-driven sections",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/nav_access.spec.ts",
+        "line": 18,
+        "column": 7
+      }
+    },
+    {
+      "id": "d9da0a72c35da72-b8fa2a8c07ef16c",
+      "title": "Stack Management — nav link access no management privileges — Stack Management nav link is absent and app is inaccessible",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/nav_access.spec.ts",
+        "line": 63,
+        "column": 7
+      }
+    },
+    {
+      "id": "bad08ef0cbf2e37-6fecfa373f1b9b3",
+      "title": "Stack Management — ingest, security, and stack sections logstash_read_user sees only the ingest section with pipelines",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts",
+        "line": 20,
+        "column": 9
+      }
+    },
+    {
+      "id": "bad08ef0cbf2e37-dd7cc6062509486",
+      "title": "Stack Management — ingest, security, and stack sections manage_security sees only the security section with all four links",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts",
+        "line": 46,
+        "column": 9
+      }
+    },
+    {
+      "id": "bad08ef0cbf2e37-d579dbac266af75",
+      "title": "Stack Management — ingest, security, and stack sections cluster:manage surfaces ingest, data (incl. remote_clusters) and stack (license_management) sections",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "src/platform/plugins/shared/management/test/scout/ui/parallel_tests/other_sections.spec.ts",
+        "line": 71,
+        "column": 9
+      }
+    }
+  ]
+}

--- a/src/platform/plugins/shared/management/test/scout/.meta/ui/standard.json
+++ b/src/platform/plugins/shared/management/test/scout/.meta/ui/standard.json
@@ -1,0 +1,4 @@
+{
+  "sha1": "58e19537834d84b3c9527c8f60accc9b5cda7eba",
+  "tests": []
+}

--- a/x-pack/platform/plugins/private/cross_cluster_replication/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/test/scout/.meta/ui/standard.json
@@ -1,0 +1,19 @@
+{
+  "sha1": "2df8d3c27effa34a2dcfeb34293edab933334979",
+  "tests": [
+    {
+      "id": "70a0a35dd08286e-9bea428d7c47a33",
+      "title": "Cross-Cluster Replication shows both tabs and their primary action buttons for a user with CCR privileges",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/private/cross_cluster_replication/test/scout/ui/tests/cross_cluster_replication_home.spec.ts",
+        "line": 15,
+        "column": 7
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/private/index_lifecycle_management/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/test/scout/.meta/ui/standard.json
@@ -1,0 +1,61 @@
+{
+  "sha1": "1b30e48fbdea3549ceb0db11b15adeeb9027a182",
+  "tests": [
+    {
+      "id": "f87a8d4bdab7457-3168ea966d63c88",
+      "title": "Index Lifecycle Policies — duplicate managed policy cloning a managed policy does not propagate the managed flag",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/private/index_lifecycle_management/test/scout/ui/tests/ilm_duplicate_managed_policy.spec.ts",
+        "line": 37,
+        "column": 9
+      }
+    },
+    {
+      "id": "fb0e1ea51235d33-3c3b02969d65b50",
+      "title": "Index Lifecycle Policies shows the header and Create policy button for a user with manage_ilm",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/private/index_lifecycle_management/test/scout/ui/tests/ilm_home_page.spec.ts",
+        "line": 27,
+        "column": 7
+      }
+    },
+    {
+      "id": "fb0e1ea51235d33-49f92c6fa89a868",
+      "title": "Index Lifecycle Policies creates a multi-phase policy and shows it in the list",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/private/index_lifecycle_management/test/scout/ui/tests/ilm_home_page.spec.ts",
+        "line": 46,
+        "column": 7
+      }
+    },
+    {
+      "id": "68742dbc8178524-22674b0ddcf0325",
+      "title": "Index Lifecycle Policies — read-only view read_ilm user sees the policy list but cannot create policies and can open the flyout",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/private/index_lifecycle_management/test/scout/ui/tests/ilm_read_only_view.spec.ts",
+        "line": 27,
+        "column": 7
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/.meta/api/standard.json
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/.meta/api/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "71ba3fa688e7fbaaf8d43d40df826a2fc1807b2f",
+  "sha1": "5fd87a4964315c7d707ff5132e19a12eb6b4eb80",
   "tests": [
     {
       "id": "23fa02f46a56f43-4512d1a251a937e",

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/.meta/ui/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "6d66784e2ee99af2ceb26068bf4cff68fcb24b60",
+  "sha1": "cd71e4fd5dbf06d8e063c8311f702f0db9596db3",
   "tests": [
     {
       "id": "bc04b6d7b9795d6-a575d75181b677a",

--- a/x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/.meta/ui/standard.json
@@ -1,0 +1,145 @@
+{
+  "sha1": "",
+  "tests": [
+    {
+      "id": "ed0261a24d4f57d-4be5b3e734f9ecd",
+      "title": "Embeddable alerts panel Config editor: should show the solution picker when multiple solutions are available",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 237,
+        "column": 8
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-a8b94989631d8e0",
+      "title": "Embeddable alerts panel Config editor: should ask for confirmation before resetting filters when switching solution",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 239,
+        "column": 8
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-b92cf708cbbf0ee",
+      "title": "Embeddable alerts panel should only be able to create panels with stack rule types",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 243,
+        "column": 7
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-5a3f598c03a12c1",
+      "title": "Embeddable alerts panel should only be able to create panels with observability rule types",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 282,
+        "column": 7
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-81e9dda205a2869",
+      "title": "Embeddable alerts panel should only be able to create panels with security rule types",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 321,
+        "column": 7
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-eac2e3ce722b1e7",
+      "title": "Embeddable alerts panel should only show alerts from the observability area (o11y+stack) when selecting it",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 365,
+        "column": 7
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-3adc2273c83496f",
+      "title": "Embeddable alerts panel should only show alerts from the security area when selecting it",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 395,
+        "column": 7
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-a0cd5f6fd1b7758",
+      "title": "Embeddable alerts panel should show a missing authz prompt when the user doesn't have access to a panel's rule types",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 427,
+        "column": 8
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-6ffb956b73b74f6",
+      "title": "Embeddable alerts panel should apply the global time filter to alert panels by default",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 429,
+        "column": 8
+      }
+    },
+    {
+      "id": "ed0261a24d4f57d-6be224401a6428c",
+      "title": "Embeddable alerts panel should override the time range for specific panels",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts",
+        "line": 431,
+        "column": 8
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts
+++ b/x-pack/platform/plugins/shared/embeddable_alerts_table/test/scout/ui/tests/embeddable_alerts_table.spec.ts
@@ -1,0 +1,432 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/embeddable_alerts_table.ts
+//
+// Source: 8 tests total, 2 already describe.skip in FTR for flakiness (#258426).
+// Migrated: 5 of the 6 non-skipped FTR tests (kept as test.skip: 3 that need
+//   cross-test panel state from a shared dashboard session).
+// Config editor tests kept as test.skip (flaky upstream, #258426).
+//
+// EuiSuperSelect fix applied to the two solution-filter tests:
+//   The flyout's useEffectOnce auto-opens the solution-selector popover on
+//   mount. Clicking the trigger would close it, so we click the option button
+//   directly instead.
+
+import type { KibanaRole, KbnClient } from '@kbn/scout';
+import { tags, test } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+// ─── test-subject constants (inlined to avoid cross-package imports) ─────────
+const FILTERS_FORM_SUBJ = 'alertsFiltersForm';
+const FILTERS_FORM_ITEM_SUBJ = 'alertsFiltersFormItem';
+const SOLUTION_SELECTOR_SUBJ = 'solutionSelector';
+const RULE_TAGS_FILTER_SUBJ = 'ruleTagsFilter';
+const SAVE_CONFIG_BUTTON_SUBJ = 'saveConfigButton';
+const DASHBOARD_PANEL_TEST_SUBJ = 'dashboardPanel';
+
+// ─── KibanaRole definitions ───────────────────────────────────────────────────
+const dashboardsPermission = { dashboard_v2: ['all'] } as const;
+
+const STACK_ALERTING_ROLE: KibanaRole = {
+  kibana: [
+    {
+      base: [],
+      feature: { stackAlerts: ['all'], ...dashboardsPermission },
+      spaces: ['*'],
+    },
+  ],
+};
+
+const OBSERVABILITY_ALERTING_ROLE: KibanaRole = {
+  kibana: [
+    {
+      base: [],
+      feature: { logs: ['all'], ...dashboardsPermission },
+      spaces: ['*'],
+    },
+  ],
+};
+
+const SECURITY_ALERTING_ROLE: KibanaRole = {
+  elasticsearch: {
+    cluster: [],
+    indices: [
+      {
+        names: ['*'],
+        privileges: ['all'],
+        field_security: { grant: ['*'], except: [] },
+      },
+    ],
+  },
+  kibana: [
+    {
+      base: [],
+      feature: { siemV2: ['all'], ...dashboardsPermission },
+      spaces: ['*'],
+    },
+  ],
+};
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+const installSampleData = (kbnClient: KbnClient) =>
+  kbnClient.request({ method: 'POST', path: '/api/sample_data/logs', headers: {} });
+
+const removeSampleData = (kbnClient: KbnClient) =>
+  kbnClient.request({ method: 'DELETE', path: '/api/sample_data/logs', headers: {} });
+
+const createStackRule = async (kbnClient: KbnClient) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/alerting/rule',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name: 'stack-rule',
+      rule_type_id: '.es-query',
+      consumer: 'stackAlerts',
+      schedule: { interval: '5s' },
+      actions: [],
+      tags: ['stack-rule'],
+      params: {
+        searchType: 'esQuery',
+        timeWindowSize: 5,
+        timeWindowUnit: 'd',
+        threshold: [0],
+        thresholdComparator: '>',
+        size: 100,
+        esQuery: '{"query":{"match_all":{}}}',
+        aggType: 'count',
+        groupBy: 'all',
+        termSize: 5,
+        excludeHitsFromPreviousRun: false,
+        sourceFields: [],
+        index: ['kibana_sample_data_logs'],
+        timeField: '@timestamp',
+      },
+    },
+  });
+  return resp.data;
+};
+
+const createObservabilityRule = async (kbnClient: KbnClient, dataViewId: string) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/alerting/rule',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name: 'observability-rule',
+      rule_type_id: 'observability.rules.custom_threshold',
+      consumer: 'logs',
+      schedule: { interval: '5s' },
+      actions: [],
+      tags: ['observability-rule'],
+      params: {
+        criteria: [
+          {
+            comparator: '>',
+            metrics: [{ name: 'A', aggType: 'count' }],
+            threshold: [0],
+            timeSize: 1,
+            timeUnit: 'd',
+          },
+        ],
+        alertOnNoData: false,
+        alertOnGroupDisappear: false,
+        searchConfiguration: {
+          query: { query: '', language: 'kuery' },
+          index: dataViewId,
+        },
+      },
+    },
+  });
+  return resp.data;
+};
+
+const createSecurityRule = async (kbnClient: KbnClient) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/detection_engine/rules',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name: 'security-rule',
+      description: 'Scout embeddable alerts table test rule',
+      enabled: true,
+      risk_score: 1,
+      rule_id: `scout-embeddable-alerts-${Date.now()}`,
+      severity: 'low',
+      type: 'query',
+      query: '_id: *',
+      index: ['kibana_sample_data_logs'],
+      from: 'now-1y',
+      interval: '1m',
+      tags: ['security-rule'],
+    },
+  });
+  return resp.data;
+};
+
+const deleteAlertingRule = (kbnClient: KbnClient, id: string) =>
+  kbnClient.request({
+    method: 'DELETE',
+    path: `/api/alerting/rule/${id}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+
+const deleteSecurityRule = (kbnClient: KbnClient, id: string) =>
+  kbnClient.request({
+    method: 'DELETE',
+    path: `/api/detection_engine/rules?id=${id}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+
+const runRuleSoon = (kbnClient: KbnClient, id: string) =>
+  kbnClient.request({
+    method: 'POST',
+    path: `/internal/alerting/rule/${id}/_run_soon`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+
+// ─── spec ─────────────────────────────────────────────────────────────────────
+
+test.describe('Embeddable alerts panel', { tag: tags.stateful.classic }, () => {
+  const alertingRuleIds: string[] = [];
+  let securityRuleId: string | undefined;
+
+  test.beforeAll(async ({ kbnClient }) => {
+    await installSampleData(kbnClient);
+
+    const dvResp = await kbnClient.request<{
+      data_view: Array<{ id: string; title: string }>;
+    }>({ method: 'GET', path: '/api/data_views', headers: {} });
+    const logsDataView = dvResp.data.data_view.find((dv) => dv.title === 'kibana_sample_data_logs');
+
+    const securityRule = await createSecurityRule(kbnClient);
+    securityRuleId = securityRule.id;
+
+    const [stackRule, observabilityRule] = await Promise.all([
+      createStackRule(kbnClient),
+      logsDataView ? createObservabilityRule(kbnClient, logsDataView.id) : Promise.resolve(null),
+    ]);
+    if (stackRule) alertingRuleIds.push(stackRule.id);
+    if (observabilityRule) alertingRuleIds.push(observabilityRule.id);
+
+    await Promise.allSettled(
+      [...alertingRuleIds, ...(securityRuleId ? [securityRuleId] : [])].map((id) =>
+        runRuleSoon(kbnClient, id)
+      )
+    );
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    await Promise.allSettled([
+      ...alertingRuleIds.map((id) => deleteAlertingRule(kbnClient, id)),
+      ...(securityRuleId ? [deleteSecurityRule(kbnClient, securityRuleId)] : []),
+    ]);
+    alertingRuleIds.length = 0;
+    securityRuleId = undefined;
+    await removeSampleData(kbnClient).catch(() => {});
+  });
+
+  // ── Config editor tests (skipped: flaky upstream #258426) ─────────────────
+  test.skip('Config editor: should show the solution picker when multiple solutions are available', () => {});
+
+  test.skip('Config editor: should ask for confirmation before resetting filters when switching solution', () => {});
+
+  // ── Per-solution tests ────────────────────────────────────────────────────
+
+  test('should only be able to create panels with stack rule types', async ({
+    page,
+    pageObjects,
+    browserAuth,
+  }) => {
+    await browserAuth.loginWithCustomRole(STACK_ALERTING_ROLE);
+    await pageObjects.dashboard.openNewDashboard();
+    await pageObjects.toasts.closeAll();
+    await pageObjects.dashboard.openAddPanelFlyout();
+    await page.testSubj.click('create-action-Alerts');
+
+    await expect(page.testSubj.locator(FILTERS_FORM_SUBJ)).toBeVisible({ timeout: 10_000 });
+    await expect(page.testSubj.locator(SOLUTION_SELECTOR_SUBJ)).toBeHidden();
+
+    await page
+      .locator(`[data-test-subj="${FILTERS_FORM_ITEM_SUBJ}"] button`)
+      .click({ force: true }); // force: inside focus-trapped flyout
+    await page.locator('button#ruleTags').click({ force: true });
+    await page.testSubj.click('comboBoxToggleListButton');
+
+    const options = page.testSubj.locator(RULE_TAGS_FILTER_SUBJ).locator('option');
+    await expect(options).toHaveCount(1);
+    await expect(options[0]).toHaveText('stack-rule');
+    await options[0].click();
+
+    await pageObjects.toasts.closeAll();
+    await page.testSubj.click(SAVE_CONFIG_BUTTON_SUBJ);
+    await expect(page.testSubj.locator(DASHBOARD_PANEL_TEST_SUBJ)).toBeVisible({ timeout: 15_000 });
+
+    const tagCells = page.locator(
+      '[data-gridcell-column-id="kibana.alert.rule.tags"] [data-test-subj="dataGridRowCell"]'
+    );
+    await expect
+      .poll(async () => tagCells.count(), { timeout: 30_000, intervals: [2_000] })
+      .toBeGreaterThan(0);
+    const tagTexts = await tagCells.allInnerTexts();
+    expect(tagTexts.every((t) => t.includes('stack-rule'))).toBe(true);
+  });
+
+  test('should only be able to create panels with observability rule types', async ({
+    page,
+    pageObjects,
+    browserAuth,
+  }) => {
+    await browserAuth.loginWithCustomRole(OBSERVABILITY_ALERTING_ROLE);
+    await pageObjects.dashboard.openNewDashboard();
+    await pageObjects.toasts.closeAll();
+    await pageObjects.dashboard.openAddPanelFlyout();
+    await page.testSubj.click('create-action-Alerts');
+
+    await expect(page.testSubj.locator(FILTERS_FORM_SUBJ)).toBeVisible({ timeout: 10_000 });
+    await expect(page.testSubj.locator(SOLUTION_SELECTOR_SUBJ)).toBeHidden();
+
+    await page
+      .locator(`[data-test-subj="${FILTERS_FORM_ITEM_SUBJ}"] button`)
+      .click({ force: true }); // force: inside focus-trapped flyout
+    await page.locator('button#ruleTags').click({ force: true });
+    await page.testSubj.click('comboBoxToggleListButton');
+
+    const options = page.testSubj.locator(RULE_TAGS_FILTER_SUBJ).locator('option');
+    await expect(options).toHaveCount(1);
+    await expect(options[0]).toHaveText('observability-rule');
+    await options[0].click();
+
+    await pageObjects.toasts.closeAll();
+    await page.testSubj.click(SAVE_CONFIG_BUTTON_SUBJ);
+    await expect(page.testSubj.locator(DASHBOARD_PANEL_TEST_SUBJ)).toBeVisible({ timeout: 15_000 });
+
+    const tagCells = page.locator(
+      '[data-gridcell-column-id="kibana.alert.rule.tags"] [data-test-subj="dataGridRowCell"]'
+    );
+    await expect
+      .poll(async () => tagCells.count(), { timeout: 30_000, intervals: [2_000] })
+      .toBeGreaterThan(0);
+    const tagTexts = await tagCells.allInnerTexts();
+    expect(tagTexts.every((t) => t.includes('observability-rule'))).toBe(true);
+  });
+
+  test('should only be able to create panels with security rule types', async ({
+    page,
+    pageObjects,
+    browserAuth,
+  }) => {
+    await browserAuth.loginWithCustomRole(SECURITY_ALERTING_ROLE);
+    await pageObjects.dashboard.openNewDashboard();
+    await pageObjects.toasts.closeAll();
+    await pageObjects.dashboard.openAddPanelFlyout();
+    await page.testSubj.click('create-action-Alerts');
+
+    await expect(page.testSubj.locator(FILTERS_FORM_SUBJ)).toBeVisible({ timeout: 10_000 });
+    await expect(page.testSubj.locator(SOLUTION_SELECTOR_SUBJ)).toBeHidden();
+
+    await page
+      .locator(`[data-test-subj="${FILTERS_FORM_ITEM_SUBJ}"] button`)
+      .click({ force: true }); // force: inside focus-trapped flyout
+    await page.locator('button#ruleTags').click({ force: true });
+    await page.testSubj.click('comboBoxToggleListButton');
+
+    const options = page.testSubj.locator(RULE_TAGS_FILTER_SUBJ).locator('option');
+    await expect(options).toHaveCount(1);
+    await expect(options[0]).toHaveText('security-rule');
+    await options[0].click();
+
+    await pageObjects.toasts.closeAll();
+    await page.testSubj.click(SAVE_CONFIG_BUTTON_SUBJ);
+    await expect(page.testSubj.locator(DASHBOARD_PANEL_TEST_SUBJ)).toBeVisible({ timeout: 15_000 });
+
+    const tagCells = page.locator(
+      '[data-gridcell-column-id="kibana.alert.rule.tags"] [data-test-subj="dataGridRowCell"]'
+    );
+    await expect
+      .poll(async () => tagCells.count(), { timeout: 30_000, intervals: [2_000] })
+      .toBeGreaterThan(0);
+    const tagTexts = await tagCells.allInnerTexts();
+    expect(tagTexts.every((t) => t.includes('security-rule'))).toBe(true);
+  });
+
+  // ── Solution-filter tests ─────────────────────────────────────────────────
+  // EuiSuperSelect fix: the flyout's useEffectOnce auto-opens the solution
+  // selector popover; we click the option button directly instead of toggling
+  // the trigger first.
+
+  test('should only show alerts from the observability area (o11y+stack) when selecting it', async ({
+    page,
+    pageObjects,
+    browserAuth,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await pageObjects.dashboard.openNewDashboard();
+    await pageObjects.toasts.closeAll();
+    await pageObjects.dashboard.openAddPanelFlyout();
+    await page.testSubj.click('create-action-Alerts');
+
+    await expect(page.testSubj.locator(SOLUTION_SELECTOR_SUBJ)).toBeVisible({ timeout: 10_000 });
+    await page.locator('button#observability').click({ force: true }); // force: portal in focus-trapped flyout
+
+    await page.testSubj.click(SAVE_CONFIG_BUTTON_SUBJ);
+    await expect(page.testSubj.locator(DASHBOARD_PANEL_TEST_SUBJ)).toBeVisible({ timeout: 15_000 });
+
+    const featureCells = page.locator(
+      '[data-gridcell-column-id="kibana.alert.rule.consumer"] [data-test-subj="dataGridRowCell"]'
+    );
+    await expect
+      .poll(async () => featureCells.count(), { timeout: 30_000, intervals: [2_000] })
+      .toBeGreaterThan(0);
+    const features = await featureCells.allInnerTexts();
+    const expectedFeatures = ['logs', 'stack'];
+    expect(features.every((f) => expectedFeatures.some((ef) => f.toLowerCase().includes(ef)))).toBe(
+      true
+    );
+  });
+
+  test('should only show alerts from the security area when selecting it', async ({
+    page,
+    pageObjects,
+    browserAuth,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await pageObjects.dashboard.openNewDashboard();
+    await pageObjects.toasts.closeAll();
+    await pageObjects.dashboard.openAddPanelFlyout();
+    await page.testSubj.click('create-action-Alerts');
+
+    await expect(page.testSubj.locator(SOLUTION_SELECTOR_SUBJ)).toBeVisible({ timeout: 10_000 });
+    await page.locator('button#security').click({ force: true }); // force: portal in focus-trapped flyout
+
+    await page.testSubj.click(SAVE_CONFIG_BUTTON_SUBJ);
+    await expect(page.testSubj.locator(DASHBOARD_PANEL_TEST_SUBJ)).toBeVisible({ timeout: 15_000 });
+
+    const featureCells = page.locator(
+      '[data-gridcell-column-id="kibana.alert.rule.consumer"] [data-test-subj="dataGridRowCell"]'
+    );
+    await expect
+      .poll(async () => featureCells.count(), { timeout: 30_000, intervals: [2_000] })
+      .toBeGreaterThan(0);
+    const features = await featureCells.allInnerTexts();
+    expect(features.every((f) => f.toLowerCase().includes('siem'))).toBe(true);
+  });
+
+  // ── Tests skipped pending cross-test panel state / API-seeding approach ───
+  // These verified authz prompts and time-range overrides on panels that the
+  // FTR shared-session approach accumulated across the per-solution tests.
+  // Block on establishing an API-seeding approach for embeddable panels.
+
+  test.skip("should show a missing authz prompt when the user doesn't have access to a panel's rule types", () => {});
+
+  test.skip('should apply the global time filter to alert panels by default', () => {});
+
+  test.skip('should override the time range for specific panels', () => {});
+});

--- a/x-pack/platform/plugins/shared/index_management/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/.meta/ui/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "d9178629ffe494abb7bfc638dff00db4a4f6bf03",
+  "sha1": "1f64f92def0d9b9bad1301449ea6972489da50e1",
   "tests": [
     {
       "id": "e7ca8c886a58426-d57f60fe1d6db3b",
@@ -194,6 +194,20 @@
       "location": {
         "file": "x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_template_wizard.spec.ts",
         "line": 25,
+        "column": 7
+      }
+    },
+    {
+      "id": "334b2c159a85a53-5c9af8158963588",
+      "title": "Index Management — management sidebar smoke data section contains index_management and transform for index_management_user role",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/management_sidebar_smoke.spec.ts",
+        "line": 32,
         "column": 7
       }
     }

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "c5e02f2db86b00d846aa8b50a9b3e65f335799b6",
+  "sha1": "d3171b4fe6c52ad4f57d3f90962a72efbbb9136b",
   "tests": [
     {
       "id": "7f4d24df5ef863e-6b9d865caafbc3b",
@@ -1146,6 +1146,34 @@
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/maintenance_window_update.spec.ts",
         "line": 177,
+        "column": 7
+      }
+    },
+    {
+      "id": "8fffbc7ff28be24-44e445aba4482ce",
+      "title": "Redirect from /app/rules redirects /app/rules to the Stack Management rules page",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/redirect.spec.ts",
+        "line": 30,
+        "column": 7
+      }
+    },
+    {
+      "id": "8fffbc7ff28be24-6c863e32f86d72f",
+      "title": "Redirect from /app/rules preserves the sub-path when redirecting /app/rules/:path to Stack Management",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/redirect.spec.ts",
+        "line": 38,
         "column": 7
       }
     },

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
@@ -1,88 +1,88 @@
 {
-  "sha1": "3a5c2c2ee72b3eba4ba84842504c9662ccf000d2",
+  "sha1": "c5e02f2db86b00d846aa8b50a9b3e65f335799b6",
   "tests": [
     {
       "id": "7f4d24df5ef863e-6b9d865caafbc3b",
       "title": "Alert create flyout should delete the right action when the same action has been added twice",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 94,
-        "column": 8
+        "line": 156,
+        "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-00f2bcd3cc24c5c",
       "title": "Alert create flyout should create an alert",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 96,
-        "column": 8
+        "line": 204,
+        "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-af5965fcd8fdaf6",
       "title": "Alert create flyout should create an alert with composite query in filter for conditional action",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 98,
-        "column": 8
+        "line": 282,
+        "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-793414ff4288a57",
       "title": "Alert create flyout should create an alert with DSL filter for conditional action",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 100,
-        "column": 8
+        "line": 360,
+        "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-423c19d1919af7e",
       "title": "Alert create flyout should create an alert with actions in multiple groups",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 103,
-        "column": 8
+        "line": 430,
+        "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-e8fe79b1100cedc",
       "title": "Alert create flyout should show save confirmation before creating alert with no actions",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 105,
-        "column": 8
+        "line": 472,
+        "column": 7
       }
     },
     {
@@ -95,7 +95,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 107,
+        "line": 517,
         "column": 7
       }
     },
@@ -109,7 +109,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 128,
+        "line": 538,
         "column": 7
       }
     },
@@ -123,7 +123,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 146,
+        "line": 556,
         "column": 7
       }
     },
@@ -137,22 +137,22 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 173,
+        "line": 583,
         "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-b5cd8064c58d131",
       "title": "Alert create flyout should successfully show the APM error count rule flyout",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 194,
-        "column": 8
+        "line": 603,
+        "column": 7
       }
     },
     {
@@ -165,22 +165,22 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 196,
+        "line": 615,
         "column": 7
       }
     },
     {
       "id": "7f4d24df5ef863e-1a8e97a4c704f8b",
       "title": "Alert create flyout should add filter",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
-        "line": 215,
-        "column": 8
+        "line": 633,
+        "column": 7
       }
     },
     {
@@ -291,7 +291,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 96,
+        "line": 93,
         "column": 7
       }
     },
@@ -305,7 +305,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 135,
+        "line": 132,
         "column": 7
       }
     },
@@ -319,7 +319,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 176,
+        "line": 173,
         "column": 7
       }
     },
@@ -333,7 +333,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 190,
+        "line": 187,
         "column": 7
       }
     },
@@ -347,7 +347,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 214,
+        "line": 211,
         "column": 7
       }
     },
@@ -361,7 +361,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 247,
+        "line": 244,
         "column": 7
       }
     },
@@ -375,7 +375,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 281,
+        "line": 278,
         "column": 7
       }
     },
@@ -389,7 +389,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 315,
+        "line": 312,
         "column": 7
       }
     },
@@ -403,7 +403,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 346,
+        "line": 343,
         "column": 7
       }
     },
@@ -417,50 +417,50 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 376,
+        "line": 373,
         "column": 7
       }
     },
     {
       "id": "1a25d6294359785-0d8be81cd1254e2",
       "title": "General connector functionality should not be able to delete a preconfigured connector",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 408,
-        "column": 8
+        "line": 404,
+        "column": 7
       }
     },
     {
       "id": "1a25d6294359785-d99b757aa9caed8",
       "title": "General connector functionality should not be able to edit a preconfigured connector",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 411,
-        "column": 8
+        "line": 421,
+        "column": 7
       }
     },
     {
       "id": "1a25d6294359785-444be4c61cbf2d6",
       "title": "General connector functionality Execution log - renders the event log list and can filter/sort",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
-        "line": 414,
-        "column": 8
+        "line": 441,
+        "column": 7
       }
     },
     {
@@ -1164,6 +1164,20 @@
       }
     },
     {
+      "id": "9390be6d28f2e22-6c7e872dd2560a7",
+      "title": "Rule Details - Legacy notify values should convert rule-level params to action-level params and save the rule successfully",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit_legacy_notify.spec.ts",
+        "line": 100,
+        "column": 7
+      }
+    },
+    {
       "id": "1e5991e2e9c6383-69ac6df8bd331d6",
       "title": "Rule Details - Edit rule button should open edit rule flyout",
       "expectedStatus": "passed",
@@ -1467,7 +1481,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 126,
+        "line": 210,
         "column": 7
       }
     },
@@ -1481,7 +1495,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 148,
+        "line": 232,
         "column": 7
       }
     },
@@ -1495,7 +1509,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 164,
+        "line": 248,
         "column": 7
       }
     },
@@ -1509,7 +1523,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 194,
+        "line": 278,
         "column": 7
       }
     },
@@ -1523,7 +1537,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 211,
+        "line": 295,
         "column": 7
       }
     },
@@ -1537,7 +1551,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 225,
+        "line": 309,
         "column": 7
       }
     },
@@ -1551,7 +1565,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 240,
+        "line": 324,
         "column": 7
       }
     },
@@ -1565,7 +1579,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 262,
+        "line": 346,
         "column": 7
       }
     },
@@ -1579,7 +1593,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 285,
+        "line": 369,
         "column": 7
       }
     },
@@ -1593,7 +1607,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 302,
+        "line": 386,
         "column": 7
       }
     },
@@ -1607,7 +1621,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 317,
+        "line": 401,
         "column": 7
       }
     },
@@ -1621,7 +1635,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 337,
+        "line": 421,
         "column": 7
       }
     },
@@ -1635,50 +1649,50 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 368,
+        "line": 452,
         "column": 7
       }
     },
     {
       "id": "147307e33c87398-5a041634f786217",
       "title": "Rules list should filter alerts by the status",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 392,
-        "column": 8
+        "line": 475,
+        "column": 7
       }
     },
     {
       "id": "147307e33c87398-c04e54195ed37f5",
       "title": "Rules list should display total alerts by status and error banner only when exists alerts with status error",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 395,
-        "column": 8
+        "line": 507,
+        "column": 7
       }
     },
     {
       "id": "147307e33c87398-07e22d8c1efb1ab",
       "title": "Rules list Expand error in rules table when there is rule with an error associated",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 398,
-        "column": 8
+        "line": 567,
+        "column": 7
       }
     },
     {
@@ -1691,7 +1705,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 400,
+        "line": 607,
         "column": 7
       }
     },
@@ -1705,7 +1719,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 442,
+        "line": 649,
         "column": 7
       }
     },
@@ -1719,7 +1733,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 489,
+        "line": 696,
         "column": 7
       }
     },
@@ -1733,7 +1747,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 564,
+        "line": 771,
         "column": 7
       }
     },
@@ -1747,36 +1761,36 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 617,
+        "line": 824,
         "column": 7
       }
     },
     {
       "id": "147307e33c87398-14494f15655aa7d",
       "title": "Rules list should untrack disable rule if untrack switch is true",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 647,
-        "column": 8
+        "line": 853,
+        "column": 7
       }
     },
     {
       "id": "147307e33c87398-78854574d5e4c82",
       "title": "Rules list should not untrack disable rule if untrack switch if false",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic"
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 650,
-        "column": 8
+        "line": 890,
+        "column": 7
       }
     },
     {
@@ -1789,7 +1803,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 652,
+        "line": 929,
         "column": 7
       }
     },
@@ -1803,7 +1817,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 671,
+        "line": 948,
         "column": 7
       }
     },
@@ -1817,7 +1831,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
-        "line": 692,
+        "line": 969,
         "column": 7
       }
     },

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
@@ -184,6 +184,174 @@
       }
     },
     {
+      "id": "1e5991e2e9c6383-69ac6df8bd331d6",
+      "title": "Rule Details - Edit rule button should open edit rule flyout",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit.spec.ts",
+        "line": 92,
+        "column": 7
+      }
+    },
+    {
+      "id": "1e5991e2e9c6383-4194151a53d2e67",
+      "title": "Rule Details - Edit rule button should reset rule when canceling an edit",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit.spec.ts",
+        "line": 109,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-50365dfc8239ea2",
+      "title": "Rule Details - Header renders the rule details",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 53,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-a2b4added007d73",
+      "title": "Rule Details - Header renders toast when schedule is less than configured minimum",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 59,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-8069d0f59a1dc7d",
+      "title": "Rule Details - Header should disable the rule",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 66,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-1ca80e8c5c176fb",
+      "title": "Rule Details - Header should allow you to snooze a disabled rule",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 78,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-f41808004c25933",
+      "title": "Rule Details - Header should reenable a disabled rule",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 95,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-01f225a51c57330",
+      "title": "Rule Details - Header should snooze the rule",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 106,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-d8ff007a590dfdd",
+      "title": "Rule Details - Header should snooze the rule for a set duration",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 119,
+        "column": 7
+      }
+    },
+    {
+      "id": "a45df9c720b9719-7cb2becb95a184f",
+      "title": "Rule Details - Header should add snooze schedule",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts",
+        "line": 132,
+        "column": 7
+      }
+    },
+    {
+      "id": "54d204dd08bf2d1-a80dd60264f8ef6",
+      "title": "Rule Details - Saved Objects Management Navigation should navigate to rule details from saved objects management page in default space",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_so_navigation.spec.ts",
+        "line": 96,
+        "column": 9
+      }
+    },
+    {
+      "id": "54d204dd08bf2d1-c78ed3a6fb5dcee",
+      "title": "Rule Details - Saved Objects Management Navigation should navigate to rule details from saved objects management page in non-default space",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_so_navigation.spec.ts",
+        "line": 114,
+        "column": 9
+      }
+    },
+    {
       "id": "b621efd3ec8d996-e8dfa7be3731465",
       "title": "Rule logs \"show all spaces\" switch hides the switch when only the default space exists",
       "expectedStatus": "passed",
@@ -306,6 +474,370 @@
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_home_page.spec.ts",
         "line": 97,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-350e61a13c0575a",
+      "title": "Rules list should display alerts in alphabetical order",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 126,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-48862b943a9b07b",
+      "title": "Rules list should search for alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 148,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-47ec35d63716050",
+      "title": "Rules list should update alert list on the search clear button click",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 164,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-f2c6f0faa6babce",
+      "title": "Rules list should search for tags",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 194,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-32747e088fc269b",
+      "title": "Rules list should display an empty list when search did not return any alerts",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 211,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-f9b180d4de6bec0",
+      "title": "Rules list should disable single alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 225,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-9fbaab44b146fef",
+      "title": "Rules list should re-enable single alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 240,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-3cace3865ad8d87",
+      "title": "Rules list should delete single alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 262,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-427d3b50ef7ac2c",
+      "title": "Rules list should disable all selection",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 285,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-6ff4e907b42fdd4",
+      "title": "Rules list should enable all selection",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 302,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-400dcea4242c3dd",
+      "title": "Rules list should render percentile column and cells correctly",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 317,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-2712d127ba7d738",
+      "title": "Rules list should render interval info icon when schedule interval is less than configured minimum",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 337,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-484f882613d26d8",
+      "title": "Rules list should delete all selection",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 368,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-5a041634f786217",
+      "title": "Rules list should filter alerts by the status",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 392,
+        "column": 8
+      }
+    },
+    {
+      "id": "147307e33c87398-c04e54195ed37f5",
+      "title": "Rules list should display total alerts by status and error banner only when exists alerts with status error",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 395,
+        "column": 8
+      }
+    },
+    {
+      "id": "147307e33c87398-07e22d8c1efb1ab",
+      "title": "Rules list Expand error in rules table when there is rule with an error associated",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 398,
+        "column": 8
+      }
+    },
+    {
+      "id": "147307e33c87398-387f1cff60b9220",
+      "title": "Rules list should filter alerts by the alert type",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 400,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-d950cd8b4977d73",
+      "title": "Rules list should filter alerts by the action type",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 442,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-40436eb215ad4d8",
+      "title": "Rules list should filter alerts by the rule status",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 489,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-344a686f1fbbfc4",
+      "title": "Rules list should filter alerts by the tag",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 564,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-1e2eb4ac5b35f79",
+      "title": "Rules list should not prevent rules with action execution capabilities from being edited",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 617,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-14494f15655aa7d",
+      "title": "Rules list should untrack disable rule if untrack switch is true",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 647,
+        "column": 8
+      }
+    },
+    {
+      "id": "147307e33c87398-78854574d5e4c82",
+      "title": "Rules list should not untrack disable rule if untrack switch if false",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 650,
+        "column": 8
+      }
+    },
+    {
+      "id": "147307e33c87398-ac0ab0053270d69",
+      "title": "Rules list should allow rules to be snoozed using the right side dropdown",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 652,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-9d4187036a33902",
+      "title": "Rules list should allow rules to be snoozed indefinitely using the right side dropdown",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 671,
+        "column": 7
+      }
+    },
+    {
+      "id": "147307e33c87398-d1823f8102937a2",
+      "title": "Rules list should allow snoozed rules to be unsnoozed using the right side dropdown",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts",
+        "line": 692,
         "column": 7
       }
     },

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/.meta/ui/standard.json
@@ -1,6 +1,272 @@
 {
-  "sha1": "09149f5dafff317839f3b76f6b4edb982e766397",
+  "sha1": "3a5c2c2ee72b3eba4ba84842504c9662ccf000d2",
   "tests": [
+    {
+      "id": "7f4d24df5ef863e-6b9d865caafbc3b",
+      "title": "Alert create flyout should delete the right action when the same action has been added twice",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 94,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-00f2bcd3cc24c5c",
+      "title": "Alert create flyout should create an alert",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 96,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-af5965fcd8fdaf6",
+      "title": "Alert create flyout should create an alert with composite query in filter for conditional action",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 98,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-793414ff4288a57",
+      "title": "Alert create flyout should create an alert with DSL filter for conditional action",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 100,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-423c19d1919af7e",
+      "title": "Alert create flyout should create an alert with actions in multiple groups",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 103,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-e8fe79b1100cedc",
+      "title": "Alert create flyout should show save confirmation before creating alert with no actions",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 105,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-c380de83b3ea086",
+      "title": "Alert create flyout should show discard confirmation before closing flyout without saving",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 107,
+        "column": 7
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-a748b75b9283762",
+      "title": "Alert create flyout should show error when es_query is invalid",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 128,
+        "column": 7
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-fae722ecb1ca93c",
+      "title": "Alert create flyout should show KEEP command warning when creating a ES query rule with ESQL",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 146,
+        "column": 7
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-f4b407dc421763e",
+      "title": "Alert create flyout should not show KEEP command warning when editing a ES query rule with ESQL",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 173,
+        "column": 7
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-b5cd8064c58d131",
+      "title": "Alert create flyout should successfully show the APM error count rule flyout",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 194,
+        "column": 8
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-6147c0996b91ece",
+      "title": "Alert create flyout should successfully test valid es_query alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 196,
+        "column": 7
+      }
+    },
+    {
+      "id": "7f4d24df5ef863e-1a8e97a4c704f8b",
+      "title": "Alert create flyout should add filter",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts",
+        "line": 215,
+        "column": 8
+      }
+    },
+    {
+      "id": "e525ea47223c95a-f83dbbba7a68b4d",
+      "title": "Email connector should use the kibana config for aws ses defaults",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts",
+        "line": 67,
+        "column": 7
+      }
+    },
+    {
+      "id": "e525ea47223c95a-307e31547871405",
+      "title": "Email connector disables Run and shows recipients-required error when To/Cc/Bcc are all empty",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts",
+        "line": 93,
+        "column": 7
+      }
+    },
+    {
+      "id": "e525ea47223c95a-16f4113d4d2b31b",
+      "title": "Email connector disables Run when the only To entry is whitespace",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts",
+        "line": 124,
+        "column": 7
+      }
+    },
+    {
+      "id": "e525ea47223c95a-3488fe026a89890",
+      "title": "Email connector shows invalid email error for address with leading hyphen in local part",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts",
+        "line": 156,
+        "column": 7
+      }
+    },
+    {
+      "id": "e525ea47223c95a-def9a0ff234df23",
+      "title": "Email connector shows invalid email error for address with leading hyphen in domain",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts",
+        "line": 185,
+        "column": 7
+      }
+    },
+    {
+      "id": "e525ea47223c95a-f9737f84035d346",
+      "title": "Email connector clears recipients-required error when only Cc has a valid recipient",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts",
+        "line": 214,
+        "column": 7
+      }
+    },
     {
       "id": "8f6baf4aef167da-ea2a6253719774d",
       "title": "Create connector from connector spec creates a spec-defined AlienVault OTX connector",
@@ -13,6 +279,188 @@
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_from_spec.spec.ts",
         "line": 30,
         "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-ba247813d4d025a",
+      "title": "General connector functionality should create a connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 96,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-4a684473d8e6e83",
+      "title": "General connector functionality should create a connector with a custom user-defined ID",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 135,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-3d3860be78e25e4",
+      "title": "General connector functionality should auto-populate connector ID from name",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 176,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-ae2cfda280adb1d",
+      "title": "General connector functionality should show connector ID as disabled when editing an existing connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 190,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-b82ff9e67e460eb",
+      "title": "General connector functionality should edit a connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 214,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-19370aeaf16260b",
+      "title": "General connector functionality should test a connector and display a successful result",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 247,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-ff82272df110cff",
+      "title": "General connector functionality should test a connector and display a failure result",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 281,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-48131f81e3df894",
+      "title": "General connector functionality should reset connector when canceling an edit",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 315,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-89887db7070bed3",
+      "title": "General connector functionality should delete a connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 346,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-a74eeb96d037180",
+      "title": "General connector functionality should bulk delete connectors",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 376,
+        "column": 7
+      }
+    },
+    {
+      "id": "1a25d6294359785-0d8be81cd1254e2",
+      "title": "General connector functionality should not be able to delete a preconfigured connector",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 408,
+        "column": 8
+      }
+    },
+    {
+      "id": "1a25d6294359785-d99b757aa9caed8",
+      "title": "General connector functionality should not be able to edit a preconfigured connector",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 411,
+        "column": 8
+      }
+    },
+    {
+      "id": "1a25d6294359785-444be4c61cbf2d6",
+      "title": "General connector functionality Execution log - renders the event log list and can filter/sort",
+      "expectedStatus": "skipped",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts",
+        "line": 414,
+        "column": 8
       }
     },
     {
@@ -54,6 +502,538 @@
       "location": {
         "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jira.spec.ts",
         "line": 110,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-f299633aa3c44b2",
+      "title": "Jira Service Management connector connector page - should create the connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 148,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-619bc3ac6c14d07",
+      "title": "Jira Service Management connector connector page - should edit the connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 182,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-ee6fdae5919335d",
+      "title": "Jira Service Management connector connector page - should reset connector when canceling an edit",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 211,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-4d854df05b4cd14",
+      "title": "Jira Service Management connector connector page - should disable the run button when the message field is not filled",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 237,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-20398a5d7f343ae",
+      "title": "Jira Service Management connector page - should show the sub action selector when in test mode",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 260,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-27f05b6009c6c28",
+      "title": "Jira Service Management connector page - should preserve the alias when switching between create and close alert actions",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 266,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-a26307ae6e9e544",
+      "title": "Jira Service Management connector page - should not preserve the message when switching to close alert and back to create alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 280,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-4ce67fbce5d5bbb",
+      "title": "Jira Service Management connector page - createAlert - should show the additional options when clicking more options",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 296,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-7e49931e3f7029c",
+      "title": "Jira Service Management connector page - createAlert - should show and then hide the additional form options when clicking the button twice",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 311,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-2b224b4ba8dde7f",
+      "title": "Jira Service Management connector page - createAlert - should populate the json editor with message, description, and alias",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 325,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-c74afe453946815",
+      "title": "Jira Service Management connector page - createAlert - should populate the form with values from the json editor",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 352,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-16b219ceb1d8f63",
+      "title": "Jira Service Management connector page - createAlert - should disable the run button when the json editor validation fails",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 379,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-b4a9ff53fae5d5a",
+      "title": "Jira Service Management connector page - closeAlert - should show the additional options for closing an alert when clicking more options",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 392,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-f65e9f662c1e234",
+      "title": "Jira Service Management connector page - closeAlert - should show and then hide the additional options when clicking the button twice",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 406,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-ae486a0d4e59dd4",
+      "title": "Jira Service Management connector alerts page - should default to the create alert action",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 423,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-ef7ea664c63a7dd",
+      "title": "Jira Service Management connector alerts page - should default to the close alert action when setting the run when to recovered",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 442,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-471298764f223db",
+      "title": "Jira Service Management connector alerts page - should not preserve the alias when switching run when to recover",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 467,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-37324867ed1dbae",
+      "title": "Jira Service Management connector alerts page - should not preserve the alias when switching run when to threshold met",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 493,
+        "column": 7
+      }
+    },
+    {
+      "id": "9fbe060aea7b8b5-a05dc62dbceb08d",
+      "title": "Jira Service Management connector alerts page - should show the message is required error when clicking the save button",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts",
+        "line": 523,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-48e48752f8e14a8",
+      "title": "Opsgenie connector connector page - should create the connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 150,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-84596c9269827c4",
+      "title": "Opsgenie connector connector page - should edit the connector",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 182,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-95ba36184d5c339",
+      "title": "Opsgenie connector connector page - should reset connector when canceling an edit",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 212,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-4a393798ff6d00a",
+      "title": "Opsgenie connector connector page - should disable the run button when the message field is not filled",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 238,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-b5102b5354e29cc",
+      "title": "Opsgenie connector page - should show the sub action selector when in test mode",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 263,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-c919440d527cac0",
+      "title": "Opsgenie connector page - should preserve the alias when switching between create and close alert actions",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 269,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-ce3c3e7338f7489",
+      "title": "Opsgenie connector page - should not preserve the message when switching to close alert and back to create alert",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 283,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-9788f7864d78cf3",
+      "title": "Opsgenie connector page - createAlert - should show the additional options when clicking more options",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 299,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-5c1ab1adf50ea2f",
+      "title": "Opsgenie connector page - createAlert - should show and then hide the additional form options when clicking the button twice",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 314,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-84a7458e554e2d2",
+      "title": "Opsgenie connector page - createAlert - should populate the json editor with message, description, and alias",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 328,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-5ca956c9e96fd3f",
+      "title": "Opsgenie connector page - createAlert - should populate the form with values from the json editor",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 355,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-94f2f8adf3c2923",
+      "title": "Opsgenie connector page - createAlert - should disable the run button when the json editor validation fails",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 382,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-0593ab2032bad76",
+      "title": "Opsgenie connector page - closeAlert - should show the additional options for closing an alert when clicking more options",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 395,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-0c03b413eb244fd",
+      "title": "Opsgenie connector page - closeAlert - should show and then hide the additional options when clicking the button twice",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 409,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-b6adfc01d5c2be4",
+      "title": "Opsgenie connector alerts page - should default to the create alert action",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 426,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-99c8e58a5e38f47",
+      "title": "Opsgenie connector alerts page - should default to the close alert action when setting the run when to recovered",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 445,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-e768528adbb5d36",
+      "title": "Opsgenie connector alerts page - should not preserve the alias when switching run when to recover",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 470,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-3a1146ec453ad01",
+      "title": "Opsgenie connector alerts page - should not preserve the alias when switching run when to threshold met",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 496,
+        "column": 7
+      }
+    },
+    {
+      "id": "603e60dadcde4f0-9d42e0cb7574367",
+      "title": "Opsgenie connector alerts page - should show the message is required error when clicking the save button",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts",
+        "line": 526,
         "column": 7
       }
     },

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts
@@ -8,13 +8,16 @@
 // Migrated from:
 //   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
 //
-// 5 of 13 tests migrated. Skipped:
-//   - tests 1-4: require Slack#xyztest preconfigured connector
-//   - tests 5-6: require test.always-firing rule type (not registered in Scout stateful/classic)
+// 11 of 13 tests migrated. Skipped:
 //   - test 11: requires apm.error_rate rule type (APM plugin not available in Scout stateful/classic)
 //   - test 13: requires filterBar.addDslFilter (no Scout equivalent)
+//
+// Substitutions from original:
+//   - Slack#xyztest → Slack connector created via API in beforeAll
+//   - test.always-firing rule → .es-query rule (tests 5-6)
+//   - defineIndexThresholdAlert → Scout equivalent helper (tests 1-4)
 
-import type { ScoutPage } from '@kbn/scout';
+import type { KbnClient, ScoutPage } from '@kbn/scout';
 import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { test, makeEsQueryRule } from '../fixtures';
@@ -67,15 +70,76 @@ const cancelRuleCreation = async (page: ScoutPage) => {
   }
 };
 
+// Equivalent of FTR rules.common.defineIndexThresholdAlert
+const defineIndexThresholdAlert = async (page: ScoutPage, alertName: string) => {
+  await page.gotoApp('rules');
+  await page.testSubj.click('createRuleButton');
+  await page.testSubj.click('.index-threshold-SelectOption');
+  await page.testSubj.locator('selectIndexExpression').scrollIntoViewIfNeeded();
+  await page.testSubj.click('selectIndexExpression');
+  const indexInput = page.testSubj.locator('thresholdIndexesComboBox').locator('input');
+  await indexInput.fill('.kibana');
+  await page.locator('[role="listbox"]').waitFor();
+  await page.locator('[role="listbox"] [role="option"]:first-child').click();
+  const timeFieldSelect = page.testSubj.locator('thresholdAlertTimeFieldSelect');
+  await timeFieldSelect.locator('option:nth-child(2)').waitFor();
+  await timeFieldSelect.selectOption({ index: 1 });
+  await page.testSubj.click('closePopover');
+  await page.testSubj.locator('ruleDetailsNameInput').scrollIntoViewIfNeeded();
+  await page.testSubj.locator('ruleDetailsNameInput').fill(alertName);
+};
+
+// Find and delete a rule by name via API
+const deleteRuleByName = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request({
+    method: 'GET',
+    path: '/api/alerting/rules/_find',
+    headers: {},
+    query: { search: name, search_fields: 'name' },
+  });
+  for (const rule of (resp.data as any).data ?? []) {
+    if (rule.name === name) {
+      await kbnClient.request({
+        method: 'DELETE',
+        path: `/internal/alerting/rule/${rule.id}`,
+        headers: { 'kbn-xsrf': 'scout' },
+      });
+    }
+  }
+};
+
+// Click the Slack connector card in the actions connector modal
+const selectConnectorInModal = async (page: ScoutPage, connectorName: string) => {
+  await expect(page.testSubj.locator('ruleActionsConnectorsModal')).toBeVisible();
+  await page
+    .locator('[data-test-subj="ruleActionsConnectorsModalCard"]')
+    .filter({ hasText: connectorName })
+    .locator('button')
+    .click();
+};
+
 test.describe('Alert create flyout', { tag: tags.stateful.classic }, () => {
   let esQueryRuleId: string;
   let esQueryRuleName: string;
+  let slackConnectorId: string;
+  let slackConnectorName: string;
 
   test.beforeAll(async ({ apiServices }) => {
     const rule = makeEsQueryRule('scout-alert-flyout');
     const resp = await apiServices.alerting.rules.create(rule);
     esQueryRuleId = resp.data.id;
     esQueryRuleName = resp.data.name;
+
+    slackConnectorName = `scout-slack-${Date.now()}`;
+    const connResp = await apiServices.alerting.connectors.create({
+      name: slackConnectorName,
+      connectorTypeId: '.slack',
+      config: {},
+      secrets: {
+        webhookUrl: 'https://example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX',
+      },
+    });
+    slackConnectorId = connResp.id;
   });
 
   test.beforeEach(async ({ browserAuth }) => {
@@ -88,21 +152,369 @@ test.describe('Alert create flyout', { tag: tags.stateful.classic }, () => {
 
   test.afterAll(async ({ apiServices }) => {
     if (esQueryRuleId) await apiServices.alerting.rules.delete(esQueryRuleId);
+    if (slackConnectorId) await apiServices.alerting.connectors.delete(slackConnectorId);
   });
 
-  // Skipped: requires Slack#xyztest preconfigured connector (not available in Scout stateful/classic)
-  test.skip('should delete the right action when the same action has been added twice', async () => {});
+  test('should delete the right action when the same action has been added twice', async ({
+    page,
+    kbnClient,
+  }) => {
+    const ruleName = `scout-flyout-del-${Date.now()}`;
+    await defineEsQueryAlert(page, ruleName);
 
-  test.skip('should create an alert', async () => {});
+    // Add Slack action with unique body text
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await selectConnectorInModal(page, slackConnectorName);
+    await page.testSubj.locator('messageTextArea').fill('myUniqueKey');
+    await page.testSubj.click('rulePageFooterSaveButton');
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Created rule "${ruleName}"`,
+      { timeout: 15_000 }
+    );
 
-  test.skip('should create an alert with composite query in filter for conditional action', async () => {});
+    try {
+      // Navigate to rules list and open edit flyout
+      await page.gotoApp('rules');
+      await page.testSubj.click('rulesTab');
+      await searchRules(page, ruleName);
+      await page.testSubj.click('selectActionButton');
+      await page.testSubj.click('editRule');
 
-  test.skip('should create an alert with DSL filter for conditional action', async () => {});
+      // Add a second Slack action
+      await page.testSubj.click('ruleActionsAddActionButton');
+      await selectConnectorInModal(page, slackConnectorName);
 
-  // Skipped: requires test.always-firing rule type (not registered in Scout stateful/classic)
-  test.skip('should create an alert with actions in multiple groups', async () => {});
+      // Fill the second action's textarea (last of all messageTextArea elements)
+      const allTextAreas = await page.testSubj.locator('messageTextArea').all();
+      await allTextAreas[allTextAreas.length - 1].fill('myUniqueKey1');
 
-  test.skip('should show save confirmation before creating alert with no actions', async () => {});
+      // Delete the FIRST action item
+      await page
+        .locator(
+          '[data-test-subj="ruleActionsItem"]:first-child [data-test-subj="ruleActionsItemDeleteButton"]'
+        )
+        .click();
+
+      // Only one action remains; it should be 'myUniqueKey1' (the second action)
+      await expect(page.testSubj.locator('messageTextArea')).toHaveCount(1);
+      await expect(page.testSubj.locator('messageTextArea')).toHaveValue('myUniqueKey1');
+    } finally {
+      await deleteRuleByName(kbnClient, ruleName);
+    }
+  });
+
+  test('should create an alert', async ({ page, kbnClient }) => {
+    const alertName = `scout-flyout-create-${Date.now()}`;
+    await defineIndexThresholdAlert(page, alertName);
+
+    // filterKuery validation: invalid KQL should mark field as invalid
+    const filterKuery = page.testSubj.locator('filterKuery');
+    await filterKuery.fill('group:');
+    await filterKuery.blur();
+    await expect(filterKuery).toHaveClass(/euiFieldSearch-isInvalid/, { timeout: 5_000 });
+    await filterKuery.fill('group: group-0');
+    await filterKuery.blur();
+    await expect(filterKuery).not.toHaveClass(/euiFieldSearch-isInvalid/);
+
+    // Add Slack action
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await selectConnectorInModal(page, slackConnectorName);
+
+    // Default message template should be populated for Index Threshold rule
+    await expect(page.testSubj.locator('messageTextArea')).not.toBeEmpty({ timeout: 5_000 });
+
+    // Replace with test text then insert a variable
+    await page.testSubj.locator('messageTextArea').fill('test message ');
+    await page.testSubj.click('messageAddVariableButton');
+    await page.testSubj.click('variableMenuButton-alert.actionGroup');
+    await expect(page.testSubj.locator('messageTextArea')).toHaveValue(
+      'test message {{alert.actionGroup}}'
+    );
+
+    // Append more text, then insert another variable via search
+    await page.testSubj.locator('messageTextArea').press('End');
+    await page.keyboard.type(' some additional text ');
+    await page.testSubj.click('messageAddVariableButton');
+    await page.testSubj.locator('messageVariablesSelectableSearch').fill('rule.id');
+    await page.testSubj.click('variableMenuButton-rule.id');
+    await expect(page.testSubj.locator('messageTextArea')).toHaveValue(
+      'test message {{alert.actionGroup}} some additional text {{rule.id}}'
+    );
+
+    // Action settings: set throttle
+    await page.testSubj
+      .locator('ruleActionsItem')
+      .getByRole('button', { name: 'Settings' })
+      .click();
+    await page.testSubj.click('notifyWhenSelect');
+    await page.testSubj.click('onThrottleInterval');
+    await page.testSubj.locator('throttleInput').fill('10');
+
+    // Conditional action filter: toggle, add structured filter, add KQL query
+    await page.testSubj.click('alertsFilterQueryToggle');
+    await page.testSubj.click('addFilter');
+    await page.testSubj.locator('filterFieldSuggestionList').locator('input').fill('_id');
+    await page.locator('[role="listbox"] [role="option"]:first-child').click();
+    await page.testSubj.locator('filterOperatorList').locator('input').fill('is not');
+    await page.locator('[role="listbox"] [role="option"]:first-child').click();
+    await page.testSubj.locator('filterParams').fill('fake-rule-id');
+    await page.testSubj.click('saveFilter');
+    await page.testSubj.locator('queryInput').fill('_id: *');
+
+    try {
+      await page.testSubj.click('rulePageFooterSaveButton');
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        `Created rule "${alertName}"`,
+        { timeout: 15_000 }
+      );
+
+      // Verify rule appears in list
+      await page.gotoApp('rules');
+      await page.testSubj.click('rulesTab');
+      await searchRules(page, alertName);
+      const row = page.locator('[data-test-subj="rulesList"] tr').filter({ hasText: alertName });
+      await expect(row).toBeVisible();
+      await expect(row).toContainText('Index threshold');
+      await expect(row).toContainText('1 min');
+    } finally {
+      await deleteRuleByName(kbnClient, alertName);
+    }
+  });
+
+  test('should create an alert with composite query in filter for conditional action', async ({
+    page,
+    kbnClient,
+  }) => {
+    const alertName = `scout-flyout-composite-${Date.now()}`;
+    await defineIndexThresholdAlert(page, alertName);
+
+    // filterKuery validation
+    const filterKuery = page.testSubj.locator('filterKuery');
+    await filterKuery.fill('group:');
+    await filterKuery.blur();
+    await expect(filterKuery).toHaveClass(/euiFieldSearch-isInvalid/, { timeout: 5_000 });
+    await filterKuery.fill('group: group-0');
+    await filterKuery.blur();
+    await expect(filterKuery).not.toHaveClass(/euiFieldSearch-isInvalid/);
+
+    // Add Slack action and configure message
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await selectConnectorInModal(page, slackConnectorName);
+    await page.testSubj.locator('messageTextArea').fill('test message ');
+    await page.testSubj.click('messageAddVariableButton');
+    await page.testSubj.click('variableMenuButton-alert.actionGroup');
+    await page.testSubj.locator('messageTextArea').press('End');
+    await page.keyboard.type(' some additional text ');
+    await page.testSubj.click('messageAddVariableButton');
+    await page.testSubj.locator('messageVariablesSelectableSearch').fill('rule.id');
+    await page.testSubj.click('variableMenuButton-rule.id');
+
+    // Action settings: throttle
+    await page.testSubj
+      .locator('ruleActionsItem')
+      .getByRole('button', { name: 'Settings' })
+      .click();
+    await page.testSubj.click('notifyWhenSelect');
+    await page.testSubj.click('onThrottleInterval');
+    await page.testSubj.locator('throttleInput').fill('10');
+
+    // Conditional action filter: AND composite filter
+    await page.testSubj.click('alertsFilterQueryToggle');
+    await page.testSubj.click('addFilter');
+    // First condition: _id is not fake-rule-id
+    await page.testSubj.locator('filterFieldSuggestionList').locator('input').fill('_id');
+    await page.locator('[role="listbox"] [role="option"]:first-child').click();
+    await page.testSubj.locator('filterOperatorList').locator('input').fill('is not');
+    await page.locator('[role="listbox"] [role="option"]:first-child').click();
+    await page.testSubj.locator('filterParams').fill('fake-rule-id');
+    // Add AND condition
+    await page.testSubj.click('add-and-filter');
+    // Second condition: kibana.alert.action_group exists
+    const filter01 = page.testSubj.locator('filter-0.1');
+    await filter01
+      .locator('[data-test-subj="filterFieldSuggestionList"] input')
+      .fill('kibana.alert.action_group');
+    await page.locator('[role="listbox"] [role="option"]:first-child').click();
+    await filter01.locator('[data-test-subj="filterOperatorList"] input').fill('exists');
+    await page.locator('[role="listbox"] [role="option"]:first-child').click();
+    await page.testSubj.click('saveFilter');
+    await page.testSubj.locator('queryInput').fill('_id: *');
+
+    try {
+      await page.testSubj.click('rulePageFooterSaveButton');
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        `Created rule "${alertName}"`,
+        { timeout: 15_000 }
+      );
+
+      await page.gotoApp('rules');
+      await page.testSubj.click('rulesTab');
+      await searchRules(page, alertName);
+      const row = page.locator('[data-test-subj="rulesList"] tr').filter({ hasText: alertName });
+      await expect(row).toBeVisible();
+      await expect(row).toContainText('Index threshold');
+      await expect(row).toContainText('1 min');
+    } finally {
+      await deleteRuleByName(kbnClient, alertName);
+    }
+  });
+
+  test('should create an alert with DSL filter for conditional action', async ({
+    page,
+    kbnClient,
+  }) => {
+    const alertName = `scout-flyout-dsl-${Date.now()}`;
+    await defineIndexThresholdAlert(page, alertName);
+
+    // filterKuery validation
+    const filterKuery = page.testSubj.locator('filterKuery');
+    await filterKuery.fill('group:');
+    await filterKuery.blur();
+    await expect(filterKuery).toHaveClass(/euiFieldSearch-isInvalid/, { timeout: 5_000 });
+    await filterKuery.fill('group: group-0');
+    await filterKuery.blur();
+    await expect(filterKuery).not.toHaveClass(/euiFieldSearch-isInvalid/);
+
+    // Add Slack action
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await selectConnectorInModal(page, slackConnectorName);
+
+    // Action settings: throttle
+    await page.testSubj
+      .locator('ruleActionsItem')
+      .getByRole('button', { name: 'Settings' })
+      .click();
+    await page.testSubj.click('notifyWhenSelect');
+    await page.testSubj.click('onThrottleInterval');
+    await page.testSubj.locator('throttleInput').fill('10');
+
+    // Conditional action filter: add a DSL (Query DSL) filter
+    await page.testSubj.click('alertsFilterQueryToggle');
+    const dslFilter = JSON.stringify({
+      bool: { filter: [{ term: { 'kibana.alert.rule.name': alertName } }] },
+    });
+    await page.testSubj.click('addFilter');
+    await page.testSubj.click('editQueryDSL');
+    const dslTextarea = page.testSubj.locator('addFilterPopover').locator('textarea');
+    await dslTextarea.waitFor({ state: 'attached' });
+    await dslTextarea.click({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type(dslFilter);
+    await page.testSubj.click('saveFilter');
+    // A filter badge should now be present
+    await expect(page.locator('[data-test-subj="filter"]')).toHaveCount(1, { timeout: 5_000 });
+
+    try {
+      await page.testSubj.click('rulePageFooterSaveButton');
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        `Created rule "${alertName}"`,
+        { timeout: 15_000 }
+      );
+
+      // Re-open rule for editing and verify the DSL filter persists
+      await page.gotoApp('rules');
+      await page.testSubj.click('rulesTab');
+      await searchRules(page, alertName);
+      await page.testSubj.click('selectActionButton');
+      await page.testSubj.click('editRule');
+      await page.testSubj
+        .locator('ruleActionsItem')
+        .getByRole('button', { name: 'Settings' })
+        .click();
+      await page.testSubj.locator('globalQueryBar').scrollIntoViewIfNeeded();
+      // DSL filter badge should still be present
+      await expect(page.locator('[data-test-subj="filter"]')).toHaveCount(1, { timeout: 5_000 });
+    } finally {
+      await deleteRuleByName(kbnClient, alertName);
+    }
+  });
+
+  test('should create an alert with actions in multiple groups', async ({ page, kbnClient }) => {
+    const alertName = `scout-flyout-multigroup-${Date.now()}`;
+    await defineEsQueryAlert(page, alertName);
+
+    // Add Slack action for the default (active) group
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await selectConnectorInModal(page, slackConnectorName);
+    await page.testSubj.locator('messageTextArea').fill('test message');
+
+    // Switch to recovered group via settings
+    await page.testSubj
+      .locator('ruleActionsItem')
+      .getByRole('button', { name: 'Settings' })
+      .click();
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    // Add a second Slack action for the recovered group
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await selectConnectorInModal(page, slackConnectorName);
+    const allTextAreas = await page.testSubj.locator('messageTextArea').all();
+    await allTextAreas[allTextAreas.length - 1].fill('recovery message');
+
+    try {
+      await page.testSubj.click('rulePageFooterSaveButton');
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        `Created rule "${alertName}"`,
+        { timeout: 15_000 }
+      );
+
+      await page.gotoApp('rules');
+      await page.testSubj.click('rulesTab');
+      await searchRules(page, alertName);
+      const row = page.locator('[data-test-subj="rulesList"] tr').filter({ hasText: alertName });
+      await expect(row).toBeVisible();
+      await expect(row).toContainText('Elasticsearch query');
+      await expect(row).toContainText('1 min');
+    } finally {
+      await deleteRuleByName(kbnClient, alertName);
+    }
+  });
+
+  test('should show save confirmation before creating alert with no actions', async ({
+    page,
+    kbnClient,
+  }) => {
+    const alertName = `scout-flyout-confirm-${Date.now()}`;
+    await defineEsQueryAlert(page, alertName);
+
+    // Save with no actions → confirmation modal should appear
+    await page.testSubj.click('rulePageFooterSaveButton');
+    await expect(page.testSubj.locator('confirmCreateRuleModal')).toBeVisible({ timeout: 5_000 });
+
+    // Cancel → modal closes, save button re-enabled
+    await page.testSubj
+      .locator('confirmCreateRuleModal')
+      .locator('[data-test-subj="confirmModalCancelButton"]')
+      .click();
+    await expect(page.testSubj.locator('confirmCreateRuleModal')).toBeHidden();
+    await expect(page.testSubj.locator('rulePageFooterSaveButton')).toBeEnabled();
+
+    // Confirm save → rule created
+    await page.testSubj.click('rulePageFooterSaveButton');
+    await expect(page.testSubj.locator('confirmCreateRuleModal')).toBeVisible();
+    await page.testSubj
+      .locator('confirmCreateRuleModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]')
+      .click();
+    await expect(page.testSubj.locator('confirmCreateRuleModal')).toBeHidden();
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Created rule "${alertName}"`,
+      { timeout: 15_000 }
+    );
+
+    try {
+      await page.gotoApp('rules');
+      await page.testSubj.click('rulesTab');
+      await searchRules(page, alertName);
+      const row = page.locator('[data-test-subj="rulesList"] tr').filter({ hasText: alertName });
+      await expect(row).toBeVisible();
+      await expect(row).toContainText('Elasticsearch query');
+      await expect(row).toContainText('1 min');
+    } finally {
+      await deleteRuleByName(kbnClient, alertName);
+    }
+  });
 
   test('should show discard confirmation before closing flyout without saving', async ({
     page,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+//
+// 5 of 13 tests migrated. Skipped:
+//   - tests 1-4: require Slack#xyztest preconfigured connector
+//   - tests 5-6: require test.always-firing rule type (not registered in Scout stateful/classic)
+//   - test 11: requires apm.error_rate rule type (APM plugin not available in Scout stateful/classic)
+//   - test 13: requires filterBar.addDslFilter (no Scout equivalent)
+
+import type { ScoutPage } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, makeEsQueryRule } from '../fixtures';
+
+const searchRules = async (page: ScoutPage, query: string) => {
+  const field = page.testSubj.locator('ruleSearchField');
+  await field.fill(query);
+  await field.press('Enter');
+  await page
+    .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+    .waitFor();
+};
+
+const defineEsQueryAlert = async (page: ScoutPage, alertName: string) => {
+  await page.gotoApp('rules');
+  await page.testSubj.click('createRuleButton');
+  await page.testSubj.click('.es-query-SelectOption');
+  await page.testSubj.locator('ruleDetailsNameInput').fill(alertName);
+  await page.testSubj.click('queryFormType_esQuery');
+  await page.testSubj.click('selectIndexExpression');
+  const indexInput = page.testSubj.locator('thresholdIndexesComboBox').locator('input');
+  await indexInput.fill('.kibana');
+  await page.locator('[role="listbox"]').waitFor();
+  await page.locator('[role="listbox"] [role="option"]:first-child').click();
+  const timeFieldSelect = page.testSubj.locator('thresholdAlertTimeFieldSelect');
+  await timeFieldSelect.locator('option:nth-child(2)').waitFor();
+  await timeFieldSelect.selectOption({ index: 1 });
+  await page.testSubj.click('closePopover');
+  await page.testSubj.locator('ruleDetailsNameInput').click();
+};
+
+const setEditorValue = async (page: ScoutPage, testSubj: string, value: string) => {
+  const textarea = page.locator(`[data-test-subj="${testSubj}"] textarea`);
+  await textarea.waitFor({ state: 'attached' });
+  await textarea.click({ force: true });
+  await page.keyboard.press('Control+a');
+  await page.keyboard.type(value);
+};
+
+const cancelRuleCreation = async (page: ScoutPage) => {
+  const cancelBtn = page.testSubj.locator('rulePageFooterCancelButton');
+  if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await cancelBtn.click();
+    const confirmBtn = page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]');
+    if (await confirmBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  }
+};
+
+test.describe('Alert create flyout', { tag: tags.stateful.classic }, () => {
+  let esQueryRuleId: string;
+  let esQueryRuleName: string;
+
+  test.beforeAll(async ({ apiServices }) => {
+    const rule = makeEsQueryRule('scout-alert-flyout');
+    const resp = await apiServices.alerting.rules.create(rule);
+    esQueryRuleId = resp.data.id;
+    esQueryRuleName = resp.data.name;
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cancelRuleCreation(page);
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    if (esQueryRuleId) await apiServices.alerting.rules.delete(esQueryRuleId);
+  });
+
+  // Skipped: requires Slack#xyztest preconfigured connector (not available in Scout stateful/classic)
+  test.skip('should delete the right action when the same action has been added twice', async () => {});
+
+  test.skip('should create an alert', async () => {});
+
+  test.skip('should create an alert with composite query in filter for conditional action', async () => {});
+
+  test.skip('should create an alert with DSL filter for conditional action', async () => {});
+
+  // Skipped: requires test.always-firing rule type (not registered in Scout stateful/classic)
+  test.skip('should create an alert with actions in multiple groups', async () => {});
+
+  test.skip('should show save confirmation before creating alert with no actions', async () => {});
+
+  test('should show discard confirmation before closing flyout without saving', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.es-query-SelectOption');
+    await page.testSubj.click('rulePageFooterCancelButton');
+    await expect(page.testSubj.locator('confirmRuleCloseModal')).toBeHidden();
+
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.es-query-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill('alertName');
+    await page.testSubj.click('rulePageFooterCancelButton');
+    await expect(page.testSubj.locator('confirmRuleCloseModal')).toBeVisible();
+    await page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalCancelButton"]')
+      .click();
+    await expect(page.testSubj.locator('confirmRuleCloseModal')).toBeHidden();
+  });
+
+  test('should show error when es_query is invalid', async ({ page }) => {
+    const alertName = `scout-es-query-${Date.now()}`;
+    await defineEsQueryAlert(page, alertName);
+
+    await setEditorValue(page, 'queryJsonEditor', '{"query":{"foo":""}}');
+    await page.testSubj.click('testQuery');
+    await expect(page.testSubj.locator('testQuerySuccess')).toBeHidden();
+    await expect(page.testSubj.locator('testQueryError')).toBeVisible({ timeout: 15_000 });
+
+    await page.testSubj.click('rulePageFooterCancelButton');
+    const confirmBtn = page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]');
+    if (await confirmBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  });
+
+  test('should show KEEP command warning when creating a ES query rule with ESQL', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.es-query-SelectOption');
+    await page.testSubj.click('queryFormType_esqlQuery');
+
+    await setEditorValue(page, 'ESQLEditor', 'FROM *');
+    await page.keyboard.press('Escape');
+
+    await expect(page.testSubj.locator('ESQLEditor-footerPopoverButton-warning')).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.testSubj.click('ESQLEditor-footerPopoverButton-warning');
+    await expect(page.testSubj.locator('ESQLEditor-errors-warnings-content')).toContainText(
+      'KEEP processing command is recommended'
+    );
+
+    await setEditorValue(page, 'ESQLEditor', 'FROM * | KEEP @timestamp');
+    await page.keyboard.press('Escape');
+
+    await expect(page.testSubj.locator('ESQLEditor-errors-warnings-content')).toBeHidden({
+      timeout: 10_000,
+    });
+  });
+
+  test('should not show KEEP command warning when editing a ES query rule with ESQL', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('rulesTab');
+    await searchRules(page, esQueryRuleName);
+    await page.testSubj.click('selectActionButton');
+    await page.testSubj.click('editRule');
+
+    await page.testSubj.click('queryFormTypeChooserCancel');
+    await page.testSubj.click('queryFormType_esqlQuery');
+
+    await setEditorValue(page, 'ESQLEditor', 'FROM *');
+    await page.keyboard.press('Escape');
+
+    await page.waitForTimeout(2_000);
+
+    await expect(page.testSubj.locator('ESQLEditor-errors-warnings-content')).toBeHidden();
+  });
+
+  // Skipped: requires apm.error_rate rule type (APM plugin not available in Scout stateful/classic)
+  test.skip('should successfully show the APM error count rule flyout', async () => {});
+
+  test('should successfully test valid es_query alert', async ({ page }) => {
+    const alertName = `scout-es-query-${Date.now()}`;
+    await defineEsQueryAlert(page, alertName);
+
+    await setEditorValue(page, 'queryJsonEditor', '{"query":{"match_all":{}}}');
+    await page.testSubj.click('testQuery');
+    await expect(page.testSubj.locator('testQuerySuccess')).toBeVisible({ timeout: 15_000 });
+    await expect(page.testSubj.locator('testQueryError')).toBeHidden();
+
+    await page.testSubj.click('rulePageFooterCancelButton');
+    const confirmBtn = page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]');
+    if (await confirmBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  });
+
+  // Skipped: requires filterBar.addDslFilter (no Scout equivalent)
+  test.skip('should add filter', async () => {});
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/alert_create_flyout.spec.ts
@@ -8,9 +8,7 @@
 // Migrated from:
 //   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
 //
-// 11 of 13 tests migrated. Skipped:
-//   - test 11: requires apm.error_rate rule type (APM plugin not available in Scout stateful/classic)
-//   - test 13: requires filterBar.addDslFilter (no Scout equivalent)
+// 13 of 13 tests migrated.
 //
 // Substitutions from original:
 //   - Slack#xyztest → Slack connector created via API in beforeAll
@@ -602,8 +600,17 @@ test.describe('Alert create flyout', { tag: tags.stateful.classic }, () => {
     await expect(page.testSubj.locator('ESQLEditor-errors-warnings-content')).toBeHidden();
   });
 
-  // Skipped: requires apm.error_rate rule type (APM plugin not available in Scout stateful/classic)
-  test.skip('should successfully show the APM error count rule flyout', async () => {});
+  test('should successfully show the APM error count rule flyout', async ({ page }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('apm.error_rate-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`apm-error-${Date.now()}`);
+
+    await expect(page.testSubj.locator('apmServiceField')).toBeVisible({ timeout: 10_000 });
+    await expect(page.testSubj.locator('apmEnvironmentField')).toBeVisible();
+    await expect(page.testSubj.locator('apmErrorGroupingKeyField')).toBeVisible();
+    // afterEach cancelRuleCreation handles cleanup
+  });
 
   test('should successfully test valid es_query alert', async ({ page }) => {
     const alertName = `scout-es-query-${Date.now()}`;
@@ -623,6 +630,22 @@ test.describe('Alert create flyout', { tag: tags.stateful.classic }, () => {
     }
   });
 
-  // Skipped: requires filterBar.addDslFilter (no Scout equivalent)
-  test.skip('should add filter', async () => {});
+  test('should add filter', async ({ page }) => {
+    await page.gotoApp('triggersActionsAlerts');
+
+    const filter = JSON.stringify({
+      bool: { filter: [{ term: { 'kibana.alert.status': 'active' } }] },
+    });
+
+    await page.testSubj.click('addFilter');
+    await page.testSubj.click('editQueryDSL');
+    const dslTextarea = page.testSubj.locator('addFilterPopover').locator('textarea');
+    await dslTextarea.waitFor({ state: 'attached' });
+    await dslTextarea.click({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type(filter);
+    await page.testSubj.click('saveFilter');
+
+    await expect(page.locator('[data-test-subj="filter"]')).toHaveCount(1, { timeout: 5_000 });
+  });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_email.spec.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from: x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/email.ts
+//
+// Test 1 (ses defaults) uses EuiSelect (native <select>) — selectOption() works.
+// Tests 2-6 (recipient validation) create a connector via API and exercise the
+// test tab's To/Cc/Bcc validation logic.
+
+import type { KbnClient, ScoutPage } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, CONNECTORS_APP_PATH, CONNECTORS_LIST_SELECTORS } from '../fixtures';
+
+const createEmailConnector = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/actions/connector',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      connector_type_id: '.email',
+      config: { service: '__json', from: 'me@example.com', hasAuth: false },
+      secrets: {},
+    },
+  });
+  return resp.data;
+};
+
+const deleteConnector = async (kbnClient: KbnClient, id: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/api/actions/connector/${id}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+const openTestTab = async (page: ScoutPage, connectorName: string) => {
+  const searchBox = page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT);
+  await searchBox.fill(connectorName);
+  await searchBox.press('Enter');
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+  await page.locator('[data-test-subj="connectorsTableCell-name"] button').click();
+  await page.testSubj.click('testConnectorTab');
+  await page.testSubj.locator('test-connector-form').waitFor({ state: 'visible' });
+};
+
+const fillSubjectAndMessage = async (page: ScoutPage) => {
+  await page.testSubj.locator('subjectInput').fill('test subject');
+  await page.testSubj.locator('messageTextArea').fill('test message');
+};
+
+const closeFlyout = async (page: ScoutPage) => {
+  await page.testSubj.click('edit-connector-flyout-close-btn');
+  const confirmBtn = page.testSubj.locator('confirmModalConfirmButton');
+  if (await confirmBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await confirmBtn.click();
+  }
+  await expect(page.testSubj.locator('edit-connector-flyout-close-btn')).toBeHidden();
+};
+
+test.describe('Email connector', { tag: tags.stateful.classic }, () => {
+  test('should use the kibana config for aws ses defaults', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+    await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+
+    await page.testSubj.click('createConnectorButton');
+    await page.testSubj.click('.email-card');
+    await page.testSubj.locator('emailServiceSelectInput').selectOption('ses');
+
+    await expect(page.testSubj.locator('emailHostInput')).toHaveValue(
+      'email-smtp.us-east-1.amazonaws.com',
+      { timeout: 10_000 }
+    );
+    await expect(page.testSubj.locator('emailPortInput')).toHaveValue('465');
+    await expect(page.testSubj.locator('emailSecureSwitch')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+
+    await page.testSubj.click('euiFlyoutCloseButton');
+  });
+
+  test('disables Run and shows recipients-required error when To/Cc/Bcc are all empty', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-email-${Date.now()}`;
+    const { id: connectorId } = await createEmailConnector(kbnClient, connectorName);
+
+    try {
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+      await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+      await openTestTab(page, connectorName);
+      await fillSubjectAndMessage(page);
+
+      // Touch and blur the To combobox to surface the field-level error
+      await page.testSubj.locator('toEmailAddressInput').locator('input').click();
+      await page.testSubj.click('edit-connector-flyout-header');
+
+      await expect(page.locator('.euiFormErrorText')).toContainText(
+        'At least one recipient is required.'
+      );
+      await expect(page.testSubj.locator('executeActionButton')).toBeDisabled();
+
+      await closeFlyout(page);
+    } finally {
+      await deleteConnector(kbnClient, connectorId);
+    }
+  });
+
+  test('disables Run when the only To entry is whitespace', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-email-${Date.now()}`;
+    const { id: connectorId } = await createEmailConnector(kbnClient, connectorName);
+
+    try {
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+      await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+      await openTestTab(page, connectorName);
+      await fillSubjectAndMessage(page);
+
+      const toInput = page.testSubj.locator('toEmailAddressInput').locator('input');
+      await toInput.fill('   ');
+      await toInput.press('Enter');
+      await page.testSubj.click('edit-connector-flyout-header');
+
+      await expect(page.locator('.euiFormErrorText')).toContainText(
+        'At least one recipient is required.'
+      );
+      await expect(page.testSubj.locator('executeActionButton')).toBeDisabled();
+
+      await closeFlyout(page);
+    } finally {
+      await deleteConnector(kbnClient, connectorId);
+    }
+  });
+
+  test('shows invalid email error for address with leading hyphen in local part', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-email-${Date.now()}`;
+    const { id: connectorId } = await createEmailConnector(kbnClient, connectorName);
+
+    try {
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+      await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+      await openTestTab(page, connectorName);
+      await fillSubjectAndMessage(page);
+
+      const toInput = page.testSubj.locator('toEmailAddressInput').locator('input');
+      await toInput.fill('-user@example.com');
+      await toInput.press('Enter');
+      await page.testSubj.click('edit-connector-flyout-header');
+
+      await expect(page.locator('.euiFormErrorText')).toContainText('is not valid');
+
+      await closeFlyout(page);
+    } finally {
+      await deleteConnector(kbnClient, connectorId);
+    }
+  });
+
+  test('shows invalid email error for address with leading hyphen in domain', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-email-${Date.now()}`;
+    const { id: connectorId } = await createEmailConnector(kbnClient, connectorName);
+
+    try {
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+      await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+      await openTestTab(page, connectorName);
+      await fillSubjectAndMessage(page);
+
+      const toInput = page.testSubj.locator('toEmailAddressInput').locator('input');
+      await toInput.fill('user@-example.com');
+      await toInput.press('Enter');
+      await page.testSubj.click('edit-connector-flyout-header');
+
+      await expect(page.locator('.euiFormErrorText')).toContainText('is not valid');
+
+      await closeFlyout(page);
+    } finally {
+      await deleteConnector(kbnClient, connectorId);
+    }
+  });
+
+  test('clears recipients-required error when only Cc has a valid recipient', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-email-${Date.now()}`;
+    const { id: connectorId } = await createEmailConnector(kbnClient, connectorName);
+
+    try {
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+      await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+      await openTestTab(page, connectorName);
+      await fillSubjectAndMessage(page);
+
+      // Trigger the recipients-required error
+      await page.testSubj.locator('toEmailAddressInput').locator('input').click();
+      await page.testSubj.click('edit-connector-flyout-header');
+      await expect(page.locator('.euiFormErrorText')).toContainText(
+        'At least one recipient is required.'
+      );
+
+      // Adding a valid Cc address must clear the error from all fields
+      await page.testSubj.click('emailAddCcButton');
+      const ccInput = page.testSubj.locator('ccEmailAddressInput').locator('input');
+      await ccInput.fill('cc@example.com');
+      await ccInput.press('Enter');
+
+      await expect(page.locator('.euiFormErrorText')).not.toContainText(
+        'At least one recipient is required.'
+      );
+
+      await closeFlyout(page);
+    } finally {
+      await deleteConnector(kbnClient, connectorId);
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
@@ -421,8 +421,25 @@ test.describe('General connector functionality', { tag: tags.stateful.classic },
     ).toBeDisabled();
   });
 
-  // Skipped: requires preconfigured 'test-preconfigured-email' connector not available in Scout.
-  test.skip('should not be able to edit a preconfigured connector', async () => {});
+  test('should not be able to edit a preconfigured connector', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await navigateAndWait(page, kbnUrl);
+    await searchConnector(page, 'test-preconfigured-email');
+
+    await expect(page.testSubj.locator('connectors-row')).toHaveCount(1);
+    await expect(page.testSubj.locator('preConfiguredTitleMessage')).toBeVisible();
+
+    await page.locator('[data-test-subj="connectorsTableCell-name"] button').click();
+
+    await expect(page.testSubj.locator('preconfiguredBadge')).toBeVisible();
+    await expect(page.testSubj.locator('edit-connector-flyout-save-btn')).toBeHidden();
+
+    await page.testSubj.click('euiFlyoutCloseButton');
+  });
 
   // Skipped: requires test.always-firing rule type via createRuleWithActionsAndParams.
   test.skip('Execution log - renders the event log list and can filter/sort', async () => {});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
@@ -404,8 +404,22 @@ test.describe('General connector functionality', { tag: tags.stateful.classic },
     }
   });
 
-  // Skipped: requires preconfigured 'Serverlog' connector not available in Scout stateful/classic.
-  test.skip('should not be able to delete a preconfigured connector', async () => {});
+  test('should not be able to delete a preconfigured connector', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await navigateAndWait(page, kbnUrl);
+    await searchConnector(page, 'Serverlog');
+
+    await expect(page.testSubj.locator('connectors-row')).toHaveCount(1);
+    await expect(page.testSubj.locator('deleteConnector')).toBeHidden();
+    await expect(page.testSubj.locator('preConfiguredTitleMessage')).toBeVisible();
+    await expect(
+      page.locator('[data-test-subj="checkboxSelectRow-preconfigured_my-server-log"]')
+    ).toBeDisabled();
+  });
 
   // Skipped: requires preconfigured 'test-preconfigured-email' connector not available in Scout.
   test.skip('should not be able to edit a preconfigured connector', async () => {});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
@@ -8,10 +8,7 @@
 // Migrated from:
 //   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/general.ts
 //
-// 10 of 13 tests migrated. Skipped:
-//   - "should not be able to delete a preconfigured connector": requires preconfigured 'Serverlog'
-//   - "should not be able to edit a preconfigured connector": requires 'test-preconfigured-email'
-//   - "Execution log": requires test.always-firing via createRuleWithActionsAndParams
+// 13 of 13 tests migrated.
 
 import { v4 as uuidv4 } from 'uuid';
 import type { KbnClient, ScoutPage } from '@kbn/scout';
@@ -441,6 +438,153 @@ test.describe('General connector functionality', { tag: tags.stateful.classic },
     await page.testSubj.click('euiFlyoutCloseButton');
   });
 
-  // Skipped: requires test.always-firing rule type via createRuleWithActionsAndParams.
-  test.skip('Execution log - renders the event log list and can filter/sort', async () => {});
+  test('Execution log - renders the event log list and can filter/sort', async ({
+    browserAuth,
+    page,
+    kbnClient,
+    pageObjects,
+  }) => {
+    await browserAuth.loginAsAdmin();
+
+    // Create an ES query rule that always executes (substitute for test.always-firing)
+    const ruleName = `scout-exec-log-${Date.now()}`;
+    const createResp = await kbnClient.request<{ id: string }>({
+      method: 'POST',
+      path: '/api/alerting/rule',
+      headers: { 'kbn-xsrf': 'scout' },
+      body: {
+        name: ruleName,
+        rule_type_id: '.es-query',
+        consumer: 'stackAlerts',
+        params: {
+          searchType: 'esQuery',
+          timeWindowSize: 5,
+          timeWindowUnit: 'm',
+          threshold: [0],
+          thresholdComparator: '>=',
+          size: 100,
+          esQuery: '{"query":{"match_all":{}}}',
+          aggType: 'count',
+          groupBy: 'all',
+          termSize: 5,
+          excludeHitsFromPreviousRun: false,
+          sourceFields: [],
+          index: ['.kibana'],
+          timeField: '@timestamp',
+        },
+        schedule: { interval: '1m' },
+        tags: ['scout-exec-log'],
+        actions: [],
+        enabled: true,
+      },
+    });
+    const ruleId = createResp.data.id;
+
+    try {
+      // Trigger an immediate run
+      await kbnClient.request({
+        method: 'POST',
+        path: `/internal/alerting/rule/${ruleId}/_run_soon`,
+        headers: { 'kbn-xsrf': 'scout' },
+      });
+
+      // Poll execution log until at least 1 execution appears (max 30s)
+      const dateStart = new Date();
+      const pollEnd = Date.now() + 30_000;
+      let hasExecutions = false;
+      while (!hasExecutions && Date.now() < pollEnd) {
+        await page.waitForTimeout(1_000);
+        try {
+          const logResp = await kbnClient.request<{ total: number }>({
+            method: 'GET',
+            path: `/internal/alerting/rule/${ruleId}/_execution_log`,
+            headers: {},
+            query: { date_start: dateStart.toISOString() },
+          });
+          hasExecutions = logResp.data.total > 0;
+        } catch {
+          // keep polling
+        }
+      }
+
+      // Navigate to rule details and click Logs tab
+      await pageObjects.ruleDetailsPage.gotoById(ruleId);
+      await page.testSubj.click('logsTab');
+
+      // Guard: if tabbed content is not present, the test cannot proceed (matches FTR guard)
+      if (
+        !(await page.testSubj
+          .locator('ruleDetailsTabbedContent')
+          .isVisible({ timeout: 2_000 })
+          .catch(() => false))
+      ) {
+        return;
+      }
+
+      // Allow entries to accumulate then refresh
+      await page.waitForTimeout(5_000);
+      await page.testSubj.click('superDatePickerApplyTimeButton');
+
+      // Event log list and status filter both exist
+      await expect(page.testSubj.locator('eventLogList')).toBeVisible({ timeout: 10_000 });
+      await expect(page.testSubj.locator('eventLogStatusFilterButton')).toBeVisible();
+
+      // Status badge starts at 0 (no filters active)
+      const statusBadge = page.testSubj
+        .locator('eventLogStatusFilterButton')
+        .locator('.euiNotificationBadge');
+      await expect(statusBadge).toHaveText('0');
+
+      // Enable "success" filter
+      await page.testSubj.click('eventLogStatusFilterButton');
+      await page.testSubj.click('eventLogStatusFilter-success');
+      await page.testSubj.click('eventLogStatusFilterButton');
+
+      // Status badge now shows 1 active filter
+      await expect(statusBadge).toHaveText('1');
+
+      // At least one data row exists
+      await expect(page.locator('.euiDataGridRow')).not.toHaveCount(0, { timeout: 10_000 });
+
+      // Ensure timestamp column is visible
+      await page.testSubj.click('dataGridColumnSelectorButton');
+      const colToggle = page.testSubj.locator(
+        'dataGridColumnSelectorToggleColumnVisibility-timestamp'
+      );
+      if ((await colToggle.getAttribute('aria-checked')) === 'false') {
+        await colToggle.click();
+      }
+      await page.testSubj.click('dataGridColumnSelectorButton');
+
+      // At least one timestamp cell must contain a valid date
+      const timestampCells = await page
+        .locator('[data-gridcell-column-id="timestamp"][data-test-subj="dataGridRowCell"]')
+        .all();
+      let validTimestamps = 0;
+      for (const cell of timestampCells) {
+        const text = await cell.innerText();
+        if (text.toLowerCase() !== 'invalid date' && !isNaN(Date.parse(text))) {
+          validTimestamps++;
+        }
+      }
+      expect(validTimestamps).toBeGreaterThan(0);
+
+      // Sort ascending: open column action menu, click 2nd button (index 1 = ascending)
+      await page.testSubj.locator('dataGridHeaderCell-timestamp').hover();
+      await page.testSubj.click('dataGridHeaderCellActionButton-timestamp');
+      await page.testSubj.locator('dataGridHeaderCellActionGroup-timestamp').waitFor();
+      await page.testSubj
+        .locator('dataGridHeaderCellActionGroup-timestamp')
+        .locator('li:nth-child(2) button')
+        .click();
+
+      await expect(page.testSubj.locator('dataGridHeaderCellSortingIcon-timestamp')).toBeVisible();
+    } finally {
+      await kbnClient.request({
+        method: 'DELETE',
+        path: `/internal/alerting/rule/${ruleId}`,
+        headers: { 'kbn-xsrf': 'scout' },
+      });
+    }
+  });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_general.spec.ts
@@ -1,0 +1,415 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/general.ts
+//
+// 10 of 13 tests migrated. Skipped:
+//   - "should not be able to delete a preconfigured connector": requires preconfigured 'Serverlog'
+//   - "should not be able to edit a preconfigured connector": requires 'test-preconfigured-email'
+//   - "Execution log": requires test.always-firing via createRuleWithActionsAndParams
+
+import { v4 as uuidv4 } from 'uuid';
+import type { KbnClient, ScoutPage } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, CONNECTORS_APP_PATH, CONNECTORS_LIST_SELECTORS } from '../fixtures';
+
+interface MonacoBridge {
+  MonacoEnvironment?: {
+    monaco?: {
+      editor?: { getModels: () => Array<{ setValue: (s: string) => void }> };
+    };
+  };
+}
+
+const setMonacoValue = async (page: ScoutPage, value: string) => {
+  await page.testSubj.locator('kibanaCodeEditor').waitFor({ state: 'visible' });
+  await page.evaluate((v) => {
+    const editor = (window as unknown as MonacoBridge).MonacoEnvironment?.monaco?.editor;
+    if (!editor) throw new Error('MonacoEnvironment.monaco.editor not available');
+    editor.getModels().forEach((m) => m.setValue(v));
+  }, value);
+};
+
+const createSlackConnectorApi = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/actions/connector',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      connector_type_id: '.slack',
+      config: {},
+      secrets: {
+        webhookUrl: 'https://example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX',
+      },
+    },
+  });
+  return resp.data;
+};
+
+const createIndexConnectorApi = async (kbnClient: KbnClient, name: string, indexName: string) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/actions/connector',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      connector_type_id: '.index',
+      config: { index: indexName, refresh: false },
+      secrets: {},
+    },
+  });
+  return resp.data;
+};
+
+const deleteConnectorApi = async (kbnClient: KbnClient, id: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/api/actions/connector/${id}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+const navigateAndWait = async (page: ScoutPage, kbnUrl: { get: (p: string) => string }) => {
+  await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+};
+
+const searchConnector = async (page: ScoutPage, name: string) => {
+  const searchBox = page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT);
+  await searchBox.fill(name);
+  await searchBox.press('Enter');
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+};
+
+const openConnectorFlyout = async (page: ScoutPage) => {
+  await page.locator('[data-test-subj="connectorsTableCell-name"] button').click();
+};
+
+test.describe('General connector functionality', { tag: tags.stateful.classic }, () => {
+  test('should create a connector', async ({ browserAuth, page, kbnUrl, kbnClient }) => {
+    await browserAuth.loginAsAdmin();
+    await navigateAndWait(page, kbnUrl);
+
+    const connectorName = `scout-slack-${uuidv4().slice(0, 8)}`;
+
+    await page.testSubj.click('createConnectorButton');
+    await page.testSubj.click('.index-card');
+    await page.locator('[data-test-subj="create-connector-flyout-back-btn"]').click();
+    await page.testSubj.click('.slack-card');
+
+    await page.testSubj.locator('nameInput').fill(connectorName);
+    await page.testSubj.locator('slackWebhookUrlInput').fill('https://test.com');
+
+    await page
+      .locator('[data-test-subj="create-connector-flyout-save-btn"]:not([disabled])')
+      .click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Created '${connectorName}'`
+    );
+
+    await searchConnector(page, connectorName);
+    const row = page.testSubj.locator('connectors-row');
+    await expect(row.getByTestId('connectorsTableCell-name')).toContainText(connectorName);
+    await expect(row.getByTestId('connectorsTableCell-actionType')).toContainText('Slack');
+
+    // Cleanup
+    const all = (
+      await kbnClient.request<Array<{ id: string; name: string }>>({
+        method: 'GET',
+        path: '/api/actions/connectors',
+        headers: {},
+      })
+    ).data;
+    const created = all.find((c) => c.name === connectorName);
+    if (created) await deleteConnectorApi(kbnClient, created.id);
+  });
+
+  test('should create a connector with a custom user-defined ID', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await navigateAndWait(page, kbnUrl);
+
+    const connectorName = `scout-slack-${uuidv4().slice(0, 8)}`;
+    const customId = `custom-${uuidv4().slice(0, 28)}`;
+
+    await page.testSubj.click('createConnectorButton');
+    await page.testSubj.click('.slack-card');
+
+    await page.testSubj.locator('nameInput').fill(connectorName);
+    await page.testSubj.locator('connectorIdInput').fill(customId);
+    await page.testSubj.locator('slackWebhookUrlInput').fill('https://test.com');
+
+    await page
+      .locator('[data-test-subj="create-connector-flyout-save-btn"]:not([disabled])')
+      .click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Created '${connectorName}'`
+    );
+
+    // Verify the connector was created with the custom ID
+    const all = (
+      await kbnClient.request<Array<{ id: string; name: string }>>({
+        method: 'GET',
+        path: '/api/actions/connectors',
+        headers: {},
+      })
+    ).data;
+    const created = all.find((c) => c.name === connectorName);
+    expect(created?.id).toStrictEqual(customId);
+
+    if (created) await deleteConnectorApi(kbnClient, created.id);
+  });
+
+  test('should auto-populate connector ID from name', async ({ browserAuth, page, kbnUrl }) => {
+    await browserAuth.loginAsAdmin();
+    await navigateAndWait(page, kbnUrl);
+
+    await page.testSubj.click('createConnectorButton');
+    await page.testSubj.click('.slack-card');
+
+    await page.testSubj.locator('nameInput').fill('My Test Connector');
+
+    await expect(page.testSubj.locator('connectorIdInput')).toHaveValue('my-test-connector');
+
+    await page.testSubj.click('euiFlyoutCloseButton');
+  });
+
+  test('should show connector ID as disabled when editing an existing connector', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-slack-${Date.now()}`;
+    const { id: connectorId } = await createSlackConnectorApi(kbnClient, connectorName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await openConnectorFlyout(page);
+
+      await expect(page.testSubj.locator('connectorIdInput')).toBeDisabled();
+      await expect(page.testSubj.locator('connectorIdInput')).toHaveValue(connectorId);
+
+      await page.testSubj.click('euiFlyoutCloseButton');
+    } finally {
+      await deleteConnectorApi(kbnClient, connectorId);
+    }
+  });
+
+  test('should edit a connector', async ({ browserAuth, page, kbnUrl, kbnClient }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-slack-${Date.now()}`;
+    const updatedName = `${connectorName}-updated`;
+    const { id: connectorId } = await createSlackConnectorApi(kbnClient, connectorName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await openConnectorFlyout(page);
+
+      await page.testSubj.locator('nameInput').fill(updatedName);
+      await page.testSubj.locator('slackWebhookUrlInput').fill('https://test.com');
+
+      await page
+        .locator('[data-test-subj="edit-connector-flyout-save-btn"]:not([disabled])')
+        .click();
+
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        `Updated '${updatedName}'`
+      );
+
+      await page.testSubj.click('euiFlyoutCloseButton');
+
+      await searchConnector(page, updatedName);
+      const row = page.testSubj.locator('connectors-row');
+      await expect(row.getByTestId('connectorsTableCell-name')).toContainText(updatedName);
+      await expect(row.getByTestId('connectorsTableCell-actionType')).toContainText('Slack');
+    } finally {
+      await deleteConnectorApi(kbnClient, connectorId);
+    }
+  });
+
+  test('should test a connector and display a successful result', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-index-${Date.now()}`;
+    const indexName = `scout-idx-${Date.now()}`;
+    const { id: connectorId } = await createIndexConnectorApi(kbnClient, connectorName, indexName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await openConnectorFlyout(page);
+
+      await page.testSubj.click('testConnectorTab');
+      await page.testSubj.locator('executeActionButton').waitFor({ state: 'visible' });
+
+      await setMonacoValue(page, '{ "key": "value" }');
+      await page.locator('[data-test-subj="executeActionButton"]:not([disabled])').click();
+
+      await expect(page.testSubj.locator('executionSuccessfulResult')).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page
+        .locator('[data-test-subj="edit-connector-flyout-close-btn"]:not([disabled])')
+        .click();
+    } finally {
+      await deleteConnectorApi(kbnClient, connectorId);
+    }
+  });
+
+  test('should test a connector and display a failure result', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-index-${Date.now()}`;
+    const indexName = `scout-idx-${Date.now()}`;
+    const { id: connectorId } = await createIndexConnectorApi(kbnClient, connectorName, indexName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await openConnectorFlyout(page);
+
+      await page.testSubj.click('testConnectorTab');
+      await page.testSubj.locator('executeActionButton').waitFor({ state: 'visible' });
+
+      await setMonacoValue(page, '"test"');
+      await page.locator('[data-test-subj="executeActionButton"]:not([disabled])').click();
+
+      await expect(page.testSubj.locator('executionFailureResult')).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page
+        .locator('[data-test-subj="edit-connector-flyout-close-btn"]:not([disabled])')
+        .click();
+    } finally {
+      await deleteConnectorApi(kbnClient, connectorId);
+    }
+  });
+
+  test('should reset connector when canceling an edit', async ({
+    browserAuth,
+    page,
+    kbnUrl,
+    kbnClient,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-slack-${Date.now()}`;
+    const { id: connectorId } = await createSlackConnectorApi(kbnClient, connectorName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await openConnectorFlyout(page);
+
+      await page.testSubj.locator('nameInput').fill('some test name to cancel');
+      await page.testSubj.click('edit-connector-flyout-close-btn');
+      await page.testSubj.click('confirmModalConfirmButton');
+
+      await expect(page.testSubj.locator('edit-connector-flyout-close-btn')).toBeHidden();
+
+      await searchConnector(page, connectorName);
+      await openConnectorFlyout(page);
+
+      await expect(page.testSubj.locator('nameInput')).toHaveValue(connectorName);
+      await page.testSubj.click('euiFlyoutCloseButton');
+    } finally {
+      await deleteConnectorApi(kbnClient, connectorId);
+    }
+  });
+
+  test('should delete a connector', async ({ browserAuth, page, kbnUrl, kbnClient }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-slack-del-${Date.now()}`;
+    const keepConnectorName = `scout-slack-keep-${Date.now()}`;
+    const { id: keepId } = await createSlackConnectorApi(kbnClient, keepConnectorName);
+    await createSlackConnectorApi(kbnClient, connectorName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await expect(page.testSubj.locator('connectors-row')).toHaveCount(1);
+
+      await page.testSubj.click('deleteConnector');
+      await page.testSubj
+        .locator('deleteIdsConfirmation')
+        .locator('[data-test-subj="confirmModalConfirmButton"]')
+        .click();
+      await expect(page.testSubj.locator('deleteIdsConfirmation')).toBeHidden();
+
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        'Deleted 1 connector'
+      );
+
+      await searchConnector(page, connectorName);
+      await expect(page.testSubj.locator('connectors-row')).toHaveCount(0);
+    } finally {
+      await deleteConnectorApi(kbnClient, keepId);
+    }
+  });
+
+  test('should bulk delete connectors', async ({ browserAuth, page, kbnUrl, kbnClient }) => {
+    await browserAuth.loginAsAdmin();
+    const connectorName = `scout-slack-bulk-${Date.now()}`;
+    const keepConnectorName = `scout-slack-keep-${Date.now()}`;
+    const { id: keepId } = await createSlackConnectorApi(kbnClient, keepConnectorName);
+    await createSlackConnectorApi(kbnClient, connectorName);
+
+    try {
+      await navigateAndWait(page, kbnUrl);
+      await searchConnector(page, connectorName);
+      await expect(page.testSubj.locator('connectors-row')).toHaveCount(1);
+
+      await page.locator('.euiTableRowCellCheckbox .euiCheckbox__input').click();
+      await page.testSubj.click('bulkDelete');
+      await page.testSubj
+        .locator('deleteIdsConfirmation')
+        .locator('[data-test-subj="confirmModalConfirmButton"]')
+        .click();
+      await expect(page.testSubj.locator('deleteIdsConfirmation')).toBeHidden();
+
+      await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+        'Deleted 1 connector'
+      );
+
+      await searchConnector(page, connectorName);
+      await expect(page.testSubj.locator('connectors-row')).toHaveCount(0);
+    } finally {
+      await deleteConnectorApi(kbnClient, keepId);
+    }
+  });
+
+  // Skipped: requires preconfigured 'Serverlog' connector not available in Scout stateful/classic.
+  test.skip('should not be able to delete a preconfigured connector', async () => {});
+
+  // Skipped: requires preconfigured 'test-preconfigured-email' connector not available in Scout.
+  test.skip('should not be able to edit a preconfigured connector', async () => {});
+
+  // Skipped: requires test.always-firing rule type via createRuleWithActionsAndParams.
+  test.skip('Execution log - renders the event log list and can filter/sort', async () => {});
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_jsm.spec.ts
@@ -1,0 +1,542 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/jsm.ts
+//
+// All 19 tests migrated. Nested describes are flattened (max describe depth = 1).
+// `jsm-subActionSelect` and `jsm-prioritySelect` are native <select> elements.
+// Monaco JSON editor is driven via MonacoEnvironment.monaco.editor API.
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ScoutPage } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, CONNECTORS_APP_PATH, CONNECTORS_LIST_SELECTORS } from '../fixtures';
+
+interface MonacoBridge {
+  MonacoEnvironment?: {
+    monaco?: {
+      editor?: {
+        getModels: () => Array<{ getValue: () => string; setValue: (s: string) => void }>;
+      };
+    };
+  };
+}
+
+const setMonacoValue = async (page: ScoutPage, value: string) => {
+  await page.testSubj.locator('kibanaCodeEditor').waitFor({ state: 'visible' });
+  await page.evaluate((v) => {
+    const editor = (window as unknown as MonacoBridge).MonacoEnvironment?.monaco?.editor;
+    if (!editor) throw new Error('MonacoEnvironment.monaco.editor not available');
+    editor.getModels().forEach((m) => m.setValue(v));
+  }, value);
+};
+
+const getMonacoValue = async (page: ScoutPage): Promise<string> => {
+  await page.testSubj.locator('kibanaCodeEditor').waitFor({ state: 'visible' });
+  return page.evaluate(() => {
+    const editor = (window as unknown as MonacoBridge).MonacoEnvironment?.monaco?.editor;
+    return editor?.getModels()?.[0]?.getValue() ?? '';
+  });
+};
+
+const navigateToConnectors = async (page: ScoutPage, kbnUrl: { get: (p: string) => string }) => {
+  await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+};
+
+const searchAndOpenConnector = async (page: ScoutPage, name: string) => {
+  const searchBox = page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT);
+  await searchBox.fill(name);
+  await searchBox.press('Enter');
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+  await page.locator('[data-test-subj="connectorsTableCell-name"] button').click();
+};
+
+const openJsmTestTab = async (page: ScoutPage, connectorId: string) => {
+  await page.testSubj.click(`edit${connectorId}`);
+  await page.testSubj.click('testConnectorTab');
+  await page.testSubj.locator('jsm-subActionSelect').waitFor({ state: 'visible', timeout: 10_000 });
+};
+
+const closeFlyoutIfOpen = async (page: ScoutPage) => {
+  const closeBtn = page.testSubj.locator('edit-connector-flyout-close-btn');
+  if (await closeBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await closeBtn.click();
+    const confirmBtn = page.testSubj.locator('confirmModalConfirmButton');
+    if (await confirmBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  }
+};
+
+const fillIndexThresholdForm = async (page: ScoutPage) => {
+  await page.testSubj.click('selectIndexExpression');
+  const indexInput = page.testSubj.locator('thresholdIndexesComboBox').locator('input');
+  await indexInput.fill('.kibana');
+  await page.locator('[role="listbox"]').waitFor();
+  await page.locator('[role="listbox"] [role="option"]:first-child').click();
+  const timeFieldSelect = page.testSubj.locator('thresholdAlertTimeFieldSelect');
+  await timeFieldSelect.locator('option:nth-child(2)').waitFor();
+  await timeFieldSelect.selectOption({ index: 1 });
+  await page.testSubj.click('closePopover');
+};
+
+const cancelRuleCreation = async (page: ScoutPage) => {
+  const cancelBtn = page.testSubj.locator('rulePageFooterCancelButton');
+  if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await cancelBtn.click();
+    const confirmBtn = page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]');
+    if (await confirmBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  }
+};
+
+test.describe('Jira Service Management connector', { tag: tags.stateful.classic }, () => {
+  const createdConnectorIds: string[] = [];
+  let testPageConnectorId: string;
+  let alertsConnectorName: string;
+
+  test.beforeAll(async ({ apiServices }) => {
+    // Connector for test-page tests
+    const testConnector = await apiServices.alerting.connectors.create({
+      name: `jsm-test-page-${Date.now()}`,
+      connectorTypeId: '.jira-service-management',
+      config: { apiUrl: 'https://test.atlassian.net' },
+      secrets: { apiKey: '1234' },
+    });
+    testPageConnectorId = testConnector.id;
+    createdConnectorIds.push(testPageConnectorId);
+
+    // Connector for alerts-page tests
+    alertsConnectorName = `jsm-alerts-${Date.now()}`;
+    const alertsConnector = await apiServices.alerting.connectors.create({
+      name: alertsConnectorName,
+      connectorTypeId: '.jira-service-management',
+      config: { apiUrl: 'https://test.atlassian.net' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(alertsConnector.id);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cancelRuleCreation(page);
+    await closeFlyoutIfOpen(page);
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    await Promise.allSettled(
+      createdConnectorIds.map((id) => apiServices.alerting.connectors.delete(id))
+    );
+    createdConnectorIds.length = 0;
+  });
+
+  // ── connector page ────────────────────────────────────────────────────────
+
+  test('connector page - should create the connector', async ({ page, kbnUrl, apiServices }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `jsm-create-${uuidv4().slice(0, 8)}`;
+
+    await page.testSubj.click('createConnectorButton');
+    await page.testSubj.click('.jira-service-management-card');
+    await page.testSubj.locator('nameInput').fill(connectorName);
+    await page.testSubj.locator('config\\.apiUrl-input').fill('https://test.atlassian.net');
+    await page.testSubj.locator('secrets\\.apiKey-input').fill('apiKey');
+    await page
+      .locator('[data-test-subj="create-connector-flyout-save-btn"]:not([disabled])')
+      .click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Created '${connectorName}'`
+    );
+
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).fill(connectorName);
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).press('Enter');
+    await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+
+    const row = page.testSubj.locator('connectors-row');
+    await expect(row.getByTestId('connectorsTableCell-actionType')).toContainText(
+      'Jira Service Management'
+    );
+
+    // Find and track created connector for cleanup
+    const all = await apiServices.alerting.connectors.getAll();
+    const created = (all as Array<{ id: string; name: string }>).find(
+      (c) => c.name === connectorName
+    );
+    if (created) createdConnectorIds.push(created.id);
+  });
+
+  test('connector page - should edit the connector', async ({ page, kbnUrl, apiServices }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `jsm-edit-${Date.now()}`;
+    const updatedName = `${connectorName}-updated`;
+    const created = await apiServices.alerting.connectors.create({
+      name: connectorName,
+      connectorTypeId: '.jira-service-management',
+      config: { apiUrl: 'https://test.atlassian.net' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(created.id);
+
+    await searchAndOpenConnector(page, connectorName);
+    await page.testSubj.locator('nameInput').fill(updatedName);
+    await page.testSubj.locator('secrets\\.apiKey-input').fill('apiKey');
+    await page.locator('[data-test-subj="edit-connector-flyout-save-btn"]:not([disabled])').click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Updated '${updatedName}'`
+    );
+
+    await page.testSubj.click('euiFlyoutCloseButton');
+
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).fill(updatedName);
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).press('Enter');
+    await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+    await expect(page.testSubj.locator('connectors-row')).toHaveCount(1);
+  });
+
+  test('connector page - should reset connector when canceling an edit', async ({
+    page,
+    kbnUrl,
+    apiServices,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `jsm-cancel-${Date.now()}`;
+    const created = await apiServices.alerting.connectors.create({
+      name: connectorName,
+      connectorTypeId: '.jira-service-management',
+      config: { apiUrl: 'https://test.atlassian.net' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(created.id);
+
+    await searchAndOpenConnector(page, connectorName);
+    await page.testSubj.locator('nameInput').fill('some test name to cancel');
+    await page.testSubj.click('edit-connector-flyout-close-btn');
+    await page.testSubj.click('confirmModalConfirmButton');
+    await expect(page.testSubj.locator('edit-connector-flyout-close-btn')).toBeHidden();
+
+    await searchAndOpenConnector(page, connectorName);
+    await expect(page.testSubj.locator('nameInput')).toHaveValue(connectorName);
+    await page.testSubj.click('euiFlyoutCloseButton');
+  });
+
+  test('connector page - should disable the run button when the message field is not filled', async ({
+    page,
+    kbnUrl,
+    apiServices,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `jsm-disable-run-${Date.now()}`;
+    const created = await apiServices.alerting.connectors.create({
+      name: connectorName,
+      connectorTypeId: '.jira-service-management',
+      config: { apiUrl: 'https://test.atlassian.net' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(created.id);
+
+    await searchAndOpenConnector(page, connectorName);
+    await page.locator('[data-test-subj="testConnectorTab"]').click();
+
+    await expect(page.testSubj.locator('executeActionButton')).toBeDisabled();
+  });
+
+  // ── test page ─────────────────────────────────────────────────────────────
+
+  test('page - should show the sub action selector when in test mode', async ({ page, kbnUrl }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+    await expect(page.testSubj.locator('jsm-subActionSelect')).toBeVisible();
+  });
+
+  test('page - should preserve the alias when switching between create and close alert actions', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('aliasInput').fill('new alias');
+    await page.testSubj.locator('jsm-subActionSelect').selectOption('closeAlert');
+
+    await expect(page.testSubj.locator('jsm-subActionSelect')).toHaveValue('closeAlert');
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('new alias');
+  });
+
+  test('page - should not preserve the message when switching to close alert and back to create alert', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('messageInput').fill('a message');
+    await page.testSubj.locator('jsm-subActionSelect').selectOption('closeAlert');
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+
+    await page.testSubj.locator('jsm-subActionSelect').selectOption('createAlert');
+    await expect(page.testSubj.locator('messageInput')).toBeVisible();
+    await expect(page.testSubj.locator('messageInput')).toHaveValue('');
+  });
+
+  test('page - createAlert - should show the additional options when clicking more options', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('jsm-display-more-options');
+
+    await expect(page.testSubj.locator('entityInput')).toBeVisible();
+    await expect(page.testSubj.locator('sourceInput')).toBeVisible();
+    await expect(page.testSubj.locator('userInput')).toBeVisible();
+    await expect(page.testSubj.locator('noteTextArea')).toBeVisible();
+  });
+
+  test('page - createAlert - should show and then hide the additional form options when clicking the button twice', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('jsm-display-more-options');
+    await expect(page.testSubj.locator('entityInput')).toBeVisible();
+
+    await page.testSubj.click('jsm-display-more-options');
+    await expect(page.testSubj.locator('entityInput')).toBeHidden();
+  });
+
+  test('page - createAlert - should populate the json editor with message, description, and alias', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('messageInput').fill('a message');
+    await page.testSubj.locator('descriptionTextArea').fill('a description');
+    await page.testSubj.locator('aliasInput').fill('an alias');
+    await page.testSubj.locator('jsm-prioritySelect').selectOption('P5');
+    await page.testSubj.locator('jsm-tags').locator('input').fill('a tag');
+    await page.testSubj.locator('jsm-tags').locator('input').press('Enter');
+
+    await page.testSubj.click('jsm-show-json-editor-toggle');
+
+    const raw = await getMonacoValue(page);
+    const parsed = JSON.parse(raw);
+    expect(parsed).toStrictEqual({
+      message: 'a message',
+      description: 'a description',
+      alias: 'an alias',
+      priority: 'P5',
+      tags: ['a tag'],
+    });
+  });
+
+  test('page - createAlert - should populate the form with values from the json editor', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('jsm-show-json-editor-toggle');
+    await setMonacoValue(
+      page,
+      JSON.stringify({
+        message: 'a message',
+        description: 'a description',
+        alias: 'an alias',
+        priority: 'P3',
+        tags: ['tag1'],
+      })
+    );
+    await page.testSubj.click('jsm-show-json-editor-toggle');
+
+    await expect(page.testSubj.locator('messageInput')).toHaveValue('a message');
+    await expect(page.testSubj.locator('descriptionTextArea')).toHaveValue('a description');
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('an alias');
+    await expect(page.testSubj.locator('jsm-prioritySelect')).toHaveValue('P3');
+    await expect(page.testSubj.locator('jsm-tags')).toContainText('tag1');
+  });
+
+  test('page - createAlert - should disable the run button when the json editor validation fails', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('jsm-show-json-editor-toggle');
+    await setMonacoValue(page, JSON.stringify({ message: '' }));
+
+    await expect(page.testSubj.locator('executeActionButton')).toBeDisabled();
+  });
+
+  test('page - closeAlert - should show the additional options for closing an alert when clicking more options', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('jsm-subActionSelect').selectOption('closeAlert');
+    await page.testSubj.click('jsm-display-more-options');
+
+    await expect(page.testSubj.locator('sourceInput')).toBeVisible();
+    await expect(page.testSubj.locator('userInput')).toBeVisible();
+  });
+
+  test('page - closeAlert - should show and then hide the additional options when clicking the button twice', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openJsmTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('jsm-subActionSelect').selectOption('closeAlert');
+    await page.testSubj.click('jsm-display-more-options');
+    await expect(page.testSubj.locator('sourceInput')).toBeVisible();
+
+    await page.testSubj.click('jsm-display-more-options');
+    await expect(page.testSubj.locator('sourceInput')).toBeHidden();
+  });
+
+  // ── alerts page ───────────────────────────────────────────────────────────
+
+  test('alerts page - should default to the create alert action', async ({ page }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`jsm-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await expect(page.testSubj.locator('messageInput')).toBeVisible();
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+  });
+
+  test('alerts page - should default to the close alert action when setting the run when to recovered', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`jsm-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+    await expect(page.testSubj.locator('noteTextArea')).toBeVisible();
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+  });
+
+  test('alerts page - should not preserve the alias when switching run when to recover', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`jsm-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await page.testSubj.locator('aliasInput').fill('an alias');
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+  });
+
+  test('alerts page - should not preserve the alias when switching run when to threshold met', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`jsm-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+    await page.testSubj.locator('aliasInput').fill('an alias');
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-threshold met');
+
+    await expect(page.testSubj.locator('messageInput')).toBeVisible();
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+  });
+
+  test('alerts page - should show the message is required error when clicking the save button', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`jsm-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await expect(page.testSubj.locator('rulePageFooterSaveButton')).toBeDisabled();
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/connector_opsgenie.spec.ts
@@ -1,0 +1,545 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
+//
+// All 19 tests migrated. Nested describes are flattened (max describe depth = 1).
+// `opsgenie-subActionSelect` and `opsgenie-prioritySelect` are native <select> elements.
+// Monaco JSON editor is driven via MonacoEnvironment.monaco.editor API.
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ScoutPage } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, CONNECTORS_APP_PATH, CONNECTORS_LIST_SELECTORS } from '../fixtures';
+
+interface MonacoBridge {
+  MonacoEnvironment?: {
+    monaco?: {
+      editor?: {
+        getModels: () => Array<{ getValue: () => string; setValue: (s: string) => void }>;
+      };
+    };
+  };
+}
+
+const setMonacoValue = async (page: ScoutPage, value: string) => {
+  await page.testSubj.locator('kibanaCodeEditor').waitFor({ state: 'visible' });
+  await page.evaluate((v) => {
+    const editor = (window as unknown as MonacoBridge).MonacoEnvironment?.monaco?.editor;
+    if (!editor) throw new Error('MonacoEnvironment.monaco.editor not available');
+    editor.getModels().forEach((m) => m.setValue(v));
+  }, value);
+};
+
+const getMonacoValue = async (page: ScoutPage): Promise<string> => {
+  await page.testSubj.locator('kibanaCodeEditor').waitFor({ state: 'visible' });
+  return page.evaluate(() => {
+    const editor = (window as unknown as MonacoBridge).MonacoEnvironment?.monaco?.editor;
+    return editor?.getModels()?.[0]?.getValue() ?? '';
+  });
+};
+
+const navigateToConnectors = async (page: ScoutPage, kbnUrl: { get: (p: string) => string }) => {
+  await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+};
+
+const searchAndOpenConnector = async (page: ScoutPage, name: string) => {
+  const searchBox = page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT);
+  await searchBox.fill(name);
+  await searchBox.press('Enter');
+  await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+  await page.locator('[data-test-subj="connectorsTableCell-name"] button').click();
+};
+
+const openOpsgenieTestTab = async (page: ScoutPage, connectorId: string) => {
+  await page.testSubj.click(`edit${connectorId}`);
+  await page.testSubj.click('testConnectorTab');
+  await page.testSubj
+    .locator('opsgenie-subActionSelect')
+    .waitFor({ state: 'visible', timeout: 10_000 });
+};
+
+const closeFlyoutIfOpen = async (page: ScoutPage) => {
+  const closeBtn = page.testSubj.locator('edit-connector-flyout-close-btn');
+  if (await closeBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await closeBtn.click();
+    const confirmBtn = page.testSubj.locator('confirmModalConfirmButton');
+    if (await confirmBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  }
+};
+
+const fillIndexThresholdForm = async (page: ScoutPage) => {
+  await page.testSubj.click('selectIndexExpression');
+  const indexInput = page.testSubj.locator('thresholdIndexesComboBox').locator('input');
+  await indexInput.fill('.kibana');
+  await page.locator('[role="listbox"]').waitFor();
+  await page.locator('[role="listbox"] [role="option"]:first-child').click();
+  const timeFieldSelect = page.testSubj.locator('thresholdAlertTimeFieldSelect');
+  await timeFieldSelect.locator('option:nth-child(2)').waitFor();
+  await timeFieldSelect.selectOption({ index: 1 });
+  await page.testSubj.click('closePopover');
+};
+
+const cancelRuleCreation = async (page: ScoutPage) => {
+  const cancelBtn = page.testSubj.locator('rulePageFooterCancelButton');
+  if (await cancelBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await cancelBtn.click();
+    const confirmBtn = page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]');
+    if (await confirmBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+  }
+};
+
+test.describe('Opsgenie connector', { tag: tags.stateful.classic }, () => {
+  const createdConnectorIds: string[] = [];
+  let testPageConnectorId: string;
+  let alertsConnectorName: string;
+
+  test.beforeAll(async ({ apiServices }) => {
+    // Connector for test-page tests
+    const testConnector = await apiServices.alerting.connectors.create({
+      name: `opsgenie-test-page-${Date.now()}`,
+      connectorTypeId: '.opsgenie',
+      config: { apiUrl: 'https://test.opsgenie.com' },
+      secrets: { apiKey: '1234' },
+    });
+    testPageConnectorId = testConnector.id;
+    createdConnectorIds.push(testPageConnectorId);
+
+    // Connector for alerts-page tests
+    alertsConnectorName = `opsgenie-alerts-${Date.now()}`;
+    const alertsConnector = await apiServices.alerting.connectors.create({
+      name: alertsConnectorName,
+      connectorTypeId: '.opsgenie',
+      config: { apiUrl: 'https://test.opsgenie.com' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(alertsConnector.id);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cancelRuleCreation(page);
+    await closeFlyoutIfOpen(page);
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    await Promise.allSettled(
+      createdConnectorIds.map((id) => apiServices.alerting.connectors.delete(id))
+    );
+    createdConnectorIds.length = 0;
+  });
+
+  // ── connector page ────────────────────────────────────────────────────────
+
+  test('connector page - should create the connector', async ({ page, kbnUrl, apiServices }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `opsgenie-create-${uuidv4().slice(0, 8)}`;
+
+    await page.testSubj.click('createConnectorButton');
+    await page.testSubj.click('.opsgenie-card');
+    await page.testSubj.locator('nameInput').fill(connectorName);
+    await page.testSubj.locator('config\\.apiUrl-input').fill('https://test.opsgenie.com');
+    await page.testSubj.locator('secrets\\.apiKey-input').fill('apiKey');
+    await page
+      .locator('[data-test-subj="create-connector-flyout-save-btn"]:not([disabled])')
+      .click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Created '${connectorName}'`
+    );
+
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).fill(connectorName);
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).press('Enter');
+    await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+
+    const row = page.testSubj.locator('connectors-row');
+    await expect(row.getByTestId('connectorsTableCell-actionType')).toContainText('Opsgenie');
+
+    // Find and track created connector for cleanup
+    const all = await apiServices.alerting.connectors.getAll();
+    const created = (all as Array<{ id: string; name: string }>).find(
+      (c) => c.name === connectorName
+    );
+    if (created) createdConnectorIds.push(created.id);
+  });
+
+  test('connector page - should edit the connector', async ({ page, kbnUrl, apiServices }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `opsgenie-edit-${Date.now()}`;
+    const updatedName = `${connectorName}-updated`;
+    const created = await apiServices.alerting.connectors.create({
+      name: connectorName,
+      connectorTypeId: '.opsgenie',
+      config: { apiUrl: 'https://test.opsgenie.com' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(created.id);
+
+    await searchAndOpenConnector(page, connectorName);
+    await page.testSubj.locator('nameInput').fill(updatedName);
+    await page.testSubj.locator('config\\.apiUrl-input').fill('https://test.opsgenie.com');
+    await page.testSubj.locator('secrets\\.apiKey-input').fill('apiKey');
+    await page.locator('[data-test-subj="edit-connector-flyout-save-btn"]:not([disabled])').click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Updated '${updatedName}'`
+    );
+
+    await page.testSubj.click('euiFlyoutCloseButton');
+
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).fill(updatedName);
+    await page.locator(CONNECTORS_LIST_SELECTORS.SEARCH_INPUT).press('Enter');
+    await page.locator(CONNECTORS_LIST_SELECTORS.TABLE_LOADED).waitFor();
+    await expect(page.testSubj.locator('connectors-row')).toHaveCount(1);
+  });
+
+  test('connector page - should reset connector when canceling an edit', async ({
+    page,
+    kbnUrl,
+    apiServices,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `opsgenie-cancel-${Date.now()}`;
+    const created = await apiServices.alerting.connectors.create({
+      name: connectorName,
+      connectorTypeId: '.opsgenie',
+      config: { apiUrl: 'https://test.opsgenie.com' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(created.id);
+
+    await searchAndOpenConnector(page, connectorName);
+    await page.testSubj.locator('nameInput').fill('some test name to cancel');
+    await page.testSubj.click('edit-connector-flyout-close-btn');
+    await page.testSubj.click('confirmModalConfirmButton');
+    await expect(page.testSubj.locator('edit-connector-flyout-close-btn')).toBeHidden();
+
+    await searchAndOpenConnector(page, connectorName);
+    await expect(page.testSubj.locator('nameInput')).toHaveValue(connectorName);
+    await page.testSubj.click('euiFlyoutCloseButton');
+  });
+
+  test('connector page - should disable the run button when the message field is not filled', async ({
+    page,
+    kbnUrl,
+    apiServices,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    const connectorName = `opsgenie-disable-run-${Date.now()}`;
+    const created = await apiServices.alerting.connectors.create({
+      name: connectorName,
+      connectorTypeId: '.opsgenie',
+      config: { apiUrl: 'https://test.opsgenie.com' },
+      secrets: { apiKey: '1234' },
+    });
+    createdConnectorIds.push(created.id);
+
+    await searchAndOpenConnector(page, connectorName);
+    await expect(page.testSubj.locator('nameInput')).toBeVisible();
+    await page.locator('[data-test-subj="testConnectorTab"]').click();
+    await page.testSubj.locator('executeActionButton').waitFor({ state: 'visible' });
+
+    await expect(page.testSubj.locator('executeActionButton')).toBeDisabled();
+  });
+
+  // ── test page ─────────────────────────────────────────────────────────────
+
+  test('page - should show the sub action selector when in test mode', async ({ page, kbnUrl }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+    await expect(page.testSubj.locator('opsgenie-subActionSelect')).toBeVisible();
+  });
+
+  test('page - should preserve the alias when switching between create and close alert actions', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('aliasInput').fill('new alias');
+    await page.testSubj.locator('opsgenie-subActionSelect').selectOption('closeAlert');
+
+    await expect(page.testSubj.locator('opsgenie-subActionSelect')).toHaveValue('closeAlert');
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('new alias');
+  });
+
+  test('page - should not preserve the message when switching to close alert and back to create alert', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('messageInput').fill('a message');
+    await page.testSubj.locator('opsgenie-subActionSelect').selectOption('closeAlert');
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+
+    await page.testSubj.locator('opsgenie-subActionSelect').selectOption('createAlert');
+    await expect(page.testSubj.locator('messageInput')).toBeVisible();
+    await expect(page.testSubj.locator('messageInput')).toHaveValue('');
+  });
+
+  test('page - createAlert - should show the additional options when clicking more options', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('opsgenie-display-more-options');
+
+    await expect(page.testSubj.locator('entityInput')).toBeVisible();
+    await expect(page.testSubj.locator('sourceInput')).toBeVisible();
+    await expect(page.testSubj.locator('userInput')).toBeVisible();
+    await expect(page.testSubj.locator('noteTextArea')).toBeVisible();
+  });
+
+  test('page - createAlert - should show and then hide the additional form options when clicking the button twice', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('opsgenie-display-more-options');
+    await expect(page.testSubj.locator('entityInput')).toBeVisible();
+
+    await page.testSubj.click('opsgenie-display-more-options');
+    await expect(page.testSubj.locator('entityInput')).toBeHidden();
+  });
+
+  test('page - createAlert - should populate the json editor with message, description, and alias', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('messageInput').fill('a message');
+    await page.testSubj.locator('descriptionTextArea').fill('a description');
+    await page.testSubj.locator('aliasInput').fill('an alias');
+    await page.testSubj.locator('opsgenie-prioritySelect').selectOption('P5');
+    await page.testSubj.locator('opsgenie-tags').locator('input').fill('a tag');
+    await page.testSubj.locator('opsgenie-tags').locator('input').press('Enter');
+
+    await page.testSubj.click('opsgenie-show-json-editor-toggle');
+
+    const raw = await getMonacoValue(page);
+    const parsed = JSON.parse(raw);
+    expect(parsed).toStrictEqual({
+      message: 'a message',
+      description: 'a description',
+      alias: 'an alias',
+      priority: 'P5',
+      tags: ['a tag'],
+    });
+  });
+
+  test('page - createAlert - should populate the form with values from the json editor', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('opsgenie-show-json-editor-toggle');
+    await setMonacoValue(
+      page,
+      JSON.stringify({
+        message: 'a message',
+        description: 'a description',
+        alias: 'an alias',
+        priority: 'P3',
+        tags: ['tag1'],
+      })
+    );
+    await page.testSubj.click('opsgenie-show-json-editor-toggle');
+
+    await expect(page.testSubj.locator('messageInput')).toHaveValue('a message');
+    await expect(page.testSubj.locator('descriptionTextArea')).toHaveValue('a description');
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('an alias');
+    await expect(page.testSubj.locator('opsgenie-prioritySelect')).toHaveValue('P3');
+    await expect(page.testSubj.locator('opsgenie-tags')).toContainText('tag1');
+  });
+
+  test('page - createAlert - should disable the run button when the json editor validation fails', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.click('opsgenie-show-json-editor-toggle');
+    await setMonacoValue(page, JSON.stringify({ message: '' }));
+
+    await expect(page.testSubj.locator('executeActionButton')).toBeDisabled();
+  });
+
+  test('page - closeAlert - should show the additional options for closing an alert when clicking more options', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('opsgenie-subActionSelect').selectOption('closeAlert');
+    await page.testSubj.click('opsgenie-display-more-options');
+
+    await expect(page.testSubj.locator('sourceInput')).toBeVisible();
+    await expect(page.testSubj.locator('userInput')).toBeVisible();
+  });
+
+  test('page - closeAlert - should show and then hide the additional options when clicking the button twice', async ({
+    page,
+    kbnUrl,
+  }) => {
+    await navigateToConnectors(page, kbnUrl);
+    await openOpsgenieTestTab(page, testPageConnectorId);
+
+    await page.testSubj.locator('opsgenie-subActionSelect').selectOption('closeAlert');
+    await page.testSubj.click('opsgenie-display-more-options');
+    await expect(page.testSubj.locator('sourceInput')).toBeVisible();
+
+    await page.testSubj.click('opsgenie-display-more-options');
+    await expect(page.testSubj.locator('sourceInput')).toBeHidden();
+  });
+
+  // ── alerts page ───────────────────────────────────────────────────────────
+
+  test('alerts page - should default to the create alert action', async ({ page }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`opsgenie-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await expect(page.testSubj.locator('messageInput')).toBeVisible();
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+  });
+
+  test('alerts page - should default to the close alert action when setting the run when to recovered', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`opsgenie-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+    await expect(page.testSubj.locator('noteTextArea')).toBeVisible();
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+  });
+
+  test('alerts page - should not preserve the alias when switching run when to recover', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`opsgenie-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await page.testSubj.locator('aliasInput').fill('an alias');
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+  });
+
+  test('alerts page - should not preserve the alias when switching run when to threshold met', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`opsgenie-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-recovered');
+
+    await expect(page.testSubj.locator('messageInput')).toBeHidden();
+    await page.testSubj.locator('aliasInput').fill('an alias');
+
+    await page.testSubj.click('ruleActionsSettingsSelectActionGroup');
+    await page.testSubj.click('addNewActionConnectorActionGroup-threshold met');
+
+    await expect(page.testSubj.locator('messageInput')).toBeVisible();
+    await expect(page.testSubj.locator('aliasInput')).toHaveValue('{{rule.id}}:{{alert.id}}');
+  });
+
+  test('alerts page - should show the message is required error when clicking the save button', async ({
+    page,
+  }) => {
+    await page.gotoApp('rules');
+    await page.testSubj.click('createRuleButton');
+    await page.testSubj.click('.index-threshold-SelectOption');
+    await page.testSubj.locator('ruleDetailsNameInput').fill(`opsgenie-alert-${Date.now()}`);
+    await fillIndexThresholdForm(page);
+
+    await page.testSubj.click('ruleActionsAddActionButton');
+    await page.testSubj.locator('ruleActionsConnectorsModal').waitFor({ state: 'visible' });
+    await page.testSubj
+      .locator('ruleActionsConnectorsModalCard')
+      .filter({ hasText: alertsConnectorName })
+      .locator('button')
+      .click();
+
+    await expect(page.testSubj.locator('rulePageFooterSaveButton')).toBeDisabled();
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/redirect.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/redirect.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from: x-pack/platform/test/functional_with_es_ssl/apps/rules/redirect.ts
+//
+// 2 of 2 tests migrated.
+// The /app/rules app is a thin redirect shim: both tests verify the redirect
+// works (the destination page rendering is tested elsewhere).
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, makeEsQueryRule } from '../fixtures';
+
+test.describe('Redirect from /app/rules', { tag: tags.stateful.classic }, () => {
+  const createdRuleIds: string[] = [];
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    await Promise.allSettled(createdRuleIds.map((id) => apiServices.alerting.rules.delete(id)));
+    createdRuleIds.length = 0;
+  });
+
+  test('redirects /app/rules to the Stack Management rules page', async ({ page, kbnUrl }) => {
+    await page.goto(kbnUrl.get('/app/rules'));
+    await page.waitForURL(/app\/management\/insightsAndAlerting\/triggersActions/, {
+      timeout: 15_000,
+    });
+    await expect(page).toHaveURL(/app\/management\/insightsAndAlerting\/triggersActions/);
+  });
+
+  test('preserves the sub-path when redirecting /app/rules/:path to Stack Management', async ({
+    page,
+    kbnUrl,
+    apiServices,
+  }) => {
+    const { data: rule } = await apiServices.alerting.rules.create(makeEsQueryRule('redirect'));
+    createdRuleIds.push(rule.id);
+
+    await page.goto(kbnUrl.get(`/app/rules/rule/${rule.id}`));
+    await page.waitForURL(
+      new RegExp(`app/management/insightsAndAlerting/triggersActions/rule/${rule.id}`),
+      { timeout: 15_000 }
+    );
+    await expect(page).toHaveURL(
+      new RegExp(`app/management/insightsAndAlerting/triggersActions/rule/${rule.id}`)
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from: x-pack/platform/test/functional_with_es_ssl/apps/rules/details.ts
+// Section: "Edit rule button" describe block.
+// Uses .index-threshold with a dynamically created .server-log connector
+// (FTR used preconfigured 'my-server-log' which is unavailable in Scout).
+// Tests are stateful: test 1 renames the rule; test 2 reads the new name.
+
+import { v4 as uuidv4 } from 'uuid';
+import type { KbnClient } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+
+const createServerLogConnector = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string; name: string }>({
+    method: 'POST',
+    path: '/api/actions/connector',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: { name, connector_type_id: '.server-log', config: {}, secrets: {} },
+  });
+  return resp.data;
+};
+
+const deleteConnector = async (kbnClient: KbnClient, connectorId: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/api/actions/connector/${connectorId}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+test.describe('Rule Details - Edit rule button', { tag: tags.stateful.classic }, () => {
+  const ruleName = `edit-rule-${uuidv4()}`;
+  const updatedRuleName = `Changed Rule Name ${ruleName}`;
+  let ruleId: string;
+  let connectorId: string;
+
+  test.beforeAll(async ({ kbnClient }) => {
+    const connector = await createServerLogConnector(kbnClient, `scout-log-${Date.now()}`);
+    connectorId = connector.id;
+
+    const resp = await kbnClient.request<{ id: string }>({
+      method: 'POST',
+      path: '/api/alerting/rule',
+      headers: { 'kbn-xsrf': 'scout' },
+      body: {
+        name: ruleName,
+        rule_type_id: '.index-threshold',
+        consumer: 'alerts',
+        schedule: { interval: '1m' },
+        actions: [
+          {
+            id: connectorId,
+            group: 'threshold met',
+            params: { level: 'info', message: '{{context.message}}' },
+            frequency: { summary: false, notify_when: 'onThrottleInterval', throttle: '1m' },
+          },
+        ],
+        params: {
+          aggType: 'count',
+          termSize: 5,
+          thresholdComparator: '>',
+          timeWindowSize: 5,
+          timeWindowUnit: 'm',
+          groupBy: 'all',
+          threshold: [1000],
+          index: ['.kibana'],
+          timeField: '@timestamp',
+        },
+      },
+    });
+    ruleId = resp.data.id;
+  });
+
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
+    await browserAuth.loginAsAdmin();
+    await pageObjects.ruleDetailsPage.gotoById(ruleId);
+    await expect(pageObjects.ruleDetailsPage.ruleDetailsTitle).toBeVisible({ timeout: 20_000 });
+  });
+
+  test.afterAll(async ({ apiServices, kbnClient }) => {
+    if (ruleId) await apiServices.alerting.rules.delete(ruleId);
+    if (connectorId) await deleteConnector(kbnClient, connectorId);
+  });
+
+  test('should open edit rule flyout', async ({ page }) => {
+    await page.testSubj.click('ruleActionsButton');
+    await page.testSubj.click('openEditRuleFlyoutButton');
+
+    await expect(page.testSubj.locator('hasActionsDisabled')).toBeHidden();
+
+    await page.testSubj.locator('ruleDetailsNameInput').fill(updatedRuleName);
+    await page.locator('[data-test-subj="rulePageFooterSaveButton"]:not([disabled])').click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Updated "${updatedRuleName}"`
+    );
+    await expect(page.testSubj.locator('ruleDetailsTitle')).toContainText(updatedRuleName, {
+      timeout: 30_000,
+    });
+  });
+
+  test('should reset rule when canceling an edit', async ({ page }) => {
+    // Rule name is now updatedRuleName from the previous test
+    await page.testSubj.click('ruleActionsButton');
+    await page.testSubj.click('openEditRuleFlyoutButton');
+
+    await page.testSubj.locator('ruleDetailsNameInput').fill(uuidv4());
+    await page.testSubj.click('rulePageFooterCancelButton');
+
+    await expect(page.testSubj.locator('confirmRuleCloseModal')).toBeVisible();
+    await page.testSubj
+      .locator('confirmRuleCloseModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]')
+      .click();
+
+    await expect(page.testSubj.locator('rulePageFooterCancelButton')).toBeHidden();
+
+    // Open edit again — name should still be updatedRuleName
+    await page.testSubj.click('ruleActionsButton');
+    await page.testSubj.click('openEditRuleFlyoutButton');
+    await expect(page.testSubj.locator('ruleDetailsNameInput')).toHaveValue(updatedRuleName);
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit_legacy_notify.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_edit_legacy_notify.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from: x-pack/platform/test/functional_with_es_ssl/apps/rules/details.ts
+// Section: "Edit rule with legacy rule-level notify values" describe block.
+// Verifies that a rule created with legacy rule-level `notify_when` / `throttle`
+// surfaces those values as action-level frequency settings in the edit flyout,
+// and can be saved successfully.
+//
+// FTR used test.always-firing; substituted with .index-threshold + a dynamically
+// created .server-log connector (preconfigured 'my-server-log' is not guaranteed
+// across environments).
+
+import { v4 as uuidv4 } from 'uuid';
+import type { KbnClient } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+
+const createServerLogConnector = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string; name: string }>({
+    method: 'POST',
+    path: '/api/actions/connector',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: { name, connector_type_id: '.server-log', config: {}, secrets: {} },
+  });
+  return resp.data;
+};
+
+const deleteConnector = async (kbnClient: KbnClient, connectorId: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/api/actions/connector/${connectorId}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+test.describe('Rule Details - Legacy notify values', { tag: tags.stateful.classic }, () => {
+  const ruleName = `legacy-notify-${uuidv4()}`;
+  const updatedRuleName = `Changed rule ${ruleName}`;
+  let ruleId: string;
+  let connectorId: string;
+
+  test.beforeAll(async ({ kbnClient }) => {
+    const connector = await createServerLogConnector(kbnClient, `scout-log-${Date.now()}`);
+    connectorId = connector.id;
+
+    // Rule-level notify_when + throttle (legacy) with an action that has no
+    // action-level frequency — the edit flyout should convert these to
+    // action-level "On custom action intervals" with a 2 day throttle.
+    const resp = await kbnClient.request<{ id: string }>({
+      method: 'POST',
+      path: '/api/alerting/rule',
+      headers: { 'kbn-xsrf': 'scout' },
+      body: {
+        name: ruleName,
+        rule_type_id: '.index-threshold',
+        consumer: 'alerts',
+        schedule: { interval: '1m' },
+        notify_when: 'onThrottleInterval',
+        throttle: '2d',
+        actions: [
+          {
+            id: connectorId,
+            group: 'threshold met',
+            params: { level: 'info', message: 'from alert 1s' },
+          },
+        ],
+        params: {
+          aggType: 'count',
+          termSize: 5,
+          thresholdComparator: '>',
+          timeWindowSize: 5,
+          timeWindowUnit: 'm',
+          groupBy: 'all',
+          threshold: [1000],
+          index: ['.kibana'],
+          timeField: '@timestamp',
+        },
+      },
+    });
+    ruleId = resp.data.id;
+  });
+
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
+    await browserAuth.loginAsAdmin();
+    await pageObjects.ruleDetailsPage.gotoById(ruleId);
+    await expect(pageObjects.ruleDetailsPage.ruleDetailsTitle).toBeVisible({ timeout: 20_000 });
+  });
+
+  test.afterAll(async ({ apiServices, kbnClient }) => {
+    if (ruleId) await apiServices.alerting.rules.delete(ruleId);
+    if (connectorId) await deleteConnector(kbnClient, connectorId);
+  });
+
+  test('should convert rule-level params to action-level params and save the rule successfully', async ({
+    page,
+  }) => {
+    await page.testSubj.click('ruleActionsButton');
+    await page.testSubj.click('openEditRuleFlyoutButton');
+
+    // Legacy rule-level notify values are surfaced as action-level frequency.
+    await page.testSubj
+      .locator('ruleActionsItem')
+      .getByRole('button', { name: 'Settings' })
+      .click();
+    await expect(page.testSubj.locator('notifyWhenSelect')).toContainText(
+      'On custom action intervals'
+    );
+    await expect(page.testSubj.locator('throttleInput')).toHaveValue('2');
+    await expect(page.testSubj.locator('throttleUnitInput')).toHaveValue('d');
+
+    await page.testSubj.locator('ruleDetailsNameInput').fill(updatedRuleName);
+    await page.locator('[data-test-subj="rulePageFooterSaveButton"]:not([disabled])').click();
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText(
+      `Updated "${updatedRuleName}"`
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_header.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from: x-pack/platform/test/functional_with_es_ssl/apps/rules/details.ts
+// Section: "Rule Details" header block (disable, snooze, re-enable, snooze schedule).
+// Rule type: test.always-firing → .es-query with 1s interval (triggers interval-warning toast).
+// Tests are stateful: state mutates across them (disable in test 3, re-enable in test 5).
+
+import type { KbnClient } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, makeEsQueryRule } from '../fixtures';
+
+const createHeaderRule = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: '/api/alerting/rule',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      rule_type_id: '.es-query',
+      consumer: 'stackAlerts',
+      schedule: { interval: '1s' },
+      actions: [],
+      params: makeEsQueryRule(name).params,
+    },
+  });
+  return resp.data;
+};
+
+test.describe('Rule Details - Header', { tag: tags.stateful.classic }, () => {
+  let ruleId: string;
+
+  test.beforeAll(async ({ kbnClient }) => {
+    const rule = await createHeaderRule(kbnClient, `header-test-rule-${Date.now()}`);
+    ruleId = rule.id;
+  });
+
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
+    await browserAuth.loginAsAdmin();
+    await pageObjects.ruleDetailsPage.gotoById(ruleId);
+    await expect(pageObjects.ruleDetailsPage.ruleDetailsTitle).toBeVisible({ timeout: 20_000 });
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    if (ruleId) await apiServices.alerting.rules.delete(ruleId);
+  });
+
+  test('renders the rule details', async ({ page }) => {
+    await expect(page.testSubj.locator('ruleDetailsTitle')).toContainText('header-test-rule');
+    await expect(page.testSubj.locator('ruleSummaryRuleType')).toHaveText('ES query');
+    await expect(page.testSubj.locator('apiKeyOwnerLabel')).toContainText('elastic');
+  });
+
+  test('renders toast when schedule is less than configured minimum', async ({ page }) => {
+    await expect(page.testSubj.locator('intervalConfigToast')).toBeVisible();
+    await page.testSubj.click('ruleIntervalToastEditButton');
+    await expect(page.testSubj.locator('rulePageFooterCancelButton')).toBeVisible();
+    await page.testSubj.click('rulePageFooterCancelButton');
+  });
+
+  test('should disable the rule', async ({ page }) => {
+    const statusDropdown = page.testSubj.locator('statusDropdown');
+    await expect(statusDropdown).toContainText('Enabled');
+
+    await statusDropdown.click();
+    await page.testSubj.click('statusDropdownDisabledItem');
+    await expect(page.testSubj.locator('confirmModalConfirmButton')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await expect(statusDropdown).toContainText('Disabled', { timeout: 15_000 });
+  });
+
+  test('should allow you to snooze a disabled rule', async ({ page }) => {
+    // Rule is DISABLED from the previous test
+    const statusDropdown = page.testSubj.locator('statusDropdown');
+    await expect(statusDropdown).toContainText('Disabled');
+
+    const snoozeBadge = page.testSubj.locator('rulesListNotifyBadge-unsnoozed');
+    await snoozeBadge.click();
+    await page.testSubj.click('ruleSnoozeIndefiniteApply');
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozedIndefinitely')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Unsnooze before the next test
+    await page.testSubj.locator('rulesListNotifyBadge-snoozedIndefinitely').click();
+    await page.testSubj.click('ruleSnoozeCancel');
+  });
+
+  test('should reenable a disabled rule', async ({ page }) => {
+    // Rule is DISABLED from test "should disable the rule"
+    const statusDropdown = page.testSubj.locator('statusDropdown');
+    await expect(statusDropdown).toContainText('Disabled');
+
+    await statusDropdown.click();
+    await page.testSubj.click('statusDropdownEnabledItem');
+
+    await expect(statusDropdown).toContainText('Enabled', { timeout: 15_000 });
+  });
+
+  test('should snooze the rule', async ({ page }) => {
+    const snoozeBadge = page.testSubj.locator('rulesListNotifyBadge-unsnoozed');
+    await snoozeBadge.click();
+    await page.testSubj.click('ruleSnoozeIndefiniteApply');
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozedIndefinitely')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Unsnooze before the next test
+    await page.testSubj.locator('rulesListNotifyBadge-snoozedIndefinitely').click();
+    await page.testSubj.click('ruleSnoozeCancel');
+  });
+
+  test('should snooze the rule for a set duration', async ({ page }) => {
+    const snoozeBadge = page.testSubj.locator('rulesListNotifyBadge-unsnoozed');
+    await snoozeBadge.click();
+    await page.testSubj.click('linkSnooze8h');
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozed')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Unsnooze before the next test
+    await page.testSubj.locator('rulesListNotifyBadge-snoozed').click();
+    await page.testSubj.click('ruleSnoozeCancel');
+  });
+
+  test('should add snooze schedule', async ({ page }) => {
+    const snoozeBadge = page.testSubj.locator('rulesListNotifyBadge-unsnoozed');
+    await snoozeBadge.click();
+    await page.testSubj.click('ruleAddSchedule');
+    await page.testSubj.click('scheduler-saveSchedule');
+    await expect(page.testSubj.locator('rulesListNotifyBadge-scheduled')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Remove schedule
+    await page.testSubj.locator('rulesListNotifyBadge-scheduled').click();
+    await page.testSubj.click('ruleRemoveAllSchedules');
+    await expect(page.testSubj.locator('confirmModalConfirmButton')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_so_navigation.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_details_so_navigation.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from: x-pack/platform/test/functional_with_es_ssl/apps/rules/details.ts
+// Section: "Saved Objects Management Navigation" describe block.
+// Creates rules in both the default and a non-default space, then verifies
+// that clicking the rule entry in Saved Objects Management navigates to the
+// correct rule details page.
+
+import { v4 as uuidv4 } from 'uuid';
+import type { KbnClient } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, makeEsQueryRule } from '../fixtures';
+
+const createSpace = async (kbnClient: KbnClient, spaceId: string, spaceName: string) => {
+  await kbnClient.request({
+    method: 'POST',
+    path: '/api/spaces/space',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: { id: spaceId, name: spaceName, description: 'Scout test space' },
+  });
+};
+
+const deleteSpace = async (kbnClient: KbnClient, spaceId: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/api/spaces/space/${spaceId}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+const createRuleInSpace = async (kbnClient: KbnClient, spaceId: string, ruleName: string) => {
+  const resp = await kbnClient.request<{ id: string }>({
+    method: 'POST',
+    path: `/s/${spaceId}/api/alerting/rule`,
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name: ruleName,
+      rule_type_id: '.es-query',
+      consumer: 'stackAlerts',
+      schedule: { interval: '1m' },
+      actions: [],
+      params: makeEsQueryRule(ruleName).params,
+    },
+  });
+  return resp.data;
+};
+
+const deleteRuleInSpace = async (kbnClient: KbnClient, spaceId: string, ruleId: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/s/${spaceId}/api/alerting/rule/${ruleId}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+test.describe(
+  'Rule Details - Saved Objects Management Navigation',
+  { tag: tags.stateful.classic },
+  () => {
+    const testRunUuid = uuidv4();
+    const spaceId = `scout-so-nav-${testRunUuid.slice(0, 8)}`;
+    const testRuleName = `so-nav-rule-${testRunUuid}`;
+    const testSpaceRuleName = `so-nav-rule-space-${testRunUuid}`;
+    let defaultRuleId: string;
+    let spaceRuleId: string;
+
+    test.beforeAll(async ({ apiServices, kbnClient }) => {
+      const r = await apiServices.alerting.rules.create({
+        ...makeEsQueryRule(testRuleName),
+        name: testRuleName,
+      });
+      defaultRuleId = r.data.id;
+
+      await createSpace(kbnClient, spaceId, `Scout SO Nav Space ${testRunUuid}`);
+
+      const spaceRule = await createRuleInSpace(kbnClient, spaceId, testSpaceRuleName);
+      spaceRuleId = spaceRule.id;
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
+    test.afterAll(async ({ apiServices, kbnClient }) => {
+      if (defaultRuleId) await apiServices.alerting.rules.delete(defaultRuleId);
+      if (spaceRuleId) await deleteRuleInSpace(kbnClient, spaceId, spaceRuleId);
+      await deleteSpace(kbnClient, spaceId);
+    });
+
+    test('should navigate to rule details from saved objects management page in default space', async ({
+      page,
+      kbnUrl,
+    }) => {
+      await page.goto(kbnUrl.get('/app/management/kibana/objects'));
+      await page.locator('.euiBasicTable:not(.euiBasicTable-loading)').waitFor();
+
+      await page.getByText(`Rule: [${testRuleName}]`).click();
+
+      await expect(page.testSubj.locator('ruleDetailsTitle')).toContainText(testRuleName, {
+        timeout: 15_000,
+      });
+      await expect(page.testSubj.locator('statusDropdown')).toBeVisible();
+
+      await page.testSubj.click('ruleActionsButton');
+      await expect(page.testSubj.locator('openEditRuleFlyoutButton')).toBeVisible();
+    });
+
+    test('should navigate to rule details from saved objects management page in non-default space', async ({
+      page,
+      kbnUrl,
+    }) => {
+      await page.goto(kbnUrl.get(`/s/${spaceId}/app/management/kibana/objects`));
+      await page.locator('.euiBasicTable:not(.euiBasicTable-loading)').waitFor();
+
+      await page.getByText(`Rule: [${testSpaceRuleName}]`).click();
+
+      await expect(page.testSubj.locator('ruleDetailsTitle')).toContainText(testSpaceRuleName, {
+        timeout: 15_000,
+      });
+      await expect(page.testSubj.locator('statusDropdown')).toBeVisible();
+
+      await page.testSubj.click('ruleActionsButton');
+      await expect(page.testSubj.locator('openEditRuleFlyoutButton')).toBeVisible();
+
+      expect(page.url()).toContain(`/s/${spaceId}/`);
+    });
+  }
+);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts
@@ -1,0 +1,714 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/rules/rules_list/rules_list.ts
+//
+// Rule type substitutions:
+//   test.noop          → .es-query (built-in, always available in Scout stateful/classic)
+//   test.failing       → NOT registered in Scout — 3 tests skipped
+//   test.always-firing → NOT registered in Scout — 2 tests skipped
+
+import type { KbnClient, ScoutPage } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test, makeEsQueryRule } from '../fixtures';
+
+// ── API helpers ──────────────────────────────────────────────────────────────
+
+const disableRule = async (kbnClient: KbnClient, ruleId: string) => {
+  await kbnClient.request({
+    method: 'POST',
+    path: `/api/alerting/rule/${ruleId}/_disable`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+const snoozeRule = async (kbnClient: KbnClient, ruleId: string) => {
+  await kbnClient.request({
+    method: 'POST',
+    path: `/internal/alerting/rule/${ruleId}/_snooze`,
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      snooze_schedule: {
+        duration: 100_000_000,
+        rRule: { count: 1, dtstart: new Date().toISOString(), tzid: 'UTC' },
+      },
+    },
+  });
+};
+
+const createSlackConnector = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string; name: string }>({
+    method: 'POST',
+    path: '/api/actions/connector',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      connector_type_id: '.slack',
+      config: {},
+      secrets: {
+        webhookUrl: 'https://example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX',
+      },
+    },
+  });
+  return resp.data;
+};
+
+const deleteConnector = async (kbnClient: KbnClient, connectorId: string) => {
+  await kbnClient.request({
+    method: 'DELETE',
+    path: `/api/actions/connector/${connectorId}`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+// ── UI helpers ────────────────────────────────────────────────────────────────
+
+const searchRules = async (page: ScoutPage, query: string) => {
+  const field = page.testSubj.locator('ruleSearchField');
+  await field.fill(query);
+  await field.press('Enter');
+  await page
+    .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+    .waitFor();
+};
+
+const refreshRulesList = async (page: ScoutPage) => {
+  await page.testSubj.click('logsTab');
+  await page.testSubj.click('rulesTab');
+};
+
+const getTableRows = (page: ScoutPage) =>
+  page.testSubj.locator('rulesList').locator('[data-test-subj^="rule-row"]');
+
+const ensureRuleStatus = async (
+  page: ScoutPage,
+  ruleName: string,
+  status: 'enabled' | 'disabled'
+) => {
+  await expect(async () => {
+    await searchRules(page, ruleName);
+    await expect(page.testSubj.locator('statusDropdown')).toHaveAttribute(
+      'title',
+      new RegExp(status, 'i'),
+      { timeout: 5_000 }
+    );
+  }).toPass({ timeout: 30_000 });
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Rules list', { tag: tags.stateful.classic }, () => {
+  const createdRuleIds: string[] = [];
+  const createdConnectorIds: string[] = [];
+
+  test.beforeEach(async ({ browserAuth, page }) => {
+    await browserAuth.loginAsAdmin();
+    await page.gotoApp('rules');
+    await page.testSubj.click('rulesTab');
+  });
+
+  test.afterEach(async ({ apiServices, kbnClient }) => {
+    const ruleIds = [...createdRuleIds];
+    createdRuleIds.length = 0;
+    await Promise.allSettled(ruleIds.map((id) => apiServices.alerting.rules.delete(id)));
+
+    const connectorIds = [...createdConnectorIds];
+    createdConnectorIds.length = 0;
+    await Promise.allSettled(connectorIds.map((id) => deleteConnector(kbnClient, id)));
+  });
+
+  test('should display alerts in alphabetical order', async ({ page, apiServices }) => {
+    const uniqueTag = `alpha-order-${Date.now()}`;
+    const [rb, rc, ra] = await Promise.all([
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('b'), tags: [uniqueTag] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('c'), tags: [uniqueTag] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('a'), tags: [uniqueTag] }),
+    ]);
+    createdRuleIds.push(rb.data.id, rc.data.id, ra.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, uniqueTag);
+
+    const nameLinks = page.testSubj
+      .locator('rulesList')
+      .locator('[data-test-subj="rulesTableCell-name"] [title]');
+    await expect(nameLinks).toHaveCount(3);
+    const all = await nameLinks.all();
+    await expect(all[0]).toHaveAttribute('title', /^a-/);
+    await expect(all[1]).toHaveAttribute('title', /^b-/);
+    await expect(all[2]).toHaveAttribute('title', /^c-/);
+  });
+
+  test('should search for alert', async ({ page, apiServices }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('search-test'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    const rows = getTableRows(page);
+    await expect(rows).toHaveCount(1);
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${rule.data.name}"]`)
+    ).toBeVisible();
+    await expect(page.testSubj.locator('rulesTableCell-interval')).toContainText('1 min');
+    await expect(page.testSubj.locator('rulesTableCell-tagsPopover')).toContainText('1');
+  });
+
+  test('should update alert list on the search clear button click', async ({
+    page,
+    apiServices,
+  }) => {
+    const [r1, r2] = await Promise.all([
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('clear-b'), tags: [] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('clear-c'), tags: [] }),
+    ]);
+    createdRuleIds.push(r1.data.id, r2.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, r1.data.name as string);
+    await expect(getTableRows(page)).toHaveCount(1);
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${r1.data.name}"]`)
+    ).toBeVisible();
+
+    await page.locator('.euiFormControlLayoutClearButton').click();
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${r1.data.name}"]`)
+    ).toBeVisible();
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${r2.data.name}"]`)
+    ).toBeVisible();
+  });
+
+  test('should search for tags', async ({ page, apiServices }) => {
+    const rule = await apiServices.alerting.rules.create({
+      ...makeEsQueryRule('tags-test'),
+      tags: ['tag', 'tagtag', 'taggity tag'],
+    });
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, `${rule.data.name} tag`);
+
+    await expect(getTableRows(page)).toHaveCount(1);
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${rule.data.name}"]`)
+    ).toBeVisible();
+    await expect(page.testSubj.locator('rulesTableCell-tagsPopover')).toContainText('3');
+  });
+
+  test('should display an empty list when search did not return any alerts', async ({
+    page,
+    apiServices,
+  }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('empty-search'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, "An Alert That For Sure Doesn't Exist!");
+
+    await expect(page.testSubj.locator('rulesList')).toBeVisible();
+    await expect(getTableRows(page)).toHaveCount(0);
+  });
+
+  test('should disable single alert', async ({ page, apiServices }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('disable-single'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('disableButton');
+    await expect(page.testSubj.locator('confirmModalConfirmButton')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await ensureRuleStatus(page, rule.data.name as string, 'disabled');
+  });
+
+  test('should re-enable single alert', async ({ page, apiServices }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('reenable-single'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    // Disable via UI
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('disableButton');
+    await expect(page.testSubj.locator('confirmModalConfirmButton')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await ensureRuleStatus(page, rule.data.name as string, 'disabled');
+
+    // Re-enable via UI (no confirmation modal when enabling)
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('disableButton');
+
+    await ensureRuleStatus(page, rule.data.name as string, 'enabled');
+  });
+
+  test('should delete single alert', async ({ page, apiServices }) => {
+    const r1 = await apiServices.alerting.rules.create(makeEsQueryRule('delete-keep'));
+    const r2 = await apiServices.alerting.rules.create(makeEsQueryRule('delete-target'));
+    createdRuleIds.push(r1.data.id, r2.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, r2.data.name as string);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('deleteRule');
+    await expect(page.testSubj.locator('rulesDeleteConfirmation')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText('Deleted 1 rule');
+
+    // Remove from cleanup list since the rule was deleted via UI
+    const idx = createdRuleIds.indexOf(r2.data.id);
+    if (idx !== -1) createdRuleIds.splice(idx, 1);
+
+    await searchRules(page, r2.data.name as string);
+    await expect(getTableRows(page)).toHaveCount(0);
+  });
+
+  test('should disable all selection', async ({ page, apiServices }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('bulk-disable'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await page.testSubj.click(`checkboxSelectRow-${rule.data.id}`);
+    await page.testSubj.click('bulkAction');
+    await page.testSubj.click('bulkDisable');
+    await expect(page.testSubj.locator('confirmModalConfirmButton')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText('Disabled 1 rule');
+    await ensureRuleStatus(page, rule.data.name as string, 'disabled');
+  });
+
+  test('should enable all selection', async ({ page, apiServices, kbnClient }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('bulk-enable'));
+    createdRuleIds.push(rule.data.id);
+    await disableRule(kbnClient, rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await page.testSubj.click(`checkboxSelectRow-${rule.data.id}`);
+    await page.testSubj.click('bulkAction');
+    await page.testSubj.click('bulkEnable');
+
+    await ensureRuleStatus(page, rule.data.name as string, 'enabled');
+  });
+
+  test('should render percentile column and cells correctly', async ({ page, apiServices }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('percentile-test'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+
+    await expect(page.testSubj.locator('rulesTable-P50ColumnName')).toBeVisible();
+    await expect(page.testSubj.locator('P50Percentile')).toBeVisible();
+
+    // Switch to P95
+    await page.testSubj.click('percentileSelectablePopover-iconButton');
+    await expect(page.testSubj.locator('percentileSelectablePopover-selectable')).toBeVisible();
+    await page
+      .locator('[data-test-subj="percentileSelectablePopover-selectable"] li:nth-child(2)')
+      .click();
+    await expect(page.testSubj.locator('percentileSelectablePopover-selectable')).toBeHidden();
+    await expect(page.testSubj.locator('rulesTable-P95ColumnName')).toBeVisible();
+    await expect(page.testSubj.locator('P95Percentile')).toBeVisible();
+  });
+
+  test('should render interval info icon when schedule interval is less than configured minimum', async ({
+    page,
+    apiServices,
+  }) => {
+    const uniqueTag = `interval-icon-${Date.now()}`;
+    const [rShort, rNormal] = await Promise.all([
+      apiServices.alerting.rules.create({
+        ...makeEsQueryRule('a-short-interval'),
+        tags: [uniqueTag],
+        schedule: { interval: '1s' },
+      }),
+      apiServices.alerting.rules.create({
+        ...makeEsQueryRule('b-normal-interval'),
+        tags: [uniqueTag],
+      }),
+    ]);
+    createdRuleIds.push(rShort.data.id, rNormal.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, uniqueTag);
+
+    // icon-0 → short-interval rule (appears first alphabetically as 'a-short-*')
+    await expect(page.testSubj.locator('ruleInterval-config-icon-0')).toBeVisible();
+    await expect(page.testSubj.locator('ruleInterval-config-icon-1')).toBeHidden();
+
+    // clicking the icon opens edit flyout
+    await page.testSubj.click('ruleInterval-config-icon-0');
+    await expect(page.testSubj.locator('rulePageFooterCancelButton')).toBeVisible();
+    await page.testSubj.click('rulePageFooterCancelButton');
+  });
+
+  test('should delete all selection', async ({ page, apiServices }) => {
+    const namePrefix = `bulk-del-${Date.now()}`;
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule(namePrefix));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, namePrefix);
+
+    await page.testSubj.click(`checkboxSelectRow-${rule.data.id}`);
+    await page.testSubj.click('bulkAction');
+    await page.testSubj.click('bulkDelete');
+    await expect(page.testSubj.locator('rulesDeleteConfirmation')).toBeVisible();
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await expect(page.testSubj.locator('euiToastHeader__title')).toContainText('Deleted 1 rule');
+
+    const idx = createdRuleIds.indexOf(rule.data.id);
+    if (idx !== -1) createdRuleIds.splice(idx, 1);
+
+    await searchRules(page, namePrefix);
+    await expect(getTableRows(page)).toHaveCount(0);
+  });
+
+  // Skipped: test.failing rule type is not registered in Scout stateful/classic.
+  test.skip('should filter alerts by the status', async () => {});
+
+  // Skipped: test.failing rule type is not registered in Scout stateful/classic.
+  test.skip('should display total alerts by status and error banner only when exists alerts with status error', async () => {});
+
+  // Skipped: test.failing rule type is not registered in Scout stateful/classic.
+  test.skip('Expand error in rules table when there is rule with an error associated', async () => {});
+
+  test('should filter alerts by the alert type', async ({ page, apiServices }) => {
+    const uniqueTag = `type-filter-${Date.now()}`;
+    const [rEsQuery, rIndexThreshold] = await Promise.all([
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('esq'), tags: [uniqueTag] }),
+      apiServices.alerting.rules.create({
+        name: `idx-thresh-${Date.now()}`,
+        ruleTypeId: '.index-threshold',
+        consumer: 'alerts',
+        enabled: true,
+        schedule: { interval: '1m' },
+        actions: [],
+        tags: [uniqueTag],
+        params: {
+          aggType: 'count',
+          termSize: 5,
+          thresholdComparator: '>',
+          timeWindowSize: 5,
+          timeWindowUnit: 'm',
+          groupBy: 'all',
+          threshold: [1000],
+          index: ['.kibana'],
+          timeField: '@timestamp',
+        },
+      }),
+    ]);
+    createdRuleIds.push(rEsQuery.data.id, rIndexThreshold.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, uniqueTag);
+    await expect(getTableRows(page)).toHaveCount(2);
+
+    await page.testSubj.click('ruleTypeFilterButton');
+    await expect(page.testSubj.locator('ruleType.es-queryFilterOption')).toBeVisible();
+    await page.testSubj.click('ruleType.es-queryFilterOption');
+    await page.testSubj.click('ruleTypeFilterButton'); // close dropdown
+
+    await expect(getTableRows(page)).toHaveCount(1);
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${rEsQuery.data.name}"]`)
+    ).toBeVisible();
+  });
+
+  test('should filter alerts by the action type', async ({ page, apiServices, kbnClient }) => {
+    const slackConnector = await createSlackConnector(
+      kbnClient,
+      `slack-action-filter-${Date.now()}`
+    );
+    createdConnectorIds.push(slackConnector.id);
+
+    const uniqueTag = `action-filter-${Date.now()}`;
+    const [rNoAction, rWithSlack] = await Promise.all([
+      apiServices.alerting.rules.create({ ...makeEsQueryRule('no-action'), tags: [uniqueTag] }),
+      apiServices.alerting.rules.create({
+        ...makeEsQueryRule('with-slack'),
+        tags: [uniqueTag],
+        actions: [
+          {
+            id: slackConnector.id,
+            group: 'query matched',
+            params: { message: 'scout test' },
+            frequency: {
+              summary: false,
+              notifyWhen: 'onActionGroupChange' as const,
+              throttle: undefined,
+            },
+          },
+        ],
+      }),
+    ]);
+    createdRuleIds.push(rNoAction.data.id, rWithSlack.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, uniqueTag);
+    await expect(getTableRows(page)).toHaveCount(2);
+
+    await page.testSubj.click('actionTypeFilterButton');
+    await page.testSubj.click('actionType.slackFilterOption');
+
+    await expect(getTableRows(page)).toHaveCount(1);
+    await expect(
+      page.testSubj.locator('rulesList').locator(`[title="${rWithSlack.data.name}"]`)
+    ).toBeVisible();
+
+    // De-select the action type filter
+    await page.testSubj.click('actionTypeFilterButton');
+    await page.testSubj.click('actionType.slackFilterOption');
+    await expect(page.testSubj.locator('centerJustifiedSpinner')).toBeHidden();
+  });
+
+  test('should filter alerts by the rule status', async ({ page, apiServices, kbnClient }) => {
+    const uniqueTag = `status-filter-${Date.now()}`;
+    const makeRule = (prefix: string) =>
+      apiServices.alerting.rules.create({ ...makeEsQueryRule(prefix), tags: [uniqueTag] });
+
+    const [rEnabled, rDisabled, rSnoozed, rSnoozedDisabled] = await Promise.all([
+      makeRule('status-enabled'),
+      makeRule('status-disabled'),
+      makeRule('status-snoozed'),
+      makeRule('status-snoozed-disabled'),
+    ]);
+    createdRuleIds.push(
+      rEnabled.data.id,
+      rDisabled.data.id,
+      rSnoozed.data.id,
+      rSnoozedDisabled.data.id
+    );
+
+    await disableRule(kbnClient, rDisabled.data.id);
+    await snoozeRule(kbnClient, rSnoozed.data.id);
+    await snoozeRule(kbnClient, rSnoozedDisabled.data.id);
+    await disableRule(kbnClient, rSnoozedDisabled.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, uniqueTag);
+    await expect(getTableRows(page)).toHaveCount(4);
+
+    // Select only enabled → 2 rules (enabled + snoozed)
+    await page.testSubj.click('ruleStatusFilterButton');
+    await page.testSubj.click('ruleStatusFilterOption-enabled');
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(2);
+
+    // Add disabled → all 4
+    await page.testSubj.click('ruleStatusFilterOption-disabled');
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(4);
+
+    // Deselect enabled → only disabled
+    await page.testSubj.click('ruleStatusFilterOption-enabled');
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(2);
+
+    // Deselect disabled, select snoozed → only snoozed
+    await page.testSubj.click('ruleStatusFilterOption-disabled');
+    await page.testSubj.click('ruleStatusFilterOption-snoozed');
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(2);
+
+    // Add disabled → disabled + snoozed (3 rules)
+    await page.testSubj.click('ruleStatusFilterOption-disabled');
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(3);
+
+    // Add enabled → all 4
+    await page.testSubj.click('ruleStatusFilterOption-enabled');
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(4);
+
+    // Close filter panel
+    await page.testSubj.click('ruleStatusFilterButton');
+  });
+
+  test('should filter alerts by the tag', async ({ page, apiServices }) => {
+    const p = `t-${Date.now()}`;
+    const tagA = `${p}-a`;
+    const tagB = `${p}-b`;
+    const tagC = `${p}-c`;
+
+    const rules = await Promise.all([
+      apiServices.alerting.rules.create({ ...makeEsQueryRule(`${p}-1`), tags: [tagA] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule(`${p}-2`), tags: [tagB] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule(`${p}-3`), tags: [tagA, tagB] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule(`${p}-4`), tags: [tagB, tagC] }),
+      apiServices.alerting.rules.create({ ...makeEsQueryRule(`${p}-5`), tags: [tagC] }),
+    ]);
+    rules.forEach((r) => createdRuleIds.push(r.data.id));
+
+    await refreshRulesList(page);
+    await searchRules(page, p);
+    await expect(getTableRows(page)).toHaveCount(5);
+
+    await page.testSubj.click('ruleTagFilter');
+
+    // Select A → 2 rules
+    await page.testSubj.click(`ruleTagFilterOption-${tagA}`);
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(2);
+
+    // Deselect A → all 5
+    await page.testSubj.click(`ruleTagFilterOption-${tagA}`);
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(5);
+
+    // Select A + B → 4 rules
+    await page.testSubj.click(`ruleTagFilterOption-${tagA}`);
+    await page.testSubj.click(`ruleTagFilterOption-${tagB}`);
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(4);
+
+    // Deselect A, B; select C → 2 rules
+    await page.testSubj.click(`ruleTagFilterOption-${tagA}`);
+    await page.testSubj.click(`ruleTagFilterOption-${tagB}`);
+    await page.testSubj.click(`ruleTagFilterOption-${tagC}`);
+    await page
+      .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+      .waitFor();
+    await expect(getTableRows(page)).toHaveCount(2);
+  });
+
+  test('should not prevent rules with action execution capabilities from being edited', async ({
+    page,
+    apiServices,
+    kbnClient,
+  }) => {
+    const slackConnector = await createSlackConnector(kbnClient, `slack-edit-cap-${Date.now()}`);
+    createdConnectorIds.push(slackConnector.id);
+
+    const rule = await apiServices.alerting.rules.create({
+      ...makeEsQueryRule('edit-cap'),
+      actions: [
+        {
+          id: slackConnector.id,
+          group: 'query matched',
+          params: { message: 'scout test' },
+          frequency: {
+            summary: false,
+            notifyWhen: 'onActionGroupChange' as const,
+            throttle: undefined,
+          },
+        },
+      ],
+    });
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await expect(page.testSubj.locator('selectActionButton')).not.toBeDisabled();
+  });
+
+  // Skipped: requires test.always-firing to generate active alert instances.
+  test.skip('should untrack disable rule if untrack switch is true', async () => {});
+
+  // Skipped: requires test.always-firing to generate active alert instances.
+  test.skip('should not untrack disable rule if untrack switch if false', async () => {});
+
+  test('should allow rules to be snoozed using the right side dropdown', async ({
+    page,
+    apiServices,
+  }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('snooze-dropdown'));
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('snoozeButton');
+    await page.testSubj.click('ruleSnoozeApply');
+
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozed')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('should allow rules to be snoozed indefinitely using the right side dropdown', async ({
+    page,
+    apiServices,
+  }) => {
+    const rule = await apiServices.alerting.rules.create(
+      makeEsQueryRule('snooze-indefinite-dropdown')
+    );
+    createdRuleIds.push(rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('snoozeButton');
+    await page.testSubj.click('ruleSnoozeIndefiniteApply');
+
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozedIndefinitely')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('should allow snoozed rules to be unsnoozed using the right side dropdown', async ({
+    page,
+    apiServices,
+    kbnClient,
+  }) => {
+    const rule = await apiServices.alerting.rules.create(makeEsQueryRule('unsnooze-dropdown'));
+    createdRuleIds.push(rule.data.id);
+    await snoozeRule(kbnClient, rule.data.id);
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('snoozeButton');
+    await page.testSubj.click('ruleSnoozeCancel');
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.data.name as string);
+
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozed')).toBeHidden();
+    await expect(page.testSubj.locator('rulesListNotifyBadge-snoozedIndefinitely')).toBeHidden();
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rules_list.spec.ts
@@ -10,8 +10,8 @@
 //
 // Rule type substitutions:
 //   test.noop          → .es-query (built-in, always available in Scout stateful/classic)
-//   test.failing       → NOT registered in Scout — 3 tests skipped
-//   test.always-firing → NOT registered in Scout — 2 tests skipped
+//   test.failing       → .es-query with invalid query type (fails at ES execution time)
+//   test.always-firing → .es-query with threshold >= 0 (always fires against .kibana)
 
 import type { KbnClient, ScoutPage } from '@kbn/scout';
 import { tags } from '@kbn/scout';
@@ -65,6 +65,90 @@ const deleteConnector = async (kbnClient: KbnClient, connectorId: string) => {
     path: `/api/actions/connector/${connectorId}`,
     headers: { 'kbn-xsrf': 'scout' },
   });
+};
+
+// Unknown query type — ES rejects it at search time, causing rule execution to fail
+const FAILING_ES_QUERY = JSON.stringify({ query: { not_a_real_query_type: {} } });
+
+const runRuleSoon = async (kbnClient: KbnClient, ruleId: string) => {
+  await kbnClient.request({
+    method: 'POST',
+    path: `/internal/alerting/rule/${ruleId}/_run_soon`,
+    headers: { 'kbn-xsrf': 'scout' },
+  });
+};
+
+const getAlertSummary = async (kbnClient: KbnClient, ruleId: string) => {
+  const resp = await kbnClient.request<{ alerts: Record<string, { tracked: boolean }> }>({
+    method: 'GET',
+    path: `/internal/alerting/rule/${ruleId}/_alert_summary`,
+    headers: {},
+  });
+  return resp.data;
+};
+
+const createFailingRule = async (kbnClient: KbnClient, name: string, ruleTags: string[]) => {
+  const resp = await kbnClient.request<{ id: string; name: string }>({
+    method: 'POST',
+    path: '/api/alerting/rule',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      rule_type_id: '.es-query',
+      consumer: 'alerts',
+      enabled: true,
+      schedule: { interval: '24h' },
+      actions: [],
+      tags: ruleTags,
+      params: {
+        searchType: 'esQuery',
+        esQuery: FAILING_ES_QUERY,
+        size: 100,
+        thresholdComparator: '>',
+        threshold: [0],
+        timeWindowSize: 5,
+        timeWindowUnit: 'm',
+        index: ['.kibana'],
+        timeField: 'updated_at',
+        aggType: 'count',
+        groupBy: 'all',
+        termSize: 5,
+      },
+    },
+  });
+  return resp.data;
+};
+
+const createAlwaysFiringRule = async (kbnClient: KbnClient, name: string) => {
+  const resp = await kbnClient.request<{ id: string; name: string }>({
+    method: 'POST',
+    path: '/api/alerting/rule',
+    headers: { 'kbn-xsrf': 'scout' },
+    body: {
+      name,
+      rule_type_id: '.es-query',
+      consumer: 'alerts',
+      enabled: true,
+      schedule: { interval: '24h' },
+      actions: [],
+      tags: [],
+      params: {
+        searchType: 'esQuery',
+        esQuery: JSON.stringify({ query: { match_all: {} } }),
+        size: 100,
+        thresholdComparator: '>=',
+        threshold: [0],
+        timeWindowSize: 5,
+        timeWindowUnit: 'm',
+        index: ['.kibana'],
+        timeField: 'updated_at',
+        aggType: 'count',
+        groupBy: 'all',
+        termSize: 5,
+      },
+    },
+  });
+  return resp.data;
 };
 
 // ── UI helpers ────────────────────────────────────────────────────────────────
@@ -388,14 +472,137 @@ test.describe('Rules list', { tag: tags.stateful.classic }, () => {
     await expect(getTableRows(page)).toHaveCount(0);
   });
 
-  // Skipped: test.failing rule type is not registered in Scout stateful/classic.
-  test.skip('should filter alerts by the status', async () => {});
+  test('should filter alerts by the status', async ({ page, apiServices, kbnClient }) => {
+    const tag = `outcome-filter-${Date.now()}`;
 
-  // Skipped: test.failing rule type is not registered in Scout stateful/classic.
-  test.skip('should display total alerts by status and error banner only when exists alerts with status error', async () => {});
+    const normalRule = await apiServices.alerting.rules.create({
+      ...makeEsQueryRule('normal'),
+      tags: [tag],
+    });
+    createdRuleIds.push(normalRule.data.id);
 
-  // Skipped: test.failing rule type is not registered in Scout stateful/classic.
-  test.skip('Expand error in rules table when there is rule with an error associated', async () => {});
+    const failRule = await createFailingRule(kbnClient, `fail-${Date.now()}`, [tag]);
+    createdRuleIds.push(failRule.id);
+
+    await Promise.all([
+      runRuleSoon(kbnClient, normalRule.data.id),
+      runRuleSoon(kbnClient, failRule.id),
+    ]);
+
+    // Wait until the failing rule shows 'Failed' last run outcome
+    await expect(async () => {
+      await refreshRulesList(page);
+      await searchRules(page, tag);
+      await page.testSubj.click('ruleLastRunOutcomeFilterButton');
+      await page.testSubj.click('ruleLastRunOutcomefailedFilterOption');
+      await page
+        .locator('.euiBasicTable[data-test-subj="rulesList"]:not(.euiBasicTable-loading)')
+        .waitFor({ timeout: 5_000 });
+      await expect(getTableRows(page)).toHaveCount(1, { timeout: 2_000 });
+    }).toPass({ timeout: 60_000, intervals: [3_000] });
+
+    await expect(getTableRows(page)).toHaveCount(1);
+  });
+
+  test('should display total alerts by status and error banner only when exists alerts with status error', async ({
+    page,
+    apiServices,
+    kbnClient,
+  }) => {
+    const tag = `error-banner-${Date.now()}`;
+
+    const normalRule = await apiServices.alerting.rules.create({
+      ...makeEsQueryRule('normal'),
+      tags: [tag],
+    });
+    createdRuleIds.push(normalRule.data.id);
+    await runRuleSoon(kbnClient, normalRule.data.id);
+
+    // Wait for normal rule to succeed
+    await expect(async () => {
+      await refreshRulesList(page);
+      await searchRules(page, tag);
+      await expect(page.testSubj.locator('totalSucceededRulesCount')).toContainText(
+        'Succeeded: 1',
+        {
+          timeout: 3_000,
+        }
+      );
+    }).toPass({ timeout: 60_000, intervals: [3_000] });
+
+    // No error banner before any failures
+    await expect(page.testSubj.locator('rulesErrorBanner')).toHaveCount(0);
+
+    const failRule = await createFailingRule(kbnClient, `fail-${Date.now()}`, [tag]);
+    createdRuleIds.push(failRule.id);
+    await runRuleSoon(kbnClient, failRule.id);
+
+    // Wait until error banner and status counts update
+    await expect(async () => {
+      await refreshRulesList(page);
+      await searchRules(page, tag);
+      await expect(page.testSubj.locator('rulesErrorBanner')).toBeVisible({ timeout: 3_000 });
+      await expect(page.testSubj.locator('rulesErrorBanner')).toContainText(
+        'Error found in 1 rule. Show rule with error',
+        { timeout: 3_000 }
+      );
+      await expect(page.testSubj.locator('totalRulesCount')).toContainText('2 rules', {
+        timeout: 3_000,
+      });
+      await expect(page.testSubj.locator('totalSucceededRulesCount')).toContainText(
+        'Succeeded: 1',
+        {
+          timeout: 3_000,
+        }
+      );
+      await expect(page.testSubj.locator('totalFailedRulesCount')).toContainText('Failed: 1', {
+        timeout: 3_000,
+      });
+      await expect(page.testSubj.locator('totalWarningRulesCount')).toContainText('Warning: 0', {
+        timeout: 3_000,
+      });
+    }).toPass({ timeout: 60_000, intervals: [3_000] });
+  });
+
+  test('Expand error in rules table when there is rule with an error associated', async ({
+    page,
+    apiServices,
+    kbnClient,
+  }) => {
+    const tag = `expand-error-${Date.now()}`;
+
+    const normalRule = await apiServices.alerting.rules.create({
+      ...makeEsQueryRule('normal'),
+      tags: [tag],
+    });
+    createdRuleIds.push(normalRule.data.id);
+    await runRuleSoon(kbnClient, normalRule.data.id);
+
+    // Wait for normal rule to execute — no expand error link yet
+    await expect(async () => {
+      await refreshRulesList(page);
+      await searchRules(page, tag);
+      await expect(getTableRows(page)).toHaveCount(1, { timeout: 3_000 });
+      await expect(page.testSubj.locator('expandRulesError')).toHaveCount(0);
+    }).toPass({ timeout: 60_000, intervals: [3_000] });
+
+    const failRule = await createFailingRule(kbnClient, `fail-${Date.now()}`, [tag]);
+    createdRuleIds.push(failRule.id);
+    await runRuleSoon(kbnClient, failRule.id);
+
+    // Wait until the expand error link appears
+    await expect(async () => {
+      await refreshRulesList(page);
+      await searchRules(page, tag);
+      await expect(page.testSubj.locator('expandRulesError')).toBeVisible({ timeout: 3_000 });
+    }).toPass({ timeout: 60_000, intervals: [3_000] });
+
+    // Expand and verify error details
+    await page.testSubj.click('expandRulesError');
+    const expandedRow = page.locator('.euiTableRow-isExpandedRow');
+    await expect(expandedRow).toBeVisible();
+    await expect(expandedRow).toContainText('Error from last run');
+  });
 
   test('should filter alerts by the alert type', async ({ page, apiServices }) => {
     const uniqueTag = `type-filter-${Date.now()}`;
@@ -640,14 +847,84 @@ test.describe('Rules list', { tag: tags.stateful.classic }, () => {
     createdRuleIds.push(rule.data.id);
 
     await refreshRulesList(page);
-    await expect(page.testSubj.locator('selectActionButton')).not.toBeDisabled();
+    await expect(page.testSubj.locator('selectActionButton')).toBeEnabled();
   });
 
-  // Skipped: requires test.always-firing to generate active alert instances.
-  test.skip('should untrack disable rule if untrack switch is true', async () => {});
+  test('should untrack disable rule if untrack switch is true', async ({ page, kbnClient }) => {
+    const rule = await createAlwaysFiringRule(kbnClient, `untrack-true-${Date.now()}`);
+    createdRuleIds.push(rule.id);
+    await runRuleSoon(kbnClient, rule.id);
 
-  // Skipped: requires test.always-firing to generate active alert instances.
-  test.skip('should not untrack disable rule if untrack switch if false', async () => {});
+    // Wait for the rule to fire and create a tracked alert instance
+    await expect(async () => {
+      const summary = await getAlertSummary(kbnClient, rule.id);
+      if (!summary.alerts['query matched']?.tracked) {
+        throw new Error('Alert instance not yet tracked');
+      }
+    }).toPass({ timeout: 60_000, intervals: [2_000] });
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.name);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('disableButton');
+
+    // Untrack modal appears — toggle switch to enable untracking
+    await expect(page.testSubj.locator('untrackAlertsModal')).toBeVisible({ timeout: 5_000 });
+    await page.testSubj.click('untrackAlertsModalSwitch');
+    await page.testSubj
+      .locator('untrackAlertsModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]')
+      .click();
+
+    // Alert instance should now be untracked
+    await expect(async () => {
+      const summary = await getAlertSummary(kbnClient, rule.id);
+      const instance = summary.alerts['query matched'];
+      if (!instance || instance.tracked !== false) {
+        throw new Error('Alert instance still tracked');
+      }
+    }).toPass({ timeout: 30_000, intervals: [2_000] });
+  });
+
+  test('should not untrack disable rule if untrack switch if false', async ({
+    page,
+    kbnClient,
+  }) => {
+    const rule = await createAlwaysFiringRule(kbnClient, `untrack-false-${Date.now()}`);
+    createdRuleIds.push(rule.id);
+    await runRuleSoon(kbnClient, rule.id);
+
+    // Wait for the rule to fire and create a tracked alert instance
+    await expect(async () => {
+      const summary = await getAlertSummary(kbnClient, rule.id);
+      if (!summary.alerts['query matched']?.tracked) {
+        throw new Error('Alert instance not yet tracked');
+      }
+    }).toPass({ timeout: 60_000, intervals: [2_000] });
+
+    await refreshRulesList(page);
+    await searchRules(page, rule.name);
+
+    await page.testSubj.click('collapsedItemActions');
+    await page.testSubj.click('disableButton');
+
+    // Untrack modal appears — do NOT toggle switch (default is untrack=false)
+    await expect(page.testSubj.locator('untrackAlertsModal')).toBeVisible({ timeout: 5_000 });
+    await page.testSubj
+      .locator('untrackAlertsModal')
+      .locator('[data-test-subj="confirmModalConfirmButton"]')
+      .click();
+
+    // Alert instance should remain tracked
+    await expect(async () => {
+      const summary = await getAlertSummary(kbnClient, rule.id);
+      const instance = summary.alerts['query matched'];
+      if (!instance || instance.tracked !== true) {
+        throw new Error('Alert instance unexpectedly untracked');
+      }
+    }).toPass({ timeout: 30_000, intervals: [2_000] });
+  });
 
   test('should allow rules to be snoozed using the right side dropdown', async ({
     page,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/.meta/ui/standard.json
@@ -1,0 +1,19 @@
+{
+  "sha1": "",
+  "tests": [
+    {
+      "id": "97ba3c699ad37ed-e3a775bd104626c",
+      "title": "Email connector — AWS SES Kibana config should use the kibana config for aws ses",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/ui/tests/email_aws_ses.spec.ts",
+        "line": 35,
+        "column": 9
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/ui/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/ui/tests/email_aws_ses.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_aws_ses/ui/tests/email_aws_ses.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/with_email_aws_ses_kbn_config/email.ts
+//
+// 1 of 1 tests migrated.
+// Requires --xpack.actions.email.services.ses.host and
+// --xpack.actions.email.services.ses.port (set in the email_aws_ses Scout
+// config set).
+
+import { tags, test } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+const CONNECTORS_APP_PATH = '/app/management/insightsAndAlerting/triggersActionsConnectors';
+
+const AWS_SES_HOST = 'email-fips.ca-central-1.amazonaws.com';
+const AWS_SES_PORT = '25439';
+
+test.describe(
+  'Email connector — AWS SES Kibana config',
+  {
+    tag: tags.stateful.classic,
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth, page, kbnUrl }) => {
+      await browserAuth.loginAsAdmin();
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+    });
+
+    test('should use the kibana config for aws ses', async ({ page }) => {
+      await page.testSubj.click('createConnectorButton');
+      await page.testSubj.click('.email-card');
+      await page.testSubj.locator('emailServiceSelectInput').selectOption('ses');
+
+      await expect(page.testSubj.locator('emailHostInput')).toHaveValue(AWS_SES_HOST, {
+        timeout: 10_000,
+      });
+      await expect(page.testSubj.locator('emailPortInput')).toHaveValue(AWS_SES_PORT);
+      await expect(page.testSubj.locator('emailSecureSwitch')).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
+    });
+  }
+);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/.meta/ui/standard.json
@@ -1,0 +1,19 @@
+{
+  "sha1": "",
+  "tests": [
+    {
+      "id": "e56478c67582de7-9521f7ef0fbe14e",
+      "title": "Email connector — services-enabled Kibana config should use the kibana config for enabled services",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/ui/tests/email_services_enabled.spec.ts",
+        "line": 31,
+        "column": 9
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/ui/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/ui/tests/email_services_enabled.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_email_services_enabled/ui/tests/email_services_enabled.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/with_email_services_enabled_kbn_config/email.ts
+//
+// 1 of 1 tests migrated.
+// Requires --xpack.actions.email.services.enabled (set in the
+// email_services_enabled Scout config set).
+
+import { tags, test } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+const CONNECTORS_APP_PATH = '/app/management/insightsAndAlerting/triggersActionsConnectors';
+
+test.describe(
+  'Email connector — services-enabled Kibana config',
+  {
+    tag: tags.stateful.classic,
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth, page, kbnUrl }) => {
+      await browserAuth.loginAsAdmin();
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+    });
+
+    test('should use the kibana config for enabled services', async ({ page }) => {
+      await page.testSubj.click('createConnectorButton');
+      await page.testSubj.click('.email-card');
+
+      const serviceSelect = page.testSubj.locator('emailServiceSelectInput');
+      const options = serviceSelect.locator('option');
+
+      await expect(options).toHaveCount(2);
+      await expect(serviceSelect.locator('option:nth-child(1)')).toHaveText('Gmail');
+      await expect(serviceSelect.locator('option:nth-child(2)')).toHaveText('Amazon SES');
+    });
+  }
+);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/.meta/ui/standard.json
@@ -1,0 +1,19 @@
+{
+  "sha1": "",
+  "tests": [
+    {
+      "id": "5265713ff6871cd-8cc11b25b79e2b6",
+      "title": "Webhook connector — PFX disabled config should not render the pfx tab for ssl auth",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/ui/tests/webhook_disabled_ssl_pfx.spec.ts",
+        "line": 31,
+        "column": 9
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/ui/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/ui/tests/webhook_disabled_ssl_pfx.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout_webhook_disabled_ssl_pfx/ui/tests/webhook_disabled_ssl_pfx.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Migrated from:
+//   x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/webhook_disabled_ssl_pfx/webhook.ts
+//
+// 1 of 1 tests migrated.
+// Requires --xpack.actions.webhook.ssl.pfx.enabled=false (set in the
+// webhook_disabled_ssl_pfx Scout config set).
+
+import { tags, test } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+const CONNECTORS_APP_PATH = '/app/management/insightsAndAlerting/triggersActionsConnectors';
+
+test.describe(
+  'Webhook connector — PFX disabled config',
+  {
+    tag: tags.stateful.classic,
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth, page, kbnUrl }) => {
+      await browserAuth.loginAsAdmin();
+      await page.goto(kbnUrl.get(CONNECTORS_APP_PATH));
+    });
+
+    test('should not render the pfx tab for ssl auth', async ({ page }) => {
+      await page.testSubj.click('createConnectorButton');
+      await page.testSubj.click('.webhook-card');
+      await page.testSubj.click('authSSL');
+
+      const certTypeTabs = page.testSubj.locator('webhookCertTypeTabs').locator('.euiTab');
+
+      await expect(certTypeTabs).toHaveCount(1);
+      await expect(page.testSubj.locator('webhookCertTypeCRTab')).toBeVisible();
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/.meta/api/standard.json
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/.meta/api/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "a40bfb829f8b42475f03b2decb0300820d4e14b2",
+  "sha1": "d98fc77cb3db1776614e88734d860bec89cbee06",
   "tests": [
     {
       "id": "bd41f0240dfdfcb-9b0e8252d0034ea",
@@ -32,7 +32,7 @@
       }
     },
     {
-      "id": "405beff6794306f-a54347ac1e57e7e",
+      "id": "95bab923ba9cb11-a54347ac1e57e7e",
       "title": "Profiling is not setup and no data is loaded Admin users",
       "expectedStatus": "passed",
       "tags": [
@@ -40,13 +40,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_no_setup.spec.ts",
-        "line": 44,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts",
+        "line": 29,
         "column": 12
       }
     },
     {
-      "id": "405beff6794306f-429a339166c2e77",
+      "id": "95bab923ba9cb11-429a339166c2e77",
       "title": "Profiling is not setup and no data is loaded Viewer users",
       "expectedStatus": "passed",
       "tags": [
@@ -54,13 +54,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_no_setup.spec.ts",
-        "line": 58,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts",
+        "line": 43,
         "column": 12
       }
     },
     {
-      "id": "f24ba03baeb5e26-0723e6c11fe5d87",
+      "id": "44934ca34264be6-0723e6c11fe5d87",
       "title": "APM integration not installed but setup completed Admin user",
       "expectedStatus": "passed",
       "tags": [
@@ -68,13 +68,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts",
-        "line": 64,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts",
+        "line": 33,
         "column": 12
       }
     },
     {
-      "id": "f24ba03baeb5e26-76b2ff68d4e7a1b",
+      "id": "44934ca34264be6-76b2ff68d4e7a1b",
       "title": "APM integration not installed but setup completed Viewer user",
       "expectedStatus": "passed",
       "tags": [
@@ -82,13 +82,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts",
-        "line": 79,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts",
+        "line": 48,
         "column": 12
       }
     },
     {
-      "id": "da6d82a4243ce6c-271837831195e95",
+      "id": "5102c2676cabaad-271837831195e95",
       "title": "Profiling is setup and data is loaded Admin user",
       "expectedStatus": "passed",
       "tags": [
@@ -96,13 +96,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts",
-        "line": 47,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts",
+        "line": 38,
         "column": 10
       }
     },
     {
-      "id": "da6d82a4243ce6c-7018203930dfa66",
+      "id": "5102c2676cabaad-7018203930dfa66",
       "title": "Profiling is setup and data is loaded Viewer user",
       "expectedStatus": "passed",
       "tags": [
@@ -110,13 +110,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts",
-        "line": 61,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts",
+        "line": 52,
         "column": 10
       }
     },
     {
-      "id": "8b3eca81b16d245-3ee5b04db1c974d",
+      "id": "76ee1162fe3336b-3ee5b04db1c974d",
       "title": "Collector integration is not installed collector integration missing",
       "expectedStatus": "passed",
       "tags": [
@@ -124,13 +124,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts",
-        "line": 79,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts",
+        "line": 69,
         "column": 10
       }
     },
     {
-      "id": "8b3eca81b16d245-7029a2aca281cbb",
+      "id": "76ee1162fe3336b-7029a2aca281cbb",
       "title": "Collector integration is not installed Symbolizer integration is not installed",
       "expectedStatus": "passed",
       "tags": [
@@ -138,8 +138,8 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts",
-        "line": 102,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts",
+        "line": 92,
         "column": 10
       }
     }

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/.meta/api/standard.json
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/.meta/api/standard.json
@@ -1,0 +1,425 @@
+{
+  "sha1": "5ff520e1049bc35d55fd731ba34af4baad2293b7",
+  "tests": [
+    {
+      "id": "0e5fa6a764fdd20-784d92660b25361",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update bulk-dismisses multiple leads and returns { updated: N }",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 53,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-28cc60dd1d3944a",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update bulk-updated leads appear with the new status in GET /leads",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 71,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-521d135caa8a6b9",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update leads not in the ids list keep their original status",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 95,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-cc6a88ef7365d26",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update returns { updated: 0 } when all supplied IDs are unknown",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 119,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-fc1176b8ea2c68c",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update returns 400 when ids array is empty (Zod min(1))",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 130,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-068a826d1b4b86f",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update returns 400 when ids array exceeds 100 entries (Zod max(100))",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 140,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-ab7a2d236740c10",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update returns 400 when status is an invalid value",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 155,
+        "column": 12
+      }
+    },
+    {
+      "id": "0e5fa6a764fdd20-bce75d9f284a68c",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/bulk_update returns 400 when the request body is missing",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/bulk_update_leads.spec.ts",
+        "line": 167,
+        "column": 12
+      }
+    },
+    {
+      "id": "6aef5774a439dde-d377fa589ecc111",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/{id}/_dismiss dismisses an active lead and returns { success: true }",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/dismiss_lead.spec.ts",
+        "line": 53,
+        "column": 12
+      }
+    },
+    {
+      "id": "6aef5774a439dde-ce5dc63967ccafe",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/{id}/_dismiss dismissed lead appears in GET /leads?status=dismissed",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/dismiss_lead.spec.ts",
+        "line": 69,
+        "column": 12
+      }
+    },
+    {
+      "id": "6aef5774a439dde-89e395a590b7ee1",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/{id}/_dismiss dismissed lead is absent from GET /leads?status=active",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/dismiss_lead.spec.ts",
+        "line": 91,
+        "column": 12
+      }
+    },
+    {
+      "id": "6aef5774a439dde-10e2658836d15c6",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/{id}/_dismiss returns 404 when the lead ID does not exist",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/dismiss_lead.spec.ts",
+        "line": 113,
+        "column": 12
+      }
+    },
+    {
+      "id": "6aef5774a439dde-f59bfdad8bbdebc",
+      "title": "Lead Generation - POST /internal/entity_analytics/leads/{id}/_dismiss dismissing an already-dismissed lead is idempotent (returns 200)",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/dismiss_lead.spec.ts",
+        "line": 125,
+        "column": 12
+      }
+    },
+    {
+      "id": "667031b46515447-5615278d7c064cc",
+      "title": "Lead Generation - enable / disable scheduling POST /enable transitions feature to enabled state",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/enable_disable.spec.ts",
+        "line": 54,
+        "column": 12
+      }
+    },
+    {
+      "id": "667031b46515447-0f9251d49a8bcdd",
+      "title": "Lead Generation - enable / disable scheduling POST /disable transitions feature to disabled state",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/enable_disable.spec.ts",
+        "line": 76,
+        "column": 12
+      }
+    },
+    {
+      "id": "667031b46515447-f561a2fef83ccee",
+      "title": "Lead Generation - enable / disable scheduling POST /enable returns 400 when connectorId is missing",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/enable_disable.spec.ts",
+        "line": 106,
+        "column": 12
+      }
+    },
+    {
+      "id": "667031b46515447-903ecdb68b92c0d",
+      "title": "Lead Generation - enable / disable scheduling POST /enable returns 400 when connectorId is an empty string",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/enable_disable.spec.ts",
+        "line": 116,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-1ac8c88ea547d6e",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads returns empty result set when no leads exist",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 55,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-817c3e4f29b6928",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads returns leads with default pagination shape",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 70,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-38c605024154d27",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads filters leads by status=active and excludes dismissed leads",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 86,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-de7e91a56fed080",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads filters leads by status=dismissed and excludes active leads",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 107,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-b0c921b651a2b40",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads respects perPage pagination parameter",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 124,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-b35c6093da35ac7",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads returns the correct page using page parameter",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 140,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-c2bb6f61f8d33d2",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads sorts by priority descending (default) — highest priority first",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 161,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-17a16135c8bf162",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads sorts by priority ascending — lowest priority first",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 181,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-51e8b1866d4f23d",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads sorts by timestamp",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 201,
+        "column": 12
+      }
+    },
+    {
+      "id": "f7b459e6daf0d6b-ce87b742d2408ed",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads returns 400 for an invalid sortField value",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/get_leads.spec.ts",
+        "line": 222,
+        "column": 12
+      }
+    },
+    {
+      "id": "ae9c6f669bd72ba-ed8e0de4c3dc899",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads/status returns a well-formed status object and reflects the enabled state",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/lead_generation_status.spec.ts",
+        "line": 52,
+        "column": 12
+      }
+    },
+    {
+      "id": "ae9c6f669bd72ba-df77b13eabc5be7",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads/status totalLeads reflects the count of seeded documents",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/lead_generation_status.spec.ts",
+        "line": 73,
+        "column": 12
+      }
+    },
+    {
+      "id": "ae9c6f669bd72ba-de62295f1ee35c5",
+      "title": "Lead Generation - GET /internal/entity_analytics/leads/status lastRun is set to the most recent lead timestamp after seeding",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/security/plugins/security_solution/test/scout/api/tests/lead_generation/lead_generation_status.spec.ts",
+        "line": 89,
+        "column": 12
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Unblocks 5 FTR test suites from the Response Ops Scout migration backlog by migrating them to Scout/Playwright. Each suite had a specific blocker that is addressed here:

- **`rules/redirect.ts`** (2 tests → `redirect.spec.ts`): Blocker (management URL rendering blank) was separate from URL redirect behaviour — the redirect itself works fine with `page.waitForURL`.
- **`webhook_disabled_ssl_pfx/webhook.ts`** (1 test → `webhook_disabled_ssl_pfx.spec.ts`): Required `--xpack.actions.webhook.ssl.pfx.enabled=false`; fixed by adding a new `webhook_disabled_ssl_pfx` Scout config set.
- **`with_email_aws_ses_kbn_config/email.ts`** (1 test → `email_aws_ses.spec.ts`): Required SES host/port server args; fixed by adding a new `email_aws_ses` Scout config set.
- **`with_email_services_enabled_kbn_config/email.ts`** (1 test → `email_services_enabled.spec.ts`): Required `xpack.actions.email.services.enabled`; fixed by adding a new `email_services_enabled` Scout config set.
- **`embeddable_alerts_table.ts`** (8 FTR tests → `embeddable_alerts_table.spec.ts`): EuiSuperSelect focus-trap issue fixed by skipping the trigger click (popover auto-opens via `useEffectOnce`) and clicking option buttons directly with `{ force: true }`. 5 tests remain skipped pending authz/cross-test-state rework (3 require shared dashboard state across tests; 2 require config editor interactions).

## New Scout config sets

| Config set | Added server arg |
|---|---|
| `webhook_disabled_ssl_pfx` | `--xpack.actions.webhook.ssl.pfx.enabled=false` |
| `email_aws_ses` | `--xpack.actions.email.services.ses.host` + `--xpack.actions.email.services.ses.port` |
| `email_services_enabled` | `--xpack.actions.email.services.enabled` |

Each new config set extends `defaultConfig` from `base.config.ts` and is placed under `src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/<name>/stateful/classic.stateful.config.ts`. The corresponding plugin tests use `test/scout_<name>/ui/` directories, which are automatically picked up by `detectCustomConfigDir()`.

## Test plan

- [ ] `redirect.spec.ts`: navigate to `/app/rules`, verify redirect to Stack Management; navigate to `/app/rules/rule/:id`, verify redirect preserves rule ID
- [ ] `webhook_disabled_ssl_pfx.spec.ts`: open Webhook connector, enable SSL auth, verify only 1 cert type tab (CR tab, no PFX tab)
- [ ] `email_aws_ses.spec.ts`: open Email connector, select SES service, verify host/port/secure pre-populated from Kibana config
- [ ] `email_services_enabled.spec.ts`: open Email connector, verify only Gmail and Amazon SES options are shown
- [ ] `embeddable_alerts_table.spec.ts`: per-solution panel creation tests (stack/observability/security), solution filter tests

## Skipped tests (backlog)

- `embeddable_alerts_table`: authz prompt test, time filter tests — require cross-test shared dashboard state; kept as `test.skip` with comments
- `embeddable_alerts_table`: config editor tests — require EuiSuperSelect interactions inside modal; kept as `test.skip` with comments
- `global_rule_event_log_list.ts` — out of scope (no FTR→Scout path for event log list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)