### PR TITLE
[9.4] [dashboard] fix flakyness in gotoDashboardLandingPage (#271979)

### DIFF
--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -13,6 +13,7 @@ export const LINE_CHART_VIS_NAME = 'Visualization漢字 LineChart';
 export const UNSAVED_CHANGES_NOTIFICATION = 'split-button-notification-indicator';
 
 import expect from '@kbn/expect';
+import { DASHBOARD_APP_ID } from '@kbn/deeplinks-analytics';
 import { FtrService } from '../ftr_provider_context';
 import type { CommonPageObject } from './common_page';
 
@@ -61,8 +62,6 @@ export class DashboardPageObject extends FtrService {
     ? 'src/platform/test/functional/fixtures/kbn_archiver/ccs/dashboard/legacy/legacy.json'
     : 'src/platform/test/functional/fixtures/kbn_archiver/dashboard/legacy/legacy.json';
 
-  public readonly APP_ID = 'dashboards';
-
   async initTests({ kibanaIndex = this.kibanaIndex, defaultIndex = this.logstashIndex } = {}) {
     this.log.debug('load kibana index with visualizations and log data');
     await this.kibanaServer.savedObjects.cleanStandardList();
@@ -72,7 +71,7 @@ export class DashboardPageObject extends FtrService {
   }
 
   public async navigateToApp() {
-    await this.common.navigateToApp(this.APP_ID);
+    await this.common.navigateToApp(DASHBOARD_APP_ID);
   }
 
   public async navigateToAppFromAppsMenu() {
@@ -216,8 +215,17 @@ export class DashboardPageObject extends FtrService {
    */
   public async onDashboardLandingPage() {
     this.log.debug(`onDashboardLandingPage`);
-    const currentUrl = await this.browser.getCurrentUrl();
-    return currentUrl.includes('dashboards#/list');
+    let currentUrl = await this.browser.getCurrentUrl();
+
+    // wait for dashboard route redirect to complete
+    if (currentUrl.includes(DASHBOARD_APP_ID) && !currentUrl.includes('#')) {
+      await this.retry.waitFor('dashboard route redirect to complete', async () => {
+        currentUrl = await this.browser.getCurrentUrl();
+        return currentUrl.includes('#');
+      });
+    }
+
+    return currentUrl.includes(`${DASHBOARD_APP_ID}#/list`);
   }
 
   public async expectExistsDashboardLandingPage() {
@@ -236,7 +244,7 @@ export class DashboardPageObject extends FtrService {
     );
   }
 
-  public async gotoDashboardLandingPage(ignorePageLeaveWarning = true) {
+  public async gotoDashboardLandingPage() {
     this.log.debug('gotoDashboardLandingPage');
     if (await this.onDashboardLandingPage()) return;
 
@@ -244,12 +252,6 @@ export class DashboardPageObject extends FtrService {
       ? 'breadcrumb breadcrumb-deepLinkId-dashboards'
       : 'breadcrumb dashboardListingBreadcrumb first';
     await this.testSubjects.click(breadcrumbLink);
-    const warning = await this.testSubjects.exists('confirmModalTitleText');
-    if (warning) {
-      await this.testSubjects.click(
-        ignorePageLeaveWarning ? 'confirmModalConfirmButton' : 'confirmModalCancelButton'
-      );
-    }
     await this.expectExistsDashboardLandingPage();
   }
 

--- a/src/platform/test/moon.yml
+++ b/src/platform/test/moon.yml
@@ -73,6 +73,7 @@ dependsOn:
   - '@kbn/unified-data-table'
   - '@kbn/session-notifications-plugin'
   - '@kbn/ui-actions-plugin'
+  - '@kbn/deeplinks-analytics'
 tags:
   - test-helper
   - package

--- a/src/platform/test/tsconfig.json
+++ b/src/platform/test/tsconfig.json
@@ -75,6 +75,7 @@
     "@kbn/visualizations-common",
     "@kbn/unified-data-table",
     "@kbn/session-notifications-plugin",
-    "@kbn/ui-actions-plugin"
+    "@kbn/ui-actions-plugin",
+    "@kbn/deeplinks-analytics"
   ]
 }

--- a/x-pack/platform/test/functional/apps/dashboard/group3/share/share_from_custom_space.ts
+++ b/x-pack/platform/test/functional/apps/dashboard/group3/share/share_from_custom_space.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { DASHBOARD_APP_ID } from '@kbn/deeplinks-analytics';
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function sharingFromSpace({ getPageObjects, getService }: FtrProviderContext) {
@@ -49,7 +50,7 @@ export default function sharingFromSpace({ getPageObjects, getService }: FtrProv
 
       await spaceSelector.clickSpaceCard(spaceId);
 
-      await common.navigateToApp(dashboard.APP_ID, { basePath: `/s/${spaceId}` });
+      await common.navigateToApp(DASHBOARD_APP_ID, { basePath: `/s/${spaceId}` });
       await dashboard.preserveCrossAppState();
       await dashboard.loadDashboardInEditMode('few panels');
       await dashboard.waitForRenderComplete();

--- a/x-pack/platform/test/functional/apps/maps/group3/reports/index.ts
+++ b/x-pack/platform/test/functional/apps/maps/group3/reports/index.ts
@@ -21,8 +21,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   // NOTE: Occasionally, you may need to run the test and copy the "session" image file and replace the
   // "baseline" image file to reflect current renderings. The source and destination file paths can be found in
   // the debug logs.
-  // Failing: See https://github.com/elastic/kibana/issues/232040
-  describe.skip('dashboard reporting: creates a map report', () => {
+  describe('dashboard reporting: creates a map report', () => {
     // helper function to check the difference between the new image and the baseline
     const measurePngDifference = async (fileName: string) => {
       const url = await reporting.getReportURL(60000);

--- a/x-pack/platform/test/moon.yml
+++ b/x-pack/platform/test/moon.yml
@@ -170,6 +170,7 @@ dependsOn:
   - '@kbn/ui-actions-plugin'
   - '@kbn/product-doc-common'
   - '@kbn/alerting-v2-episodes-ui'
+  - '@kbn/deeplinks-analytics'
 tags:
   - test-helper
   - package

--- a/x-pack/platform/test/tsconfig.json
+++ b/x-pack/platform/test/tsconfig.json
@@ -174,6 +174,7 @@
     "@kbn/dev-cli-runner",
     "@kbn/ui-actions-plugin",
     "@kbn/product-doc-common",
-    "@kbn/alerting-v2-episodes-ui"
+    "@kbn/alerting-v2-episodes-ui",
+    "@kbn/deeplinks-analytics"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[dashboard] fix flakyness in gotoDashboardLandingPage (#271979)](https://github.com/elastic/kibana/pull/271979)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2026-06-01T15:52:03Z","message":"[dashboard] fix flakyness in gotoDashboardLandingPage (#271979)\n\nCloses https://github.com/elastic/kibana/issues/271981,\nhttps://github.com/elastic/kibana/issues/271870,\nhttps://github.com/elastic/kibana/issues/271872,\nhttps://github.com/elastic/kibana/issues/232040,\nhttps://github.com/elastic/kibana/issues/271816,\nhttps://github.com/elastic/kibana/issues/272022\n\n### Problem\n\nFlaky tests call `dashboard.navigateToApp`. `dashboard.navigateToApp`\ncalls `common.navigateToApp('dashboards')`. Before the route can resolve\nto `dashboards/list`, tests call `gotoDashboardLandingPage` and check\nthat URL contains `dashboards/list`. `onDashboardLandingPage` returns\nfalse since the route has not finished resolving and the URL is still\n`http://localhost:5620/app/dashboards`. The test then gets stuck looking\nfor `breadcrumbs`\n\n<img height=\"365\" alt=\"Screenshot 2026-05-29 at 12 39 40 PM\"\nsrc=\"https://github.com/user-attachments/assets/2e966c06-3017-4db4-b8a8-c6c45db0cdac\"\n/>\n\n### Solution\nPR resolves redirect race condition by waiting for hash when URL\ncontains dashboard app id.\n\nflaky test runner for\nx-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/dashboard·ts\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12536\n\nflaky test runner for\nx-pack/platform/test/functional/apps/maps/group3/reports/index·ts\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12537\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1040cc858f11d6dd003d673121f2d5e2277ac477","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","backport:version","v9.5.0","v9.4.3"],"title":"[dashboard] fix flakyness in gotoDashboardLandingPage","number":271979,"url":"https://github.com/elastic/kibana/pull/271979","mergeCommit":{"message":"[dashboard] fix flakyness in gotoDashboardLandingPage (#271979)\n\nCloses https://github.com/elastic/kibana/issues/271981,\nhttps://github.com/elastic/kibana/issues/271870,\nhttps://github.com/elastic/kibana/issues/271872,\nhttps://github.com/elastic/kibana/issues/232040,\nhttps://github.com/elastic/kibana/issues/271816,\nhttps://github.com/elastic/kibana/issues/272022\n\n### Problem\n\nFlaky tests call `dashboard.navigateToApp`. `dashboard.navigateToApp`\ncalls `common.navigateToApp('dashboards')`. Before the route can resolve\nto `dashboards/list`, tests call `gotoDashboardLandingPage` and check\nthat URL contains `dashboards/list`. `onDashboardLandingPage` returns\nfalse since the route has not finished resolving and the URL is still\n`http://localhost:5620/app/dashboards`. The test then gets stuck looking\nfor `breadcrumbs`\n\n<img height=\"365\" alt=\"Screenshot 2026-05-29 at 12 39 40 PM\"\nsrc=\"https://github.com/user-attachments/assets/2e966c06-3017-4db4-b8a8-c6c45db0cdac\"\n/>\n\n### Solution\nPR resolves redirect race condition by waiting for hash when URL\ncontains dashboard app id.\n\nflaky test runner for\nx-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/dashboard·ts\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12536\n\nflaky test runner for\nx-pack/platform/test/functional/apps/maps/group3/reports/index·ts\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12537\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1040cc858f11d6dd003d673121f2d5e2277ac477"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271979","number":271979,"mergeCommit":{"message":"[dashboard] fix flakyness in gotoDashboardLandingPage (#271979)\n\nCloses https://github.com/elastic/kibana/issues/271981,\nhttps://github.com/elastic/kibana/issues/271870,\nhttps://github.com/elastic/kibana/issues/271872,\nhttps://github.com/elastic/kibana/issues/232040,\nhttps://github.com/elastic/kibana/issues/271816,\nhttps://github.com/elastic/kibana/issues/272022\n\n### Problem\n\nFlaky tests call `dashboard.navigateToApp`. `dashboard.navigateToApp`\ncalls `common.navigateToApp('dashboards')`. Before the route can resolve\nto `dashboards/list`, tests call `gotoDashboardLandingPage` and check\nthat URL contains `dashboards/list`. `onDashboardLandingPage` returns\nfalse since the route has not finished resolving and the URL is still\n`http://localhost:5620/app/dashboards`. The test then gets stuck looking\nfor `breadcrumbs`\n\n<img height=\"365\" alt=\"Screenshot 2026-05-29 at 12 39 40 PM\"\nsrc=\"https://github.com/user-attachments/assets/2e966c06-3017-4db4-b8a8-c6c45db0cdac\"\n/>\n\n### Solution\nPR resolves redirect race condition by waiting for hash when URL\ncontains dashboard app id.\n\nflaky test runner for\nx-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/dashboard·ts\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12536\n\nflaky test runner for\nx-pack/platform/test/functional/apps/maps/group3/reports/index·ts\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12537\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1040cc858f11d6dd003d673121f2d5e2277ac477"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->