### PR TITLE
[Discover] Make reporting tests more stable

### DIFF
--- a/x-pack/platform/test/serverless/functional/configs/observability/config.reporting.ts
+++ b/x-pack/platform/test/serverless/functional/configs/observability/config.reporting.ts
@@ -18,6 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...kbnTestServer.serverArgs,
         '--xpack.reporting.csv.scroll.duration=10m',
+        '--xpack.reporting.csv.scroll.size=1000',
         '--xpack.reporting.queue.timeout=600000',
         '--elasticsearch.requestTimeout=600000',
       ],

--- a/x-pack/platform/test/serverless/functional/configs/search/config.reporting.ts
+++ b/x-pack/platform/test/serverless/functional/configs/search/config.reporting.ts
@@ -18,6 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...kbnTestServer.serverArgs,
         '--xpack.reporting.csv.scroll.duration=10m',
+        '--xpack.reporting.csv.scroll.size=1000',
         '--xpack.reporting.queue.timeout=600000',
         '--elasticsearch.requestTimeout=600000',
       ],

--- a/x-pack/platform/test/serverless/functional/configs/security/config.reporting.ts
+++ b/x-pack/platform/test/serverless/functional/configs/security/config.reporting.ts
@@ -18,6 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...kbnTestServer.serverArgs,
         '--xpack.reporting.csv.scroll.duration=10m',
+        '--xpack.reporting.csv.scroll.size=1000',
         '--xpack.reporting.queue.timeout=600000',
         '--elasticsearch.requestTimeout=600000',
       ],

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/x_pack_reporting/reporting.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/x_pack_reporting/reporting.ts
@@ -175,6 +175,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.discover.clickFieldSort('order_id', 'Sort A-Z');
         await PageObjects.discover.waitUntilTabIsLoaded();
+        await PageObjects.discover.saveSearch('large export');
+        await PageObjects.discover.waitUntilTabIsLoaded();
         const { text: csvFileOrderId } = await getReport({ timeout: 80 * 1000 });
         expectSnapshot(csvFileOrderId.slice(0, 5000)).toMatch();
         expectSnapshot(csvFileOrderId.slice(-5000)).toMatch();


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/272159
- Closes https://github.com/elastic/kibana/issues/267747
- Closes https://github.com/elastic/kibana/issues/269628
- Closes https://github.com/elastic/kibana/issues/268162

## Summary

Fix 1 (pagination boundary race): Added --xpack.reporting.csv.scroll.size=1000 to the three serverless reporting configs so the 510-row sparse data test completes in a single page fetch.

Fix 2 (sort state propagation race): Added saveSearch('large export') after adding the order_id column and sort direction, ensuring the search definition is fully persisted before the CSV export reads it. This eliminates the race between the UI sort update and the server-side reporting task.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->