### PR TITLE
[CI] Fix Renovate helper to regenerate gh-aw locks

### DIFF
--- a/.buildkite/scripts/steps/renovate/renovate_helper.sh
+++ b/.buildkite/scripts/steps/renovate/renovate_helper.sh
@@ -31,21 +31,35 @@ regenerate_gh_aw_locks() {
   fi
 
   gh extension install github/gh-aw --pin "$gh_aw_version" --force
-
-  local cmd
-  cmd="gh aw compile --purge --validate --no-check-update && gh aw lint"
-  eval "$cmd"
-  check_for_changed_files "$cmd" true "Regenerate gh-aw workflow locks"
+  gh aw compile --purge --validate --no-check-update
+  gh aw lint
 }
 
+# Both yarn deduplication and gh-aw lock regeneration are committed together in a
+# single commit below. Committing after yarn dedup alone would exit before the
+# gh-aw recompile could run (the push turns the next build into a `synchronize`
+# event, which does not re-run this helper).
 echo --- Deduplicate yarn.lock
 cmd="node scripts/yarn_deduplicate.js && yarn kbn bootstrap && node scripts/yarn_deduplicate.js"
 eval "$cmd"
-check_for_changed_files "$cmd" true
+
+commit_message_parts=()
+if [[ -n "$(git status --porcelain -- . ':!:config/node.options' ':!config/kibana.yml')" ]]; then
+  commit_message_parts+=("yarn dedupe")
+fi
 
 if has_gh_aw_version_change; then
   regenerate_gh_aw_locks
+  commit_message_parts+=("gh-aw compilation")
 fi
+
+commit_message="Changes from Renovate helper:"
+if [[ ${#commit_message_parts[@]} -gt 0 ]]; then
+  joined="$(printf '%s, ' "${commit_message_parts[@]}")"
+  commit_message="$commit_message ${joined%, }"
+fi
+
+check_for_changed_files "Renovate helper auto-fixes" true "$commit_message"
 
 echo --- Additional helpers
 # We only want the deploy label on the main branch instead of all branches in the Renovate group

--- a/.buildkite/scripts/steps/renovate/renovate_helper.sh
+++ b/.buildkite/scripts/steps/renovate/renovate_helper.sh
@@ -35,10 +35,6 @@ regenerate_gh_aw_locks() {
   gh aw lint
 }
 
-# Both yarn deduplication and gh-aw lock regeneration are committed together in a
-# single commit below. Committing after yarn dedup alone would exit before the
-# gh-aw recompile could run (the push turns the next build into a `synchronize`
-# event, which does not re-run this helper).
 echo --- Deduplicate yarn.lock
 cmd="node scripts/yarn_deduplicate.js && yarn kbn bootstrap && node scripts/yarn_deduplicate.js"
 eval "$cmd"


### PR DESCRIPTION
Follow-up to #270026. The gh-aw recompile it added never ran: the yarn-dedupe step commits, pushes, and exits before reaching it, and the resulting `synchronize` build doesn't re-run the helper. See https://github.com/elastic/kibana/pull/270906 and https://buildkite.com/elastic/kibana-renovate-helper/builds/94753

Now yarn dedupe and the gh-aw recompile both run before a single `check_for_changed_files`, so all auto-fixes land in one commit on the `opened` build.