### PR TITLE
 [Console] Add Buildkite pipeline to publish @kbn/one-console to artifactory

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-console-packaging-publish.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-console-packaging-publish.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-console-packaging-publish
+  description: Builds and publishes @kbn/one-console to Artifactory on each merge to main when console code changes
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-console-packaging-publish'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  owner: 'group:kibana-management'
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / console / packaging / publish
+      description: Builds and publishes @kbn/one-console to Artifactory on each merge to main when console code changes
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-management'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+      allow_rebuilds: true
+      branch_configuration: main
+      default_branch: main
+      repository: elastic/kibana
+      pipeline_file: .buildkite/pipelines/console_packaging_publish.yml
+      skip_intermediate_builds: false
+      provider_settings:
+        build_branches: true
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: code
+        build_tags: false
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: false
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        kibana-management:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-tech-leads:
+          access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -20,6 +20,7 @@ spec:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-chromium-linux-build.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-codeql.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-console-packaging-publish.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-deploy-cloud.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-deploy-project.yml

--- a/.buildkite/pipelines/console_packaging_publish.yml
+++ b/.buildkite/pipelines/console_packaging_publish.yml
@@ -1,0 +1,9 @@
+steps:
+  - command: .buildkite/scripts/steps/console_packaging_publish.sh
+    label: console packaging publish
+    timeout_in_minutes: 30
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-2

