### PR TITLE
Unskip Observability Landing Page Scout tests

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts
@@ -10,8 +10,7 @@ import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../fixtures';
 import { generateApmData, generateLogsData } from '../fixtures/generators';
 
-// Failing: See https://github.com/elastic/kibana/issues/253824
-test.describe.skip(
+test.describe(
   'Observability Landing Page',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {


### PR DESCRIPTION
## Summary

Unskips the Observability Landing Page Scout test suite that was disabled by automation in #253824.

The test was auto-skipped on 9.3 in April when the issue accumulated new CI failures — however, those failures were all on `main` in parallel execution mode (race condition with `defaultRoute` uiSetting propagation). The 9.3-specific failure (beforeEach timeout under CI load) had already been resolved in February by #254151, which bumped assertion timeouts from 10s to 20s.

The fix for the `main` failures (PR #265788, merged to 9.5) wraps navigation in a `toPass()` retry block for parallel execution. That fix is not needed on 9.3 since tests here run sequentially, eliminating the race condition.

Made with [Cursor](https://cursor.com)