### PR TITLE
[One workflow] Filter run modal using workflow triggers

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx
@@ -185,10 +185,10 @@ describe('WorkflowExecuteModal', () => {
       );
 
       expect(getByText('Alert')).toBeInTheDocument();
+      expect(getByText('Manual')).toBeInTheDocument();
       expect(getByText('Historical')).toBeInTheDocument();
       expect(queryByText('Document')).not.toBeInTheDocument();
       expect(queryByText('Event')).not.toBeInTheDocument();
-      expect(queryByText('Manual')).not.toBeInTheDocument();
     });
 
     it('uses the test run title and still exposes the full trigger tab set', () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.test.tsx
@@ -154,7 +154,7 @@ describe('WorkflowExecuteModal', () => {
       expect(getByText('Run Workflow')).toBeInTheDocument();
     });
 
-    it('renders all trigger type buttons', () => {
+    it('renders all trigger type buttons when the workflow definition is missing', () => {
       const { getByText } = renderWithProviders(
         <WorkflowExecuteModal
           isTestRun={false}
@@ -169,6 +169,26 @@ describe('WorkflowExecuteModal', () => {
       expect(getByText('Event')).toBeInTheDocument();
       expect(getByText('Manual')).toBeInTheDocument();
       expect(getByText('Historical')).toBeInTheDocument();
+    });
+
+    it('shows only tabs that match triggers declared in the workflow', () => {
+      const { getByText, queryByText } = renderWithProviders(
+        <WorkflowExecuteModal
+          isTestRun={false}
+          definition={{
+            ...baseWorkflowDefinition,
+            triggers: [{ type: 'alert' }],
+          }}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(getByText('Alert')).toBeInTheDocument();
+      expect(getByText('Historical')).toBeInTheDocument();
+      expect(queryByText('Document')).not.toBeInTheDocument();
+      expect(queryByText('Event')).not.toBeInTheDocument();
+      expect(queryByText('Manual')).not.toBeInTheDocument();
     });
 
     it('uses the test run title and still exposes the full trigger tab set', () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -31,7 +31,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { WorkflowYaml } from '@kbn/workflows';
 import { extractNormalizedInputsFromYaml } from '@kbn/workflows/spec/lib/field_conversion';
 import { useWorkflowsCapabilities } from '@kbn/workflows-ui';
-import { ENABLED_TRIGGER_TABS } from './constants';
 import { TRIGGER_TABS_DESCRIPTIONS, TRIGGER_TABS_LABELS } from './translations';
 import type { WorkflowTriggerTab } from './types';
 import { WorkflowExecuteAlertForm } from './workflow_execute_alert_form';
@@ -41,7 +40,9 @@ import { WorkflowExecuteIndexForm } from './workflow_execute_index_form';
 import { WorkflowExecuteManualForm } from './workflow_execute_manual_form';
 import { getWorkflowExecuteModalGlobalStyles } from './workflow_execute_modal_global_styles';
 import {
+  ensureSelectedTriggerTabVisible,
   getFallbackTriggerTab,
+  getVisibleWorkflowTriggerTabs,
   hasCustomEventTrigger,
   hasWorkflowInputFields,
   isRacAlertsApiForbiddenError,
@@ -90,6 +91,11 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
     const normalizedInputs = useMemo(
       () => extractNormalizedInputsFromYaml(definition, yamlString),
       [definition, yamlString]
+    );
+
+    const visibleTriggerTabs = useMemo(
+      () => getVisibleWorkflowTriggerTabs(definition, normalizedInputs),
+      [definition, normalizedInputs]
     );
 
     const [selectedTrigger, setSelectedTrigger] = useState<WorkflowTriggerTab>(() =>
@@ -213,16 +219,18 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
 
     useEffect(() => {
       setSelectedTrigger((current) => {
+        let next = current;
         if (current === 'alert' && !hasAlertRacAccess) {
-          return getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
+          next = getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
+        } else if (current === 'historical' && !canReadWorkflowExecution) {
+          next = getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
+        } else if (
+          current === 'event' &&
+          (!canReadWorkflowExecution || !eventDrivenExecutionEnabled)
+        ) {
+          next = getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
         }
-        if (current === 'historical' && !canReadWorkflowExecution) {
-          return getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
-        }
-        if (current === 'event' && (!canReadWorkflowExecution || !eventDrivenExecutionEnabled)) {
-          return getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
-        }
-        return current;
+        return ensureSelectedTriggerTabVisible(next, visibleTriggerTabs);
       });
     }, [
       hasAlertRacAccess,
@@ -230,6 +238,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
       eventDrivenExecutionEnabled,
       normalizedInputs,
       definition,
+      visibleTriggerTabs,
     ]);
 
     if (shouldAutoRun) {
@@ -363,7 +372,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
                   `}
                 >
                   <EuiFlexGroup direction="row" gutterSize="s" alignItems="stretch">
-                    {ENABLED_TRIGGER_TABS.map((trigger) => {
+                    {visibleTriggerTabs.map((trigger) => {
                       let triggerDisabledTooltip: string | undefined;
                       if (trigger === 'alert' && !hasAlertRacAccess) {
                         triggerDisabledTooltip = alertTabDisabledTooltip;

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -46,7 +46,9 @@ import {
   hasCustomEventTrigger,
   hasWorkflowInputFields,
   isRacAlertsApiForbiddenError,
+  isWorkflowTriggerTabDisabled,
   resolveInitialSelectedTrigger,
+  type WorkflowTriggerTabAvailability,
 } from './workflow_execute_modal_helpers';
 import { useKibana } from '../../../hooks/use_kibana';
 import { sanitizeText } from '../../../shared/lib/sanitize_text';
@@ -98,13 +100,23 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
       [definition]
     );
 
+    const triggerTabAvailability = useMemo<WorkflowTriggerTabAvailability>(
+      () => ({
+        hasAlertRacAccess,
+        canReadWorkflowExecution,
+        eventDrivenExecutionEnabled,
+      }),
+      [hasAlertRacAccess, canReadWorkflowExecution, eventDrivenExecutionEnabled]
+    );
+
     const [selectedTrigger, setSelectedTrigger] = useState<WorkflowTriggerTab>(() =>
       resolveInitialSelectedTrigger(
         definition,
         initialExecutionId,
         hasAlertRacAccess,
         canReadWorkflowExecution,
-        normalizedInputs
+        normalizedInputs,
+        eventDrivenExecutionEnabled
       )
     );
 
@@ -169,13 +181,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
 
     const handleChangeTrigger = useCallback(
       (trigger: WorkflowTriggerTab): void => {
-        if (trigger === 'alert' && !hasAlertRacAccess) {
-          return;
-        }
-        if (trigger === 'historical' && !canReadWorkflowExecution) {
-          return;
-        }
-        if (trigger === 'event' && (!canReadWorkflowExecution || !eventDrivenExecutionEnabled)) {
+        if (isWorkflowTriggerTabDisabled(trigger, triggerTabAvailability)) {
           return;
         }
         if (trigger === selectedTrigger) {
@@ -186,7 +192,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
         setEventTriggerTableSelectionCount(0);
         setSelectedTrigger(trigger);
       },
-      [hasAlertRacAccess, canReadWorkflowExecution, eventDrivenExecutionEnabled, selectedTrigger]
+      [triggerTabAvailability, selectedTrigger]
     );
 
     const shouldAutoRun = useMemo(() => {
@@ -230,15 +236,16 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
         ) {
           next = getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
         }
-        return ensureSelectedTriggerTabVisible(next, visibleTriggerTabs);
+        return ensureSelectedTriggerTabVisible(next, visibleTriggerTabs, triggerTabAvailability);
       });
     }, [
-      hasAlertRacAccess,
-      canReadWorkflowExecution,
-      eventDrivenExecutionEnabled,
+      triggerTabAvailability,
       normalizedInputs,
       definition,
       visibleTriggerTabs,
+      hasAlertRacAccess,
+      canReadWorkflowExecution,
+      eventDrivenExecutionEnabled,
     ]);
 
     if (shouldAutoRun) {
@@ -385,7 +392,10 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
                           triggerDisabledTooltip = eventTabEventDrivenDisabledTooltip;
                         }
                       }
-                      const isTriggerTabDisabled = triggerDisabledTooltip !== undefined;
+                      const isTriggerTabDisabled = isWorkflowTriggerTabDisabled(
+                        trigger,
+                        triggerTabAvailability
+                      );
                       const triggerButton = (
                         <EuiButton
                           color={selectedTrigger === trigger ? 'primary' : 'text'}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -94,8 +94,8 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
     );
 
     const visibleTriggerTabs = useMemo(
-      () => getVisibleWorkflowTriggerTabs(definition, normalizedInputs),
-      [definition, normalizedInputs]
+      () => getVisibleWorkflowTriggerTabs(definition),
+      [definition]
     );
 
     const [selectedTrigger, setSelectedTrigger] = useState<WorkflowTriggerTab>(() =>

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
@@ -142,7 +142,7 @@ describe('buildDefaultTriggerEventSearchQuery', () => {
 
 describe('getVisibleWorkflowTriggerTabs', () => {
   it('returns all tabs when the workflow has no triggers', () => {
-    expect(getVisibleWorkflowTriggerTabs(null, undefined)).toEqual([
+    expect(getVisibleWorkflowTriggerTabs(null)).toEqual([
       'alert',
       'index',
       'event',
@@ -151,43 +151,22 @@ describe('getVisibleWorkflowTriggerTabs', () => {
     ]);
   });
 
-  it('returns alert and historical for alert-only workflows', () => {
+  it('returns alert, manual, and historical for alert-only workflows', () => {
     expect(
-      getVisibleWorkflowTriggerTabs({ ...baseDefinition, triggers: [{ type: 'alert' }] }, undefined)
-    ).toEqual(['alert', 'historical']);
+      getVisibleWorkflowTriggerTabs({ ...baseDefinition, triggers: [{ type: 'alert' }] })
+    ).toEqual(['alert', 'manual', 'historical']);
   });
 
-  it('returns document and historical for manual-only workflows without inputs', () => {
+  it('returns document, manual, and historical for manual-only workflows', () => {
     expect(
-      getVisibleWorkflowTriggerTabs(
-        { ...baseDefinition, triggers: [{ type: 'manual' }] },
-        undefined
-      )
-    ).toEqual(['index', 'historical']);
-  });
-
-  it('returns manual, document, and historical when manual trigger defines inputs', () => {
-    const normalizedWithOneField = normalizeFieldsToJsonSchema([
-      { name: 'x', type: 'string', required: true },
-    ]);
-    expect(
-      getVisibleWorkflowTriggerTabs(
-        {
-          ...baseDefinition,
-          triggers: [{ type: 'manual', inputs: [{ name: 'x', type: 'string', required: true }] }],
-        } as WorkflowYaml,
-        normalizedWithOneField
-      )
+      getVisibleWorkflowTriggerTabs({ ...baseDefinition, triggers: [{ type: 'manual' }] })
     ).toEqual(['index', 'manual', 'historical']);
   });
 
-  it('returns event and historical for custom event-driven workflows', () => {
+  it('returns event, manual, and historical for custom event-driven workflows', () => {
     expect(
-      getVisibleWorkflowTriggerTabs(
-        workflowWithExtensionTriggers([{ type: 'cases.created' }]),
-        undefined
-      )
-    ).toEqual(['event', 'historical']);
+      getVisibleWorkflowTriggerTabs(workflowWithExtensionTriggers([{ type: 'cases.created' }]))
+    ).toEqual(['event', 'manual', 'historical']);
   });
 });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
@@ -14,6 +14,7 @@ import {
   buildDefaultTriggerEventSearchQuery,
   buildWorkflowTriggerScopeKql,
   getFallbackTriggerTab,
+  getVisibleWorkflowTriggerTabs,
   getWorkflowCustomTriggerTypeIds,
   hasCustomEventTrigger,
   resolveInitialSelectedTrigger,
@@ -139,6 +140,57 @@ describe('buildDefaultTriggerEventSearchQuery', () => {
   });
 });
 
+describe('getVisibleWorkflowTriggerTabs', () => {
+  it('returns all tabs when the workflow has no triggers', () => {
+    expect(getVisibleWorkflowTriggerTabs(null, undefined)).toEqual([
+      'alert',
+      'index',
+      'event',
+      'manual',
+      'historical',
+    ]);
+  });
+
+  it('returns alert and historical for alert-only workflows', () => {
+    expect(
+      getVisibleWorkflowTriggerTabs({ ...baseDefinition, triggers: [{ type: 'alert' }] }, undefined)
+    ).toEqual(['alert', 'historical']);
+  });
+
+  it('returns document and historical for manual-only workflows without inputs', () => {
+    expect(
+      getVisibleWorkflowTriggerTabs(
+        { ...baseDefinition, triggers: [{ type: 'manual' }] },
+        undefined
+      )
+    ).toEqual(['index', 'historical']);
+  });
+
+  it('returns manual, document, and historical when manual trigger defines inputs', () => {
+    const normalizedWithOneField = normalizeFieldsToJsonSchema([
+      { name: 'x', type: 'string', required: true },
+    ]);
+    expect(
+      getVisibleWorkflowTriggerTabs(
+        {
+          ...baseDefinition,
+          triggers: [{ type: 'manual', inputs: [{ name: 'x', type: 'string', required: true }] }],
+        } as WorkflowYaml,
+        normalizedWithOneField
+      )
+    ).toEqual(['index', 'manual', 'historical']);
+  });
+
+  it('returns event and historical for custom event-driven workflows', () => {
+    expect(
+      getVisibleWorkflowTriggerTabs(
+        workflowWithExtensionTriggers([{ type: 'cases.created' }]),
+        undefined
+      )
+    ).toEqual(['event', 'historical']);
+  });
+});
+
 describe('getFallbackTriggerTab', () => {
   const normalizedWithOneField: NormalizedWorkflowInputs = normalizeFieldsToJsonSchema([
     { name: 'x', type: 'string', required: true },
@@ -174,9 +226,9 @@ describe('resolveInitialSelectedTrigger', () => {
     );
   });
 
-  it('falls back when custom triggers exist but execution read is denied', () => {
+  it('falls back to the first visible tab when custom triggers exist but execution read is denied', () => {
     expect(resolveInitialSelectedTrigger(customOnly, undefined, true, false, undefined)).toBe(
-      'index'
+      'event'
     );
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.test.ts
@@ -13,6 +13,7 @@ import type { NormalizedWorkflowInputs } from './workflow_execute_modal_helpers'
 import {
   buildDefaultTriggerEventSearchQuery,
   buildWorkflowTriggerScopeKql,
+  ensureSelectedTriggerTabVisible,
   getFallbackTriggerTab,
   getVisibleWorkflowTriggerTabs,
   getWorkflowCustomTriggerTypeIds,
@@ -196,6 +197,38 @@ describe('getFallbackTriggerTab', () => {
   });
 });
 
+describe('ensureSelectedTriggerTabVisible', () => {
+  const allEnabled = {
+    hasAlertRacAccess: true,
+    canReadWorkflowExecution: true,
+    eventDrivenExecutionEnabled: true,
+  };
+
+  it('keeps the selected tab when it is visible and enabled', () => {
+    expect(
+      ensureSelectedTriggerTabVisible('manual', ['alert', 'manual', 'historical'], allEnabled)
+    ).toBe('manual');
+  });
+
+  it('chooses the first visible enabled tab when the selected tab is not visible', () => {
+    expect(
+      ensureSelectedTriggerTabVisible('index', ['alert', 'manual', 'historical'], {
+        ...allEnabled,
+        hasAlertRacAccess: false,
+      })
+    ).toBe('manual');
+  });
+
+  it('skips event when execution read is denied', () => {
+    expect(
+      ensureSelectedTriggerTabVisible('index', ['event', 'manual', 'historical'], {
+        ...allEnabled,
+        canReadWorkflowExecution: false,
+      })
+    ).toBe('manual');
+  });
+});
+
 describe('resolveInitialSelectedTrigger', () => {
   const customOnly = workflowWithExtensionTriggers([{ type: 'example.custom_trigger' }]);
 
@@ -205,10 +238,22 @@ describe('resolveInitialSelectedTrigger', () => {
     );
   });
 
-  it('falls back to the first visible tab when custom triggers exist but execution read is denied', () => {
+  it('falls back to manual when custom triggers exist but execution read is denied', () => {
     expect(resolveInitialSelectedTrigger(customOnly, undefined, true, false, undefined)).toBe(
-      'event'
+      'manual'
     );
+  });
+
+  it('falls back to manual for alert-only workflows without RAC access', () => {
+    expect(
+      resolveInitialSelectedTrigger(
+        { ...baseDefinition, triggers: [{ type: 'alert' }] },
+        undefined,
+        false,
+        true,
+        undefined
+      )
+    ).toBe('manual');
   });
 
   it('prefers alert when an alert trigger exists alongside custom triggers', () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
@@ -12,6 +12,7 @@ import type { WorkflowYaml } from '@kbn/workflows';
 import { isTriggerType } from '@kbn/workflows';
 import { getInputsFromDefinition } from '@kbn/workflows/spec/lib/field_conversion';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
+import { ENABLED_TRIGGER_TABS } from './constants';
 import type { WorkflowTriggerTab } from './types';
 
 export type NormalizedWorkflowInputs = JsonModelSchemaType | undefined;
@@ -50,6 +51,51 @@ export function isRacAlertsApiForbiddenError(error: unknown): boolean {
     msg.includes('Kibana privileges [rac]') ||
     msg.includes('/internal/rac/alerts')
   );
+}
+
+export function workflowDefinitionHasTriggerType(
+  definition: WorkflowYaml | null,
+  triggerType: string
+): boolean {
+  return Boolean(definition?.triggers?.some((trigger) => trigger.type === triggerType));
+}
+
+/** Run-modal tabs to show based on triggers declared in the workflow definition. */
+export function getVisibleWorkflowTriggerTabs(
+  definition: WorkflowYaml | null,
+  normalizedInputs: NormalizedWorkflowInputs | undefined
+): readonly WorkflowTriggerTab[] {
+  if (!definition?.triggers?.length) {
+    return ENABLED_TRIGGER_TABS;
+  }
+
+  const visible: WorkflowTriggerTab[] = [];
+
+  if (workflowDefinitionHasTriggerType(definition, 'alert')) {
+    visible.push('alert');
+  }
+  if (hasCustomEventTrigger(definition)) {
+    visible.push('event');
+  }
+  if (workflowDefinitionHasTriggerType(definition, 'manual')) {
+    visible.push('index');
+  }
+  if (hasWorkflowInputFields(normalizedInputs)) {
+    visible.push('manual');
+  }
+  visible.push('historical');
+
+  return visible;
+}
+
+export function ensureSelectedTriggerTabVisible(
+  selected: WorkflowTriggerTab,
+  visibleTabs: readonly WorkflowTriggerTab[]
+): WorkflowTriggerTab {
+  if (visibleTabs.includes(selected)) {
+    return selected;
+  }
+  return visibleTabs[0] ?? 'historical';
 }
 
 export function hasCustomEventTrigger(definition: WorkflowYaml | null): boolean {
@@ -147,36 +193,36 @@ export function resolveInitialSelectedTrigger(
   canReadWorkflowExecution: boolean,
   normalizedInputs: NormalizedWorkflowInputs | undefined
 ): WorkflowTriggerTab {
+  const visibleTabs = getVisibleWorkflowTriggerTabs(definition, normalizedInputs);
+
+  let selected: WorkflowTriggerTab;
+
   if (initialExecutionId) {
-    return canReadWorkflowExecution
+    selected = canReadWorkflowExecution
       ? 'historical'
       : getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
+  } else {
+    const hasAlertTrigger = workflowDefinitionHasTriggerType(definition, 'alert');
+    const hasEventTrigger = hasCustomEventTrigger(definition);
+
+    if (hasAlertTrigger) {
+      selected = hasAlertRacAccess
+        ? 'alert'
+        : getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
+    } else if (hasEventTrigger && canReadWorkflowExecution) {
+      selected = 'event';
+    } else if (hasEventTrigger && !canReadWorkflowExecution) {
+      selected = getFallbackTriggerTab(normalizedInputs, definition, false);
+    } else if (hasWorkflowInputFields(normalizedInputs)) {
+      selected = getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
+    } else {
+      const preferred = getDefaultTrigger(definition);
+      selected =
+        preferred === 'alert' && !hasAlertRacAccess
+          ? getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution)
+          : preferred;
+    }
   }
 
-  const hasAlertTrigger = Boolean(definition?.triggers?.some((t) => t.type === 'alert'));
-  const hasEventTrigger = hasCustomEventTrigger(definition);
-
-  if (hasAlertTrigger) {
-    return hasAlertRacAccess
-      ? 'alert'
-      : getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
-  }
-
-  if (hasEventTrigger && canReadWorkflowExecution) {
-    return 'event';
-  }
-
-  if (hasEventTrigger && !canReadWorkflowExecution) {
-    return getFallbackTriggerTab(normalizedInputs, definition, false);
-  }
-
-  if (hasWorkflowInputFields(normalizedInputs)) {
-    return getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
-  }
-
-  const preferred = getDefaultTrigger(definition);
-  if (preferred === 'alert' && !hasAlertRacAccess) {
-    return getFallbackTriggerTab(normalizedInputs, definition, canReadWorkflowExecution);
-  }
-  return preferred;
+  return ensureSelectedTriggerTabVisible(selected, visibleTabs);
 }

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
@@ -84,14 +84,45 @@ export function getVisibleWorkflowTriggerTabs(
   return visible;
 }
 
+export interface WorkflowTriggerTabAvailability {
+  hasAlertRacAccess: boolean;
+  canReadWorkflowExecution: boolean;
+  eventDrivenExecutionEnabled: boolean;
+}
+
+export function isWorkflowTriggerTabDisabled(
+  trigger: WorkflowTriggerTab,
+  availability: WorkflowTriggerTabAvailability
+): boolean {
+  if (trigger === 'alert' && !availability.hasAlertRacAccess) {
+    return true;
+  }
+  if (trigger === 'historical' && !availability.canReadWorkflowExecution) {
+    return true;
+  }
+  if (
+    trigger === 'event' &&
+    (!availability.canReadWorkflowExecution || !availability.eventDrivenExecutionEnabled)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function ensureSelectedTriggerTabVisible(
   selected: WorkflowTriggerTab,
-  visibleTabs: readonly WorkflowTriggerTab[]
+  visibleTabs: readonly WorkflowTriggerTab[],
+  availability?: WorkflowTriggerTabAvailability
 ): WorkflowTriggerTab {
-  if (visibleTabs.includes(selected)) {
+  const isEnabled = (tab: WorkflowTriggerTab) =>
+    !availability || !isWorkflowTriggerTabDisabled(tab, availability);
+
+  if (visibleTabs.includes(selected) && isEnabled(selected)) {
     return selected;
   }
-  return visibleTabs[0] ?? 'historical';
+
+  const firstEnabledVisible = visibleTabs.find(isEnabled);
+  return firstEnabledVisible ?? visibleTabs[0] ?? 'manual';
 }
 
 export function hasCustomEventTrigger(definition: WorkflowYaml | null): boolean {
@@ -187,7 +218,8 @@ export function resolveInitialSelectedTrigger(
   initialExecutionId: string | undefined,
   hasAlertRacAccess: boolean,
   canReadWorkflowExecution: boolean,
-  normalizedInputs: NormalizedWorkflowInputs | undefined
+  normalizedInputs: NormalizedWorkflowInputs | undefined,
+  eventDrivenExecutionEnabled = true
 ): WorkflowTriggerTab {
   const visibleTabs = getVisibleWorkflowTriggerTabs(definition);
 
@@ -220,5 +252,9 @@ export function resolveInitialSelectedTrigger(
     }
   }
 
-  return ensureSelectedTriggerTabVisible(selected, visibleTabs);
+  return ensureSelectedTriggerTabVisible(selected, visibleTabs, {
+    hasAlertRacAccess,
+    canReadWorkflowExecution,
+    eventDrivenExecutionEnabled,
+  });
 }

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal_helpers.ts
@@ -62,8 +62,7 @@ export function workflowDefinitionHasTriggerType(
 
 /** Run-modal tabs to show based on triggers declared in the workflow definition. */
 export function getVisibleWorkflowTriggerTabs(
-  definition: WorkflowYaml | null,
-  normalizedInputs: NormalizedWorkflowInputs | undefined
+  definition: WorkflowYaml | null
 ): readonly WorkflowTriggerTab[] {
   if (!definition?.triggers?.length) {
     return ENABLED_TRIGGER_TABS;
@@ -80,10 +79,7 @@ export function getVisibleWorkflowTriggerTabs(
   if (workflowDefinitionHasTriggerType(definition, 'manual')) {
     visible.push('index');
   }
-  if (hasWorkflowInputFields(normalizedInputs)) {
-    visible.push('manual');
-  }
-  visible.push('historical');
+  visible.push('manual', 'historical');
 
   return visible;
 }
@@ -193,7 +189,7 @@ export function resolveInitialSelectedTrigger(
   canReadWorkflowExecution: boolean,
   normalizedInputs: NormalizedWorkflowInputs | undefined
 ): WorkflowTriggerTab {
-  const visibleTabs = getVisibleWorkflowTriggerTabs(definition, normalizedInputs);
+  const visibleTabs = getVisibleWorkflowTriggerTabs(definition);
 
   let selected: WorkflowTriggerTab;
 

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/console_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/console_workflows.ts
@@ -54,6 +54,22 @@ steps:
 `;
 
 /**
+ * Workflow with an event-driven trigger so the Run/Test modal shows the Event tab.
+ */
+export const getTestRunEventTabWorkflowYaml = (name: string) => `
+name: ${name}
+enabled: false
+description: Workflow with workflows.failed trigger for Event tab scout test
+triggers:
+  - type: workflows.failed
+steps:
+  - name: hello_world_step
+    type: console
+    with:
+      message: "Test run: {{ execution.isTestRun }}"
+`;
+
+/**
  * Workflow with a foreach loop (4 items) and a nested console step.
  * Used for individual step run and context override tests.
  */

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
@@ -12,6 +12,7 @@ export { getCreateGetUpdateCaseWorkflowYaml } from './create_get_update_case';
 export {
   getListTestWorkflowYaml,
   getTestRunWorkflowYaml,
+  getTestRunEventTabWorkflowYaml,
   getWorkflowWithLoopYaml,
   getIterationLoopWorkflowYaml,
   getManyIterationsWorkflowYaml,

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/test_run.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/test_run.spec.ts
@@ -12,7 +12,11 @@ import { expect } from '@kbn/scout/ui';
 import { spaceTest as test } from '../../fixtures';
 import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
 import { EXECUTION_TIMEOUT } from '../../fixtures/constants';
-import { getTestRunWorkflowYaml, getWorkflowWithLoopYaml } from '../../fixtures/workflows';
+import {
+  getTestRunEventTabWorkflowYaml,
+  getTestRunWorkflowYaml,
+  getWorkflowWithLoopYaml,
+} from '../../fixtures/workflows';
 import { getWorkflowWithEventInputYaml } from '../../fixtures/workflows/console_workflows';
 
 test.describe('Workflow execution - Test runs', { tag: [...tags.stateful.classic] }, () => {
@@ -56,7 +60,9 @@ test.describe('Workflow execution - Test runs', { tag: [...tags.stateful.classic
     const workflowName = 'Test Workflow Event Tab From Editor';
 
     await pageObjects.workflowEditor.gotoNewWorkflow();
-    await pageObjects.workflowEditor.setYamlEditorValue(getTestRunWorkflowYaml(workflowName));
+    await pageObjects.workflowEditor.setYamlEditorValue(
+      getTestRunEventTabWorkflowYaml(workflowName)
+    );
     await pageObjects.workflowEditor.saveWorkflow();
 
     await pageObjects.workflowEditor.clickRunButton();


### PR DESCRIPTION
Relates to https://github.com/elastic/security-team/issues/16717.

## Summary

The **Run Workflow** and **Test Workflow** modals no longer show every trigger tab on every workflow. Tabs are derived from triggers declared in the workflow definition. **Manual** and **Historical** are always shown when the workflow defines triggers. Initial tab selection and permission fallbacks are constrained to tabs that remain visible, so users are not left on a hidden tab after RAC or capability changes.

## What changed

### Tab visibility rules

| Tab | Shown when |
| --- | --- |
| **Alert** | Workflow includes an `alert` trigger |
| **Event** | Workflow includes custom event-driven triggers (extension trigger types, e.g. `cases.created`) |
| **Document** | Workflow includes a `manual` trigger |
| **Manual** | Always |
| **Historical** | Always |

When the definition is missing or has no triggers, all tabs are still shown (unchanged behavior for incomplete or legacy callers).

## 🎥 Demo

https://github.com/user-attachments/assets/a37e10ef-80ab-49b1-9fbe-438c3c85f12c