### PR TITLE
[backport 9.4] Fixes KB recall for inference endpoint connectors (#271753)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/context/context.register.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/context/context.register.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lastValueFrom } from 'rxjs';
+import { InferenceConnectorType } from '@kbn/inference-common';
+import { loggerMock } from '@kbn/logging-mocks';
+import { httpServerMock } from '@kbn/core/server/mocks';
+import type { FunctionRegistrationParameters } from '..';
+import { registerContextFunction } from './context';
+import { recallAndScore } from './utils/recall_and_score';
+
+jest.mock('./utils/recall_and_score', () => ({
+  recallAndScore: jest.fn(),
+}));
+
+const recallAndScoreMock = recallAndScore as jest.MockedFunction<typeof recallAndScore>;
+
+describe('registerContextFunction connector resolution', () => {
+  const inferenceEndpointId = 'elastic-llm';
+  const getConnectorById = jest.fn();
+  const request = httpServerMock.createKibanaRequest();
+  const logger = loggerMock.create();
+
+  const inferenceConnector = {
+    connectorId: inferenceEndpointId,
+    name: inferenceEndpointId,
+    type: InferenceConnectorType.Inference,
+    config: { inferenceId: inferenceEndpointId },
+    isInferenceEndpoint: true,
+    isPreconfigured: true,
+    isEis: true,
+    capabilities: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getConnectorById.mockResolvedValue(inferenceConnector);
+    recallAndScoreMock.mockResolvedValue({
+      suggestions: [],
+      relevantDocuments: [],
+      llmScores: [],
+    });
+  });
+
+  function registerAndGetHandler(isKnowledgeBaseReady = true) {
+    const functions = { registerFunction: jest.fn() };
+    registerContextFunction({
+      client: { recall: jest.fn() },
+      functions,
+      resources: {
+        request,
+        logger,
+        plugins: {
+          core: {
+            start: jest.fn().mockResolvedValue({
+              analytics: { reportEvent: jest.fn() },
+            }),
+          },
+          inference: {
+            start: jest.fn().mockResolvedValue({ getConnectorById }),
+          },
+        },
+      },
+      scopes: ['observability'],
+      isKnowledgeBaseReady,
+    } as unknown as FunctionRegistrationParameters & { isKnowledgeBaseReady: boolean });
+
+    return functions.registerFunction.mock.calls[0][1];
+  }
+
+  it('resolves inference endpoint IDs via inference.getConnectorById', async () => {
+    const handler = registerAndGetHandler();
+
+    const response$ = await handler({
+      connectorId: inferenceEndpointId,
+      messages: [],
+      screenContexts: [{ screenDescription: 'User is viewing a service map.' }],
+      chat: jest.fn(),
+      signal: new AbortController().signal,
+    });
+
+    await lastValueFrom(response$);
+
+    expect(getConnectorById).toHaveBeenCalledWith(inferenceEndpointId, request);
+    expect(recallAndScoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connector: inferenceConnector,
+      })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/context/context.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/context/context.ts
@@ -35,9 +35,6 @@ export function registerContextFunction({
     async ({ connectorId, messages, screenContexts, chat }, signal) => {
       const { request, plugins } = resources;
       const { analytics } = await plugins.core.start();
-      const actionsClient = await (
-        await plugins.actions.start()
-      ).getActionsClientWithRequest(request);
 
       async function getContext() {
         const screenDescription = compact(
@@ -64,10 +61,8 @@ export function registerContextFunction({
           return { content };
         }
 
-        const connector = await actionsClient.get({
-          id: connectorId,
-          throwIfSystemAction: true,
-        });
+        const inferenceStart = await plugins.inference.start();
+        const connector = await inferenceStart.getConnectorById(connectorId, request);
 
         const { llmScores, relevantDocuments, suggestions } = await recallAndScore({
           recall: client.recall,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/context/utils/recall_and_score.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/context/utils/recall_and_score.ts
@@ -8,7 +8,7 @@
 import type { Logger } from '@kbn/logging';
 import type { AnalyticsServiceStart } from '@kbn/core/server';
 import type { AssistantScope } from '@kbn/ai-assistant-common';
-import type { Connector } from '@kbn/actions-plugin/server';
+import type { InferenceConnector } from '@kbn/inference-common';
 import { scoreSuggestions } from './score_suggestions';
 import type { Message } from '../../../../common';
 import { getInferenceConnectorInfo } from '../../../../common/utils/get_inference_connector';
@@ -36,7 +36,7 @@ export async function recallAndScore({
   chat: FunctionCallChatFunction;
   analytics: AnalyticsServiceStart;
   scopes: AssistantScope[];
-  connector?: Connector;
+  connector?: InferenceConnector;
   screenDescription: string;
   messages: Message[];
   logger: Logger;

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
@@ -203,16 +203,10 @@ const chatRecallRoute = createObservabilityAIAssistantServerRoute({
 
     const { request, plugins } = resources;
 
-    const actionsClient = await (
-      await plugins.actions.start()
-    ).getActionsClientWithRequest(request);
-
     const { connectorId, screenDescription, messages, scopes } = resources.params.body;
 
-    const connector = await actionsClient.get({
-      id: connectorId,
-      throwIfSystemAction: true,
-    });
+    const inferenceStart = await plugins.inference.start();
+    const connector = await inferenceStart.getConnectorById(connectorId, request);
     const response$ = from(
       recallAndScore({
         analytics: (await resources.plugins.core.start()).analytics,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/tsconfig.json
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/tsconfig.json
@@ -67,6 +67,7 @@
     "@kbn/inference-connectors",
     "@kbn/react-query",
     "@kbn/shared-ux-ai-components",
+    "@kbn/logging-mocks",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/connectors/connector_resolution.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/connectors/connector_resolution.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { MessageRole } from '@kbn/observability-ai-assistant-plugin/common';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+import { getInferenceEndpointOnlyConnectorId } from '../utils/get_chat_completion_inference_endpoint';
+
+export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
+
+  describe('inference endpoint connector resolution', function () {
+    let inferenceEndpointId: string;
+
+    before(async function () {
+      const endpointId = await getInferenceEndpointOnlyConnectorId(getService);
+      if (!endpointId) {
+        this.skip();
+      }
+      inferenceEndpointId = endpointId!;
+    });
+
+    it('resolves inference endpoint IDs via GET /connectors/{connectorId}', async () => {
+      const { status, body } = await observabilityAIAssistantAPIClient.editor({
+        endpoint: 'GET /internal/observability_ai_assistant/connectors/{connectorId}',
+        params: {
+          path: {
+            connectorId: inferenceEndpointId,
+          },
+        },
+      });
+
+      expect(status).to.be(200);
+      expect(body.connectorId).to.be(inferenceEndpointId);
+      expect(body.isInferenceEndpoint).to.be(true);
+    });
+
+    it('resolves inference endpoint IDs for chat recall (KB context path)', async () => {
+      const { status, body } = await observabilityAIAssistantAPIClient.editor({
+        endpoint: 'POST /internal/observability_ai_assistant/chat/recall',
+        params: {
+          body: {
+            connectorId: inferenceEndpointId,
+            screenDescription: 'User is investigating a service outage.',
+            scopes: ['observability'],
+            messages: [
+              {
+                '@timestamp': new Date().toISOString(),
+                message: {
+                  role: MessageRole.User,
+                  content: 'What should I check first?',
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(status).to.not.be(404);
+      expect(String(body)).to.not.contain('No connector or inference endpoint found');
+    });
+  });
+}

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/index.ts
@@ -42,6 +42,7 @@ export default function aiAssistantApiIntegrationTests({
     loadTestFile(require.resolve('./complete/public_complete.spec.ts'));
     loadTestFile(require.resolve('./index_assets/index_assets.spec.ts'));
     loadTestFile(require.resolve('./connectors/connectors.spec.ts'));
+    loadTestFile(require.resolve('./connectors/connector_resolution.spec.ts'));
     loadTestFile(require.resolve('./conversations/conversations.spec.ts'));
     loadTestFile(require.resolve('./anonymization/anonymization.spec.ts'));
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/get_chat_completion_inference_endpoint.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/utils/get_chat_completion_inference_endpoint.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+
+/**
+ * Returns a chat_completion inference endpoint ID that is not backed by an action
+ * connector saved object (EIS / native ES inference endpoints).
+ */
+export async function getInferenceEndpointOnlyConnectorId(
+  getService: DeploymentAgnosticFtrProviderContext['getService']
+): Promise<string | undefined> {
+  const es = getService('es');
+  const log = getService('log');
+
+  const response = await es.inference.get();
+  const endpoints = response.endpoints ?? [];
+
+  const chatCompletionEndpoints = endpoints.filter(
+    (endpoint) => endpoint.task_type === 'chat_completion'
+  );
+
+  const elasticEndpoint = chatCompletionEndpoints.find(
+    (endpoint) => endpoint.service === 'elastic'
+  );
+  const inferenceEndpointId =
+    elasticEndpoint?.inference_id ?? chatCompletionEndpoints[0]?.inference_id;
+
+  if (!inferenceEndpointId) {
+    log.warning(
+      'No chat_completion inference endpoints found in the cluster; skipping inference-endpoint connector resolution tests.'
+    );
+    return undefined;
+  }
+
+  return inferenceEndpointId;
+}


### PR DESCRIPTION
## Backport
This will backport the following commits from main to 9.4:


https://github.com/elastic/kibana/pull/271753
### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)