### PR TITLE
[POC] Add sessionlessUserProfileRetrievalEnabled config

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -11136,6 +11136,12 @@
           "_meta": {
             "description": "The credential type that is configured for the anonymous authentication provider."
           }
+        },
+        "sessionlessUserProfileRetrievalEnabled": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Indicates if sessionless user profile retrieval is enabled for HTTP authentication."
+          }
         }
       }
     },

--- a/x-pack/platform/plugins/shared/security/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.test.ts
@@ -35,6 +35,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Object {
             "anonymous": undefined,
@@ -93,6 +94,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Object {
             "anonymous": undefined,
@@ -151,6 +153,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Object {
             "anonymous": undefined,
@@ -211,6 +214,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Object {
             "anonymous": undefined,
@@ -404,6 +408,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "oidc": Object {
             "realm": "realm-1",
@@ -436,6 +441,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "oidc": Object {
             "realm": "realm-1",
@@ -468,6 +474,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Array [
             "saml",
@@ -487,6 +494,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Array [
             "saml",
@@ -509,6 +517,7 @@ describe('config schema', () => {
               "apikey",
               "bearer",
             ],
+            "sessionlessUserProfileRetrievalEnabled": true,
           },
           "providers": Array [
             "saml",
@@ -1656,6 +1665,30 @@ describe('config schema', () => {
         ).authc.http.jwt.taggedRoutesOnly
       ).toEqual(false);
     });
+
+    describe('sessionlessUserProfileRetrievalEnabled', () => {
+      it('defaults to true', () => {
+        expect(ConfigSchema.validate({}).authc.http.sessionlessUserProfileRetrievalEnabled).toBe(
+          true
+        );
+      });
+
+      it('can be explicitly set to true', () => {
+        expect(
+          ConfigSchema.validate({
+            authc: { http: { sessionlessUserProfileRetrievalEnabled: true } },
+          }).authc.http.sessionlessUserProfileRetrievalEnabled
+        ).toBe(true);
+      });
+
+      it('can be set to false to disable sessionless user profile retrieval', () => {
+        expect(
+          ConfigSchema.validate({
+            authc: { http: { sessionlessUserProfileRetrievalEnabled: false } },
+          }).authc.http.sessionlessUserProfileRetrievalEnabled
+        ).toBe(false);
+      });
+    });
   });
 
   describe('ui', () => {
@@ -2025,6 +2058,7 @@ describe('createConfig()', () => {
             "apikey",
             "bearer",
           ],
+          "sessionlessUserProfileRetrievalEnabled": true,
         },
         "providers": Object {
           "basic": Object {

--- a/x-pack/platform/plugins/shared/security/server/config.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.ts
@@ -298,6 +298,7 @@ export const ConfigSchema = schema.object({
           taggedRoutesOnly: schema.boolean({ defaultValue: true }),
         }),
       }),
+      sessionlessUserProfileRetrievalEnabled: schema.boolean({ defaultValue: true }),
     }),
   }),
   audit: schema.object({

--- a/x-pack/platform/plugins/shared/security/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/security/server/plugin.ts
@@ -414,7 +414,12 @@ export class SecurityPlugin
     });
     this.session = session;
 
-    this.userProfileStart = this.userProfileService.start({ clusterClient, session });
+    this.userProfileStart = this.userProfileService.start({
+      clusterClient,
+      session,
+      sessionlessUserProfileRetrievalEnabled:
+        this.getConfig().authc.http.sessionlessUserProfileRetrievalEnabled,
+    });
 
     // In serverless, we want to redirect users to the list of projects instead of standard "Logged Out" page.
     const customLogoutURL =

--- a/x-pack/platform/plugins/shared/security/server/usage_collector/security_usage_collector.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/usage_collector/security_usage_collector.test.ts
@@ -54,6 +54,7 @@ describe('Security UsageCollector', () => {
     sessionCleanupInMinutes: 60,
     sessionConcurrentSessionsMaxSessions: 0,
     anonymousCredentialType: undefined,
+    sessionlessUserProfileRetrievalEnabled: true,
   };
 
   describe('initialization', () => {
@@ -117,6 +118,7 @@ describe('Security UsageCollector', () => {
       sessionCleanupInMinutes: 0,
       sessionConcurrentSessionsMaxSessions: 0,
       anonymousCredentialType: undefined,
+      sessionlessUserProfileRetrievalEnabled: true,
     });
   });
 
@@ -557,6 +559,38 @@ describe('Security UsageCollector', () => {
         sessionCleanupInMinutes: 789,
         sessionConcurrentSessionsMaxSessions: 321,
       });
+    });
+  });
+
+  describe('sessionlessUserProfileRetrievalEnabled', () => {
+    it('reports true by default', async () => {
+      const config = createSecurityConfig(ConfigSchema.validate({}));
+      const usageCollection = usageCollectionPluginMock.createSetupContract();
+      const license = createSecurityLicense({ isLicenseAvailable: true });
+      registerSecurityUsageCollector({ usageCollection, config, license });
+
+      const usage = await usageCollection
+        .getCollectorByType('security')
+        ?.fetch(collectorFetchContext);
+
+      expect(usage).toEqual({ ...DEFAULT_USAGE, sessionlessUserProfileRetrievalEnabled: true });
+    });
+
+    it('reports false when explicitly disabled', async () => {
+      const config = createSecurityConfig(
+        ConfigSchema.validate({
+          authc: { http: { sessionlessUserProfileRetrievalEnabled: false } },
+        })
+      );
+      const usageCollection = usageCollectionPluginMock.createSetupContract();
+      const license = createSecurityLicense({ isLicenseAvailable: true });
+      registerSecurityUsageCollector({ usageCollection, config, license });
+
+      const usage = await usageCollection
+        .getCollectorByType('security')
+        ?.fetch(collectorFetchContext);
+
+      expect(usage).toEqual({ ...DEFAULT_USAGE, sessionlessUserProfileRetrievalEnabled: false });
     });
   });
 

