### PR TITLE
[Console] Add missing ingest processors to autocomplete suggestions

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SpecDefinitionsService } from '../../../services';
+import { BOOLEAN } from './shared';
 
 const commonPipelineParams = {
   on_failure: [],
@@ -16,6 +17,7 @@ const commonPipelineParams = {
   },
   if: '',
   tag: '',
+  description: '',
 };
 
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/append-processor.html
@@ -31,6 +33,28 @@ const appendProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/attachment.html
+const attachmentProcessorDefinition = {
+  attachment: {
+    __template: {
+      field: '',
+    },
+    field: '',
+    target_field: 'attachment',
+    indexed_chars: 100000,
+    indexed_chars_field: '',
+    properties: [''],
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    remove_binary: {
+      __one_of: [false, true],
+    },
+    resource_name: '',
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/bytes-processor.html
 const bytesProcessorDefinition = {
   bytes: {
@@ -42,6 +66,23 @@ const bytesProcessorDefinition = {
     ignore_missing: {
       __one_of: [false, true],
     },
+    ...commonPipelineParams,
+  },
+};
+
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/cef-processor.html
+const cefProcessorDefinition = {
+  cef: {
+    __template: {
+      field: '',
+    },
+    field: '',
+    target_field: '',
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    ignore_empty_values: BOOLEAN,
+    timezone: 'UTC',
     ...commonPipelineParams,
   },
 };
@@ -67,6 +108,27 @@ const circleProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/community-id-processor.html
+const communityIdProcessorDefinition = {
+  community_id: {
+    __template: {},
+    source_ip: 'source.ip',
+    source_port: 'source.port',
+    destination_ip: 'destination.ip',
+    destination_port: 'destination.port',
+    iana_number: 'network.iana_number',
+    icmp_type: 'icmp.type',
+    icmp_code: 'icmp.code',
+    transport: '',
+    target_field: 'network.community_id',
+    seed: 0,
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/csv-processor.html
 const csvProcessorDefinition = {
   csv: {
@@ -79,9 +141,7 @@ const csvProcessorDefinition = {
     separator: '',
     quote: '',
     empty_value: '',
-    trim: {
-      __one_of: [true, false],
-    },
+    trim: BOOLEAN,
     ignore_missing: {
       __one_of: [false, true],
     },
@@ -194,9 +254,7 @@ const enrichProcessorDefinition = {
     ignore_missing: {
       __one_of: [false, true],
     },
-    override: {
-      __one_of: [true, false],
-    },
+    override: BOOLEAN,
     max_matches: 1,
     shape_relation: 'INTERSECTS',
     ...commonPipelineParams,
@@ -210,6 +268,25 @@ const failProcessorDefinition = {
       message: '',
     },
     message: '',
+    ...commonPipelineParams,
+  },
+};
+
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/fingerprint-processor.html
+const fingerprintProcessorDefinition = {
+  fingerprint: {
+    __template: {
+      fields: [],
+    },
+    fields: [],
+    target_field: 'fingerprint',
+    salt: '',
+    method: {
+      __one_of: ['SHA-1', 'SHA-256', 'SHA-512', 'MD5', 'MurmurHash3'],
+    },
+    ignore_missing: {
+      __one_of: [false, true],
+    },
     ...commonPipelineParams,
   },
 };
@@ -245,6 +322,33 @@ const geoipProcessorDefinition = {
     first_only: {
       __one_of: [false, true],
     },
+    ...commonPipelineParams,
+  },
+};
+
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-geo-grid-processor.html
+const geoGridProcessorDefinition = {
+  geo_grid: {
+    __template: {
+      field: '',
+      tile_type: '',
+    },
+    field: '',
+    tile_type: {
+      __one_of: ['geotile', 'geohex', 'geohash'],
+    },
+    target_field: '',
+    target_format: {
+      __one_of: ['GeoJSON', 'WKT'],
+    },
+    parent_field: '',
+    children_field: '',
+    non_children_field: '',
+    precision_field: '',
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    ...commonPipelineParams,
   },
 };
 
@@ -327,6 +431,24 @@ const inferenceProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ip-location-processor.html
+const ipLocationProcessorDefinition = {
+  ip_location: {
+    __template: {
+      field: '',
+    },
+    field: '',
+    target_field: 'ip_location',
+    database_file: '',
+    properties: [''],
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    first_only: BOOLEAN,
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/join-processor.html
 const joinProcessorDefinition = {
   join: {
@@ -389,6 +511,24 @@ const lowercaseProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/network-direction-processor.html
+const networkDirectionProcessorDefinition = {
+  network_direction: {
+    __template: {
+      internal_networks: [],
+    },
+    source_ip: 'source.ip',
+    destination_ip: 'destination.ip',
+    target_field: 'network.direction',
+    internal_networks: [],
+    internal_networks_field: '',
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline-processor.html
 const pipelineProcessorDefinition = {
   pipeline: {
@@ -411,6 +551,46 @@ const removeProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/redact-processor.html
+const redactProcessorDefinition = {
+  redact: {
+    __template: {
+      field: '',
+      patterns: [],
+    },
+    field: '',
+    patterns: [],
+    pattern_definitions: {},
+    prefix: '<',
+    suffix: '>',
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    skip_if_unlicensed: {
+      __one_of: [false, true],
+    },
+    trace_redact: {
+      __one_of: [false, true],
+    },
+    ...commonPipelineParams,
+  },
+};
+
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/registered-domain-processor.html
+const registeredDomainProcessorDefinition = {
+  registered_domain: {
+    __template: {
+      field: '',
+    },
+    field: '',
+    target_field: '',
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/rename-processor.html
 const renameProcessorDefinition = {
   rename: {
@@ -423,6 +603,17 @@ const renameProcessorDefinition = {
     ignore_missing: {
       __one_of: [false, true],
     },
+    ...commonPipelineParams,
+  },
+};
+
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/reroute-processor.html
+const rerouteProcessorDefinition = {
+  reroute: {
+    __template: {},
+    destination: '',
+    dataset: '',
+    namespace: '',
     ...commonPipelineParams,
   },
 };
@@ -449,9 +640,7 @@ const setProcessorDefinition = {
     },
     field: '',
     value: '',
-    override: {
-      __one_of: [true, false],
-    },
+    override: BOOLEAN,
     ...commonPipelineParams,
   },
 };
@@ -510,6 +699,14 @@ const trimProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/terminate-processor.html
+const terminateProcessorDefinition = {
+  terminate: {
+    __template: {},
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/uppercase-processor.html
 const uppercaseProcessorDefinition = {
   uppercase: {
@@ -539,6 +736,25 @@ const urlDecodeProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/uri-parts-processor.html
+const uriPartsProcessorDefinition = {
+  uri_parts: {
+    __template: {
+      field: '',
+    },
+    field: '',
+    target_field: 'url',
+    keep_original: BOOLEAN,
+    remove_if_successful: {
+      __one_of: [false, true],
+    },
+    ignore_missing: {
+      __one_of: [false, true],
+    },
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/user-agent-processor.html
 const userAgentProcessorDefinition = {
   user_agent: {
@@ -552,16 +768,20 @@ const userAgentProcessorDefinition = {
     ignore_missing: {
       __one_of: [false, true],
     },
+    ...commonPipelineParams,
   },
 };
 
 const processorDefinition = {
   __one_of: [
     appendProcessorDefinition,
+    attachmentProcessorDefinition,
     bytesProcessorDefinition,
-    csvProcessorDefinition,
+    cefProcessorDefinition,
     circleProcessorDefinition,
+    communityIdProcessorDefinition,
     convertProcessorDefinition,
+    csvProcessorDefinition,
     dateProcessorDefinition,
     dateIndexNameProcessorDefinition,
     dissectProcessorDefinition,
@@ -569,26 +789,35 @@ const processorDefinition = {
     dropProcessorDefinition,
     enrichProcessorDefinition,
     failProcessorDefinition,
+    fingerprintProcessorDefinition,
     foreachProcessorDefinition,
+    geoGridProcessorDefinition,
     geoipProcessorDefinition,
     grokProcessorDefinition,
     gsubProcessorDefinition,
     htmlStripProcessorDefinition,
     inferenceProcessorDefinition,
+    ipLocationProcessorDefinition,
     joinProcessorDefinition,
     jsonProcessorDefinition,
     kvProcessorDefinition,
     lowercaseProcessorDefinition,
+    networkDirectionProcessorDefinition,
     pipelineProcessorDefinition,
+    redactProcessorDefinition,
+    registeredDomainProcessorDefinition,
     removeProcessorDefinition,
     renameProcessorDefinition,
+    rerouteProcessorDefinition,
     scriptProcessorDefinition,
     setProcessorDefinition,
     setSecurityUserProcessorDefinition,
-    splitProcessorDefinition,
     sortProcessorDefinition,
+    splitProcessorDefinition,
+    terminateProcessorDefinition,
     trimProcessorDefinition,
     uppercaseProcessorDefinition,
+    uriPartsProcessorDefinition,
     urlDecodeProcessorDefinition,
     userAgentProcessorDefinition,
   ],

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
@@ -20,7 +20,7 @@ const commonPipelineParams = {
   description: '',
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/append-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/append-processor
 const appendProcessorDefinition = {
   append: {
     __template: {
@@ -33,7 +33,7 @@ const appendProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/attachment.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/attachment
 const attachmentProcessorDefinition = {
   attachment: {
     __template: {
@@ -55,7 +55,7 @@ const attachmentProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/bytes-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/bytes-processor
 const bytesProcessorDefinition = {
   bytes: {
     __template: {
@@ -70,7 +70,7 @@ const bytesProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/cef-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/cef-processor
 const cefProcessorDefinition = {
   cef: {
     __template: {
@@ -87,7 +87,7 @@ const cefProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-circle-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/ingest-circle-processor
 const circleProcessorDefinition = {
   circle: {
     __template: {
@@ -108,7 +108,7 @@ const circleProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/community-id-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/community-id-processor
 const communityIdProcessorDefinition = {
   community_id: {
     __template: {},
@@ -129,7 +129,7 @@ const communityIdProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/csv-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/csv-processor
 const csvProcessorDefinition = {
   csv: {
     __template: {
@@ -149,7 +149,7 @@ const csvProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/convert-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/convert-processor
 const convertProcessorDefinition = {
   convert: {
     __template: {
@@ -168,7 +168,7 @@ const convertProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/date-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/date-processor
 const dateProcessorDefinition = {
   date: {
     __template: {
@@ -184,7 +184,7 @@ const dateProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/date-index-name-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/date-index-name-processor
 const dateIndexNameProcessorDefinition = {
   date_index_name: {
     __template: {
@@ -203,7 +203,7 @@ const dateIndexNameProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/dissect-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/dissect-processor
 const dissectProcessorDefinition = {
   dissect: {
     __template: {
@@ -220,7 +220,7 @@ const dissectProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/dot-expand-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/dot-expand-processor
 const dotExpanderProcessorDefinition = {
   dot_expander: {
     __template: {
@@ -232,7 +232,7 @@ const dotExpanderProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/drop-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/drop-processor
 const dropProcessorDefinition = {
   drop: {
     __template: {},
@@ -240,7 +240,7 @@ const dropProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/enrich-processor
 const enrichProcessorDefinition = {
   enrich: {
     __template: {
@@ -261,7 +261,7 @@ const enrichProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/fail-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/fail-processor
 const failProcessorDefinition = {
   fail: {
     __template: {
@@ -272,7 +272,7 @@ const failProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/fingerprint-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/fingerprint-processor
 const fingerprintProcessorDefinition = {
   fingerprint: {
     __template: {
@@ -291,7 +291,7 @@ const fingerprintProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/foreach-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/foreach-processor
 const foreachProcessorDefinition = {
   foreach: {
     __template: {
@@ -306,7 +306,7 @@ const foreachProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/geoip-processor
 const geoipProcessorDefinition = {
   geoip: {
     __template: {
@@ -326,7 +326,7 @@ const geoipProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-geo-grid-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/ingest-geo-grid-processor
 const geoGridProcessorDefinition = {
   geo_grid: {
     __template: {
@@ -352,7 +352,7 @@ const geoGridProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/grok-processor
 const grokProcessorDefinition = {
   grok: {
     __template: {
@@ -372,7 +372,7 @@ const grokProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/gsub-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/gsub-processor
 const gsubProcessorDefinition = {
   gsub: {
     __template: {
@@ -387,7 +387,7 @@ const gsubProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/htmlstrip-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/htmlstrip-processor
 const htmlStripProcessorDefinition = {
   html_strip: {
     __template: {
@@ -402,7 +402,7 @@ const htmlStripProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/inference-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/inference-processor
 const inferenceProcessorDefinition = {
   inference: {
     __template: {
@@ -431,7 +431,7 @@ const inferenceProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ip-location-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/ip-location-processor
 const ipLocationProcessorDefinition = {
   ip_location: {
     __template: {
@@ -449,7 +449,7 @@ const ipLocationProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/join-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/join-processor
 const joinProcessorDefinition = {
   join: {
     __template: {
@@ -462,7 +462,7 @@ const joinProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/json-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/json-processor
 const jsonProcessorDefinition = {
   json: {
     __template: {
@@ -477,7 +477,7 @@ const jsonProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/kv-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/kv-processor
 const kvProcessorDefinition = {
   kv: {
     __template: {
@@ -497,7 +497,7 @@ const kvProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/lowercase-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/lowercase-processor
 const lowercaseProcessorDefinition = {
   lowercase: {
     __template: {
@@ -511,7 +511,7 @@ const lowercaseProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/network-direction-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/network-direction-processor
 const networkDirectionProcessorDefinition = {
   network_direction: {
     __template: {
@@ -529,7 +529,7 @@ const networkDirectionProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/pipeline-processor
 const pipelineProcessorDefinition = {
   pipeline: {
     __template: {
@@ -540,7 +540,7 @@ const pipelineProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/remove-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/remove-processor
 const removeProcessorDefinition = {
   remove: {
     __template: {
@@ -551,7 +551,7 @@ const removeProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/redact-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/redact-processor
 const redactProcessorDefinition = {
   redact: {
     __template: {
@@ -576,7 +576,7 @@ const redactProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/registered-domain-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/registered-domain-processor
 const registeredDomainProcessorDefinition = {
   registered_domain: {
     __template: {
@@ -591,7 +591,7 @@ const registeredDomainProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/rename-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/rename-processor
 const renameProcessorDefinition = {
   rename: {
     __template: {
@@ -607,7 +607,7 @@ const renameProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/reroute-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/reroute-processor
 const rerouteProcessorDefinition = {
   reroute: {
     __template: {},
@@ -618,7 +618,7 @@ const rerouteProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/script-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/script-processor
 const scriptProcessorDefinition = {
   script: {
     __template: {},
@@ -631,7 +631,7 @@ const scriptProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/set-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/set-processor
 const setProcessorDefinition = {
   set: {
     __template: {
@@ -645,7 +645,7 @@ const setProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-node-set-security-user-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/ingest-node-set-security-user-processor
 const setSecurityUserProcessorDefinition = {
   set_security_user: {
     __template: {
@@ -657,7 +657,7 @@ const setSecurityUserProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/split-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/split-processor
 const splitProcessorDefinition = {
   split: {
     __template: {
@@ -673,7 +673,7 @@ const splitProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/sort-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/sort-processor
 const sortProcessorDefinition = {
   sort: {
     __template: {
@@ -685,7 +685,7 @@ const sortProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/trim-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/trim-processor
 const trimProcessorDefinition = {
   trim: {
     __template: {
@@ -699,7 +699,7 @@ const trimProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/terminate-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/terminate-processor
 const terminateProcessorDefinition = {
   terminate: {
     __template: {},
@@ -707,7 +707,7 @@ const terminateProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/uppercase-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/uppercase-processor
 const uppercaseProcessorDefinition = {
   uppercase: {
     __template: {
@@ -721,7 +721,7 @@ const uppercaseProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/urldecode-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/urldecode-processor
 const urlDecodeProcessorDefinition = {
   urldecode: {
     __template: {
@@ -736,7 +736,7 @@ const urlDecodeProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/uri-parts-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/uri-parts-processor
 const uriPartsProcessorDefinition = {
   uri_parts: {
     __template: {
@@ -755,7 +755,7 @@ const uriPartsProcessorDefinition = {
   },
 };
 
-// Based on https://www.elastic.co/guide/en/elasticsearch/reference/master/user-agent-processor.html
+// Based on https://www.elastic.co/docs/reference/enrich-processor/user-agent-processor
 const userAgentProcessorDefinition = {
   user_agent: {
     __template: {

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
@@ -543,6 +543,14 @@ const pipelineProcessorDefinition = {
   },
 };
 
+// Based on https://www.elastic.co/docs/reference/enrich-processor/recover-failure-document-processor
+const recoverFailureDocumentProcessorDefinition = {
+  recover_failure_document: {
+    __template: {},
+    ...commonPipelineParams,
+  },
+};
+
 // Based on https://www.elastic.co/docs/reference/enrich-processor/remove-processor
 const removeProcessorDefinition = {
   remove: {
@@ -807,6 +815,7 @@ const processorDefinition = {
     lowercaseProcessorDefinition,
     networkDirectionProcessorDefinition,
     pipelineProcessorDefinition,
+    recoverFailureDocumentProcessorDefinition,
     redactProcessorDefinition,
     registeredDomainProcessorDefinition,
     removeProcessorDefinition,

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
@@ -43,7 +43,7 @@ const attachmentProcessorDefinition = {
     target_field: 'attachment',
     indexed_chars: 100000,
     indexed_chars_field: '',
-    max_field_bytes: '',
+    max_field_bytes: -1,
     properties: [''],
     ignore_missing: {
       __one_of: [false, true],

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/ingest.ts
@@ -43,6 +43,7 @@ const attachmentProcessorDefinition = {
     target_field: 'attachment',
     indexed_chars: 100000,
     indexed_chars_field: '',
+    max_field_bytes: '',
     properties: [''],
     ignore_missing: {
       __one_of: [false, true],
@@ -322,6 +323,7 @@ const geoipProcessorDefinition = {
     first_only: {
       __one_of: [false, true],
     },
+    download_database_on_pipeline_creation: BOOLEAN,
     ...commonPipelineParams,
   },
 };
@@ -445,6 +447,7 @@ const ipLocationProcessorDefinition = {
       __one_of: [false, true],
     },
     first_only: BOOLEAN,
+    download_database_on_pipeline_creation: BOOLEAN,
     ...commonPipelineParams,
   },
 };


### PR DESCRIPTION
Addresses #259253 (missing-processors half; the dynamic-templates half is #272278).

> Authored by @TimBosman; taken over to completion by kibana-management.

## Summary

- Adds the 13 ingest processors missing from Console autocomplete in `_ingest/pipeline` / `_ingest/pipeline/_simulate` bodies: `attachment`, `cef`, `community_id`, `fingerprint`, `geo_grid`, `ip_location`, `network_direction`, `recover_failure_document`, `redact`, `registered_domain`, `reroute`, `terminate`, `uri_parts` — including `reroute`, explicitly called out in #259253.
- Brings the processor catalog to parity with the Elasticsearch specification `ProcessorContainer` (**46/46**, verified programmatically via three-way set diff spec vs `main` vs this branch) **plus** `recover_failure_document`, which is GA-documented but missing from the spec (upstream spec gap, reported separately).
- Deliberately excluded: `normalize_for_stream` — documented but still `preview` (9.1), its shape may change before GA.
- Adds fields that entered the spec after the PR was opened: `attachment.max_field_bytes`, `geoip.download_database_on_pipeline_creation`, `ip_location.download_database_on_pipeline_creation`.
- Housekeeping: alphabetized processor list, shared `BOOLEAN` const, `description` added to common pipeline params, doc-link comments moved to the current `elastic.co/docs/reference/enrich-processor/*` URLs (spot-checked, all 200).

## Test Plan

- `node scripts/jest src/platform/plugins/shared/console/server/lib/spec_definitions` — pass
- `node scripts/eslint` on changed files — pass; `node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json` — pass
- Live-verified (local Kibana, this branch): typing `"re` inside a `_simulate` processor object (the exact repro from #259253) suggests `redact, registered_domain, remove, rename, reroute`; inside `"reroute": { }` the fields `dataset, destination, namespace` + common params are suggested.

## Screenshots

- `reroute` suggested in `_ingest/pipeline/_simulate`

<img width="620" height="380" alt="272246_reroute_suggested" src="https://github.com/user-attachments/assets/43a0b219-7be0-4e41-b502-a04122436a26" />


## Backport

- Enhancement ⇒ `backport:skip`. Also branch-blocked: `cef` does not exist in ES 8.19 and `max_field_bytes` is 9.5+.

Assisted with Copilot using Claude Fable 5

