### PR TITLE
[One workflow] Allow dashes in event-driven trigger id namespace segment

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
@@ -75,9 +75,19 @@ describe('TriggerRegistry', () => {
 
     it('accepts valid id formats', () => {
       registry.register(createValidDefinition({ id: 'cases.updated' }));
-      registry.register(createValidDefinition({ id: 'alerts.severity_high' }));
-      registry.register(createValidDefinition({ id: 'my_plugin.my_event' }));
+      registry.register(createValidDefinition({ id: 'alerts.severityHigh' }));
+      registry.register(createValidDefinition({ id: 'my-namespace.myEvent' }));
       expect(registry.list()).toHaveLength(3);
+    });
+
+    it('rejects snake_case namespace or event segments', () => {
+      expect(() => {
+        registry.register(createValidDefinition({ id: 'my_plugin.myEvent' }));
+      }).toThrow('must follow namespaced format');
+
+      expect(() => {
+        registry.register(createValidDefinition({ id: 'my-namespace.my_event' }));
+      }).toThrow('must follow namespaced format');
     });
 
     it('accepts kebab-case namespace ids from naming conventions', () => {

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
@@ -80,6 +80,31 @@ describe('TriggerRegistry', () => {
       expect(registry.list()).toHaveLength(3);
     });
 
+    it('accepts kebab-case namespace ids from naming conventions', () => {
+      const idsFromDocs = [
+        'my-namespace.customTrigger',
+        'cases.updated',
+        'custom-feature.alertFired',
+        'my-plugin.myTrigger',
+        'alertingV2.episodeAssigned',
+      ];
+
+      for (const id of idsFromDocs) {
+        registry.register(createValidDefinition({ id }));
+      }
+
+      expect(registry.list()).toHaveLength(idsFromDocs.length);
+      for (const id of idsFromDocs) {
+        expect(registry.has(id)).toBe(true);
+      }
+    });
+
+    it('rejects event segment with dashes (event must be camelCase)', () => {
+      expect(() => {
+        registry.register(createValidDefinition({ id: 'my-namespace.custom-trigger' }));
+      }).toThrow('must follow namespaced format');
+    });
+
     it('throws if eventSchema is null', () => {
       expect(() => {
         registry.register(

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.ts
@@ -11,7 +11,7 @@ import type { z } from '@kbn/zod/v4';
 import type { ServerTriggerDefinition } from '../types';
 
 /** Id must be <namespace>.<event> (kebab-case namespace, camelCase event; e.g. my-namespace.customTrigger) */
-const TRIGGER_ID_REGEX = /^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.]+$/;
+const TRIGGER_ID_REGEX = /^[a-zA-Z0-9-]+\.[a-zA-Z0-9.]+$/;
 
 function isZodObject(schema: z.ZodType): schema is z.ZodObject<z.ZodRawShape> {
   return typeof schema === 'object' && schema !== null && 'shape' in schema;

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.ts
@@ -10,8 +10,8 @@
 import type { z } from '@kbn/zod/v4';
 import type { ServerTriggerDefinition } from '../types';
 
-/** Id must be <domain>.<event> (e.g. cases.updated, alerts.recovered) */
-const TRIGGER_ID_REGEX = /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_.]+$/;
+/** Id must be <namespace>.<event> (kebab-case namespace, camelCase event; e.g. my-namespace.customTrigger) */
+const TRIGGER_ID_REGEX = /^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.]+$/;
 
 function isZodObject(schema: z.ZodType): schema is z.ZodObject<z.ZodRawShape> {
   return typeof schema === 'object' && schema !== null && 'shape' in schema;
@@ -25,7 +25,7 @@ function validateDefinition(definition: ServerTriggerDefinition): void {
   }
   if (!TRIGGER_ID_REGEX.test(id)) {
     throw new Error(
-      `Trigger id "${id}" must follow namespaced format <domain>.<event> (e.g. cases.updated).`
+      `Trigger id "${id}" must follow namespaced format <namespace>.<event> (e.g. my-namespace.customTrigger).`
     );
   }
   if (!eventSchema || typeof eventSchema.safeParse !== 'function') {


### PR DESCRIPTION
## Summary

- `TRIGGERS.md` specifies trigger ids as `<namespace>.<event>` with a **kebab-case** namespace (e.g. `my-namespace.customTrigger`), but `TriggerRegistry` validation used a regex that did not allow `-` in the namespace segment.
- Updated `TRIGGER_ID_REGEX` to allow hyphens in the namespace part only; the event segment is unchanged (still no dashes, consistent with camelCase).
- Added unit tests that register ids from the naming docs and assert ids with dashes in the event segment are rejected.