--- a/x-pack/platform/plugins/shared/security/server/usage_collector/security_usage_collector.ts
+++ b/x-pack/platform/plugins/shared/security/server/usage_collector/security_usage_collector.ts
@@ -23,6 +23,7 @@ interface Usage {
   sessionCleanupInMinutes: number;
   sessionConcurrentSessionsMaxSessions: number;
   anonymousCredentialType: string | undefined;
+  sessionlessUserProfileRetrievalEnabled: boolean;
 }
 
 interface Deps {
@@ -144,6 +145,13 @@ export function registerSecurityUsageCollector({ usageCollection, config, licens
             'The credential type that is configured for the anonymous authentication provider.',
         },
       },
+      sessionlessUserProfileRetrievalEnabled: {
+        type: 'boolean',
+        _meta: {
+          description:
+            'Indicates if sessionless user profile retrieval is enabled for HTTP authentication.',
+        },
+      },
     },
     fetch: () => {
       const { allowRbac, allowAccessAgreement, allowAuditLogging, allowFips } =
@@ -162,6 +170,7 @@ export function registerSecurityUsageCollector({ usageCollection, config, licens
           sessionCleanupInMinutes: 0,
           sessionConcurrentSessionsMaxSessions: 0,
           anonymousCredentialType: undefined,
+          sessionlessUserProfileRetrievalEnabled: true,
         };
       }
 
@@ -207,6 +216,9 @@ export function registerSecurityUsageCollector({ usageCollection, config, licens
           anonymousCredentialType = credUsernamePassword;
       }
 
+      const sessionlessUserProfileRetrievalEnabled =
+        config.authc.http.sessionlessUserProfileRetrievalEnabled;
+
       return {
         auditLoggingEnabled,
         loginSelectorEnabled,
@@ -220,6 +232,7 @@ export function registerSecurityUsageCollector({ usageCollection, config, licens
         sessionCleanupInMinutes,
         sessionConcurrentSessionsMaxSessions,
         anonymousCredentialType,
+        sessionlessUserProfileRetrievalEnabled,
       };
     },
   });

--- a/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts
@@ -466,10 +466,7 @@ describe('UserProfileService', () => {
           mockStartParams.clusterClient.asInternalUser.security.getUserProfile
         ).not.toHaveBeenCalled();
 
-        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenCalledTimes(1);
-        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenLastCalledWith({
-          outcome: 'success',
-        });
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
       });
     });
 
