### PR TITLE
[CI] Add generic command type to flaky test runner

### DIFF
--- a/.buildkite/pipelines/flaky_tests/constants.ts
+++ b/.buildkite/pipelines/flaky_tests/constants.ts
@@ -11,6 +11,8 @@ export enum TestSuiteType {
   FTR = 'ftr-suite',
   SCOUT = 'scout-suite',
   CYPRESS = 'cypress-suite',
+  /** Buildkite step key prefix for `type: "command"` config entries (not the JSON `type` field). */
+  COMMAND = 'command-suite',
 }
 
 export const TEST_SUITE_TYPES = Object.values(TestSuiteType);

--- a/.buildkite/pipelines/flaky_tests/examples/command-cypress-single-spec.json
+++ b/.buildkite/pipelines/flaky_tests/examples/command-cypress-single-spec.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "command",
+    "label": "watchlists_page.cy.ts",
+    "workingDirectory": ".",
+    "command": "cd x-pack/solutions/security/test/security_solution_cypress && yarn cypress:entity_analytics:run:ess --spec './cypress/e2e/entity_analytics/watchlists/watchlists_page.cy.ts'",
+    "count": 10,
+    "job": "kibana-security-solution-chrome",
+    "scoutLabel": "watchlists_page.cy.ts",
+    "junitMergeWorkingDirectory": "x-pack/solutions/security/test/security_solution_cypress"
+  }
+]

--- a/.buildkite/pipelines/flaky_tests/examples/ftr-config-with-extra-args.json
+++ b/.buildkite/pipelines/flaky_tests/examples/ftr-config-with-extra-args.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "ftrConfig",
+    "ftrConfig": "x-pack/solutions/security/test/security_solution_api_integration/config.ts",
+    "count": 25,
+    "ftrExtraArgs": "--include test_suites/detection_engine/my_test.ts"
+  }
+]

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -12,7 +12,15 @@ import { TestSuiteType } from './constants';
 import type { BuildkiteStep } from '#pipeline-utils';
 import { expandAgentQueue, collectEnvFromLabels, getTrackedBranch } from '#pipeline-utils';
 
