### PR TITLE
Fix webdriver unhandledPromptBehavior

### DIFF
--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
@@ -174,6 +174,7 @@ function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean
   options.setUserPreferences(chromiumUserPrefs);
   options.setLoggingPrefs(prefs);
   options.set('unexpectedAlertBehaviour', 'accept');
+  options.set('unhandledPromptBehavior', 'accept');
   options.setAcceptInsecureCerts(acceptInsecureCerts);
 
   return options;


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/271881

> [!NOTE]  
> I'm not exactly sure if this is a proper solution, this might need more research

This PR improves the FTR WebDriver configuration for Chromium-based browsers by setting the W3C `unhandledPromptBehavior` capability to `accept`.

This ensures native browser prompts, including `beforeunload` dialogs left open during test teardown, are accepted by ChromeDriver instead of causing lifecycle hooks to fail with `Unexpected dialog type beforeunload`.