### PR TITLE
[Alerting v2] Rename labels from "Detection only" to "Signal"

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/rule_overview_panel.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/rule_overview_panel.test.tsx
@@ -19,15 +19,20 @@ const mockRule = {
   evaluation: { query: { base: 'FROM logs-* | WHERE foo=1' } },
 } as unknown as RuleResponse;
 
+const alertRule = { ...mockRule, kind: 'alert' } as unknown as RuleResponse;
+
 const mockRuleDetailsHref = '/rules/rule-1';
+
+const renderPanel = (rule: RuleResponse) =>
+  render(
+    <I18nProvider>
+      <AlertEpisodeRuleOverviewPanel rule={rule} ruleDetailsHref={mockRuleDetailsHref} />
+    </I18nProvider>
+  );
 
 describe('AlertEpisodeRuleOverviewPanel', () => {
   it('renders the rule name, esql code block and view-rule-details link', () => {
-    render(
-      <I18nProvider>
-        <AlertEpisodeRuleOverviewPanel rule={mockRule} ruleDetailsHref={mockRuleDetailsHref} />
-      </I18nProvider>
-    );
+    renderPanel(mockRule);
 
     expect(screen.getByText('My rule')).toBeInTheDocument();
     expect(screen.getByTestId('alertingV2EpisodeDetailsRuleQueryCodeBlock')).toHaveTextContent(
@@ -36,5 +41,19 @@ describe('AlertEpisodeRuleOverviewPanel', () => {
     const viewBtn = screen.getByTestId('alertingV2EpisodeDetailsViewRuleDetailsButton');
     expect(viewBtn).toHaveAttribute('href', '/rules/rule-1');
     expect(screen.getByTestId('alertingV2EpisodeDetailsRuleOverviewPanel')).toBeInTheDocument();
+  });
+
+  it('renders "Signal" kind badge for signal rules', () => {
+    renderPanel(mockRule);
+
+    const badge = screen.getByTestId('alertingV2EpisodeDetailsRuleKindBadge');
+    expect(badge).toHaveTextContent('Signal');
+  });
+
+  it('renders "Alert" kind badge for alert rules', () => {
+    renderPanel(alertRule);
+
+    const badge = screen.getByTestId('alertingV2EpisodeDetailsRuleKindBadge');
+    expect(badge).toHaveTextContent('Alert');
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/rule_overview_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/rule_overview_panel.tsx
@@ -12,11 +12,11 @@ import {
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
 import * as i18n from './translations';
@@ -67,16 +67,17 @@ export const AlertEpisodeRuleOverviewPanel = ({
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiIcon type="bell" size="s" aria-hidden />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText size="xs" color="subdued">
-                {ruleKindLabel}
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <EuiToolTip content={i18n.RULE_OVERVIEW_KIND_TOOLTIP}>
+            <EuiBadge
+              color="hollow"
+              iconType={rule.kind === 'signal' ? 'radar' : 'bell'}
+              iconSide="left"
+              tabIndex={0}
+              data-test-subj="alertingV2EpisodeDetailsRuleKindBadge"
+            >
+              {ruleKindLabel}
+            </EuiBadge>
+          </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued">

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/translations.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/details/translations.ts
@@ -283,7 +283,14 @@ export const RULE_OVERVIEW_KIND_SIGNAL = i18n.translate(
 export const RULE_OVERVIEW_KIND_ALERTING = i18n.translate(
   'xpack.alertingV2EpisodesUi.details.ruleOverview.kind.alerting',
   {
-    defaultMessage: 'Alerting',
+    defaultMessage: 'Alert',
+  }
+);
+
+export const RULE_OVERVIEW_KIND_TOOLTIP = i18n.translate(
+  'xpack.alertingV2EpisodesUi.details.ruleOverview.kind.tooltip',
+  {
+    defaultMessage: 'Mode can be changed in the rule edit form',
   }
 );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/quick_filters.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/quick_filters.test.tsx
@@ -113,8 +113,8 @@ describe('RuleFilter', () => {
 
     await user.click(screen.getByTestId('quickFilterRule'));
 
-    expect(screen.getByText('Alerting')).toBeInTheDocument();
-    expect(screen.getByText('Detect only')).toBeInTheDocument();
+    expect(screen.getByText('Alert')).toBeInTheDocument();
+    expect(screen.getByText('Signal')).toBeInTheDocument();
   });
 
   it('calls onChange with rule.id clause when selecting a rule', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/rule_filter.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/rule_filter.tsx
@@ -37,10 +37,10 @@ interface RuleSelectableMeta {
 const kindLabel = (kind: RuleResponse['kind']): string =>
   kind === 'alert'
     ? i18n.translate('xpack.alertingV2.actionPolicy.form.quickFilters.rule.kind.alert', {
-        defaultMessage: 'Alerting',
+        defaultMessage: 'Alert',
       })
     : i18n.translate('xpack.alertingV2.actionPolicy.form.quickFilters.rule.kind.signal', {
-        defaultMessage: 'Detect only',
+        defaultMessage: 'Signal',
       });
 
 export const RuleFilter = ({ matcher, onChange }: QuickFiltersProps) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/popovers/mode_filter_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/popovers/mode_filter_popover.test.tsx
@@ -26,31 +26,31 @@ describe('ModeFilterPopover', () => {
     expect(screen.getByText('Mode')).toBeInTheDocument();
   });
 
-  it('displays Alerting and Detect only options when opened', () => {
+  it('displays Alert and Signal options when opened', () => {
     render(<ModeFilterPopover {...defaultProps} />);
 
     fireEvent.click(screen.getByTestId('rulesListModeFilter'));
 
-    expect(screen.getByText('Alerting')).toBeInTheDocument();
-    expect(screen.getByText('Detect only')).toBeInTheDocument();
+    expect(screen.getByText('Alert')).toBeInTheDocument();
+    expect(screen.getByText('Signal')).toBeInTheDocument();
   });
 
-  it('calls onChange with "alert" when Alerting is selected', () => {
+  it('calls onChange with "alert" when Alert is selected', () => {
     const onChange = jest.fn();
     render(<ModeFilterPopover value="" onChange={onChange} />);
 
     fireEvent.click(screen.getByTestId('rulesListModeFilter'));
-    fireEvent.click(screen.getByText('Alerting'));
+    fireEvent.click(screen.getByText('Alert'));
 
     expect(onChange).toHaveBeenCalledWith('alert');
   });
 
-  it('calls onChange with "signal" when Detect only is selected', () => {
+  it('calls onChange with "signal" when Signal is selected', () => {
     const onChange = jest.fn();
     render(<ModeFilterPopover value="" onChange={onChange} />);
 
     fireEvent.click(screen.getByTestId('rulesListModeFilter'));
-    fireEvent.click(screen.getByText('Detect only'));
+    fireEvent.click(screen.getByText('Signal'));
 
     expect(onChange).toHaveBeenCalledWith('signal');
   });
@@ -60,7 +60,7 @@ describe('ModeFilterPopover', () => {
     render(<ModeFilterPopover value="alert" onChange={onChange} />);
 
     fireEvent.click(screen.getByTestId('rulesListModeFilter'));
-    fireEvent.click(screen.getByText('Alerting'));
+    fireEvent.click(screen.getByText('Alert'));
 
     expect(onChange).toHaveBeenCalledWith('');
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/popovers/mode_filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/popovers/mode_filter_popover.tsx
@@ -14,14 +14,14 @@ const MODE_FILTER_OPTIONS: FilterPopoverOption[] = [
   {
     value: 'alert',
     label: i18n.translate('xpack.alertingV2.rulesList.modeFilter.alert', {
-      defaultMessage: 'Alerting',
+      defaultMessage: 'Alert',
     }),
     iconType: 'bell',
   },
   {
     value: 'signal',
     label: i18n.translate('xpack.alertingV2.rulesList.modeFilter.signal', {
-      defaultMessage: 'Detect only',
+      defaultMessage: 'Signal',
     }),
     iconType: 'radar',
   },

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.test.tsx
@@ -80,14 +80,14 @@ describe('RuleTitleWithBadges', () => {
     expect(screen.getByTestId('ruleName')).toHaveTextContent('My Rule');
   });
 
-  it('renders kind as Detect only for signal rules', () => {
+  it('renders kind as Signal for signal rules', () => {
     wrap(<RuleTitleWithBadges />);
-    expect(screen.getByTestId('kindBadge')).toHaveTextContent('Detect only');
+    expect(screen.getByTestId('kindBadge')).toHaveTextContent('Signal');
   });
 
-  it('renders kind as Alerting for alert rules', () => {
+  it('renders kind as Alert for alert rules', () => {
     wrap(<RuleTitleWithBadges />, { ...baseRule, kind: 'alert' } as RuleApiResponse);
-    expect(screen.getByTestId('kindBadge')).toHaveTextContent('Alerting');
+    expect(screen.getByTestId('kindBadge')).toHaveTextContent('Alert');
   });
 
   it('renders enabled badge when rule is enabled', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
@@ -5,24 +5,28 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useRule } from './rule_context';
 
 const KIND_LABELS: Record<string, string> = {
   signal: i18n.translate('xpack.alertingV2.ruleDetails.kindSignal', {
-    defaultMessage: 'Detect only',
+    defaultMessage: 'Signal',
   }),
   alert: i18n.translate('xpack.alertingV2.ruleDetails.kindAlert', {
-    defaultMessage: 'Alerting',
+    defaultMessage: 'Alert',
   }),
 };
 
 const KIND_ICONS: Record<string, string> = {
-  signal: 'securitySignalResolved',
+  signal: 'radar',
   alert: 'bell',
 };
+
+const KIND_BADGE_TOOLTIP = i18n.translate('xpack.alertingV2.ruleDetails.kindBadgeTooltip', {
+  defaultMessage: 'Mode can be changed in the rule edit form',
+});
 
 /**
  * Renders the description and tags row below the page title.
@@ -78,22 +82,17 @@ export const RuleTitleWithBadges: React.FC<RuleTitleWithBadgesProps> = ({ varian
   const isSummary = variant === 'summary';
 
   const kindBadge = (
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="xs"
-      wrap={false}
-      responsive={false}
-      data-test-subj="kindBadge"
-    >
-      <EuiFlexItem grow={false}>
-        <EuiIcon type={KIND_ICONS[rule.kind] ?? 'dot'} size="m" color="text" aria-hidden={true} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiText size="s" color="text">
-          {KIND_LABELS[rule.kind] ?? rule.kind}
-        </EuiText>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <EuiToolTip content={KIND_BADGE_TOOLTIP}>
+      <EuiBadge
+        color="hollow"
+        iconType={KIND_ICONS[rule.kind] ?? 'dot'}
+        iconSide="left"
+        tabIndex={0}
+        data-test-subj="kindBadge"
+      >
+        {KIND_LABELS[rule.kind] ?? rule.kind}
+      </EuiBadge>
+    </EuiToolTip>
   );
 
   const statusBadge = rule.enabled ? (

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_conditions.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_conditions.test.tsx
@@ -83,7 +83,7 @@ describe('RuleConditions', () => {
     expect(screen.getByTestId('alertingV2RuleDetailsTimeField')).toHaveTextContent('@timestamp');
     expect(screen.getByTestId('alertingV2RuleDetailsSchedule')).toHaveTextContent('Every 5m');
     expect(screen.getByTestId('alertingV2RuleDetailsLookback')).toHaveTextContent('10m');
-    expect(screen.getByTestId('alertingV2RuleDetailsMode')).toHaveTextContent('Alerting');
+    expect(screen.getByTestId('alertingV2RuleDetailsMode')).toHaveTextContent('Alert');
     expect(screen.getByTestId('alertingV2RuleDetailsAlertDelay')).toHaveTextContent(
       'After 3 matches or 5m'
     );
@@ -186,7 +186,7 @@ describe('RuleConditions', () => {
       expect(screen.getByTestId('alertingV2RuleDetailsTimeField')).toHaveTextContent('@timestamp');
       expect(screen.getByTestId('alertingV2RuleDetailsSchedule')).toHaveTextContent('Every 5m');
       expect(screen.getByTestId('alertingV2RuleDetailsLookback')).toHaveTextContent('10m');
-      expect(screen.getByTestId('alertingV2RuleDetailsMode')).toHaveTextContent('Alerting');
+      expect(screen.getByTestId('alertingV2RuleDetailsMode')).toHaveTextContent('Alert');
     });
   });
 
@@ -201,7 +201,7 @@ describe('RuleConditions', () => {
     expect(screen.getByTestId('alertingV2RuleDetailsDataSource')).toHaveTextContent('-');
     expect(screen.getByTestId('alertingV2RuleDetailsGroupBy')).toHaveTextContent('-');
     expect(screen.getByTestId('alertingV2RuleDetailsLookback')).toHaveTextContent('-');
-    expect(screen.getByTestId('alertingV2RuleDetailsMode')).toHaveTextContent('Detect only');
+    expect(screen.getByTestId('alertingV2RuleDetailsMode')).toHaveTextContent('Signal');
     expect(screen.getByTestId('alertingV2RuleDetailsNoDataConfig')).toHaveTextContent('-');
     expect(screen.queryByTestId('alertingV2RuleDetailsAlertDelay')).not.toBeInTheDocument();
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_conditions.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_conditions.tsx
@@ -17,10 +17,10 @@ import { EMPTY_VALUE, formatAlertDelay, formatRecoveryDelay } from '../utils';
 
 const MODE_LABELS: Record<string, string> = {
   signal: i18n.translate('xpack.alertingV2.ruleDetails.modeSignal', {
-    defaultMessage: 'Detect only',
+    defaultMessage: 'Signal',
   }),
   alert: i18n.translate('xpack.alertingV2.ruleDetails.modeAlert', {
-    defaultMessage: 'Alerting',
+    defaultMessage: 'Alert',
   }),
 };
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/translations.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/translations.ts
@@ -73,7 +73,7 @@ export const RULE_KIND_SIGNAL = i18n.translate('xpack.alertingV2.episodeDetails.
 export const RULE_KIND_ALERTING = i18n.translate(
   'xpack.alertingV2.episodeDetails.ruleKindAlerting',
   {
-    defaultMessage: 'Alerting',
+    defaultMessage: 'Alert',
   }
 );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.test.tsx
@@ -157,11 +157,11 @@ describe('RulesListTable', () => {
       expect(screen.getByTestId('ruleStatusDisabled')).toHaveTextContent('Disabled');
     });
 
-    it('renders Mode column with Alerting and Detect only', () => {
+    it('renders Mode column with Alert and Signal', () => {
       renderTable();
 
-      expect(screen.getByText('Alerting')).toBeInTheDocument();
-      expect(screen.getByText('Detect only')).toBeInTheDocument();
+      expect(screen.getByText('Alert')).toBeInTheDocument();
+      expect(screen.getByText('Signal')).toBeInTheDocument();
     });
 
     it('renders tag badges for rules with tags', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -202,15 +202,22 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
         name: '',
         width: '32px',
         render: (rule: RuleApiResponse) => (
-          <EuiButtonIcon
-            iconType="expand"
-            color="text"
-            onClick={() => onExpand(rule)}
-            aria-label={i18n.translate('xpack.alertingV2.rulesList.action.expand', {
+          <EuiToolTip
+            content={i18n.translate('xpack.alertingV2.rulesList.action.expand', {
               defaultMessage: 'Open rule summary',
             })}
-            data-test-subj={`expandRule-${rule.id}`}
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              iconType="expand"
+              color="text"
+              onClick={() => onExpand(rule)}
+              aria-label={i18n.translate('xpack.alertingV2.rulesList.action.expand', {
+                defaultMessage: 'Open rule summary',
+              })}
+              data-test-subj={`expandRule-${rule.id}`}
+            />
+          </EuiToolTip>
         ),
       },
       {
@@ -366,15 +373,22 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
             justifyContent="flexEnd"
           >
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType="pencil"
-                color="text"
-                onClick={() => onQuickEdit(rule)}
-                aria-label={i18n.translate('xpack.alertingV2.rulesList.action.quickEdit', {
+              <EuiToolTip
+                content={i18n.translate('xpack.alertingV2.rulesList.action.quickEdit', {
                   defaultMessage: 'Quick edit rule',
                 })}
-                data-test-subj={`quickEditRule-${rule.id}`}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  iconType="pencil"
+                  color="text"
+                  onClick={() => onQuickEdit(rule)}
+                  aria-label={i18n.translate('xpack.alertingV2.rulesList.action.quickEdit', {
+                    defaultMessage: 'Quick edit rule',
+                  })}
+                  data-test-subj={`quickEditRule-${rule.id}`}
+                />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <RuleActionsMenu

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -305,24 +305,26 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
         width: '10%',
         sortable: true,
         render: (kind: string) => (
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiIcon
-                type={kind === 'alert' ? 'bell' : 'securitySignalResolved'}
-                size="m"
-                aria-hidden={true}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+          <EuiToolTip
+            content={i18n.translate('xpack.alertingV2.rulesList.modeTooltip', {
+              defaultMessage: 'Mode can be changed in the rule edit form',
+            })}
+          >
+            <EuiBadge
+              color="hollow"
+              iconType={kind === 'alert' ? 'bell' : 'radar'}
+              iconSide="left"
+              tabIndex={0}
+            >
               {kind === 'alert'
-                ? i18n.translate('xpack.alertingV2.rulesList.modeAlerting', {
-                    defaultMessage: 'Alerting',
+                ? i18n.translate('xpack.alertingV2.rulesList.modeAlert', {
+                    defaultMessage: 'Alert',
                   })
-                : i18n.translate('xpack.alertingV2.rulesList.modeDetectOnly', {
-                    defaultMessage: 'Detect only',
+                : i18n.translate('xpack.alertingV2.rulesList.modeSignal', {
+                    defaultMessage: 'Signal',
                   })}
-            </EuiFlexItem>
-          </EuiFlexGroup>
+            </EuiBadge>
+          </EuiToolTip>
         ),
       },
       {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -32,14 +32,14 @@ Rules declare a \`kind\` of \`alert\` or \`signal\`. This is the most important 
 - **Stateful alerting** with full episode lifecycle: pending, active, recovering, inactive.
 - Supports state transitions (\`consecutive_breaches\`), recovery detection, and notification dispatch.
 - Produces \`type: 'alert'\` events that participate in the dispatcher pipeline.
-- UI label: **"Alerting"**.
+- UI label: **"Alert"**.
 - Use when the user wants to be **notified**, needs **lifecycle tracking**, or wants **recovery detection**.
 
 ### Signal (\`kind: signal\`)
 - **Stateless detection** (observation-only).
 - Produces \`type: 'signal'\` events but **skips** episode lifecycle and dispatcher processing entirely.
 - No notifications, no recovery, no state transitions.
-- UI label: **"Detect only"**.
+- UI label: **"Signal"**.
 - Use for logging or detection without automated action.
 
 ### Immutability
@@ -231,7 +231,7 @@ Action policies only process alert episodes. Signal rules (\`kind: signal\`) do 
 
 When a user asks for notifications on a rule that is currently \`kind: signal\` (or when composing a new rule where the user wants notifications):
 
-1. **Explain the difference**: signal rules are observation-only ("Detect only") and do not trigger notifications. Alert rules ("Alerting") track episode lifecycle and can dispatch to action policies.
+1. **Explain the difference**: signal rules are observation-only ("Signal") and do not trigger notifications. Alert rules ("Alert") track episode lifecycle and can dispatch to action policies.
 2. If the rule is a **draft (in-memory)**: use \`set_kind\` to change it to \`alert\`, then proceed with notification setup (Part 3).
 3. If the rule is **persisted**: \`kind\` is immutable after creation. Inform the user that the existing signal rule cannot be converted. Offer to create a new alert rule with the same query and schedule, then set up notifications on the new rule.
 4. After ensuring the rule is \`kind: alert\`, proceed with the notification setup flow (Part 3).


### PR DESCRIPTION
Closes https://github.com/elastic/rna-program/issues/531

Renames labels for rule kind signal from "detection only" to "signal"

<img width="397" height="260" alt="Screenshot 2026-06-01 at 10 12 42 AM" src="https://github.com/user-attachments/assets/f7f3f93a-6fd8-4b13-8cc7-df9808b5ac2e" />

