### PR TITLE
[9.4] fix(a11y): add aria-label/aria-labelledby to EuiPopover/EuiModal components in @elastic/security-solution (#270551)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/components/top_values_popover/top_values_popover.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { EuiWrappingPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useLocation } from 'react-router-dom';
 import useObservable from 'react-use/lib/useObservable';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
@@ -51,6 +52,9 @@ export const TopValuesPopover = React.memo(() => {
       repositionOnScroll
       ownFocus
       attachToAnchor={false}
+      aria-label={i18n.translate('xpack.securitySolution.topValuesPopover.ariaLabel', {
+        defaultMessage: 'Top values',
+      })}
     >
       <StatefulTopN
         field={data.fieldName}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiOutsideClickDetector,
   EuiPopover,
   EuiText,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -72,7 +73,11 @@ const CountdownComponent: React.FC<Props> = ({
   }, [approximateFutureTime]);
 
   const iconInQuestionButton = useMemo(
-    () => <EuiButtonIcon aria-label={i18n.INFORMATION} iconType="question" onClick={onClick} />,
+    () => (
+      <EuiToolTip content={i18n.INFORMATION} disableScreenReaderOutput>
+        <EuiButtonIcon aria-label={i18n.INFORMATION} iconType="question" onClick={onClick} />
+      </EuiToolTip>
+    ),
     [onClick]
   );
 
@@ -91,6 +96,7 @@ const CountdownComponent: React.FC<Props> = ({
         <EuiOutsideClickDetector isDisabled={!isPopoverOpen} onOutsideClick={() => closePopover()}>
           <EuiPopover
             anchorPosition="upCenter"
+            aria-label={i18n.INFORMATION}
             button={iconInQuestionButton}
             closePopover={closePopover}
             data-test-subj="infoPopover"

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/shared_badge/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/shared_badge/index.tsx
@@ -183,6 +183,7 @@ const SharedBadgeComponent: React.FC<Props> = ({ attackDiscovery }) => {
       position="top"
     >
       <EuiPopover
+        aria-label={i18n.VISIBILITY}
         button={button}
         closePopover={closePopover}
         data-test-subj="sharedBadgePopover"

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/status_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/status_filter/index.tsx
@@ -74,6 +74,7 @@ const StatusFilterComponent: React.FC<Props> = ({
   return (
     <EuiFilterGroup>
       <EuiPopover
+        aria-label={i18n.STATUS}
         button={button}
         closePopover={closePopover}
         data-test-subj="statusFilterPopover"

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/visibility_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/visibility_filter/index.tsx
@@ -159,6 +159,7 @@ const VisibilityFilterComponent: React.FC<Props> = ({ isLoading = false, setShar
   return (
     <EuiFilterGroup>
       <EuiPopover
+        aria-label={i18n.VISIBILITY}
         button={button}
         closePopover={closePopover}
         id={filterGroupPopoverId}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
@@ -394,6 +394,7 @@ const TakeActionComponent: React.FC<Props> = ({
   return (
     <>
       <EuiPopover
+        aria-label={i18n.TAKE_ACTION}
         anchorPosition="downCenter"
         button={button}
         closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/confirmation_modal/index.tsx
@@ -16,6 +16,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React from 'react';
@@ -27,43 +28,47 @@ interface Props {
   onDiscard: () => void;
 }
 
-const ConfirmationModalComponent: React.FC<Props> = ({ onCancel, onDiscard }) => (
-  <EuiModal
-    css={css`
-      max-width: 454px;
-    `}
-    data-test-subj="confirmationModal"
-    onClose={onCancel}
-  >
-    <EuiModalHeader>
-      <EuiModalHeaderTitle data-test-subj="title">
-        {i18n.DISCARD_UNSAVED_CHANGES}
-      </EuiModalHeaderTitle>
-    </EuiModalHeader>
+const ConfirmationModalComponent: React.FC<Props> = ({ onCancel, onDiscard }) => {
+  const modalTitleId = useGeneratedHtmlId();
+  return (
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      css={css`
+        max-width: 454px;
+      `}
+      data-test-subj="confirmationModal"
+      onClose={onCancel}
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle data-test-subj="title" id={modalTitleId}>
+          {i18n.DISCARD_UNSAVED_CHANGES}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
 
-    <EuiModalBody data-test-subj="body">
-      {i18n.YOU_MADE_CHANGES}
-      <EuiSpacer size="m" />
-      {i18n.ARE_YOU_SURE}
-    </EuiModalBody>
+      <EuiModalBody data-test-subj="body">
+        {i18n.YOU_MADE_CHANGES}
+        <EuiSpacer size="m" />
+        {i18n.ARE_YOU_SURE}
+      </EuiModalBody>
 
-    <EuiModalFooter>
-      <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty data-test-subj="cancel" onClick={onCancel}>
-            {i18n.CANCEL}
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+      <EuiModalFooter>
+        <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty data-test-subj="cancel" onClick={onCancel}>
+              {i18n.CANCEL}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton color="danger" data-test-subj="discardChanges" fill onClick={onDiscard}>
-            {i18n.DISCARD_CHANGES}
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiModalFooter>
-  </EuiModal>
-);
+          <EuiFlexItem grow={false}>
+            <EuiButton color="danger" data-test-subj="discardChanges" fill onClick={onDiscard}>
+              {i18n.DISCARD_CHANGES}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};
 
 ConfirmationModalComponent.displayName = 'ConfirmationModal';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/components/multiselect_popover/multiselect_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status/components/multiselect_popover/multiselect_popover.tsx
@@ -46,6 +46,7 @@ export const MultiSelectPopover = React.memo(
 
     return (
       <EuiPopover
+        aria-label={title}
         ownFocus
         button={
           <EuiFilterGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/summary_view_select/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/summary_view_select/index.tsx
@@ -141,6 +141,9 @@ const SummaryViewSelectorComponent = ({ viewSelected, onViewChange }: SummaryVie
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.securitySolution.summaryViewSelector.popover.ariaLabel', {
+        defaultMessage: 'View selection',
+      })}
       panelPaddingSize="none"
       button={button}
       isOpen={isPopoverOpen}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/filter_by_assignees_popover/filter_by_assignees_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/filter_by_assignees_popover/filter_by_assignees_popover.tsx
@@ -89,6 +89,10 @@ export const FilterByAssigneesPopover: FC<FilterByAssigneesPopoverProps> = memo(
     return (
       <EuiFilterGroup compressed={compressed}>
         <EuiPopover
+          aria-label={i18n.translate(
+            'xpack.securitySolution.filtersGroup.assignees.popoverAriaLabel',
+            { defaultMessage: 'Filter by assignees' }
+          )}
           panelPaddingSize="none"
           initialFocus={`[id="${searchInputId}"]`}
           button={button}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/hover_popover/hover_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/hover_popover/hover_popover.tsx
@@ -7,6 +7,7 @@
 
 import type { PopoverAnchorPosition } from '@elastic/eui';
 import { EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
 import type { PropsWithChildren } from 'react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -19,6 +20,7 @@ const HOVER_INTENT_DELAY = 100; // ms
 export interface HoverPopoverProps {
   hoverContent: React.ReactNode;
   anchorPosition?: PopoverAnchorPosition;
+  'aria-label'?: string;
 }
 
 /**
@@ -38,7 +40,7 @@ export interface HoverPopoverProps {
  * reader users to navigate to and from your popover.
  */
 export const HoverPopover = React.memo<PropsWithChildren<HoverPopoverProps>>(
-  ({ hoverContent, anchorPosition = 'downCenter', children }) => {
+  ({ hoverContent, anchorPosition = 'downCenter', 'aria-label': ariaLabel, children }) => {
     const [isOpen, setIsOpen] = useState(hoverContent != null);
     const [showHoverContent, setShowHoverContent] = useState(false);
     const [, setHoverTimeout] = useState<number | undefined>(undefined);
@@ -96,6 +98,12 @@ export const HoverPopover = React.memo<PropsWithChildren<HoverPopoverProps>>(
         <EuiPopover
           ref={popoverRef}
           anchorPosition={anchorPosition}
+          aria-label={
+            ariaLabel ??
+            i18n.translate('xpack.securitySolution.hoverPopover.ariaLabel', {
+              defaultMessage: 'Hover actions',
+            })
+          }
           button={
             <div data-test-subj="HoverPopoverButton" onMouseEnter={onMouseEnter}>
               {children}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/links/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/links/helpers.tsx
@@ -22,6 +22,7 @@ import {
   EuiPopover,
 } from '@elastic/eui';
 import styled from '@emotion/styled';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 export interface ReputationLinkSetting {
   name: string;
@@ -113,6 +114,10 @@ export const ReputationLinksOverflow = React.memo<ReputationLinkOverflowProps>(
         {rowItems.length > overflowIndexStart && (
           <EuiPopover
             id="popover"
+            aria-label={i18n.translate(
+              'xpack.securitySolution.reputationLinks.overflowPopover.ariaLabel',
+              { defaultMessage: 'More reputation links' }
+            )}
             button={button}
             isOpen={isOpen}
             closePopover={togglePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml/score/__snapshots__/anomaly_score.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml/score/__snapshots__/anomaly_score.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`anomaly_scores renders correctly against snapshot 1`] = `
   >
     <EuiPopover
       anchorPosition="downLeft"
+      aria-label="Anomaly score details"
       button={
         <Icon
           type="info"

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml/score/anomaly_score.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml/score/anomaly_score.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiPopover, EuiDescriptionList, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
 import type { NarrowDateRange, Anomaly } from '../types';
 import { Score } from './score';
@@ -46,6 +47,9 @@ export const AnomalyScoreComponent = ({
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiPopover
+          aria-label={i18n.translate('xpack.securitySolution.anomalyScore.popover.ariaLabel', {
+            defaultMessage: 'Anomaly score details',
+          })}
           data-test-subj="anomaly-score-popover"
           id="anomaly-score-popover"
           isOpen={isOpen}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml/tables/job_id_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml/tables/job_id_filter.tsx
@@ -64,6 +64,7 @@ export const JobIdFilter: React.FC<{
   return (
     <EuiFilterGroup>
       <EuiPopover
+        aria-label={title}
         button={button}
         isOpen={isPopoverOpen}
         closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/__snapshots__/groups_filter_popover.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/__snapshots__/groups_filter_popover.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`GroupsFilterPopover renders correctly against snapshot 1`] = `
 <EuiPopover
   anchorPosition="downLeft"
+  aria-label="Groups"
   button={
     <EuiFilterButton
       data-test-subj="groups-filter-popover-button"

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/groups_filter_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/groups_filter_popover.tsx
@@ -53,6 +53,7 @@ export const GroupsFilterPopoverComponent = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.GROUPS}
       ownFocus
       button={
         <EuiFilterButton
@@ -84,7 +85,7 @@ export const GroupsFilterPopoverComponent = ({
       {uniqueGroups.length === 0 && (
         <EuiFlexGroup gutterSize="m" justifyContent="spaceAround">
           <EuiFlexItem grow={true}>
-            <EuiIcon type="minusCircle" />
+            <EuiIcon type="minusCircle" aria-hidden={true} />
             <EuiSpacer size="xs" />
             <p>{i18n.NO_GROUPS_AVAILABLE}</p>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
@@ -11,6 +11,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useMemo } from 'react';
@@ -46,6 +47,7 @@ const defaultFilterProps: JobsFilters = {
 };
 
 export const MlPopover = React.memo(() => {
+  const mlPopoverTitleId = useGeneratedHtmlId();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [filterProperties, setFilterProperties] = useState(defaultFilterProps);
   const [mlNodesAvailable, setMlNodesAvailable] = useState(false);
@@ -93,6 +95,7 @@ export const MlPopover = React.memo(() => {
     return (
       <EuiPopover
         anchorPosition="downRight"
+        aria-label={i18n.ML_JOB_SETTINGS}
         id="integrations-popover"
         button={
           <EuiHeaderSectionItemButton
@@ -121,6 +124,7 @@ export const MlPopover = React.memo(() => {
     return (
       <EuiPopover
         anchorPosition="downRight"
+        aria-labelledby={mlPopoverTitleId}
         id="integrations-popover"
         button={
           <EuiHeaderSectionItemButton
@@ -145,7 +149,7 @@ export const MlPopover = React.memo(() => {
         repositionOnScroll
       >
         <PopoverContentsDiv data-test-subj="ml-popover-contents">
-          <EuiPopoverTitle>{i18n.ML_JOB_SETTINGS}</EuiPopoverTitle>
+          <EuiPopoverTitle id={mlPopoverTitleId}>{i18n.ML_JOB_SETTINGS}</EuiPopoverTitle>
           <PopoverDescription />
 
           <EuiSpacer />

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/multiselect_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/multiselect_filter/index.tsx
@@ -85,6 +85,7 @@ const MultiselectFilterComponent = <T extends unknown>({
 
   return (
     <EuiPopover
+      aria-label={title}
       data-test-subj={dataTestSubj}
       button={
         <EuiFilterButton

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
@@ -80,6 +80,7 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
   return (
     <BulkActionsContainer data-test-subj="bulk-actions-button-container">
       <EuiPopover
+        aria-label={selectText}
         isOpen={isActionsPopoverOpen}
         anchorPosition="upCenter"
         panelPaddingSize="none"

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/utility_bar/utility_bar_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/utility_bar/utility_bar_action.tsx
@@ -24,6 +24,7 @@ const LoadingButtonEmpty = styled(EuiButtonEmpty)`
 
 const Popover = React.memo<UtilityBarActionProps>(
   ({
+    ariaLabel,
     children,
     color,
     iconSide,
@@ -47,6 +48,7 @@ const Popover = React.memo<UtilityBarActionProps>(
 
     return (
       <EuiPopover
+        aria-label={ariaLabel}
         ownFocus={ownFocus}
         panelPaddingSize={popoverPanelPaddingSize}
         button={

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { buildContextMenuForActions } from '@kbn/ui-actions-plugin/public';
 
 import React, { useCallback, useMemo, useState } from 'react';
@@ -139,13 +139,15 @@ const VisualizationActionsComponent: React.FC<VisualizationActionsProps> = ({
 
   const button = useMemo(
     () => (
-      <EuiButtonIcon
-        aria-label={MORE_ACTIONS}
-        className={VISUALIZATION_ACTIONS_BUTTON_CLASS}
-        data-test-subj={dataTestSubj}
-        iconType="boxesVertical"
-        onClick={onButtonClick}
-      />
+      <EuiToolTip content={MORE_ACTIONS} disableScreenReaderOutput>
+        <EuiButtonIcon
+          aria-label={MORE_ACTIONS}
+          className={VISUALIZATION_ACTIONS_BUTTON_CLASS}
+          data-test-subj={dataTestSubj}
+          iconType="boxesVertical"
+          onClick={onButtonClick}
+        />
+      </EuiToolTip>
     ),
     [dataTestSubj, onButtonClick]
   );
@@ -154,6 +156,7 @@ const VisualizationActionsComponent: React.FC<VisualizationActionsProps> = ({
     <Wrapper className={className}>
       {panels.value && panels.value.length > 0 && (
         <EuiPopover
+          aria-label={MORE_ACTIONS}
           button={button}
           isOpen={isPopoverOpen}
           closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiPopoverTitle,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { ControlColumnProps } from '../../../common/types';
 
@@ -62,16 +63,19 @@ const TestTrailingColumn = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   return (
     <EuiPopover
+      aria-label="Actions"
       isOpen={isPopoverOpen}
       anchorPosition="upCenter"
       panelPaddingSize="s"
       button={
-        <EuiButtonIcon
-          aria-label="show actions"
-          iconType="boxesVertical"
-          color="text"
-          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-        />
+        <EuiToolTip content="show actions" disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label="show actions"
+            iconType="boxesVertical"
+            color="text"
+            onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+          />
+        </EuiToolTip>
       }
       data-test-subj="test-trailing-column-popover-button"
       closePopover={() => setIsPopoverOpen(false)}
@@ -81,7 +85,9 @@ const TestTrailingColumn = () => {
         <button type="button" onClick={() => {}}>
           <EuiFlexGroup alignItems="center" component="span" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon aria-label="Pin selected items" iconType="pin" color="text" />
+              <EuiToolTip content="Pin selected items" disableScreenReaderOutput>
+                <EuiButtonIcon aria-label="Pin selected items" iconType="pin" color="text" />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem>{'Pin'}</EuiFlexItem>
           </EuiFlexGroup>
@@ -90,7 +96,9 @@ const TestTrailingColumn = () => {
         <button type="button" onClick={() => {}}>
           <EuiFlexGroup alignItems="center" component="span" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon aria-label="Delete selected items" iconType="trash" color="text" />
+              <EuiToolTip content="Delete selected items" disableScreenReaderOutput>
+                <EuiButtonIcon aria-label="Delete selected items" iconType="trash" color="text" />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem>{'Delete'}</EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/components/related_integrations/integrations_popover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/components/related_integrations/integrations_popover/index.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexGroup,
   EuiText,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { RelatedIntegrationArray } from '../../../../../../common/api/detection_engine/model/rule_schema';
 import { IntegrationDescription } from '../integrations_description';
@@ -53,6 +54,7 @@ const IntegrationListItem = styled('li')`
 const IntegrationsPopoverComponent = ({ relatedIntegrations }: IntegrationsPopoverProps) => {
   const [isPopoverOpen, setPopoverOpen] = useState(false);
   const { integrations, isLoaded } = useRelatedIntegrations(relatedIntegrations);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const enabledIntegrations = useMemo(() => {
     return integrations.filter(
@@ -77,6 +79,7 @@ const IntegrationsPopoverComponent = ({ relatedIntegrations }: IntegrationsPopov
       <EuiPopover
         ownFocus
         data-test-subj={'IntegrationsDisplayPopover'}
+        aria-labelledby={popoverTitleId}
         button={
           <EuiBadge
             iconType={'package'}
@@ -92,7 +95,7 @@ const IntegrationsPopoverComponent = ({ relatedIntegrations }: IntegrationsPopov
         closePopover={() => setPopoverOpen(!isPopoverOpen)}
         repositionOnScroll
       >
-        <PopoverTitleWrapper data-test-subj={'IntegrationsPopoverTitle'}>
+        <PopoverTitleWrapper id={popoverTitleId} data-test-subj={'IntegrationsPopoverTitle'}>
           {i18n.INTEGRATIONS_POPOVER_TITLE(numIntegrations)}
         </PopoverTitleWrapper>
         <PopoverContentWrapper data-test-subj={'IntegrationsPopoverContentWrapper'}>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/translations.ts
@@ -1208,6 +1208,13 @@ export const REFRESH_RULE_POPOVER_DESCRIPTION = i18n.translate(
   }
 );
 
+export const AUTO_REFRESH_POPOVER_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.autoRefreshPopoverAriaLabel',
+  {
+    defaultMessage: 'Auto refresh settings',
+  }
+);
+
 export const CLEAR_RULES_TABLE_FILTERS = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.clearRulesTableFilters',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_info_icon.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_info_icon.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiLink, EuiPopover, EuiText, EuiButtonIcon } from '@elastic/eui';
+import { EuiLink, EuiPopover, EuiText, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useBoolean } from '@kbn/react-hooks';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -22,15 +22,25 @@ export function SuppressionInfoIcon(): JSX.Element {
   const { docLinks } = useKibana().services;
 
   const button = (
-    <EuiButtonIcon
-      iconType="question"
-      onClick={togglePopover}
-      aria-label={ALERT_SUPPRESSION_MISSING_FIELDS_HELP_ARIA_LABEL}
-    />
+    <EuiToolTip
+      content={ALERT_SUPPRESSION_MISSING_FIELDS_HELP_ARIA_LABEL}
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        iconType="question"
+        onClick={togglePopover}
+        aria-label={ALERT_SUPPRESSION_MISSING_FIELDS_HELP_ARIA_LABEL}
+      />
+    </EuiToolTip>
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      aria-label={ALERT_SUPPRESSION_MISSING_FIELDS_HELP_ARIA_LABEL}
+    >
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.alertSuppressionMissingFieldsTooltipContent"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/errors_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/errors_popover.tsx
@@ -7,7 +7,13 @@
 
 import type { FC } from 'react';
 import React, { useCallback, useState } from 'react';
-import { EuiButtonEmpty, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 
 import * as i18n from './translations';
 
@@ -18,6 +24,7 @@ export interface ErrorsPopoverProps {
 
 export const ErrorsPopover: FC<ErrorsPopoverProps> = ({ ariaLabel, errors }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const handleToggle = useCallback(() => {
     setIsOpen(!isOpen);
@@ -30,6 +37,7 @@ export const ErrorsPopover: FC<ErrorsPopoverProps> = ({ ariaLabel, errors }) => 
   return (
     <EuiPopover
       data-test-subj="eql-validation-errors-popover"
+      aria-labelledby={popoverTitleId}
       button={
         <EuiButtonEmpty
           data-test-subj="eql-validation-errors-popover-button"
@@ -47,7 +55,7 @@ export const ErrorsPopover: FC<ErrorsPopoverProps> = ({ ariaLabel, errors }) => 
       anchorPosition="downCenter"
     >
       <div data-test-subj="eql-validation-errors-popover-content">
-        <EuiPopoverTitle>{i18n.EQL_VALIDATION_ERRORS_TITLE}</EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId}>{i18n.EQL_VALIDATION_ERRORS_TITLE}</EuiPopoverTitle>
         {errors.map((message, idx) => (
           <EuiText key={idx}>{message}</EuiText>
         ))}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/footer.tsx
@@ -17,6 +17,8 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   useEuiTheme,
+  useGeneratedHtmlId,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { FC } from 'react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -56,6 +58,7 @@ export const EqlQueryBarFooter: FC<EqlQueryBarFooterProps> = ({
   const [openEqlSettings, setIsOpenEqlSettings] = useState(false);
   const [localSize, setLocalSize] = useState<number>(eqlOptions?.size ?? 100);
   const debounceSize = useRef<DebouncedFunc<SizeVoidFunc>>();
+  const eqlSettingsTitleId = useGeneratedHtmlId();
 
   const { euiTheme } = useEuiTheme();
   const containerStyles = useMemo(
@@ -233,20 +236,25 @@ export const EqlQueryBarFooter: FC<EqlQueryBarFooterProps> = ({
                 <EuiFlexItem className={groupItemStyles} grow={false}>
                   <EuiPopover
                     button={
-                      <EuiButtonIcon
-                        onClick={openEqlSettingsHandler}
-                        iconType="controls"
-                        isDisabled={openEqlSettings}
-                        aria-label="eql settings"
-                        data-test-subj="eql-settings-trigger"
-                      />
+                      <EuiToolTip content="eql settings" disableScreenReaderOutput>
+                        <EuiButtonIcon
+                          onClick={openEqlSettingsHandler}
+                          iconType="controls"
+                          isDisabled={openEqlSettings}
+                          aria-label="eql settings"
+                          data-test-subj="eql-settings-trigger"
+                        />
+                      </EuiToolTip>
                     }
                     isOpen={openEqlSettings}
                     closePopover={closeEqlSettingsHandler}
                     anchorPosition="downCenter"
                     ownFocus={false}
+                    aria-labelledby={eqlSettingsTitleId}
                   >
-                    <EuiPopoverTitle>{i18n.EQL_SETTINGS_TITLE}</EuiPopoverTitle>
+                    <EuiPopoverTitle id={eqlSettingsTitleId}>
+                      {i18n.EQL_SETTINGS_TITLE}
+                    </EuiPopoverTitle>
                     <div css={{ width: '300px' }}>
                       {!isSizeOptionDisabled && (
                         <EuiFormRow

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/esql_query_edit/esql_info_icon.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/esql_query_edit/esql_info_icon.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo } from 'react';
-import { EuiPopover, EuiText, EuiButtonIcon, EuiLink } from '@elastic/eui';
+import { EuiPopover, EuiText, EuiButtonIcon, EuiLink, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useBoolean } from '@kbn/react-hooks';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -20,11 +20,18 @@ export const EsqlInfoIcon = memo(function EsqlInfoIcon(): JSX.Element {
   const [isPopoverOpen, { off: closePopover, on: togglePopover }] = useBoolean(false);
 
   const button = (
-    <EuiButtonIcon iconType="info" onClick={togglePopover} aria-label={i18n.ARIA_LABEL} />
+    <EuiToolTip content={i18n.ARIA_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon iconType="info" onClick={togglePopover} aria-label={i18n.ARIA_LABEL} />
+    </EuiToolTip>
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      aria-label={i18n.ARIA_LABEL}
+    >
       <EuiText size="s">
         <FormattedMessage
           id="xpack.securitySolution.ruleManagement.esqlQuery.esqlInfoTooltipContent"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations_help_info.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import useToggle from 'react-use/lib/useToggle';
-import { EuiLink, EuiPopover, EuiText, EuiButtonIcon } from '@elastic/eui';
+import { EuiLink, EuiPopover, EuiText, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../../../../common/lib/kibana';
 import { RELATED_INTEGRATIONS_HELP_ARIA_LABEL } from './translations';
@@ -26,15 +26,22 @@ export function RelatedIntegrationsHelpInfo(): JSX.Element {
   const { docLinks } = useKibana().services;
 
   const button = (
-    <EuiButtonIcon
-      iconType="question"
-      onClick={togglePopover}
-      aria-label={RELATED_INTEGRATIONS_HELP_ARIA_LABEL}
-    />
+    <EuiToolTip content={RELATED_INTEGRATIONS_HELP_ARIA_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="question"
+        onClick={togglePopover}
+        aria-label={RELATED_INTEGRATIONS_HELP_ARIA_LABEL}
+      />
+    </EuiToolTip>
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={togglePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={togglePopover}
+      aria-label={RELATED_INTEGRATIONS_HELP_ARIA_LABEL}
+    >
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.ruleDescription.relatedIntegrations.fieldRelatedIntegrationsHelpText"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/required_fields/required_fields_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/required_fields/required_fields_help_info.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import useToggle from 'react-use/lib/useToggle';
-import { EuiPopover, EuiText, EuiButtonIcon } from '@elastic/eui';
+import { EuiPopover, EuiText, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as defineRuleI18n from '../../../rule_creation_ui/components/step_define_rule/translations';
 import * as i18n from './translations';
@@ -25,15 +25,22 @@ export function RequiredFieldsHelpInfo(): JSX.Element {
   const [isPopoverOpen, togglePopover] = useToggle(false);
 
   const button = (
-    <EuiButtonIcon
-      iconType="question"
-      onClick={togglePopover}
-      aria-label={i18n.OPEN_HELP_POPOVER_ARIA_LABEL}
-    />
+    <EuiToolTip content={i18n.OPEN_HELP_POPOVER_ARIA_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="question"
+        onClick={togglePopover}
+        aria-label={i18n.OPEN_HELP_POPOVER_ARIA_LABEL}
+      />
+    </EuiToolTip>
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={togglePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={togglePopover}
+      aria-label={i18n.OPEN_HELP_POPOVER_ARIA_LABEL}
+    >
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.ruleDescription.requiredFields.fieldRequiredFieldsHelpText"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -19,6 +19,7 @@ import {
   EuiSpacer,
   EuiToolTip,
   EuiWindowEvent,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import { Route, Routes } from '@kbn/shared-ux-router';
@@ -319,6 +320,7 @@ export const RuleDetailsPage = connector(
 
     const pageTabs = useRuleDetailsTabs({ rule, ruleId, isExistingRule, canReadAlerts });
 
+    const confirmModalTitleId = useGeneratedHtmlId();
     const [isDeleteConfirmationVisible, showDeleteConfirmation, hideDeleteConfirmation] =
       useBoolState();
 
@@ -670,6 +672,8 @@ export const RuleDetailsPage = connector(
             buttonColor="danger"
             defaultFocusedButton="confirm"
             data-test-subj="deleteRulesConfirmationModal"
+            aria-labelledby={confirmModalTitleId}
+            titleProps={{ id: confirmModalTitleId }}
           >
             {i18n.DELETE_CONFIRMATION_BODY}
           </EuiConfirmModal>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/rule_actions_overflow/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/rule_actions_overflow/index.tsx
@@ -297,6 +297,7 @@ const RuleActionsOverflowComponent = ({
         ownFocus={true}
         panelPaddingSize="none"
         repositionOnScroll
+        aria-label={i18n.ALL_ACTIONS}
       >
         <EuiContextMenuPanel data-test-subj="rules-details-menu-panel" items={actions} />
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_card/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_card/header.tsx
@@ -14,9 +14,11 @@ import {
   EuiFlexItem,
   EuiPopover,
   EuiTitle,
+  EuiToolTip,
   EuiContextMenuItem,
 } from '@elastic/eui';
 import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import { EXCEPTION_ITEM_ACTIONS_MENU_ARIA_LABEL } from './translations';
 
 export interface ExceptionItemCardHeaderProps {
   item: ExceptionListItemSchema;
@@ -58,18 +60,24 @@ export const ExceptionItemCardHeader = memo<ExceptionItemCardHeaderProps>(
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButtonIcon
-                isDisabled={disableActions}
-                aria-label="Exception item actions menu"
-                iconType="boxesVertical"
-                onClick={onItemActionsClick}
-                data-test-subj={`${dataTestSubj}-actionButton`}
-              />
+              <EuiToolTip
+                content={EXCEPTION_ITEM_ACTIONS_MENU_ARIA_LABEL}
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  isDisabled={disableActions}
+                  aria-label={EXCEPTION_ITEM_ACTIONS_MENU_ARIA_LABEL}
+                  iconType="boxesVertical"
+                  onClick={onItemActionsClick}
+                  data-test-subj={`${dataTestSubj}-actionButton`}
+                />
+              </EuiToolTip>
             }
             panelPaddingSize="none"
             isOpen={isPopoverOpen}
             closePopover={onClosePopover}
             data-test-subj={`${dataTestSubj}-items`}
+            aria-label={EXCEPTION_ITEM_ACTIONS_MENU_ARIA_LABEL}
           >
             <EuiContextMenuPanel size="s" items={itemActions} />
           </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_card/meta.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_card/meta.tsx
@@ -100,6 +100,7 @@ export const ExceptionItemCardMetaInfo = memo<ExceptionItemCardMetaInfoProps>(
             closePopover={onCloseRulesPopover}
             data-test-subj={`${dataTestSubj}-rulesPopover`}
             id={'rulesPopover'}
+            aria-label={i18n.AFFECTED_RULES_POPOVER_ARIA_LABEL}
           >
             <EuiContextMenuPanel size="s" css={referenceLinksContainerStyles} items={itemActions} />
           </EuiPopover>
@@ -135,6 +136,7 @@ export const ExceptionItemCardMetaInfo = memo<ExceptionItemCardMetaInfoProps>(
               closePopover={onClosListsPopover}
               data-test-subj={`${dataTestSubj}-listsPopover`}
               id={'listsPopover'}
+              aria-label={i18n.AFFECTED_LIST_POPOVER_ARIA_LABEL}
             >
               <EuiContextMenuPanel
                 size="s"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_card/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_card/translations.ts
@@ -200,3 +200,24 @@ export const AFFECTED_LIST = i18n.translate(
     defaultMessage: 'Affects shared list',
   }
 );
+
+export const EXCEPTION_ITEM_ACTIONS_MENU_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleExceptions.exceptionItem.actionsMenuAriaLabel',
+  {
+    defaultMessage: 'Exception item actions menu',
+  }
+);
+
+export const AFFECTED_RULES_POPOVER_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleExceptions.exceptionItem.affectedRulesPopoverAriaLabel',
+  {
+    defaultMessage: 'Affected rules',
+  }
+);
+
+export const AFFECTED_LIST_POPOVER_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleExceptions.exceptionItem.affectedListPopoverAriaLabel',
+  {
+    defaultMessage: 'Affects shared list',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_options/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_options/index.tsx
@@ -15,6 +15,7 @@ import {
   EuiPopover,
   EuiButtonEmpty,
   EuiPopoverFooter,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import type { ExceptionListSchema, ListArray } from '@kbn/securitysolution-io-ts-list-types';
@@ -60,15 +61,21 @@ const ExceptionsAddToListsOptionsComponent: React.FC<ExceptionsAddToListsOptions
             <EuiFlexItem grow={false} data-test-subj="addToListsOption">
               <EuiPopover
                 button={
-                  <EuiButtonIcon
-                    iconType="info"
-                    onClick={onPopOverButtonClick}
-                    aria-label={i18n.ADD_TO_LISTS_OPTION_TOOLTIP_ARIA_LABEL}
-                  />
+                  <EuiToolTip
+                    content={i18n.ADD_TO_LISTS_OPTION_TOOLTIP_ARIA_LABEL}
+                    disableScreenReaderOutput
+                  >
+                    <EuiButtonIcon
+                      iconType="info"
+                      onClick={onPopOverButtonClick}
+                      aria-label={i18n.ADD_TO_LISTS_OPTION_TOOLTIP_ARIA_LABEL}
+                    />
+                  </EuiToolTip>
                 }
                 isOpen={isPopoverOpen}
                 closePopover={closePopover}
                 anchorPosition="upCenter"
+                aria-label={i18n.ADD_TO_LISTS_OPTION_TOOLTIP_ARIA_LABEL}
               >
                 <div css={{ width: '300px' }}>
                   <EuiText size="s">

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/comparison_side/comparison_side_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/comparison_side/comparison_side_help_info.tsx
@@ -42,7 +42,12 @@ export function ComparisonSideHelpInfo({ options }: ComparisonSideHelpInfoProps)
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={togglePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={togglePopover}
+      aria-label={i18n.VERSION_COMPARISON_HELP_ARIA_LABEL}
+    >
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.rules.upgradeRules.comparisonSide.upgradeHelpText"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/field_final_side/components/field_final_side_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/field_final_side/components/field_final_side_help_info.tsx
@@ -34,7 +34,12 @@ export function FieldFinalSideHelpInfo(): JSX.Element {
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={togglePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={togglePopover}
+      aria-label={i18n.FINAL_UPDATE_HELP_ARIA_LABEL}
+    >
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.rules.upgradeRules.upgradeHelpText"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/auto_refresh_button/auto_refresh_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/auto_refresh_button/auto_refresh_button.tsx
@@ -63,6 +63,7 @@ const AutoRefreshButtonComponent = ({
     <EuiPopover
       isOpen={isPopoverOpen}
       closePopover={closePopover}
+      aria-label={i18n.AUTO_REFRESH_POPOVER_ARIA_LABEL}
       button={
         <EuiButtonEmpty
           data-test-subj="autoRefreshButton"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/ml_rule_warning_popover/ml_rule_warning_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/ml_rule_warning_popover/ml_rule_warning_popover.tsx
@@ -14,6 +14,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
@@ -44,6 +45,7 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
   jobs,
 }) => {
   const [isPopoverOpen, , closePopover, togglePopover] = useBoolState();
+  const popoverTitleId = useGeneratedHtmlId();
   const ruleDetailsUrl = getRuleDetailsUrl(rule.id);
   const jobIds = getMachineLearningJobId(rule);
 
@@ -77,8 +79,9 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       anchorPosition="leftCenter"
+      aria-labelledby={popoverTitleId}
     >
-      <EuiPopoverTitle>{popoverTitle}</EuiPopoverTitle>
+      <EuiPopoverTitle id={popoverTitleId}>{popoverTitle}</EuiPopoverTitle>
       <div css={{ width: POPOVER_WIDTH }}>
         <EuiText size="s">
           <p>{i18n.ML_RULE_JOBS_WARNING_DESCRIPTION}</p>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
@@ -104,6 +104,7 @@ export const AddPrebuiltRulesHeaderButtons = () => {
               closePopover={closeOverflowPopover}
               panelPaddingSize="s"
               anchorPosition="downRight"
+              aria-label={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
             >
               <EuiContextMenuPanel size="s" items={overflowItems} />
             </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_install_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_install_button.tsx
@@ -118,6 +118,7 @@ export const PrebuiltRulesInstallButton = ({
           closePopover={closeOverflowPopover}
           panelPaddingSize="s"
           anchorPosition="downRight"
+          aria-label={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
         >
           <EuiContextMenuPanel size="s" items={overflowItems} />
         </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/ml_rule_warning_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/ml_rule_warning_popover.tsx
@@ -14,6 +14,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
@@ -44,6 +45,7 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
   jobs,
 }) => {
   const [isPopoverOpen, , closePopover, togglePopover] = useBoolState();
+  const popoverTitleId = useGeneratedHtmlId();
   const jobIds = getMachineLearningJobId(rule);
   const ruleDetailsUrl = getRuleDetailsUrl(rule.id);
 
@@ -77,8 +79,9 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       anchorPosition="leftCenter"
+      aria-labelledby={popoverTitleId}
     >
-      <EuiPopoverTitle>{popoverTitle}</EuiPopoverTitle>
+      <EuiPopoverTitle id={popoverTitleId}>{popoverTitle}</EuiPopoverTitle>
       <div css={{ width: POPOVER_WIDTH }}>
         <EuiText size="s">
           <p>{i18n.ML_RULE_JOBS_WARNING_DESCRIPTION}</p>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/popover_tooltip.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/popover_tooltip.tsx
@@ -52,6 +52,7 @@ const PopoverTooltipComponent = ({
       anchorPosition={'upCenter'}
       isOpen={isPopoverOpen}
       closePopover={() => setIsPopoverOpen(false)}
+      aria-label={i18n.POPOVER_TOOLTIP_ARIA_LABEL(columnName)}
       button={
         <EuiIcon
           aria-label={i18n.POPOVER_TOOLTIP_ARIA_LABEL(columnName)}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/gap_fill_status_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/gap_fill_status_selector.tsx
@@ -88,6 +88,7 @@ export const GapFillStatusSelector = ({
       closePopover={close}
       panelPaddingSize="none"
       repositionOnScroll
+      aria-label={GAP_FILL_STATUS_FILTER_LABEL}
     >
       <EuiSelectable
         aria-label={GAP_FILL_STATUS_FILTER_LABEL}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
@@ -95,6 +95,7 @@ const RuleExecutionStatusSelectorComponent = ({
       }}
       panelPaddingSize="none"
       repositionOnScroll
+      aria-label={i18n.RULE_EXECUTION_STATUS_FILTER}
     >
       <EuiSelectable
         aria-label={i18n.RULE_EXECUTION_STATUS_FILTER}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -89,6 +89,7 @@ const TagsFilterPopoverComponent = ({
       panelProps={{
         'data-test-subj': 'tags-filter-popover',
       }}
+      aria-label={i18n.TAGS}
     >
       <EuiSelectable
         searchable

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_rule_customization_filter_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_rule_customization_filter_popover.tsx
@@ -76,6 +76,7 @@ const RuleCustomizationFilterPopoverComponent = ({
       panelProps={{
         'data-test-subj': 'rule-customization-filter-popover',
       }}
+      aria-label={i18n.RULE_SOURCE}
     >
       <EuiSelectable options={selectableOptions} onChange={handleSelectableOptionsChange}>
         {(list) => <div css={{ width: RULE_CUSTOMIZATION_POPOVER_WIDTH }}>{list}</div>}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/rule_activity_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/rule_activity_filter.tsx
@@ -15,6 +15,7 @@ import {
   EuiPopoverTitle,
   EuiButtonEmpty,
   EuiPopoverFooter,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/css';
 import type { CoverageOverviewRuleActivity } from '../../../../../common/api/detection_engine';
@@ -38,6 +39,7 @@ const RuleActivityFilterComponent = ({
   isLoading,
 }: RuleActivityFilterComponentProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const onButtonClick = useCallback(() => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -93,8 +95,11 @@ const RuleActivityFilterComponent = ({
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         panelPaddingSize="none"
+        aria-labelledby={popoverTitleId}
       >
-        <EuiPopoverTitle paddingSize="s">{i18n.CoverageOverviewFilterPopoverTitle}</EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
+          {i18n.CoverageOverviewFilterPopoverTitle}
+        </EuiPopoverTitle>
         <EuiSelectable<{ label: CoverageOverviewRuleActivity }>
           data-test-subj="coverageOverviewFilterList"
           options={options}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/rule_source_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/rule_source_filter.tsx
@@ -15,6 +15,7 @@ import {
   EuiPopoverTitle,
   EuiButtonEmpty,
   EuiPopoverFooter,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/css';
 import type { CoverageOverviewRuleSource } from '../../../../../common/api/detection_engine';
@@ -38,6 +39,7 @@ const RuleSourceFilterComponent = ({
   isLoading,
 }: RuleSourceFilterComponentProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const onButtonClick = useCallback(() => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -95,8 +97,11 @@ const RuleSourceFilterComponent = ({
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         panelPaddingSize="none"
+        aria-labelledby={popoverTitleId}
       >
-        <EuiPopoverTitle paddingSize="s">{i18n.CoverageOverviewFilterPopoverTitle}</EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
+          {i18n.CoverageOverviewFilterPopoverTitle}
+        </EuiPopoverTitle>
         <EuiSelectable
           data-test-subj="coverageOverviewFilterList"
           options={options}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/technique_panel_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/technique_panel_popover.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   EuiSpacer,
   EuiAccordion,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css, cx } from '@emotion/css';
 import React, { memo, useCallback, useMemo, useState } from 'react';
@@ -40,6 +41,7 @@ const CoverageOverviewMitreTechniquePanelPopoverComponent = ({
   const canEnableRules = useUserPrivileges().rulesPrivileges.enableDisable.edit;
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
   const isEnableButtonDisabled = useMemo(
     () => !canEnableRules || technique.disabledRules.length === 0,
@@ -135,8 +137,10 @@ const CoverageOverviewMitreTechniquePanelPopoverComponent = ({
       anchorPosition="rightCenter"
       data-test-subj="coverageOverviewPopover"
       ownFocus={false}
+      aria-labelledby={popoverTitleId}
     >
       <EuiPopoverTitle
+        id={popoverTitleId}
         className={css`
           min-width: 30em;
         `}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring/components/basic/filters/multiselect_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring/components/basic/filters/multiselect_filter/index.tsx
@@ -81,6 +81,7 @@ const MultiselectFilterComponent = <T extends unknown>(props: MultiselectFilterP
         closePopover={closePopover}
         panelPaddingSize="none"
         repositionOnScroll
+        aria-label={title}
       >
         {filterItemElements}
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.tsx
@@ -33,6 +33,13 @@ const INTEGRATIONS_BUTTON = i18n.translate(
   }
 );
 
+const INTEGRATIONS_POPOVER_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.alertSummary.integrations.popoverAriaLabel',
+  {
+    defaultMessage: 'Integrations filter',
+  }
+);
+
 export interface IntegrationFilterButtonProps {
   /**
    * List of integrations the user can select or deselect
@@ -110,6 +117,7 @@ export const IntegrationFilterButton = memo(({ integrations }: IntegrationFilter
   return (
     <EuiFilterGroup compressed={true}>
       <EuiPopover
+        aria-label={INTEGRATIONS_POPOVER_ARIA_LABEL}
         button={button}
         closePopover={togglePopover}
         id={filterGroupPopoverId}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { i18n } from '@kbn/i18n';
 import { flattenObject } from '@kbn/object-utils';
@@ -53,12 +53,14 @@ export const MoreActionsRowControlColumn = memo(
 
     const button = useMemo(
       () => (
-        <EuiButtonIcon
-          aria-label={MORE_ACTIONS_BUTTON_ARIA_LABEL}
-          data-test-subj={MORE_ACTIONS_BUTTON_TEST_ID}
-          iconType="boxesVertical"
-          onClick={togglePopover}
-        />
+        <EuiToolTip content={MORE_ACTIONS_BUTTON_ARIA_LABEL} disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label={MORE_ACTIONS_BUTTON_ARIA_LABEL}
+            data-test-subj={MORE_ACTIONS_BUTTON_TEST_ID}
+            iconType="boxesVertical"
+            onClick={togglePopover}
+          />
+        </EuiToolTip>
       ),
       [togglePopover]
     );
@@ -96,6 +98,7 @@ export const MoreActionsRowControlColumn = memo(
 
     return (
       <EuiPopover
+        aria-label={MORE_ACTIONS_BUTTON_ARIA_LABEL}
         button={button}
         closePopover={togglePopover}
         isOpen={isPopoverOpen}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
@@ -15,6 +15,8 @@ import {
   EuiProgress,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
@@ -85,23 +87,28 @@ export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const onButtonClick = () => setIsPopoverOpen(!isPopoverOpen);
   const closePopover = () => setIsPopoverOpen(false);
+  const dataStatsTitleId = useGeneratedHtmlId();
 
   const [nonEmpty, formattedNonEmptyPercent] = useMemo(() => getAggregateData(data), [data]);
   const sourcererScopeId = useMemo(() => getSourcererScopeId(TableId.alertsOnAlertsPage), []);
 
   const dataStatsButton = (
-    <EuiButtonIcon
-      color="text"
-      iconType="info"
-      aria-label="info"
-      size="xs"
-      onClick={onButtonClick}
-    />
+    <EuiToolTip content="info" disableScreenReaderOutput>
+      <EuiButtonIcon
+        color="text"
+        iconType="info"
+        aria-label="info"
+        size="xs"
+        onClick={onButtonClick}
+      />
+    </EuiToolTip>
   );
 
   const dataStatsMessage = (
     <DataStatsWrapper>
-      <EuiPopoverTitle>{i18n.DATA_STATISTICS_TITLE(formattedNonEmptyPercent)}</EuiPopoverTitle>
+      <EuiPopoverTitle id={dataStatsTitleId}>
+        {i18n.DATA_STATISTICS_TITLE(formattedNonEmptyPercent)}
+      </EuiPopoverTitle>
       <EuiText size="s">
         {i18n.DATA_STATISTICS_MESSAGE(groupBySelection)}
         <EuiLink
@@ -129,6 +136,7 @@ export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiPopover
+            aria-labelledby={dataStatsTitleId}
             button={dataStatsButton}
             isOpen={isPopoverOpen}
             closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_settings_popover/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 
 import { BUTTON_CLASS } from '../../../../../common/components/inspect';
@@ -34,19 +34,22 @@ const ChartSettingsPopoverComponent: React.FC<Props> = ({
 
   const button = useMemo(
     () => (
-      <EuiButtonIcon
-        aria-label={i18n.CHART_SETTINGS_POPOVER_ARIA_LABEL}
-        color="text"
-        iconType="boxesVertical"
-        onClick={onButtonClick}
-        size="xs"
-      />
+      <EuiToolTip content={i18n.CHART_SETTINGS_POPOVER_ARIA_LABEL} disableScreenReaderOutput>
+        <EuiButtonIcon
+          aria-label={i18n.CHART_SETTINGS_POPOVER_ARIA_LABEL}
+          color="text"
+          iconType="boxesVertical"
+          onClick={onButtonClick}
+          size="xs"
+        />
+      </EuiToolTip>
     ),
     [onButtonClick]
   );
 
   return (
     <EuiPopover
+      aria-label={i18n.CHART_SETTINGS_POPOVER_ARIA_LABEL}
       anchorPosition="downCenter"
       button={button}
       className={BUTTON_CLASS}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -351,6 +351,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
         <EventsTdContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
           <EuiPopover
             id="singlePanel"
+            aria-label={ariaLabel}
             button={button}
             isOpen={isPopoverOpen}
             closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
@@ -66,6 +66,7 @@ const renderContextMenu = (items: AlertTableContextMenuItem[]) => {
   const panels = [{ id: 0, items }];
   render(
     <EuiPopover
+      aria-label="Context menu"
       isOpen={true}
       panelPaddingSize="none"
       anchorPosition="downLeft"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
@@ -52,6 +52,7 @@ const renderContextMenu = (
   const panelsToRender = [{ id: 0, items }, ...panels];
   return render(
     <EuiPopover
+      aria-label="Context menu"
       isOpen={true}
       panelPaddingSize="none"
       anchorPosition="downLeft"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_tags_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_tags_actions.test.tsx
@@ -41,6 +41,7 @@ const renderContextMenu = (
   const panelsToRender = [{ id: 0, items }, ...panels];
   return render(
     <EuiPopover
+      aria-label="Context menu"
       isOpen={true}
       panelPaddingSize="none"
       anchorPosition="downLeft"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.test.tsx
@@ -243,6 +243,7 @@ const renderContextMenu = (items: AlertTableContextMenuItem[]) => {
   const panels = [{ id: 0, items }];
   return render(
     <EuiPopover
+      aria-label="Context menu"
       isOpen={true}
       panelPaddingSize="none"
       anchorPosition="downLeft"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.test.tsx
@@ -107,6 +107,7 @@ const renderContextMenu = (
   const panelsToRender = [{ id: 0, items }, ...panels];
   return render(
     <EuiPopover
+      aria-label="Context menu"
       isOpen={true}
       panelPaddingSize="none"
       anchorPosition="downLeft"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel.test.tsx
@@ -98,6 +98,7 @@ const renderContextMenu = (
   const panelsToRender = [{ id: 0, items }, ...panels];
   return render(
     <EuiPopover
+      aria-label="Context menu"
       isOpen={true}
       panelPaddingSize="none"
       anchorPosition="downLeft"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_table_sort_select.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_table_sort_select.tsx
@@ -133,6 +133,7 @@ export const AttacksTableSortSelect = React.memo(
 
     return (
       <EuiPopover
+        aria-label={i18n.SORT_BY}
         button={button}
         isOpen={isPopoverOpen}
         closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.tsx
@@ -13,6 +13,7 @@ import {
   EuiSwitch,
   EuiFormRow,
   EuiSpacer,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 
@@ -71,17 +72,20 @@ export const AttacksViewOptionsPopover: React.FC<AttacksViewOptionsPopoverProps>
   );
 
   const button = (
-    <EuiButtonIcon
-      iconType="controls"
-      aria-label={i18n.VIEW_OPTIONS_ARIA_LABEL}
-      onClick={onButtonClick}
-      data-test-subj={`${TABLE_SECTION_TEST_ID}-view-options-button`}
-    />
+    <EuiToolTip content={i18n.VIEW_OPTIONS_ARIA_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="controls"
+        aria-label={i18n.VIEW_OPTIONS_ARIA_LABEL}
+        onClick={onButtonClick}
+        data-test-subj={`${TABLE_SECTION_TEST_ID}-view-options-button`}
+      />
+    </EuiToolTip>
   );
 
   return (
     <EuiPopover
       id="attacksViewOptionsPopover"
+      aria-label={i18n.VIEW_OPTIONS_ARIA_LABEL}
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
@@ -22,6 +22,7 @@ import {
   EuiScreenReaderLive,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import styled from '@emotion/styled';
 
@@ -507,14 +508,16 @@ export const SharedLists = React.memo(() => {
                   <EuiText>{i18n.ALL_EXCEPTIONS_SUBTITLE}</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiButtonIcon
-                    iconType="external"
-                    aria-label="go-to-rules"
-                    color="primary"
-                    onClick={() =>
-                      navigateToApp('security', { openInNewTab: true, path: '/rules' })
-                    }
-                  />
+                  <EuiToolTip content="go-to-rules" disableScreenReaderOutput>
+                    <EuiButtonIcon
+                      iconType="external"
+                      aria-label="go-to-rules"
+                      color="primary"
+                      onClick={() =>
+                        navigateToApp('security', { openInNewTab: true, path: '/rules' })
+                      }
+                    />
+                  </EuiToolTip>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>
@@ -528,6 +531,7 @@ export const SharedLists = React.memo(() => {
         }
         rightSideItems={[
           <EuiPopover
+            aria-label={i18n.CREATE_BUTTON}
             data-test-subj="manageExceptionListCreateButton"
             button={
               canEditExceptions && (
@@ -675,6 +679,7 @@ export const SharedLists = React.memo(() => {
             <EuiFlexGroup alignItems="flexStart">
               <EuiFlexItem>
                 <EuiPopover
+                  aria-label={i18n.allExceptionsRowPerPage(rowSize)}
                   button={rowSizeButton}
                   isOpen={isRowSizePopoverOpen}
                   closePopover={closeRowSizePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section_settings.tsx
@@ -16,6 +16,7 @@ import {
   EuiPopoverTitle,
   EuiSwitch,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
@@ -115,18 +116,34 @@ export const AISummarySectionSettings: React.FC<AISummarySectionSettingsProps> =
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.securitySolution.attackDetailsFlyout.overview.AISummary.settingsPopoverAriaLabel',
+        {
+          defaultMessage: 'Attack summary settings',
+        }
+      )}
       button={
-        <EuiButtonIcon
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.securitySolution.attackDetailsFlyout.overview.AISummary.openMenuAriaLabel',
             {
               defaultMessage: 'Attack summary settings menu',
             }
           )}
-          data-test-subj="overview-tab-ai-summary-settings-menu"
-          iconType="boxesVertical"
-          onClick={openPopover}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            aria-label={i18n.translate(
+              'xpack.securitySolution.attackDetailsFlyout.overview.AISummary.openMenuAriaLabel',
+              {
+                defaultMessage: 'Attack summary settings menu',
+              }
+            )}
+            data-test-subj="overview-tab-ai-summary-settings-menu"
+            iconType="boxesVertical"
+            onClick={openPopover}
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.tsx
@@ -16,6 +16,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isNonLocalIndexName } from '@kbn/es-query';
@@ -68,6 +69,7 @@ export const Assignees = memo(() => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const togglePopover = useCallback(() => setIsPopoverOpen((prev) => !prev), []);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+  const assigneesTitleId = useGeneratedHtmlId();
 
   const attacksWithAssignees = useMemo(
     () => [{ attackId, relatedAlertIds: alertIds, assignees }],
@@ -128,13 +130,14 @@ export const Assignees = memo(() => {
       )}
       <EuiFlexItem grow={false}>
         <EuiPopover
+          aria-labelledby={assigneesTitleId}
           button={button}
           isOpen={isPopoverOpen}
           closePopover={closePopover}
           panelPaddingSize="none"
           data-test-subj="attack-details-flyout-header-assignees-popover"
         >
-          <EuiPopoverTitle paddingSize="m">
+          <EuiPopoverTitle id={assigneesTitleId} paddingSize="m">
             {i18n.translate(
               'xpack.securitySolution.attackDetailsFlyout.header.assignees.popoverTitle',
               {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status_popover_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status_popover_button.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiContextMenu, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import { EuiContextMenu, EuiPopover, EuiPopoverTitle, useGeneratedHtmlId } from '@elastic/eui';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
@@ -50,6 +50,7 @@ export const StatusPopoverButton = memo(
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
     const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+    const statusTitleId = useGeneratedHtmlId();
 
     const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuery(), []);
 
@@ -122,13 +123,14 @@ export const StatusPopoverButton = memo(
     return (
       <>
         <EuiPopover
+          aria-labelledby={statusTitleId}
           button={button}
           isOpen={isPopoverOpen}
           closePopover={closePopover}
           panelPaddingSize="none"
           data-test-subj={STATUS_POPOVER_TEST_ID}
         >
-          <EuiPopoverTitle paddingSize="m">
+          <EuiPopoverTitle id={statusTitleId} paddingSize="m">
             {i18n.translate(
               'xpack.securitySolution.attackDetailsFlyout.header.popover.changeAttackStatus',
               {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
@@ -16,6 +16,7 @@ import {
   EuiPopover,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { AttacksGroupTakeActionItems } from '../../detections/components/attacks/table/attacks_group_take_action_items';
 import { AttackAiAssistantButton } from '../../detections/components/attacks/table/attack_details/attack_ai_assistant_button';
 import {
@@ -78,6 +79,10 @@ export const PanelFooter = () => {
           <EuiFlexItem grow={false}>
             <EuiPopover
               id="AttackDetailsTakeActionPanel"
+              aria-label={i18n.translate(
+                'xpack.securitySolution.flyout.attackDetails.footer.takeActionPopoverAriaLabel',
+                { defaultMessage: 'Take action' }
+              )}
               button={takeActionButton}
               isOpen={isPopoverOpen}
               closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_tab_setting_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_tab_setting_button.tsx
@@ -121,17 +121,20 @@ export const TableTabSettingButton = ({
   return (
     <EuiToolTip content={TABLE_TAB_SETTING_BUTTON_LABEL}>
       <EuiPopover
+        aria-label={TABLE_TAB_SETTING_BUTTON_LABEL}
         button={
-          <EuiButtonIcon
-            aria-label={TABLE_TAB_SETTING_BUTTON_LABEL}
-            onClick={onClick}
-            iconType="gear"
-            size="m"
-            css={css`
-              border: 1px solid ${euiTheme.colors.backgroundLightText};
-              margin-left: -5px;
-            `}
-          />
+          <EuiToolTip content={TABLE_TAB_SETTING_BUTTON_LABEL} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={TABLE_TAB_SETTING_BUTTON_LABEL}
+              onClick={onClick}
+              iconType="gear"
+              size="m"
+              css={css`
+                border: 1px solid ${euiTheme.colors.backgroundLightText};
+                margin-left: -5px;
+              `}
+            />
+          </EuiToolTip>
         }
         isOpen={isPopoverOpen}
         closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
@@ -420,6 +420,7 @@ export const TakeActionDropdown = memo(
     return items.length && dataAsNestedObject ? (
       <EuiPopover
         id="AlertTakeActionPanel"
+        aria-label={TAKE_ACTION}
         button={takeActionButton}
         isOpen={isPopoverOpen}
         closePopover={closePopoverHandler}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/components/conversations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/components/conversations.tsx
@@ -100,6 +100,7 @@ export const Conversations = memo(({ alertId }: ConversationsProps) => {
             {conversationCount > 0 && (
               <EuiFlexItem grow={false}>
                 <EuiPopover
+                  aria-label={YOUR_CONVERSATIONS}
                   button={
                     <EuiButtonEmpty
                       data-test-subj={VIEW_CONVERSATIONS_BUTTON_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/components/settings_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/components/settings_menu.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { EuiButtonIcon, EuiContextMenu, EuiPanel, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { AnonymizationSwitch } from './anonymization_switch';
 
@@ -36,13 +36,15 @@ export const AlertSummaryOptionsMenu = memo(({ hasAlertSummary }: AlertSummaryOp
 
   const button = useMemo(
     () => (
-      <EuiButtonIcon
-        aria-label={OPTIONS_MENU}
-        data-test-subj={ALERT_SUMMARY_OPTIONS_MENU_BUTTON_TEST_ID}
-        color="text"
-        iconType="boxesVertical"
-        onClick={togglePopover}
-      />
+      <EuiToolTip content={OPTIONS_MENU} disableScreenReaderOutput>
+        <EuiButtonIcon
+          aria-label={OPTIONS_MENU}
+          data-test-subj={ALERT_SUMMARY_OPTIONS_MENU_BUTTON_TEST_ID}
+          color="text"
+          iconType="boxesVertical"
+          onClick={togglePopover}
+        />
+      </EuiToolTip>
     ),
     [togglePopover]
   );
@@ -62,6 +64,7 @@ export const AlertSummaryOptionsMenu = memo(({ hasAlertSummary }: AlertSummaryOp
   );
   return (
     <EuiPopover
+      aria-label={OPTIONS_MENU}
       button={button}
       isOpen={isPopoverOpen}
       closePopover={togglePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/components/take_action_button.tsx
@@ -93,6 +93,7 @@ export const TakeActionButton = memo(() => {
 
   return (
     <EuiPopover
+      aria-label={TAKE_ACTION_BUTTON}
       button={button}
       closePopover={togglePopover}
       isOpen={isPopoverOpen}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ioc_details/components/take_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ioc_details/components/take_action.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiContextMenuPanel, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { BlockListFlyout } from '../../../threat_intelligence/modules/block_list/containers/flyout';
 import { useIOCDetailsContext } from '../context';
 import { canAddToBlockList } from '../../../threat_intelligence/modules/block_list/utils/can_add_to_block_list';
@@ -89,6 +90,10 @@ export const TakeAction = memo(() => {
     <>
       <EuiPopover
         id={smallContextMenuPopoverId}
+        aria-label={i18n.translate(
+          'xpack.securitySolution.threatIntelligence.indicators.flyout.take-action.popoverAriaLabel',
+          { defaultMessage: 'Take action' }
+        )}
         button={button}
         isOpen={isPopoverOpen}
         closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/highlighted_fields_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/highlighted_fields_modal.tsx
@@ -202,9 +202,9 @@ export const HighlightedFieldsModal: FC<HighlightedFieldsModalProps> = ({
 
   return (
     <EuiModal
+      aria-labelledby={modalTitleId}
       css={{ width: '600px' }}
       data-test-subj={HIGHLIGHTED_FIELDS_MODAL_TEST_ID}
-      id={modalTitleId}
       onClose={onCancel}
     >
       <EuiModalHeader data-test-subj={HIGHLIGHTED_FIELDS_MODAL_TITLE_TEST_ID}>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/actions_context_menu/actions_context_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/actions_context_menu/actions_context_menu.tsx
@@ -66,15 +66,22 @@ export const ActionsContextMenu = memo<ActionsContextMenuProps>(
 
     const menuButton = useMemo(() => {
       const button = (
-        <EuiButtonIcon
-          data-test-subj={getTestId('button')}
-          iconType={icon}
-          onClick={handleToggleMenu}
-          isDisabled={isDisabled}
-          aria-label={i18n.translate('xpack.securitySolution.actionsContextMenu.label', {
+        <EuiToolTip
+          content={i18n.translate('xpack.securitySolution.actionsContextMenu.label', {
             defaultMessage: 'Open',
           })}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj={getTestId('button')}
+            iconType={icon}
+            onClick={handleToggleMenu}
+            isDisabled={isDisabled}
+            aria-label={i18n.translate('xpack.securitySolution.actionsContextMenu.label', {
+              defaultMessage: 'Open',
+            })}
+          />
+        </EuiToolTip>
       );
 
       if (isDisabled && disabledTooltip) {
@@ -93,6 +100,9 @@ export const ActionsContextMenu = memo<ActionsContextMenuProps>(
         button={menuButton}
         isOpen={isOpen}
         closePopover={handleCloseMenu}
+        aria-label={i18n.translate('xpack.securitySolution.actionsContextMenu.popover.ariaLabel', {
+          defaultMessage: 'Actions menu',
+        })}
       >
         <EuiContextMenuPanel items={menuItems} data-test-subj={getTestId('contextMenuPanel')} />
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_input/components/input_area_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_input/components/input_area_popover.tsx
@@ -8,6 +8,7 @@
 import type { CSSProperties, ReactElement } from 'react';
 import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import { EuiFocusTrap, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
 import { CommandInputHistory } from './command_input_history';
 import { useConsoleStateDispatch } from '../../../hooks/state_selectors/use_console_state_dispatch';
@@ -66,6 +67,9 @@ export const InputAreaPopover = memo<InputAreaPopoverProps>(({ children, width =
       focusTrapProps={focusTrapProps}
       ownFocus={false}
       data-test-subj={getTestId('inputPopover')}
+      aria-label={i18n.translate('xpack.securitySolution.console.inputAreaPopover.ariaLabel', {
+        defaultMessage: 'Command input history',
+      })}
     >
       {show && (
         <EuiFocusTrap clickOutsideDisables={true}>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/custom_scripts_selector/custom_script_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/custom_scripts_selector/custom_script_selector.tsx
@@ -18,6 +18,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import type { EuiSelectableOption } from '@elastic/eui/src/components/selectable/selectable_option';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { CustomScriptsRequestQueryParams } from '../../../../../common/api/endpoint/custom_scripts/get_custom_scripts_route';
 import type { EndpointCommandDefinitionMeta } from '../../endpoint_responder/types';
@@ -208,6 +209,10 @@ export const CustomScriptSelector = memo<
       closePopover={handleClosePopover}
       panelProps={{ 'data-test-subj': testId('popoverPanel') }}
       panelPaddingSize="s"
+      aria-label={i18n.translate(
+        'xpack.securitySolution.endpoint.customScriptSelector.popover.ariaLabel',
+        { defaultMessage: 'Select script' }
+      )}
       button={
         <EuiToolTip content={CUSTOM_SCRIPTS_CONFIG.tooltipText} position="top" display="block">
           <EuiFlexGroup responsive={false} alignItems="center" gutterSize="none" tabIndex={0}>
@@ -258,7 +263,7 @@ export const CustomScriptSelector = memo<
     </EuiPopover>
   ) : (
     <EuiText size="s" color="subdued" data-test-subj={testId('noMultipleArgs')}>
-      <EuiIcon type="warning" size="s" color="subdued" />{' '}
+      <EuiIcon type="warning" size="s" color="subdued" aria-hidden={true} />{' '}
       <FormattedMessage
         id="xpack.securitySolution.endpoint.customScriptSelector.noMultipleArgs"
         defaultMessage="Argument is only supported once per command"

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/file_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/file_selector.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
+  EuiToolTip,
   htmlIdGenerator,
 } from '@elastic/eui';
 import type { EuiFilePickerProps } from '@elastic/eui/src/components/form/file_picker/file_picker';
@@ -129,6 +130,10 @@ export const ArgumentFileSelector = memo<
         closePopover={handleClosePopover}
         anchorPosition="upCenter"
         initialFocus={`[id="${filePickerUUID}"]`}
+        aria-label={i18n.translate(
+          'xpack.securitySolution.consoleArgumentSelectors.fileSelector.popover.ariaLabel',
+          { defaultMessage: 'Select file' }
+        )}
         button={
           <EuiFlexGroup responsive={false} alignItems="center" gutterSize="none">
             <EuiFlexItem grow={false} className="eui-textTruncate" onClick={handleOpenPopover}>
@@ -137,12 +142,14 @@ export const ArgumentFileSelector = memo<
               </div>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType="folderOpen"
-                size="xs"
-                onClick={handleOpenPopover}
-                aria-label={OPEN_FILE_PICKER_LABEL}
-              />
+              <EuiToolTip content={OPEN_FILE_PICKER_LABEL} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  iconType="folderOpen"
+                  size="xs"
+                  onClick={handleOpenPopover}
+                  aria-label={OPEN_FILE_PICKER_LABEL}
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/textarea_input_argument/textarea_input_argument.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/textarea_input_argument/textarea_input_argument.test.tsx
@@ -60,10 +60,10 @@ describe('TextareaInputArgument component', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('test-popoverPanel')).toBeTruthy();
-    expect(getByTestId('test-openInputButton').title).toEqual(OPEN_INPUT);
+    expect(getByTestId('test-openInputButton').getAttribute('aria-label')).toEqual(OPEN_INPUT);
     expect(getByTestId('test-selectionDisplay').textContent).toEqual(NO_INPUT_ENTERED_MESSAGE);
     expect(getByTestId('test-closeButton').textContent).toEqual(CLOSE_POPUP_BUTTON_LABEL);
-    expect(getByTestId('test-helpButton').title).toEqual(HELP_ICON_LABEL);
+    expect(getByTestId('test-helpButton').getAttribute('aria-label')).toEqual(HELP_ICON_LABEL);
     expect(getByTestId('test-title').textContent).toEqual('foo'); // << Default is the argument name
     expect((getByTestId('test-textarea') as HTMLTextAreaElement).placeholder).toEqual(
       TEXTAREA_PLACEHOLDER_TEXT
@@ -82,14 +82,18 @@ describe('TextareaInputArgument component', () => {
     });
     const { getByTestId } = render();
 
-    expect(getByTestId('test-openInputButton').title).toEqual(componentPropsMock.openLabel);
+    expect(getByTestId('test-openInputButton').getAttribute('aria-label')).toEqual(
+      componentPropsMock.openLabel
+    );
     expect(getByTestId('test-selectionDisplay').textContent).toEqual(
       componentPropsMock.noInputEnteredMessage
     );
     expect(getByTestId('test-closeButton').textContent).toEqual(
       componentPropsMock.closePopupButtonLabel
     );
-    expect(getByTestId('test-helpButton').title).toEqual(componentPropsMock.helpIconLabel);
+    expect(getByTestId('test-helpButton').getAttribute('aria-label')).toEqual(
+      componentPropsMock.helpIconLabel
+    );
     expect(getByTestId('test-title').textContent).toEqual(componentPropsMock.textareaLabel);
     expect((getByTestId('test-textarea') as HTMLTextAreaElement).placeholder).toEqual(
       componentPropsMock.textareaPlaceholderLabel

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/textarea_input_argument/textarea_input_argument.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/textarea_input_argument/textarea_input_argument.tsx
@@ -23,6 +23,7 @@ import {
   EuiButton,
   EuiSpacer,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -142,6 +143,8 @@ export const TextareaInputArgument = memo<TextareaInputArgumentProps>(
       return htmlIdGenerator('textarea')();
     }, []);
 
+    const popoverTitleId = useGeneratedHtmlId();
+
     const textareaContainerCss = useMemo(() => {
       return css`
         --height: 15rem;
@@ -241,6 +244,7 @@ export const TextareaInputArgument = memo<TextareaInputArgumentProps>(
         initialFocus={`textarea.${textAreaHtmlId}`}
         panelProps={{ 'data-test-subj': testId('popoverPanel') }}
         panelPaddingSize="s"
+        aria-labelledby={popoverTitleId}
         button={
           <EuiFlexGroup responsive={false} alignItems="center" gutterSize="xs">
             <EuiFlexItem grow={false} className="eui-textTruncate" onClick={handleOpenPopover}>
@@ -254,18 +258,19 @@ export const TextareaInputArgument = memo<TextareaInputArgumentProps>(
             </EuiFlexItem>
             {showHelpIcon && (
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType="pencil"
-                  size="xs"
-                  onClick={handleOpenPopover}
-                  title={openLabel}
-                  aria-label={openLabel}
-                  data-test-subj={testId('openInputButton')}
-                  css={css`
-                    inline-size: auto;
-                    block-size: auto;
-                  `}
-                />
+                <EuiToolTip content={openLabel} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="pencil"
+                    size="xs"
+                    onClick={handleOpenPopover}
+                    aria-label={openLabel}
+                    data-test-subj={testId('openInputButton')}
+                    css={css`
+                      inline-size: auto;
+                      block-size: auto;
+                    `}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             )}
           </EuiFlexGroup>
@@ -277,7 +282,7 @@ export const TextareaInputArgument = memo<TextareaInputArgumentProps>(
               <EuiFlexGroup alignItems="center" gutterSize="s">
                 <EuiFlexItem>
                   <EuiTitle size="xxxs" data-test-subj={testId('title')}>
-                    <h5>{textareaLabel ?? argName}</h5>
+                    <h5 id={popoverTitleId}>{textareaLabel ?? argName}</h5>
                   </EuiTitle>
                 </EuiFlexItem>
 
@@ -288,7 +293,6 @@ export const TextareaInputArgument = memo<TextareaInputArgumentProps>(
                       size="xs"
                       onClick={handleHelpOnClick}
                       isSelected={showHelpContent}
-                      title={helpIconLabel}
                       aria-label={helpIconLabel}
                       disabled={!helpContent}
                       data-test-subj={testId('helpButton')}
@@ -356,7 +360,7 @@ export const TextareaInputArgument = memo<TextareaInputArgumentProps>(
       </EuiPopover>
     ) : (
       <EuiText size="s" color="subdued" data-test-subj={testId('noMultipleArgs')}>
-        <EuiIcon type="warning" size="s" color="subdued" />{' '}
+        <EuiIcon type="warning" size="s" color="subdued" aria-hidden={true} />{' '}
         <FormattedMessage
           id="xpack.securitySolution.consoleArgumentSelectors.textAreaInputArgument.noMultipleArgs"
           defaultMessage="Argument is only supported once per command"

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filter_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filter_popover.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useMemo } from 'react';
 import { EuiFilterButton, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FILTER_NAMES } from '../translations';
 import type { FilterName } from './hooks';
 import { useTestIdGenerator } from '../../../hooks/use_test_id_generator';
@@ -71,6 +72,10 @@ export const ActionsLogFilterPopover = memo(
         id={filterGroupPopoverId}
         isOpen={isPopoverOpen}
         panelPaddingSize="none"
+        aria-label={i18n.translate(
+          'xpack.securitySolution.endpointResponseActions.filterPopover.ariaLabel',
+          { defaultMessage: 'Filter options' }
+        )}
       >
         {children}
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/policy_selector/policy_selector_menu_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/policy_selector/policy_selector_menu_button.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiFilterButton, EuiFilterGroup, EuiPopover, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useTestIdGenerator } from '../../hooks/use_test_id_generator';
 import type { PolicySelectorProps } from './policy_selector';
@@ -82,6 +83,10 @@ export const PolicySelectorMenuButton = memo<PolicySelectorMenuButtonProps>((pro
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         panelPaddingSize="none"
+        aria-label={i18n.translate(
+          'xpack.securitySolution.management.policiesSelector.popover.ariaLabel',
+          { defaultMessage: 'Policies selector' }
+        )}
       >
         <PolicySelector {...props} onFetch={onFetch} data-test-subj={getTestId('policySelector')} />
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/table_row_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/table_row_actions.tsx
@@ -7,7 +7,7 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import type { EuiContextMenuPanelProps, EuiPopoverProps } from '@elastic/eui';
-import { EuiButtonIcon, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenuPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ContextMenuItemNavByRouter } from '../../../../components/context_menu_with_router_support/context_menu_item_nav_by_router';
 import type { HostInfo } from '../../../../../../common/endpoint/types';
@@ -50,17 +50,28 @@ export const TableRowActions = memo<TableRowActionProps>(({ endpointInfo }) => {
       panelPaddingSize="none"
       panelProps={panelProps}
       button={
-        <EuiButtonIcon
-          data-test-subj="endpointTableRowActions"
-          iconType="boxesVertical"
-          onClick={handleToggleMenu}
-          aria-label={i18n.translate('xpack.securitySolution.endpoint.list.actionmenu', {
+        <EuiToolTip
+          content={i18n.translate('xpack.securitySolution.endpoint.list.actionmenu', {
             defaultMessage: 'Open',
           })}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="endpointTableRowActions"
+            iconType="boxesVertical"
+            onClick={handleToggleMenu}
+            aria-label={i18n.translate('xpack.securitySolution.endpoint.list.actionmenu', {
+              defaultMessage: 'Open',
+            })}
+          />
+        </EuiToolTip>
       }
       isOpen={isOpen}
       closePopover={handleCloseMenu}
+      aria-label={i18n.translate(
+        'xpack.securitySolution.endpoint.list.actionmenu.popover.ariaLabel',
+        { defaultMessage: 'Endpoint row actions' }
+      )}
     >
       <EuiContextMenuPanel items={menuItems} />
     </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/actions_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/actions_menu.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { HostInfo } from '../../../../../../../common/endpoint/types';
 import { useEndpointActionItems } from '../../hooks';
@@ -64,6 +65,10 @@ export const ActionsMenu = memo<{ hostInfo: HostInfo }>(({ hostInfo }) => {
       panelPaddingSize="none"
       anchorPosition="downLeft"
       data-test-subj="endpointDetailsActionsPopover"
+      aria-label={i18n.translate(
+        'xpack.securitySolution.endpoint.detailsActions.popover.ariaLabel',
+        { defaultMessage: 'Endpoint actions' }
+      )}
     >
       <EuiContextMenuPanel size="s" items={takeActionItems} />
     </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/index.tsx
@@ -6,6 +6,7 @@
  */
 import React, { useCallback, memo } from 'react';
 import { EuiFlyout } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useHistory } from 'react-router-dom';
 import { useEndpointSelector } from '../hooks';
 import { uiQueryParams } from '../../store/selectors';
@@ -35,6 +36,9 @@ export const EndpointDetailsFlyout = memo(() => {
       size="m"
       paddingSize="l"
       ownFocus={false}
+      aria-label={i18n.translate('xpack.securitySolution.endpoint.details.flyout.ariaLabel', {
+        defaultMessage: 'Endpoint details',
+      })}
     >
       <EndpointDetails />
     </EuiFlyout>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/script_library/view/components/details/script_details_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/script_library/view/components/details/script_details_actions.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
 import type { EndpointScript } from '../../../../../../../common/endpoint/types';
@@ -78,6 +79,10 @@ export const EndpointScriptDetailsActions = memo<EndpointScriptDetailsActionsPro
         panelPaddingSize="none"
         anchorPosition="downLeft"
         data-test-subj={getTestId('actionsPopover')}
+        aria-label={i18n.translate(
+          'xpack.securitySolution.script.detailsActions.popover.ariaLabel',
+          { defaultMessage: 'Script actions' }
+        )}
       >
         <EuiContextMenuPanel size="s" items={takeActionItems} />
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/note_content.tsx
@@ -15,6 +15,13 @@ const OPEN_POPOVER = i18n.translate('xpack.securitySolution.notes.expandRow.butt
   defaultMessage: 'Expand',
 });
 
+const NOTE_CONTENT_POPOVER_LABEL = i18n.translate(
+  'xpack.securitySolution.notes.expandRow.popoverAriaLabel',
+  {
+    defaultMessage: 'Note content',
+  }
+);
+
 export interface NoteContentProps {
   /**
    * The note content to display
@@ -62,6 +69,7 @@ export const NoteContent = memo(({ note }: NoteContentProps) => {
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelStyle={{ maxWidth: '50%', maxHeight: '50%', overflow: 'auto' }}
+      aria-label={NOTE_CONTENT_POPOVER_LABEL}
     >
       <EuiMarkdownFormat textSize="s" data-test-subj={NOTE_CONTENT_POPOVER_TEST_ID}>
         {note}

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/common.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/common.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import * as i18n from './translations';
 import { EntityAnalyticsLearnMoreLink } from '../../entity_analytics/components/entity_analytics_learn_more_link';
@@ -17,6 +24,7 @@ export const RiskScoreInfoTooltip: React.FC<{
   anchorPosition?: EuiPopover['props']['anchorPosition'];
 }> = ({ toolTipContent, toolTipTitle, width = 270, anchorPosition = 'leftCenter' }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const onClick = useCallback(() => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -31,18 +39,21 @@ export const RiskScoreInfoTooltip: React.FC<{
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       anchorPosition={anchorPosition}
+      aria-labelledby={popoverTitleId}
       button={
-        <EuiButtonIcon
-          color="text"
-          size="xs"
-          iconSize="m"
-          iconType="info"
-          aria-label={i18n.INFORMATION_ARIA_LABEL}
-          onClick={onClick}
-        />
+        <EuiToolTip content={i18n.INFORMATION_ARIA_LABEL} disableScreenReaderOutput>
+          <EuiButtonIcon
+            color="text"
+            size="xs"
+            iconSize="m"
+            iconType="info"
+            aria-label={i18n.INFORMATION_ARIA_LABEL}
+            onClick={onClick}
+          />
+        </EuiToolTip>
       }
     >
-      {toolTipTitle && <EuiPopoverTitle>{toolTipTitle}</EuiPopoverTitle>}
+      {toolTipTitle && <EuiPopoverTitle id={popoverTitleId}>{toolTipTitle}</EuiPopoverTitle>}
       <EuiText size="s" style={{ width: `${width}px` }}>
         {toolTipContent}
       </EuiText>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/date_picker.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/date_picker.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, memo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { i18n } from '@kbn/i18n';
-import { EuiPopover, EuiPopoverTitle, EuiSuperDatePicker } from '@elastic/eui';
+import { EuiPopover, EuiPopoverTitle, EuiSuperDatePicker, useGeneratedHtmlId } from '@elastic/eui';
 import type { ShortDate, EuiSuperDatePickerProps } from '@elastic/eui';
 import { formatDate } from '../../../common/components/super_date_picker';
 import { StyledEuiButtonIcon } from './styles';
@@ -51,6 +51,7 @@ export const DateSelectionButton = memo(
     isOpen: boolean;
   }) => {
     const dispatch = useDispatch();
+    const datePickerTitleId = useGeneratedHtmlId();
     const setAsActivePopover = useCallback(
       () => setActivePopover('datePicker'),
       [setActivePopover]
@@ -98,8 +99,9 @@ export const DateSelectionButton = memo(
         isOpen={isOpen}
         closePopover={closePopover}
         anchorPosition="leftCenter"
+        aria-labelledby={datePickerTitleId}
       >
-        <EuiPopoverTitle css={{ textTransform: 'uppercase' }}>
+        <EuiPopoverTitle id={datePickerTitleId} css={{ textTransform: 'uppercase' }}>
           {dateRangeDescription}
         </EuiPopoverTitle>
         <EuiSuperDatePicker

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/legend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/legend.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import { EuiPopover, EuiPopoverTitle, useGeneratedHtmlId } from '@elastic/eui';
 import { useColors } from '../use_colors';
 import { StyledDescriptionList } from '../panels/styles';
 import { CubeForProcess } from '../panels/cube_for_process';
@@ -34,6 +34,7 @@ export const NodeLegend = ({
 }) => {
   const setAsActivePopover = useCallback(() => setActivePopover('nodeLegend'), [setActivePopover]);
   const colorMap = useColors();
+  const nodeLegendTitleId = useGeneratedHtmlId();
 
   const nodeLegendButtonTitle = i18n.translate(
     'xpack.securitySolution.resolver.graphControls.nodeLegendButtonTitle',
@@ -60,8 +61,9 @@ export const NodeLegend = ({
       isOpen={isOpen}
       closePopover={closePopover}
       anchorPosition="leftCenter"
+      aria-labelledby={nodeLegendTitleId}
     >
-      <EuiPopoverTitle css={{ textTransform: 'uppercase' }}>
+      <EuiPopoverTitle id={nodeLegendTitleId} css={{ textTransform: 'uppercase' }}>
         {i18n.translate('xpack.securitySolution.resolver.graphControls.nodeLegend', {
           defaultMessage: 'legend',
         })}

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/schema.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/schema.tsx
@@ -12,6 +12,7 @@ import {
   EuiPopoverTitle,
   EuiIconTip,
   EuiDescriptionListDescription,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useSelector } from 'react-redux';
 import * as selectors from '../../store/selectors';
@@ -33,6 +34,7 @@ export const SchemaInformation = ({
   isOpen: boolean;
 }) => {
   const colorMap = useColors();
+  const schemaInfoTitleId = useGeneratedHtmlId();
   const sourceAndSchema = useSelector((state: State) =>
     selectors.resolverTreeSourceAndSchema(state.analyzer[id])
   );
@@ -70,8 +72,9 @@ export const SchemaInformation = ({
       isOpen={isOpen}
       closePopover={closePopover}
       anchorPosition="leftCenter"
+      aria-labelledby={schemaInfoTitleId}
     >
-      <EuiPopoverTitle css={{ textTransform: 'uppercase' }}>
+      <EuiPopoverTitle id={schemaInfoTitleId} css={{ textTransform: 'uppercase' }}>
         {i18n.translate('xpack.securitySolution.resolver.graphControls.schemaInfoTitle', {
           defaultMessage: 'process tree',
         })}

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.tsx
@@ -58,6 +58,7 @@ export const SourcererButton = memo(
         isOpen={isOpen}
         closePopover={closePopover}
         anchorPosition="leftCenter"
+        aria-label={nodeLegendButtonTitle}
       >
         {newDataViewPickerEnabled ? (
           <DataViewPicker scope={PageScope.analyzer} onClosePopover={closePopover} />

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/filters/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/filters/status.tsx
@@ -79,6 +79,7 @@ const StatusFilterButtonComponent = <T,>({
       }}
       panelPaddingSize="none"
       repositionOnScroll
+      aria-label={i18n.STATUS_FILTER_ARIAL_LABEL}
     >
       <EuiSelectable
         aria-label={i18n.STATUS_FILTER_ARIAL_LABEL}

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_panels/migration_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_panels/migration_title.tsx
@@ -153,18 +153,21 @@ export const MigrationPanelTitle = React.memo(function MigrationPanelTitle({
           <EuiFlexItem grow={false} onClick={stopPropagation}>
             <EuiPopover
               button={
-                <EuiButtonIcon
-                  iconType="boxesVertical"
-                  onClick={togglePopover}
-                  aria-label={i18n.OPEN_MIGRATION_OPTIONS_BUTTON}
-                  data-test-subj="openMigrationOptionsButton"
-                  isLoading={isUpdating || isDeleting}
-                />
+                <EuiToolTip content={i18n.OPEN_MIGRATION_OPTIONS_BUTTON} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="boxesVertical"
+                    onClick={togglePopover}
+                    aria-label={i18n.OPEN_MIGRATION_OPTIONS_BUTTON}
+                    data-test-subj="openMigrationOptionsButton"
+                    isLoading={isUpdating || isDeleting}
+                  />
+                </EuiToolTip>
               }
               isOpen={isPopoverOpen}
               closePopover={closePopover}
               panelPaddingSize="none"
               anchorPosition="downCenter"
+              aria-label={i18n.OPEN_MIGRATION_OPTIONS_BUTTON}
             >
               <EuiContextMenuPanel size="s">
                 <EuiContextMenuItem

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/filters/author.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/filters/author.tsx
@@ -82,6 +82,7 @@ export const AuthorFilterButton: React.FC<AuthorFilterButtonProps> = React.memo(
         }}
         panelPaddingSize="none"
         repositionOnScroll
+        aria-label={i18n.AUTHOR_FILTER_ARIAL_LABEL}
       >
         <EuiSelectable
           aria-label={i18n.AUTHOR_FILTER_ARIAL_LABEL}

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiPopoverTitle,
   EuiSpacer,
   EuiSuperSelect,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { ChangeEventHandler } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -58,6 +59,7 @@ interface SourcererPopoverProps {
   setMissingPatterns: (missingPatterns: string[]) => void;
   setDataViewId: (dataViewId: string | null) => void;
   scopeId: PageScope;
+  popoverTitleId: string;
   children: React.ReactNode;
 }
 
@@ -81,6 +83,7 @@ const SourcererPopover = React.memo<SourcererPopoverProps>(
     setMissingPatterns,
     setDataViewId,
     scopeId,
+    popoverTitleId,
     children,
   }) => {
     if (!showSourcerer) {
@@ -111,6 +114,7 @@ const SourcererPopover = React.memo<SourcererPopoverProps>(
           isOpen={isPopoverOpen}
           ownFocus
           repositionOnScroll
+          aria-labelledby={popoverTitleId}
         >
           <>{children}</>
         </EuiPopover>
@@ -126,6 +130,7 @@ SourcererPopover.displayName = 'SourcererPopover';
  */
 export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }) => {
   const dispatch = useDispatch();
+  const sourcererTitleId = useGeneratedHtmlId();
   const isDetectionsSourcerer = scopeId === PageScope.alerts;
   const isTimelineSourcerer = scopeId === PageScope.timeline;
   const isDefaultSourcerer = scopeId === PageScope.default;
@@ -377,9 +382,10 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
       setMissingPatterns={setMissingPatterns}
       setDataViewId={setDataViewId}
       scopeId={scopeId}
+      popoverTitleId={sourcererTitleId}
     >
       <PopoverContent>
-        <EuiPopoverTitle data-test-subj="sourcerer-title">
+        <EuiPopoverTitle id={sourcererTitleId} data-test-subj="sourcerer-title">
           <>{i18n.SELECT_DATA_VIEW}</>
         </EuiPopoverTitle>
         <SourcererCallout

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/barchart/legend_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/barchart/legend_action.tsx
@@ -101,6 +101,7 @@ export const IndicatorBarchartLegendAction: FC<IndicatorBarchartLegendActionProp
       closePopover={() => setPopover(false)}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={BUTTON_LABEL}
     >
       <ReduxProvider store={store}>
         <EuiContextMenuPanel size="s" items={popoverItems} />

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/more_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/table/more_actions.tsx
@@ -100,6 +100,7 @@ export const MoreActions = memo(({ indicator }: TakeActionProps) => {
         closePopover={closePopover}
         panelPaddingSize="none"
         anchorPosition="downLeft"
+        aria-label={MORE_ACTIONS_BUTTON_LABEL}
       >
         <EuiContextMenuPanel size="s" items={items} />
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/bottom_bar/add_timeline_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/bottom_bar/add_timeline_button.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import * as i18n from './translations';
 import { useCreateTimeline } from '../../hooks/use_create_timeline';
@@ -58,14 +65,16 @@ export const AddTimelineButton = React.memo<AddTimelineButtonComponentProps>(({ 
 
   const plusButton = useMemo(
     () => (
-      <EuiButtonIcon
-        iconType="plusCircle"
-        iconSize="m"
-        color="primary"
-        data-test-subj="timeline-bottom-bar-open-button"
-        aria-label={i18n.ADD_TIMELINE}
-        onClick={togglePopover}
-      />
+      <EuiToolTip content={i18n.ADD_TIMELINE} disableScreenReaderOutput>
+        <EuiButtonIcon
+          iconType="plusCircle"
+          iconSize="m"
+          color="primary"
+          data-test-subj="timeline-bottom-bar-open-button"
+          aria-label={i18n.ADD_TIMELINE}
+          onClick={togglePopover}
+        />
+      </EuiToolTip>
     ),
     [togglePopover]
   );
@@ -78,6 +87,8 @@ export const AddTimelineButton = React.memo<AddTimelineButtonComponentProps>(({ 
           isOpen={isPopoverOpen}
           closePopover={() => setPopover(false)}
           repositionOnScroll
+          panelPaddingSize="s"
+          aria-label={i18n.ADD_TIMELINE}
         >
           <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="none">
             <EuiFlexItem grow={false}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(a11y): add aria-label/aria-labelledby to EuiPopover/EuiModal components in @elastic/security-solution (#270551)](https://github.com/elastic/kibana/pull/270551)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-05-28T20:27:56Z","message":"fix(a11y): add aria-label/aria-labelledby to EuiPopover/EuiModal components in @elastic/security-solution (#270551)\n\n## Summary\n\nFixes **111** ESLint violations for rule\n`@elastic/eui/require-aria-label-for-modals` across **100** files in\n`@elastic/security-solution`.\n\nCloses #270532\n\n## Changes\n\nEach `EuiPopover`, `EuiModal`, `EuiConfirmModal`, `EuiWrappingPopover`,\nand `EuiFlyout` component now has an accessible name via:\n\n- **`aria-labelledby`** (preferred): when a visible title exists\n(`EuiPopoverTitle`, `EuiModalHeaderTitle`, etc.) — wired via\n`useGeneratedHtmlId()`\n- **`aria-label`** with i18n string: when no visible title exists\n(context menus, filter popovers, icon-only triggers)\n\nAll i18n strings follow existing patterns in each file (reusing\nconstants or `i18n.translate`). Test files use plain `aria-label`\nstrings without i18n.\n\n## Skipped files (documented)\n\n-\n`x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/pending_actions_selector/pending_actions_selector.tsx`\n— file does not exist in the repository (not present on `main` or\n`origin/main`)\n\n## PR checklist\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (1 skip documented above — file does not exist)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>","sha":"7f58231a00d5627d0b67e32c872f387a6502b69b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","backport:version","a11y:agent-pr","v9.5.0","v9.4.2"],"title":"fix(a11y): add aria-label/aria-labelledby to EuiPopover/EuiModal components in @elastic/security-solution","number":270551,"url":"https://github.com/elastic/kibana/pull/270551","mergeCommit":{"message":"fix(a11y): add aria-label/aria-labelledby to EuiPopover/EuiModal components in @elastic/security-solution (#270551)\n\n## Summary\n\nFixes **111** ESLint violations for rule\n`@elastic/eui/require-aria-label-for-modals` across **100** files in\n`@elastic/security-solution`.\n\nCloses #270532\n\n## Changes\n\nEach `EuiPopover`, `EuiModal`, `EuiConfirmModal`, `EuiWrappingPopover`,\nand `EuiFlyout` component now has an accessible name via:\n\n- **`aria-labelledby`** (preferred): when a visible title exists\n(`EuiPopoverTitle`, `EuiModalHeaderTitle`, etc.) — wired via\n`useGeneratedHtmlId()`\n- **`aria-label`** with i18n string: when no visible title exists\n(context menus, filter popovers, icon-only triggers)\n\nAll i18n strings follow existing patterns in each file (reusing\nconstants or `i18n.translate`). Test files use plain `aria-label`\nstrings without i18n.\n\n## Skipped files (documented)\n\n-\n`x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/pending_actions_selector/pending_actions_selector.tsx`\n— file does not exist in the repository (not present on `main` or\n`origin/main`)\n\n## PR checklist\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (1 skip documented above — file does not exist)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>","sha":"7f58231a00d5627d0b67e32c872f387a6502b69b"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270551","number":270551,"mergeCommit":{"message":"fix(a11y): add aria-label/aria-labelledby to EuiPopover/EuiModal components in @elastic/security-solution (#270551)\n\n## Summary\n\nFixes **111** ESLint violations for rule\n`@elastic/eui/require-aria-label-for-modals` across **100** files in\n`@elastic/security-solution`.\n\nCloses #270532\n\n## Changes\n\nEach `EuiPopover`, `EuiModal`, `EuiConfirmModal`, `EuiWrappingPopover`,\nand `EuiFlyout` component now has an accessible name via:\n\n- **`aria-labelledby`** (preferred): when a visible title exists\n(`EuiPopoverTitle`, `EuiModalHeaderTitle`, etc.) — wired via\n`useGeneratedHtmlId()`\n- **`aria-label`** with i18n string: when no visible title exists\n(context menus, filter popovers, icon-only triggers)\n\nAll i18n strings follow existing patterns in each file (reusing\nconstants or `i18n.translate`). Test files use plain `aria-label`\nstrings without i18n.\n\n## Skipped files (documented)\n\n-\n`x-pack/solutions/security/plugins/security_solution/public/management/components/console_argument_selectors/pending_actions_selector/pending_actions_selector.tsx`\n— file does not exist in the repository (not present on `main` or\n`origin/main`)\n\n## PR checklist\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (1 skip documented above — file does not exist)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>","sha":"7f58231a00d5627d0b67e32c872f387a6502b69b"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->