### PR TITLE
[9.4] [Entity Store] Improve WHERE clause (#271664)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/__snapshots__/esql.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/__snapshots__/esql.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getEuidEsqlDocumentsContainsIdFilter returns documents filter AND postAggFilter for user (IDP or non-IDP only) 1`] = `"(\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (NOT(\`user.email\` IS NULL) AND \`user.email\` != \\"\\" OR NOT(\`user.id\` IS NULL) AND \`user.id\` != \\"\\" OR NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\")"`;
+exports[`getEuidEsqlDocumentsContainsIdFilter returns documents filter AND postAggFilter for user (IDP or non-IDP only) 1`] = `"(\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (user.email IS NOT NULL AND user.email != \\"\\" OR user.id IS NOT NULL AND user.id != \\"\\" OR user.name IS NOT NULL AND user.name != \\"\\")"`;

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
@@ -207,7 +207,7 @@ describe('getEuidEsqlDocumentsContainsIdFilter', () => {
     const result = getEuidEsqlDocumentsContainsIdFilter('host');
 
     const expected =
-      'NOT(`host.id` IS NULL) AND `host.id` != "" OR NOT(`host.name` IS NULL) AND `host.name` != "" OR NOT(`host.hostname` IS NULL) AND `host.hostname` != ""';
+      'host.id IS NOT NULL AND host.id != "" OR host.name IS NOT NULL AND host.name != "" OR host.hostname IS NOT NULL AND host.hostname != ""';
     expect(result).toBe(expected);
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { conditionToESQL } from '@kbn/streamlang';
+import { entityStoreConditionToESQL as conditionToESQL } from '../../esql/condition_to_esql';
 import type {
   EntityDefinitionWithoutId,
   FieldEvaluation,

--- a/x-pack/solutions/security/plugins/entity_store/common/esql/condition_to_esql.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/esql/condition_to_esql.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { conditionToESQL } from '@kbn/streamlang';
+import { fieldNotOneOfCondition, isNotEmptyCondition } from '../domain/definitions/common_fields';
+import { LOCAL_NAMESPACE_EXCLUDED_USER_NAMES } from '../domain/definitions/user_entity_constants';
+import { entityStoreConditionToESQL } from './condition_to_esql';
+
+describe('entityStoreConditionToESQL', () => {
+  describe('homogeneous OR-of-EQ optimization', () => {
+    it('rewrites OR-of-EQ to COALESCE(IN) when all children are same-field eq', () => {
+      const result = entityStoreConditionToESQL({
+        or: [
+          { field: 'user.name', eq: 'root' },
+          { field: 'user.name', eq: 'bin' },
+          { field: 'user.name', eq: 'daemon' },
+        ],
+      });
+      expect(result).toBe('`user.name` IN ("root", "bin", "daemon")');
+    });
+
+    it('wraps not(or-of-EQ) as NOT (COALESCE(IN))', () => {
+      const condition = fieldNotOneOfCondition('user.name', ['root', 'bin']);
+      const result = entityStoreConditionToESQL(condition);
+      expect(result).toBe('NOT (`user.name` IN ("root", "bin"))');
+    });
+
+    it('optimizes the full LOCAL_NAMESPACE_EXCLUDED_USER_NAMES list', () => {
+      const condition = fieldNotOneOfCondition('user.name', [
+        ...LOCAL_NAMESPACE_EXCLUDED_USER_NAMES,
+      ]);
+      const result = entityStoreConditionToESQL(condition);
+      const names = LOCAL_NAMESPACE_EXCLUDED_USER_NAMES.map((n) => `"${n}"`).join(', ');
+      expect(result).toBe(`NOT (\`user.name\` IN (${names}))`);
+      expect(result).not.toContain(' OR ');
+    });
+
+    it('finds nested not(or-of-EQ) inside an AND', () => {
+      const condition = {
+        and: [
+          { field: 'user.name', exists: true },
+          fieldNotOneOfCondition('user.name', ['root', 'bin']),
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition);
+      expect(result).toContain('`user.name` IN (');
+      expect(result).toContain(' AND ');
+      expect(result).not.toContain(' OR ');
+    });
+  });
+
+  describe('isNotEmpty condition optimization', () => {
+    it('rewrites AND(exists:true, neq:"") on same field to IS NOT NULL AND != ""', () => {
+      const result = entityStoreConditionToESQL(isNotEmptyCondition('host.id'));
+      expect(result).toBe('host.id IS NOT NULL AND host.id != ""');
+    });
+
+    it('does not optimize AND(exists:true, neq:"") with different fields', () => {
+      const condition = {
+        and: [
+          { field: 'host.id', exists: true },
+          { field: 'host.name', neq: '' },
+        ],
+      };
+      // Falls through to general AND handling
+      const result = entityStoreConditionToESQL(condition as any);
+      expect(result).not.toBe('host.id IS NOT NULL AND host.id != ""');
+    });
+
+    it('optimizes isNotEmpty inside OR (documentsFilter pattern)', () => {
+      const condition = {
+        or: [
+          isNotEmptyCondition('host.id'),
+          isNotEmptyCondition('host.name'),
+          isNotEmptyCondition('host.hostname'),
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition);
+      expect(result).toBe(
+        'host.id IS NOT NULL AND host.id != "" OR ' +
+          'host.name IS NOT NULL AND host.name != "" OR ' +
+          'host.hostname IS NOT NULL AND host.hostname != ""'
+      );
+    });
+
+    it('optimizes isNotEmpty inside AND + OR (user documentsFilter pattern)', () => {
+      const condition = {
+        and: [
+          {
+            or: [
+              { field: 'event.outcome', exists: false },
+              { field: 'event.outcome', neq: 'failure' },
+            ],
+          },
+          {
+            or: [
+              isNotEmptyCondition('user.email'),
+              isNotEmptyCondition('user.id'),
+              isNotEmptyCondition('user.name'),
+            ],
+          },
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition as any);
+      expect(result).toContain('user.email IS NOT NULL AND user.email != ""');
+      expect(result).toContain('user.id IS NOT NULL AND user.id != ""');
+      expect(result).toContain('user.name IS NOT NULL AND user.name != ""');
+      // event.outcome arms fall through to streamlang (not isNotEmpty pattern)
+      expect(result).not.toContain('NOT(`event.outcome`');
+    });
+  });
+
+  describe('non-optimized fallthrough', () => {
+    it('delegates single-item OR to conditionToESQL', () => {
+      const condition = { or: [{ field: 'user.name', eq: 'root' }] };
+      expect(entityStoreConditionToESQL(condition)).toBe(conditionToESQL(condition));
+    });
+
+    it('delegates heterogeneous OR (non-eq child) to conditionToESQL path', () => {
+      const condition = {
+        or: [
+          { field: 'user.name', eq: 'root' },
+          { field: 'user.name', exists: false },
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition);
+      expect(result).not.toContain(' IN ');
+    });
+
+    it('delegates OR-of-EQ on different fields to conditionToESQL path', () => {
+      const condition = {
+        or: [
+          { field: 'user.name', eq: 'root' },
+          { field: 'host.name', eq: 'server1' },
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition);
+      expect(result).not.toContain(' IN ');
+    });
+
+    it('passes leaf filter conditions through unchanged', () => {
+      const condition = { field: 'user.name', eq: 'alice' };
+      expect(entityStoreConditionToESQL(condition)).toBe(conditionToESQL(condition));
+    });
+
+    it('passes always-condition through unchanged', () => {
+      const condition = { always: {} };
+      expect(entityStoreConditionToESQL(condition)).toBe(conditionToESQL(condition));
+    });
+  });
+
+  describe('operator precedence', () => {
+    it('wraps non-IN OR in parens when it appears inside AND', () => {
+      const condition = {
+        and: [
+          { field: 'user.name', exists: true },
+          {
+            or: [
+              { field: 'event.kind', eq: 'asset' },
+              { field: 'event.kind', eq: 'alert' },
+            ],
+          },
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition);
+      // The OR has two different values but same field → optimized to IN, no parens needed
+      expect(result).toContain('`event.kind` IN (');
+    });
+
+    it('wraps genuinely non-homogeneous OR in parens inside AND', () => {
+      const condition = {
+        and: [
+          { field: 'user.name', exists: true },
+          {
+            or: [
+              { field: 'event.kind', eq: 'asset' },
+              { field: 'event.type', eq: 'creation' }, // different field
+            ],
+          },
+        ],
+      };
+      const result = entityStoreConditionToESQL(condition);
+      // Non-homogeneous OR inside AND must be wrapped in parens
+      expect(result).toMatch(/\(.*OR.*\)/);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/common/esql/condition_to_esql.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/esql/condition_to_esql.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  conditionToESQL,
+  isAndCondition,
+  isFilterCondition,
+  isNotCondition,
+  isOrCondition,
+  type Condition,
+} from '@kbn/streamlang';
+import { escapeEsqlStringLiteral, esqlIsNotNullOrEmpty } from './strings';
+
+/**
+ * Drop-in wrapper around the streamlang `conditionToESQL` that optimizes two patterns:
+ *
+ * 1. Homogeneous OR-of-EQ chains into a single `` `field` IN (…) ``.
+ *    The 18-name `fieldNotOneOfCondition` used by the user entity definition is the
+ *    canonical example — eliminating 18 per-row scalar guards in the ES|QL planner.
+ *
+ * 2. `isNotEmpty` AND pattern `{and: [{field: X, exists: true}, {field: X, neq: ''}]}`
+ *    into `X IS NOT NULL AND X != ""`, which the planner can push down more efficiently
+ *    than streamlang's verbose `NOT(X IS NULL) AND COALESCE(X != "", TRUE)` form.
+ *
+ * All other condition shapes are passed through to the upstream `conditionToESQL`.
+ * The upstream `@kbn/streamlang` transpiler is not modified.
+ */
+export function entityStoreConditionToESQL(condition: Condition): string {
+  if (isOrCondition(condition)) {
+    const inClause = buildInClauseOrNull(condition.or);
+    if (inClause !== null) {
+      return inClause;
+    }
+    return condition.or.map(entityStoreConditionToESQL).join(' OR ');
+  }
+  if (isNotCondition(condition)) {
+    return `NOT (${entityStoreConditionToESQL(condition.not)})`;
+  }
+  if (isAndCondition(condition)) {
+    const notEmptyField = getNotEmptyField(condition);
+    if (notEmptyField !== null) {
+      return esqlIsNotNullOrEmpty(notEmptyField);
+    }
+    return condition.and
+      .map((c) => {
+        const s = entityStoreConditionToESQL(c);
+        // OR (non-IN) inside AND needs parens: AND binds tighter than OR in ES|QL
+        if (isOrCondition(c) && buildInClauseOrNull(c.or) === null) {
+          return `(${s})`;
+        }
+        return s;
+      })
+      .join(' AND ');
+  }
+  return conditionToESQL(condition);
+}
+
+/** Detects `{and: [{field: X, exists: true}, {field: X, neq: ''}]}` → returns X, or null. */
+function getNotEmptyField(condition: Condition): string | null {
+  if (!isAndCondition(condition) || condition.and.length !== 2) {
+    return null;
+  }
+  const [first, second] = condition.and;
+  if (!isFilterCondition(first) || !isFilterCondition(second)) {
+    return null;
+  }
+  const f = first as unknown as Record<string, unknown>;
+  const s = second as unknown as Record<string, unknown>;
+  if (f.exists !== true || s.neq !== '' || f.field !== s.field) {
+    return null;
+  }
+  return f.field as string;
+}
+
+/**
+ * Returns null when IN optimization is not possible
+ */
+function buildInClauseOrNull(conditions: Condition[]): string | null {
+  if (conditions.length < 2) {
+    // only 1 condition, we let the upstream `conditionToESQL` handle it;
+    return null;
+  }
+  if (!conditions.every((c) => isFilterCondition(c) && 'eq' in c)) {
+    // we don't have a homogeneous OR-of-EQ pattern, bail out;
+    return null;
+  }
+
+  const typed = conditions as Array<{ field: string; eq: unknown }>;
+  const fieldSet = new Set(typed.map((c) => c.field));
+  if (fieldSet.size !== 1) {
+    // We have multiple fields, so it's not a homogeneous OR-of-EQ;
+    return null;
+  }
+
+  const values = typed.map((c) => c.eq);
+  if (!values.every((v) => typeof v === 'string')) {
+    // If we are not comparing strings on every condition we won't optimize to IN clause
+    return null;
+  }
+
+  const [field] = fieldSet;
+  const inList = (values as string[]).map((v) => `"${escapeEsqlStringLiteral(v)}"`).join(', ');
+  return `\`${field}\` IN (${inList})`;
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
@@ -6,7 +6,7 @@ FROM remote:metrics-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")
+      AND (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -174,7 +174,7 @@ FROM remote:logs-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")
+      AND (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")
       AND @timestamp >= TO_DATETIME(\\"2022-01-01T06:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T12:00:00.000Z\\")
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
@@ -344,7 +344,7 @@ FROM remote:logs-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (NOT(\`user.email\` IS NULL) AND \`user.email\` != \\"\\" OR NOT(\`user.id\` IS NULL) AND \`user.id\` != \\"\\" OR NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\"))
+      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (user.email IS NOT NULL AND user.email != \\"\\" OR user.id IS NOT NULL AND user.id != \\"\\" OR user.name IS NOT NULL AND user.name != \\"\\"))
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -353,7 +353,7 @@ FROM remote:logs-*
  _src_entity_namespace0 = MV_FIRST(event.module),
  _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(data_stream.dataset), \\".\\")),
  _src_entity_namespace = CASE((_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\"), _src_entity_namespace0, (_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\"), _src_entity_namespace1, NULL),
- entity.namespace = CASE((NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\" AND NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" AND NOT (\`user.name\` == \\"root\\" OR \`user.name\` == \\"bin\\" OR \`user.name\` == \\"daemon\\" OR \`user.name\` == \\"sys\\" OR \`user.name\` == \\"nobody\\" OR \`user.name\` == \\"jenkins\\" OR \`user.name\` == \\"ansible\\" OR \`user.name\` == \\"deploy\\" OR \`user.name\` == \\"terraform\\" OR \`user.name\` == \\"gitlab-runner\\" OR \`user.name\` == \\"postgres\\" OR \`user.name\` == \\"mysql\\" OR \`user.name\` == \\"redis\\" OR \`user.name\` == \\"elasticsearch\\" OR \`user.name\` == \\"kafka\\" OR \`user.name\` == \\"admin\\" OR \`user.name\` == \\"operator\\" OR \`user.name\` == \\"service\\") AND (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR NOT (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR (\`event.kind\` != \\"enrichment\\" OR \`event.kind\` IS NULL) AND MV_CONTAINS(\`event.category\`, \\"iam\\") AND (MV_CONTAINS(\`event.type\`, \\"user\\") OR MV_CONTAINS(\`event.type\`, \\"creation\\") OR MV_CONTAINS(\`event.type\`, \\"deletion\\") OR MV_CONTAINS(\`event.type\`, \\"group\\"))))), \\"local\\", (_src_entity_namespace == \\"okta\\" OR _src_entity_namespace == \\"entityanalytics_okta\\"), \\"okta\\", (_src_entity_namespace == \\"azure\\" OR _src_entity_namespace == \\"entityanalytics_entra_id\\"), \\"entra_id\\", (_src_entity_namespace == \\"o365\\" OR _src_entity_namespace == \\"o365_metrics\\"), \\"microsoft_365\\", (_src_entity_namespace == \\"entityanalytics_ad\\"), \\"active_directory\\", (_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\"), \\"unknown\\", _src_entity_namespace)
+ entity.namespace = CASE((user.name IS NOT NULL AND user.name != \\"\\" AND host.id IS NOT NULL AND host.id != \\"\\" AND NOT (\`user.name\` IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR NOT (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR (\`event.kind\` != \\"enrichment\\" OR \`event.kind\` IS NULL) AND MV_CONTAINS(\`event.category\`, \\"iam\\") AND (MV_CONTAINS(\`event.type\`, \\"user\\") OR MV_CONTAINS(\`event.type\`, \\"creation\\") OR MV_CONTAINS(\`event.type\`, \\"deletion\\") OR MV_CONTAINS(\`event.type\`, \\"group\\"))))), \\"local\\", (_src_entity_namespace == \\"okta\\" OR _src_entity_namespace == \\"entityanalytics_okta\\"), \\"okta\\", (_src_entity_namespace == \\"azure\\" OR _src_entity_namespace == \\"entityanalytics_entra_id\\"), \\"entra_id\\", (_src_entity_namespace == \\"o365\\" OR _src_entity_namespace == \\"o365_metrics\\"), \\"microsoft_365\\", (_src_entity_namespace == \\"entityanalytics_ad\\"), \\"active_directory\\", (_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\"), \\"unknown\\", _src_entity_namespace)
 | EVAL entity.id = CONCAT(\\"user:\\", CASE((\`entity.namespace\` == \\"local\\"), CASE((user.name IS NOT NULL AND user.name != \\"\\" AND host.id IS NOT NULL AND host.id != \\"\\" AND entity.namespace IS NOT NULL AND entity.namespace != \\"\\"), CONCAT(user.name, \\"@\\", host.id, \\"@\\", entity.namespace), NULL),
 true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace IS NOT NULL AND entity.namespace != \\"\\"), CONCAT(user.email, \\"@\\", entity.namespace),
 (user.id IS NOT NULL AND user.id != \\"\\" AND entity.namespace IS NOT NULL AND entity.namespace != \\"\\"), CONCAT(user.id, \\"@\\", entity.namespace),
@@ -475,8 +475,8 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
  host.id = VALUES(TO_STRING(host.id)),
  host.name = LAST(TO_STRING(host.name), @timestamp) WHERE TO_STRING(host.name) IS NOT NULL
     BY entity.id
-| EVAL entity.name = CASE((\`entity.namespace\` == \\"local\\" AND NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\"), CONCAT(TO_STRING(user.name), \\"@\\", TO_STRING(host.name)), entity.name)
-| EVAL entity.name = CASE((\`entity.namespace\` == \\"local\\" AND NOT (NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\")), TO_STRING(user.name), entity.name)
+| EVAL entity.name = CASE((\`entity.namespace\` == \\"local\\" AND host.name IS NOT NULL AND host.name != \\"\\"), CONCAT(TO_STRING(user.name), \\"@\\", TO_STRING(host.name)), entity.name)
+| EVAL entity.name = CASE((\`entity.namespace\` == \\"local\\" AND NOT (host.name IS NOT NULL AND host.name != \\"\\")), TO_STRING(user.name), entity.name)
 | EVAL entity.name = CASE((\`entity.namespace\` != \\"local\\"), TO_STRING(user.name), entity.name),
     entity.confidence = CASE((\`entity.namespace\` != \\"local\\"), \\"high\\", entity.confidence)
 | EVAL entity.confidence = CASE((\`entity.namespace\` == \\"local\\"), \\"medium\\", entity.confidence)

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
@@ -5,7 +5,7 @@ exports[`buildLogPaginationCursorProbeEsql sorts ASC, limits, then aggregates MA
   | WHERE
       @timestamp >= TO_DATETIME(\\"2024-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2024-01-02T00:00:00.000Z\\")
-      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (NOT(\`user.email\` IS NULL) AND \`user.email\` != \\"\\" OR NOT(\`user.id\` IS NULL) AND \`user.id\` != \\"\\" OR NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\"))
+      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (user.email IS NOT NULL AND user.email != \\"\\" OR user.id IS NOT NULL AND user.id != \\"\\" OR user.name IS NOT NULL AND user.name != \\"\\"))
   | SORT @timestamp ASC
   | LIMIT 100
   | STATS @timestamp = MAX(@timestamp), total_logs = COUNT(*)"

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
@@ -281,7 +281,7 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for host enti
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")
+      AND (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -595,7 +595,7 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for host with
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")
+      AND (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -912,7 +912,7 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for host with
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")
+      AND (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -1476,7 +1476,7 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for user enti
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (NOT(\`user.email\` IS NULL) AND \`user.email\` != \\"\\" OR NOT(\`user.id\` IS NULL) AND \`user.id\` != \\"\\" OR NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\"))
+      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (user.email IS NOT NULL AND user.email != \\"\\" OR user.id IS NOT NULL AND user.id != \\"\\" OR user.name IS NOT NULL AND user.name != \\"\\"))
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -1485,7 +1485,7 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for user enti
  _src_entity_namespace0 = MV_FIRST(event.module),
  _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(data_stream.dataset), \\".\\")),
  _src_entity_namespace = CASE((_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\"), _src_entity_namespace0, (_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\"), _src_entity_namespace1, NULL),
- entity.namespace = CASE((NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\" AND NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" AND NOT (\`user.name\` == \\"root\\" OR \`user.name\` == \\"bin\\" OR \`user.name\` == \\"daemon\\" OR \`user.name\` == \\"sys\\" OR \`user.name\` == \\"nobody\\" OR \`user.name\` == \\"jenkins\\" OR \`user.name\` == \\"ansible\\" OR \`user.name\` == \\"deploy\\" OR \`user.name\` == \\"terraform\\" OR \`user.name\` == \\"gitlab-runner\\" OR \`user.name\` == \\"postgres\\" OR \`user.name\` == \\"mysql\\" OR \`user.name\` == \\"redis\\" OR \`user.name\` == \\"elasticsearch\\" OR \`user.name\` == \\"kafka\\" OR \`user.name\` == \\"admin\\" OR \`user.name\` == \\"operator\\" OR \`user.name\` == \\"service\\") AND (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR NOT (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR (\`event.kind\` != \\"enrichment\\" OR \`event.kind\` IS NULL) AND MV_CONTAINS(\`event.category\`, \\"iam\\") AND (MV_CONTAINS(\`event.type\`, \\"user\\") OR MV_CONTAINS(\`event.type\`, \\"creation\\") OR MV_CONTAINS(\`event.type\`, \\"deletion\\") OR MV_CONTAINS(\`event.type\`, \\"group\\"))))), \\"local\\", (_src_entity_namespace == \\"okta\\" OR _src_entity_namespace == \\"entityanalytics_okta\\"), \\"okta\\", (_src_entity_namespace == \\"azure\\" OR _src_entity_namespace == \\"entityanalytics_entra_id\\"), \\"entra_id\\", (_src_entity_namespace == \\"o365\\" OR _src_entity_namespace == \\"o365_metrics\\"), \\"microsoft_365\\", (_src_entity_namespace == \\"entityanalytics_ad\\"), \\"active_directory\\", (_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\"), \\"unknown\\", _src_entity_namespace)
+ entity.namespace = CASE((user.name IS NOT NULL AND user.name != \\"\\" AND host.id IS NOT NULL AND host.id != \\"\\" AND NOT (\`user.name\` IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR NOT (MV_CONTAINS(\`event.kind\`, \\"asset\\") OR (\`event.kind\` != \\"enrichment\\" OR \`event.kind\` IS NULL) AND MV_CONTAINS(\`event.category\`, \\"iam\\") AND (MV_CONTAINS(\`event.type\`, \\"user\\") OR MV_CONTAINS(\`event.type\`, \\"creation\\") OR MV_CONTAINS(\`event.type\`, \\"deletion\\") OR MV_CONTAINS(\`event.type\`, \\"group\\"))))), \\"local\\", (_src_entity_namespace == \\"okta\\" OR _src_entity_namespace == \\"entityanalytics_okta\\"), \\"okta\\", (_src_entity_namespace == \\"azure\\" OR _src_entity_namespace == \\"entityanalytics_entra_id\\"), \\"entra_id\\", (_src_entity_namespace == \\"o365\\" OR _src_entity_namespace == \\"o365_metrics\\"), \\"microsoft_365\\", (_src_entity_namespace == \\"entityanalytics_ad\\"), \\"active_directory\\", (_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\"), \\"unknown\\", _src_entity_namespace)
 | EVAL recent.entity.EngineMetadata.UntypedId = CASE((\`entity.namespace\` == \\"local\\"), CASE((user.name IS NOT NULL AND user.name != \\"\\" AND host.id IS NOT NULL AND host.id != \\"\\" AND entity.namespace IS NOT NULL AND entity.namespace != \\"\\"), CONCAT(user.name, \\"@\\", host.id, \\"@\\", entity.namespace), NULL),
 true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace IS NOT NULL AND entity.namespace != \\"\\"), CONCAT(user.email, \\"@\\", entity.namespace),
 (user.id IS NOT NULL AND user.id != \\"\\" AND entity.namespace IS NOT NULL AND entity.namespace != \\"\\"), CONCAT(user.id, \\"@\\", entity.namespace),
@@ -1613,8 +1613,8 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
 | WHERE NOT(\`entity.id\` IS NULL) OR \`recent.entity.namespace\` == \\"local\\" OR MV_CONTAINS(\`recent.event.kind\`, \\"asset\\") OR (\`recent.event.kind\` != \\"enrichment\\" OR \`recent.event.kind\` IS NULL) AND MV_CONTAINS(\`recent.event.category\`, \\"iam\\") AND (MV_CONTAINS(\`recent.event.type\`, \\"user\\") OR MV_CONTAINS(\`recent.event.type\`, \\"creation\\") OR MV_CONTAINS(\`recent.event.type\`, \\"deletion\\") OR MV_CONTAINS(\`recent.event.type\`, \\"group\\")) 
 | SORT entity.EngineMetadata.FirstSeenLogInPage ASC, recent.entity.EngineMetadata.UntypedId ASC
 | LIMIT 10000
-| EVAL recent.entity.name = CASE((\`recent.entity.namespace\` == \\"local\\" AND NOT(\`recent.host.name\` IS NULL) AND \`recent.host.name\` != \\"\\"), CONCAT(TO_STRING(recent.user.name), \\"@\\", TO_STRING(recent.host.name)), recent.entity.name)
-| EVAL recent.entity.name = CASE((\`recent.entity.namespace\` == \\"local\\" AND NOT (NOT(\`recent.host.name\` IS NULL) AND \`recent.host.name\` != \\"\\")), TO_STRING(recent.user.name), recent.entity.name)
+| EVAL recent.entity.name = CASE((\`recent.entity.namespace\` == \\"local\\" AND recent.host.name IS NOT NULL AND recent.host.name != \\"\\"), CONCAT(TO_STRING(recent.user.name), \\"@\\", TO_STRING(recent.host.name)), recent.entity.name)
+| EVAL recent.entity.name = CASE((\`recent.entity.namespace\` == \\"local\\" AND NOT (recent.host.name IS NOT NULL AND recent.host.name != \\"\\")), TO_STRING(recent.user.name), recent.entity.name)
 | EVAL recent.entity.name = CASE((\`recent.entity.namespace\` != \\"local\\"), TO_STRING(recent.user.name), recent.entity.name),
     recent.entity.confidence = CASE((\`recent.entity.namespace\` != \\"local\\"), \\"high\\", recent.entity.confidence)
 | EVAL recent.entity.confidence = CASE((\`recent.entity.namespace\` == \\"local\\"), \\"medium\\", recent.entity.confidence)
@@ -1761,7 +1761,7 @@ exports[`buildRemainingLogsCountQuery generates the expected query for host enti
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")
+      AND (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")
   | STATS document_count = COUNT()"
 `;
 
@@ -1779,6 +1779,6 @@ exports[`buildRemainingLogsCountQuery generates the expected query for user enti
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
-      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (NOT(\`user.email\` IS NULL) AND \`user.email\` != \\"\\" OR NOT(\`user.id\` IS NULL) AND \`user.id\` != \\"\\" OR NOT(\`user.name\` IS NULL) AND \`user.name\` != \\"\\"))
+      AND ((\`event.outcome\` IS NULL OR \`event.outcome\` != \\"failure\\") AND (user.email IS NOT NULL AND user.email != \\"\\" OR user.id IS NOT NULL AND user.id != \\"\\" OR user.name IS NOT NULL AND user.name != \\"\\"))
   | STATS document_count = COUNT()"
 `;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.ts
@@ -7,7 +7,7 @@
 
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { Condition } from '@kbn/streamlang';
-import { conditionToESQL } from '@kbn/streamlang';
+import { entityStoreConditionToESQL as conditionToESQL } from '../../../common/esql/condition_to_esql';
 import { HASH_ALG } from '../../../common/domain/euid';
 import { recentData } from '../../../common/domain/definitions/esql';
 import { esqlIsNotNullOrEmpty } from '../../../common/esql/strings';

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.ts
@@ -7,7 +7,6 @@
 
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import {
-  conditionToESQL,
   isAlwaysCondition,
   isAndCondition,
   isFilterCondition,
@@ -16,6 +15,7 @@ import {
   isOrCondition,
   type Condition,
 } from '@kbn/streamlang';
+import { entityStoreConditionToESQL as conditionToESQL } from '../../../common/esql/condition_to_esql';
 import { recentData } from '../../../common/domain/definitions/esql';
 import type {
   EntityDefinition,

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics/inline_tools/asset_criticality/__snapshots__/asset_criticality_esql.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics/inline_tools/asset_criticality/__snapshots__/asset_criticality_esql.test.ts.snap
@@ -4,7 +4,7 @@ exports[`assetCriticalityDynamicInlineToolHandler should modify additional conte
 "
         This is a set of rules that you must follow strictly:
         * The criticality value is stored in the field 'criticality_level'.,
-        * When searching the asset criticality of an entity of type 'host', you must **ALWAYS** use exact and entire filter: \\"'WHERE (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")'\\""
+        * When searching the asset criticality of an entity of type 'host', you must **ALWAYS** use exact and entire filter: \\"'WHERE (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")'\\""
 `;
 
 exports[`assetCriticalityDynamicInlineToolHandler should return asset criticality message with ESQL query when asset criticality index exists 1`] = `

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics/inline_tools/risk_score/__snapshots__/risk_score_esql.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics/inline_tools/risk_score/__snapshots__/risk_score_esql.test.ts.snap
@@ -8,7 +8,7 @@ exports[`riskScoreInlineToolHandler should modify additional context when entity
         * When querying the risk score for a entity you must **ALWAYS** use the normalized field 'host.risk.calculated_score_norm'.
         * The field 'host.risk.calculated_level' contains a textual description of the risk level.
         * The inputs field inside the risk score document contains the 10 highest-risk documents (sorted by 'kibana.alert.risk_score') that contributed to the risk score of an entity.
-        * When searching the risk score of an entity of type 'host', you must **ALWAYS** use exact and entire filter: \\"'WHERE (NOT(\`host.id\` IS NULL) AND \`host.id\` != \\"\\" OR NOT(\`host.name\` IS NULL) AND \`host.name\` != \\"\\" OR NOT(\`host.hostname\` IS NULL) AND \`host.hostname\` != \\"\\")'\\""
+        * When searching the risk score of an entity of type 'host', you must **ALWAYS** use exact and entire filter: \\"'WHERE (host.id IS NOT NULL AND host.id != \\"\\" OR host.name IS NOT NULL AND host.name != \\"\\" OR host.hostname IS NOT NULL AND host.hostname != \\"\\")'\\""
 `;
 
 exports[`riskScoreInlineToolHandler should return generic security solution message when risk score index does not exist 1`] = `"Risk score index does not exist for this space. The user needs to enable the risk engine so that this agent can answer risk-related questions."`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Store] Improve WHERE clause (#271664)](https://github.com/elastic/kibana/pull/271664)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rômulo Farias","email":"romulo.farias@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T15:31:16Z","message":"[Entity Store] Improve WHERE clause (#271664)\n\n## Summary\n\nOptimise entity store queries.\n\n- Identify patterns in streamlang query \n- If it has repeated string comparisons with the same field, use `IN`\nclause\n- Negate `OR` on entity store level\n- If it follows \"not empty\" pattern, use a more optimal ``${field} IS\nNOT NULL AND ${field} != \"\"``\n\nThe optimization meaningfully reduces `FilterOperator` CPU time for\nentities with large OR-of-EQ chains (`user`), but the dominant\nbottleneck — `EvalOperator[CaseLazyEvaluator]` — is unaffected and\naccounts for 95–98% of total operator process time. This causes\nwall-time numbers to appear inconclusive due to run-to-run variance in\nthe evaluator.\n\nThis change, however, helps us reduce the EvalOperator on later PRs\n\n  ## Wall time results (`took` ms)\n\n  ### All runs\n\n| Entity | main (ms) | local (ms) |\n\n|---------|-----------------------------------------------------|-----------------------------------------------------|\n| user | 86 792 / 115 275 / 91 255 / 84 240 / 86 752 | 107 801 / 113 522\n/ 113 146 / 107 440 / 89 194 |\n| service | 5 794 / 9 803 / 6 161 / 9 312 / 8 349 | 11 235 / 7 137 / 10\n058 / 10 027 / 9 833 |\n| host | 2 798 / 4 104 / 2 835 / 4 018 / 4 286 | 4 075 / 3 599 / 3 945 /\n3 713 / 3 688 |\n| generic | 2 056 / 3 686 / 3 315 / 3 060 / 3 923 | 3 580 / 3 830 / 2\n989 / 3 512 / 3 476 |\n\n  ### Averages\n\n| Entity | main avg | local avg | Δ (ms) | Δ (%) | Interpretation |\n\n|---------|----------|-----------|---------|--------|-----------------------------|\n| user | 92 863 | 106 221 | +13 358 | +14.4% | Within variance (see\nbelow) |\n| service | 7 884 | 9 658 | +1 774 | +22.5% | Inflated by outlier |\n| host | 3 608 | 3 804 | +196 | +5.4% | Within variance |\n| generic | 3 208 | 3 477 | +269 | +8.4% | Within variance |\n\n> **Note:** `user` ranges ±30% within the same branch (84 s to 115 s),\nso the +14.4% average difference is not statistically meaningful. For\n`service`, a single main outlier (`main-where-5` at 12.49 s\n`CaseLazyEvaluator` vs 7–8 s in other runs) pulls the main average down\nand creates a spurious regression.\n\n  ---\n\n  ## Operator-level breakdown\n\n  ### FilterOperator[BooleanLogicExpressionEvaluator]\n\n  The optimization primarily affects this operator.\n\n| Entity | main avg (ms) | local avg (ms) | Δ | Assessment |\n\n|---------|---------------|----------------|----------|-----------------------------------------------------|\n| user | ~348 | ~39 | **-89%** | Strong improvement — IN() eliminates\n18-guard OR chain |\n| host | ~268 | ~491 | **+84%** | Systematic regression — host filter\nshape does not benefit |\n| generic | — | — | n/a | No filter condition in query |\n| service | — | — | n/a | No filter condition in query |\n\nFor `user`, this is the intended optimization: the\n`fieldNotOneOfCondition` (18 equality checks) becomes a single `IN (…)`\nexpression, cutting `FilterOperator` time from ~348 ms to ~39 ms.\nHowever, this operator is less than 0.15% of total user query process\ntime, so the wall-time impact is negligible.\n\nFor `host`, the `IN(...)` form consistently runs slower (~491 ms flat\nacross all 5 local runs vs ~268 ms average in main). This is a\nsystematic regression and warrants investigation before merging.\n\n  ### EvalOperator[CaseLazyEvaluator] — the real bottleneck\n\n  | Entity  | main range     | local range    | Share of total CPU |\n  |---------|----------------|----------------|--------------------|\n  | user    | 265 s – 369 s  | 274 s – 368 s  | ~95–98%            |\n  | service | 7.6 s – 12.5 s | 7.9 s – 9.8 s  | ~76–80%            |\n  | host    | 3.2 s – 3.8 s  | 1.8 s – 4.0 s  | ~51–56%            |\n  | generic | 1.5 s – 2.2 s  | 1.3 s – 2.6 s  | ~55–65%            |\n\n`CaseLazyEvaluator` dominates total CPU time for every entity type. Its\nrun-to-run variance (up to 100 s for `user`) completely overwhelms the\nFilterOperator savings. Wall time is governed by this operator, not by\nthe WHERE clause.\n\n  ---\n\n  ## Conclusions\n\n  ### What the optimization does accomplish\n\n- `FilterOperator` time for `user` drops from ~348 ms to ~39 ms\n(**-89%**). The `IN(...)` rewrite is structurally correct and measurably\nimproves the filter evaluation step.\n- `FilterOperator` row count also drops for `user` (~1.6 M rows → ~36 k\nrows reaching the operator), suggesting the `IN(...)` form allows the\nplanner to push more work to the Lucene layer.","sha":"da09bc7cb0ed75ea5e4f5e9488e43ea5b28ab882","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.2"],"title":"[Entity Store] Improve WHERE clause","number":271664,"url":"https://github.com/elastic/kibana/pull/271664","mergeCommit":{"message":"[Entity Store] Improve WHERE clause (#271664)\n\n## Summary\n\nOptimise entity store queries.\n\n- Identify patterns in streamlang query \n- If it has repeated string comparisons with the same field, use `IN`\nclause\n- Negate `OR` on entity store level\n- If it follows \"not empty\" pattern, use a more optimal ``${field} IS\nNOT NULL AND ${field} != \"\"``\n\nThe optimization meaningfully reduces `FilterOperator` CPU time for\nentities with large OR-of-EQ chains (`user`), but the dominant\nbottleneck — `EvalOperator[CaseLazyEvaluator]` — is unaffected and\naccounts for 95–98% of total operator process time. This causes\nwall-time numbers to appear inconclusive due to run-to-run variance in\nthe evaluator.\n\nThis change, however, helps us reduce the EvalOperator on later PRs\n\n  ## Wall time results (`took` ms)\n\n  ### All runs\n\n| Entity | main (ms) | local (ms) |\n\n|---------|-----------------------------------------------------|-----------------------------------------------------|\n| user | 86 792 / 115 275 / 91 255 / 84 240 / 86 752 | 107 801 / 113 522\n/ 113 146 / 107 440 / 89 194 |\n| service | 5 794 / 9 803 / 6 161 / 9 312 / 8 349 | 11 235 / 7 137 / 10\n058 / 10 027 / 9 833 |\n| host | 2 798 / 4 104 / 2 835 / 4 018 / 4 286 | 4 075 / 3 599 / 3 945 /\n3 713 / 3 688 |\n| generic | 2 056 / 3 686 / 3 315 / 3 060 / 3 923 | 3 580 / 3 830 / 2\n989 / 3 512 / 3 476 |\n\n  ### Averages\n\n| Entity | main avg | local avg | Δ (ms) | Δ (%) | Interpretation |\n\n|---------|----------|-----------|---------|--------|-----------------------------|\n| user | 92 863 | 106 221 | +13 358 | +14.4% | Within variance (see\nbelow) |\n| service | 7 884 | 9 658 | +1 774 | +22.5% | Inflated by outlier |\n| host | 3 608 | 3 804 | +196 | +5.4% | Within variance |\n| generic | 3 208 | 3 477 | +269 | +8.4% | Within variance |\n\n> **Note:** `user` ranges ±30% within the same branch (84 s to 115 s),\nso the +14.4% average difference is not statistically meaningful. For\n`service`, a single main outlier (`main-where-5` at 12.49 s\n`CaseLazyEvaluator` vs 7–8 s in other runs) pulls the main average down\nand creates a spurious regression.\n\n  ---\n\n  ## Operator-level breakdown\n\n  ### FilterOperator[BooleanLogicExpressionEvaluator]\n\n  The optimization primarily affects this operator.\n\n| Entity | main avg (ms) | local avg (ms) | Δ | Assessment |\n\n|---------|---------------|----------------|----------|-----------------------------------------------------|\n| user | ~348 | ~39 | **-89%** | Strong improvement — IN() eliminates\n18-guard OR chain |\n| host | ~268 | ~491 | **+84%** | Systematic regression — host filter\nshape does not benefit |\n| generic | — | — | n/a | No filter condition in query |\n| service | — | — | n/a | No filter condition in query |\n\nFor `user`, this is the intended optimization: the\n`fieldNotOneOfCondition` (18 equality checks) becomes a single `IN (…)`\nexpression, cutting `FilterOperator` time from ~348 ms to ~39 ms.\nHowever, this operator is less than 0.15% of total user query process\ntime, so the wall-time impact is negligible.\n\nFor `host`, the `IN(...)` form consistently runs slower (~491 ms flat\nacross all 5 local runs vs ~268 ms average in main). This is a\nsystematic regression and warrants investigation before merging.\n\n  ### EvalOperator[CaseLazyEvaluator] — the real bottleneck\n\n  | Entity  | main range     | local range    | Share of total CPU |\n  |---------|----------------|----------------|--------------------|\n  | user    | 265 s – 369 s  | 274 s – 368 s  | ~95–98%            |\n  | service | 7.6 s – 12.5 s | 7.9 s – 9.8 s  | ~76–80%            |\n  | host    | 3.2 s – 3.8 s  | 1.8 s – 4.0 s  | ~51–56%            |\n  | generic | 1.5 s – 2.2 s  | 1.3 s – 2.6 s  | ~55–65%            |\n\n`CaseLazyEvaluator` dominates total CPU time for every entity type. Its\nrun-to-run variance (up to 100 s for `user`) completely overwhelms the\nFilterOperator savings. Wall time is governed by this operator, not by\nthe WHERE clause.\n\n  ---\n\n  ## Conclusions\n\n  ### What the optimization does accomplish\n\n- `FilterOperator` time for `user` drops from ~348 ms to ~39 ms\n(**-89%**). The `IN(...)` rewrite is structurally correct and measurably\nimproves the filter evaluation step.\n- `FilterOperator` row count also drops for `user` (~1.6 M rows → ~36 k\nrows reaching the operator), suggesting the `IN(...)` form allows the\nplanner to push more work to the Lucene layer.","sha":"da09bc7cb0ed75ea5e4f5e9488e43ea5b28ab882"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271664","number":271664,"mergeCommit":{"message":"[Entity Store] Improve WHERE clause (#271664)\n\n## Summary\n\nOptimise entity store queries.\n\n- Identify patterns in streamlang query \n- If it has repeated string comparisons with the same field, use `IN`\nclause\n- Negate `OR` on entity store level\n- If it follows \"not empty\" pattern, use a more optimal ``${field} IS\nNOT NULL AND ${field} != \"\"``\n\nThe optimization meaningfully reduces `FilterOperator` CPU time for\nentities with large OR-of-EQ chains (`user`), but the dominant\nbottleneck — `EvalOperator[CaseLazyEvaluator]` — is unaffected and\naccounts for 95–98% of total operator process time. This causes\nwall-time numbers to appear inconclusive due to run-to-run variance in\nthe evaluator.\n\nThis change, however, helps us reduce the EvalOperator on later PRs\n\n  ## Wall time results (`took` ms)\n\n  ### All runs\n\n| Entity | main (ms) | local (ms) |\n\n|---------|-----------------------------------------------------|-----------------------------------------------------|\n| user | 86 792 / 115 275 / 91 255 / 84 240 / 86 752 | 107 801 / 113 522\n/ 113 146 / 107 440 / 89 194 |\n| service | 5 794 / 9 803 / 6 161 / 9 312 / 8 349 | 11 235 / 7 137 / 10\n058 / 10 027 / 9 833 |\n| host | 2 798 / 4 104 / 2 835 / 4 018 / 4 286 | 4 075 / 3 599 / 3 945 /\n3 713 / 3 688 |\n| generic | 2 056 / 3 686 / 3 315 / 3 060 / 3 923 | 3 580 / 3 830 / 2\n989 / 3 512 / 3 476 |\n\n  ### Averages\n\n| Entity | main avg | local avg | Δ (ms) | Δ (%) | Interpretation |\n\n|---------|----------|-----------|---------|--------|-----------------------------|\n| user | 92 863 | 106 221 | +13 358 | +14.4% | Within variance (see\nbelow) |\n| service | 7 884 | 9 658 | +1 774 | +22.5% | Inflated by outlier |\n| host | 3 608 | 3 804 | +196 | +5.4% | Within variance |\n| generic | 3 208 | 3 477 | +269 | +8.4% | Within variance |\n\n> **Note:** `user` ranges ±30% within the same branch (84 s to 115 s),\nso the +14.4% average difference is not statistically meaningful. For\n`service`, a single main outlier (`main-where-5` at 12.49 s\n`CaseLazyEvaluator` vs 7–8 s in other runs) pulls the main average down\nand creates a spurious regression.\n\n  ---\n\n  ## Operator-level breakdown\n\n  ### FilterOperator[BooleanLogicExpressionEvaluator]\n\n  The optimization primarily affects this operator.\n\n| Entity | main avg (ms) | local avg (ms) | Δ | Assessment |\n\n|---------|---------------|----------------|----------|-----------------------------------------------------|\n| user | ~348 | ~39 | **-89%** | Strong improvement — IN() eliminates\n18-guard OR chain |\n| host | ~268 | ~491 | **+84%** | Systematic regression — host filter\nshape does not benefit |\n| generic | — | — | n/a | No filter condition in query |\n| service | — | — | n/a | No filter condition in query |\n\nFor `user`, this is the intended optimization: the\n`fieldNotOneOfCondition` (18 equality checks) becomes a single `IN (…)`\nexpression, cutting `FilterOperator` time from ~348 ms to ~39 ms.\nHowever, this operator is less than 0.15% of total user query process\ntime, so the wall-time impact is negligible.\n\nFor `host`, the `IN(...)` form consistently runs slower (~491 ms flat\nacross all 5 local runs vs ~268 ms average in main). This is a\nsystematic regression and warrants investigation before merging.\n\n  ### EvalOperator[CaseLazyEvaluator] — the real bottleneck\n\n  | Entity  | main range     | local range    | Share of total CPU |\n  |---------|----------------|----------------|--------------------|\n  | user    | 265 s – 369 s  | 274 s – 368 s  | ~95–98%            |\n  | service | 7.6 s – 12.5 s | 7.9 s – 9.8 s  | ~76–80%            |\n  | host    | 3.2 s – 3.8 s  | 1.8 s – 4.0 s  | ~51–56%            |\n  | generic | 1.5 s – 2.2 s  | 1.3 s – 2.6 s  | ~55–65%            |\n\n`CaseLazyEvaluator` dominates total CPU time for every entity type. Its\nrun-to-run variance (up to 100 s for `user`) completely overwhelms the\nFilterOperator savings. Wall time is governed by this operator, not by\nthe WHERE clause.\n\n  ---\n\n  ## Conclusions\n\n  ### What the optimization does accomplish\n\n- `FilterOperator` time for `user` drops from ~348 ms to ~39 ms\n(**-89%**). The `IN(...)` rewrite is structurally correct and measurably\nimproves the filter evaluation step.\n- `FilterOperator` row count also drops for `user` (~1.6 M rows → ~36 k\nrows reaching the operator), suggesting the `IN(...)` form allows the\nplanner to push more work to the Lucene layer.","sha":"da09bc7cb0ed75ea5e4f5e9488e43ea5b28ab882"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/271927","number":271927,"branch":"deploy-fix@1779817240","state":"MERGED","mergeCommit":{"sha":"05d3bd6d7b9a329ece49d161cadc51396ae61c68","message":"[Entity Store][Emergency Fix] Cherry pick 2 PRs for emergency release (#271927)\n\n## Summary\n\nRelated to\n[incident-3147-extraction-failing-on-indices-with-inconsistent-mappings](https://elastic.slack.com/archives/C0B6TFFL3PB)\n\nCherry pick of 2 PRs:\n- **[Entity Store] Improve WHERE clause (#271664)**\n- **[Entity Store] Cast all fields on entity store query (#271752)**\n\n---------\n\nCo-authored-by: Rômulo Farias <romulo.farias@elastic.co>"}}]}] BACKPORT-->