### PR TITLE
[Chrome Next] Add newsfeed and feedback to help menu

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -72,7 +72,7 @@ pageLoadAssetSize:
   expressionTagcloud: 14009
   expressionXY: 45000
   features: 4145
-  feedback: 6248
+  feedback: 7642
   fieldFormats: 64634
   fieldsMetadata: 4901
   files: 6037

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
+import { TestChromeProviders } from '../../test_helpers';
+import { ChromeNextGlobalHeader } from './global_header';
+
+describe('ChromeNextGlobalHeader', () => {
+  it('renders the help menu button', async () => {
+    renderWithI18n(
+      <TestChromeProviders>
+        <ChromeNextGlobalHeader />
+      </TestChromeProviders>
+    );
+
+    await userEvent.click(screen.getByTestId('chromeNextGlobalHeaderHelpButton'));
+
+    expect(screen.getByText('Help')).toBeInTheDocument();
+    expect(screen.getByText('Kibana documentation')).toBeInTheDocument();
+  });
+
+  it('renders a registered newsfeed handler in the help menu', async () => {
+    const chrome = chromeServiceMock.createStartContract();
+    chrome.getChromeStyle.mockReturnValue('project');
+    chrome.getChromeStyle$.mockReturnValue(new BehaviorSubject('project'));
+    Object.defineProperty(chrome.next, 'isEnabled', { configurable: true, get: () => true });
+    chrome.getNewsfeedHandler$.mockReturnValue(
+      new BehaviorSubject({
+        open: jest.fn(),
+        hasNew$: new BehaviorSubject(false),
+      })
+    );
+
+    renderWithI18n(
+      <TestChromeProviders chrome={chrome}>
+        <ChromeNextGlobalHeader />
+      </TestChromeProviders>
+    );
+
+    await userEvent.click(screen.getByTestId('chromeNextGlobalHeaderHelpButton'));
+
+    expect(screen.getByTestId('helpMenuWhatsNewButton')).toBeInTheDocument();
+  });
+
+  it('renders a registered newsfeed handler before unread state emits', async () => {
+    const chrome = chromeServiceMock.createStartContract();
+    chrome.getChromeStyle.mockReturnValue('project');
+    chrome.getChromeStyle$.mockReturnValue(new BehaviorSubject('project'));
+    Object.defineProperty(chrome.next, 'isEnabled', { configurable: true, get: () => true });
+    chrome.getNewsfeedHandler$.mockReturnValue(
+      new BehaviorSubject({
+        open: jest.fn(),
+        hasNew$: new Subject<boolean>(),
+      })
+    );
+
+    renderWithI18n(
+      <TestChromeProviders chrome={chrome}>
+        <ChromeNextGlobalHeader />
+      </TestChromeProviders>
+    );
+
+    await userEvent.click(screen.getByTestId('chromeNextGlobalHeaderHelpButton'));
+
+    expect(screen.getByTestId('helpMenuWhatsNewButton')).toBeInTheDocument();
+  });
+});

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.test.tsx
@@ -35,7 +35,7 @@ describe('ChromeNextGlobalHeader', () => {
     chrome.getChromeStyle.mockReturnValue('project');
     chrome.getChromeStyle$.mockReturnValue(new BehaviorSubject('project'));
     Object.defineProperty(chrome.next, 'isEnabled', { configurable: true, get: () => true });
-    chrome.getNewsfeedHandler$.mockReturnValue(
+    chrome.next.getNewsfeedHandler$.mockReturnValue(
       new BehaviorSubject({
         open: jest.fn(),
         hasNew$: new BehaviorSubject(false),
@@ -58,7 +58,7 @@ describe('ChromeNextGlobalHeader', () => {
     chrome.getChromeStyle.mockReturnValue('project');
     chrome.getChromeStyle$.mockReturnValue(new BehaviorSubject('project'));
     Object.defineProperty(chrome.next, 'isEnabled', { configurable: true, get: () => true });
-    chrome.getNewsfeedHandler$.mockReturnValue(
+    chrome.next.getNewsfeedHandler$.mockReturnValue(
       new BehaviorSubject({
         open: jest.fn(),
         hasNew$: new Subject<boolean>(),

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { ChromeNextGlobalHeaderLogo } from './global_header_logo';
 import { SearchButton } from './search_button';
+import { HelpButton } from './help_button';
 import { ChromeNextGlobalHeaderShell } from './global_header_shell';
 import { useContextSwitcher } from '../../shared/chrome_hooks';
 
@@ -17,6 +18,7 @@ export const ChromeNextGlobalHeader = React.memo(() => (
   <ChromeNextGlobalHeaderShell
     logo={<ChromeNextGlobalHeaderLogo />}
     search={<SearchButton />}
+    help={<HelpButton />}
     switcher={useContextSwitcher()}
   />
 ));

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/help_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/help_button.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { EuiIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { HeaderHelpMenu } from '../../shared/header_help_menu';
+import { HeaderActionButton } from './header_action_button';
+
+const HELP_ARIA_LABEL = i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuButtonAriaLabel', {
+  defaultMessage: 'Help menu',
+});
+
+export const HelpButton = React.memo(() => {
+  const renderButton = useCallback(
+    ({ isOpen, toggleMenu }: { isOpen: boolean; toggleMenu: () => void }) => (
+      <HeaderActionButton
+        variant="bordered"
+        onClick={toggleMenu}
+        aria-expanded={isOpen}
+        aria-haspopup={true}
+        aria-label={HELP_ARIA_LABEL}
+        data-test-subj="chromeNextGlobalHeaderHelpButton"
+      >
+        <EuiIcon type="question" size="m" color="subdued" aria-hidden />
+      </HeaderActionButton>
+    ),
+    []
+  );
+
+  return <HeaderHelpMenu renderButton={renderButton} />;
+});
+
+HelpButton.displayName = 'HelpButton';

--- a/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
@@ -29,6 +29,8 @@ import { useObservable } from '@kbn/use-observable';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { useChromeComponentsDeps } from '../context';
 
+export { useIsNextChrome } from '@kbn/core-chrome-browser-hooks';
+
 /**
  * Returns the current classic breadcrumbs set via `chrome.setBreadcrumbs()`.
  * Used by `ClassicHeader`.

--- a/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
@@ -7,260 +7,40 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { MouseEvent } from 'react';
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { EuiContextMenuPanelItemDescriptor, IconType } from '@elastic/eui';
 import {
   EuiContextMenu,
-  EuiContextMenuItem,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHeaderSectionItemButton,
   EuiIcon,
   EuiPopover,
-  useEuiTheme,
 } from '@elastic/eui';
-
-import type { ChromeHelpMenuLink } from '@kbn/core-chrome-browser';
-import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import { useIsServerless, useKibanaVersion } from '@kbn/react-env';
-import { useChromeStyle } from '@kbn/core-chrome-browser-hooks';
+import { useHelpMenuItems } from './help_links_hooks';
 
-import { css } from '@emotion/react';
-import { isModifiedOrPrevented } from './nav_link';
-import { useHelpMenu, useNavigateToUrl, useDocLinks } from './chrome_hooks';
-
-interface MenuItemOptions {
-  name: string;
-  key: string;
-  icon?: IconType;
-  href?: string;
-  target?: string;
-  rel?: string;
-  onClick?: () => void;
-  isExternal?: boolean;
-  dataTestSubj?: string;
+interface HeaderHelpMenuProps {
+  renderButton?: (props: {
+    isOpen: boolean;
+    toggleMenu: () => void;
+  }) => NonNullable<React.ReactNode>;
 }
 
-type ItemClickHandler = (opts: {
-  onClick?: () => void;
-  href?: string;
-  isExternal?: boolean;
-}) => (e: MouseEvent) => void;
-
-const createItemClickHandler =
-  ({
-    closeMenu,
-    navigateToUrl,
-  }: {
-    closeMenu: () => void;
-    navigateToUrl: (url: string) => void;
-  }): ItemClickHandler =>
-  ({ onClick, href, isExternal }) =>
-  (e: MouseEvent) => {
-    if (onClick) {
-      e.preventDefault();
-      onClick();
-    } else if (
-      href &&
-      !isExternal &&
-      !isModifiedOrPrevented(e as MouseEvent<HTMLElement>) &&
-      e.button === 0
-    ) {
-      e.preventDefault();
-      navigateToUrl(href);
-    }
-    closeMenu();
-  };
-
-const createMenuItem = (
-  options: MenuItemOptions,
-  onItemClick: ItemClickHandler
-): EuiContextMenuPanelItemDescriptor => ({
-  name: options.name,
-  key: options.key,
-  icon: options.icon,
-  'data-test-subj': options.dataTestSubj,
-  ...(options.href ? { href: options.href } : {}),
-  target: options.target,
-  rel: options.rel,
-  onClick: onItemClick({
-    onClick: options.onClick,
-    href: options.href,
-    isExternal: options.isExternal,
-  }),
-});
-
-const buildDefaultContentLinks = ({
-  kibanaDocLink,
-  docLinks,
-  helpSupportUrl,
-}: {
-  kibanaDocLink: string;
-  docLinks: DocLinksStart;
-  helpSupportUrl: string;
-}): ChromeHelpMenuLink[] => [
-  {
-    title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuOpenGitHubIssueTitle', {
-      defaultMessage: 'Open GitHub issue',
-    }),
-    href: docLinks.links.kibana.createGithubIssue,
-    iconType: 'logoGithub',
-  },
-  {
-    title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuKibanaDocumentationTitle', {
-      defaultMessage: 'Kibana documentation',
-    }),
-    href: kibanaDocLink,
-    iconType: 'documentation',
-  },
-  {
-    title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuAskElasticTitle', {
-      defaultMessage: 'Ask support',
-    }),
-    href: helpSupportUrl,
-    iconType: 'question',
-  },
-];
-
-export const HeaderHelpMenu = () => {
-  const navigateToUrl = useNavigateToUrl();
-  const docLinks = useDocLinks();
-  const { euiTheme } = useEuiTheme();
+export const HeaderHelpMenu = ({ renderButton }: HeaderHelpMenuProps = {}) => {
   const [isOpen, setIsOpen] = useState(false);
   const isServerless = useIsServerless();
   const kibanaVersion = useKibanaVersion();
-  const chromeStyle = useChromeStyle();
-  const kibanaDocLink =
-    chromeStyle === 'project' ? docLinks.links.elasticStackGetStarted : docLinks.links.kibana.guide;
-
-  const appNameStyle = useMemo(
-    () => css`
-      font-weight: ${euiTheme.font.weight.bold};
-    `,
-    [euiTheme.font.weight.bold]
-  );
-
-  const {
-    menuLinks: providedDefaultContentLinks,
-    extension: helpExtension,
-    supportUrl: helpSupportUrl,
-    globalExtensionMenuLinks: globalHelpExtensionMenuLinks,
-  } = useHelpMenu();
-
-  const defaultContentLinks = useMemo(
-    () =>
-      providedDefaultContentLinks.length === 0
-        ? buildDefaultContentLinks({ kibanaDocLink, docLinks, helpSupportUrl })
-        : providedDefaultContentLinks,
-    [providedDefaultContentLinks, kibanaDocLink, docLinks, helpSupportUrl]
-  );
 
   const closeMenu = useCallback(() => setIsOpen(false), []);
   const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
 
-  const handleItemClick = useMemo(
-    () => createItemClickHandler({ closeMenu, navigateToUrl }),
-    [closeMenu, navigateToUrl]
-  );
+  const items = useHelpMenuItems({ closeMenu });
 
-  const items = useMemo(() => {
-    const menuItems: EuiContextMenuPanelItemDescriptor[] = [];
-
-    // Global extension links (e.g. cloud data migration)
-    globalHelpExtensionMenuLinks
-      .sort((a, b) => b.priority - a.priority)
-      .forEach((link) => {
-        menuItems.push(
-          createMenuItem(
-            {
-              name: link.content,
-              key: `global-${link.href}`,
-              href: link.href,
-              target: link.target,
-              rel: link.rel,
-              icon: link.iconType,
-              isExternal: link.external,
-              dataTestSubj: link['data-test-subj'],
-            },
-            handleItemClick
-          )
-        );
-      });
-
-    // Default links (Kibana docs, Ask Elastic, GitHub)
-    defaultContentLinks.forEach((link, idx) => {
-      if (link.href && link.onClick) {
-        throw new Error(
-          'Only one of `href` and `onClick` should be provided for the help menu link.'
-        );
-      }
-
-      menuItems.push(
-        createMenuItem(
-          {
-            name: link.title,
-            key: `default-${idx}`,
-            icon: link.iconType,
-            href: link.href,
-            target: link.href ? '_blank' : undefined,
-            onClick: link.onClick,
-            isExternal: !!link.href,
-            dataTestSubj: link.dataTestSubj,
-          },
-          handleItemClick
-        )
-      );
-    });
-
-    // App-specific extension links
-    if (helpExtension) {
-      menuItems.push({ isSeparator: true, key: 'extension-separator' });
-
-      menuItems.push({
-        renderItem: () => (
-          <EuiContextMenuItem css={appNameStyle}>{helpExtension.appName}</EuiContextMenuItem>
-        ),
-        key: 'extension-title',
-      });
-
-      helpExtension.links?.forEach((link, idx) => {
-        const isDocumentation = link.linkType === 'documentation';
-        menuItems.push(
-          createMenuItem(
-            {
-              name: isDocumentation
-                ? i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuDocumentation', {
-                    defaultMessage: 'Documentation',
-                  })
-                : link.content,
-              key: `extension-${idx}`,
-              icon: link.iconType,
-              href: link.href,
-              target: link.target ?? (isDocumentation ? '_blank' : undefined),
-              rel: link.rel ?? (isDocumentation ? 'noopener' : undefined),
-              onClick: !isDocumentation ? link.onClick : undefined,
-              isExternal: isDocumentation || link.external,
-              dataTestSubj: link['data-test-subj'],
-            },
-            handleItemClick
-          )
-        );
-      });
-    }
-
-    return menuItems;
-  }, [
-    globalHelpExtensionMenuLinks,
-    defaultContentLinks,
-    helpExtension,
-    handleItemClick,
-    appNameStyle,
-  ]);
-
-  const button = (
+  const button = renderButton ? (
+    renderButton({ isOpen, toggleMenu })
+  ) : (
     <EuiHeaderSectionItemButton
       aria-expanded={isOpen}
       aria-haspopup="true"

--- a/src/core/packages/chrome/browser-components/src/shared/help_links_hooks.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/help_links_hooks.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import type { Observable } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map, of, startWith, switchMap } from 'rxjs';
+import equal from 'fast-deep-equal';
+import { EuiContextMenuItem, EuiIcon, useEuiTheme } from '@elastic/eui';
+import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
+import { useObservable } from '@kbn/use-observable';
+import { useChromeService } from '@kbn/core-chrome-browser-context';
+import { useChromeStyle } from '@kbn/core-chrome-browser-hooks';
+import { useIsServerless } from '@kbn/react-env';
+import { css } from '@emotion/react';
+import type { HelpLinks, HelpMenuLinkItem } from './help_menu_links';
+import { buildHelpLinks, toContextMenuItem } from './help_menu_links';
+import { useNavigateToUrl, useIsNextChrome } from './chrome_hooks';
+import { useChromeComponentsDeps } from '../context';
+
+/**
+ * Returns an observable of pre-built help menu link groups for the given chrome style.
+ * Used by both `HeaderHelpMenu` (via `useObservable`) and the project sidenav (via `combineLatest`).
+ */
+export function useHelpLinks$(): Observable<HelpLinks> {
+  const chrome = useChromeService();
+  const chromeStyle = useChromeStyle();
+  const docLinks = useChromeComponentsDeps().docLinks;
+  const isNextChrome = useIsNextChrome();
+  const isServerless = useIsServerless();
+  const isProjectAndNextChrome = chromeStyle === 'project' && isNextChrome;
+  const showNewsfeed = isProjectAndNextChrome && !isServerless;
+
+  return useMemo(
+    () =>
+      combineLatest([
+        chrome.getHelpMenuLinks$(),
+        chrome.getHelpExtension$(),
+        chrome.getHelpSupportUrl$(),
+        chrome.getGlobalHelpExtensionMenuLinks$(),
+        chrome.getFeedbackHandler$(),
+        chrome.getNewsfeedHandler$().pipe(
+          switchMap((handler) =>
+            handler
+              ? handler.hasNew$.pipe(
+                  map((hasNew) => ({ open: handler.open, hasNew })),
+                  startWith({ open: handler.open, hasNew: false })
+                )
+              : of(undefined)
+          )
+        ),
+      ]).pipe(
+        map(
+          ([
+            menuLinks,
+            extension,
+            supportUrl,
+            globalExtensionMenuLinks,
+            feedbackHandler,
+            newsfeedInfo,
+          ]) =>
+            buildHelpLinks({
+              chromeStyle,
+              helpData: {
+                menuLinks,
+                extension,
+                supportUrl,
+                globalExtensionMenuLinks,
+                docLinks,
+                feedbackHandler: isProjectAndNextChrome ? feedbackHandler : undefined,
+                newsfeedHandler: showNewsfeed ? newsfeedInfo?.open : undefined,
+                newsfeedHasNew: showNewsfeed ? newsfeedInfo?.hasNew : undefined,
+              },
+            })
+        ),
+        distinctUntilChanged(equal)
+      ),
+    [chrome, chromeStyle, docLinks, isProjectAndNextChrome, showNewsfeed]
+  );
+}
+
+export const useHelpMenuItems = ({
+  closeMenu,
+}: {
+  closeMenu: () => void;
+}): EuiContextMenuPanelItemDescriptor[] => {
+  const helpLinks$ = useHelpLinks$();
+  const helpLinks = useObservable(helpLinks$, { global: [], default: [] });
+  const navigateToUrl = useNavigateToUrl();
+  const { euiTheme } = useEuiTheme();
+
+  const stableNavigate = useCallback((url: string) => navigateToUrl(url), [navigateToUrl]);
+
+  const appNameStyle = useMemo(
+    () =>
+      css`
+        font-weight: ${euiTheme.font.weight.bold};
+      `,
+    [euiTheme.font.weight.bold]
+  );
+
+  const indicatorStyle = useMemo(
+    () =>
+      css`
+        position: absolute;
+        top: -3px;
+        right: -3px;
+        pointer-events: none;
+        stroke: ${euiTheme.components.buttons.backgroundText};
+        stroke-width: 2px;
+        paint-order: stroke;
+      `,
+    [euiTheme.components.buttons.backgroundText]
+  );
+
+  return useMemo(() => {
+    const toIcon = (item: HelpMenuLinkItem): React.ReactElement | string | undefined => {
+      if (!item.icon) return undefined;
+      if (!item.hasNewIndicator) return item.icon as string;
+      return (
+        <span
+          css={css`
+            position: relative;
+            display: inline-flex;
+          `}
+        >
+          <EuiIcon type={item.icon} size="m" aria-hidden={true} />
+          <EuiIcon css={indicatorStyle} color="primary" type="dot" size="m" aria-hidden={true} />
+        </span>
+      );
+    };
+
+    const mapItems = (items: HelpLinks['global']) =>
+      items.map((item) => {
+        const menuItem = toContextMenuItem(item, stableNavigate, closeMenu);
+        const iconOverride = toIcon(item);
+        if (iconOverride !== undefined) {
+          menuItem.icon = iconOverride;
+        }
+        return menuItem;
+      });
+
+    const menuItems: EuiContextMenuPanelItemDescriptor[] = [
+      ...mapItems(helpLinks.global),
+      ...mapItems(helpLinks.default),
+    ];
+
+    if (helpLinks.extension) {
+      menuItems.push({ isSeparator: true, key: 'extension-separator' });
+
+      menuItems.push({
+        renderItem: () => (
+          <EuiContextMenuItem css={appNameStyle}>{helpLinks.extension?.label}</EuiContextMenuItem>
+        ),
+        key: 'extension-title',
+      } as EuiContextMenuPanelItemDescriptor);
+
+      menuItems.push(...mapItems(helpLinks.extension.items));
+    }
+
+    return menuItems;
+  }, [helpLinks, stableNavigate, closeMenu, appNameStyle, indicatorStyle]);
+};

--- a/src/core/packages/chrome/browser-components/src/shared/help_links_hooks.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/help_links_hooks.tsx
@@ -43,8 +43,8 @@ export function useHelpLinks$(): Observable<HelpLinks> {
         chrome.getHelpExtension$(),
         chrome.getHelpSupportUrl$(),
         chrome.getGlobalHelpExtensionMenuLinks$(),
-        chrome.getFeedbackHandler$(),
-        chrome.getNewsfeedHandler$().pipe(
+        chrome.next.getFeedbackHandler$(),
+        chrome.next.getNewsfeedHandler$().pipe(
           switchMap((handler) =>
             handler
               ? handler.hasNew$.pipe(

--- a/src/core/packages/chrome/browser-components/src/shared/help_menu_links.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/help_menu_links.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  ChromeGlobalHelpExtensionMenuLink,
+  ChromeHelpExtension,
+  ChromeHelpMenuLink,
+  ChromeStyle,
+} from '@kbn/core-chrome-browser';
+import type { DocLinksStart } from '@kbn/core-doc-links-browser';
+import type { EuiContextMenuPanelItemDescriptor, IconType } from '@elastic/eui';
+import type React from 'react';
+import { i18n } from '@kbn/i18n';
+import { isModifiedOrPrevented } from './nav_link';
+
+interface HelpData {
+  menuLinks: ChromeHelpMenuLink[];
+  extension: ChromeHelpExtension | undefined;
+  supportUrl: string;
+  globalExtensionMenuLinks: ChromeGlobalHelpExtensionMenuLink[];
+  docLinks: DocLinksStart;
+  feedbackHandler?: () => void;
+  newsfeedHandler?: () => void;
+  newsfeedHasNew?: boolean;
+}
+
+export interface HelpMenuLinkItem {
+  name: string;
+  key: string;
+  icon?: IconType;
+  href?: string;
+  target?: string;
+  rel?: string;
+  onClick?: () => void;
+  isExternal?: boolean;
+  hasNewIndicator?: boolean;
+  dataTestSubj?: string;
+}
+
+export interface HelpLinks {
+  global: HelpMenuLinkItem[];
+  default: HelpMenuLinkItem[];
+  extension?: {
+    label?: string;
+    items: HelpMenuLinkItem[];
+  };
+}
+
+export const toContextMenuItem = (
+  options: HelpMenuLinkItem,
+  navigateToUrl: (url: string) => Promise<void> | void,
+  closeMenu: () => void
+): EuiContextMenuPanelItemDescriptor =>
+  ({
+    name: options.name,
+    key: options.key,
+    icon: options.icon,
+    'data-test-subj': options.dataTestSubj,
+    ...(options.href
+      ? {
+          href: options.href,
+          target: options.target,
+          rel: options.rel,
+        }
+      : {}),
+    onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+      const isUnmodifiedPrimaryClick = !isModifiedOrPrevented(event) && event.button === 0;
+
+      if (!isModifiedOrPrevented(event)) {
+        options.onClick?.();
+      }
+
+      if (options.href && !options.isExternal && isUnmodifiedPrimaryClick) {
+        event.preventDefault();
+        closeMenu();
+        navigateToUrl(options.href);
+        return;
+      }
+
+      if (isUnmodifiedPrimaryClick) {
+        closeMenu();
+      }
+    },
+  } as EuiContextMenuPanelItemDescriptor);
+
+const buildNewsfeedLink = (newsfeedHandler?: () => void): ChromeHelpMenuLink[] =>
+  newsfeedHandler
+    ? [
+        {
+          title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuWhatsNewTitle', {
+            defaultMessage: "What's new?",
+          }),
+          iconType: 'cheer',
+          onClick: newsfeedHandler,
+          dataTestSubj: 'helpMenuWhatsNewButton',
+        },
+      ]
+    : [];
+
+const buildFeedbackLink = (feedbackHandler?: () => void): ChromeHelpMenuLink[] =>
+  feedbackHandler
+    ? [
+        {
+          title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuGiveFeedbackTitle', {
+            defaultMessage: 'Give feedback',
+          }),
+          iconType: 'comment',
+          onClick: feedbackHandler,
+          dataTestSubj: 'helpMenuGiveFeedbackButton',
+        },
+      ]
+    : [];
+
+export const buildDefaultContentLinks = ({
+  chromeStyle,
+  docLinks,
+  helpSupportUrl,
+  feedbackHandler,
+  newsfeedHandler,
+}: {
+  chromeStyle: ChromeStyle;
+  docLinks: DocLinksStart;
+  helpSupportUrl: string;
+  feedbackHandler?: () => void;
+  newsfeedHandler?: () => void;
+  newsfeedHasNew?: boolean;
+}): ChromeHelpMenuLink[] => [
+  ...buildNewsfeedLink(newsfeedHandler),
+  {
+    title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuOpenGitHubIssueTitle', {
+      defaultMessage: 'Open GitHub issue',
+    }),
+    href: docLinks.links.kibana.createGithubIssue,
+    iconType: 'logoGithub',
+  },
+  {
+    title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuAskElasticTitle', {
+      defaultMessage: 'Ask support',
+    }),
+    href: helpSupportUrl,
+    iconType: 'question',
+  },
+  ...buildFeedbackLink(feedbackHandler),
+  {
+    title: i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuKibanaDocumentationTitle', {
+      defaultMessage: 'Kibana documentation',
+    }),
+    href:
+      chromeStyle === 'project'
+        ? docLinks.links.elasticStackGetStarted
+        : docLinks.links.kibana.guide,
+    iconType: 'documentation',
+  },
+];
+
+export const buildHelpLinks = ({
+  chromeStyle,
+  helpData,
+}: {
+  chromeStyle: ChromeStyle;
+  helpData: HelpData;
+}): HelpLinks => {
+  const global = [...helpData.globalExtensionMenuLinks]
+    .sort((a, b) => b.priority - a.priority)
+    .map((link) => ({
+      name: link.content,
+      key: `global-${link.href}`,
+      href: link.href,
+      target: link.target,
+      rel: link.rel,
+      icon: link.iconType,
+      isExternal: link.external,
+      dataTestSubj: link['data-test-subj'],
+    }));
+
+  const rawDefaultLinks =
+    helpData.menuLinks.length > 0
+      ? [
+          ...buildNewsfeedLink(helpData.newsfeedHandler),
+          ...helpData.menuLinks,
+          ...buildFeedbackLink(helpData.feedbackHandler),
+        ]
+      : buildDefaultContentLinks({
+          chromeStyle,
+          docLinks: helpData.docLinks,
+          helpSupportUrl: helpData.supportUrl,
+          feedbackHandler: helpData.feedbackHandler,
+          newsfeedHandler: helpData.newsfeedHandler,
+          newsfeedHasNew: helpData.newsfeedHasNew,
+        });
+
+  const defaultLinks = rawDefaultLinks.map(
+    ({ title, href, onClick, dataTestSubj, iconType }, index) => ({
+      name: title,
+      key: `default-${index}`,
+      icon: iconType,
+      href,
+      target: href ? '_blank' : undefined,
+      onClick,
+      isExternal: Boolean(href),
+      hasNewIndicator:
+        dataTestSubj === 'helpMenuWhatsNewButton' && helpData.newsfeedHasNew === true,
+      dataTestSubj,
+    })
+  );
+
+  const extensionItems = helpData.extension?.links?.map((link, index) => {
+    const isDocumentation = link.linkType === 'documentation';
+    return {
+      name: isDocumentation
+        ? i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuDocumentation', {
+            defaultMessage: 'Documentation',
+          })
+        : link.content,
+      key: `extension-${index}`,
+      href: link.href,
+      target: link.target ?? (isDocumentation ? '_blank' : undefined),
+      rel: link.rel ?? (isDocumentation ? 'noopener' : undefined),
+      onClick: !isDocumentation ? link.onClick : undefined,
+      isExternal: isDocumentation || link.external,
+      dataTestSubj: link['data-test-subj'],
+    };
+  });
+
+  const hasExtension = (extensionItems?.length ?? 0) > 0;
+
+  return {
+    global,
+    default: defaultLinks,
+    ...(hasExtension
+      ? {
+          extension: {
+            label: helpData.extension?.appName,
+            items: extensionItems ?? [],
+          },
+        }
+      : {}),
+  };
+};

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { type ReactNode } from 'react';
-import { distinctUntilChanged, map, shareReplay } from 'rxjs';
+import { type Observable, distinctUntilChanged, map, shareReplay } from 'rxjs';
 import type { RecentlyAccessedService } from '@kbn/recently-accessed';
 import type { AppHeaderConfig } from '@kbn/core-chrome-browser';
 import { SidebarServiceProvider } from '@kbn/core-chrome-sidebar-context';
@@ -212,6 +212,22 @@ export function createChromeApi({
       },
     },
     sidebar,
+
+    registerFeedbackHandler: (handler: () => void) => {
+      state.feedbackHandler.set(handler);
+      return () => {
+        state.feedbackHandler.update((current) => (current === handler ? undefined : current));
+      };
+    },
+    getFeedbackHandler$: () => state.feedbackHandler.$,
+
+    registerNewsfeedHandler: (handler: { open: () => void; hasNew$: Observable<boolean> }) => {
+      state.newsfeedHandler.set(handler);
+      return () => {
+        state.newsfeedHandler.update((current) => (current === handler ? undefined : current));
+      };
+    },
+    getNewsfeedHandler$: () => state.newsfeedHandler.$,
   };
 
   return chromeStart;

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -210,24 +210,22 @@ export function createChromeApi({
           };
         },
       },
