### PR TITLE
[Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/test/scout/ui/tests/feature_controls.spec.ts
+++ b/x-pack/platform/plugins/private/monitoring/test/scout/ui/tests/feature_controls.spec.ts
@@ -79,13 +79,11 @@ test.describe('Stack Monitoring feature controls', { tag: tags.stateful.classic 
   test('Kibana base:all user does NOT see the Stack Monitoring sidebar link', async ({
     browserAuth,
     samlAuth,
-    page,
     pageObjects,
-    kbnUrl,
   }) => {
     await samlAuth.setCustomRole(CUSTOM_ROLES.global_all_kibana_only);
     await browserAuth.loginAs(samlAuth.customRoleName);
-    await page.goto(kbnUrl.app('home'));
+    await pageObjects.home.goto();
 
     const navLinks = await pageObjects.collapsibleNav.getNavLinks();
     expect(navLinks).not.toContain('Stack Monitoring');

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -167,6 +167,7 @@ function renderController(services: ReturnType<typeof buildServices>['services']
 describe('AgentBuilderAnnouncementModalController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
   });
 
   it('does not render the modal when hideAnnouncements is true', async () => {
@@ -349,5 +350,39 @@ describe('AgentBuilderAnnouncementModalController', () => {
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementModal-2a')).toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
+  });
+
+  it('does not show the modal on remount when dismissed before a slow profile update completes', async () => {
+    // Simulate a slow profile update (e.g. high-latency proxy environment) that hasn't
+    // resolved by the time the user navigates to the next page and the component remounts.
+    let resolvePartialUpdate!: () => void;
+    const slowPartialUpdate = jest.fn(
+      () => new Promise<void>((resolve) => (resolvePartialUpdate = resolve))
+    );
+    const { services } = buildServices();
+    (services.userProfile as { partialUpdate: jest.Mock }).partialUpdate = slowPartialUpdate;
+
+    const { unmount } = renderController(services);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toBeInTheDocument()
+    );
+
+    // Dismiss the modal — markSeen() fires but partialUpdate is still pending.
+    await userEvent.click(screen.getByTestId('agentBuilderAnnouncementContinueButton'));
+
+    // Simulate navigation: unmount and remount before the profile update resolves.
+    unmount();
+    renderController(services);
+
+    // The modal must not reappear even though partialUpdate hasn't finished.
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('agentBuilderAnnouncementContinueButton')
+      ).not.toBeInTheDocument();
+    });
+
+    // Let the pending update resolve to avoid unhandled promise warnings.
+    resolvePartialUpdate();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
@@ -70,7 +70,8 @@ export async function getAnnouncementModalSeen(
 
 /**
  * Persists global dismissal in user profile data.
- * No-ops when user profiles are disabled.
+ * Also writes to localStorage immediately so the modal does not reappear on fast
+ * navigation before the async profile update completes.
  */
 export async function setAnnouncementModalSeen(
   userProfile: UserProfileServiceStart
@@ -79,6 +80,9 @@ export async function setAnnouncementModalSeen(
     if (localStorage.getItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY) === 'true') {
       return;
     }
+    // Write synchronously so getAnnouncementModalSeen returns true on the next
+    // page even if the profile update below hasn't finished yet.
+    localStorage.setItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY, 'true');
   } catch {
     // ignore storage access errors
   }
@@ -103,12 +107,7 @@ export async function setAnnouncementModalSeen(
       },
     });
   } catch {
-    // Fall back to localStorage when user profile updates are unavailable (e.g., reverse proxy auth).
-    try {
-      localStorage.setItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY, 'true');
-    } catch {
-      // ignore storage access errors
-    }
+    // localStorage was already written above; nothing more to do.
   }
 }
 


### PR DESCRIPTION
## Summary

### What
Fixes a race condition where the Agent Builder announcement modal could reappear on page navigation after the user had already dismissed it.

### Why
`markSeen()` is called fire-and-forget when the user dismisses the modal. In high-latency or proxy environments (e.g. Eden, Instruqt), the async `userProfile.partialUpdate()` network call may not have completed by the time the user navigates to the next page. The new page mounts a fresh component, reads the user profile (not yet updated), gets `isSeen = false`, and shows the modal again — explaining the "pops up on nearly every page, goes away after 1–2 times" reports.

Fixes #272269

### Changes

- `setAnnouncementModalSeen`: write to localStorage **synchronously** at the start, before the async profile update. Since `getAnnouncementModalSeen` checks localStorage first, any subsequent read on the next page hits the short-circuit and returns `true` immediately — regardless of whether the profile API call has finished.
- `setAnnouncementModalSeen`: simplified the `catch` block comment (localStorage is already set before the `try`, so the old fallback write there was redundant).
- Test: added `localStorage.clear()` to `beforeEach` to keep tests isolated.
- Test: added a new test that simulates the race — slow `partialUpdate`, fast navigation (unmount + remount) — and asserts the modal does not reappear.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Identify risks

**Race condition between async profile write and next page mount (fixed):** The root bug was that dismissal state was not immediately available to the next page when the profile API was slow. Fixed by writing to localStorage synchronously before the async work. Severity: low post-fix — localStorage write happens before any await, so it is atomic from JavaScript's perspective. The only remaining edge case is if localStorage itself throws (caught and ignored), in which case the user may see the modal once more on the next page but the profile update will still persist it server-side.

No data loss, no breaking changes, no performance impact.

### Release note

> Fixes an issue where the Agent Builder announcement modal could reappear on page navigation after being dismissed, particularly in high-latency or proxy environments.

**Suggested label:** `release_note:fix`

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->