### PR TITLE
Adds @skipInServerlessMKI to SIEM Sentinel rule migration API tests

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/get_prebuilt_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/get_prebuilt_rules.ts
@@ -31,7 +31,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const migrationRulesRoutes = ruleMigrationRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless @serverlessQA Get Prebuilt Rules API', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Get Prebuilt Rules API', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllTimelines(es, log);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/install.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/install.ts
@@ -37,7 +37,7 @@ export default ({ getService }: FtrProviderContext) => {
   const detectionsApi = getService('detectionsApi');
   const migrationRulesRoutes = ruleMigrationRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless @serverlessQA Install API', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Install API', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllTimelines(es, log);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/resources/sentinel/upsert.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/resources/sentinel/upsert.ts
@@ -47,7 +47,7 @@ export default ({ getService }: FtrProviderContext) => {
   const ruleMigrationRoutes = ruleMigrationRouteHelpersFactory(supertest);
   const resourceRoutes = ruleMigrationResourcesRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless @serverlessQA Rule migration resources upsert API', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Rule migration resources upsert API', () => {
     beforeEach(async () => {
       await deleteAllRuleMigrations(es);
       await es.indices.delete({ index: LOOKUP_INDEX_NAME, ignore_unavailable: true });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/rules/sentinel_create.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/rules/sentinel_create.ts
@@ -21,7 +21,7 @@ export default ({ getService }: FtrProviderContext) => {
   const migrationRulesRoutes = ruleMigrationRouteHelpersFactory(supertest);
   const migrationResourcesRoutes = ruleMigrationResourcesRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless @serverlessQA Create Sentinel Rules API', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Create Sentinel Rules API', () => {
     let migrationId: string;
     beforeEach(async () => {
       await deleteAllRuleMigrations(es);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/start.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/start.ts
@@ -13,7 +13,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const migrationRulesRoutes = ruleMigrationRouteHelpersFactory(supertest);
 
-  describe('Start Migration', () => {
+  describe('@skipInServerlessMKI Start Migration', () => {
     let migrationId: string;
     beforeEach(async () => {
       const createMigrationRespose = await migrationRulesRoutes.create({});

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/stop.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/stop.ts
@@ -13,7 +13,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const migrationRulesRoutes = ruleMigrationRouteHelpersFactory(supertest);
 
-  describe('Stop Migration', () => {
+  describe('@skipInServerlessMKI Stop Migration', () => {
     let migrationId: string;
     beforeEach(async () => {
       const createMigrationRespose = await migrationRulesRoutes.create({});


### PR DESCRIPTION
### Summary

The MKI periodic pipeline started running the SIEM migrations rules API suite recently. https://github.com/elastic/kibana/pull/260791/changes#diff-2733c85c9c0a325584d2a264f962a0daeacc3f1fa70d054502240ab138130360R248
The tests themselves existed for a while, but they were not being exercised by the MKI periodic job before.

To address [this error on the serverless MKI](https://elastic.slack.com/archives/C012TJZ72J1/p1780061468223089).
Adds @skipInServerlessMKI to SIEM rule migration API suites that rely on MKI-unsupported setup:

Sentinel migration routes require sentinelRulesMigration, but MKI API runs do not apply local kbnTestServerArgs and cannot enable experimental flags.
These suites continue to run in ESS and local serverless FTR; they are only excluded from MKI QA.


## The excluded APIs that are tied to `sentinelRulesMigration` are these two suites:

1. `Create Sentinel Rules API`

This tests the Sentinel-specific route:

`POST /internal/siem_migrations/rules/{migration_id}/sentinel/rules`

The test calls `addSentinelRulesToMigration(...)`, which posts to `SIEM_RULE_MIGRATION_SENTINEL_RULES_PATH`. That path is the Sentinel route:

```23:29:x-pack/solutions/security/plugins/security_solution/common/siem_migrations/constants.ts
export const SIEM_RULE_MIGRATION_RULES_PATH = `${SIEM_RULE_MIGRATION_PATH}/rules` as const;
export const SIEM_RULE_MIGRATION_RULES_ENHANCE_PATH =
  `${SIEM_RULE_MIGRATION_RULES_PATH}/enhance` as const;
export const SIEM_RULE_MIGRATION_QRADAR_RULES_PATH =
  `${SIEM_RULE_MIGRATION_PATH}/qradar/rules` as const;
export const SIEM_RULE_MIGRATION_SENTINEL_RULES_PATH =
  `${SIEM_RULE_MIGRATION_PATH}/sentinel/rules` as const;
```

The server only registers that Sentinel route when `sentinelRulesMigration` is enabled:

```60:63:x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/index.ts
  /** Sentinel */
  if (config.experimentalFeatures.sentinelRulesMigration) {
    registerSiemRuleMigrationsCreateSentinelRulesRoute(router, logger);
  }
```

So in MKI, where that flag is not enabled, every `addSentinelRulesToMigration(...)` call hits a generic `404 Not Found`.

2. `Rule migration resources upsert API`

This suite is not skipped because the resources upsert route itself is behind `sentinelRulesMigration`. It is skipped because the Sentinel-specific test cases first create a Sentinel migration by calling the same gated Sentinel route:

```56:64:x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/rule_migrations/resources/sentinel/upsert.ts
    it('should normalize Sentinel watchlists and create a denormalized lookup index', async () => {
      const {
        body: { migration_id: migrationId },
      } = await ruleMigrationRoutes.create({});

      await ruleMigrationRoutes.addSentinelRulesToMigration({
        migrationId,
        payload: sentinelArmResourcesWithWatchlist,
      });
```

Same for the unsupported content type test in that file.

The other skipped suites are unrelated to `sentinelRulesMigration`:

- `Start Migration` / `Stop Migration`: skipped because MKI does not have `preconfigured-bedrock`.
- `Get Prebuilt Rules API` / `Install API`: skipped because their setup directly deletes/writes restricted security solution indices that the MKI test user cannot access.



## Why Start Migration / Stop Migration Are Skipped
These tests require a GenAI connector named preconfigured-bedrock.
In the test, migration start is called with:

```
settings: {
  connector_id: 'preconfigured-bedrock',
}
```

On the server side, the start route validates that the connector exists before starting the migration:
const inferenceClient = ctx.securitySolution.getInferenceClient();
await inferenceClient.getConnectorById(connectorId);

In local ESS/serverless FTR, this connector is created by the test config using --xpack.actions.preconfigured.
In MKI QA, the tests run against an already-created Cloud project, so local kbnTestServerArgs are not applied. That means preconfigured-bedrock does not exist in MKI, and the route returns:
No connector or inference endpoint found for ID 'preconfigured-bedrock'

So we skip these suites in MKI until the MKI environment can provision the connector or the tests create one dynamically.

##  Why Get Prebuilt Rules API / Install API Are Skipped
These tests fail during setup, before the actual API assertions run.
Their beforeEach cleanup calls helpers like:
```
await deleteAllTimelines(es, log);
await deleteAllPrebuiltRuleAssets(es, log);
```

Those helpers directly call Elasticsearch against the restricted Kibana saved object index:
```
await es.deleteByQuery({
  index: SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
  q: 'type:siem-ui-timeline',
});
```
SECURITY_SOLUTION_SAVED_OBJECT_INDEX resolves to:
.kibana_security_solution
In MKI, the testing-internal user does not have permission to run delete_by_query against restricted indices like .kibana_security_solution.
That causes a security error during beforeEach, so the tests never reach the actual Get Prebuilt Rules or Install API logic.





