### PR TITLE
[Agent Builder] Add authorization HITL for connector subactions

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/index.ts
@@ -65,6 +65,8 @@ export {
   type AuthorizationPrompt,
   type AuthorizationPromptResponse,
   type AuthorizationMethod,
+  AUTHORIZATION_METHODS,
+  isAuthorizationMethod,
   type PromptResponse,
   type PromptRequest,
   type ToolCallPromptRequestSource,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/prompts.ts
@@ -59,7 +59,12 @@ export interface ConfirmPromptDefinition {
   color?: ConfirmPromptColor;
 }
 
-export type AuthorizationMethod = 'oauth_authorization_code';
+export const AUTHORIZATION_METHODS = ['oauth_authorization_code', 'ears'] as const;
+
+export type AuthorizationMethod = (typeof AUTHORIZATION_METHODS)[number];
+
+export const isAuthorizationMethod = (value: unknown): value is AuthorizationMethod =>
+  typeof value === 'string' && (AUTHORIZATION_METHODS as readonly string[]).includes(value);
 
 export interface AuthorizationPromptDefinition {
   id: string;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/connector_type_icon.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/connector_type_icon.tsx
@@ -6,8 +6,9 @@
  */
 
 import React, { Suspense } from 'react';
-import type { EuiSkeletonCircleProps, IconSize } from '@elastic/eui';
+import type { EuiSkeletonCircleProps, IconSize, IconType } from '@elastic/eui';
 import { EuiIcon, EuiSkeletonCircle } from '@elastic/eui';
+import { ConnectorIconsMap } from '@kbn/connector-specs/icons';
 import { useKibana } from '../../hooks/use_kibana';
 
 export interface ConnectorTypeIconProps {
@@ -33,13 +34,15 @@ export const ConnectorTypeIcon: React.FC<ConnectorTypeIconProps> = ({
 
   const { actionTypeRegistry } = triggersActionsUi;
 
-  const iconClass = actionTypeRegistry.has(actionTypeId)
-    ? actionTypeRegistry.get(actionTypeId).iconClass
-    : 'plugs';
+  const iconType: IconType =
+    ConnectorIconsMap.get(actionTypeId) ?? // v2 connector icons
+    (actionTypeRegistry.has(actionTypeId)
+      ? actionTypeRegistry.get(actionTypeId).iconClass // legacy connector icons
+      : 'plugs');
 
   return (
     <Suspense fallback={<EuiSkeletonCircle size={toSkeletonSize(size)} />}>
-      <EuiIcon type={iconClass} size={size} aria-hidden={true} />
+      <EuiIcon type={iconType} size={size} aria-hidden={true} />
     </Suspense>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.test.ts
@@ -6,12 +6,13 @@
  */
 
 import type { ConverseInput } from '@kbn/agent-builder-common';
+import { ConversationRoundStatus } from '@kbn/agent-builder-common';
 import {
   AgentPromptType,
   AuthorizationStatus,
   ConfirmationStatus,
 } from '@kbn/agent-builder-common/agents/prompts';
-import { createEmptyConversation } from '../../../../test_utils/conversations';
+import { createEmptyConversation, createRound } from '../../../../test_utils/conversations';
 import { createPromptManager, getAgentPromptStorageState, toolConfirmationId } from './prompts';
 
 describe('prompts utilities', () => {
@@ -351,6 +352,101 @@ describe('prompts utilities', () => {
       expect(result.responses['auth-prompt']).toEqual({
         type: AgentPromptType.authorization,
         response: { authorized: true },
+      });
+    });
+
+    describe('authorization scoping', () => {
+      const declinedResponse = {
+        type: AgentPromptType.authorization as const,
+        response: { authorized: false },
+      };
+      const authorizedResponse = {
+        type: AgentPromptType.authorization as const,
+        response: { authorized: true },
+      };
+      const confirmationResponse = {
+        type: AgentPromptType.confirmation as const,
+        response: { allow: true },
+      };
+
+      const conversationWith = ({
+        lastRoundStatus,
+        responses,
+      }: {
+        lastRoundStatus: ConversationRoundStatus;
+        responses: Record<
+          string,
+          typeof declinedResponse | typeof authorizedResponse | typeof confirmationResponse
+        >;
+      }) =>
+        createEmptyConversation({
+          rounds: [createRound({ status: lastRoundStatus })],
+          state: { prompt: { responses } },
+        });
+
+      it('drops carried-over declined authorization responses when starting a new round', () => {
+        const conversation = conversationWith({
+          lastRoundStatus: ConversationRoundStatus.completed,
+          responses: { 'auth-prompt': declinedResponse },
+        });
+
+        const result = getAgentPromptStorageState({ input: { message: 'hello' }, conversation });
+
+        expect(result.responses['auth-prompt']).toBeUndefined();
+      });
+
+      it('drops carried-over authorized responses when starting a new round', () => {
+        const conversation = conversationWith({
+          lastRoundStatus: ConversationRoundStatus.completed,
+          responses: { 'auth-prompt': authorizedResponse },
+        });
+
+        const result = getAgentPromptStorageState({ input: { message: 'hello' }, conversation });
+
+        expect(result.responses['auth-prompt']).toBeUndefined();
+      });
+
+      it('keeps carried-over authorization responses when resuming an interrupted round', () => {
+        const conversation = conversationWith({
+          lastRoundStatus: ConversationRoundStatus.awaitingPrompt,
+          responses: {
+            'declined-prompt': declinedResponse,
+            'authorized-prompt': authorizedResponse,
+          },
+        });
+
+        const result = getAgentPromptStorageState({
+          input: { prompts: { 'other-prompt': { authorized: false } } },
+          conversation,
+        });
+
+        expect(result.responses['declined-prompt']).toEqual(declinedResponse);
+        expect(result.responses['authorized-prompt']).toEqual(authorizedResponse);
+      });
+
+      it('keeps carried-over confirmation responses when starting a new round', () => {
+        const conversation = conversationWith({
+          lastRoundStatus: ConversationRoundStatus.completed,
+          responses: { 'conf-prompt': confirmationResponse },
+        });
+
+        const result = getAgentPromptStorageState({ input: { message: 'hello' }, conversation });
+
+        expect(result.responses['conf-prompt']).toEqual(confirmationResponse);
+      });
+
+      it('does not drop an authorization response supplied via input.prompts on a new round', () => {
+        const conversation = conversationWith({
+          lastRoundStatus: ConversationRoundStatus.completed,
+          responses: {},
+        });
+
+        const result = getAgentPromptStorageState({
+          input: { prompts: { 'auth-prompt': { authorized: false } } },
+          conversation,
+        });
+
+        expect(result.responses['auth-prompt']).toEqual(declinedResponse);
       });
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
@@ -139,6 +139,7 @@ export const getAgentPromptStorageState = ({
   // Create a shallow copy to avoid mutating the original conversation state
   const responses = { ...(conversation?.state?.prompt?.responses ?? {}) };
 
+  // Scope authorization responses to the conversation round (subsequent rounds can re-prompt)
   if (!isResumingRound) {
     Object.entries(responses).forEach(([promptId, { response }]) => {
       if (isAuthorizationPromptResponse(response)) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/prompts.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Conversation, ConverseInput } from '@kbn/agent-builder-common';
+import { ConversationRoundStatus } from '@kbn/agent-builder-common';
 import type {
   PromptManager,
   ToolPromptManager,
@@ -131,10 +132,22 @@ export const getAgentPromptStorageState = ({
   input: ConverseInput;
   conversation?: Conversation;
 }): PromptStorageState => {
+  const rounds = conversation?.rounds ?? [];
+  const lastRound = rounds[rounds.length - 1];
+  const isResumingRound = lastRound?.status === ConversationRoundStatus.awaitingPrompt;
+
   // Create a shallow copy to avoid mutating the original conversation state
-  const state: PromptStorageState = {
-    responses: { ...(conversation?.state?.prompt?.responses ?? {}) },
-  };
+  const responses = { ...(conversation?.state?.prompt?.responses ?? {}) };
+
+  if (!isResumingRound) {
+    Object.entries(responses).forEach(([promptId, { response }]) => {
+      if (isAuthorizationPromptResponse(response)) {
+        delete responses[promptId];
+      }
+    });
+  }
+
+  const state: PromptStorageState = { responses };
 
   if (input.prompts) {
     Object.entries(input.prompts).forEach(([promptId, response]) => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts
@@ -446,7 +446,7 @@ describe('createExecuteConnectorSubActionTool', () => {
       expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
     });
 
-    it('does not re-raise the prompt when authorization was declined', async () => {
+    it('returns an explicit "user declined" error when authorization was declined', async () => {
       mockCheckAuthorizationStatus.mockReturnValue({ status: AuthorizationStatus.declined });
       mockExecute.mockResolvedValue(authErrorResult());
 
@@ -457,7 +457,13 @@ describe('createExecuteConnectorSubActionTool', () => {
       );
 
       expect(mockAskForAuthorization).not.toHaveBeenCalled();
-      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
+      const errorResult = (result as ToolHandlerStandardReturn).results[0] as ErrorResult;
+      expect(errorResult.type).toBe(ToolResultType.error);
+      expect(errorResult.data.message).toContain('declined to authorize');
+      expect(errorResult.data.message).toContain('My Slack');
+      expect(errorResult.data.metadata).toMatchObject({
+        authorizationStatus: AuthorizationStatus.declined,
+      });
     });
 
     it('does not re-raise the prompt when already authorized but execution still fails', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts
@@ -6,13 +6,20 @@
  */
 
 import { platformCoreTools, ToolType } from '@kbn/agent-builder-common';
+import { AgentPromptType, AuthorizationStatus } from '@kbn/agent-builder-common/agents';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { ErrorResult, OtherResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type {
   ToolHandlerContext,
+  ToolHandlerPromptReturn,
   ToolHandlerStandardReturn,
 } from '@kbn/agent-builder-server/tools/handler';
-import { getConnectorSpec, isToolAction } from '@kbn/connector-specs';
+import {
+  getConnectorSpec,
+  isToolAction,
+  OAUTH_AUTHORIZATION_CODE_AUTH_ID,
+  EARS_AUTH_ID,
+} from '@kbn/connector-specs';
 import {
   createExecuteConnectorSubActionTool,
   executeConnectorSubActionArgsSchema,
@@ -20,6 +27,7 @@ import {
 import type { ConnectorToolsOptions } from './types';
 
 jest.mock('@kbn/connector-specs', () => ({
+  ...jest.requireActual('@kbn/connector-specs'),
   getConnectorSpec: jest.fn(),
   isToolAction: jest.fn(),
 }));
@@ -38,6 +46,9 @@ const getActions: ConnectorToolsOptions['getActions'] = jest.fn(() =>
   })
 ) as unknown as ConnectorToolsOptions['getActions'];
 
+const mockCheckAuthorizationStatus = jest.fn();
+const mockAskForAuthorization = jest.fn();
+
 const mockContext = {
   spaceId: 'default',
   esClient: { asCurrentUser: {} },
@@ -45,6 +56,17 @@ const mockContext = {
   savedObjectsClient: {},
   attachments: {},
   logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+  callContext: {
+    toolId: platformCoreTools.executeConnectorSubAction,
+    toolCallId: 'call-1',
+    callSource: 'agent',
+  },
+  prompts: {
+    checkConfirmationStatus: jest.fn(),
+    checkAuthorizationStatus: mockCheckAuthorizationStatus,
+    askForConfirmation: jest.fn(),
+    askForAuthorization: mockAskForAuthorization,
+  },
 } as unknown as ToolHandlerContext;
 
 describe('createExecuteConnectorSubActionTool', () => {
@@ -67,6 +89,10 @@ describe('createExecuteConnectorSubActionTool', () => {
       },
     });
     isToolActionMock.mockReturnValue(true);
+    mockCheckAuthorizationStatus.mockReturnValue({ status: AuthorizationStatus.unprompted });
+    mockAskForAuthorization.mockImplementation((definition) => ({
+      prompt: { type: AgentPromptType.authorization, ...definition },
+    }));
   });
 
   it('has correct id, type, and tags', () => {
@@ -318,6 +344,134 @@ describe('createExecuteConnectorSubActionTool', () => {
     expect((result as ToolHandlerStandardReturn).results).toHaveLength(1);
     expect(((result as ToolHandlerStandardReturn).results[0] as OtherResult).data).toEqual({
       message: 'Sub-action executed successfully',
+    });
+  });
+
+  describe('connector authorization (HITL prompt)', () => {
+    const expectedPromptId = `tools.${platformCoreTools.executeConnectorSubAction}.authorization.conn-123`;
+
+    const authErrorResult = (overrides: Record<string, unknown> = {}) => ({
+      status: 'error' as const,
+      message: 'an error occurred while running the action',
+      serviceMessage: 'No access token found. User must complete OAuth authorization flow.',
+      errorName: 'ConnectorAuthorizationError',
+      errorMeta: {
+        connectorName: 'My Slack',
+        authMethod: OAUTH_AUTHORIZATION_CODE_AUTH_ID,
+        reason: 'no_token',
+      },
+      ...overrides,
+    });
+
+    it('raises an authorization prompt for an oauth_authorization_code connector', async () => {
+      mockExecute.mockResolvedValue(authErrorResult());
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        mockContext
+      );
+
+      expect(mockCheckAuthorizationStatus).toHaveBeenCalledWith(expectedPromptId);
+      expect(mockAskForAuthorization).toHaveBeenCalledTimes(1);
+      expect((result as ToolHandlerPromptReturn).prompt).toEqual({
+        type: AgentPromptType.authorization,
+        id: expectedPromptId,
+        connector_id: 'conn-123',
+        connector_name: 'My Slack',
+        connector_type: '.slack2',
+        auth_method: OAUTH_AUTHORIZATION_CODE_AUTH_ID,
+      });
+    });
+
+    it('raises an authorization prompt for an EARS connector', async () => {
+      mockExecute.mockResolvedValue(
+        authErrorResult({
+          errorMeta: {
+            connectorName: 'My Google',
+            authMethod: EARS_AUTH_ID,
+            reason: 'token_expired',
+          },
+        })
+      );
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        mockContext
+      );
+
+      expect((result as ToolHandlerPromptReturn).prompt).toEqual({
+        type: AgentPromptType.authorization,
+        id: expectedPromptId,
+        connector_id: 'conn-123',
+        connector_name: 'My Google',
+        connector_type: '.slack2',
+        auth_method: EARS_AUTH_ID,
+      });
+    });
+
+    it('falls back to connectorId when the connector name is missing from the metadata', async () => {
+      mockExecute.mockResolvedValue(
+        authErrorResult({
+          errorMeta: { authMethod: OAUTH_AUTHORIZATION_CODE_AUTH_ID, reason: 'no_token' },
+        })
+      );
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        mockContext
+      );
+
+      expect((result as ToolHandlerPromptReturn).prompt).toMatchObject({
+        connector_name: 'conn-123',
+      });
+    });
+
+    it('does not raise a prompt for an unsupported auth method', async () => {
+      mockExecute.mockResolvedValue(
+        authErrorResult({
+          errorMeta: { connectorName: 'My Connector', authMethod: 'basic', reason: 'no_token' },
+        })
+      );
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        mockContext
+      );
+
+      expect(mockAskForAuthorization).not.toHaveBeenCalled();
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
+    });
+
+    it('does not re-raise the prompt when authorization was declined', async () => {
+      mockCheckAuthorizationStatus.mockReturnValue({ status: AuthorizationStatus.declined });
+      mockExecute.mockResolvedValue(authErrorResult());
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        mockContext
+      );
+
+      expect(mockAskForAuthorization).not.toHaveBeenCalled();
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
+    });
+
+    it('does not re-raise the prompt when already authorized but execution still fails', async () => {
+      mockCheckAuthorizationStatus.mockReturnValue({ status: AuthorizationStatus.authorized });
+      mockExecute.mockResolvedValue(authErrorResult());
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        mockContext
+      );
+
+      expect(mockAskForAuthorization).not.toHaveBeenCalled();
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.ts
@@ -129,7 +129,7 @@ export const createExecuteConnectorSubActionTool = ({
       };
     }
 
-    const askForAuthorization = ({
+    const resolveAuthorizationResult = ({
       authMethod,
       connectorName,
     }: {
@@ -141,17 +141,33 @@ export const createExecuteConnectorSubActionTool = ({
       }
       const promptId = `tools.${context.callContext.toolId}.authorization.${connectorId}`;
       const { status } = context.prompts.checkAuthorizationStatus(promptId);
+      const resolvedConnectorName = connectorName ?? connectorId;
 
-      if (status !== AuthorizationStatus.unprompted) {
-        return undefined;
+      if (status === AuthorizationStatus.unprompted) {
+        return context.prompts.askForAuthorization({
+          id: promptId,
+          connector_id: connectorId,
+          connector_name: resolvedConnectorName,
+          connector_type: connectorType,
+          auth_method: authMethod,
+        });
       }
-      return context.prompts.askForAuthorization({
-        id: promptId,
-        connector_id: connectorId,
-        connector_name: connectorName ?? connectorId,
-        connector_type: connectorType,
-        auth_method: authMethod,
-      });
+
+      if (status === AuthorizationStatus.declined) {
+        return {
+          results: [
+            createErrorResult({
+              message:
+                `The user declined to authorize the '${resolvedConnectorName}' connector, so the '${subAction}' sub-action cannot run. ` +
+                'Do not retry this sub-action and do not instruct the user to authorize the connector themselves. ' +
+                'Briefly let the user know the request was not completed because authorization was declined.',
+              metadata: { connectorId, connectorType, subAction, authorizationStatus: status },
+            }),
+          ],
+        };
+      }
+
+      return undefined;
     };
 
     let executeResult;
@@ -183,12 +199,12 @@ export const createExecuteConnectorSubActionTool = ({
         const { errorMeta } = executeResult;
         const connectorName =
           typeof errorMeta?.connectorName === 'string' ? errorMeta.connectorName : undefined;
-        const authPrompt = askForAuthorization({
+        const authResult = resolveAuthorizationResult({
           authMethod: errorMeta?.authMethod,
           connectorName,
         });
-        if (authPrompt) {
-          return authPrompt;
+        if (authResult) {
+          return authResult;
         }
       }
       return {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.ts
@@ -7,6 +7,7 @@
 
 import { z } from '@kbn/zod/v4';
 import { platformCoreTools, ToolType } from '@kbn/agent-builder-common';
+import { AuthorizationStatus, isAuthorizationMethod } from '@kbn/agent-builder-common/agents';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { getToolResultId, createErrorResult } from '@kbn/agent-builder-server';
@@ -128,6 +129,31 @@ export const createExecuteConnectorSubActionTool = ({
       };
     }
 
+    const askForAuthorization = ({
+      authMethod,
+      connectorName,
+    }: {
+      authMethod: unknown;
+      connectorName?: string;
+    }) => {
+      if (!isAuthorizationMethod(authMethod)) {
+        return undefined;
+      }
+      const promptId = `tools.${context.callContext.toolId}.authorization.${connectorId}`;
+      const { status } = context.prompts.checkAuthorizationStatus(promptId);
+
+      if (status !== AuthorizationStatus.unprompted) {
+        return undefined;
+      }
+      return context.prompts.askForAuthorization({
+        id: promptId,
+        connector_id: connectorId,
+        connector_name: connectorName ?? connectorId,
+        connector_type: connectorType,
+        auth_method: authMethod,
+      });
+    };
+
     let executeResult;
     try {
       executeResult = await actionsClient.execute({
@@ -153,6 +179,18 @@ export const createExecuteConnectorSubActionTool = ({
     }
 
     if (executeResult.status === 'error') {
+      if (executeResult.errorName === 'ConnectorAuthorizationError') {
+        const { errorMeta } = executeResult;
+        const connectorName =
+          typeof errorMeta?.connectorName === 'string' ? errorMeta.connectorName : undefined;
+        const authPrompt = askForAuthorization({
+          authMethod: errorMeta?.authMethod,
+          connectorName,
+        });
+        if (authPrompt) {
+          return authPrompt;
+        }
+      }
       return {
         results: [
           createErrorResult({


### PR DESCRIPTION
## Summary

Adds human-in-the-loop (HITL) authorization prompts to the `executeConnectorSubAction` platform tool and introduces EARS as a supported auth method. When a connector subaction fails with a `ConnectorAuthorizationError`, the tool now raises an authorization prompt so the user can complete the auth flow, instead of returning a plain error to the agent.

Includes a bugfix for v2 connector icons not resolving when using the `ConnectorTypeIcon` component.

### Demo

https://github.com/user-attachments/assets/436c9310-0ecc-421f-9560-e45ab4a9f6e1

_Minor correction from the demo: Sonnet attempts to correct its understanding of what the current date is, but still gets it wrong. Regardless, the connector returns the correct schedules for each date I requested._

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