--- a/.buildkite/scripts/steps/console_packaging_publish.sh
+++ b/.buildkite/scripts/steps/console_packaging_publish.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish pipeline for @kbn/one-console.
+#
+# On each merge to main, detect whether any relevant console source changed
+# (excluding server/ and test/), run the packaging build, stamp the version
+# as 0.0.0-<git-sha> and npm-publish the resulting tarball to Artifactory.
+#
+# Env overrides:
+#   DRY_RUN=1         — build everything but skip the publish step.
+#   BASE_REF=<ref>    — override the git base used for change detection.
+#   FORCE_ALL=1       — build and publish regardless of diff.
+#   SKIP_BOOTSTRAP=1  — skip `yarn kbn bootstrap` (local re-runs).
+#   SKIP_BUILD=1      — skip packaging/scripts/build.sh; use whatever is
+#                       already in target/ (useful when re-running after a
+#                       successful build, or when testing the publish logic).
+
+report_step() {
+  echo "--- $1"
+}
+
+KIBANA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$KIBANA_ROOT"
+
+source .buildkite/scripts/common/vault_fns.sh
+
+if [[ "${SKIP_BOOTSTRAP:-}" == "1" ]]; then
+  report_step "Bootstrap (skipped via SKIP_BOOTSTRAP=1)"
+else
+  report_step "Bootstrap"
+  .buildkite/scripts/bootstrap.sh
+fi
+
+# ---- Change detection -------------------------------------------------------
+
+if [[ -n "${BASE_REF:-}" ]]; then
+  base_ref="$BASE_REF"
+elif [[ -n "${BUILDKITE_COMMIT:-}" ]]; then
+  base_ref="${BUILDKITE_COMMIT}^"
+else
+  base_ref="HEAD^"
+fi
+
+CONSOLE_DIR="src/platform/plugins/shared/console"
+
+# Pipeline infrastructure files — a change here rebuilds regardless of source diff.
+PIPELINE_FILES=(
+  ".buildkite/pipelines/console_packaging_publish.yml"
+  ".buildkite/scripts/steps/console_packaging_publish.sh"
+  ".buildkite/pipeline-resource-definitions/kibana-console-packaging-publish.yml"
+)
+
+report_step "Detect changes (base=$base_ref)"
+
+if [[ "${FORCE_ALL:-}" == "1" ]]; then
+  do_build=1
+  echo "FORCE_ALL=1 — building unconditionally."
+else
+  # Console source changes, excluding server/, test/, and build artifacts.
+  console_changed="$(git diff --name-only "$base_ref" HEAD -- "$CONSOLE_DIR/" |
+    grep -v "^${CONSOLE_DIR}/test/" |
+    grep -v "^${CONSOLE_DIR}/server/" |
+    grep -v "^${CONSOLE_DIR}/packaging/target/" || true)"
+
+  # Pipeline file changes also trigger a rebuild.
+  pipeline_changed="$(git diff --name-only "$base_ref" HEAD -- "${PIPELINE_FILES[@]}" || true)"
+
+  if [[ -n "$console_changed" || -n "$pipeline_changed" ]]; then
+    do_build=1
+    echo "Changed files:"
+    if [[ -n "$console_changed" ]]; then
+      echo "$console_changed" | sed 's/^/  - /'
+    fi
+    if [[ -n "$pipeline_changed" ]]; then
+      echo "$pipeline_changed" | sed 's/^/  - /'
+    fi
+  else
+    do_build=0
+  fi
+fi
+
+if [[ "${do_build:-0}" == "0" ]]; then
+  echo "No relevant console changes detected. Exiting."
+  exit 0
+fi
+
+# ---- Build ------------------------------------------------------------------
+
+PACKAGING_DIR="$KIBANA_ROOT/$CONSOLE_DIR/packaging"
+TARGET_DIR="$PACKAGING_DIR/target"
+
+if [[ "${SKIP_BUILD:-}" == "1" ]]; then
+  report_step "Build @kbn/one-console (skipped via SKIP_BUILD=1)"
+else
+  report_step "Build @kbn/one-console"
+  "$PACKAGING_DIR/scripts/build.sh"
+fi
+
+# ---- Prepare tarball --------------------------------------------------------
+
+report_step "Prepare tarball"
+
+# Write a publish-ready package.json into target/: fix the relative paths that
+# point from packaging/ → target/ (../target/index.js) to paths relative to
+# where the file will live inside the tarball (./index.js).
+node -e "
+  const fs = require('fs');
+  const src = JSON.parse(fs.readFileSync('$PACKAGING_DIR/package.json', 'utf8'));
+  src.main = './index.js';
+  src.types = './index.d.ts';
+  delete src.private;
+  fs.writeFileSync('$TARGET_DIR/package.json', JSON.stringify(src, null, 2) + '\n');
+"
+
+GIT_HASH="${BUILDKITE_COMMIT:-$(git rev-parse HEAD)}"
+VERSION="0.0.0-${GIT_HASH:0:12}"
+
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('$TARGET_DIR/package.json', 'utf8'));
+  p.version = '$VERSION';
+  fs.writeFileSync('$TARGET_DIR/package.json', JSON.stringify(p, null, 2) + '\n');
+  console.log('  ' + p.name + '@' + p.version);
+"
+
+rm -f "$TARGET_DIR"/*.tgz
+(cd "$TARGET_DIR" && npm pack --pack-destination "$TARGET_DIR" > /dev/null)
+TARBALL="$(ls -t "$TARGET_DIR"/*.tgz | head -1)"
+
+if [[ -z "$TARBALL" ]]; then
+  echo "ERROR: no tarball produced." >&2
+  exit 1
+fi
+
+echo "Tarball: $(basename "$TARBALL")"
+
+# ---- Publish ----------------------------------------------------------------
+
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  report_step "DRY_RUN=1 — skipping publish. Built tarball:"
+  echo "  $TARBALL"
+  exit 0
+fi
+
+report_step "Fetching Artifactory credentials"
+NPM_REGISTRY="$(vault_get kbn-ui-artifactory registry)"
+NPM_TOKEN="$(vault_get kbn-ui-artifactory npm_token)"
+if [[ -z "$NPM_REGISTRY" || -z "$NPM_TOKEN" ]]; then
+  echo "ERROR: Artifactory credentials missing from vault." >&2
+  exit 1
+fi
+
+NPMRC="$(mktemp)"
+trap 'rm -f "$NPMRC"' EXIT
+REGISTRY_HOST="${NPM_REGISTRY#https:}"
+REGISTRY_HOST="${REGISTRY_HOST#http:}"
+cat > "$NPMRC" <<EOF
+@kbn:registry=${NPM_REGISTRY}
+${REGISTRY_HOST}:_authToken=${NPM_TOKEN}
+always-auth=true
+EOF
+
+PKG_MANIFEST="$TARGET_DIR/package.json"
+
+report_step "Publishing $(basename "$TARBALL") → $NPM_REGISTRY"
+npm publish "$TARBALL" --tag latest --userconfig "$NPMRC" || {
+  publish_rc=$?
+  if npm view "$(node -p "require('$PKG_MANIFEST').name")@$(node -p "require('$PKG_MANIFEST').version")" \
+       --userconfig "$NPMRC" >/dev/null 2>&1; then
+    echo "Already published at this version — no-op."
+  else
+    exit $publish_rc
+  fi
+}
+
+report_step "Done"

--- a/.buildkite/scripts/steps/console_packaging_publish.sh
+++ b/.buildkite/scripts/steps/console_packaging_publish.sh
@@ -44,7 +44,7 @@ fi
 
 CONSOLE_DIR="src/platform/plugins/shared/console"
 
-# Pipeline infrastructure files — a change here rebuilds regardless of source diff.
+# Pipeline infrastructure files, a change here rebuilds regardless of source diff.
 PIPELINE_FILES=(
   ".buildkite/pipelines/console_packaging_publish.yml"
   ".buildkite/scripts/steps/console_packaging_publish.sh"
@@ -102,7 +102,7 @@ fi
 report_step "Prepare tarball"
 
 # Write a publish-ready package.json into target/: fix the relative paths that
-# point from packaging/ → target/ (../target/index.js) to paths relative to
+# point from packaging/ -> target/ (../target/index.js) to paths relative to
 # where the file will live inside the tarball (./index.js).
 node -e "
   const fs = require('fs');

--- a/src/platform/plugins/shared/console/packaging/scripts/build.sh
+++ b/src/platform/plugins/shared/console/packaging/scripts/build.sh
@@ -57,7 +57,7 @@ echo "Build react TS definitions..."
 # tsc --outFile wraps everything in 'declare module "types" { ... }' which is
 # not usable as a package declaration. Compile first, then strip the wrapper,
 # dedent, and append the OneConsole component export.
-npx tsc "$CONSOLE_PACKAGING_DIR/react/types.ts" --declaration --emitDeclarationOnly --outFile "$OUTPUT_DIR/index.d.ts" --skipLibCheck
+"$KIBANA_ROOT/node_modules/.bin/tsc" "$CONSOLE_PACKAGING_DIR/react/types.ts" --declaration --emitDeclarationOnly --outFile "$OUTPUT_DIR/index.d.ts" --skipLibCheck
 node -e "
   const fs = require('fs');
   let src = fs.readFileSync('$OUTPUT_DIR/index.d.ts', 'utf8');

--- a/src/platform/plugins/shared/console/packaging/scripts/build.sh
+++ b/src/platform/plugins/shared/console/packaging/scripts/build.sh
@@ -3,12 +3,14 @@
 # Exit on any error
 set -e
 
-# Default output directory
-OUTPUT_DIR="../../../console/packaging/target"
+# Resolve paths relative to this script's location so the script works
+# regardless of the caller's working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIBANA_ROOT="$(cd "$SCRIPT_DIR/../../../../../../.." && pwd)"
+CONSOLE_PACKAGING_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Set directory variables
-KIBANA_ROOT="../../../../../../.."
-CONSOLE_PACKAGING_DIR="$(pwd)"
+# Default output directory
+OUTPUT_DIR="$CONSOLE_PACKAGING_DIR/target"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/src/platform/plugins/shared/console/packaging/scripts/build.sh
+++ b/src/platform/plugins/shared/console/packaging/scripts/build.sh
@@ -52,7 +52,25 @@ cd "$KIBANA_ROOT" && NODE_ENV=production BUILD_OUTPUT_DIR="$OUTPUT_DIR" yarn web
 cd "$CONSOLE_PACKAGING_DIR"
 
 echo "Build react TS definitions..."
+# tsc --outFile wraps everything in 'declare module "types" { ... }' which is
+# not usable as a package declaration. Compile first, then strip the wrapper,
+# dedent, and append the OneConsole component export.
 npx tsc ../react/types.ts --declaration --emitDeclarationOnly --outFile "$OUTPUT_DIR/index.d.ts" --skipLibCheck
+node -e "
+  const fs = require('fs');
+  let src = fs.readFileSync('$OUTPUT_DIR/index.d.ts', 'utf8');
+  // Strip 'declare module \"types\" {' header line and closing '}'
+  src = src
+    .split('\n')
+    .filter(l => !l.match(/^declare module \"types\" \{/))
+    .join('\n')
+    .replace(/\n\}\n?$/, '\n');
+  // Dedent 4 spaces added by the module wrapper
+  src = src.split('\n').map(l => l.startsWith('    ') ? l.slice(4) : l).join('\n').trimEnd();
+  // Append the component export (no React import needed — 'any' keeps it portable)
+  src += '\nexport declare function OneConsole(props: OneConsoleProps): any;\n';
+  fs.writeFileSync('$OUTPUT_DIR/index.d.ts', src);
+"
 
 echo "Build complete! Files generated in: $OUTPUT_DIR"
 ls -la "$OUTPUT_DIR/"

--- a/src/platform/plugins/shared/console/packaging/scripts/build.sh
+++ b/src/platform/plugins/shared/console/packaging/scripts/build.sh
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --help|-h)
       echo "Usage: $0 [--output-dir|-o <directory>]"
-      echo "  --output-dir, -o    Output directory for build assets (default: ../../../console/packaging/target)"
+      echo "  --output-dir, -o    Output directory for build assets (default: <packaging>/target)"
       exit 0
       ;;
     *)
@@ -57,7 +57,7 @@ echo "Build react TS definitions..."
 # tsc --outFile wraps everything in 'declare module "types" { ... }' which is
 # not usable as a package declaration. Compile first, then strip the wrapper,
 # dedent, and append the OneConsole component export.
-npx tsc ../react/types.ts --declaration --emitDeclarationOnly --outFile "$OUTPUT_DIR/index.d.ts" --skipLibCheck
+npx tsc "$CONSOLE_PACKAGING_DIR/react/types.ts" --declaration --emitDeclarationOnly --outFile "$OUTPUT_DIR/index.d.ts" --skipLibCheck
 node -e "
   const fs = require('fs');
   let src = fs.readFileSync('$OUTPUT_DIR/index.d.ts', 'utf8');


### PR DESCRIPTION
## Summary

Adds a post-merge pipeline that detects changes to the console plugin, builds the `@kbn/one-console` standalone package, and publishes it to the internal Artifactory npm registry. Versioning follows the same `0.0.0-<git-sha>` scheme used by the `kbn-ui` pipeline, and the same `kbn-ui-artifactory` vault secret is reused since it's the same registry. Also fixes the packaging/scripts/build.sh type declaration generation: the previous `tsc --outFile` invocation wrapped all exports in an unusable declare module "types" block and omitted the `OneConsole` component export entirely.


Staging buildkite job run: https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/382/canvas?sid=019e8791-dafe-4dc5-848b-128fe6a96729&tab=output