### PR TITLE
[Cases] Add optimistic update for attachments file delete 

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/containers/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/constants.ts
@@ -45,8 +45,9 @@ export const casesQueriesKeys = {
   case: (id: string) => [...casesQueriesKeys.caseView(), id] as const,
   caseFiles: (id: string, params: unknown) =>
     [...casesQueriesKeys.case(id), 'files', params] as const,
+  caseFileStatsAll: (id: string) => [...casesQueriesKeys.case(id), 'files', 'stats'] as const,
   caseFileStats: (id: string, params?: unknown) =>
-    [...casesQueriesKeys.case(id), 'files', 'stats', params] as const,
+    [...casesQueriesKeys.caseFileStatsAll(id), params] as const,
   caseMetrics: (id: string, features: SingleCaseMetricsFeature[]) =>
     [...casesQueriesKeys.case(id), 'metrics', features] as const,
   caseConnectors: (id: string) => [...casesQueriesKeys.case(id), 'connectors'],

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.test.tsx
@@ -5,13 +5,16 @@
  * 2.0.
  */
 
+import React from 'react';
 import { act, waitFor, renderHook } from '@testing-library/react';
+import type { QueryClient } from '@kbn/react-query';
 import * as api from './api';
 import { basicCaseId, basicFileMock } from './mock';
+import { casesQueriesKeys } from './constants';
 import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 import { useToasts } from '../common/lib/kibana';
 import { useDeleteFileAttachment } from './use_delete_file_attachment';
-import { TestProviders } from '../common/mock';
+import { TestProviders, createTestQueryClient } from '../common/mock';
 
 jest.mock('./api');
 jest.mock('../common/lib/kibana');
@@ -107,5 +110,85 @@ describe('useDeleteFileAttachment', () => {
     });
 
     expect(addError).toHaveBeenCalled();
+  });
+
+  describe('optimistic file stats update', () => {
+    let queryClient: QueryClient;
+    const statsKey = casesQueriesKeys.caseFileStats(basicCaseId, { searchTerm: undefined });
+
+    beforeEach(() => {
+      queryClient = createTestQueryClient();
+    });
+
+    const getWrapper =
+      (qc: QueryClient): React.FC<{ children: React.ReactNode }> =>
+      // eslint-disable-next-line react/display-name
+      ({ children }) =>
+        <TestProviders queryClient={qc}>{children}</TestProviders>;
+
+    it('decrements the file stats count optimistically on mutate', async () => {
+      queryClient.setQueryData(statsKey, { total: 3 });
+
+      const spyOnDeleteFileAttachments = jest.spyOn(api, 'deleteFileAttachments');
+      let resolveDelete: () => void;
+      spyOnDeleteFileAttachments.mockImplementationOnce(
+        () => new Promise<void>((resolve) => (resolveDelete = resolve))
+      );
+
+      const { result } = renderHook(() => useDeleteFileAttachment(), {
+        wrapper: getWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate({ caseId: basicCaseId, fileId: basicFileMock.id });
+      });
+
+      await waitFor(() => {
+        expect(queryClient.getQueryData(statsKey)).toEqual({ total: 2 });
+      });
+
+      await act(async () => resolveDelete!());
+    });
+
+    it('does not set file stats below zero', async () => {
+      queryClient.setQueryData(statsKey, { total: 0 });
+
+      let resolveDelete: () => void;
+      jest
+        .spyOn(api, 'deleteFileAttachments')
+        .mockImplementationOnce(() => new Promise<void>((resolve) => (resolveDelete = resolve)));
+
+      const { result } = renderHook(() => useDeleteFileAttachment(), {
+        wrapper: getWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate({ caseId: basicCaseId, fileId: basicFileMock.id });
+      });
+
+      await waitFor(() => {
+        expect(queryClient.getQueryData(statsKey)).toEqual({ total: 0 });
+      });
+
+      await act(async () => resolveDelete!());
+    });
+
+    it('rolls back file stats on error', async () => {
+      jest.spyOn(api, 'deleteFileAttachments').mockRejectedValueOnce(new Error('Error'));
+
+      queryClient.setQueryData(statsKey, { total: 5 });
+
+      const { result } = renderHook(() => useDeleteFileAttachment(), {
+        wrapper: getWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate({ caseId: basicCaseId, fileId: basicFileMock.id });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(queryClient.getQueryData(statsKey)).toEqual({ total: 5 });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.test.tsx
@@ -113,12 +113,8 @@ describe('useDeleteFileAttachment', () => {
   });
 
   describe('optimistic file stats update', () => {
-    let queryClient: QueryClient;
+    const queryClient = createTestQueryClient();
     const statsKey = casesQueriesKeys.caseFileStats(basicCaseId, { searchTerm: undefined });
-
-    beforeEach(() => {
-      queryClient = createTestQueryClient();
-    });
 
     const getWrapper =
       (qc: QueryClient): React.FC<{ children: React.ReactNode }> =>

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { useMutation } from '@kbn/react-query';
-import { casesMutationsKeys } from './constants';
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import { casesMutationsKeys, casesQueriesKeys } from './constants';
 import type { ServerError } from '../types';
 import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 import { useCasesToast } from '../common/use_cases_toast';
@@ -19,6 +19,7 @@ interface MutationArgs {
 }
 
 export const useDeleteFileAttachment = () => {
+  const queryClient = useQueryClient();
   const { showErrorToast, showSuccessToast } = useCasesToast();
   const refreshAttachmentsTable = useRefreshCaseViewPage();
 
@@ -26,11 +27,32 @@ export const useDeleteFileAttachment = () => {
     ({ caseId, fileId }: MutationArgs) => deleteFileAttachments({ caseId, fileIds: [fileId] }),
     {
       mutationKey: casesMutationsKeys.deleteFileAttachment,
+      onMutate: async ({ caseId }) => {
+        // caseFileStats(id, params) = [...case(id), 'files', 'stats', params]
+        // Drop the trailing `params` segment to get a prefix that matches all
+        // file-stats queries for this case regardless of search term.
+        const statsKey = casesQueriesKeys.caseFileStats(caseId).slice(0, -1);
+
+        await queryClient.cancelQueries(statsKey);
+
+        const previousStats = queryClient.getQueriesData<{ total: number }>(statsKey);
+
+        queryClient.setQueriesData<{ total: number }>(statsKey, (old) =>
+          old ? { total: Math.max(0, old.total - 1) } : old
+        );
+
+        return { previousStats };
+      },
       onSuccess: () => {
         showSuccessToast(i18n.FILE_DELETE_SUCCESS);
         refreshAttachmentsTable();
       },
-      onError: (error: ServerError) => {
+      onError: (error: ServerError, _variables, context) => {
+        if (context?.previousStats) {
+          for (const [key, data] of context.previousStats) {
+            queryClient.setQueryData(key, data);
+          }
+        }
         showErrorToast(error, { title: i18n.ERROR_DELETING_FILE });
       },
     }

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.tsx
@@ -27,11 +27,11 @@ export const useDeleteFileAttachment = () => {
     ({ caseId, fileId }: MutationArgs) => deleteFileAttachments({ caseId, fileIds: [fileId] }),
     {
       mutationKey: casesMutationsKeys.deleteFileAttachment,
+      // Optimistically decrement the file count so the UI (e.g. the files
+      // accordion) updates immediately instead of waiting for the server
+      // round-trip + cache invalidation, which caused flaky FTR timeouts.
       onMutate: async ({ caseId }) => {
-        // caseFileStats(id, params) = [...case(id), 'files', 'stats', params]
-        // Drop the trailing `params` segment to get a prefix that matches all
-        // file-stats queries for this case regardless of search term.
-        const statsKey = casesQueriesKeys.caseFileStats(caseId).slice(0, -1);
+        const statsKey = casesQueriesKeys.caseFileStatsAll(caseId);
 
         await queryClient.cancelQueries(statsKey);
 


### PR DESCRIPTION
## What & Why
Fixes a flaky FTR test (`files added to a case can be deleted`) that timed out waiting for the file accordion to disappear after deletion, because the UI relied on a network refetch (default 2.5s `missingOrFail` timeout) rather than updating the count immediately. Adds an optimistic cache update to `useDeleteFileAttachment` so the file stats count decrements instantly on delete — the accordion disappears without waiting for the server round-trip.


## How to Test
1. Open a case with at least one file attachment and go to the **Attachments** tab.
2. Delete the file via the row actions menu and confirm the delete.
3. Verify the **Files** accordion disappears immediately without any visible delay.
4. Run `node scripts/jest.js x-pack/platform/plugins/shared/cases/public/containers/use_delete_file_attachment.test.tsx` and confirm all 7 tests pass (including the 3 new optimistic update tests).