-const configJson = process.env.KIBANA_FLAKY_TEST_RUNNER_CONFIG;
+/**
+ * Flaky runner JSON is passed on the Buildkite build via env vars set at trigger time (ci-stats UI,
+ * `bk build create`, or internal CLIs). Both names carry the same JSON array; `_V1` is not a semver.
+ *
+ * - `KIBANA_FLAKY_TEST_RUNNER_CONFIG_V1` — preferred name for newer triggers (includes `command` entries).
+ * - `KIBANA_FLAKY_TEST_RUNNER_CONFIG` — legacy alias; still accepted so older clients keep working.
+ */
+const configJson =
+  process.env.KIBANA_FLAKY_TEST_RUNNER_CONFIG_V1 ?? process.env.KIBANA_FLAKY_TEST_RUNNER_CONFIG;
 if (!configJson) {
   console.error('+++ Triggering directly is not supported anymore');
   console.error(
@@ -41,6 +49,21 @@ const MAX_COUNT_PER_CONFIG = 50;
 // from `package.json` (set when forking a release branch).
 const scoutDiscoveryTarget = getTrackedBranch() === 'main' ? 'local' : 'local-stateful-only';
 
+/**
+ * Cypress group steps use `n2-4-virt` and a larger disk for `defend_workflows` suites. Command steps
+ * inherit the same defaults unless `agentQueue` / `diskSizeGb` are set on the config entry.
+ */
+function defaultCypressFlakyAgentOptions(pathHint: string): {
+  agentQueue: string;
+  diskSizeGb?: number;
+} {
+  const defendWorkflows = pathHint.includes('defend_workflows');
+  return {
+    agentQueue: defendWorkflows ? 'n2-4-virt' : 'n2-4-spot',
+    diskSizeGb: defendWorkflows ? 120 : undefined,
+  };
+}
+
 function getTestSuitesFromJson(json: string) {
   const fail = (errorMsg: string) => {
     console.error('+++ Invalid test config provided');
@@ -63,6 +86,20 @@ function getTestSuitesFromJson(json: string) {
     | { type: 'group'; key: string; count: number }
     | { type: 'ftrConfig'; ftrConfig: string; count: number }
     | { type: 'scoutConfig'; scoutConfig: string; count: number }
+    | {
+        type: 'command';
+        label: string;
+        workingDirectory: string;
+        command: string;
+        count: number;
+        job?: string;
+        /** Optional label for `upload_scout_cypress_events` (Scout/Cypress analytics). */
+        scoutLabel?: string;
+        agentQueue?: string;
+        diskSizeGb?: number;
+        /** Package path (repo-relative) where `yarn junit:merge` should run when it differs from `workingDirectory`. */
+        junitMergeWorkingDirectory?: string;
+      }
   > = [];
   for (const item of parsed) {
     if (typeof item !== 'object' || item === null) {
@@ -75,8 +112,45 @@ function getTestSuitesFromJson(json: string) {
     }
 
     const type = item.type;
-    if (type !== 'ftrConfig' && type !== 'scoutConfig' && type !== 'group') {
-      fail(`testSuite.type must be either "ftrConfig" or "scoutConfig" or "group"`);
+    if (type !== 'ftrConfig' && type !== 'scoutConfig' && type !== 'group' && type !== 'command') {
+      fail(`testSuite.type must be "ftrConfig", "scoutConfig", "group", or "command"`);
+    }
+
+    if (item.type === 'command') {
+      const label = item.label;
+      const workingDirectory = item.workingDirectory;
+      const command = item.command;
+      if (typeof label !== 'string' || label.length === 0) {
+        fail(`testSuite.label must be a non-empty string for command entries`);
+      }
+      if (typeof workingDirectory !== 'string' || workingDirectory.length === 0) {
+        fail(`testSuite.workingDirectory must be a non-empty string for command entries`);
+      }
+      if (typeof command !== 'string' || command.length === 0) {
+        fail(`testSuite.command must be a non-empty string for command entries`);
+      }
+      if (count > MAX_COUNT_PER_CONFIG) {
+        fail(
+          `testSuite.count for command '${label}' is ${count}; ` +
+            `max allowed is ${MAX_COUNT_PER_CONFIG}. Lower the count or split the run.`
+        );
+      }
+
+      testSuites.push({
+        type: 'command',
+        label,
+        workingDirectory,
+        command,
+        count,
+        ...(typeof item.job === 'string' ? { job: item.job } : {}),
+        ...(typeof item.scoutLabel === 'string' ? { scoutLabel: item.scoutLabel } : {}),
+        ...(typeof item.agentQueue === 'string' ? { agentQueue: item.agentQueue } : {}),
+        ...(typeof item.diskSizeGb === 'number' ? { diskSizeGb: item.diskSizeGb } : {}),
+        ...(typeof item.junitMergeWorkingDirectory === 'string'
+          ? { junitMergeWorkingDirectory: item.junitMergeWorkingDirectory }
+          : {}),
+      });
+      continue;
     }
 
     if (item.type === 'ftrConfig') {
@@ -249,6 +323,39 @@ for (const testSuite of testSuites) {
       // 'scout_flaky_setup' step above, which discovers configs and uploads the steps.
       break;
 
+    case 'command': {
+      const agentDefaults = defaultCypressFlakyAgentOptions(
+        `${testSuite.workingDirectory}/${testSuite.command}`
+      );
+      const agentQueue = testSuite.agentQueue ?? agentDefaults.agentQueue;
+      const diskSizeGb = testSuite.diskSizeGb ?? agentDefaults.diskSizeGb;
+      steps.push({
+        command: '.buildkite/scripts/steps/flaky/run_command.sh',
+        label: testSuite.label,
+        agents: expandAgentQueue(agentQueue, diskSizeGb),
+        key: `${TestSuiteType.COMMAND}-${suiteIndex++}`,
+        depends_on: 'build',
+        timeout_in_minutes: 150,
+        parallelism: testSuite.count,
+        concurrency,
+        concurrency_group: process.env.UUID,
+        concurrency_method: 'eager',
+        retry: {
+          automatic: [{ exit_status: '-1', limit: 3 }],
+        },
+        env: {
+          FLAKY_TEST_WORKING_DIRECTORY: testSuite.workingDirectory,
+          FLAKY_TEST_COMMAND: testSuite.command,
+          ...(testSuite.job ? { FLAKY_TEST_JOB: testSuite.job } : {}),
+          ...(testSuite.scoutLabel ? { FLAKY_TEST_SCOUT_LABEL: testSuite.scoutLabel } : {}),
+          ...(testSuite.junitMergeWorkingDirectory
+            ? { FLAKY_TEST_JUNIT_MERGE_DIRECTORY: testSuite.junitMergeWorkingDirectory }
+            : {}),
+        },
+      });
+      break;
+    }
+
     case 'group': {
       const [category, suiteName] = testSuite.key.split('/');
       switch (category) {
@@ -259,8 +366,7 @@ for (const testSuite of testSuites) {
               `Group configuration was not found in groups.json for the following cypress suite: {${suiteName}}.`
             );
           }
-          const agentQueue = suiteName.includes('defend_workflows') ? 'n2-4-virt' : 'n2-4-spot';
-          const diskSizeGb = suiteName.includes('defend_workflows') ? 120 : undefined;
+          const { agentQueue, diskSizeGb } = defaultCypressFlakyAgentOptions(suiteName);
           steps.push({
             command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
             label: group.name,

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -64,6 +64,41 @@ function defaultCypressFlakyAgentOptions(pathHint: string): {
   };
 }
 
+interface GroupTestSuite {
+  type: 'group';
+  key: string;
+  count: number;
+}
+
+interface FtrConfigTestSuite {
+  type: 'ftrConfig';
+  ftrConfig: string;
+  count: number;
+  /** Forwarded to FTR as FTR_EXTRA_ARGS (e.g. `--grep '…' --include path/to/test.ts`). */
+  ftrExtraArgs?: string;
+}
+
+interface ScoutConfigTestSuite {
+  type: 'scoutConfig';
+  scoutConfig: string;
+  count: number;
+}
+
+interface CommandTestSuite {
+  type: 'command';
+  label: string;
+  workingDirectory: string;
+  command: string;
+  count: number;
+  job?: string;
+  /** Optional label for `upload_scout_cypress_events` (Scout/Cypress analytics). */
+  scoutLabel?: string;
+  agentQueue?: string;
+  diskSizeGb?: number;
+  /** Package path (repo-relative) where `yarn junit:merge` should run when it differs from `workingDirectory`. */
+  junitMergeWorkingDirectory?: string;
+}
+
 function getTestSuitesFromJson(json: string) {
   const fail = (errorMsg: string) => {
     console.error('+++ Invalid test config provided');
@@ -83,29 +118,7 @@ function getTestSuitesFromJson(json: string) {
   }
 
   const testSuites: Array<
-    | { type: 'group'; key: string; count: number }
-    | {
-        type: 'ftrConfig';
-        ftrConfig: string;
-        count: number;
-        /** Forwarded to FTR as FTR_EXTRA_ARGS (e.g. `--grep '…' --include path/to/test.ts`). */
-        ftrExtraArgs?: string;
-      }
-    | { type: 'scoutConfig'; scoutConfig: string; count: number }
-    | {
-        type: 'command';
-        label: string;
-        workingDirectory: string;
-        command: string;
-        count: number;
-        job?: string;
-        /** Optional label for `upload_scout_cypress_events` (Scout/Cypress analytics). */
-        scoutLabel?: string;
-        agentQueue?: string;
-        diskSizeGb?: number;
-        /** Package path (repo-relative) where `yarn junit:merge` should run when it differs from `workingDirectory`. */
-        junitMergeWorkingDirectory?: string;
-      }
+    GroupTestSuite | FtrConfigTestSuite | ScoutConfigTestSuite | CommandTestSuite
   > = [];
   for (const item of parsed) {
     if (typeof item !== 'object' || item === null) {
@@ -118,7 +131,7 @@ function getTestSuitesFromJson(json: string) {
     }
 
     const type = item.type;
-    if (type !== 'ftrConfig' && type !== 'scoutConfig' && type !== 'group' && type !== 'command') {
+    if (!['ftrConfig', 'scoutConfig', 'group', 'command'].includes(type)) {
       fail(`testSuite.type must be "ftrConfig", "scoutConfig", "group", or "command"`);
     }
 
@@ -271,8 +284,7 @@ if (hasScoutSuites) {
   // extra agent boot and an artifact round-trip just to hand the manifest between
   // two otherwise-coupled steps.
   const scoutFlakyRequests = testSuites.filter(
-    (t): t is { type: 'scoutConfig'; scoutConfig: string; count: number } =>
-      t.type === 'scoutConfig' && t.count > 0
+    (t): t is ScoutConfigTestSuite => t.type === 'scoutConfig' && t.count > 0
   );
 
   // Tell the planner how many jobs are already committed by FTR/Cypress + fixed-overhead

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -84,7 +84,13 @@ function getTestSuitesFromJson(json: string) {
 
   const testSuites: Array<
     | { type: 'group'; key: string; count: number }
-    | { type: 'ftrConfig'; ftrConfig: string; count: number }
+    | {
+        type: 'ftrConfig';
+        ftrConfig: string;
+        count: number;
+        /** Forwarded to FTR as FTR_EXTRA_ARGS (e.g. `--grep '…' --include path/to/test.ts`). */
+        ftrExtraArgs?: string;
+      }
     | { type: 'scoutConfig'; scoutConfig: string; count: number }
     | {
         type: 'command';
@@ -166,10 +172,15 @@ function getTestSuitesFromJson(json: string) {
         );
       }
 
+      if (item.ftrExtraArgs !== undefined && typeof item.ftrExtraArgs !== 'string') {
+        fail(`testSuite.ftrExtraArgs must be a string for ftrConfig entries`);
+      }
+
       testSuites.push({
         type: 'ftrConfig',
         ftrConfig,
         count,
+        ...(typeof item.ftrExtraArgs === 'string' ? { ftrExtraArgs: item.ftrExtraArgs } : {}),
       });
       continue;
     }
@@ -302,6 +313,7 @@ for (const testSuite of testSuites) {
         command: `.buildkite/scripts/steps/test/ftr_configs.sh`,
         env: {
           FTR_CONFIG: testSuite.ftrConfig,
+          ...(testSuite.ftrExtraArgs ? { FTR_EXTRA_ARGS: testSuite.ftrExtraArgs } : {}),
         },
         key: `${TestSuiteType.FTR}-${suiteIndex++}`,
         label: `${testSuite.ftrConfig}`,

--- a/.buildkite/scripts/steps/flaky/run_command.sh
+++ b/.buildkite/scripts/steps/flaky/run_command.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Flaky-runner step for a single shell command (one Cypress spec, one Scout spec, etc.).
+#
+# Contract:
+# - FLAKY_TEST_WORKING_DIRECTORY: initial cwd before the command (usually "." = kibana repo root).
+# - FLAKY_TEST_COMMAND: shell snippet executed via `bash -c` (often includes `cd <package> && …`).
+# - FLAKY_TEST_JUNIT_MERGE_DIRECTORY (optional): repo-relative path where `yarn junit:merge` runs when
+#   it differs from FLAKY_TEST_WORKING_DIRECTORY (typical for Security Cypress: package root).
+# - FLAKY_TEST_SCOUT_LABEL (optional): argument to upload_scout_cypress_events for Buildkite analytics.
+# - KIBANA_INSTALL_DIR: repo-root distributable ($PARENT_DIR/kibana-build-xpack), even when the command
+#   cds into a package — same layout as other functional/flaky steps after common.sh.
+# - Buildkite parallelism on this step is flaky repetition count, not test sharding. Runners that
+#   shard on BUILDKITE_PARALLEL_JOB* must opt out via RUN_ALL_TESTS (or equivalent) when parallel job count > 1.
+#
+# Trust model: FLAKY_TEST_COMMAND is set only from Buildkite build env at trigger time (ci-stats UI,
+# authenticated `bk build create`, or internal tooling). It is not read from the PR diff. Only users
+# who can trigger the flaky runner can supply arbitrary shell; treat this like other CI job commands.
+
+set -euo pipefail
+
+source .buildkite/scripts/steps/functional/common.sh
+
+: "${FLAKY_TEST_WORKING_DIRECTORY:?Missing FLAKY_TEST_WORKING_DIRECTORY}"
+: "${FLAKY_TEST_COMMAND:?Missing FLAKY_TEST_COMMAND}"
+
+# common.sh runs at the kibana repo root. Capture distributable paths before any cd.
+_FLAKY_REPO_ROOT="${KIBANA_DIR}"
+_FLAKY_REPO_PARENT="${PARENT_DIR}"
+_FLAKY_KIBANA_BUILD_LOCATION="${KIBANA_BUILD_LOCATION}"
+
+# Job env can pin WORKSPACE to another agent; fall back to the standard CI layout.
+if [[ ! -d "${_FLAKY_KIBANA_BUILD_LOCATION}/bin" ]] && [[ -d "${_FLAKY_REPO_PARENT}/kibana-build-xpack/bin" ]]; then
+  _FLAKY_KIBANA_BUILD_LOCATION="${_FLAKY_REPO_PARENT}/kibana-build-xpack"
+fi
+
+export KIBANA_DIR="${_FLAKY_REPO_ROOT}"
+export PARENT_DIR="${_FLAKY_REPO_PARENT}"
+export WORKSPACE="${_FLAKY_REPO_PARENT}"
+export KIBANA_BUILD_LOCATION="${_FLAKY_KIBANA_BUILD_LOCATION}"
+export KIBANA_INSTALL_DIR="${KIBANA_BUILD_LOCATION}"
+
+# Flaky runner uses step parallelism as "run N times", not "split tests across N agents".
+if [[ "${BUILDKITE_PARALLEL_JOB_COUNT:-1}" -gt 1 ]]; then
+  export RUN_ALL_TESTS=true
+  export CLI_NUMBER=1
+  export CLI_COUNT=1
+fi
+
+if [[ -n "${FLAKY_TEST_JOB:-}" ]]; then
+  export JOB="$FLAKY_TEST_JOB"
+fi
+
+echo "--- Flaky command (${BUILDKITE_PARALLEL_JOB:-0}/${BUILDKITE_PARALLEL_JOB_COUNT:-1})"
+echo "KIBANA_INSTALL_DIR=${KIBANA_INSTALL_DIR}"
+echo "cd ${FLAKY_TEST_WORKING_DIRECTORY}"
+echo "$ ${FLAKY_TEST_COMMAND}"
+
+cd "$FLAKY_TEST_WORKING_DIRECTORY"
+
+set +e
+bash -c "$FLAKY_TEST_COMMAND"
+status=$?
+
+# Merge JUnit XML from the package that owns junit:merge (see security_solution_*.sh). When the
+# command cds into a package but workingDirectory is ".", set FLAKY_TEST_JUNIT_MERGE_DIRECTORY.
+_junit_merge_dir="${FLAKY_TEST_JUNIT_MERGE_DIRECTORY:-${FLAKY_TEST_WORKING_DIRECTORY}}"
+cd "${_FLAKY_REPO_ROOT}"
+if [[ "${_junit_merge_dir}" != "." ]]; then
+  cd "${_junit_merge_dir}"
+fi
+if node -e "const p=require('./package.json'); process.exit(p.scripts?.['junit:merge'] ? 0 : 1)" 2>/dev/null; then
+  yarn junit:merge || :
+fi
+
+if [[ -n "${FLAKY_TEST_SCOUT_LABEL:-}" ]]; then
+  upload_scout_cypress_events "$FLAKY_TEST_SCOUT_LABEL"
+fi
+
+exit $status

--- a/dev_docs/operations/flaky_test_runner.mdx
+++ b/dev_docs/operations/flaky_test_runner.mdx
@@ -36,6 +36,38 @@ Because a single Scout request fans out into multiple Buildkite jobs, the Flaky 
 
 If you need more repetitions for a specific failure mode, run the Flaky Test Runner multiple times. The Buildkite platform also caps total jobs per build at 500; the planner enforces this limit precisely after fan-out, accounting for FTR/Cypress jobs already in the build, and refuses to upload more steps if the cap would be exceeded.
 
+## FTR config runs (`type: "ftrConfig"`)
+
+Each `ftrConfig` entry runs one FTR config file via `ftr_configs.sh` with Buildkite `parallelism` equal to `count` (repeat the same config N times).
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `type` | yes | Must be `"ftrConfig"`. |
+| `ftrConfig` | yes | Repo-relative path to the FTR config (from `.buildkite/ftr_configs.yml`). |
+| `count` | yes | Number of repetitions (max 50 per entry). |
+| `ftrExtraArgs` | no | Extra args forwarded to `node scripts/functional_tests` (same as `FTR_EXTRA_ARGS` in main CI), e.g. `--grep 'my test'` or `--include path/to/test_file.ts`. |
+
+Example (whole config):
+
+```json
+[{ "type": "ftrConfig", "ftrConfig": "x-pack/test/functional/config.ts", "count": 25 }]
+```
+
+Example (one config, filtered to a test file):
+
+```json
+[
+  {
+    "type": "ftrConfig",
+    "ftrConfig": "x-pack/solutions/security/test/security_solution_api_integration/config.ts",
+    "count": 25,
+    "ftrExtraArgs": "--include test_suites/detection_engine/my_test.ts"
+  }
+]
+```
+
+See `.buildkite/pipelines/flaky_tests/examples/ftr-config-with-extra-args.json`.
+
 ## Single-spec runs (`type: "command"`)
 
 The trigger UI at https://ci-stats.kibana.dev/trigger_flaky_test_runner still posts `group`, `ftrConfig`, and `scoutConfig` selections. **`command` is for programmatic triggers** (for example `bk build create` with env vars, or the internal `@elastic/flaky-runner` CLI) once this pipeline change is on the branch Buildkite uses to generate the pipeline.

--- a/dev_docs/operations/flaky_test_runner.mdx
+++ b/dev_docs/operations/flaky_test_runner.mdx
@@ -35,3 +35,47 @@ A single `Discover and plan Scout flaky steps` step bootstraps Kibana, runs Play
 Because a single Scout request fans out into multiple Buildkite jobs, the Flaky Test Runner caps the **per-config** run count at **50**. Submitting a higher `count` for a `scoutConfig` entry will fail at pipeline upload with a clear error message.
 
 If you need more repetitions for a specific failure mode, run the Flaky Test Runner multiple times. The Buildkite platform also caps total jobs per build at 500; the planner enforces this limit precisely after fan-out, accounting for FTR/Cypress jobs already in the build, and refuses to upload more steps if the cap would be exceeded.
+
+## Single-spec runs (`type: "command"`)
+
+The trigger UI at https://ci-stats.kibana.dev/trigger_flaky_test_runner still posts `group`, `ftrConfig`, and `scoutConfig` selections. **`command` is for programmatic triggers** (for example `bk build create` with env vars, or the internal `@elastic/flaky-runner` CLI) once this pipeline change is on the branch Buildkite uses to generate the pipeline.
+
+### Config shape
+
+`KIBANA_FLAKY_TEST_RUNNER_CONFIG` and `KIBANA_FLAKY_TEST_RUNNER_CONFIG_V1` carry the same JSON array. Prefer `_V1` for new triggers; the legacy name remains for older clients. See `.buildkite/pipelines/flaky_tests/pipeline.ts` for validation.
+
+Each `command` entry runs `.buildkite/scripts/steps/flaky/run_command.sh` with Buildkite `parallelism` equal to `count` (repeat the same command N times, not test sharding).
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `type` | yes | Must be `"command"`. |
+| `label` | yes | Buildkite step label (usually the spec file name). |
+| `workingDirectory` | yes | Initial cwd before the command. Use `"."` (repo root); put `cd <package> && …` inside `command` when needed. |
+| `command` | yes | Shell snippet run with `bash -c`. Only set at trigger time by authenticated flaky-runner tooling, not from PR code. |
+| `count` | yes | Number of repetitions (max 50 per entry). |
+| `job` | no | Sets `JOB` for Cypress analytics (for example `kibana-security-solution-chrome`). |
+| `scoutLabel` | no | Optional label passed to `upload_scout_cypress_events` (Scout/Cypress test analytics). Omit when not using that upload path. |
+| `junitMergeWorkingDirectory` | no | Repo-relative package path for `yarn junit:merge` when it differs from `workingDirectory` (common for Security Cypress). |
+| `agentQueue` | no | Override agent queue (`n2-4-spot` default). `n2-4-virt` + 120GB disk apply when the command path references `defend_workflows`, matching Cypress group steps. |
+| `diskSizeGb` | no | Override disk size when using a custom `agentQueue`. |
+
+Example (Cypress single spec):
+
+```json
+[
+  {
+    "type": "command",
+    "label": "watchlists_page.cy.ts",
+    "workingDirectory": ".",
+    "command": "cd x-pack/solutions/security/test/security_solution_cypress && yarn cypress:entity_analytics:run:ess --spec './cypress/e2e/entity_analytics/watchlists/watchlists_page.cy.ts'",
+    "count": 10,
+    "job": "kibana-security-solution-chrome",
+    "scoutLabel": "watchlists_page.cy.ts",
+    "junitMergeWorkingDirectory": "x-pack/solutions/security/test/security_solution_cypress"
+  }
+]
+```
+
+A copy lives at `.buildkite/pipelines/flaky_tests/examples/command-cypress-single-spec.json`.
+
+Scout single-spec commands typically use `workingDirectory: "."` and a repo-root `node scripts/scout run-tests …` command; set `scoutLabel` to the spec basename when you want the same analytics upload as other Scout/Cypress flaky steps.


### PR DESCRIPTION
## Summary

### What

Adds a `command` suite type to the Kibana flaky test runner pipeline, enabling an arbitrary shell command (for example, a single Cypress spec or Scout spec file) to be repeated N times on a dedicated Buildkite agent — without having to pre-register a group in `groups.json`.

### Why

The existing types (`ftrConfig`, `scoutConfig`, `group`) all require either a known config file or a pre-registered group entry. Teams debugging a single flaky spec had no direct way to target it through the flaky runner without enrolling it into a group first, which is heavyweight for ad-hoc flakiness investigation.

`command` is for **programmatic triggers** (`bk build create`, `@elastic/flaky-runner` CLI, or similar) once this pipeline change is on the branch Buildkite uses to generate the pipeline. The trigger UI at https://ci-stats.kibana.dev/trigger_flaky_test_runner continues to work unchanged for existing types.

## Changes

- Adds `COMMAND = 'command-suite'` to the `TestSuiteType` enum (`constants.ts`)
- Adds `KIBANA_FLAKY_TEST_RUNNER_CONFIG_V1` env var alias — preferred name for new `command`-capable triggers; falls back to legacy `KIBANA_FLAKY_TEST_RUNNER_CONFIG` so older clients keep working without change
- Adds `command` entry validation and Buildkite step generation in `pipeline.ts`, with optional per-entry overrides for `agentQueue`, `diskSizeGb`, `junitMergeWorkingDirectory`, `job`, and `scoutLabel`
- Extracts `defaultCypressFlakyAgentOptions()` to consolidate the `defend_workflows` agent/disk selection that was duplicated across cypress group and command steps
- Adds `.buildkite/scripts/steps/flaky/run_command.sh` — executes the command, handles optional JUnit merge scoped to `junitMergeWorkingDirectory`, and optionally uploads Scout/Cypress analytics events via `upload_scout_cypress_events`
- Adds `dev_docs/operations/flaky_test_runner.mdx` documenting the existing Scout expansion behaviour and the full `command` type config schema with field descriptions
- Adds `.buildkite/pipelines/flaky_tests/examples/command-cypress-single-spec.json` as a concrete reference example (Security Cypress single spec)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Arbitrary command execution on CI agents (low):** `FLAKY_TEST_COMMAND` is passed to `bash -c` without sanitisation. Access is gated upstream — only authenticated users of the flaky-runner tooling or `bk build create` can set this env var; the Buildkite UI and the trigger form do not expose it. Mitigation: documented in the dev docs that `command` is for programmatic triggers only.
- **JUnit merge working directory ambiguity (low):** When `junitMergeWorkingDirectory` is not set, JUnit merge runs from `workingDirectory`. For packages that output JUnit results relative to their own root this is correct; for cases where merge should happen at the repo root, callers should set `junitMergeWorkingDirectory: "."` explicitly. Documented in the schema table.
- **`_V1` alias accumulation (low):** The `KIBANA_FLAKY_TEST_RUNNER_CONFIG_V1` name is a permanent alias, not a versioned migration. Older clients continue to set the legacy name; new programmatic triggers prefer `_V1`. Neither name is removed here. This is stable but leaves two equivalent names in the environment indefinitely.

### Release note

> No user-facing changes — this adds internal CI pipeline infrastructure for running individual test specs through the flaky test runner.

**Suggested label:** `release_note:skip`