### PR TITLE
fix: reinstall node after switching branches in version bump script

### DIFF
--- a/.buildkite/scripts/steps/version_bump/bump_package_json_versions.sh
+++ b/.buildkite/scripts/steps/version_bump/bump_package_json_versions.sh
@@ -11,6 +11,9 @@ branch_to_merge_into="${OVERRIDE_BRANCH:-$BRANCH}"
 git fetch origin $branch_to_merge_into
 git checkout -B "$branch_to_merge_into" "origin/$branch_to_merge_into"
 
+# Re-source after the checkout so the Node version matches the branches .node-version
+source .buildkite/scripts/common/setup_node.sh
+
 old_version=""
 store_old_version() {
   old_version=$(jq -r '.version' package.json)


### PR DESCRIPTION
## Summary

- Re-sources `setup_node.sh` after `git checkout` in the version bump script so the Node version matches the `.node-version` file of the target branch, not the original branch.

## Why

When the script switches to a different branch (`git checkout -B "$branch_to_merge_into"`), the Node version in the environment may no longer match what that branch requires. This caused failures when branches use different Node versions.