### PR TITLE
[SLO] Do not build "remote" object for local SLOs when kibanaUrl is defined

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/search_slo_definitions.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/search_slo_definitions.test.ts
@@ -36,12 +36,12 @@ function createMockSummaryDocResponse(docs: MockSummaryDocOptions[] = []): {
             _source: {
               ...(doc.name !== undefined || doc.groupBy !== undefined
                 ? {
-                    slo: {
-                      id: doc.id || 'slo-1',
-                      ...(doc.name !== undefined && { name: doc.name }),
-                      ...(doc.groupBy !== undefined && { groupBy: doc.groupBy }),
-                    },
-                  }
+                  slo: {
+                    id: doc.id || 'slo-1',
+                    ...(doc.name !== undefined && { name: doc.name }),
+                    ...(doc.groupBy !== undefined && { groupBy: doc.groupBy }),
+                  },
+                }
                 : {}),
               ...(doc.kibanaUrl && { kibanaUrl: doc.kibanaUrl }),
             },
@@ -330,6 +330,24 @@ describe('SearchSLODefinitions', () => {
           name: 'Local SLO',
           groupBy: [],
           remoteName: 'local',
+        },
+      ]);
+
+      mockEsClient.search.mockResolvedValueOnce(mockResponse as any);
+
+      const result = await searchSLODefinitions.execute({});
+
+      expect(result.results[0].remote).toBeUndefined();
+    });
+
+    it('does not build a remote object for a local SLO when kibanaUrl is set', async () => {
+      const mockResponse = createMockSummaryDocResponse([
+        {
+          id: 'slo-1',
+          name: 'Local SLO',
+          groupBy: [],
+          remoteName: 'local',
+          kibanaUrl: 'https://local-kibana.example.com',
         },
       ]);
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/search_slo_definitions.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/search_slo_definitions.test.ts
@@ -36,12 +36,12 @@ function createMockSummaryDocResponse(docs: MockSummaryDocOptions[] = []): {
             _source: {
               ...(doc.name !== undefined || doc.groupBy !== undefined
                 ? {
-                  slo: {
-                    id: doc.id || 'slo-1',
-                    ...(doc.name !== undefined && { name: doc.name }),
-                    ...(doc.groupBy !== undefined && { groupBy: doc.groupBy }),
-                  },
-                }
+                    slo: {
+                      id: doc.id || 'slo-1',
+                      ...(doc.name !== undefined && { name: doc.name }),
+                      ...(doc.groupBy !== undefined && { groupBy: doc.groupBy }),
+                    },
+                  }
                 : {}),
               ...(doc.kibanaUrl && { kibanaUrl: doc.kibanaUrl }),
             },

--- a/x-pack/solutions/observability/plugins/slo/server/services/search_slo_definitions.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/search_slo_definitions.ts
@@ -162,8 +162,8 @@ export class SearchSLODefinitions {
           groupBy,
         };
 
-        if (remoteName || kibanaUrl) {
-          item.remote = { remoteName: remoteName ?? '', kibanaUrl: kibanaUrl ?? '' };
+        if (remoteName) {
+          item.remote = { remoteName, kibanaUrl: kibanaUrl ?? '' };
         }
 
         return item;


### PR DESCRIPTION
## Summary

The Composite SLO members form was broken: local SLOs were identified as remote and filtered out, so users couldn't add their own SLOs as members.

Root cause is in `GET /internal/observability/slos/_search_definitions`. `kibanaUrl` is populated on every summary doc when `server.publicBaseUrl` is set (e.g. Cloud), and the result builder gated `remote` on `remoteName || kibanaUrl` — so a local SLO with a `kibanaUrl` got a spurious `remote: { remoteName: '', kibanaUrl }`. The form filters out members with a `remote`, so local SLOs disappeared.

Fix: gate `remote` on `remoteName` only (a real remote cluster name; `'local'` is already normalized to `undefined`). Adds a regression test.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



