### PR TITLE
[Console] Add dynamic templates and dynamic mapping autocomplete suggestions

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/index.test.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/index.test.ts
@@ -103,4 +103,70 @@ describe('console query DSL autocomplete globals', () => {
       );
     });
   });
+
+  describe('WHEN generating put_mapping autocomplete rules', () => {
+    const dynamicTemplateMatchTypeValues = [
+      '*',
+      'string',
+      'object',
+      'long',
+      'double',
+      'boolean',
+      'date',
+      'binary',
+    ];
+
+    it('SHOULD expose dynamic mapping and dynamic template suggestions', () => {
+      expect(endpoints.put_mapping.data_autocomplete_rules).toMatchObject({
+        dynamic: {
+          __one_of: ['true', 'false', 'strict', 'runtime'],
+        },
+        dynamic_templates: [
+          {
+            '*': {
+              mapping: expect.any(Object),
+              runtime: expect.any(Object),
+              match: '',
+              match_pattern: {
+                __one_of: ['simple', 'regex'],
+              },
+              match_mapping_type: {
+                __one_of: [
+                  {
+                    __one_of: dynamicTemplateMatchTypeValues,
+                  },
+                  [
+                    {
+                      __one_of: dynamicTemplateMatchTypeValues,
+                    },
+                  ],
+                ],
+              },
+              path_match: '',
+              path_unmatch: '',
+              unmatch: '',
+              unmatch_mapping_type: {
+                __one_of: [
+                  {
+                    __one_of: dynamicTemplateMatchTypeValues,
+                  },
+                  [
+                    {
+                      __one_of: dynamicTemplateMatchTypeValues,
+                    },
+                  ],
+                ],
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('SHOULD link the generated indices.put_mapping endpoint to the put_mapping body rules', () => {
+      expect(endpoints['indices.put_mapping'].data_autocomplete_rules).toEqual({
+        __scope_link: 'put_mapping',
+      });
+    });
+  });
 });

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -41,7 +41,7 @@ export const mappings = (specService: SpecDefinitionsService) => {
         default: '',
       },
       dynamic_date_formats: ['yyyy-MM-dd'],
-      dynamic: {__one_of: ['true', 'false', 'strict', 'runtime']},
+      dynamic: { __one_of: ['true', 'false', 'strict', 'runtime'] },
       dynamic_templates: DynamicTemplateSettings,
       date_detection: BOOLEAN,
       numeric_detection: BOOLEAN,
@@ -69,7 +69,6 @@ const DenseVectorIndexOptions = {
   ef_construction: 100,
   confidence_interval: 0,
 };
-
 
 const FieldMappingOptions = {
   type: {
@@ -293,17 +292,11 @@ const FieldMappingOptions = {
   dims: 3,
 };
 
-const DynamicTemplateMatchTypes = [{
-  __one_of: [
-    'string',
-    'object',
-    'long',
-    'double',
-    'boolean',
-    'date',
-    'binary',
-  ],
-}]
+const DynamicTemplateMatchTypes = [
+  {
+    __one_of: ['string', 'object', 'long', 'double', 'boolean', 'date', 'binary'],
+  },
+];
 
 const DynamicTemplateSettings = [
   {
@@ -316,5 +309,5 @@ const DynamicTemplateSettings = [
       unmatch: '',
       unmatch_mapping_type: DynamicTemplateMatchTypes,
     },
-  }
-]
+  },
+];

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -292,17 +292,79 @@ const FieldMappingOptions = {
   dims: 3,
 };
 
-const DynamicTemplateMatchTypes = [
-  {
-    __one_of: ['string', 'object', 'long', 'double', 'boolean', 'date', 'binary'],
+const RuntimeFieldTypes = {
+  __one_of: [
+    'boolean',
+    'composite',
+    'date',
+    'double',
+    'geo_point',
+    'geo_shape',
+    'ip',
+    'keyword',
+    'long',
+    'lookup',
+  ],
+};
+
+const RuntimeFieldOptions = {
+  type: RuntimeFieldTypes,
+  fields: {
+    '*': {
+      type: RuntimeFieldTypes,
+    },
   },
+  fetch_fields: [
+    {
+      field: '{field}',
+      format: '',
+    },
+  ],
+  format: '',
+  input_field: '{field}',
+  target_field: '{field}',
+  target_index: '{index}',
+  script: {
+    __scope_link: 'GLOBAL.script',
+  },
+  on_script_error: {
+    __one_of: ['fail', 'continue'],
+  },
+};
+
+const DynamicTemplateMatchTypeValues = [
+  '*',
+  'string',
+  'object',
+  'long',
+  'double',
+  'boolean',
+  'date',
+  'binary',
 ];
+
+const DynamicTemplateMatchTypes = {
+  __one_of: [
+    {
+      __one_of: DynamicTemplateMatchTypeValues,
+    },
+    [
+      {
+        __one_of: DynamicTemplateMatchTypeValues,
+      },
+    ],
+  ],
+};
 
 const DynamicTemplateSettings = [
   {
     '*': {
       mapping: FieldMappingOptions,
+      runtime: RuntimeFieldOptions,
       match: '',
+      match_pattern: {
+        __one_of: ['simple', 'regex'],
+      },
       match_mapping_type: DynamicTemplateMatchTypes,
       path_match: '',
       path_unmatch: '',

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/mappings.ts
@@ -41,248 +41,12 @@ export const mappings = (specService: SpecDefinitionsService) => {
         default: '',
       },
       dynamic_date_formats: ['yyyy-MM-dd'],
+      dynamic: {__one_of: ['true', 'false', 'strict', 'runtime']},
+      dynamic_templates: DynamicTemplateSettings,
       date_detection: BOOLEAN,
       numeric_detection: BOOLEAN,
       properties: {
-        '*': {
-          type: {
-            __one_of: [
-              'alias',
-              'binary',
-              'boolean',
-              'completion',
-              'constant_keyword',
-              'date',
-              'date_nanos',
-              'dense_vector',
-              'flattened',
-              'geo_point',
-              'geo_shape',
-              'histogram',
-              'ip',
-              'join',
-              'keyword',
-              'match_only_text',
-              'nested',
-              'numeric',
-              'object',
-              'passthrough',
-              'percolator',
-              'point',
-              'range',
-              'rank_feature',
-              'rank_features',
-              'search_as_you_type',
-              'semantic_text',
-              'shape',
-              'sparse_vector',
-              'text',
-              'token_count',
-              'version',
-              'wildcard',
-            ],
-          },
-
-          // strings
-          store: BOOLEAN,
-          index: BOOLEAN,
-          term_vector: {
-            __one_of: ['no', 'yes', 'with_offsets', 'with_positions', 'with_positions_offsets'],
-          },
-          boost: 1.0,
-          null_value: '',
-          doc_values: BOOLEAN,
-          eager_global_ordinals: BOOLEAN,
-          norms: BOOLEAN,
-          coerce: BOOLEAN,
-
-          // Not actually available in V6 of ES. Add when updating the autocompletion system.
-          // index_phrases: BOOLEAN,
-          // index_prefixes: { min_chars, max_chars },
-
-          index_options: {
-            // leave the first item blank because the default depends on type
-            __one_of: [
-              '',
-              // text-based types
-              'docs',
-              'freqs',
-              'positions',
-              'offsets',
-              // semantic_text type
-              {
-                dense_vector: DenseVectorIndexOptions,
-              },
-              // dense_vector type
-              DenseVectorIndexOptions,
-            ],
-          },
-          chunking_settings: ChunkingSettings,
-          analyzer: 'standard',
-          search_analyzer: 'standard',
-          include_in_all: {
-            __one_of: [false, true],
-          },
-          ignore_above: 10,
-          normalizer: '',
-          position_increment_gap: 0,
-
-          // numeric
-          precision_step: 4,
-          ignore_malformed: BOOLEAN,
-          scaling_factor: 100,
-
-          // geo_point
-          lat_lon: {
-            __one_of: [true, false],
-          },
-          geohash: {
-            __one_of: [true, false],
-          },
-          geohash_precision: '1m',
-          geohash_prefix: {
-            __one_of: [true, false],
-          },
-          validate: {
-            __one_of: [true, false],
-          },
-          validate_lat: {
-            __one_of: [true, false],
-          },
-          validate_lon: {
-            __one_of: [true, false],
-          },
-          normalize: {
-            __one_of: [true, false],
-          },
-          normalize_lat: {
-            __one_of: [true, false],
-          },
-          normalize_lon: {
-            __one_of: [true, false],
-          },
-
-          // geo_shape
-          tree: {
-            __one_of: ['geohash', 'quadtree'],
-          },
-          precision: '5km',
-          tree_levels: 12,
-          distance_error_pct: 0.025,
-          orientation: 'ccw',
-
-          // dates
-          format: {
-            // outer array required to for an array of string values
-            __one_of: [
-              [
-                ...[
-                  'date',
-                  'date_time',
-                  'date_time_no_millis',
-                  'ordinal_date',
-                  'ordinal_date_time',
-                  'ordinal_date_time_no_millis',
-                  'time',
-                  'time_no_millis',
-                  't_time',
-                  't_time_no_millis',
-                  'week_date',
-                  'week_date_time',
-                  'week_date_time_no_millis',
-                ].flatMap(function (s) {
-                  return ['basic_' + s, 'strict_' + s];
-                }),
-                ...[
-                  'date',
-                  'date_hour',
-                  'date_hour_minute',
-                  'date_hour_minute_second',
-                  'date_hour_minute_second_fraction',
-                  'date_hour_minute_second_millis',
-                  'date_optional_time',
-                  'date_time',
-                  'date_time_no_millis',
-                  'hour',
-                  'hour_minute',
-                  'hour_minute_second',
-                  'hour_minute_second_fraction',
-                  'hour_minute_second_millis',
-                  'ordinal_date',
-                  'ordinal_date_time',
-                  'ordinal_date_time_no_millis',
-                  'time',
-                  'time_no_millis',
-                  't_time',
-                  't_time_no_millis',
-                  'week_date',
-                  'week_date_time',
-                  'weekDateTimeNoMillis',
-                  'weekyear',
-                  'strict_weekyear',
-                  'weekyear_week',
-                  'strict_weekyear_week',
-                  'strict_date_optional_time_nanos',
-                  'weekyear_week_day',
-                  'strict_weekyear_week_day',
-                  'year',
-                  'year_month',
-                  'year_month_day',
-                  'epoch_millis',
-                  'epoch_second',
-                ],
-              ].sort(),
-            ],
-          },
-
-          fielddata: {
-            filter: {
-              regex: '',
-              frequency: {
-                min: 0.001,
-                max: 0.1,
-                min_segment_size: 500,
-              },
-            },
-          },
-          similarity: {
-            // leave the first item blank because the default depends on type
-            __one_of: [
-              '',
-              // text-based types
-              'BM25',
-              'boolean',
-              // dense_vector type
-              'l2_norm',
-              'dot_product',
-              'cosine',
-              'max_inner_product',
-            ],
-          },
-
-          // objects
-          properties: {
-            __scope_link: 'put_mapping.properties',
-          },
-
-          // multi_field
-          fields: {
-            '*': {
-              __scope_link: 'put_mapping.properties.field',
-            },
-          },
-          copy_to: { __one_of: ['{field}', ['{field}']] },
-
-          // nested
-          include_in_parent: BOOLEAN,
-          include_in_root: BOOLEAN,
-
-          // dense_vector
-          element_type: {
-            __one_of: ['float', 'byte', 'bit'],
-          },
-          dims: 3,
-        },
+        '*': FieldMappingOptions,
       },
     },
   });
@@ -305,3 +69,252 @@ const DenseVectorIndexOptions = {
   ef_construction: 100,
   confidence_interval: 0,
 };
+
+
+const FieldMappingOptions = {
+  type: {
+    __one_of: [
+      'alias',
+      'binary',
+      'boolean',
+      'completion',
+      'constant_keyword',
+      'date',
+      'date_nanos',
+      'dense_vector',
+      'flattened',
+      'geo_point',
+      'geo_shape',
+      'histogram',
+      'ip',
+      'join',
+      'keyword',
+      'match_only_text',
+      'nested',
+      'numeric',
+      'object',
+      'passthrough',
+      'percolator',
+      'point',
+      'range',
+      'rank_feature',
+      'rank_features',
+      'search_as_you_type',
+      'semantic_text',
+      'shape',
+      'sparse_vector',
+      'text',
+      'token_count',
+      'version',
+      'wildcard',
+    ],
+  },
+
+  // strings
+  store: BOOLEAN,
+  index: BOOLEAN,
+  term_vector: {
+    __one_of: ['no', 'yes', 'with_offsets', 'with_positions', 'with_positions_offsets'],
+  },
+  boost: 1.0,
+  null_value: '',
+  doc_values: BOOLEAN,
+  eager_global_ordinals: BOOLEAN,
+  norms: BOOLEAN,
+  coerce: BOOLEAN,
+
+  // Not actually available in V6 of ES. Add when updating the autocompletion system.
+  // index_phrases: BOOLEAN,
+  // index_prefixes: { min_chars, max_chars },
+
+  index_options: {
+    // leave the first item blank because the default depends on type
+    __one_of: [
+      '',
+      // text-based types
+      'docs',
+      'freqs',
+      'positions',
+      'offsets',
+      // semantic_text type
+      {
+        dense_vector: DenseVectorIndexOptions,
+      },
+      // dense_vector type
+      DenseVectorIndexOptions,
+    ],
+  },
+  chunking_settings: ChunkingSettings,
+  analyzer: 'standard',
+  search_analyzer: 'standard',
+  include_in_all: {
+    __one_of: [false, true],
+  },
+  ignore_above: 10,
+  normalizer: '',
+  position_increment_gap: 0,
+
+  // numeric
+  precision_step: 4,
+  ignore_malformed: BOOLEAN,
+  scaling_factor: 100,
+
+  // geo_point
+  lat_lon: BOOLEAN,
+  geohash: BOOLEAN,
+  geohash_precision: '1m',
+  geohash_prefix: BOOLEAN,
+  validate: BOOLEAN,
+  validate_lat: BOOLEAN,
+  validate_lon: BOOLEAN,
+  normalize: BOOLEAN,
+  normalize_lat: BOOLEAN,
+  normalize_lon: BOOLEAN,
+
+  // geo_shape
+  tree: {
+    __one_of: ['geohash', 'quadtree'],
+  },
+  precision: '5km',
+  tree_levels: 12,
+  distance_error_pct: 0.025,
+  orientation: 'ccw',
+
+  // dates
+  format: {
+    // outer array required to for an array of string values
+    __one_of: [
+      [
+        ...[
+          'date',
+          'date_time',
+          'date_time_no_millis',
+          'ordinal_date',
+          'ordinal_date_time',
+          'ordinal_date_time_no_millis',
+          'time',
+          'time_no_millis',
+          't_time',
+          't_time_no_millis',
+          'week_date',
+          'week_date_time',
+          'week_date_time_no_millis',
+        ].flatMap(function (s) {
+          return ['basic_' + s, 'strict_' + s];
+        }),
+        ...[
+          'date',
+          'date_hour',
+          'date_hour_minute',
+          'date_hour_minute_second',
+          'date_hour_minute_second_fraction',
+          'date_hour_minute_second_millis',
+          'date_optional_time',
+          'date_time',
+          'date_time_no_millis',
+          'hour',
+          'hour_minute',
+          'hour_minute_second',
+          'hour_minute_second_fraction',
+          'hour_minute_second_millis',
+          'ordinal_date',
+          'ordinal_date_time',
+          'ordinal_date_time_no_millis',
+          'time',
+          'time_no_millis',
+          't_time',
+          't_time_no_millis',
+          'week_date',
+          'week_date_time',
+          'weekDateTimeNoMillis',
+          'weekyear',
+          'strict_weekyear',
+          'weekyear_week',
+          'strict_weekyear_week',
+          'strict_date_optional_time_nanos',
+          'weekyear_week_day',
+          'strict_weekyear_week_day',
+          'year',
+          'year_month',
+          'year_month_day',
+          'epoch_millis',
+          'epoch_second',
+        ],
+      ].sort(),
+    ],
+  },
+
+  fielddata: {
+    filter: {
+      regex: '',
+      frequency: {
+        min: 0.001,
+        max: 0.1,
+        min_segment_size: 500,
+      },
+    },
+  },
+  similarity: {
+    // leave the first item blank because the default depends on type
+    __one_of: [
+      '',
+      // text-based types
+      'BM25',
+      'boolean',
+      // dense_vector type
+      'l2_norm',
+      'dot_product',
+      'cosine',
+      'max_inner_product',
+    ],
+  },
+
+  // objects
+  properties: {
+    __scope_link: 'put_mapping.properties',
+  },
+
+  // multi_field
+  fields: {
+    '*': {
+      __scope_link: 'put_mapping.properties.field',
+    },
+  },
+  copy_to: { __one_of: ['{field}', ['{field}']] },
+
+  // nested
+  include_in_parent: BOOLEAN,
+  include_in_root: BOOLEAN,
+
+  // dense_vector
+  element_type: {
+    __one_of: ['float', 'byte', 'bit'],
+  },
+  dims: 3,
+};
+
+const DynamicTemplateMatchTypes = [{
+  __one_of: [
+    'string',
+    'object',
+    'long',
+    'double',
+    'boolean',
+    'date',
+    'binary',
+  ],
+}]
+
+const DynamicTemplateSettings = [
+  {
+    '*': {
+      mapping: FieldMappingOptions,
+      match: '',
+      match_mapping_type: DynamicTemplateMatchTypes,
+      path_match: '',
+      path_unmatch: '',
+      unmatch: '',
+      unmatch_mapping_type: DynamicTemplateMatchTypes,
+    },
+  }
+]

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/json/overrides/indices.put_mapping.json
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/json/overrides/indices.put_mapping.json
@@ -1,0 +1,7 @@
+{
+  "indices.put_mapping": {
+    "data_autocomplete_rules": {
+      "__scope_link": "put_mapping"
+    }
+  }
+}


### PR DESCRIPTION
Addresses #259253 (dynamic-templates half; the missing-processors half is #272246).

> Authored by @TimBosman; taken over to completion by kibana-management.

## Summary

- Adds `dynamic_templates` and `dynamic` suggestions to the `put_mapping` autocomplete rules, modeled 1:1 on the Elasticsearch surface (`DynamicTemplate.java` / spec `dynamic-template.ts`): `match`, `unmatch`, `path_match`, `path_unmatch`, `match_mapping_type` / `unmatch_mapping_type` (scalar or array, including the `*` wildcard), `match_pattern` (`simple` / `regex`), `mapping`, and `runtime` (modeled on the spec `RuntimeField`, with `script` scope-linked to `GLOBAL.script`).
- Extracts the per-field mapping options into a reusable `FieldMappingOptions` (verified refactor-safe: identical key paths and enum values before/after).
- New `json/overrides/indices.put_mapping.json` scope-links the generated endpoint to these rules — direct `PUT/POST {index}/_mapping` requests get body autocomplete for the first time (previously only `indices.create`, index/component templates, and rollover reached them).
- Repoints the dead `put_mapping.type.properties` scope links (pre-ES7 leftover) — this bug fix is also extracted standalone as #278508 (closes #278506) so it can be backported; this PR remains `backport:skip`. Whichever lands second rebases trivially.
- Regression tests for the new rules and the override.

## Decisions

- **`match_mapping_type` accepts scalar or array** (`copy_to` idiom) — risk: if the engine mishandled nested alternatives it would suggest invalid shapes; covered by live verification and tests.
- **`runtime` mirrors spec `RuntimeField` fields exactly** (incl. `lookup`-type fields) — risk: over-suggesting fields that only apply to some runtime types; matches how `mapping` options are already modeled (superset per slot).

## Test Plan

- `node scripts/jest src/platform/plugins/shared/console/server/lib/spec_definitions` — pass (incl. new `put_mapping` describe block)
- `node scripts/eslint` on changed files — pass; `node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json` — pass
- Live-verified (local Kibana, this branch):
  - direct `PUT test-index/_mapping` (new override): all 9 template keys suggested inside `dynamic_templates[].<name>` — `mapping, match, match_mapping_type, match_pattern, path_match, path_unmatch, runtime, unmatch, unmatch_mapping_type`
  - `match_mapping_type` value position offers `*`, the 7 types, and `[` (array form) — the scalar-or-array modeling compiles correctly
  - `runtime` block suggests exactly the `RuntimeField` surface: `fetch_fields, fields, format, input_field, on_script_error, script, target_field, target_index, type`
  - precedence: with #278510's generated coarse rules present as siblings, the scope-linked rich rules still win (verified live)

## Screenshots

- dynamic template keys on direct `PUT {index}/_mapping`
<img width="620" height="380" alt="272278_dynamic_templates_keys" src="https://github.com/user-attachments/assets/147cdc0a-c270-4ae8-9362-73a671db8a6b" />

- `match_mapping_type` scalar + `[` array suggestions
<img width="620" height="380" alt="272278_match_mapping_type_values" src="https://github.com/user-attachments/assets/adbeda50-d0ff-4d31-8bbd-16ed56270106" />

- `runtime` block suggestions
<img width="620" height="380" alt="272278_runtime_keys" src="https://github.com/user-attachments/assets/49e67df0-c4ef-43a4-b8b1-15c011ba7d61" />


Assisted with Copilot using Claude Fable 5
