### PR TITLE
[Evals] Wire trajectory & trace observability into agent-loop security suites

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-endpoint/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-endpoint/src/evaluate_dataset.ts
@@ -11,7 +11,9 @@ import type {
   Evaluator,
   EvalsExecutorClient,
   Example,
+  TaskOutput,
 } from '@kbn/evals';
+import { createTrajectoryEvaluator, getToolCallSteps } from '@kbn/evals';
 import type { SecurityEvalChatClient } from './chat_client';
 
 export interface SecurityDatasetExample extends Example {
@@ -20,6 +22,13 @@ export interface SecurityDatasetExample extends Example {
   };
   output: {
     criteria: string[];
+    /**
+     * Optional golden tool-call sequence. When present, the trajectory
+     * evaluator scores the agent's actual tool path (order + coverage)
+     * against it. Examples without an annotation report N/A so partial
+     * datasets don't dilute averages. Authored per-example in follow-up work.
+     */
+    expectedToolSequence?: string[];
   };
 }
 
@@ -42,6 +51,36 @@ export function createEndpointCriteriaEvaluator({
     evaluate: async ({ expected, ...rest }) => {
       const criteria: string[] = (expected as SecurityDatasetExample['output'])?.criteria ?? [];
       return evaluators.criteria(criteria).evaluate({ expected, ...rest });
+    },
+  };
+}
+
+export function createEndpointTrajectoryEvaluator(): Evaluator {
+  const inner = createTrajectoryEvaluator({
+    extractToolCalls: (output) =>
+      getToolCallSteps(output as TaskOutput)
+        .map((step) => step.tool_id)
+        .filter((id): id is string => Boolean(id)),
+    goldenPathExtractor: (expected) =>
+      (expected as SecurityDatasetExample['output'] | undefined)?.expectedToolSequence ?? [],
+    orderWeight: 0.4,
+    coverageWeight: 0.6,
+  });
+
+  return {
+    ...inner,
+    name: 'Trajectory',
+    evaluate: async (args) => {
+      const seq = (args.expected as SecurityDatasetExample['output'] | undefined)
+        ?.expectedToolSequence;
+      if (!seq || seq.length === 0) {
+        return {
+          score: null,
+          label: 'N/A',
+          explanation: 'No expectedToolSequence annotation — skipping trajectory evaluation.',
+        };
+      }
+      return inner.evaluate(args);
     },
   };
 }
@@ -70,6 +109,13 @@ export function createEvaluateSecurityDataset({
       examples,
     } satisfies EvaluationDataset;
 
+    // Observability (trace-based, zero per-example LLM cost): baseline signals
+    // derived from OTel spans for this task's trace.id. Tracks regressions in
+    // latency / token usage / tool-call counts over time without paying for
+    // additional LLM judging.
+    const { inputTokens, outputTokens, cachedTokens, toolCalls, latency } =
+      evaluators.traceBasedEvaluators;
+
     await executorClient.runExperiment(
       {
         datasets: [dataset],
@@ -84,7 +130,15 @@ export function createEvaluateSecurityDataset({
           };
         },
       },
-      [createEndpointCriteriaEvaluator({ evaluators })]
+      [
+        createEndpointCriteriaEvaluator({ evaluators }),
+        createEndpointTrajectoryEvaluator(),
+        toolCalls,
+        latency,
+        inputTokens,
+        outputTokens,
+        cachedTokens,
+      ]
     );
   };
 }

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/chat_client.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/chat_client.ts
@@ -7,7 +7,15 @@
 
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { HttpHandler } from '@kbn/core/public';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import pRetry from 'p-retry';
+
+// Drive the default Agent Builder agent (`elastic-ai-agent`) explicitly. The
+// entity-analytics skills/tools are registered globally, so the default agent
+// can route to them. An explicit `agent_id` (rather than relying on the server
+// default) keeps the suite stable if the server-side default ever changes, and
+// allows a deliberate custom-agent override via `AGENT_BUILDER_AGENT_ID`.
+const ENTITY_ANALYTICS_AGENT_ID = process.env.AGENT_BUILDER_AGENT_ID ?? agentBuilderDefaultAgentId;
 
 export type Messages = { message: string }[];
 
