### PR TITLE
[Entity Resolution] FTR coverage for basic-license route gating

### DIFF
--- a/.buildkite/ftr-manifests/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr-manifests/ftr_security_stateful_configs.yml
@@ -102,6 +102,7 @@ enabled:
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/ml_anomaly_detection_maintainer/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/trial_license_complete_tier/configs/ess.config.ts
+  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/basic_license_essentials_tier/configs/ess.config.ts

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/api_feature_access.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/api_feature_access.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { ENTITY_STORE_ROUTES, API_VERSIONS } from '@kbn/entity-store/common';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+const ENTERPRISE_LICENSE_MESSAGE = 'Entity Resolution requires an Enterprise license';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertest');
+
+  // Request bodies/queries below are placeholders — `enterpriseLicenseMiddleware`
+  // fires before request validation, so any well-formed payload triggers the 403.
+  describe('@ess basic license api access', () => {
+    it('should reject link with 403', async () => {
+      const { status, body } = await supertest
+        .post(ENTITY_STORE_ROUTES.public.RESOLUTION_LINK)
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', API_VERSIONS.public.v1)
+        .send({ target_id: 'any-id', entity_ids: ['another-id'] });
+
+      expect(status).toBe(403);
+      expect(body.message).toBe(ENTERPRISE_LICENSE_MESSAGE);
+    });
+
+    it('should reject unlink with 403', async () => {
+      const { status, body } = await supertest
+        .post(ENTITY_STORE_ROUTES.public.RESOLUTION_UNLINK)
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', API_VERSIONS.public.v1)
+        .send({ entity_ids: ['any-id'] });
+
+      expect(status).toBe(403);
+      expect(body.message).toBe(ENTERPRISE_LICENSE_MESSAGE);
+    });
+
+    it('should reject group with 403', async () => {
+      const { status, body } = await supertest
+        .get(ENTITY_STORE_ROUTES.public.RESOLUTION_GROUP)
+        .query({ entity_id: 'any-id' })
+        .set('elastic-api-version', API_VERSIONS.public.v1);
+
+      expect(status).toBe(403);
+      expect(body.message).toBe(ENTERPRISE_LICENSE_MESSAGE);
+    });
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/configs/ess.config.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+import type { ExperimentalFeatures } from '@kbn/security-solution-plugin/common';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(
+    require.resolve('../../../../../config/ess/config.base.basic')
+  );
+
+  const securitySolutionEnableExperimental: Array<keyof ExperimentalFeatures> = [
+    'entityAnalyticsEntityStoreV2',
+  ];
+
+  return {
+    ...functionalConfig.getAll(),
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig
+          .get('kbnTestServer.serverArgs')
+          .filter((arg: string) => !arg.includes('xpack.securitySolution.enableExperimental')),
+        `--xpack.securitySolution.enableExperimental=${JSON.stringify(
+          securitySolutionEnableExperimental
+        )}`,
+      ],
+    },
+    testFiles: [require.resolve('..')],
+    junit: {
+      reportName:
+        'Entity Analytics - Entity Resolution Integration Tests - ESS Env - Basic License',
+    },
+  };
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/configs/ess.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/configs/ess.config.ts
@@ -6,30 +6,14 @@
  */
 
 import type { FtrConfigProviderContext } from '@kbn/test';
-import type { ExperimentalFeatures } from '@kbn/security-solution-plugin/common';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const functionalConfig = await readConfigFile(
     require.resolve('../../../../../config/ess/config.base.basic')
   );
 
-  const securitySolutionEnableExperimental: Array<keyof ExperimentalFeatures> = [
-    'entityAnalyticsEntityStoreV2',
-  ];
-
   return {
     ...functionalConfig.getAll(),
-    kbnTestServer: {
-      ...functionalConfig.get('kbnTestServer'),
-      serverArgs: [
-        ...functionalConfig
-          .get('kbnTestServer.serverArgs')
-          .filter((arg: string) => !arg.includes('xpack.securitySolution.enableExperimental')),
-        `--xpack.securitySolution.enableExperimental=${JSON.stringify(
-          securitySolutionEnableExperimental
-        )}`,
-      ],
-    },
     testFiles: [require.resolve('..')],
     junit: {
       reportName:

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Entity Analytics - Entity Resolution', function () {
+    loadTestFile(require.resolve('./api_feature_access'));
+  });
+}


### PR DESCRIPTION
## Summary

Adds an ESS basic-license FTR API integration suite that verifies the three Entity Resolution routes (`link`, `unlink`, `group`) return `403` with the enterprise-license error message when the cluster runs on basic license. Closes the server-side license-gating coverage gap introduced by https://github.com/elastic/kibana/pull/260548

### Scope: stateful basic only — no serverless config

`enterpriseLicenseMiddleware` checks `license.hasAtLeast('enterprise')`. On serverless the cluster always reports an enterprise-equivalent license regardless of product tier, so this middleware never fires on serverless. Serverless Essentials rejection happens through a *different* mechanism: the resolution routes' `requiredPrivileges` include `securitySolution-entity-analytics`, granted by the `advancedInsights` PLI feature key, which is enabled on Complete and disabled on Essentials. On Essentials the RBAC layer returns a generic missing-privileges 403 with a different message — `enterpriseLicenseMiddleware` is never reached.

That serverless RBAC/PLI path is **a separate coverage deliverable**, tracked separately 

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) — `release_note:skip` (test-only)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels — `backport:skip` (test-only)