### PR TITLE
[9.3] [Fleet] Fix asset ref bucketing in multispace package installs (#271800)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.ts
@@ -215,7 +215,6 @@ export async function installKibanaAssetsAndReferencesMultispace({
   installedPkg,
   spaceId,
   assetTags,
-  installAsAdditionalSpace,
 }: {
   savedObjectsClient: SavedObjectsClientContract;
   logger: Logger;
@@ -225,8 +224,13 @@ export async function installKibanaAssetsAndReferencesMultispace({
   installedPkg?: SavedObject<Installation>;
   spaceId: string;
   assetTags?: PackageSpecTags[];
-  installAsAdditionalSpace?: boolean;
 }) {
+  // Derive whether this is an additional-space install from the package's sticky primary space.
+  // Any request from a space other than installed_kibana_space_id is an additional-space install.
+  const installAsAdditionalSpace = installedPkg
+    ? (installedPkg.attributes.installed_kibana_space_id ?? DEFAULT_SPACE_ID) !== spaceId
+    : false;
+
   if (installedPkg && !installAsAdditionalSpace) {
     // Install in every space => upgrades
     const refs = await installKibanaAssetsAndReferences({
@@ -241,9 +245,10 @@ export async function installKibanaAssetsAndReferencesMultispace({
       installAsAdditionalSpace,
     });
 
+    const primarySpaceId = installedPkg.attributes.installed_kibana_space_id ?? DEFAULT_SPACE_ID;
     for (const additionnalSpaceId of Object.keys(
       installedPkg.attributes.additional_spaces_installed_kibana ?? {}
-    )) {
+    ).filter((s) => s !== primarySpaceId)) {
       await installKibanaAssetsAndReferences({
         savedObjectsClient,
         logger,
@@ -332,6 +337,7 @@ export async function installKibanaAssetsAndReferences({
     savedObjectsClient,
     pkgName,
     assets,
+    spaceId,
     installedPkg && installedPkg.attributes.installed_kibana_space_id === spaceId
       ? false
       : installAsAdditionalSpace
@@ -375,7 +381,7 @@ export async function deleteKibanaAssetsAndReferencesForSpace({
     );
   }
   await deleteKibanaSavedObjectsAssets({ savedObjectsClient, installedPkg, spaceId });
-  await saveKibanaAssetsRefs(savedObjectsClient, pkgName, null, true);
+  await saveKibanaAssetsRefs(savedObjectsClient, pkgName, null, spaceId, true);
 }
 
 const kibanaAssetTypes = Object.values(KibanaAssetType);

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_multispace.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_multispace.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+jest.mock('timers/promises', () => ({ setTimeout: jest.fn() }));
+jest.mock('../../packages/install', () => ({
+  saveKibanaAssetsRefs: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../../packages/remove', () => ({
+  deleteKibanaSavedObjectsAssets: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./saved_objects', () => ({
+  getSpaceAwareSaveobjectsClients: jest.fn().mockReturnValue({
+    savedObjectsImporter: {
+      import: jest.fn().mockResolvedValue({ successResults: [], errors: [], warnings: [] }),
+    },
+    savedObjectTagAssignmentService: { updateTagAssignments: jest.fn() },
+    savedObjectTagClient: { create: jest.fn(), get: jest.fn(), find: jest.fn() },
+  }),
+}));
+jest.mock('./tag_assets', () => ({
+  tagKibanaAssets: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../..', () => ({
+  appContextService: {
+    getExperimentalFeatures: jest.fn().mockReturnValue({
+      enableAgentStatusAlerting: false,
+      enableSloTemplates: false,
+    }),
+  },
+}));
+
+import type { SavedObject } from '@kbn/core/server';
+
+import { saveKibanaAssetsRefs } from '../../packages/install';
+import type { Installation } from '../../../../../common/types';
+
+import { installKibanaAssetsAndReferencesMultispace } from './install';
+
+const mockSaveKibanaAssetsRefs = saveKibanaAssetsRefs as jest.MockedFunction<
+  typeof saveKibanaAssetsRefs
+>;
+
+const mockLogger = loggingSystemMock.createLogger();
+
+const makeInstalledPkg = (
+  installedKibanaSpaceId: string,
+  additionalSpaces: string[] = []
+): SavedObject<Installation> =>
+  ({
+    id: 'nginx',
+    type: 'epm-packages',
+    references: [],
+    attributes: {
+      installed_kibana_space_id: installedKibanaSpaceId,
+      installed_kibana: [],
+      additional_spaces_installed_kibana: Object.fromEntries(
+        additionalSpaces.map((s) => [s, [{ id: `${s}-dash`, type: 'dashboard' }]])
+      ),
+    } as unknown as Installation,
+  } as SavedObject<Installation>);
+
+const makePackageInstallContext = () => ({
+  packageInfo: { name: 'nginx', title: 'Nginx', version: '2.3.2' } as never,
+  paths: [],
+  archiveIterator: {
+    traverseEntries: jest.fn().mockResolvedValue(undefined),
+    getPaths: jest.fn().mockReturnValue([]),
+  },
+});
+
+const baseArgs = () => ({
+  savedObjectsClient: savedObjectsClientMock.create(),
+  logger: mockLogger,
+  pkgName: 'nginx',
+  pkgTitle: 'Nginx',
+  packageInstallContext: makePackageInstallContext(),
+});
+
+describe('installKibanaAssetsAndReferencesMultispace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when the requesting space is the primary (installed_kibana_space_id)', () => {
+    it('installs into the primary space with saveAsAdditionalSpace=false', async () => {
+      const installedPkg = makeInstalledPkg('default');
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'default',
+        installedPkg,
+      });
+
+      const primaryCall = mockSaveKibanaAssetsRefs.mock.calls.find(
+        ([, , , spaceId, saveAsAdditional]) => !saveAsAdditional && spaceId === 'default'
+      );
+      expect(primaryCall).toBeDefined();
+    });
+
+    it('installs into each additional space with saveAsAdditionalSpace=true', async () => {
+      const installedPkg = makeInstalledPkg('default', ['space-a', 'space-b']);
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'default',
+        installedPkg,
+      });
+
+      const additionalCalls = mockSaveKibanaAssetsRefs.mock.calls.filter(
+        ([, , , , saveAsAdditional]) => saveAsAdditional === true
+      );
+      expect(additionalCalls.map(([, , , spaceId]) => spaceId)).toEqual(
+        expect.arrayContaining(['space-a', 'space-b'])
+      );
+    });
+
+    it('does not call saveKibanaAssetsRefs with the primary space as an additional space', async () => {
+      const installedPkg = makeInstalledPkg('default', ['space-a']);
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'default',
+        installedPkg,
+      });
+
+      const invalidCall = mockSaveKibanaAssetsRefs.mock.calls.find(
+        ([, , , spaceId, saveAsAdditional]) => saveAsAdditional === true && spaceId === 'default'
+      );
+      expect(invalidCall).toBeUndefined();
+    });
+  });
+
+  describe('when the requesting space is not the primary', () => {
+    it('installs only into the requesting space with saveAsAdditionalSpace=true', async () => {
+      const installedPkg = makeInstalledPkg('default');
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'space-b',
+        installedPkg,
+      });
+
+      expect(mockSaveKibanaAssetsRefs).toHaveBeenCalledTimes(1);
+      const [, , , spaceId, saveAsAdditional] = mockSaveKibanaAssetsRefs.mock.calls[0];
+      expect(saveAsAdditional).toBe(true);
+      expect(spaceId).toBe('space-b');
+    });
+
+    it('does not overwrite the primary space (installed_kibana)', async () => {
+      const installedPkg = makeInstalledPkg('default');
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'space-b',
+        installedPkg,
+      });
+
+      const primaryOverwriteCall = mockSaveKibanaAssetsRefs.mock.calls.find(
+        ([, , , , saveAsAdditional]) => saveAsAdditional === false
+      );
+      expect(primaryOverwriteCall).toBeUndefined();
+    });
+  });
+
+  describe('when no package is installed yet (fresh install)', () => {
+    it('installs with saveAsAdditionalSpace=false using the requesting space', async () => {
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'default',
+        installedPkg: undefined,
+      });
+
+      expect(mockSaveKibanaAssetsRefs).toHaveBeenCalledTimes(1);
+      const [, , , spaceId, saveAsAdditional] = mockSaveKibanaAssetsRefs.mock.calls[0];
+      expect(saveAsAdditional).toBeFalsy();
+      expect(spaceId).toBe('default');
+    });
+  });
+
+  describe('when additional_spaces_installed_kibana contains a misplaced primary-space key', () => {
+    it('skips the primary-space key while still iterating legitimate additional spaces', async () => {
+      const installedPkg = makeInstalledPkg('default', ['space-b']);
+      (installedPkg.attributes as any).additional_spaces_installed_kibana = {
+        default: [{ id: 'misplaced-dash', type: 'dashboard' }],
+        'space-b': [{ id: 'space-b-dash', type: 'dashboard' }],
+      };
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'default',
+        installedPkg,
+      });
+
+      const additionalCalls = mockSaveKibanaAssetsRefs.mock.calls.filter(
+        ([, , , , saveAsAdditional]) => saveAsAdditional === true
+      );
+      expect(additionalCalls.map(([, , , sid]) => sid)).toContain('space-b');
+      expect(additionalCalls.map(([, , , sid]) => sid)).not.toContain('default');
+    });
+
+    it('skips the primary-space key when the request comes from a non-primary space', async () => {
+      const installedPkg = makeInstalledPkg('default');
+      (installedPkg.attributes as any).additional_spaces_installed_kibana = {
+        default: [{ id: 'misplaced-dash', type: 'dashboard' }],
+      };
+
+      await installKibanaAssetsAndReferencesMultispace({
+        ...baseArgs(),
+        spaceId: 'space-b',
+        installedPkg,
+      });
+
+      expect(mockSaveKibanaAssetsRefs).toHaveBeenCalledTimes(1);
+      const [, , , spaceId, saveAsAdditional] = mockSaveKibanaAssetsRefs.mock.calls[0];
+      expect(saveAsAdditional).toBe(true);
+      expect(spaceId).toBe('space-b');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install_with_streaming.ts
@@ -108,7 +108,7 @@ export async function installKibanaAssetsWithStreaming({
   }
 
   // Update the installation saved object with installed kibana assets
-  await saveKibanaAssetsRefs(savedObjectsClient, pkgName, assetRefs);
+  await saveKibanaAssetsRefs(savedObjectsClient, pkgName, assetRefs, spaceId);
 
   return assetRefs;
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -26,6 +26,7 @@ import {
   handleInstallPackageFailure,
   installPackage,
   isPackageVersionOrLaterInstalled,
+  saveKibanaAssetsRefs,
 } from './install';
 import * as installStateMachine from './install_state_machine/_state_machine_package_install';
 import { getBundledPackageByPkgKey } from './bundled_packages';

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -1023,3 +1023,160 @@ describe('isPackageVersionOrLaterInstalled', () => {
     await expect(res).rejects.toThrowError('test unexpected error');
   });
 });
+
+describe('saveKibanaAssetsRefs', () => {
+  const soClient = savedObjectsClientMock.create();
+
+  beforeEach(() => {
+    soClient.get.mockReset();
+    soClient.update.mockReset();
+  });
+
+  it('should append to existing additional space refs when saveAsAdditionnalSpace and append are both true', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        additional_spaces_installed_kibana: {
+          'my-space': [{ id: 'existing-dashboard', type: 'dashboard' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'new-template', type: 'alerting_rule_template' as any }],
+      'my-space',
+      true,
+      true
+    );
+
+    expect(soClient.update).toHaveBeenCalledWith(
+      PACKAGES_SAVED_OBJECT_TYPE,
+      'test-pkg',
+      expect.objectContaining({
+        additional_spaces_installed_kibana: {
+          'my-space': expect.arrayContaining([
+            { id: 'new-template', type: 'alerting_rule_template' },
+            { id: 'existing-dashboard', type: 'dashboard' },
+          ]),
+        },
+      }),
+      expect.anything()
+    );
+  });
+
+  it('should deduplicate refs when appending to additional space', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        additional_spaces_installed_kibana: {
+          'my-space': [{ id: 'existing-template', type: 'alerting_rule_template' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'existing-template', type: 'alerting_rule_template' as any }],
+      'my-space',
+      true,
+      true
+    );
+
+    const updateCall = soClient.update.mock.calls[0][2] as any;
+    const spaceRefs = updateCall.additional_spaces_installed_kibana['my-space'];
+    expect(spaceRefs).toHaveLength(1);
+    expect(spaceRefs[0].id).toBe('existing-template');
+  });
+
+  it('should overwrite additional space refs when append is false', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        additional_spaces_installed_kibana: {
+          'my-space': [{ id: 'old-dashboard', type: 'dashboard' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'new-dashboard', type: 'dashboard' as any }],
+      'my-space',
+      true
+    );
+
+    const updateCall = soClient.update.mock.calls[0][2] as any;
+    const spaceRefs = updateCall.additional_spaces_installed_kibana['my-space'];
+    expect(spaceRefs).toHaveLength(1);
+    expect(spaceRefs[0].id).toBe('new-dashboard');
+  });
+
+  it('should strip the installed_kibana_space_id key from additional_spaces when writing a new additional-space entry', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        installed_kibana_space_id: 'default',
+        additional_spaces_installed_kibana: {
+          default: [{ id: 'misplaced-dash', type: 'dashboard' }],
+          'space-a': [{ id: 'a-dash', type: 'dashboard' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'b-dash', type: 'dashboard' as any }],
+      'space-b',
+      true
+    );
+
+    const updateCall = soClient.update.mock.calls[0][2] as any;
+    const keys = Object.keys(updateCall.additional_spaces_installed_kibana);
+    expect(keys).not.toContain('default');
+    expect(keys).toContain('space-a');
+    expect(keys).toContain('space-b');
+  });
+
+  it('should be a no-op and log an error when saveAsAdditionnalSpace is true and spaceId matches installed_kibana_space_id', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        installed_kibana_space_id: 'my-space',
+        additional_spaces_installed_kibana: {},
+      },
+    } as any);
+
+    const mockLogger = appContextService.getLogger();
+    (mockLogger.error as jest.Mock).mockClear();
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'some-dash', type: 'dashboard' as any }],
+      'my-space',
+      true
+    );
+
+    expect(soClient.update).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('my-space'));
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -1302,6 +1302,7 @@ export const saveKibanaAssetsRefs = async (
   savedObjectsClient: SavedObjectsClientContract,
   pkgName: string,
   assetRefs: KibanaAssetReference[] | null,
+  spaceId: string,
   saveAsAdditionnalSpace = false,
   append = false
 ) => {
@@ -1311,8 +1312,6 @@ export const saveKibanaAssetsRefs = async (
     name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
-
-  const spaceId = savedObjectsClient.getCurrentNamespace() || DEFAULT_SPACE_ID;
 
   // Because Kibana assets are installed in parallel with ES assets with refresh: false, we almost always run into an
   // issue that causes a conflict error due to this issue: https://github.com/elastic/kibana/issues/126240. This is safe
@@ -1332,13 +1331,40 @@ export const saveKibanaAssetsRefs = async (
           : undefined;
 
       if (saveAsAdditionnalSpace) {
+        const primarySpaceId = installation?.attributes?.installed_kibana_space_id;
+
+        if (primarySpaceId && primarySpaceId === spaceId) {
+          appContextService
+            .getLogger()
+            .error(
+              `saveKibanaAssetsRefs: unexpectedly received spaceId '${spaceId}' for package '${pkgName}' for saving as additional space that matches primary installation space. Skipping.`
+            );
+          return; // no-op: skip SO update
+        }
+
+        // Strip the primary-space key if it was unexpectedly written there
+        const keysToOmit = primarySpaceId ? [spaceId, primarySpaceId] : [spaceId];
+
+        let spaceAssetRefs = assetRefs !== null ? assetRefs : [];
+        if (append && installation) {
+          const existingSpaceRefs =
+            installation.attributes?.additional_spaces_installed_kibana?.[spaceId] ?? [];
+          spaceAssetRefs = uniqBy(
+            [...spaceAssetRefs, ...existingSpaceRefs],
+            (asset) => asset.id + asset.type
+          );
+        }
+
         return savedObjectsClient.update<Installation>(
           PACKAGES_SAVED_OBJECT_TYPE,
           pkgName,
           {
             additional_spaces_installed_kibana: {
-              ...omit(installation?.attributes?.additional_spaces_installed_kibana ?? {}, spaceId),
-              ...(assetRefs !== null ? { [spaceId]: assetRefs } : {}),
+              ...omit(
+                installation?.attributes?.additional_spaces_installed_kibana ?? {},
+                keysToOmit
+              ),
+              ...(assetRefs !== null ? { [spaceId]: spaceAssetRefs } : {}),
             },
           },
           { refresh: false }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_rules.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_rules.test.ts
@@ -8,6 +8,7 @@
 import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { RulesClientApi } from '@kbn/alerting-plugin/server/types';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 
 import { appContextService } from '../../../../app_context';
 import type { ArchiveAsset } from '../../../kibana/assets/install';
@@ -184,6 +185,7 @@ describe('stepCreateAlertingRules', () => {
 
     const context = {
       savedObjectsClient,
+      spaceId: DEFAULT_SPACE_ID,
       packageInstallContext: {
         packageInfo: { name: 'elastic_agent' },
         archiveIterator: createArchiveIteratorFromMap(
@@ -216,6 +218,7 @@ describe('stepCreateAlertingRules', () => {
           deferred: false,
         },
       ],
+      DEFAULT_SPACE_ID,
       false,
       true
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_rules.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_rules.ts
@@ -154,6 +154,6 @@ export async function stepCreateAlertingRules(
       { concurrency: MAX_CONCURRENT_RULE_CREATION_OPERATIONS }
     );
 
-    await saveKibanaAssetsRefs(savedObjectsClient, pkgName, assetRefs, false, true);
+    await saveKibanaAssetsRefs(savedObjectsClient, pkgName, assetRefs, spaceId, false, true);
   });
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/package_install.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/package_install.ts
@@ -353,5 +353,163 @@ export default function (providerContext: FtrProviderContext) {
         expect(err?.message).to.match(/400 "Bad Request"/);
       });
     });
+
+    describe('multispace upgrade correctness', () => {
+      describe('with package installed in default space and kibana assets installed in an additional space', () => {
+        before(async () => {
+          await kibanaServer.savedObjects.cleanStandardList();
+          await kibanaServer.savedObjects.cleanStandardList({ space: TEST_SPACE_1 });
+          await cleanFleetIndices(esClient);
+          await apiClient.installPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+            force: true,
+          });
+          await apiClient.installPackageKibanaAssets(
+            { pkgName: 'nginx', pkgVersion: NGINX_PACKAGE_VERSION },
+            TEST_SPACE_1
+          );
+        });
+
+        after(async () => {
+          await kibanaServer.savedObjects.cleanStandardList();
+          await kibanaServer.savedObjects.cleanStandardList({ space: TEST_SPACE_1 });
+          await cleanFleetIndices(esClient);
+        });
+
+        it('should preserve additional_spaces_installed_kibana refs after reinstall from primary space', async () => {
+          await apiClient.installPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+            force: true,
+          });
+
+          const res = await apiClient.getPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+          });
+          if (!('installationInfo' in res.item)) {
+            throw new Error('package not installed');
+          }
+
+          expect(res.item.installationInfo?.installed_kibana_space_id).eql('default');
+
+          const additionalSpaceKeys = Object.keys(
+            res.item.installationInfo?.additional_spaces_installed_kibana ?? {}
+          );
+          expect(additionalSpaceKeys).to.contain(TEST_SPACE_1);
+          expect(additionalSpaceKeys).not.to.contain('default');
+
+          const dashboard = res.item.installationInfo!.additional_spaces_installed_kibana?.[
+            TEST_SPACE_1
+          ]?.find((asset) => asset.originId === 'nginx-046212a0-a2a1-11e7-928f-5dbe6f6f5519');
+          expect(dashboard).not.eql(undefined);
+        });
+      });
+
+      describe('with package installed in default space', () => {
+        before(async () => {
+          await kibanaServer.savedObjects.cleanStandardList();
+          await kibanaServer.savedObjects.cleanStandardList({ space: TEST_SPACE_1 });
+          await cleanFleetIndices(esClient);
+          await apiClient.installPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+            force: true,
+          });
+        });
+
+        after(async () => {
+          await kibanaServer.savedObjects.cleanStandardList();
+          await kibanaServer.savedObjects.cleanStandardList({ space: TEST_SPACE_1 });
+          await cleanFleetIndices(esClient);
+        });
+
+        it('should route refs to additional_spaces_installed_kibana when installing from a non-primary space', async () => {
+          await apiClient.installPackage(
+            {
+              pkgName: 'nginx',
+              pkgVersion: NGINX_PACKAGE_VERSION,
+              force: true,
+            },
+            TEST_SPACE_1
+          );
+
+          const res = await apiClient.getPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+          });
+          if (!('installationInfo' in res.item)) {
+            throw new Error('package not installed');
+          }
+
+          expect(res.item.installationInfo?.installed_kibana_space_id).eql('default');
+
+          const primaryDashboard = res.item.installationInfo!.installed_kibana.find(
+            (asset) =>
+              asset.id === 'nginx-046212a0-a2a1-11e7-928f-5dbe6f6f5519' &&
+              asset.type === 'dashboard'
+          );
+          expect(primaryDashboard).not.eql(undefined);
+
+          const additionalSpaceKeys = Object.keys(
+            res.item.installationInfo?.additional_spaces_installed_kibana ?? {}
+          );
+          expect(additionalSpaceKeys).to.contain(TEST_SPACE_1);
+        });
+      });
+
+      describe('with package installed in a non-default space', () => {
+        before(async () => {
+          await kibanaServer.savedObjects.cleanStandardList();
+          await kibanaServer.savedObjects.cleanStandardList({ space: TEST_SPACE_1 });
+          await cleanFleetIndices(esClient);
+          await apiClient.installPackage(
+            {
+              pkgName: 'nginx',
+              pkgVersion: NGINX_PACKAGE_VERSION,
+              force: true,
+            },
+            TEST_SPACE_1
+          );
+        });
+
+        after(async () => {
+          await kibanaServer.savedObjects.cleanStandardList();
+          await kibanaServer.savedObjects.cleanStandardList({ space: TEST_SPACE_1 });
+          await cleanFleetIndices(esClient);
+        });
+
+        it('should route refs to additional_spaces_installed_kibana when reinstalling from a non-primary space', async () => {
+          await apiClient.installPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+            force: true,
+          });
+
+          const res = await apiClient.getPackage({
+            pkgName: 'nginx',
+            pkgVersion: NGINX_PACKAGE_VERSION,
+          });
+          if (!('installationInfo' in res.item)) {
+            throw new Error('package not installed');
+          }
+
+          expect(res.item.installationInfo?.installed_kibana_space_id).eql(TEST_SPACE_1);
+
+          const additionalSpaceKeys = Object.keys(
+            res.item.installationInfo?.additional_spaces_installed_kibana ?? {}
+          );
+          expect(additionalSpaceKeys).to.contain('default');
+          expect(additionalSpaceKeys).not.to.contain(TEST_SPACE_1);
+
+          const dashboard =
+            res.item.installationInfo!.additional_spaces_installed_kibana?.default?.find(
+              (asset) => asset.originId === 'nginx-046212a0-a2a1-11e7-928f-5dbe6f6f5519'
+            );
+          expect(dashboard).not.eql(undefined);
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Fix asset ref bucketing in multispace package installs (#271800)](https://github.com/elastic/kibana/pull/271800)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2026-06-01T16:31:39Z","message":"[Fleet] Fix asset ref bucketing in multispace package installs (#271800)\n\nResolves: https://github.com/elastic/kibana/issues/270013\n\nThis fixes an issue where a package that is upgraded or reinstalled in a\nspace different from the originating install space would result in\neither `installed_kibana` being populated with asset references from the\nrequesting space, and not the primary install space or `additional_spaces_installed_kibana` map incorrectly bucketing assets all into the default space.","sha":"0827fbd323bef219d53690cf51645a42a11053fb","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.3.0","v9.4.0","v9.5.0"],"title":"[Fleet] Fix asset ref bucketing in multispace package installs","number":271800,"url":"https://github.com/elastic/kibana/pull/271800","mergeCommit":{"message":"[Fleet] Fix asset ref bucketing in multispace package installs (#271800)\n\nResolves: https://github.com/elastic/kibana/issues/270013\n\nThis fixes an issue where a package that is upgraded or reinstalled in a\nspace different from the originating install space would result in\neither `installed_kibana` being populated with asset references from the\nrequesting space, and not the primary install space or `additional_spaces_installed_kibana` map incorrectly bucketing assets all into the default space.","sha":"0827fbd323bef219d53690cf51645a42a11053fb"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/272178","number":272178,"state":"OPEN"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271800","number":271800,"mergeCommit":{"message":"[Fleet] Fix asset ref bucketing in multispace package installs (#271800)\n\nResolves: https://github.com/elastic/kibana/issues/270013\n\nThis fixes an issue where a package that is upgraded or reinstalled in a\nspace different from the originating install space would result in\neither `installed_kibana` being populated with asset references from the\nrequesting space, and not the primary install space or `additional_spaces_installed_kibana` map incorrectly bucketing assets all into the default space.","sha":"0827fbd323bef219d53690cf51645a42a11053fb"}}]}] BACKPORT-->