### PR TITLE
[Discover][Metrics] Remove unnecessary wrapper on Metrics E2E tests

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
@@ -53,34 +53,12 @@ export const spaceTest = spaceBaseTest.extend<
     },
     use: (pageObjects: MetricsExperienceTestFixtures['pageObjects']) => Promise<void>
   ) => {
-    const extendedPageObjects = {
+    await use({
       ...pageObjects,
-      // The core DiscoverApp.goto() was previously fixed for a flaky load issue,
-      // but metrics experience tests continued to fail at a low rate due to
-      // Discover not fully loading in time. Since this is not related to metrics
-      // experience itself and does not add value to the experience testing, we
-      // override goto here with an explicit 30s timeout instead of modifying
-      // the core page object.
-      // See https://github.com/elastic/kibana/issues/257436
-      discover: extendPageObject(pageObjects.discover, {
-        goto: async (options = {}) => {
-          if (options.queryMode) {
-            await pageObjects.discover.setQueryMode(options.queryMode);
-          }
-          await page.gotoApp('discover');
-          await page.testSubj.locator('dscPage').waitFor({ state: 'visible', timeout: 30_000 });
-        },
-      }),
       metricsExperience: createLazyPageObject(MetricsExperiencePage, page),
-    };
-
-    await use(extendedPageObjects);
+    });
   },
 });
-
-function extendPageObject<T extends object>(base: T, overrides: Partial<T>): T {
-  return Object.assign(Object.create(base), overrides) as T;
-}
 
 export * as testData from './constants';
 export * from './generators';


### PR DESCRIPTION
This PR removes the redundant `DiscoverApp.goto()` override from the Metrics Experience Scout fixture. Core Scout already waits up to 30s for `dscPage`, so the local wrapper duplicated behavior added in #260001 is no longer needed.

Closes elastic/observability-dev#5570