### PR TITLE
[EDR Workflows] Skip Endpoint exceptions OR operator Cypress test on MKI

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/artifacts/endpoint_exceptions.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/artifacts/endpoint_exceptions.cy.ts
@@ -154,7 +154,8 @@ describe(
       });
     });
 
-    describe('OR operator', { tags: ['@ess', '@serverless'] }, () => {
+    // Skipped in Serverless MKI due to interactions with internal indices
+    describe('OR operator', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
       let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
       const artifactNameActions: FormAction[] = [


### PR DESCRIPTION
## Summary

It seem that on MKI, we don't run our tests which use the `indexEndpointHosts` task, as it works with internal indices. Hence, this PR skips on MKI the new Endpoint exceptions OR operator tests added here:
- #266687

Backporting just to keep the test env tags in sync.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->