### PR TITLE
[content list] fix: fix wide viewport flows for name and action cell

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: src/platform/packages/shared/content-management/content_list/kbn-content-list-docs
 dependsOn:
   - '@kbn/content-list'
+  - '@kbn/content-list-provider-client'
   - '@kbn/content-list-provider'
   - '@kbn/content-list-mock-data'
   - '@kbn/content-management-favorites-public'

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/README.md
@@ -91,7 +91,7 @@ import {
 } from '@kbn/content-list-mock-data';
 
 // Use directly in tests or custom implementations
-console.log(MOCK_DASHBOARDS.length); // 8 dashboard items
+console.log(MOCK_DASHBOARDS.length); // 10 dashboard items
 console.log(MOCK_TAGS.length);       // 8 tag items
 ```
 
@@ -146,10 +146,10 @@ const profile = MOCK_USER_PROFILES_MAP['u_jane_doe'];
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `MOCK_DASHBOARDS` | `DashboardMockItem[]` | 8 dashboard items with titles, descriptions, tags, and metadata. |
-| `MOCK_VISUALIZATIONS` | `VisualizationMockItem[]` | 8 visualization items spanning multiple viz types (Lens, Pie, Table, etc.). |
-| `MOCK_MAPS` | `MapMockItem[]` | 5 map items representing geographic visualizations. |
-| `MOCK_FILES` | `FileMockItem[]` | 6 file items demonstrating custom content type attributes. |
+| `MOCK_DASHBOARDS` | `DashboardMockItem[]` | 10 dashboard items, tuned to span the name-cell permutation matrix (short/long title × empty/short/long description × no/few/many tags) so stories exercise both narrow and wide-viewport layouts. |
+| `MOCK_VISUALIZATIONS` | `VisualizationMockItem[]` | 8 visualization items covering the name-cell permutation matrix (title × description × tag count) and a variety of `visType`s (Lens, Pie, Table, Area, Metric, Tag Cloud, Vega, Line+error). |
+| `MOCK_MAPS` | `MapMockItem[]` | 5 map items spanning the name-cell permutation matrix (title × description × tag count) within the smaller fixture size — covers sparse-favorited, rich, description-wrap, long-title-only, and most-sparse rows. |
+| `MOCK_FILES` | `FileMockItem[]` | 6 file items spanning the name-cell `title × description` matrix (the Files Management story does not render tags inline), with realistic short/long filenames and short/long/missing descriptions. |
 | `MOCK_TAGS` | `MockTag[]` | 8 tags including both user-created and managed (Fleet) tags. |
 | `MOCK_USERS` | `readonly string[]` | Array of mock user IDs used across content items. |
 | `MOCK_USER_PROFILES` | `UserProfile[]` | User profile objects corresponding to `MOCK_USERS`. |

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/dashboards.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/dashboards.ts
@@ -27,9 +27,27 @@ export interface DashboardMockItem extends UserContentCommonSchema {
 }
 
 /**
- * Mock dashboard items
+ * Mock dashboard items.
+ *
+ * The set is deliberately tuned to span the name-cell content permutation
+ * matrix — short/long title × empty/short/long description × no/few/many
+ * tags — so every story that consumes `MOCK_DASHBOARDS` exercises the
+ * column-stack (narrow) and wrap-on-overflow row (≥ 2560px) layouts
+ * without a dedicated fixture. Each entry's leading comment names its
+ * permutation; the matrix uses `t{s,m,l}` for title length, `d{0,s,l}`
+ * for description length, and `g{0,f,m}` for tag count.
+ *
+ * Pinned IDs preserved for story call-sites:
+ *
+ * - `dashboard-001`, `dashboard-003`, `dashboard-007` — initial favorites
+ *   (see `services.ts` and `dashboard_listing.stories.tsx`).
+ * - `dashboard-002`, `dashboard-005` — managed dashboards used by the
+ *   bulk-delete partition story.
  */
 export const MOCK_DASHBOARDS: DashboardMockItem[] = [
+  // ts-ds-gm — sparse-but-favorited (short title, short description, many
+  // tags). At wide viewports this row collapses tightly onto one line,
+  // demonstrating the "pull cells together" intent of the row layout.
   {
     id: 'dashboard-001',
     type: 'dashboard',
@@ -38,17 +56,23 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-10-01T09:00:00.000Z',
     createdBy: 'u_665722084_cloud',
     attributes: {
-      title: '[eCommerce] Revenue Dashboard',
-      description: 'Analyze mock eCommerce orders and revenue metrics',
+      title: 'Sales Pulse',
+      description: 'Daily revenue and conversion KPIs.',
       timeRestore: true,
     },
     references: [
       { type: 'tag', id: 'tag-production', name: 'Production' },
       { type: 'tag', id: 'tag-important', name: 'Important' },
+      { type: 'tag', id: 'tag-security', name: 'Security' },
+      { type: 'tag', id: 'tag-development', name: 'Development' },
+      { type: 'tag', id: 'tag-archived', name: 'Archived' },
+      { type: 'tag', id: 'fleet-managed-default', name: 'Managed' },
     ],
     managed: false,
     canFavorite: true,
   },
+  // tl-ds-gf — managed long-title row. Exercises wrap behavior with a
+  // title that alone consumes most of the cell width.
   {
     id: 'dashboard-002',
     type: 'dashboard',
@@ -57,8 +81,8 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-09-15T11:30:00.000Z',
     createdBy: 'u_admin_local',
     attributes: {
-      title: 'Detection Rule Monitoring',
-      description: 'Monitor the health and performance of detection rules',
+      title: 'Detection Rule Monitoring — Coverage, Suppressions, Backlog & SLA',
+      description: 'Per-rule health snapshots.',
       timeRestore: false,
     },
     references: [
@@ -68,6 +92,9 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     managed: true,
     canFavorite: true,
   },
+  // ts-dl-gf — short title + long description (favorited). At wide
+  // viewports the long description wraps within the cell, while the short
+  // title and few tags stay inline.
   {
     id: 'dashboard-003',
     type: 'dashboard',
@@ -76,14 +103,17 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-08-20T14:00:00.000Z',
     createdBy: 'u_665722084_cloud',
     attributes: {
-      title: '[Flights] Global Flight Dashboard',
-      description: 'Analyze mock flight data for ES-Air, Logstash Airways, Kibana Airlines',
+      title: 'Flights',
+      description:
+        'Aggregated mock flight data for ES-Air, Logstash Airways, and Kibana Airlines — broken down by carrier, route, and arrival punctuality, with comparative weekly and seasonal trend overlays. Includes a cancellation-cause attribution funnel (weather, mechanical, crew, ATC, upstream-leg) and a per-airport on-time-arrival heatmap that the Operations team reviews in the daily standup. Panels are bound to the sample `kibana_sample_data_flights` index pattern so the dashboard works out of the box on a fresh deployment, and the time range defaults to the previous 30 days when restored.',
       timeRestore: true,
     },
     references: [{ type: 'tag', id: 'tag-development', name: 'Development' }],
     managed: false,
     canFavorite: true,
   },
+  // tl-dl-gf — the prototypical "rich" row. At wide viewports the title
+  // sits on its own line and the description wraps below.
   {
     id: 'dashboard-004',
     type: 'dashboard',
@@ -92,14 +122,18 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-07-10T08:30:00.000Z',
     createdBy: 'u_john_smith',
     attributes: {
-      title: '[Logs] Web Traffic Analysis',
-      description: "Analyze web traffic log data for Elastic's website",
+      title:
+        '[Logs] Global Web Traffic Analysis — Sessions, Page Views, Geo Breakdown & Funnel Conversion',
+      description:
+        "Analyzes web traffic log data for Elastic's website across regions and acquisition channels with day-over-day comparisons; intended to be the canonical traffic source-of-truth for Marketing and Growth. Drill-downs cover landing page, referrer, campaign UTM, device class, and authenticated vs. anonymous sessions, with a sticky conversion funnel that tracks first-touch → docs-read → trial-signup → activation. Backed by the `kibana_sample_data_logs` rollover stream plus the `marketing-attribution-*` data view, and gated behind the Marketing space so partner-shared exports never leak sensitive UTM parameters. The weekly review meeting opens this dashboard pinned to the `prev_7d` time range.",
       timeRestore: true,
     },
     references: [{ type: 'tag', id: 'tag-production', name: 'Production' }],
     managed: false,
     canFavorite: true,
   },
+  // tm-ds-g0 — managed medium-title row with a short description and no
+  // tags. Visually quiet but still stacks in narrow viewports.
   {
     id: 'dashboard-005',
     type: 'dashboard',
@@ -108,13 +142,16 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdBy: 'u_admin_local',
     attributes: {
       title: 'Infrastructure Overview',
-      description: 'Server and container metrics overview',
+      description: 'Server and container metrics overview.',
       timeRestore: false,
     },
     references: [],
     managed: false,
     canFavorite: true,
   },
+  // ts-d0-g0 — most-sparse row: title only, nothing else. At wide
+  // viewports there is nothing to wrap so the cell renders a single
+  // inline element.
   {
     id: 'dashboard-006',
     type: 'dashboard',
@@ -123,14 +160,16 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-05-20T15:45:00.000Z',
     createdBy: 'u_jane_doe',
     attributes: {
-      title: 'APM Service Map',
-      description: 'Application performance monitoring service dependencies',
+      title: 'APM',
       timeRestore: false,
     },
-    references: [{ type: 'tag', id: 'tag-archived', name: 'Archived' }],
+    references: [],
     managed: false,
     canFavorite: true,
   },
+  // tl-dl-gm — favorited kitchen-sink row: long title + long description
+  // + many tags. At wide viewports each part wraps to its own line,
+  // mirroring the narrow-viewport column stack.
   {
     id: 'dashboard-007',
     type: 'dashboard',
@@ -139,17 +178,24 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-04-10T13:00:00.000Z',
     createdBy: 'u_admin_local',
     attributes: {
-      title: 'ML Anomaly Explorer',
-      description: 'Machine learning anomaly detection results',
+      title: 'ML Anomaly Explorer — Cross-Cluster Detector Coverage and Severity by Service',
+      description:
+        'Surfaces machine-learning anomaly detection outcomes across all configured detectors with drill-downs into service, cluster, and severity. Pairs with the on-call rotation page for incident triage: each anomaly row links into the corresponding APM trace, the upstream log stream filtered to the affected pod, and a pre-canned timeline overlay that aligns deploys, feature flag flips, and infrastructure changes against the anomaly window. Coverage is reconciled nightly against the service catalog so newly-onboarded services surface as `uncovered` rather than silently dropping out of the explorer. Owners: ML platform team; consumers: SRE on-call, Customer Engineering, and the Incident Commander rotation.',
       timeRestore: false,
     },
     references: [
       { type: 'tag', id: 'tag-development', name: 'Development' },
       { type: 'tag', id: 'tag-important', name: 'Important' },
+      { type: 'tag', id: 'tag-security', name: 'Security' },
+      { type: 'tag', id: 'tag-archived', name: 'Archived' },
+      { type: 'tag', id: 'fleet-pkg-endpoint-default', name: 'Elastic Defend' },
+      { type: 'tag', id: 'fleet-managed-default', name: 'Managed' },
     ],
     managed: false,
     canFavorite: true,
   },
+  // ts-ds-gf — baseline short/short/few row, the most "typical" content
+  // shape.
   {
     id: 'dashboard-008',
     type: 'dashboard',
@@ -157,14 +203,16 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-03-05T09:15:00.000Z',
     createdBy: 'u_john_smith',
     attributes: {
-      title: 'Uptime Monitoring',
-      description: 'Monitor service uptime and availability',
+      title: 'Uptime',
+      description: 'Service uptime and availability.',
       timeRestore: true,
     },
     references: [{ type: 'tag', id: 'tag-production', name: 'Production' }],
     managed: false,
     canFavorite: true,
   },
+  // tm-d0-gf — medium title + no description + few tags. Exercises the
+  // "tags only" wrap behavior (tags fill the row alongside the title).
   {
     id: 'dashboard-009',
     type: 'dashboard',
@@ -172,24 +220,35 @@ export const MOCK_DASHBOARDS: DashboardMockItem[] = [
     createdAt: '2025-02-18T08:00:00.000Z',
     attributes: {
       title: 'Legacy Metrics Overview',
-      description: 'Imported before user tracking was enabled',
       timeRestore: false,
     },
-    references: [{ type: 'tag', id: 'tag-archived', name: 'Archived' }],
+    references: [
+      { type: 'tag', id: 'tag-archived', name: 'Archived' },
+      { type: 'tag', id: 'tag-development', name: 'Development' },
+    ],
     managed: false,
     canFavorite: true,
   },
+  // tl-ds-gm — long title + short description + many tags. Title and tag
+  // chain compete for horizontal space when the row tries to pack inline.
   {
     id: 'dashboard-010',
     type: 'dashboard',
     updatedAt: '2025-06-05T16:30:00.000Z',
     createdAt: '2025-01-10T12:00:00.000Z',
     attributes: {
-      title: 'API-Created Dashboard',
-      description: 'Created via the saved objects API without a user context',
+      title:
+        'API-Created Dashboard With An Auto-Generated Name From Continuous Saved-Objects Imports',
+      description: 'Imported via the saved-objects API without a user context.',
       timeRestore: false,
     },
-    references: [],
+    references: [
+      { type: 'tag', id: 'tag-production', name: 'Production' },
+      { type: 'tag', id: 'tag-archived', name: 'Archived' },
+      { type: 'tag', id: 'tag-development', name: 'Development' },
+      { type: 'tag', id: 'fleet-managed-default', name: 'Managed' },
+      { type: 'tag', id: 'fleet-pkg-endpoint-default', name: 'Elastic Defend' },
+    ],
     managed: false,
     canFavorite: true,
   },

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/files.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/files.ts
@@ -28,9 +28,21 @@ export interface FileMockItem extends UserContentCommonSchema {
 }
 
 /**
- * Mock file items
+ * Mock file items.
+ *
+ * Tuned to span the name-cell permutation matrix (short/long filename ×
+ * empty/short/long description) so the Files Management stories exercise
+ * both the custom-render (`Original`) and `Column.Name showDescription`
+ * (`Proposal`) layouts at narrow and ≥ 2560px viewports. The Files story
+ * does not render tags inline, so the matrix collapses to `t × d` and
+ * tag counts are kept low. The matrix uses `t{s,m,l}` for filename
+ * length and `d{0,s,l}` for description length.
+ *
+ * No pinned IDs — story consumers iterate the list without ID
+ * references.
  */
 export const MOCK_FILES: FileMockItem[] = [
+  // ts-ds — short filename + short description. Baseline compact row.
   {
     id: 'file-001',
     type: 'file',
@@ -39,15 +51,17 @@ export const MOCK_FILES: FileMockItem[] = [
     createdAt: '2025-10-20T14:30:00.000Z',
     createdBy: 'u_665722084_cloud',
     attributes: {
-      title: 'quarterly-report-q3.pdf',
-      description: 'Q3 2025 quarterly financial report',
-      size: 2457600, // 2.4 MB
+      title: 'q3-report.pdf',
+      description: 'Q3 2025 financial report.',
+      size: 2457600,
       extension: 'pdf',
       mimeType: 'application/pdf',
       fileKind: 'reports',
     },
     references: [{ type: 'tag', id: 'tag-important', name: 'Important' }],
   },
+  // tl-ds — long descriptive filename + short description. Exercises
+  // filename truncation/wrap when paired with the description.
   {
     id: 'file-002',
     type: 'file',
@@ -56,15 +70,18 @@ export const MOCK_FILES: FileMockItem[] = [
     createdAt: '2025-09-15T10:00:00.000Z',
     createdBy: 'u_jane_doe',
     attributes: {
-      title: 'dashboard-screenshot.png',
-      description: 'Screenshot of main analytics dashboard',
-      size: 524288, // 512 KB
+      title:
+        'analytics-dashboard-overview-screenshot-with-annotations-2025-11-12-1080p-final-v3.png',
+      description: 'Primary dashboard screenshot.',
+      size: 524288,
       extension: 'png',
       mimeType: 'image/png',
       fileKind: 'images',
     },
     references: [],
   },
+  // ts-dl — short filename + long description. Description wraps across
+  // multiple lines while the filename stays on one.
   {
     id: 'file-003',
     type: 'file',
@@ -73,14 +90,17 @@ export const MOCK_FILES: FileMockItem[] = [
     createdBy: 'u_admin_local',
     attributes: {
       title: 'config-backup.json',
-      description: 'Kibana configuration backup',
-      size: 102400, // 100 KB
+      description:
+        'Full Kibana configuration backup captured nightly before the rolling restart; restores require running the bootstrap migration in order and validating the audit log seed before re-enabling alerting rules. The dump includes the encrypted saved-object payload, every space-scoped UI setting override, the registered connector secrets (re-keyed against the backup KMS), and the role/role-mapping graph as of the snapshot timestamp. Used as the canonical input for both disaster-recovery drills and the quarterly migration rehearsals; the file kind is pinned so the retention policy keeps it for 13 months even when general file pruning runs.',
+      size: 102400,
       extension: 'json',
       mimeType: 'application/json',
       fileKind: 'config',
     },
     references: [{ type: 'tag', id: 'tag-archived', name: 'Archived' }],
   },
+  // tl-dl — kitchen-sink row: long filename + long description. Both
+  // wrap at narrow widths; at wide viewports they share the wrap row.
   {
     id: 'file-004',
     type: 'file',
@@ -89,15 +109,19 @@ export const MOCK_FILES: FileMockItem[] = [
     createdAt: '2025-07-25T15:45:00.000Z',
     createdBy: 'u_john_smith',
     attributes: {
-      title: 'sample-data.csv',
-      description: 'Sample dataset for testing',
-      size: 1048576, // 1 MB
+      title:
+        'sample-data-ecommerce-orders-customers-products-categories-2025-q4-extended-with-returns-and-refunds.csv',
+      description:
+        'Mixed sample dataset combining ecommerce orders, customers, products, categories, returns, and refunds for the entire 2025 Q4 demo — used by the onboarding tutorial, the integration tests, and the canonical ESQL training notebook. Schema mirrors the production `ecommerce-*` index template so example queries copy-paste against real data without changes, and the customer identifiers are synthetic but referentially consistent (every refund row resolves back to an order, every order resolves to a customer and a SKU). Refresh cadence is quarterly; new versions roll forward by appending a `-vN` suffix rather than overwriting so referenced notebooks pin to a stable snapshot.',
+      size: 1048576,
       extension: 'csv',
       mimeType: 'text/csv',
       fileKind: 'data',
     },
     references: [{ type: 'tag', id: 'tag-development', name: 'Development' }],
   },
+  // tm-d0 — medium filename, no description. Exercises the "title only"
+  // path with a realistic filename.
   {
     id: 'file-005',
     type: 'file',
@@ -106,14 +130,14 @@ export const MOCK_FILES: FileMockItem[] = [
     createdBy: 'u_analyst_1',
     attributes: {
       title: 'security-audit-log.txt',
-      description: 'Security audit log export',
-      size: 5242880, // 5 MB
+      size: 5242880,
       extension: 'txt',
       mimeType: 'text/plain',
       fileKind: 'logs',
     },
     references: [{ type: 'tag', id: 'tag-security', name: 'Security' }],
   },
+  // ts-d0 — most-sparse row: short filename, no description.
   {
     id: 'file-006',
     type: 'file',
@@ -122,9 +146,8 @@ export const MOCK_FILES: FileMockItem[] = [
     createdAt: '2025-05-30T16:20:00.000Z',
     createdBy: 'u_665722084_cloud',
     attributes: {
-      title: 'architecture-diagram.svg',
-      description: 'System architecture diagram',
-      size: 204800, // 200 KB
+      title: 'arch.svg',
+      size: 204800,
       extension: 'svg',
       mimeType: 'image/svg+xml',
       fileKind: 'images',

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/maps.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/maps.ts
@@ -24,9 +24,22 @@ export interface MapMockItem extends UserContentCommonSchema {
 }
 
 /**
- * Mock map items
+ * Mock map items.
+ *
+ * Tuned to span the name-cell permutation matrix (short/long title ×
+ * empty/short/long description × no/few/many tags) so the Maps stories
+ * exercise both narrow-viewport column-stack and ≥ 2560px wrap-on-overflow
+ * layouts without a dedicated fixture. The matrix uses `t{s,m,l}` for
+ * title length, `d{0,s,l}` for description length, and `g{0,f,m}` for tag
+ * count.
+ *
+ * Pinned IDs preserved for story call-sites:
+ *
+ * - `map-001` — initial favorite (see `services.ts`).
  */
 export const MOCK_MAPS: MapMockItem[] = [
+  // ts-ds-gm — sparse-but-favorited (short title, short description, many
+  // tags). At wide viewports this row packs onto a single line.
   {
     id: 'map-001',
     type: 'map',
@@ -36,11 +49,19 @@ export const MOCK_MAPS: MapMockItem[] = [
     createdBy: 'u_665722084_cloud',
     managed: false,
     attributes: {
-      title: 'eCommerce Orders by Location',
-      description: 'Geographic distribution of eCommerce orders',
+      title: 'Orders',
+      description: 'Orders by storefront region.',
     },
-    references: [{ type: 'tag', id: 'tag-production', name: 'Production' }],
+    references: [
+      { type: 'tag', id: 'tag-production', name: 'Production' },
+      { type: 'tag', id: 'tag-important', name: 'Important' },
+      { type: 'tag', id: 'tag-security', name: 'Security' },
+      { type: 'tag', id: 'tag-development', name: 'Development' },
+      { type: 'tag', id: 'fleet-managed-default', name: 'Managed' },
+    ],
   },
+  // tl-dl-gf — prototypical rich row. At wide viewports the long title
+  // sits on its own line and the description wraps below.
   {
     id: 'map-002',
     type: 'map',
@@ -50,11 +71,14 @@ export const MOCK_MAPS: MapMockItem[] = [
     createdBy: 'u_jane_doe',
     managed: false,
     attributes: {
-      title: 'Flight Routes Visualization',
-      description: 'Interactive map of flight routes and destinations',
+      title: 'Flight Routes — Carrier, Aircraft Type, Arrival Punctuality & Seasonal Demand',
+      description:
+        'Interactive map of mock flight routes for ES-Air, Logstash Airways, and Kibana Airlines with overlays for carrier, aircraft type, on-time performance, and seasonal demand variance — designed for the Network Planning team during quarterly route reviews. Includes a great-circle layer for scheduled corridors, a heatmap of cancellation-cause attribution at the destination airport, and a per-route load-factor choropleth that crossfilters with the codeshare partner picker in the legend. Time slider snaps to the quarterly review window by default; tooltips link out to the originating flight log, the maintenance backlog for the assigned tail number, and the slot-allocation sheet for both endpoints.',
     },
     references: [{ type: 'tag', id: 'tag-development', name: 'Development' }],
   },
+  // ts-dl-gf — short title + long description; description wraps within
+  // its cell while the short title and few tags stay inline.
   {
     id: 'map-003',
     type: 'map',
@@ -64,14 +88,17 @@ export const MOCK_MAPS: MapMockItem[] = [
     createdBy: 'u_admin_local',
     managed: false,
     attributes: {
-      title: 'Web Traffic by Country',
-      description: 'Heatmap of website visitors by geographic location',
+      title: 'Traffic',
+      description:
+        'Heatmap of elastic.co visitors aggregated by geographic location with drill-downs by country, region, and acquisition channel; refreshed daily and intended for the Growth and Marketing teams. The base layer is a clustered hexbin of session origins enriched with the regional sales-territory overlay so marketing campaigns can be scoped to a specific GTM motion. A second layer plots inbound link sources (search, social, partner referral, organic docs) and animates intra-day cadence so the team can spot campaign blasts that briefly distort the underlying organic baseline. Click-through on any cell opens the matching pre-filtered Lens dashboard.',
     },
     references: [
       { type: 'tag', id: 'tag-production', name: 'Production' },
       { type: 'tag', id: 'tag-important', name: 'Important' },
     ],
   },
+  // tl-ds-g0 — managed long-title row with a short description and no
+  // tags. Wide viewports surface the long title alone on its line.
   {
     id: 'map-004',
     type: 'map',
@@ -80,11 +107,13 @@ export const MOCK_MAPS: MapMockItem[] = [
     createdBy: 'u_john_smith',
     managed: true,
     attributes: {
-      title: 'Infrastructure Locations',
-      description: 'Data center and server locations worldwide',
+      title: 'Infrastructure Locations — Cross-Region Data Centers, Edge POPs & On-Call Coverage',
+      description: 'Per-site rollups.',
     },
     references: [],
   },
+  // ts-d0-g0 — most-sparse row: title only, nothing else. At wide
+  // viewports the cell renders a single inline element.
   {
     id: 'map-005',
     type: 'map',
@@ -94,9 +123,8 @@ export const MOCK_MAPS: MapMockItem[] = [
     createdBy: 'u_analyst_1',
     managed: false,
     attributes: {
-      title: 'Security Threats Heatmap',
-      description: 'Geographic distribution of detected security threats',
+      title: 'Threats',
     },
-    references: [{ type: 'tag', id: 'tag-security', name: 'Security' }],
+    references: [],
   },
 ];

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/visualizations.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/visualizations.ts
@@ -35,9 +35,23 @@ export interface VisualizationMockItem extends UserContentCommonSchema {
 }
 
 /**
- * Mock visualization items
+ * Mock visualization items.
+ *
+ * Tuned to span the name-cell permutation matrix (short/long title ×
+ * empty/short/long description × no/few/many tags) so consumers of this
+ * fixture exercise both narrow-viewport column-stack and ≥ 2560px
+ * wrap-on-overflow layouts. The matrix uses `t{s,m,l}` for title length,
+ * `d{0,s,l}` for description length, and `g{0,f,m}` for tag count.
+ * `visType` is held variety-rich so the fixture also covers the
+ * type-icon code path.
+ *
+ * Pinned IDs preserved for story call-sites:
+ *
+ * - `vis-001` — initial favorite (see `services.ts`).
  */
 export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
+  // ts-ds-gm — sparse-but-favorited (short title, short description, many
+  // tags). Wide viewports pack this row onto a single line.
   {
     id: 'vis-001',
     type: 'visualization',
@@ -48,8 +62,8 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     managed: false,
     attributes: {
       id: 'vis-001',
-      title: 'Revenue Over Time',
-      description: 'Line chart showing revenue trends',
+      title: 'Revenue',
+      description: 'Daily revenue trend.',
       visType: 'lens',
       typeTitle: 'Lens',
       icon: 'lensApp',
@@ -59,8 +73,15 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
       editUrl: '/app/lens#/edit/vis-001',
       editApp: 'lens',
     },
-    references: [{ type: 'tag', id: 'tag-production', name: 'Production' }],
+    references: [
+      { type: 'tag', id: 'tag-production', name: 'Production' },
+      { type: 'tag', id: 'tag-important', name: 'Important' },
+      { type: 'tag', id: 'tag-security', name: 'Security' },
+      { type: 'tag', id: 'tag-development', name: 'Development' },
+      { type: 'tag', id: 'fleet-managed-default', name: 'Managed' },
+    ],
   },
+  // tm-ds-gf — baseline medium/short/few row, the most "typical" shape.
   {
     id: 'vis-002',
     type: 'visualization',
@@ -72,7 +93,7 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     attributes: {
       id: 'vis-002',
       title: 'Order Distribution by Category',
-      description: 'Pie chart of orders by product category',
+      description: 'Pie chart of orders by product category.',
       visType: 'pie',
       typeTitle: 'Pie',
       icon: 'chartPie',
@@ -83,6 +104,8 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     },
     references: [{ type: 'tag', id: 'tag-important', name: 'Important' }],
   },
+  // ts-dl-g0 — short title, long description, no tags. Description wraps
+  // within its cell at wide viewports.
   {
     id: 'vis-003',
     type: 'visualization',
@@ -92,8 +115,9 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     managed: false,
     attributes: {
       id: 'vis-003',
-      title: 'Top Products Table',
-      description: 'Data table of top selling products',
+      title: 'Top Products',
+      description:
+        'Data table of best-selling SKUs across all storefronts with breakdowns by region, channel, and seasonal demand variance — refreshed nightly and intended as the canonical source for Merchandising weekly reviews. Columns include 7-day units sold, 28-day rolling revenue, return rate, in-stock percentage at the regional DC, and the assigned merchandising owner; each row links into the SKU master record, the demand-forecast notebook, and the markdown-decision audit trail. Seasonality is normalized against the prior-year curve so a launch week does not visually dominate the long tail. Anchored to `ecommerce-*` plus the regional inventory data view.',
       visType: 'table',
       typeTitle: 'Data Table',
       icon: 'table',
@@ -104,6 +128,8 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     },
     references: [],
   },
+  // tl-ds-gf — long title, short description, few tags. Title and the
+  // tag chain compete for horizontal space when the row tries to pack.
   {
     id: 'vis-004',
     type: 'visualization',
@@ -114,8 +140,9 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     managed: false,
     attributes: {
       id: 'vis-004',
-      title: 'Server Response Times',
-      description: 'Area chart of server response latencies',
+      title:
+        'Server Response Times — p50, p95, p99 Latencies by Region, Endpoint & Deployment Channel',
+      description: 'Per-endpoint latency.',
       visType: 'area',
       typeTitle: 'Area',
       icon: 'chartArea',
@@ -126,6 +153,8 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     },
     references: [{ type: 'tag', id: 'tag-development', name: 'Development' }],
   },
+  // tl-dl-gm — managed kitchen-sink row: long title + long description +
+  // many tags. At wide viewports each part wraps to its own line.
   {
     id: 'vis-005',
     type: 'visualization',
@@ -135,8 +164,10 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     managed: true,
     attributes: {
       id: 'vis-005',
-      title: 'Alert Count Metric',
-      description: 'Single metric showing total alerts',
+      title:
+        'Alert Count — Cross-Cluster Totals With Severity, Source, and On-Call Rotation Breakdowns',
+      description:
+        'Single metric showing the cluster-wide alert count rolled up across all configured detectors, with drill-downs into severity, originating source, and the on-call rotation assignment in effect at firing time. Pairs with the incident triage workspace and is embedded at the top of the Security and SRE landing pages so the on-call always sees the live total before opening any individual rule. The metric reconciles dedupe windows across the Defend, Endpoint, and stack-monitoring rule packs so a single root cause that fires across packs counts once; suppressions, snoozes, and acknowledged-but-open alerts are tracked in companion sparklines and surfaced as the trend annotation.',
       visType: 'metric',
       typeTitle: 'Metric',
       icon: 'chartMetric',
@@ -145,8 +176,15 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     editor: {
       editUrl: '/app/visualize#/edit/vis-005',
     },
-    references: [{ type: 'tag', id: 'tag-security', name: 'Security' }],
+    references: [
+      { type: 'tag', id: 'tag-security', name: 'Security' },
+      { type: 'tag', id: 'tag-important', name: 'Important' },
+      { type: 'tag', id: 'tag-archived', name: 'Archived' },
+      { type: 'tag', id: 'fleet-pkg-endpoint-default', name: 'Elastic Defend' },
+      { type: 'tag', id: 'fleet-managed-default', name: 'Managed' },
+    ],
   },
+  // ts-d0-g0 — most-sparse row: title only.
   {
     id: 'vis-006',
     type: 'visualization',
@@ -157,8 +195,7 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     managed: false,
     attributes: {
       id: 'vis-006',
-      title: 'Tag Cloud - Keywords',
-      description: 'Word cloud of popular search terms',
+      title: 'Keywords',
       visType: 'tagcloud',
       typeTitle: 'Tag Cloud',
       icon: 'chartTagCloud',
@@ -167,8 +204,10 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     editor: {
       editUrl: '/app/visualize#/edit/vis-006',
     },
-    references: [{ type: 'tag', id: 'tag-archived', name: 'Archived' }],
+    references: [],
   },
+  // tl-dl-gf — prototypical rich row: long title + long description with
+  // few tags. Title sits on its own line and the description wraps below.
   {
     id: 'vis-007',
     type: 'visualization',
@@ -179,8 +218,9 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     managed: false,
     attributes: {
       id: 'vis-007',
-      title: 'Custom Vega Chart',
-      description: 'Advanced visualization using Vega-Lite',
+      title: 'Custom Vega Chart — Multi-Series Latency Distribution With Cohort Annotations',
+      description:
+        'Advanced visualization rendered with Vega-Lite that overlays multi-series latency distributions with rolling-window cohort annotations; intended for performance regression triage during release sign-off. Each series renders the p50/p95/p99 ribbon for one upstream service with a faceted overlay for the requesting client cohort so a regression isolated to a single client SDK version is visually obvious. Annotation layers cross-reference the deploy stream, feature-flag flips, and any active scheduled load test so a spike that coincides with a soak-test window does not get mis-attributed to a deploy. Vega spec lives in the saved-object body; a sibling ES|QL panel exposes the underlying query for engineers who want to fork the chart for ad-hoc analysis.',
       visType: 'vega',
       typeTitle: 'Vega',
       icon: 'code',
@@ -191,6 +231,9 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     },
     references: [{ type: 'tag', id: 'tag-development', name: 'Development' }],
   },
+  // tm-d0-gf — medium title, no description, few tags. Exercises the
+  // "tags only" wrap behavior (tags fill the row alongside the title).
+  // Also exercises the `error` rendering path.
   {
     id: 'vis-008',
     type: 'visualization',
@@ -201,7 +244,6 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
     attributes: {
       id: 'vis-008',
       title: 'Broken Visualization',
-      description: 'This visualization has an error',
       visType: 'line',
       typeTitle: 'Line',
       icon: 'chartLine',
@@ -209,6 +251,9 @@ export const MOCK_VISUALIZATIONS: VisualizationMockItem[] = [
       error: 'Index pattern not found: logs-*',
     },
     error: 'Index pattern not found: logs-*',
-    references: [],
+    references: [
+      { type: 'tag', id: 'tag-archived', name: 'Archived' },
+      { type: 'tag', id: 'tag-development', name: 'Development' },
+    ],
   },
 ];

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/README.md
@@ -79,6 +79,8 @@ There is no DOM, accessibility, or clipboard impact: the rendered table has exac
 
 On viewports ≥ `2560px` (common 4K external displays), `ContentListTable` widens `Column.Name` from `64em` to `90em` via a media-query CSS override (`cssWideViewportNameWidth` in `content_list_table.tsx`). The trailing pseudo-cell still absorbs whatever horizontal slack remains, so populated sibling columns (`UpdatedAt`, `CreatedBy`, `Actions`, etc.) stay at their preferred footprints; only the Name column / spacer ratio shifts. Because EUI applies `width` / `max-width` as inline styles, the rule uses `!important` and so applies regardless of consumer-supplied `width` overrides — the wide-viewport bump is a cross-cutting layout decision rather than a per-instance default.
 
+At the same breakpoint, `NameCell` flips its in-cell title / description / tags from a column stack to a wrapping flex row (`flex-direction: row; flex-wrap: wrap`). Sparse rows (short title, short description, few tags) collapse onto a single line so the populated cells stay close to the next column; rich rows (long title or long description) wrap back to additional lines instead of being squeezed in-place. See `cssWideViewportNameWidth` and `NameCell` for the rationale.
+
 #### Overriding defaults
 
 There are two ways to opt out of a baked-in default:

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/breakpoints.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/breakpoints.ts
@@ -17,10 +17,16 @@
  */
 
 /**
- * Viewport width (px) at which `Column.Name` is allowed to grow past its
- * default `64em` cap. `2560px` matches a common 4K external display width
- * — at that size the default footprint leaves enough trailing whitespace
- * that giving some of it back to the title column is a clear win.
+ * Viewport width (px) at which two `Column.Name` layout adjustments kick in:
+ * 1. The column is allowed to grow past its default `64em` cap (see
+ *    `cssWideViewportNameWidth` in `content_list_table.tsx`).
+ * 2. The in-cell title/description/tags stack flips to a wrapping row so
+ *    sparse rows pull together instead of leaving a wide gap to the next
+ *    column (see `NameCell` in `column/name/name_cell.tsx`).
+ *
+ * `2560px` matches a common 4K external display width — at that size the
+ * default footprint leaves enough trailing whitespace that giving some of
+ * it back to the title column is a clear win.
  *
  * Not tied to a named EUI breakpoint because EUI tops out at `xl` (~1200px),
  * so the value would have to be a hard-coded magic number either way.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -43,7 +43,10 @@ const DEFAULT_ACTIONS_COLUMN_TITLE = i18n.translate(
  * EUI's action cells ship `flex-wrap: wrap` on desktop, which without
  * intervention would let the icons stack vertically when the column squeezes.
  * `cssActionsCellNoWrap` (in `content_list_table.tsx`) pins the cell's flex
- * container to `flex-wrap: nowrap` so the column's `min-width: 'max-content'`
+ * container to `flex-wrap: nowrap` — keyed on EUI's
+ * `td.euiTableRowCell--hasActions` so the rule actually matches body cells,
+ * not just the header (which is the only `<td>`/`<th>` that receives the
+ * column's `data-test-subj`) — so the column's `min-width: 'max-content'`
  * floor resolves to the full icon-row width and the auto table-layout
  * algorithm can't shrink the column past that point.
  *

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
@@ -98,14 +98,21 @@ export const NameCell = memo(
       [euiTheme]
     );
 
-    // Switches the name cell from column to row layout on wide viewports,
-    // and adds a gap between items in that layout.
+    // At ≥ 2560px (~4K), pull title/description/tags onto a shared row so
+    // sparse rows don't strand the populated cells in a tiny pocket on the
+    // left of an otherwise empty Name column. `flex-wrap: wrap` lets rich
+    // rows fall back to the column stack — a long description (or a long
+    // title) wraps to the next line instead of being squeezed by a sibling
+    // ({@link https://github.com/elastic/kibana/issues/271707}). `row-gap: 0`
+    // preserves the original column-stack visual when wrapping kicks in.
     const wideRowCss = useMemo(
       () => css`
         @media (min-width: ${WIDE_VIEWPORT_NAME_BREAKPOINT_PX}px) {
           flex-direction: row;
+          flex-wrap: wrap;
           align-items: center;
-          gap: ${euiTheme.size.s};
+          column-gap: ${euiTheme.size.s};
+          row-gap: 0;
         }
       `,
       [euiTheme]

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.test.tsx
@@ -14,6 +14,7 @@ import {
   contentListQueryClient,
   type FindItemsResult,
   type FindItemsParams,
+  type ContentListItemConfig,
 } from '@kbn/content-list-provider';
 import { ContentListTable, getRowId } from './content_list_table';
 
@@ -36,9 +37,11 @@ const createWrapper =
     findItems?: jest.Mock;
     isReadOnly?: boolean;
     getHref?: (item: { id: string }) => string;
+    item?: ContentListItemConfig;
   }) =>
   ({ children }: { children: React.ReactNode }) => {
-    const { findItems = createFindItems(), isReadOnly, getHref } = options ?? {};
+    const { findItems = createFindItems(), isReadOnly, getHref, item } = options ?? {};
+    const resolvedItem = item ?? (getHref ? { getHref } : undefined);
 
     return (
       <ContentListProvider
@@ -46,7 +49,7 @@ const createWrapper =
         labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
         dataSource={{ findItems }}
         isReadOnly={isReadOnly}
-        item={getHref ? { getHref } : undefined}
+        item={resolvedItem}
       >
         {children}
       </ContentListProvider>
@@ -498,29 +501,58 @@ describe('ContentListTable', () => {
     });
 
     /**
-     * `Column.Actions` ships `min-width: 'max-content'` to keep its row icons
-     * (including EUI's auto-collapsed 3-dot overflow trigger) on a single
-     * line. That floor only resolves to the unwrapped icon-row width if the
-     * cell's flex container is forbidden from wrapping; otherwise EUI's
-     * default `flex-wrap: wrap` lets `max-content` collapse to the widest
-     * single icon and the column shrinks underneath the trigger.
+     * `Column.Actions` ships `min-width: 'max-content'` to keep its row
+     * icons (including EUI's auto-collapsed 3-dot overflow trigger) on a
+     * single line. That floor only resolves to the unwrapped icon-row
+     * width if the cell's flex container is forbidden from wrapping;
+     * otherwise EUI's default `flex-wrap: wrap` on
+     * `.euiTableCellContent` lets `max-content` collapse to the widest
+     * single icon and the column shrinks, stacking the icons vertically.
      *
-     * jsdom doesn't lay out tables, so we can't observe the visual outcome
-     * directly. We instead assert the CSS rule reaches the document — same
-     * approach as the wide-viewport `Column.Name` test above.
+     * Asserts that the override's selector actually matches body action
+     * cells in the DOM — not just that the rule text is present in a
+     * stylesheet. A previous incarnation of this override targeted
+     * `td[data-test-subj='content-list-table-column-actions']`, but
+     * `EuiBasicTable.renderItemActionsCell` never forwards a column's
+     * `data-test-subj` to its body `<td>` cells (only the header `<th>`
+     * receives it), so the selector matched zero nodes and the rule was
+     * dead. The old test only checked that the rule text was emitted,
+     * which is why the regression kept reappearing. The cascade itself
+     * isn't asserted because jsdom's `getComputedStyle` does not honor
+     * specificity reliably; in a real browser our `(0,3,1)` selector
+     * wins over EUI's single-class `(0,1,0)` rule.
      */
-    it('emits the actions-cell nowrap override as a CSS rule', async () => {
-      const Wrapper = createWrapper();
+    it('emits an actions-cell nowrap override whose selector matches body cells', async () => {
+      const Wrapper = createWrapper({ item: { actions: { delete: { onBulkAction: jest.fn() } } } });
+      const { Column, Action } = ContentListTable;
+
       render(
         <Wrapper>
-          <ContentListTable title="Dashboards" />
+          <ContentListTable title="Dashboards">
+            <Column.Name />
+            <Column.Actions>
+              <Action.Delete />
+            </Column.Actions>
+          </ContentListTable>
         </Wrapper>
       );
 
       expect(await screen.findByText('Dashboard One')).toBeInTheDocument();
 
+      // Sanity: EUI must be tagging body action `<td>`s with the class our
+      // selector anchors on. If this breaks, EUI's class naming changed
+      // and the override needs a new anchor.
+      const actionCells = document.querySelectorAll(
+        'td.euiTableRowCell--hasActions .euiTableCellContent'
+      );
+      expect(actionCells.length).toBeGreaterThan(0);
+
+      // Find the override in the stylesheet by its content (flex-wrap: nowrap
+      // anchored on .euiTableRowCell--hasActions). Scanning by content rather
+      // than by hashed Emotion class keeps the assertion stable across
+      // refactors of `cssActionsCellNoWrap`.
       const styleSheets = Array.from(document.styleSheets);
-      const allRulesText = styleSheets
+      const overrideRule = styleSheets
         .flatMap((sheet) => {
           try {
             return Array.from(sheet.cssRules);
@@ -528,12 +560,20 @@ describe('ContentListTable', () => {
             return [];
           }
         })
-        .map((rule) => rule.cssText)
-        .join('\n');
+        .find(
+          (rule): rule is CSSStyleRule =>
+            rule instanceof CSSStyleRule &&
+            rule.selectorText.includes('.euiTableRowCell--hasActions') &&
+            /nowrap/.test(rule.style.flexWrap ?? rule.cssText)
+        );
+      expect(overrideRule).toBeDefined();
 
-      expect(allRulesText).toMatch(
-        /td\[data-test-subj=['"]content-list-table-column-actions['"]\][^{]*\.euiTableCellContent[^{]*\{[^}]*flex-wrap:\s*nowrap/
-      );
+      // The crucial assertion the old test missed: the rule's selector must
+      // resolve to the same body action cells in the DOM. If a future
+      // refactor anchors the selector on something EUI doesn't emit (the
+      // original regression), this fails immediately.
+      const matchedByOverride = document.querySelectorAll(overrideRule!.selectorText);
+      expect(matchedByOverride.length).toBe(actionCells.length);
     });
 
     it('keeps cell counts in lockstep when consumers add their own columns', async () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -249,29 +249,41 @@ const cssWideViewportNameWidth = css`
  * 3-dot overflow trigger) on a single line at every viewport width.
  *
  * EUI's `euiTableCellContent` ships `flex-wrap: wrap` for action cells on