@@ -609,10 +606,7 @@ describe('UserProfileService', () => {
           mockStartParams.clusterClient.asInternalUser.security.getUserProfile
         ).not.toHaveBeenCalled();
 
-        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenCalledTimes(1);
-        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenLastCalledWith({
-          outcome: 'success',
-        });
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
       });
 
       it('should get user profile and application data scoped to Kibana', async () => {

--- a/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts
@@ -39,6 +39,7 @@ describe('UserProfileService', () => {
   let mockStartParams: {
     clusterClient: ReturnType<typeof elasticsearchServiceMock.createClusterClient>;
     session: ReturnType<typeof sessionMock.create>;
+    sessionlessUserProfileRetrievalEnabled: boolean;
   };
   let mockAuthz: ReturnType<typeof authorizationMock.create>;
   let userProfileService: UserProfileService;
@@ -46,6 +47,7 @@ describe('UserProfileService', () => {
     mockStartParams = {
       clusterClient: elasticsearchServiceMock.createClusterClient(),
       session: sessionMock.create(),
+      sessionlessUserProfileRetrievalEnabled: true,
     };
     mockAuthz = authorizationMock.create();
 
@@ -441,6 +443,34 @@ describe('UserProfileService', () => {
           profileActivationRequired: true,
         });
       });
+
+      it('returns `null` when es-security-runas-user header is present', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const runAsRequest = httpServerMock.createKibanaRequest({
+          headers: {
+            authorization: `basic ${Buffer.from(`${testUsername}:${testPassword}`).toString(
+              'base64'
+            )}`,
+            'es-security-runas-user': 'effective-user',
+          },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request: runAsRequest })).resolves.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.activateUserProfile
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenCalledTimes(1);
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenLastCalledWith({
+          outcome: 'success',
+        });
+      });
     });
 
     describe(`with api key`, () => {
@@ -559,6 +589,32 @@ describe('UserProfileService', () => {
         });
       });
 
