### PR TITLE
Fix to show the security rule name in the integration assets accordion

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_bulk_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_bulk_assets.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ISavedObjectTypeRegistry, SavedObjectsClientContract } from '@kbn/core/server';
+
+import { KibanaSavedObjectType } from '../../../../common/types';
+
+import { getBulkAssets } from './get_bulk_assets';
+
+describe('getBulkAssets', () => {
+  it('uses attributes.name as the display title when attributes.title is unavailable', async () => {
+    const soClient = {
+      bulkResolve: jest.fn().mockResolvedValue({
+        resolved_objects: [
+          {
+            saved_object: {
+              id: 'sample_security_rule',
+              type: KibanaSavedObjectType.securityRule,
+              updated_at: '2026-05-28T00:00:00.000Z',
+              attributes: {
+                name: 'Svchost spawning Cmd',
+                description:
+                  'Identifies a suspicious parent child process relationship with cmd.exe descending from svchost.exe',
+              },
+            },
+          },
+        ],
+      }),
+    } as unknown as SavedObjectsClientContract;
+
+    const soTypeRegistry = {
+      getType: jest.fn().mockReturnValue({
+        management: {},
+      }),
+    } as unknown as ISavedObjectTypeRegistry;
+
+    const assets = await getBulkAssets(soClient, soTypeRegistry, [
+      {
+        id: 'sample_security_rule',
+        type: KibanaSavedObjectType.securityRule,
+      },
+    ]);
+
+    expect(assets).toEqual([
+      {
+        id: 'sample_security_rule',
+        type: KibanaSavedObjectType.securityRule,
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        attributes: {
+          title: 'Svchost spawning Cmd',
+          description:
+            'Identifies a suspicious parent child process relationship with cmd.exe descending from svchost.exe',
+        },
+        appLink: '',
+      },
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_bulk_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_bulk_assets.ts
@@ -18,6 +18,10 @@ import { displayedAssetTypesLookup } from '../../../../common/constants';
 
 import type { SimpleSOAssetAttributes } from '../../../types';
 
+type DisplayableSOAssetAttributes = SimpleSOAssetAttributes & {
+  name?: string;
+};
+
 const getKibanaLinkForESAsset = (type: ElasticsearchAssetType, id: string): string => {
   switch (type) {
     case 'index':
@@ -48,9 +52,8 @@ export async function getBulkAssets(
   soTypeRegistry: ISavedObjectTypeRegistry,
   assetIds: AssetSOObject[]
 ) {
-  const { resolved_objects: resolvedObjects } = await soClient.bulkResolve<SimpleSOAssetAttributes>(
-    assetIds
-  );
+  const { resolved_objects: resolvedObjects } =
+    await soClient.bulkResolve<DisplayableSOAssetAttributes>(assetIds);
   const types: Record<string, SavedObjectsType | undefined> = {};
 
   const res: SimpleSOAssetType[] = resolvedObjects
@@ -88,7 +91,10 @@ export async function getBulkAssets(
         }
       }
 
-      const title = types[obj.type]?.management?.getTitle?.(obj) ?? obj.attributes?.title;
+      const title =
+        types[obj.type]?.management?.getTitle?.(obj) ??
+        obj.attributes?.title ??
+        obj.attributes?.name;
 
       return {
         id: obj.id,


### PR DESCRIPTION
## Summary

Fix to show the security rule name in the integration assets accordion.

Security rule objects don't have a title, they only have a name. Use the name field if there's no value in title.

Screenshot of the problem:

<img width="1920" height="2013" alt="image" src="https://github.com/user-attachments/assets/2bc3cb21-e58b-4d1d-be3d-5233fe97c10b" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->