### PR TITLE
[ES|QL] Fixes a11y issue at the warning popover

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
@@ -89,6 +89,8 @@ function ErrorsWarningsContent({
           return (
             <EuiDescriptionListDescription
               key={index}
+              role="button"
+              tabIndex={0}
               className={classNameCss`
                 &:hover {
                   cursor: pointer;
@@ -97,6 +99,9 @@ function ErrorsWarningsContent({
                 user-select: text;
               `}
               onClick={() => handleClick(item)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') handleClick(item);
+              }}
             >
               <EuiFlexGroup gutterSize="xl" alignItems="flexStart">
                 <EuiFlexItem grow={false}>
@@ -181,7 +186,7 @@ export function ErrorsWarningsFooterPopover({
               {isSpaceReduced ? visibleItems.length : message}
             </EuiButtonEmpty>
           }
-          ownFocus={false}
+          ownFocus={true}
           isOpen={isPopoverOpen}
           closePopover={closePopover}
         >

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -195,6 +195,7 @@ const ESQLEditorInternal = function ESQLEditor({
   const variablesService = esqlService?.variablesService;
   const histogramBarTarget = uiSettings?.get('histogram:barTarget') ?? 50;
   const [code, setCode] = useState<string>(fixedQuery ?? '');
+  console.log('meow', serverWarning);
 
   // To make server side errors less "sticky", register the query that last errored
   const [lastErroredCode, setLastErroredCode] = useState<string | undefined>(() =>

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -195,7 +195,6 @@ const ESQLEditorInternal = function ESQLEditor({
   const variablesService = esqlService?.variablesService;
   const histogramBarTarget = uiSettings?.get('histogram:barTarget') ?? 50;
   const [code, setCode] = useState<string>(fixedQuery ?? '');
-  console.log('meow', serverWarning);
 
   // To make server side errors less "sticky", register the query that last errored
   const [lastErroredCode, setLastErroredCode] = useState<string | undefined>(() =>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/260213

Now it gets the focus, user needs to press ESC to close and move on which is WCAG 2.1.2 compliant. Tab closing the popover and going to the next element is more complex mostly because EUI doesnt make it very easy. I prefer to solve it like that, we are solving the compliance problem 