+      it('returns `null` when es-security-runas-user header is present', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const runAsRequest = httpServerMock.createKibanaRequest({
+          headers: {
+            authorization: `apikey ${testEncodedApiKey}`,
+            'es-security-runas-user': 'effective-user',
+          },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request: runAsRequest })).resolves.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asScoped().asCurrentUser.security.getApiKey
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenCalledTimes(1);
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).toHaveBeenLastCalledWith({
+          outcome: 'success',
+        });
+      });
+
       it('should get user profile and application data scoped to Kibana', async () => {
         mockStartParams.clusterClient
           .asScoped()
@@ -633,6 +689,73 @@ describe('UserProfileService', () => {
           outcome: 'success',
           apiKeyRetrievalRequired: true,
         });
+      });
+    });
+
+    describe(`with sessionlessUserProfileRetrievalEnabled set to false`, () => {
+      beforeEach(() => {
+        mockStartParams.sessionlessUserProfileRetrievalEnabled = false;
+      });
+
+      it('returns `null` for basic auth requests without calling any ES APIs or recording telemetry', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const request = httpServerMock.createKibanaRequest({
+          headers: {
+            authorization: `basic ${Buffer.from('user:pass').toString('base64')}`,
+          },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request })).resolves.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.activateUserProfile
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
+      });
+
+      it('returns `null` for API key requests without calling any ES APIs or recording telemetry', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const testApiKeyId = 'some-api-key-id';
+        const testApiKeyValue = 'some-api-key-value';
+        const request = httpServerMock.createKibanaRequest({
+          headers: {
+            authorization: `apikey ${Buffer.from(`${testApiKeyId}:${testApiKeyValue}`).toString(
+              'base64'
+            )}`,
+          },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request })).resolves.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asScoped().asCurrentUser.security.getApiKey
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
+      });
+
+      it('still retrieves the profile for session-authenticated requests', async () => {
+        mockStartParams.session.getSID.mockResolvedValue('some-session-id');
+        mockStartParams.session.get.mockResolvedValue({
+          error: null,
+          value: sessionMock.createValue({ userProfileId: 'UID' }),
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request: mockRequest })).resolves.not.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts
@@ -752,6 +752,96 @@ describe('UserProfileService', () => {
         ).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe(`when security is disabled`, () => {
+      beforeEach(() => {
+        userProfileService = new UserProfileService(logger);
+        const license = licenseMock.create({ allowUserProfileCollaboration: true });
+        license.isEnabled.mockReturnValue(false);
+        userProfileService.setup({ authz: mockAuthz, license });
+      });
+
+      it('returns `null` for basic auth requests without calling any ES APIs or recording telemetry', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const request = httpServerMock.createKibanaRequest({
+          headers: {
+            authorization: `basic ${Buffer.from('user:pass').toString('base64')}`,
+          },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request })).resolves.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.activateUserProfile
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
+      });
+
+      it('returns `null` for API key requests without calling any ES APIs or recording telemetry', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const testApiKeyId = 'some-api-key-id';
+        const testApiKeyValue = 'some-api-key-value';
+        const request = httpServerMock.createKibanaRequest({
+          headers: {
+            authorization: `apikey ${Buffer.from(`${testApiKeyId}:${testApiKeyValue}`).toString(
+              'base64'
+            )}`,
+          },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request })).resolves.toBeNull();
+
+        expect(
+          mockStartParams.clusterClient.asScoped().asCurrentUser.security.getApiKey
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
+      });
+
+      it('returns `null` for session-authenticated requests without calling any ES APIs or recording telemetry', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+        mockStartParams.session.getSID.mockResolvedValue('some-session-id');
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request: mockRequest })).resolves.toBeNull();
+
+        expect(mockStartParams.session.getSID).not.toHaveBeenCalled();
+        expect(mockStartParams.session.get).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
+      });
+
+      it('returns `null` for requests with runas header without calling any ES APIs or recording telemetry', async () => {
+        (securityTelemetry.recordGetCurrentProfileInvocation as jest.Mock).mockClear();
+
+        const request = httpServerMock.createKibanaRequest({
+          headers: { 'es-security-runas-user': 'some-user' },
+        });
+
+        const startContract = userProfileService.start(mockStartParams);
+        await expect(startContract.getCurrent({ request })).resolves.toBeNull();
+
+        expect(mockStartParams.session.getSID).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.activateUserProfile
+        ).not.toHaveBeenCalled();
+        expect(
+          mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+        ).not.toHaveBeenCalled();
+        expect(securityTelemetry.recordGetCurrentProfileInvocation).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('#update', () => {

--- a/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.ts
@@ -43,6 +43,7 @@ const DEFAULT_SUGGESTIONS_COUNT = 10;
 const MIN_SUGGESTIONS_FOR_PRIVILEGES_CHECK = 10;
 const BULK_GET_MAX_UIDS_PER_BATCH = 50;
 const BULK_GET_MAX_CONCURRENT_BATCH_REQUESTS = 5;
+const RUNAS_HEADER = 'es-security-runas-user';
 
 export interface UserProfileServiceStartInternal extends UserProfileServiceStart {
   /**
@@ -67,6 +68,7 @@ export interface UserProfileServiceSetupParams {
 export interface UserProfileServiceStartParams {
   clusterClient: IClusterClient;
   session: PublicMethodsOf<Session>;
+  sessionlessUserProfileRetrievalEnabled: boolean;
 }
 
 function parseUserProfile<D extends UserProfileData>(
@@ -115,10 +117,19 @@ export class UserProfileService {
     this.license = license;
   }
 
-  start({ clusterClient, session }: UserProfileServiceStartParams) {
+  start({
+    clusterClient,
+    session,
+    sessionlessUserProfileRetrievalEnabled,
+  }: UserProfileServiceStartParams) {
     return {
       activate: this.activate.bind(this, clusterClient),
-      getCurrent: this.getCurrent.bind(this, clusterClient, session),
+      getCurrent: this.getCurrent.bind(
+        this,
+        clusterClient,
+        session,
+        sessionlessUserProfileRetrievalEnabled
+      ),
       bulkGet: this.bulkGet.bind(this, clusterClient),
       update: this.update.bind(this, clusterClient),
       suggest: this.suggest.bind(this, clusterClient),
@@ -342,6 +353,7 @@ export class UserProfileService {
   private async getCurrent<D extends UserProfileData>(
     clusterClient: IClusterClient,
     session: PublicMethodsOf<Session>,
+    sessionlessUserProfileRetrievalEnabled: boolean,
     { request, dataPath }: UserProfileGetCurrentParams
   ) {
     if (request.auth.isAuthenticated === false) {
@@ -356,6 +368,18 @@ export class UserProfileService {
     if (await session.getSID(request)) {
       this.logger.debug(`Request to get current user profile is authenticated via session.`);
       ({ profileId, sessionId } = await this.getCurrentUserProfileIdViaSession(session, request));
+    } else if (!sessionlessUserProfileRetrievalEnabled) {
+      this.logger.debug(`Skipping user profile retrieval: sessionless retrieval is disabled.`);
+      return null;
+    } else if (request.headers[RUNAS_HEADER]) {
+      // When a proxy sets `es-security-runas-user`, the Authorization header belongs to the proxy
+      // credential (e.g. `elastic`), not the effective user. Activating a profile from those
+      // credentials would associate the avatar with the proxy account, not the impersonated user.
+      // Return null because a user profile is not applicable in this context.
+      this.logger.debug(
+        `Skipping user profile retrieval for request with 'es-security-runas-user' header.`
+      );
+      return null;
     } else {
       const authType = this.getAuthHeaderType(request.headers.authorization);
 

--- a/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.ts
@@ -356,6 +356,13 @@ export class UserProfileService {
     sessionlessUserProfileRetrievalEnabled: boolean,
     { request, dataPath }: UserProfileGetCurrentParams
   ) {
+    if (!this.license?.isEnabled()) {
+      this.logger.debug(
+        'Skipping user profile retrieval: security features are disabled in Elasticsearch.'
+      );
+      return null;
+    }
+
     if (request.auth.isAuthenticated === false) {
       throw new Error('Request to get current user profile is not authenticated.');
     }

--- a/x-pack/platform/test/security_api_integration/tests/user_profiles/get_current.ts
+++ b/x-pack/platform/test/security_api_integration/tests/user_profiles/get_current.ts
@@ -376,5 +376,25 @@ export default function ({ getService }: FtrProviderContext) {
       `);
       expect(userWithProfileId.profile_uid).toBeUndefined(); // The /me endpoint is only applicable with an active session
     });
+
+    it('returns 404 with basic auth when es-security-runas-user header is present', async () => {
+      const authHeaderValue = `Basic ${Buffer.from(`${testUserName}:${testUserPassword}`).toString(
+        'base64'
+      )}`;
+
+      await supertestWithoutAuth
+        .get('/internal/security/user_profile')
+        .set('Authorization', authHeaderValue)
+        .set('es-security-runas-user', testUserName)
+        .expect(404);
+    });
+
+    it('returns 404 with API key when es-security-runas-user header is present', async () => {
+      await supertestWithoutAuth
+        .get('/internal/security/user_profile')
+        .set('Authorization', `apikey ${apiKey.encoded}`)
+        .set('es-security-runas-user', testUserName)
+        .expect(404);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Adds a new `xpack.security.authc.http.sessionlessUserProfileRetrievalEnabled` boolean config setting (default `true`) that lets operators disable sessionless user profile retrieval in the User Profile Service for HTTP-authenticated (non-session) requests.

This is a **follow-up** to #271314 ("[Security] Fix user profile retrieval for proxy run_as sessions"), which was kept focused on the run_as bug fix. The setting was extracted from that PR so it can be reviewed independently.

> **Note:** Until #271314 merges to `main`, the diff on this branch also includes the core fix changes from that PR (the security-disabled guard and the `es-security-runas-user` header guard in `getCurrent`). After #271314 merges, this branch can be rebased onto the updated `main` so the diff shows only the setting changes.

### Changes

- **`config.ts`**: New `xpack.security.authc.http.sessionlessUserProfileRetrievalEnabled` boolean (default `true`) allows operators to disable sessionless profile retrieval entirely
- **`user_profile_service.ts`**: Passes the config flag through `UserProfileServiceStartParams` into `getCurrent`, which returns `null` early when the flag is `false` for sessionless (non-session) requests
- **`plugin.ts`**: Passes the new config flag into `userProfileService.start()`
- **`security_usage_collector.ts`**: Reports the new config flag in telemetry
- Unit tests for the config schema, the flag's gating behavior (null for basic/apikey, still works for session), and telemetry reporting

## Test plan

- [ ] Unit tests: `node scripts/jest x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.test.ts`
- [ ] Unit tests: `node scripts/jest x-pack/platform/plugins/shared/security/server/config.test.ts`
- [ ] Unit tests: `node scripts/jest x-pack/platform/plugins/shared/security/server/usage_collector/security_usage_collector.test.ts`
- [ ] Manual: set `xpack.security.authc.http.sessionlessUserProfileRetrievalEnabled: false` and verify `getCurrent` returns null for basic/apikey requests while session-based requests still resolve a profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)