+      registerFeedbackHandler: (handler: () => void) => {
+        state.feedbackHandler.set(handler);
+        return () => {
+          state.feedbackHandler.update((current) => (current === handler ? undefined : current));
+        };
+      },
+      getFeedbackHandler$: () => state.feedbackHandler.$,
+      registerNewsfeedHandler: (handler: { open: () => void; hasNew$: Observable<boolean> }) => {
+        state.newsfeedHandler.set(handler);
+        return () => {
+          state.newsfeedHandler.update((current) => (current === handler ? undefined : current));
+        };
+      },
+      getNewsfeedHandler$: () => state.newsfeedHandler.$,
     },
     sidebar,
-
-    registerFeedbackHandler: (handler: () => void) => {
-      state.feedbackHandler.set(handler);
-      return () => {
-        state.feedbackHandler.update((current) => (current === handler ? undefined : current));
-      };
-    },
-    getFeedbackHandler$: () => state.feedbackHandler.$,
-
-    registerNewsfeedHandler: (handler: { open: () => void; hasNew$: Observable<boolean> }) => {
-      state.newsfeedHandler.set(handler);
-      return () => {
-        state.newsfeedHandler.update((current) => (current === handler ? undefined : current));
-      };
-    },
-    getNewsfeedHandler$: () => state.newsfeedHandler.$,
   };
 
   return chromeStart;

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -77,6 +77,12 @@ export interface ChromeState {
     supportUrl: State<string>;
     globalMenuLinks: ArrayState<ChromeGlobalHelpExtensionMenuLink>;
   };