- * desktop (see `_table_cell_content.styles.js` in `@elastic/eui`). With the
- * wrap enabled, the cell's `max-content` intrinsic width collapses to the
- * widest single icon (~28px) instead of the full inline row, so the auto
- * table-layout algorithm happily shrinks the actions column whenever the
- * container squeezes — which lands the overflow trigger on a second line
- * underneath the primary icons.
+ * desktop (see the `hasActions.desktop` style in `_table_cell_content.styles.js`
+ * in `@elastic/eui`). With the wrap enabled, the cell's `max-content`
+ * intrinsic width collapses to the widest single icon (~28px) instead of
+ * the full inline row, so the auto table-layout algorithm happily shrinks
+ * the actions column whenever the container squeezes — which lands the
+ * overflow trigger (or the trailing icons) on a second line underneath
+ * the primary icons.
  *
  * Pinning the cell's flex container to `flex-wrap: nowrap` restores the
  * unwrapped intrinsic width (`36N + 12` at the default theme), so the
  * column's `min-width: 'max-content'` floor (set in
- * {@link buildActionsColumn}) actually holds at the icon-row width and the
- * browser stops shrinking the column past that point. When the rest of the
- * row genuinely cannot fit, `scrollableInline` takes over and the icons
- * stay inline inside the horizontal scroll instead of wrapping vertically.
+ * {@link buildActionsColumn}) actually holds at the icon-row width and
+ * the browser stops shrinking the column past that point. When the rest
+ * of the row genuinely cannot fit, `scrollableInline` takes over and the
+ * icons stay inline inside the horizontal scroll instead of wrapping
+ * vertically.
  *