@@ -99,6 +107,7 @@ export class EvaluationChatClient {
         method: 'POST',
         version: '2023-10-31',
         body: JSON.stringify({
+          agent_id: ENTITY_ANALYTICS_AGENT_ID,
           connector_id: this.connectorId,
           conversation_id: conversationId,
           input: messages[messages.length - 1].message,

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/evaluate_dataset.ts
@@ -258,6 +258,14 @@ export function createEvaluateDataset({
   }: EvaluateDatasetOpts) {
     const dataset = { name, description, examples } satisfies EvaluationDataset;
 
+    // Observability (trace-based, zero per-example LLM cost): baseline latency /
+    // token-usage signals derived from OTel spans for this task's trace.id.
+    // NOTE: the framework fixture's `toolCalls` trace evaluator is intentionally
+    // NOT wired here — this suite already defines a richer LLM-judged
+    // `ToolCalls` evaluator (asserting against `expected.toolCalls`), and the
+    // two share the same name, which would collide in the report.
+    const { inputTokens, outputTokens, cachedTokens, latency } = evaluators.traceBasedEvaluators;
+
     await executorClient.runExperiment(
       {
         datasets: [dataset],
@@ -318,6 +326,11 @@ export function createEvaluateDataset({
             // ground truth text, so quantitative correctness comparison produces noise (low scores).
           ),
         ]),
+        // Observability (trace-based, zero per-example LLM cost)
+        latency as Evaluator<DatasetExample, ChatTaskOutput>,
+        inputTokens as Evaluator<DatasetExample, ChatTaskOutput>,
+        outputTokens as Evaluator<DatasetExample, ChatTaskOutput>,
+        cachedTokens as Evaluator<DatasetExample, ChatTaskOutput>,
       ]
     );
   };

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/tsconfig.json
@@ -11,6 +11,7 @@
   ],
   "exclude": ["target/**/*"],
   "kbn_references": [
+    "@kbn/agent-builder-common",
     "@kbn/evals",
     "@kbn/tooling-log",
     "@kbn/core",

--- a/x-pack/solutions/security/packages/kbn-evals-suite-pci-compliance/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-pci-compliance/src/evaluate_dataset.ts
@@ -13,8 +13,13 @@ import type {
   Evaluator,
   EvalsExecutorClient,
   Example,
+  TaskOutput,
 } from '@kbn/evals';
-import { createSkillInvocationEvaluator } from '@kbn/evals';
+import {
+  createSkillInvocationEvaluator,
+  createTrajectoryEvaluator,
+  getToolCallSteps,
+} from '@kbn/evals';
 import type { PciEvalChatClient } from './chat_client';
 
 export interface PciDatasetExample extends Example {
@@ -23,6 +28,13 @@ export interface PciDatasetExample extends Example {
   };
   output: {
     criteria: string[];
+    /**
+     * Optional golden tool-call sequence. When present, the trajectory
+     * evaluator scores the agent's actual tool path (order + coverage)
+     * against it. Examples without an annotation report N/A so partial
+     * datasets don't dilute averages. Authored per-example in follow-up work.
+     */
+    expectedToolSequence?: string[];
   };
 }
 
@@ -70,6 +82,44 @@ export function createPciCriteriaEvaluator({
   };
 }
 
+/**
+ * Trajectory evaluator wrapper. Scores the agent's tool-call sequence against a
+ * per-example `expectedToolSequence` annotation using LCS (order) + set
+ * intersection (coverage). Returns N/A when an example has no annotation so
+ * partial-coverage datasets aren't penalised. Mirrors the alerts-rag suite's
+ * `createAlertsRagTrajectoryEvaluator`. Annotations are authored per-example in
+ * follow-up work; until then every example reports N/A (the infra is in place
+ * to start scoring the moment golden paths land).
+ */
+export function createPciTrajectoryEvaluator(): Evaluator {
+  const inner = createTrajectoryEvaluator({
+    extractToolCalls: (output) =>
+      getToolCallSteps(output as TaskOutput)
+        .map((step) => step.tool_id)
+        .filter((id): id is string => Boolean(id)),
+    goldenPathExtractor: (expected) =>
+      (expected as PciDatasetExample['output'] | undefined)?.expectedToolSequence ?? [],
+    orderWeight: 0.4,
+    coverageWeight: 0.6,
+  });
+
+  return {
+    ...inner,
+    name: 'Trajectory',
+    evaluate: async (args) => {
+      const seq = (args.expected as PciDatasetExample['output'] | undefined)?.expectedToolSequence;
+      if (!seq || seq.length === 0) {
+        return {
+          score: null,
+          label: 'N/A',
+          explanation: 'No expectedToolSequence annotation — skipping trajectory evaluation.',
+        };
+      }
+      return inner.evaluate(args);
+    },
+  };
+}
+
 export function createEvaluatePciDataset({
   evaluators,
   executorClient,
@@ -98,6 +148,14 @@ export function createEvaluatePciDataset({
       examples,
     } satisfies EvaluationDataset;
 
+    // Observability (trace-based, zero per-example LLM cost): baseline signals
+    // derived from OTel spans for this task's trace.id. Tracks regressions in
+    // latency / token usage / tool-call counts over time without paying for
+    // additional LLM judging. Sourced from the framework fixture so the queries
+    // stay consistent across suites.
+    const { inputTokens, outputTokens, cachedTokens, toolCalls, latency } =
+      evaluators.traceBasedEvaluators;
+
     await executorClient.runExperiment(
       {
         datasets: [dataset],
@@ -119,6 +177,12 @@ export function createEvaluatePciDataset({
           log,
           skillName: 'pci-compliance',
         }),
+        createPciTrajectoryEvaluator(),
+        toolCalls,
+        latency,
+        inputTokens,
+        outputTokens,
+        cachedTokens,
       ]
     );
   };

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/datasets/sample_rules.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/datasets/sample_rules.ts
@@ -31,6 +31,13 @@ export interface ReferenceRule {
   interval?: string;
   /** Native ES|QL translation of the original query (for non-ES|QL rules) */
   esqlQuery?: string;
+  /**
+   * Optional golden tool-call sequence. When present, the trajectory
+   * evaluator scores the agent's actual tool path (order + coverage)
+   * against it. Examples without an annotation report N/A so partial
+   * datasets don't dilute averages. Authored per-example in follow-up work.
+   */
+  expectedToolSequence?: string[];
 }
 
 /**

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/src/chat_client.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/src/chat_client.ts
@@ -5,12 +5,20 @@
  * 2.0.
  */
 
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import type { ReferenceRule } from '../datasets/sample_rules';
 
 // These string literals mirror the constants defined in security_solution/common/constants.
 // They are inlined here to avoid a package→plugin import boundary violation.
-const THREAT_HUNTING_AGENT_ID = 'security.agent';
 const SECURITY_RULE_ATTACHMENT_TYPE = 'security.rule';
+
+// Drive the default Agent Builder agent (`elastic-ai-agent`). The detection-rule
+// creation tool (`security.create_detection_rule`) is registered globally via
+// `agentBuilder.tools.register(...)` in
+// `security_solution/server/agent_builder/tools/register_tools.ts`, so it is
+// available to the default agent — there is no separately-registered
+// `security.agent`. Allow an explicit override for deliberate custom-agent runs.
+const RULE_GENERATION_AGENT_ID = process.env.AGENT_BUILDER_AGENT_ID ?? agentBuilderDefaultAgentId;
 
 const AGENT_BUILDER_CONVERSE_API_PATH = '/api/agent_builder/converse';
 const SECURITY_CREATE_DETECTION_RULE_TOOL_ID = 'security.create_detection_rule';
@@ -46,9 +54,10 @@ export class SecurityRuleGenerationClient {
   public async generateRule(prompt: string): Promise<{
     generatedRule?: Partial<ReferenceRule>;
     error?: string;
+    steps?: RuleToolStep[];
   }> {
     const payload = {
-      agent_id: THREAT_HUNTING_AGENT_ID,
+      agent_id: RULE_GENERATION_AGENT_ID,
       input: `Create a detection rule based on the following user_query using the dedicated detection rule creation tool. Do not perform any other actions after creating the rule. user_query: ${prompt}`,
       connector_id: this.connectorId,
       capabilities: { visualizations: true },
@@ -74,6 +83,7 @@ export class SecurityRuleGenerationClient {
     if (extracted.ruleData) {
       return {
         generatedRule: mapGeneratedRule(extracted.ruleData),
+        steps: syncResponse.steps,
       };
     }
 
@@ -84,6 +94,7 @@ export class SecurityRuleGenerationClient {
     );
     return {
       error: extracted.error || 'No rule returned from agent',
+      steps: syncResponse.steps,
     };
   }
 }

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/src/evaluate_dataset.ts
@@ -11,8 +11,13 @@ import type {
   EvaluationDataset,
   Example,
   EvalsExecutorClient,
+  TaskOutput,
 } from '@kbn/evals';
-import { createEsqlEquivalenceEvaluator } from '@kbn/evals';
+import {
+  createEsqlEquivalenceEvaluator,
+  createTrajectoryEvaluator,
+  getToolCallSteps,
+} from '@kbn/evals';
 import type { BoundInferenceClient } from '@kbn/inference-common';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { ReferenceRule } from '../datasets/sample_rules';
@@ -32,6 +37,13 @@ import {
 export interface RuleGenerationTaskOutput {
   generatedRule?: Partial<ReferenceRule>;
   error?: string;
+  /**
+   * Tool-call steps from the converse response, threaded through so the
+   * trajectory evaluator can score the agent's tool path. Present on the
+   * success path; absent on negative/refusal cases (which the trajectory
+   * evaluator reports N/A for anyway).
+   */
+  steps?: Array<{ type: string; tool_id?: string }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -436,6 +448,49 @@ export function createRuleDescriptionEvaluator(
 }
 
 // ---------------------------------------------------------------------------
+// Trajectory evaluator — scores the agent's tool-call path (LLM-free)
+// ---------------------------------------------------------------------------
+
+/**
+ * Trajectory evaluator wrapper. Scores the agent's tool-call sequence against a
+ * per-example `expectedToolSequence` annotation (carried on the reference rule)
+ * using LCS (order) + set intersection (coverage). Returns N/A when an example
+ * has no annotation so partial-coverage datasets aren't penalised. Mirrors the
+ * pci-compliance suite's `createPciTrajectoryEvaluator`.
+ */
+export function createAiRulesTrajectoryEvaluator(): Evaluator<
+  RuleExample,
+  RuleGenerationTaskOutput
+> {
+  const inner = createTrajectoryEvaluator({
+    extractToolCalls: (output) =>
+      getToolCallSteps(output as TaskOutput)
+        .map((step) => step.tool_id)
+        .filter((id): id is string => Boolean(id)),
+    goldenPathExtractor: (expected) =>
+      (expected as Partial<ReferenceRule> | undefined)?.expectedToolSequence ?? [],
+    orderWeight: 0.4,
+    coverageWeight: 0.6,
+  });
+
+  return {
+    ...inner,
+    name: 'Trajectory',
+    evaluate: async (args) => {
+      const seq = (args.expected as Partial<ReferenceRule> | undefined)?.expectedToolSequence;
+      if (!seq || seq.length === 0) {
+        return {
+          score: null,
+          label: 'N/A',
+          explanation: 'No expectedToolSequence annotation — skipping trajectory evaluation.',
+        };
+      }
+      return inner.evaluate(args);
+    },
+  } as Evaluator<RuleExample, RuleGenerationTaskOutput>;
+}
+
+// ---------------------------------------------------------------------------
 // Factory — mirrors the agent-builder createEvaluateDataset pattern
 // ---------------------------------------------------------------------------
 
@@ -466,6 +521,14 @@ export function createEvaluateDataset({
   const skip = (e: Evaluator<RuleExample, RuleGenerationTaskOutput>) =>
     skipAgentErrors(skipMissingIndexFailures(e));
 
+  // Observability (trace-based, zero per-example LLM cost): baseline latency /
+  // token-usage / tool-call signals derived from OTel spans for each task's
+  // trace.id. Sourced from the framework fixture so query shape stays
+  // consistent across suites. These are unconditional (no skip wrapper) because
+  // they measure cost/efficiency of the run regardless of functional outcome.
+  const { inputTokens, outputTokens, cachedTokens, toolCalls, latency } =
+    evaluators.traceBasedEvaluators;
+
   const allEvaluators: Array<Evaluator<RuleExample, RuleGenerationTaskOutput>> = [
     // CODE — deterministic
     skip(skipNegativeCases(createQuerySyntaxValidityEvaluator())),
@@ -486,6 +549,16 @@ export function createEvaluateDataset({
     // skip(skipNegativeCases(createRuleDescriptionEvaluator(evaluators))),
     // Rejection — scores 1 when model correctly refuses a negative case, N/A otherwise
     skip(createRejectionEvaluator()),
+    // Observability (trace-based, zero per-example LLM cost)
+    toolCalls as Evaluator<RuleExample, RuleGenerationTaskOutput>,
+    latency as Evaluator<RuleExample, RuleGenerationTaskOutput>,
+    inputTokens as Evaluator<RuleExample, RuleGenerationTaskOutput>,
+    outputTokens as Evaluator<RuleExample, RuleGenerationTaskOutput>,
+    cachedTokens as Evaluator<RuleExample, RuleGenerationTaskOutput>,
+    // Trajectory (LLM-free): scores the agent's tool-call path against a
+    // per-example golden sequence. Added raw (no skip wrapper) so it reports
+    // N/A on its own for unannotated examples. Reports N/A until annotations land.
+    createAiRulesTrajectoryEvaluator(),
   ];
 
   return async function evaluateDataset({

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-ai-rules/tsconfig.json
@@ -10,6 +10,7 @@
     "target/**/*"
   ],
   "kbn_references": [
+    "@kbn/agent-builder-common",
     "@kbn/evals",
     "@kbn/inference-common",
     "@kbn/scout",

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-esql-generation-regression/src/dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-esql-generation-regression/src/dataset.ts
@@ -15,7 +15,21 @@ import type { Example } from '@kbn/evals';
  * entry to this array; tests in `dataset.test.ts` pin the example count and
  * basic shape so accidental drops are caught.
  */
-export const esqlGenerationDataset: Array<Example<{ question: string }, { query: string }>> = [
+export const esqlGenerationDataset: Array<
+  Example<
+    { question: string },
+    {
+      query: string;
+      /**
+       * Optional golden tool-call sequence. When present, the trajectory
+       * evaluator scores the agent's actual tool path (order + coverage)
+       * against it. Examples without an annotation report N/A so partial
+       * datasets don't dilute averages. Authored per-example in follow-up work.
+       */
+      expectedToolSequence?: string[];
+    }
+  >
+> = [
   {
     input: {
       question: `I want to see an ES|QL query that does the following: extract the query duration from the message field in postgres-logs*, and calculate the avg`,

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-esql-generation-regression/src/evaluate_dataset.test.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-esql-generation-regression/src/evaluate_dataset.test.ts
@@ -79,7 +79,7 @@ describe('createEvaluateEsqlGenerationDataset', () => {
 
     expect(deps.runExperiment).toHaveBeenCalledTimes(1);
     const [, evaluatorArray] = deps.runExperiment.mock.calls[0];
-    expect(evaluatorArray).toHaveLength(9);
+    expect(evaluatorArray).toHaveLength(10);
 
     expect(evaluatorArray[0].name).toBe('ES|QL Functional Equivalence');
     expect(evaluatorArray[0].kind).toBe('LLM');
@@ -93,12 +93,15 @@ describe('createEvaluateEsqlGenerationDataset', () => {
     expect(evaluatorArray[3].name).toBe('ES|QL Result Equivalence');
     expect(evaluatorArray[3].kind).toBe('CODE');
 
+    // Trajectory — scores the agent's tool-call path (LLM-free).
+    expect(evaluatorArray[4].name).toBe('Trajectory');
+
     // Observability tier — trace-based evaluators sourced from the framework.
-    expect(evaluatorArray[4].name).toBe('Tool calls');
-    expect(evaluatorArray[5].name).toBe('Latency');
-    expect(evaluatorArray[6].name).toBe('Input tokens');
-    expect(evaluatorArray[7].name).toBe('Output tokens');
-    expect(evaluatorArray[8].name).toBe('Cached tokens');
+    expect(evaluatorArray[5].name).toBe('Tool calls');
+    expect(evaluatorArray[6].name).toBe('Latency');
+    expect(evaluatorArray[7].name).toBe('Input tokens');
+    expect(evaluatorArray[8].name).toBe('Output tokens');
+    expect(evaluatorArray[9].name).toBe('Cached tokens');
   });
 
   it('drives the agent builder converse client for each example', async () => {

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-esql-generation-regression/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-esql-generation-regression/src/evaluate_dataset.ts
@@ -6,8 +6,8 @@
  */
 
 import type { Client as EsClient } from '@elastic/elasticsearch';
-import type { DefaultEvaluators, Evaluator, EvalsExecutorClient } from '@kbn/evals';
-import { withEvaluatorSpan } from '@kbn/evals';
+import type { DefaultEvaluators, Evaluator, EvalsExecutorClient, TaskOutput } from '@kbn/evals';
+import { createTrajectoryEvaluator, getToolCallSteps, withEvaluatorSpan } from '@kbn/evals';
 import type { BoundInferenceClient } from '@kbn/inference-common';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { EsqlRegressionAgentBuilderChatClient } from './chat_client';
@@ -66,6 +66,52 @@ function sliceDataset<T>(examples: readonly T[]): T[] {
 }
 
 export type EvaluateEsqlGenerationDataset = () => Promise<void>;
+
+/**
+ * Ground-truth shape carried by each dataset example's `output`. `query` is the
+ * canonical ES|QL the quality evaluators compare against; `expectedToolSequence`
+ * is the optional golden tool path the trajectory evaluator scores against.
+ */
+interface EsqlExpectedOutput {
+  query: string;
+  expectedToolSequence?: string[];
+}
+
+/**
+ * Trajectory evaluator wrapper. Scores the agent's tool-call sequence against a
+ * per-example `expectedToolSequence` annotation using LCS (order) + set
+ * intersection (coverage). Returns N/A when an example has no annotation so
+ * partial-coverage datasets aren't penalised. Mirrors the pci-compliance suite's
+ * `createPciTrajectoryEvaluator`.
+ */
+export function createEsqlTrajectoryEvaluator(): Evaluator {
+  const inner = createTrajectoryEvaluator({
+    extractToolCalls: (output) =>
+      getToolCallSteps(output as TaskOutput)
+        .map((step) => step.tool_id)
+        .filter((id): id is string => Boolean(id)),
+    goldenPathExtractor: (expected) =>
+      (expected as EsqlExpectedOutput | undefined)?.expectedToolSequence ?? [],
+    orderWeight: 0.4,
+    coverageWeight: 0.6,
+  });
+
+  return {
+    ...inner,
+    name: 'Trajectory',
+    evaluate: async (args) => {
+      const seq = (args.expected as EsqlExpectedOutput | undefined)?.expectedToolSequence;
+      if (!seq || seq.length === 0) {
+        return {
+          score: null,
+          label: 'N/A',
+          explanation: 'No expectedToolSequence annotation — skipping trajectory evaluation.',
+        };
+      }
+      return inner.evaluate(args);
+    },
+  };
+}
 
 export function createEvaluateEsqlGenerationDataset({
   chatClient,
@@ -186,6 +232,9 @@ export function createEvaluateEsqlGenerationDataset({
         esqlValidityEvaluator,
         esqlExecutionEvaluator,
         esqlResultEquivalenceEvaluator,
+        // Trajectory (LLM-free): scores the agent's tool-call path against a
+        // per-example golden sequence. Reports N/A until annotations land.
+        createEsqlTrajectoryEvaluator(),
         // Observability (trace-based, zero per-example LLM cost): baseline
         // signals derived from OTel spans for this task's trace.id. Used to
         // track regressions in latency / token usage / tool-call counts over


### PR DESCRIPTION
## Summary
Standardises the default-agent policy across all 6 agent-loop security eval suites and fills coverage gaps with zero-LLM-cost trajectory + observability evaluators.

### Agent-id consistency (item 2)
- **security-ai-rules**: hardcoded `agent_id: 'security.agent'` — an unregistered phantom agent. Switched to `agentBuilderDefaultAgentId` (`elastic-ai-agent`) via the standard override pattern (`process.env.AGENT_BUILDER_AGENT_ID ?? agentBuilderDefaultAgentId`).
- **entity-analytics**: previously relied on server fallback. Now sends `agent_id` explicitly via the same override pattern.

### Trace-based observability (item 4)
Wired fixture `traceBasedEvaluators` into:
- `pci-compliance` — input/output/cached tokens, latency, tool calls
- `security-ai-rules` — same
- `endpoint` — same
- `entity-analytics` — tokens + latency only (excluded fixture `toolCalls` to avoid a name collision with its existing LLM-judged `ToolCalls` evaluator)
- `esql-generation` — already had all 5; no change

### Trajectory evaluator (item 1)
Added a `create*TrajectoryEvaluator` wrapper (N/A-on-missing-golden, matching alerts-rag convention) to:
- `pci-compliance`, `endpoint`, `esql-generation`, `security-ai-rules`, `entity-analytics`

Each wrapper reads an optional `expectedToolSequence` annotation from the example ground-truth. No suites have annotations today, so every example reports **N/A** until follow-up work fills them. This is intentional — the infra is in place and will start scoring the moment annotations arrive.

Also threaded `steps` through the ai-rules chat client → task output so the extractor will have data to work with once annotations exist.

### Test updates
- `esql-generation` evaluator-count test: `9` → `10` (added Trajectory)

## Scope
12 files, +313/−14 across 5 eval-suite packages.

## Validation
- `node scripts/type_check --project tsconfig.json` for all 5 packages → **exit 0**
- `node scripts/eslint --fix` on changed source files → **no errors**
- Pre-existing tsconfig JSON5 parsing noise ignored (not source files)