+
+  /** Feedback handler registered by the feedback plugin */
+  feedbackHandler: State<(() => void) | undefined>;
+
+  /** Newsfeed handler registered by the newsfeed plugin */
+  newsfeedHandler: State<{ open: () => void; hasNew$: Observable<boolean> } | undefined>;
 }
 
 export interface ChromeStateDeps {
@@ -124,6 +130,14 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
   const helpSupportUrl = createState<string>(docLinks.links.kibana.askElastic);
   const globalHelpMenuLinks = createArrayState<ChromeGlobalHelpExtensionMenuLink>();
 
+  // Feedback
+  const feedbackHandler = createState<(() => void) | undefined>(undefined);
+
+  // Newsfeed
+  const newsfeedHandler = createState<
+    { open: () => void; hasNew$: Observable<boolean> } | undefined
+  >(undefined);
+
   return {
     visibility,
     style,
@@ -151,5 +165,7 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
       globalMenuLinks: globalHelpMenuLinks,
     },
     contextSwitcher,
+    feedbackHandler,
+    newsfeedHandler,
   };
 }

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -152,6 +152,10 @@ const createStartContractMock = () => {
     getAppMenu$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
     setAppMenu: jest.fn(),
     setBreadcrumbsBadges: jest.fn(),
+    getFeedbackHandler$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
+    registerFeedbackHandler: jest.fn().mockReturnValue(() => {}),
+    getNewsfeedHandler$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
+    registerNewsfeedHandler: jest.fn().mockReturnValue(() => {}),
   });
 
   return startContract;

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -146,16 +146,16 @@ const createStartContractMock = () => {
           };
         }),
       }),
