### PR TITLE
[Security Solution][Entity Analytics] Collect related.user on user entity (asset-event gated)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/user.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/user.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { applyWhenConditionTrueSetFields } from '../euid/commons';
+import { getEuidFromObject } from '../euid/memory';
+import { userEntityDefinition } from './user';
+
+const SAFE_RELATED_USER = '_safe_related_user';
+
+const applyPreAgg = (doc: Record<string, unknown>) => {
+  const working: Record<string, unknown> = { ...doc };
+  const entries = userEntityDefinition.whenConditionTrueSetFieldsPreAgg ?? [];
+  applyWhenConditionTrueSetFields(working, entries);
+  return working;
+};
+
+describe('userEntityDefinition related.user collection', () => {
+  it('exposes a pre-agg override that copies related.user → _safe_related_user', () => {
+    const entries = userEntityDefinition.whenConditionTrueSetFieldsPreAgg ?? [];
+    expect(entries).toHaveLength(1);
+
+    const [entry] = entries;
+    expect(entry.fields).toEqual({
+      [SAFE_RELATED_USER]: { source: 'related.user' },
+    });
+    expect(entry.condition).toEqual({
+      and: [
+        { field: 'event.kind', includes: 'asset' },
+        { field: 'event.type', includes: 'user' },
+      ],
+    });
+  });
+
+  it('declares a collect_values field that writes the private source into related.user', () => {
+    const collected = userEntityDefinition.fields.find(
+      (field) => field.destination === 'related.user'
+    );
+    expect(collected).toBeDefined();
+    expect(collected?.source).toBe(SAFE_RELATED_USER);
+    expect(collected?.retention.operation).toBe('collect_values');
+    expect(collected?.mapping?.type).toBe('keyword');
+  });
+
+  describe('gate behavior across pollution paths', () => {
+    it('case 1: user-typed asset event populates the private field and yields an okta EUID', () => {
+      const doc = {
+        'event.kind': ['asset'],
+        'event.category': ['iam'],
+        'event.type': ['user', 'info'],
+        'user.email': 'alice@acme.com',
+        'event.module': 'entityanalytics_okta',
+        'related.user': ['alice@acme.com', 'alice-okta-id', 'Alice Smith'],
+      };
+
+      const result = applyPreAgg(doc);
+      expect(result[SAFE_RELATED_USER]).toBeDefined();
+
+      expect(getEuidFromObject('user', doc)).toBe('user:alice@acme.com@okta');
+    });
+
+    it('case 2: group-typed asset event (Authentik-style) does not populate the private field', () => {
+      const doc = {
+        'event.kind': ['asset'],
+        'event.category': ['iam'],
+        'event.type': ['group', 'info'],
+        'user.email': 'alice@acme.com',
+        'event.module': 'authentik',
+        'related.user': ['alice@acme.com', 'bob@acme.com', 'carol@acme.com'],
+      };
+
+      const result = applyPreAgg(doc);
+      expect(result[SAFE_RELATED_USER]).toBeUndefined();
+    });
+
+    it('case 3: non-asset IAM event (same-EUID rescue branch) does not populate the private field', () => {
+      const doc = {
+        'event.kind': ['event'],
+        'event.category': ['iam'],
+        'event.type': ['user'],
+        'user.email': 'alice@acme.com',
+        'event.module': 'azure',
+        'related.user': ['alice@acme.com', 'other-actor@acme.com'],
+      };
+
+      const result = applyPreAgg(doc);
+      expect(result[SAFE_RELATED_USER]).toBeUndefined();
+    });
+
+    it('case 4: endpoint event in local namespace does not populate the private field', () => {
+      const doc = {
+        'event.kind': ['event'],
+        'event.category': ['process'],
+        'user.name': 'jdoe',
+        'host.id': 'HW-UUID-ABC',
+        'event.module': 'endpoint',
+        'related.user': ['jdoe', 'jdoe@acme.com', 'Other Person'],
+      };
+
+      const result = applyPreAgg(doc);
+      expect(result[SAFE_RELATED_USER]).toBeUndefined();
+
+      expect(getEuidFromObject('user', doc)).toBe('user:jdoe@HW-UUID-ABC@local');
+    });
+
+    it('case 5: IAM lifecycle event passing idpGate (admin↔target) does not populate the private field', () => {
+      const doc = {
+        'event.kind': ['event'],
+        'event.category': ['iam'],
+        'event.type': ['user'],
+        'user.email': 'admin@acme.com',
+        'event.module': 'azure',
+        'related.user': ['admin@acme.com', 'alice@acme.com', 'Alice Smith'],
+      };
+
+      const result = applyPreAgg(doc);
+      expect(result[SAFE_RELATED_USER]).toBeUndefined();
+
+      expect(getEuidFromObject('user', doc)).toBe('user:admin@acme.com@entra_id');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/user.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/user.ts
@@ -56,6 +56,18 @@ const idpGate: Condition = {
   ],
 };
 
+// Group-typed asset events (authentik/group, entityanalytics_ad group pipeline) emit the
+// member roster in `related.user` — accreting that into a user entity would conflate identities.
+// Restricting to event.type=user keeps the same-person guarantee.
+const relatedUserCollectionGate: Condition = {
+  and: [
+    { field: 'event.kind', includes: 'asset' },
+    { field: 'event.type', includes: 'user' },
+  ],
+};
+
+const SAFE_RELATED_USER_FIELD = '_safe_related_user';
+
 const localNamespaceGate: Condition = {
   and: [
     isNotEmptyCondition('user.name'),
@@ -181,6 +193,15 @@ export const userEntityDefinition: EntityDefinitionWithoutId = {
     ],
   },
 
+  whenConditionTrueSetFieldsPreAgg: [
+    {
+      condition: relatedUserCollectionGate,
+      fields: {
+        [SAFE_RELATED_USER_FIELD]: { source: 'related.user' },
+      },
+    },
+  ],
+
   /**
    * Post-STATS: entity.name for local vs non-local; entity.confidence from namespace (local → medium,
    * else → high). Logs ESQL maps to `recent.*` after STATS.
@@ -252,6 +273,7 @@ export const userEntityDefinition: EntityDefinitionWithoutId = {
     collect({ source: 'user.group.domain' }),
     collect({ source: 'user.group.id' }),
     collect({ source: 'user.group.name' }),
+    collect({ source: SAFE_RELATED_USER_FIELD, destination: 'related.user' }),
     ...getCommonFieldDescriptions('user'),
     ...getEntityFieldsDescriptions('user'),
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
@@ -354,6 +354,7 @@ FROM remote:logs-*
  _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), \\".\\")),
  _src_entity_namespace = CASE((_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\"), _src_entity_namespace0, (_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\"), _src_entity_namespace1, NULL),
  entity.namespace = CASE((TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND NOT (TO_STRING(user.name) IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR NOT (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR (TO_STRING(event.kind) != \\"enrichment\\" OR TO_STRING(event.kind) IS NULL) AND MV_CONTAINS(TO_STRING(event.category), \\"iam\\") AND (MV_CONTAINS(TO_STRING(event.type), \\"user\\") OR MV_CONTAINS(TO_STRING(event.type), \\"creation\\") OR MV_CONTAINS(TO_STRING(event.type), \\"deletion\\") OR MV_CONTAINS(TO_STRING(event.type), \\"group\\"))))), \\"local\\", (_src_entity_namespace == \\"okta\\" OR _src_entity_namespace == \\"entityanalytics_okta\\"), \\"okta\\", (_src_entity_namespace == \\"azure\\" OR _src_entity_namespace == \\"entityanalytics_entra_id\\"), \\"entra_id\\", (_src_entity_namespace == \\"o365\\" OR _src_entity_namespace == \\"o365_metrics\\"), \\"microsoft_365\\", (_src_entity_namespace == \\"entityanalytics_ad\\"), \\"active_directory\\", (_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\"), \\"unknown\\", _src_entity_namespace)
+| EVAL _safe_related_user = CASE((MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") AND MV_CONTAINS(TO_STRING(event.type), \\"user\\")), TO_STRING(related.user), TO_STRING(_safe_related_user))
 | EVAL entity.id = CONCAT(\\"user:\\", CASE((TO_STRING(entity.namespace) == \\"local\\"), CASE((TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\"), CONCAT(TO_STRING(user.name), \\"@\\", TO_STRING(host.id), \\"@\\", TO_STRING(entity.namespace)), NULL),
 true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\" AND TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\"), CONCAT(TO_STRING(user.email), \\"@\\", TO_STRING(entity.namespace)),
 (TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\" AND TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\"), CONCAT(TO_STRING(user.id), \\"@\\", TO_STRING(entity.namespace)),
@@ -379,6 +380,7 @@ true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\
  user.group.domain = VALUES(TO_STRING(user.group.domain)),
  user.group.id = VALUES(TO_STRING(user.group.id)),
  user.group.name = VALUES(TO_STRING(user.group.name)),
+ related.user = VALUES(TO_STRING(_safe_related_user)),
  asset.id = LAST(TO_STRING(asset.id), @timestamp) WHERE TO_STRING(asset.id) IS NOT NULL,
  asset.name = LAST(TO_STRING(asset.name), @timestamp) WHERE TO_STRING(asset.name) IS NOT NULL,
  asset.owner = LAST(TO_STRING(asset.owner), @timestamp) WHERE TO_STRING(asset.owner) IS NOT NULL,
@@ -483,6 +485,7 @@ true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\
 | KEEP entity*,
 event*,
 user*,
+related*,
 asset*,
 data_stream*,
 host*,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
@@ -1486,6 +1486,7 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for user enti
  _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), \\".\\")),
  _src_entity_namespace = CASE((_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\"), _src_entity_namespace0, (_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\"), _src_entity_namespace1, NULL),
  entity.namespace = CASE((TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND NOT (TO_STRING(user.name) IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR NOT (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR (TO_STRING(event.kind) != \\"enrichment\\" OR TO_STRING(event.kind) IS NULL) AND MV_CONTAINS(TO_STRING(event.category), \\"iam\\") AND (MV_CONTAINS(TO_STRING(event.type), \\"user\\") OR MV_CONTAINS(TO_STRING(event.type), \\"creation\\") OR MV_CONTAINS(TO_STRING(event.type), \\"deletion\\") OR MV_CONTAINS(TO_STRING(event.type), \\"group\\"))))), \\"local\\", (_src_entity_namespace == \\"okta\\" OR _src_entity_namespace == \\"entityanalytics_okta\\"), \\"okta\\", (_src_entity_namespace == \\"azure\\" OR _src_entity_namespace == \\"entityanalytics_entra_id\\"), \\"entra_id\\", (_src_entity_namespace == \\"o365\\" OR _src_entity_namespace == \\"o365_metrics\\"), \\"microsoft_365\\", (_src_entity_namespace == \\"entityanalytics_ad\\"), \\"active_directory\\", (_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\"), \\"unknown\\", _src_entity_namespace)
+| EVAL _safe_related_user = CASE((MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") AND MV_CONTAINS(TO_STRING(event.type), \\"user\\")), TO_STRING(related.user), TO_STRING(_safe_related_user))
 | EVAL recent.entity.EngineMetadata.UntypedId = CASE((TO_STRING(entity.namespace) == \\"local\\"), CASE((TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\"), CONCAT(TO_STRING(user.name), \\"@\\", TO_STRING(host.id), \\"@\\", TO_STRING(entity.namespace)), NULL),
 true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\" AND TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\"), CONCAT(TO_STRING(user.email), \\"@\\", TO_STRING(entity.namespace)),
 (TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\" AND TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\"), CONCAT(TO_STRING(user.id), \\"@\\", TO_STRING(entity.namespace)),
@@ -1511,6 +1512,7 @@ true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\
  recent.user.group.domain = VALUES(TO_STRING(user.group.domain)),
  recent.user.group.id = VALUES(TO_STRING(user.group.id)),
  recent.user.group.name = VALUES(TO_STRING(user.group.name)),
+ recent.related.user = VALUES(TO_STRING(_safe_related_user)),
  recent.asset.id = LAST(TO_STRING(asset.id), @timestamp) WHERE TO_STRING(asset.id) IS NOT NULL,
  recent.asset.name = LAST(TO_STRING(asset.name), @timestamp) WHERE TO_STRING(asset.name) IS NOT NULL,
  recent.asset.owner = LAST(TO_STRING(asset.owner), @timestamp) WHERE TO_STRING(asset.owner) IS NOT NULL,
@@ -1635,6 +1637,7 @@ true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\
  user.group.domain = MV_SLICE(MV_UNION(recent.user.group.domain, user.group.domain), 0, 49),
  user.group.id = MV_SLICE(MV_UNION(recent.user.group.id, user.group.id), 0, 49),
  user.group.name = MV_SLICE(MV_UNION(recent.user.group.name, user.group.name), 0, 49),
+ related.user = MV_SLICE(MV_UNION(recent.related.user, related.user), 0, 49),
  asset.id = COALESCE(recent.asset.id, asset.id),
  asset.name = COALESCE(recent.asset.name, asset.name),
  asset.owner = COALESCE(recent.asset.owner, asset.owner),
@@ -1741,6 +1744,7 @@ true, CASE((TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\
 | KEEP entity*,
 event*,
 user*,
+related*,
 asset*,
 data_stream*,
 host*,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.test.ts
@@ -73,6 +73,44 @@ describe('buildCcsLogsExtractionEsqlQuery', () => {
     await expect(validateQuery(query)).resolves.toHaveProperty('errors', []);
   });
 
+  it('inserts whenConditionTrueSetFieldsPreAgg EVAL before STATS', () => {
+    const base = getEntityDefinition('host', 'default');
+    const query = buildCcsLogsExtractionEsqlQuery({
+      indexPatterns: ['remote:metrics-*'],
+      entityDefinition: {
+        ...base,
+        whenConditionTrueSetFieldsPreAgg: [
+          {
+            condition: { field: 'event.kind', includes: 'asset' },
+            fields: { _custom_field: { source: 'host.name' } },
+          },
+        ],
+      },
+      fromDateISO: '2022-01-01T00:00:00.000Z',
+      toDateISO: '2022-01-01T23:59:59.999Z',
+      docsLimit: 100,
+    });
+    const preAggEvalIdx = query.indexOf('_custom_field = CASE(');
+    const statsIdx = query.indexOf('| STATS');
+    expect(preAggEvalIdx).toBeGreaterThan(-1);
+    expect(statsIdx).toBeGreaterThan(preAggEvalIdx);
+  });
+
+  it('emits related.user collection on user entity via _safe_related_user pre-agg EVAL', () => {
+    const query = buildCcsLogsExtractionEsqlQuery({
+      indexPatterns: ['remote:logs-*'],
+      entityDefinition: getEntityDefinition('user', 'default'),
+      fromDateISO: '2022-01-01T00:00:00.000Z',
+      toDateISO: '2022-01-01T23:59:59.999Z',
+      docsLimit: 100,
+    });
+    expect(query).toContain(
+      '_safe_related_user = CASE((MV_CONTAINS(TO_STRING(event.kind), "asset")'
+    );
+    expect(query).toContain('MV_CONTAINS(TO_STRING(event.type), "user")');
+    expect(query).toContain('related.user = VALUES(TO_STRING(_safe_related_user))');
+  });
+
   it('inserts whenConditionTrueSetFieldsAfterStats EVAL after STATS and before KEEP without recent. prefix', () => {
     const base = getEntityDefinition('host', 'default');
     const query = buildCcsLogsExtractionEsqlQuery({

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.test.ts
@@ -64,6 +64,49 @@ describe('buildLogsExtractionEsqlQuery', () => {
     await expect(validateQuery(query)).resolves.toHaveProperty('errors', []);
   });
 
+  it('inserts whenConditionTrueSetFieldsPreAgg EVAL after fieldEvaluations and before EUID EVAL', () => {
+    const base = getEntityDefinition('host', 'default');
+    const query = buildLogsExtractionEsqlQuery({
+      indexPatterns: ['test-index-*'],
+      latestIndex: 'latest-index',
+      entityDefinition: {
+        ...base,
+        whenConditionTrueSetFieldsPreAgg: [
+          {
+            condition: { field: 'event.kind', includes: 'asset' },
+            fields: { _custom_field: { source: 'host.name' } },
+          },
+        ],
+      },
+      docsLimit: 100,
+      fromDateISO: '2022-01-01T00:00:00.000Z',
+      toDateISO: '2022-01-01T23:59:59.999Z',
+    });
+    const preAggEvalIdx = query.indexOf('_custom_field = CASE(');
+    const euidEvalIdx = query.indexOf('recent.entity.EngineMetadata.UntypedId = ');
+    const statsIdx = query.indexOf('| STATS');
+    expect(preAggEvalIdx).toBeGreaterThan(-1);
+    expect(euidEvalIdx).toBeGreaterThan(preAggEvalIdx);
+    expect(statsIdx).toBeGreaterThan(euidEvalIdx);
+  });
+
+  it('emits related.user collection on user entity via _safe_related_user pre-agg EVAL', () => {
+    const query = buildLogsExtractionEsqlQuery({
+      indexPatterns: ['test-index-*'],
+      latestIndex: 'latest-index',
+      entityDefinition: getEntityDefinition('user', 'default'),
+      docsLimit: 100,
+      fromDateISO: '2022-01-01T00:00:00.000Z',
+      toDateISO: '2022-01-01T23:59:59.999Z',
+    });
+    expect(query).toContain(
+      '_safe_related_user = CASE((MV_CONTAINS(TO_STRING(event.kind), "asset")'
+    );
+    expect(query).toContain('MV_CONTAINS(TO_STRING(event.type), "user")');
+    expect(query).toContain('recent.related.user = VALUES(TO_STRING(_safe_related_user))');
+    expect(query).toContain('related.user = MV_SLICE(MV_UNION(recent.related.user, related.user)');
+  });
+
   it('inserts whenConditionTrueSetFieldsAfterStats EVAL after LOOKUP and before merge EVAL', () => {
     const base = getEntityDefinition('host', 'default');
     const query = buildLogsExtractionEsqlQuery({


### PR DESCRIPTION
## Summary

Adds `related.user` to user entity documents in `.entities.v2.latest.security_{namespace}`. Collection is gated on `event.kind` includes `"asset"` AND `event.type` includes `"user"`.

**Why the gate is necessary.** `related.user` is a heterogeneous ECS bag. Many events list multiple humans (admin↔target IAM lifecycle, sender↔recipient email, etc.). Plain `event.kind=asset` gating is not safe either: group-typed asset events (`authentik/group`, `entityanalytics_ad` group pipeline) emit `event.type=[group, info]` with `related.user` carrying the full group member roster — adding that into one user entity would conflate identities. Restricting to `event.type` includes `"user"` keeps the same-person guarantee. All three user-sync integrations (`entityanalytics_entra_id`, `entityanalytics_okta`, `entityanalytics_ad`) emit `event.type=["user", "info"]` on their user pipelines.

The gate is **field-level, not document-level**. Non-asset events still need to enrich the entity in other ways (event categories, recent timestamps, namespace propagation) — only the `related.user` value from non-user-asset events is dropped.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