- * Scoped via the column's `data-test-subj` rather than EUI's
- * `.euiTableCellContent--hasActions` class so the rule is anchored to our
- * column identity (stable across EUI internal CSS refactors) and limited
- * to the Content List actions column — leaving any other action columns
- * inside Kibana untouched.
+ * Anchored on `td.euiTableRowCell--hasActions` because that is the class
+ * EUI actually applies to body action `<td>`s
+ * ({@link https://github.com/elastic/eui/blob/main/packages/eui/src/components/table/table_row_cell.tsx | `EuiTableRowCell`}).
+ * An earlier revision of this rule targeted
+ * `td[data-test-subj='content-list-table-column-actions']`, but
+ * `EuiBasicTable.renderItemActionsCell` does not forward the column's
+ * `data-test-subj` to the body cell — only the header `<th>` receives
+ * it — so the selector matched zero DOM nodes and the rule silently did
+ * nothing. The accompanying unit test only asserted the rule text was
+ * in the stylesheet, which is why the regression kept reappearing.
+ *
+ * The rule is scoped to this `ContentListTable` instance via the parent
+ * `<div className="euiBasicTable">` that the `tableCss` prop lands on,
+ * so other Kibana tables that use `EuiBasicTable` action columns are
+ * unaffected.
  */
 const cssActionsCellNoWrap = css`
-  td[data-test-subj='content-list-table-column-actions'] .euiTableCellContent {
+  td.euiTableRowCell--hasActions .euiTableCellContent {
     flex-wrap: nowrap;
   }
 `;

--- a/src/platform/packages/shared/content-management/kbn-content-management-storybook/README.md
+++ b/src/platform/packages/shared/content-management/kbn-content-management-storybook/README.md
@@ -159,10 +159,10 @@ All exports from `@kbn/content-list-mock-data` are available from this package:
 | `mockFindMaps` | Pre-configured `findItems` for map content. |
 | `mockFindFiles` | Pre-configured `findItems` for file content. |
 | `mockFindVisualizations` | Pre-configured `findItems` for visualization content. |
-| `MOCK_DASHBOARDS` | Array of 8 dashboard mock items. |
-| `MOCK_VISUALIZATIONS` | Array of 8 visualization mock items. |
-| `MOCK_MAPS` | Array of 5 map mock items. |
-| `MOCK_FILES` | Array of 6 file mock items. |
+| `MOCK_DASHBOARDS` | Array of 10 dashboard mock items spanning the name-cell `title × description × tag count` permutation matrix. |
+| `MOCK_VISUALIZATIONS` | Array of 8 visualization mock items spanning the name-cell permutation matrix and a variety of `visType`s. |
+| `MOCK_MAPS` | Array of 5 map mock items spanning the name-cell permutation matrix within a 5-item budget. |
+| `MOCK_FILES` | Array of 6 file mock items spanning the name-cell `title × description` matrix (no inline tags in the Files story). |
 | `MOCK_TAGS` | Array of 8 tag items. |
 | `MOCK_USER_PROFILES` | Array of user profile objects. |
 | `MOCK_USER_PROFILES_MAP` | Map of user UIDs to profile objects. |


### PR DESCRIPTION
## Summary

Closes #271707, and bundles a long-standing Actions cell wrap regression that recurred whenever EUI re-emitted the actions cell with `wrapText`.


<img width="1491" height="1810" alt="Screenshot 2026-06-02 at 2 10 34 PM" src="https://github.com/user-attachments/assets/24311379-e120-4191-a73b-33710617ac79" />
<img width="2650" height="1810" alt="Screenshot 2026-06-02 at 2 10 27 PM" src="https://github.com/user-attachments/assets/31145707-f854-4425-9287-73a014949f2f" />
<img width="3050" height="1810" alt="Screenshot 2026-06-02 at 2 10 22 PM" src="https://github.com/user-attachments/assets/2a122343-baf1-4812-8f4f-38626b935f81" />

### 1. Wide-viewport Name cell (`#271707`)

On viewports ≥ 2560px, `NameCell` flipped from a column stack to a single inline row, which crammed long titles and descriptions into the remaining width and pushed sibling cells (`CreatedBy`, `UpdatedAt`, `Actions`) far away. The intent of the breakpoint was to keep _sparse_ rows compact, not to squeeze _rich_ rows.

`NameCell.wideRowCss` now wraps on overflow: `flex-direction: row; flex-wrap: wrap` with `row-gap: 0`. Sparse rows still collapse onto one line, but long titles or descriptions wrap back to additional lines in-place — same intent at the breakpoint, no squish on rich content.

### 2. Actions cell wrap regression (no issue, but recurring)

This bug has popped back at least six times. The previous CSS override anchored on a `data-test-subj` selector that EUI does not forward to the body `<td>` (it only lives on the `<th>`). The only test for the override asserted the CSS rule _existed in the stylesheet_, not that it _matched any DOM elements_, so the dead selector was silently invisible to CI.

- `ContentListTable.cssActionsCellNoWrap` now anchors on `td.euiTableRowCell--hasActions .euiTableCellContent` — the class EUI actually applies to action cells in the body.
- The rewritten test asserts the override rule's `selectorText` matches the rendered cell elements (using `document.querySelectorAll(rule.selectorText)`), so a future selector drift will fail the test instead of silently disabling the rule.
- `actions_builder.tsx` JSDoc updated to reflect the corrected anchor.

### 3. Fixture permutation matrix

To make this layout work visible in existing stories without a dedicated wide-viewport story, the four Content List mock-data collections have been retuned to span the Name cell content permutation matrix — short/long title × empty/short/long description × no/few/many tags. Three "long" descriptions per fixture are multi-sentence so they actually exercise real wrapping at the breakpoint.

- `MOCK_DASHBOARDS` (10 items)
- `MOCK_MAPS` (5 items)
- `MOCK_VISUALIZATIONS` (8 items, retains `visType` variety)
- `MOCK_FILES` (6 items, title + description only)

Pinned IDs (used by story call-sites for favorites, managed flags, etc.) are preserved; each entry carries a leading comment naming its permutation cell.

## Changes

- `kbn-content-list-table/src/column/name/name_cell.tsx` — wrap-on-overflow `wideRowCss`.
- `kbn-content-list-table/src/breakpoints.ts` — JSDoc clarifying both layout adjustments.
- `kbn-content-list-table/src/content_list_table.tsx` — corrected `cssActionsCellNoWrap` selector and JSDoc.
- `kbn-content-list-table/src/content_list_table.test.tsx` — new test that verifies the selector matches live DOM.
- `kbn-content-list-table/src/column/actions/actions_builder.tsx` — updated JSDoc reference.
- `kbn-content-list-table/README.md` — wide-viewport section updated.
- `kbn-content-list-mock-data/storybook/{dashboards,maps,visualizations,files}.ts` — permutation matrix.
- `kbn-content-list-mock-data/README.md` and `kbn-content-management-storybook/README.md` — fixture intent documented.

## Test plan

- [ ] Run jest unit tests for `kbn-content-list-table` (covers actions-cell wrap regression test).
- [ ] Open the `content_management` storybook and browse Dashboard Listing → Original / Proposal / Bulk Delete Partition, Maps, Visualizations, and Files Management stories.
- [ ] Resize to ≥ 2560px and confirm: sparse rows collapse to a single line; rich rows wrap title / description / tags onto additional lines without horizontal squish.
- [ ] At any viewport, confirm the Actions column icons (Edit, Delete, etc.) stay on a single row and do not wrap, including when the cell contains the full edit/delete pair.

## Release notes
- Content List: long titles and descriptions no longer get horizontally squeezed at viewports ≥ 2560px; they wrap onto additional lines in-place.
- Content List: Actions column icons no longer wrap vertically when both Edit and Delete are present.