+      getFeedbackHandler$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
+      registerFeedbackHandler: jest.fn().mockReturnValue(() => {}),
+      getNewsfeedHandler$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
+      registerNewsfeedHandler: jest.fn().mockReturnValue(() => {}),
     }),
     setGlobalFooter: jest.fn(),
     getGlobalFooter$: jest.fn().mockReturnValue(new BehaviorSubject(null)),
     getAppMenu$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
     setAppMenu: jest.fn(),
     setBreadcrumbsBadges: jest.fn(),
-    getFeedbackHandler$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
-    registerFeedbackHandler: jest.fn().mockReturnValue(() => {}),
-    getNewsfeedHandler$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
-    registerNewsfeedHandler: jest.fn().mockReturnValue(() => {}),
   });
 
   return startContract;

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ReactElement, ReactNode, MouseEventHandler } from 'react';
+import type { Observable } from 'rxjs';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import type { GlobalSearchConfig } from './global_search';
 
@@ -166,4 +167,20 @@ export interface ChromeNext {
      */
     set(config: AppHeaderConfig): () => void;
   };
+  /**
+   * Register a handler that opens the feedback UI in the Chrome Next help menu.
+   *
+   * @returns A function to unregister the handler.
+   */
+  registerFeedbackHandler(handler: () => void): () => void;
+  /** Get the currently registered Chrome Next feedback handler. */
+  getFeedbackHandler$(): Observable<(() => void) | undefined>;
+  /**
+   * Register a handler that opens the newsfeed UI in the Chrome Next help menu.
+   *
+   * @returns A function to unregister the handler.
+   */
+  registerNewsfeedHandler(handler: { open: () => void; hasNew$: Observable<boolean> }): () => void;
+  /** Get the currently registered Chrome Next newsfeed handler. */
+  getNewsfeedHandler$(): Observable<{ open: () => void; hasNew$: Observable<boolean> } | undefined>;
 }

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -329,6 +329,32 @@ export interface ChromeStart {
   getActiveSolutionNavId(): SolutionId | null;
 
   /**
+   * Register a handler that opens the feedback UI.
+   * Called by the feedback plugin during `start`.
+   *
+   * @returns A function to unregister the handler.
+   */
+  registerFeedbackHandler(handler: () => void): () => void;
+
+  /**
+   * Get an observable of the currently registered feedback handler, or `undefined` if none.
+   */
+  getFeedbackHandler$(): Observable<(() => void) | undefined>;
+
+  /**
+   * Register a handler that opens the newsfeed UI.
+   * Called by the newsfeed plugin during `start`.
+   *
+   * @returns A function to unregister the handler.
+   */
+  registerNewsfeedHandler(handler: { open: () => void; hasNew$: Observable<boolean> }): () => void;
+
+  /**
+   * Get an observable of the currently registered newsfeed handler, or `undefined` if none.
+   */
+  getNewsfeedHandler$(): Observable<{ open: () => void; hasNew$: Observable<boolean> } | undefined>;
+
+  /**
    * Used only by the rendering service and KibanaRenderingContextProvider to wrap the rendering tree in the Chrome context providers
    */
   withProvider(component: ReactNode): ReactNode;

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -329,32 +329,6 @@ export interface ChromeStart {
   getActiveSolutionNavId(): SolutionId | null;
 
   /**
-   * Register a handler that opens the feedback UI.
-   * Called by the feedback plugin during `start`.
-   *
-   * @returns A function to unregister the handler.
-   */
-  registerFeedbackHandler(handler: () => void): () => void;
-
-  /**
-   * Get an observable of the currently registered feedback handler, or `undefined` if none.
-   */
-  getFeedbackHandler$(): Observable<(() => void) | undefined>;
-
-  /**
-   * Register a handler that opens the newsfeed UI.
-   * Called by the newsfeed plugin during `start`.
-   *
-   * @returns A function to unregister the handler.
-   */
-  registerNewsfeedHandler(handler: { open: () => void; hasNew$: Observable<boolean> }): () => void;
-
-  /**
-   * Get an observable of the currently registered newsfeed handler, or `undefined` if none.
-   */
-  getNewsfeedHandler$(): Observable<{ open: () => void; hasNew$: Observable<boolean> } | undefined>;
-
-  /**
    * Used only by the rendering service and KibanaRenderingContextProvider to wrap the rendering tree in the Chrome context providers
    */
   withProvider(component: ReactNode): ReactNode;

--- a/src/core/packages/chrome/browser/src/help_extension.ts
+++ b/src/core/packages/chrome/browser/src/help_extension.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiButtonEmptyProps } from '@elastic/eui';
+import type { EuiButtonEmptyProps, IconType } from '@elastic/eui';
 
 /** @public */
 export interface ChromeHelpExtension {
@@ -24,8 +24,13 @@ export interface ChromeHelpExtension {
 /** @public */
 export type ChromeHelpExtensionLinkBase = Pick<
   EuiButtonEmptyProps,
-  'iconType' | 'target' | 'rel' | 'data-test-subj'
->;
+  'target' | 'rel' | 'data-test-subj'
+> & {
+  /**
+   * @deprecated Extension items don't support icons. This property will be removed in a future release.
+   */
+  iconType?: IconType;
+};
 
 /** @public */
 export interface ChromeHelpExtensionMenuDocumentationLink extends ChromeHelpExtensionLinkBase {

--- a/src/platform/plugins/shared/newsfeed/public/components/flyout_list.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/components/flyout_list.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import type { EuiFlyoutProps } from '@elastic/eui';
 import {
   EuiFlyout,
@@ -26,16 +26,112 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { NewsfeedContext } from './newsfeed_header_nav_button';
-import type { NewsfeedItem } from '../types';
+import type { NewsfeedItem, FetchResult } from '../types';
+import type { NewsfeedApi } from '../lib/api';
 import { NewsEmptyPrompt } from './empty_news';
 import { NewsLoadingPrompt } from './loading_news';
 
+export interface NewsfeedContainerProps {
+  newsfeedApi: NewsfeedApi;
+  onClose: () => void;
+  showPlainSpinner: boolean;
+  isServerless: boolean;
+  newsFetchResult?: FetchResult | null | void;
+}
+
+export const NewsfeedContainer = ({
+  newsfeedApi,
+  onClose,
+  showPlainSpinner,
+  isServerless,
+  newsFetchResult: externalFetchResult,
+}: NewsfeedContainerProps) => {
+  const [internalFetchResult, setInternalFetchResult] = useState<FetchResult | null | void>(null);
+
+  useEffect(() => {
+    if (externalFetchResult !== undefined) return;
+    const subscription = newsfeedApi.fetchResults$.subscribe((results) => {
+      setInternalFetchResult(results);
+    });
+    return () => subscription.unsubscribe();
+  }, [newsfeedApi, externalFetchResult]);
+
+  const newsFetchResult =
+    externalFetchResult !== undefined ? externalFetchResult : internalFetchResult;
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="s">
+          <h2 id="flyoutSmallTitle">
+            <FormattedMessage
+              id="newsfeed.flyoutList.whatsNewTitle"
+              defaultMessage="What's new at Elastic"
+            />
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody className={'kbnNews__flyoutAlerts'}>
+        {!newsFetchResult ? (
+          <NewsLoadingPrompt showPlainSpinner={showPlainSpinner} />
+        ) : newsFetchResult.feedItems.length > 0 ? (
+          newsFetchResult.feedItems.map((item: NewsfeedItem) => {
+            return (
+              <EuiHeaderAlert
+                key={item.hash}
+                title={item.title}
+                text={item.description}
+                data-test-subj="newsHeadAlert"
+                action={
+                  <EuiLink target="_blank" href={item.linkUrl} external>
+                    {item.linkText}
+                  </EuiLink>
+                }
+                date={item.publishOn.format('DD MMMM YYYY')}
+                badge={item.badge ? <EuiBadge color="hollow">{item.badge}</EuiBadge> : undefined}
+              />
+            );
+          })
+        ) : (
+          <NewsEmptyPrompt />
+        )}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty iconType="cross" onClick={onClose} flush="left">
+              <FormattedMessage id="newsfeed.flyoutList.closeButtonLabel" defaultMessage="Close" />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            {newsFetchResult && !isServerless ? (
+              <EuiText color="subdued" size="s">
+                <p>
+                  <FormattedMessage
+                    id="newsfeed.flyoutList.versionTextLabel"
+                    defaultMessage="{version}"
+                    values={{ version: `Version ${newsFetchResult.kibanaVersion}` }}
+                  />
+                </p>
+              </EuiText>
+            ) : null}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};
+
 export const NewsfeedFlyout = (
-  props: Partial<EuiFlyoutProps> & { showPlainSpinner: boolean; isServerless: boolean }
+  props: Partial<EuiFlyoutProps> & {
+    newsfeedApi: NewsfeedApi;
+    showPlainSpinner: boolean;
+    isServerless: boolean;
+  }
 ) => {
-  const { newsFetchResult, setFlyoutVisible } = useContext(NewsfeedContext);
+  const { setFlyoutVisible, newsFetchResult } = useContext(NewsfeedContext);
   const closeFlyout = useCallback(() => setFlyoutVisible(false), [setFlyoutVisible]);
-  const { showPlainSpinner, isServerless, ...rest } = props;
+  const { showPlainSpinner, isServerless, newsfeedApi, ...rest } = props;
   return (
     <EuiPortal>
       <EuiFlyout
@@ -47,66 +143,13 @@ export const NewsfeedFlyout = (
         data-test-subj="NewsfeedFlyout"
         session="start"
       >
-        <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="s">
-            <h2 id="flyoutSmallTitle">
-              <FormattedMessage
-                id="newsfeed.flyoutList.whatsNewTitle"
-                defaultMessage="What's new at Elastic"
-              />
-            </h2>
-          </EuiTitle>
-        </EuiFlyoutHeader>
-        <EuiFlyoutBody className={'kbnNews__flyoutAlerts'}>
-          {!newsFetchResult ? (
-            <NewsLoadingPrompt showPlainSpinner={props.showPlainSpinner} />
-          ) : newsFetchResult.feedItems.length > 0 ? (
-            newsFetchResult.feedItems.map((item: NewsfeedItem) => {
-              return (
-                <EuiHeaderAlert
-                  key={item.hash}
-                  title={item.title}
-                  text={item.description}
-                  data-test-subj="newsHeadAlert"
-                  action={
-                    <EuiLink target="_blank" href={item.linkUrl} external>
-                      {item.linkText}
-                    </EuiLink>
-                  }
-                  date={item.publishOn.format('DD MMMM YYYY')}
-                  badge={item.badge ? <EuiBadge color="hollow">{item.badge}</EuiBadge> : undefined}
-                />
-              );
-            })
-          ) : (
-            <NewsEmptyPrompt />
-          )}
-        </EuiFlyoutBody>
-        <EuiFlyoutFooter>
-          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty iconType="cross" onClick={closeFlyout} flush="left">
-                <FormattedMessage
-                  id="newsfeed.flyoutList.closeButtonLabel"
-                  defaultMessage="Close"
-                />
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              {newsFetchResult && !isServerless ? (
-                <EuiText color="subdued" size="s">
-                  <p>
-                    <FormattedMessage
-                      id="newsfeed.flyoutList.versionTextLabel"
-                      defaultMessage="{version}"
-                      values={{ version: `Version ${newsFetchResult.kibanaVersion}` }}
-                    />
-                  </p>
-                </EuiText>
-              ) : null}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlyoutFooter>
+        <NewsfeedContainer
+          newsfeedApi={newsfeedApi}
+          onClose={closeFlyout}
+          showPlainSpinner={showPlainSpinner}
+          isServerless={isServerless}
+          newsFetchResult={newsFetchResult}
+        />
       </EuiFlyout>
     </EuiPortal>
   );

--- a/src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx
@@ -79,6 +79,7 @@ export const NewsfeedNavButton = ({ newsfeedApi, hasCustomBranding$, isServerles
         </EuiHeaderSectionItemButton>
         {flyoutVisible ? (
           <NewsfeedFlyout
+            newsfeedApi={newsfeedApi}
             isServerless={isServerless}
             focusTrapProps={{ shards: [buttonRef] }}
             showPlainSpinner={hasCustomBranding}

--- a/src/platform/plugins/shared/newsfeed/public/plugin.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/plugin.tsx
@@ -16,6 +16,7 @@ import type { NewsfeedPluginBrowserConfig, NewsfeedPluginStartDependencies } fro
 import { NewsfeedNavButton } from './components/newsfeed_header_nav_button';
 import type { NewsfeedApi } from './lib/api';
 import { getApi, NewsfeedApiEndpoint } from './lib/api';
+import { registerNewsfeedHandler } from './register_newsfeed_handler';
 
 export type NewsfeedPublicPluginSetup = ReturnType<NewsfeedPublicPlugin['setup']>;
 export type NewsfeedPublicPluginStart = ReturnType<NewsfeedPublicPlugin['start']>;
@@ -48,6 +49,9 @@ export class NewsfeedPublicPlugin
     const isScreenshotMode = screenshotMode.isScreenshotMode();
 
     const api = this.createNewsfeedApi(this.config, NewsfeedApiEndpoint.KIBANA, isScreenshotMode);
+
+    registerNewsfeedHandler({ core, api, isServerless: this.isServerless });
+
     core.chrome.navControls.registerRight({
       order: 1000,
       content: (

--- a/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.test.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import moment from 'moment';
+import type { CoreStart } from '@kbn/core/public';
+import { registerNewsfeedHandler } from './register_newsfeed_handler';
+import type { NewsfeedApi } from './lib/api';
+import type { FetchResult } from './types';
+
+const createFetchResult = (): FetchResult => ({
+  kibanaVersion: '9.5.0',
+  hasNew: true,
+  feedItems: [
+    {
+      title: 'Test news item',
+      description: 'A test news description',
+      linkText: 'Read more',
+      linkUrl: 'https://elastic.co/blog/test',
+      badge: null,
+      publishOn: moment('2026-01-01'),
+      expireOn: moment('2027-01-01'),
+      hash: 'test-hash-1',
+    },
+  ],
+  error: null,
+});
+
+describe('registerNewsfeedHandler', () => {
+  it('registers a chrome newsfeed handler and returns its cleanup callback', () => {
+    const unregister = jest.fn();
+    const registerNewsfeedHandlerMock = jest.fn().mockReturnValue(unregister);
+    const openSystemFlyout = jest.fn().mockReturnValue({ close: jest.fn() });
+    const fetchResults$ = new BehaviorSubject<FetchResult | null | void>(createFetchResult());
+    const markAsRead = jest.fn();
+    const api: NewsfeedApi = { fetchResults$, markAsRead };
+    const core = {
+      chrome: {
+        registerNewsfeedHandler: registerNewsfeedHandlerMock,
+      },
+      overlays: {
+        openSystemFlyout,
+      },
+    } as unknown as CoreStart;
+
+    const cleanup = registerNewsfeedHandler({ core, api, isServerless: false });
+
+    expect(cleanup).toBe(unregister);
+    expect(registerNewsfeedHandlerMock).toHaveBeenCalledTimes(1);
+
+    const [{ open, hasNew$ }] = registerNewsfeedHandlerMock.mock.calls[0];
+    const hasNewValues: boolean[] = [];
+    const subscription = hasNew$.subscribe((hasNew: boolean) => hasNewValues.push(hasNew));
+
+    expect(hasNewValues).toEqual([true]);
+
+    open();
+
+    expect(markAsRead).toHaveBeenCalledWith(['test-hash-1']);
+    expect(openSystemFlyout).toHaveBeenCalledWith(expect.anything(), { size: 's' });
+
+    subscription.unsubscribe();
+  });
+});

--- a/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.test.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.test.tsx
@@ -42,7 +42,9 @@ describe('registerNewsfeedHandler', () => {
     const api: NewsfeedApi = { fetchResults$, markAsRead };
     const core = {
       chrome: {
-        registerNewsfeedHandler: registerNewsfeedHandlerMock,
+        next: {
+          registerNewsfeedHandler: registerNewsfeedHandlerMock,
+        },
       },
       overlays: {
         openSystemFlyout,

--- a/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.tsx
@@ -32,7 +32,7 @@ export const registerNewsfeedHandler = ({
   );
   const handlerApi: NewsfeedApi = { ...api, fetchResults$: handlerResults$ };
 
-  return core.chrome.registerNewsfeedHandler({
+  return core.chrome.next.registerNewsfeedHandler({
     open: () => {
       if (lastFetchResult) {
         handlerApi.markAsRead(lastFetchResult.feedItems.map((item) => item.hash));

--- a/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/register_newsfeed_handler.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { shareReplay, map, tap } from 'rxjs';
+import React from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import type { FetchResult } from './types';
+import { NewsfeedContainer } from './components/flyout_list';
+import type { NewsfeedApi } from './lib/api';
+
+export const registerNewsfeedHandler = ({
+  core,
+  api,
+  isServerless,
+}: {
+  core: CoreStart;
+  api: NewsfeedApi;
+  isServerless: boolean;
+}) => {
+  let lastFetchResult: FetchResult | null | void = null;
+  const handlerResults$ = api.fetchResults$.pipe(
+    tap((result) => {
+      lastFetchResult = result;
+    }),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+  const handlerApi: NewsfeedApi = { ...api, fetchResults$: handlerResults$ };
+
+  return core.chrome.registerNewsfeedHandler({
+    open: () => {
+      if (lastFetchResult) {
+        handlerApi.markAsRead(lastFetchResult.feedItems.map((item) => item.hash));
+      }
+      const flyoutRef = core.overlays.openSystemFlyout(
+        <NewsfeedContainer
+          newsfeedApi={handlerApi}
+          onClose={() => flyoutRef.close()}
+          showPlainSpinner={false}
+          isServerless={isServerless}
+        />,
+        {
+          size: 's',
+        }
+      );
+    },
+    hasNew$: handlerResults$.pipe(map((result) => result?.hasNew ?? false)),
+  });
+};

--- a/x-pack/platform/plugins/private/feedback/moon.yml
+++ b/x-pack/platform/plugins/private/feedback/moon.yml
@@ -25,6 +25,9 @@ dependsOn:
   - '@kbn/feedback-registry'
   - '@kbn/feedback-components'
   - '@kbn/core-http-router-server-mocks'
+  - '@kbn/core-chrome-feature-flags'
+  - '@kbn/react-kibana-mount'
+  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
@@ -43,13 +43,13 @@ describe('Feedback Plugin', () => {
       expect(React.isValidElement(content)).toBe(true);
     });
 
-    it('should register feedback handler when Chrome Next is enabled', () => {
+    it('should register feedback handler in the Chrome Next namespace when Chrome Next is enabled', () => {
       enableFeedback();
       coreStartMock.featureFlags.getBooleanValue.mockReturnValue(true);
 
       plugin.start(coreStartMock, { cloud: cloudStartMock, telemetry: telemetryStartMock });
 
-      expect(coreStartMock.chrome.registerFeedbackHandler).toHaveBeenCalledWith(
+      expect(coreStartMock.chrome.next.registerFeedbackHandler).toHaveBeenCalledWith(
         expect.any(Function)
       );
     });
@@ -60,7 +60,7 @@ describe('Feedback Plugin', () => {
 
       plugin.start(coreStartMock, { cloud: cloudStartMock, telemetry: telemetryStartMock });
 
-      expect(coreStartMock.chrome.registerFeedbackHandler).not.toHaveBeenCalled();
+      expect(coreStartMock.chrome.next.registerFeedbackHandler).not.toHaveBeenCalled();
     });
 
     it('should not register feedback button when feedback is disabled', () => {

--- a/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
@@ -20,12 +20,17 @@ describe('Feedback Plugin', () => {
   describe('start', () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      sessionStorage.clear();
     });
 
-    it('should register feedback button when feedback is enabled, telemetry is enabled and user is opted in', () => {
+    const enableFeedback = () => {
       coreStartMock.notifications.feedback.isEnabled.mockReturnValue(true);
       jest.spyOn(telemetryStartMock.telemetryService, 'canSendTelemetry').mockReturnValue(true);
       jest.spyOn(telemetryStartMock.telemetryService, 'getIsOptedIn').mockReturnValue(true);
+    };
+
+    it('should register feedback button when feedback is enabled, telemetry is enabled and user is opted in', () => {
+      enableFeedback();
 
       plugin.start(coreStartMock, { cloud: cloudStartMock, telemetry: telemetryStartMock });
 
@@ -36,6 +41,26 @@ describe('Feedback Plugin', () => {
         content: expect.anything(),
       });
       expect(React.isValidElement(content)).toBe(true);
+    });
+
+    it('should register feedback handler when Chrome Next is enabled', () => {
+      enableFeedback();
+      coreStartMock.featureFlags.getBooleanValue.mockReturnValue(true);
+
+      plugin.start(coreStartMock, { cloud: cloudStartMock, telemetry: telemetryStartMock });
+
+      expect(coreStartMock.chrome.registerFeedbackHandler).toHaveBeenCalledWith(
+        expect.any(Function)
+      );
+    });
+
+    it('should not register feedback handler when Chrome Next is disabled', () => {
+      enableFeedback();
+      coreStartMock.featureFlags.getBooleanValue.mockReturnValue(false);
+
+      plugin.start(coreStartMock, { cloud: cloudStartMock, telemetry: telemetryStartMock });
+
+      expect(coreStartMock.chrome.registerFeedbackHandler).not.toHaveBeenCalled();
     });
 
     it('should not register feedback button when feedback is disabled', () => {

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -119,7 +119,7 @@ export class FeedbackPlugin implements Plugin {
         overflow-y: auto;
       `;
 
-      core.chrome.registerFeedbackHandler(() => {
+      core.chrome.next.registerFeedbackHandler(() => {
         const modal = core.overlays.openModal(
           toMountPoint(
             core.rendering.addContext(

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -6,11 +6,16 @@
  */
 
 import React, { lazy, Suspense } from 'react';
+import { EuiModal } from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { TelemetryPluginStart } from '@kbn/telemetry-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { FeedbackRegistryEntry } from '@kbn/feedback-components';
+import { isNextChrome } from '@kbn/core-chrome-feature-flags';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+import { i18n } from '@kbn/i18n';
 import type { FeedbackFormData } from '../common';
 import { getAppDetails } from './src/utils';
 
@@ -27,6 +32,12 @@ interface FeedbackPluginStartDependencies {
 const LazyFeedbackTriggerButton = lazy(() =>
   import('@kbn/feedback-components').then(({ FeedbackTriggerButton }) => ({
     default: FeedbackTriggerButton,
+  }))
+);
+
+const LazyFeedbackContainer = lazy(() =>
+  import('@kbn/feedback-components').then(({ FeedbackContainer }) => ({
+    default: FeedbackContainer,
   }))
 );
 
@@ -102,6 +113,40 @@ export class FeedbackPlugin implements Plugin {
         return false;
       }
     };
+
+    if (isNextChrome(core.featureFlags)) {
+      const modalCss = css`
+        overflow-y: auto;
+      `;
+
+      core.chrome.registerFeedbackHandler(() => {
+        const modal = core.overlays.openModal(
+          toMountPoint(
+            core.rendering.addContext(
+              <EuiModal
+                onClose={() => modal.close()}
+                aria-label={i18n.translate('feedback.modal.ariaLabel', {
+                  defaultMessage: 'Feedback form',
+                })}
+                css={modalCss}
+              >
+                <Suspense fallback={null}>
+                  <LazyFeedbackContainer
+                    getQuestions={getQuestions}
+                    getAppDetails={getAppDetailsWrapper}
+                    getCurrentUserEmail={getCurrentUserEmail}
+                    sendFeedback={sendFeedback}
+                    showToast={showToast}
+                    hideFeedbackContainer={() => modal.close()}
+                  />
+                </Suspense>
+              </EuiModal>
+            ),
+            core
+          )
+        );
+      });
+    }
 
     core.chrome.navControls.registerRight({
       order: 1001,

--- a/x-pack/platform/plugins/private/feedback/tsconfig.json
+++ b/x-pack/platform/plugins/private/feedback/tsconfig.json
@@ -16,7 +16,10 @@
     "@kbn/config-schema",
     "@kbn/feedback-registry",
     "@kbn/feedback-components",
-    "@kbn/core-http-router-server-mocks"
+    "@kbn/core-http-router-server-mocks",
+    "@kbn/core-chrome-feature-flags",
+    "@kbn/react-kibana-mount",
+    "@kbn/i18n"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR adds Chrome Next help menu changes - moves newsfeed and feedback inside the new global header help button. The changes are behind `core.chrome.next` feature flag.

### Visuals
<img width="1444" height="309" alt="Screenshot 2026-06-02 at 12 36 16" src="https://github.com/user-attachments/assets/db63824b-fc26-400b-b0c5-ad9385792d84" />




