### PR TITLE
[SharedUX][Chrome Next] Change header logo and side nav home item

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_logo.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_logo.tsx
@@ -7,63 +7,46 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
-import { useEuiTheme } from '@elastic/eui';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { useBasePath, useCustomBranding, useProjectHome } from '../../shared/chrome_hooks';
 import { LoadingIndicator } from '../../shared/loading_indicator';
+import { headerButtonBaseStyles, useHeaderButtonStyleVars } from './header_action_button';
 
 const LOGO_ARIA_LABEL = i18n.translate('core.ui.chrome.globalHeader.logoAriaLabel', {
   defaultMessage: 'Elastic home',
 });
 
-const useLogoStyles = () => {
-  const { euiTheme } = useEuiTheme();
+const logoLinkStyles = css`
+  ${headerButtonBaseStyles};
+  width: 32px;
+  justify-content: center;
+  border: none;
+  text-decoration: none;
+  color: inherit;
 
-  return useMemo(
-    () => css`
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 32px;
-      height: 32px;
-      border-radius: ${euiTheme.border.radius.medium};
-      color: ${euiTheme.colors.text};
-      text-decoration: none;
-
-      &:hover {
-        background: ${euiTheme.colors.backgroundBaseInteractiveHover};
-      }
-
-      &:focus-visible {
-        outline: 2px solid ${euiTheme.colors.primary};
-        outline-offset: -2px;
-      }
-
-      svg {
-        width: 20px;
-        height: 20px;
-      }
-    `,
-    [euiTheme]
-  );
-};
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
 
 export const ChromeNextGlobalHeaderLogo = React.memo(() => {
   const basePath = useBasePath();
   const homeHref = basePath.prepend(useProjectHome());
   const { logo: customLogo } = useCustomBranding();
-  const logoStyles = useLogoStyles();
+  const styleVars = useHeaderButtonStyleVars();
 
   return (
     <a
       href={homeHref}
       aria-label={LOGO_ARIA_LABEL}
       data-test-subj="chromeNextGlobalHeaderLogo"
-      css={logoStyles}
+      css={logoLinkStyles}
+      style={styleVars}
     >
-      <LoadingIndicator customLogo={customLogo} />
+      <LoadingIndicator customLogo={customLogo} elasticLogoColor={'text'} />
     </a>
   );
 });

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
@@ -58,6 +58,7 @@ const useGlobalHeaderStyles = () => {
       align-items: center;
       gap: ${euiTheme.size.xs};
       margin-inline-end: ${euiTheme.size.xs};
+      margin-inline-start: ${euiTheme.size.xs};
     `;
 
     const spacer = css`
@@ -129,9 +130,12 @@ export const ChromeNextGlobalHeaderShell = React.memo<ChromeNextGlobalHeaderShel
             {logo}
           </div>
           {switcher && (
-            <div css={styles.switcherSlot} data-test-subj="chromeNextGlobalHeaderSwitcher">
-              {switcher}
-            </div>
+            <>
+              <div css={styles.separator} />
+              <div css={styles.switcherSlot} data-test-subj="chromeNextGlobalHeaderSwitcher">
+                {switcher}
+              </div>
+            </>
           )}
         </div>
         <div css={styles.separator} />

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
@@ -15,6 +15,7 @@ import type { SolutionId } from '@kbn/core-chrome-browser';
 import { useObservable } from '@kbn/use-observable';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
+import { useIsNextChrome } from '@kbn/core-chrome-browser-hooks';
 import { useBasePath } from '../../../shared/chrome_hooks';
 import type { NavigationItems } from './to_navigation_items';
 import { toNavigationItems } from './to_navigation_items';
@@ -28,6 +29,7 @@ export interface ChromeNavigationProps {
 
 export const Navigation = (props: ChromeNavigationProps) => {
   const state = useNavigationItems();
+  const isNextChrome = useIsNextChrome();
 
   if (!state) {
     return null;
@@ -44,6 +46,7 @@ export const Navigation = (props: ChromeNavigationProps) => {
         setWidth={props.setWidth}
         onToggleCollapsed={props.onToggleCollapsed}
         activeItemId={activeItemId}
+        showTopSeparator={isNextChrome}
         data-test-subj={classnames(`${solutionId}SideNav`, 'projectSideNav', 'projectSideNavV2')}
       />
     </KibanaSectionErrorBoundary>
@@ -57,16 +60,17 @@ export default Navigation;
 const useNavigationItems = (): (NavigationItems & { solutionId: SolutionId }) | null => {
   const chrome = useChromeService();
   const basePath = useBasePath();
+  const isNextChrome = useIsNextChrome();
 
   const items$ = useMemo(() => {
     const panelStateManager = new PanelStateManager(basePath.get());
     return chrome.project.getNavigation$().pipe(
       map((nav) => ({
-        ...toNavigationItems(nav.navigationTree, nav.activeNodes, panelStateManager),
+        ...toNavigationItems(nav.navigationTree, nav.activeNodes, panelStateManager, isNextChrome),
         solutionId: nav.solutionId,
       }))
     );
-  }, [chrome, basePath]);
+  }, [chrome, basePath, isNextChrome]);
 
   return useObservable(items$, null);
 };

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_navigation_items.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_navigation_items.test.tsx
@@ -290,3 +290,33 @@ describe('hidden panel link', () => {
     expect(activeItemId).toBe('stack_management');
   });
 });
+
+describe('Chrome Next mode (isNextChrome)', () => {
+  const createChromeNextNavigationItems = (
+    tree: NavigationTreeDefinitionUI = navigationTree,
+    activeNodes: ChromeProjectNavigationNode[][] = []
+  ) => {
+    return toNavigationItems(tree, activeNodes, mockPanelStateManager, true);
+  };
+
+  it('should not extract logoItem when isNextChrome is true', () => {
+    const { logoItem } = createChromeNextNavigationItems();
+    expect(logoItem).toBeUndefined();
+  });
+
+  it('should extract logoItem when isNextChrome is false (default)', () => {
+    const { logoItem } = createNavigationItems();
+    expect(logoItem).toBeDefined();
+    expect(logoItem?.id).toBe('security_solution_home');
+  });
+
+  it('should keep visible home node in primaryItems with title "Home" and icon "home"', () => {
+    const {
+      navItems: { primaryItems },
+    } = createChromeNextNavigationItems();
+    const homeItem = primaryItems.find((item) => item.id === 'security_solution_home');
+    expect(homeItem).toBeDefined();
+    expect(homeItem?.label).toBe('Home');
+    expect(homeItem?.iconType).toBe('home');
+  });
+});

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_navigation_items.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_navigation_items.tsx
@@ -21,14 +21,19 @@ import type {
 } from '@kbn/ui-side-navigation/types';
 import { toSentenceCase } from '@kbn/shared-ux-label-formatter';
 
+import { i18n } from '@kbn/i18n';
 import { AppDeepLinkIdToIcon } from './known_icons_mappings';
 import type { PanelStateManager } from './panel_state_manager';
 import { isActiveFromUrl } from './utils/is_active_from_url';
 
 const SKIP_WARNINGS = process.env.NODE_ENV === 'production';
 
+const HOME_TITLE = i18n.translate('core.ui.chrome.sideNavigation.homeItemTitle', {
+  defaultMessage: 'Home',
+});
+
 export interface NavigationItems {
-  logoItem: SideNavLogo;
+  logoItem?: SideNavLogo;
   navItems: NavigationStructure;
   activeItemId?: string;
 }
@@ -54,16 +59,16 @@ export interface NavigationItems {
  * @param navLinks
  * @param activeNodes
  * @param panelStateManager - Manager for panel opener state
+ * @param isNextChrome - Whether the navigation is in the next chrome
  */
 export const toNavigationItems = (
   navigationTree: NavigationTreeDefinitionUI,
   activeNodes: ChromeProjectNavigationNode[][],
-  panelStateManager: PanelStateManager
+  panelStateManager: PanelStateManager,
+  isNextChrome: boolean = false
 ): NavigationItems => {
-  // HACK: extract the logo, primary and footer nodes from the navigation tree
-  let logoNode: ChromeProjectNavigationNode | null = null;
-  let primaryNodes: ChromeProjectNavigationNode[] = [];
-  let footerNodes: ChromeProjectNavigationNode[] = [];
+  let primaryNodes: ChromeProjectNavigationNode[] = navigationTree.body;
+  const footerNodes: ChromeProjectNavigationNode[] = navigationTree.footer ?? [];
 
   let deepestActiveItemId: string | undefined;
   let currentActiveItemIdLevel = -1;
@@ -102,27 +107,33 @@ export const toNavigationItems = (
     );
   };
 
-  primaryNodes = navigationTree.body;
-  footerNodes = navigationTree.footer ?? [];
+  let logoItem: SideNavLogo | undefined;
 
   const homeNodeIndex = primaryNodes.findIndex((node) => node.renderAs === 'home');
   if (homeNodeIndex !== -1) {
-    logoNode = primaryNodes[homeNodeIndex];
-    primaryNodes = primaryNodes.filter((_, index) => index !== homeNodeIndex); // Remove the logo node from primary items
-    maybeMarkActive(logoNode, 0);
+    const homeNode = primaryNodes[homeNodeIndex];
+    maybeMarkActive(homeNode, 0);
+
+    if (isNextChrome) {
+      // TODO: https://github.com/elastic/kibana/issues/272291
+      primaryNodes = primaryNodes.map((node, i) =>
+        i === homeNodeIndex ? { ...node, title: HOME_TITLE, icon: 'home' } : node
+      );
+    } else {
+      primaryNodes = primaryNodes.filter((_, i) => i !== homeNodeIndex);
+      logoItem = {
+        href: warnIfMissing(homeNode, 'href', '/missing-href-😭'),
+        iconType: getIcon(homeNode),
+        id: warnIfMissing(homeNode, 'id', 'kibana'),
+        label: warnIfMissing(homeNode, 'title', 'Kibana'),
+        'data-test-subj': getTestSubj(homeNode, ['nav-item-home']),
+      };
+    }
   } else {
     warnOnce(
       `No "home" node found in primary nodes. There should be a logo node with solution logo, name and home page href. renderAs: "home" is expected.`
     );
   }
-
-  const logoItem: SideNavLogo = {
-    href: warnIfMissing(logoNode, 'href', '/missing-href-😭'),
-    iconType: getIcon(logoNode),
-    id: warnIfMissing(logoNode, 'id', 'kibana'),
-    label: warnIfMissing(logoNode, 'title', 'Kibana'),
-    'data-test-subj': logoNode ? getTestSubj(logoNode, ['nav-item-home']) : undefined,
-  };
 
   const toMenuItem = (navNode: ChromeProjectNavigationNode): MenuItem[] | MenuItem | null => {
     if (!navNode) return null;
@@ -358,13 +369,12 @@ function warnAboutDuplicates(
 }
 
 function warnAboutDuplicateIcons(
-  logoItem: SideNavLogo,
+  logoItem: SideNavLogo | undefined,
   primaryItems: MenuItem[],
   footerItems: MenuItem[]
 ) {
   if (SKIP_WARNINGS) return;
-  // Collect all items with icons (only logo + primary items, excluding fallback)
-  const icons = [logoItem, ...primaryItems, ...footerItems]
+  const icons = [...(logoItem ? [logoItem] : []), ...primaryItems, ...footerItems]
     .filter(
       (item) =>
         item.iconType && item.iconType !== FALLBACK_ICON && typeof item.iconType === 'string'
@@ -379,13 +389,12 @@ function warnAboutDuplicateIcons(
 }
 
 function warnAboutDuplicateIds(
-  logoItem: SideNavLogo,
+  logoItem: SideNavLogo | undefined,
   primaryItems: MenuItem[],
   footerItems: MenuItem[]
 ) {
   if (SKIP_WARNINGS) return;
-  // Collect all IDs from all items, including secondary menu items
-  let allIds: string[] = [logoItem.id];
+  let allIds: string[] = logoItem ? [logoItem.id] : [];
 
   // Helper to extract IDs from menu items including their secondary sections
   const collectIds = (items: MenuItem[]) => {

--- a/src/core/packages/chrome/browser-components/src/shared/loading_indicator.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/loading_indicator.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Global, css } from '@emotion/react';
+import type { EuiIconProps } from '@elastic/eui';
 import { EuiLoadingSpinner, EuiProgress, EuiIcon, EuiImage } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -16,9 +17,14 @@ import { useIsLoading } from './chrome_hooks';
 export interface LoadingIndicatorProps {
   showAsBar?: boolean;
   customLogo?: string;
+  elasticLogoColor?: EuiIconProps['color'];
 }
 
-export const LoadingIndicator = ({ showAsBar = false, customLogo }: LoadingIndicatorProps) => {
+export const LoadingIndicator = ({
+  showAsBar = false,
+  customLogo,
+  elasticLogoColor,
+}: LoadingIndicatorProps) => {
   const isLoading = useIsLoading();
 
   const loadingSubj = isLoading ? 'globalLoadingIndicator' : 'globalLoadingIndicator-hidden';
@@ -42,6 +48,7 @@ export const LoadingIndicator = ({ showAsBar = false, customLogo }: LoadingIndic
     <EuiIcon
       type={'logoElastic'}
       size="l"
+      color={elasticLogoColor}
       data-test-subj={testSubj}
       aria-label={i18n.translate('core.ui.chrome.headerGlobalNav.logoAriaLabel', {
         defaultMessage: 'Elastic Logo',

--- a/src/platform/kbn-ui/side-navigation/packaging/react/types.ts
+++ b/src/platform/kbn-ui/side-navigation/packaging/react/types.ts
@@ -120,6 +120,8 @@ export interface NavigationProps {
   onItemClick?: (item: MenuItem | SecondaryMenuItem | SideNavLogo) => void;
   /** Callback fired when the collapse button is toggled. Omit to hide the toggle button. */
   onToggleCollapsed?: (isCollapsed: boolean) => void;
+  /** When true, renders a centered horizontal separator at the top of the side nav. */
+  showTopSeparator?: boolean;
   /** Content to display inside the side panel footer. */
   sidePanelFooter?: ReactNode;
   /** Optional `data-test-subj` attribute for testing purposes. */

--- a/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
@@ -11,7 +11,7 @@ import React, { useState, type ReactNode } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { useIsWithinBreakpoints } from '@elastic/eui';
+import { useEuiTheme, useIsWithinBreakpoints } from '@elastic/eui';
 
 import type { NavigationStructure, SideNavLogo, MenuItem, SecondaryMenuItem } from '../../types';
 import {
@@ -29,6 +29,7 @@ import { useLayoutWidth } from '../hooks/use_layout_width';
 import { useNavigation } from '../hooks/use_navigation';
 import { useNewItems } from '../hooks/use_new_items';
 import { useResponsiveMenu } from '../hooks/use_responsive_menu';
+import { getHighContrastSeparator } from '../hooks/use_high_contrast_mode_styles';
 
 const navigationWrapperStyles = css`
   display: flex;
@@ -50,7 +51,7 @@ export interface NavigationProps {
   /**
    * The logo object containing the route ID, href, label, and type.
    */
-  logo: SideNavLogo;
+  logo?: SideNavLogo;
   /**
    * Required by the grid layout to set the width of the navigation slot.
    */
@@ -71,6 +72,11 @@ export interface NavigationProps {
    */
   sidePanelFooter?: ReactNode;
   /**
+   * When true, renders a centered horizontal separator at the top of the side nav,
+   * between the global header and the logo/primary menu.
+   */
+  showTopSeparator?: boolean;
+  /**
    * (optional) data-test-subj attribute for testing purposes.
    */
   'data-test-subj'?: string;
@@ -84,11 +90,20 @@ export const Navigation = ({
   onItemClick,
   onToggleCollapsed,
   setWidth,
+  showTopSeparator = false,
   sidePanelFooter,
   ...rest
 }: NavigationProps) => {
   const forcedCollapsed = useIsWithinBreakpoints(['xs', 's']);
   const isCollapsed = forcedCollapsed || isCollapsedProp;
+  const euiThemeContext = useEuiTheme();
+
+  const topSeparatorStyles = css`
+    position: relative;
+    flex-shrink: 0;
+    ${getHighContrastSeparator(euiThemeContext, { side: 'bottom' })}
+  `;
+
   const popoverItemPrefix = `${NAVIGATION_SELECTOR_PREFIX}-popoverItem`;
   const popoverFooterItemPrefix = `${NAVIGATION_SELECTOR_PREFIX}-popoverFooterItem`;
   const sidePanelItemPrefix = `${NAVIGATION_SELECTOR_PREFIX}-sidePanelItem`;
@@ -100,7 +115,7 @@ export const Navigation = ({
     visuallyActiveSubpageId,
     isSidePanelOpen,
     openerNode,
-  } = useNavigation(isCollapsed, items, logo.id, activeItemId);
+  } = useNavigation(isCollapsed, items, logo?.id, activeItemId);
 
   const [isAnyPopoverLocked, setIsAnyPopoverLocked] = useState(false);
 
@@ -131,13 +146,16 @@ export const Navigation = ({
       id={NAVIGATION_ROOT_SELECTOR}
     >
       <SideNav isCollapsed={isCollapsed}>
-        <SideNav.Logo
-          isCollapsed={isCollapsed}
-          isCurrent={actualActiveItemId === logo.id}
-          isHighlighted={visuallyActivePageId === logo.id}
-          onClick={() => onItemClick?.(logo)}
-          {...logo}
-        />
+        {showTopSeparator && <div css={topSeparatorStyles} aria-hidden />}
+        {logo && (
+          <SideNav.Logo
+            isCollapsed={isCollapsed}
+            isCurrent={actualActiveItemId === logo.id}
+            isHighlighted={visuallyActivePageId === logo.id}
+            onClick={() => onItemClick?.(logo)}
+            {...logo}
+          />
+        )}
 
         <SideNav.PrimaryMenu ref={primaryMenuRef} isCollapsed={isCollapsed}>
           {({ mainNavigationInstructionsId }) => (

--- a/src/platform/kbn-ui/side-navigation/src/hooks/use_navigation.ts
+++ b/src/platform/kbn-ui/side-navigation/src/hooks/use_navigation.ts
@@ -39,7 +39,7 @@ interface NavigationState {
 export const useNavigation = (
   isCollapsed: boolean,
   items: NavigationStructure,
-  logoId: string,
+  logoId: string | undefined,
   activeItemId?: string
 ) => {
   const { primaryItem, secondaryItem, isLogoActive } = useMemo(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/3411

## Summary
Extracted from [d7697d37fdbe](https://github.com/elastic/kibana/commit/d7697d37fdbee38ab2c7af00a1621f5fca256572) from `feature/chrome-next` with modifications:

- Updates the Chrome Next global header logo and side navigation home item behavior to align with the new Chrome Next design:
  - Elastic logo is now monochrome and navigates to UI setting default route URL or fallbacks to side nav home item
  - Solution logo is removed/replaced by home item
- Still to do: update solution nav trees with different home item or hidden home item. Currently both Search and Security lead to the same route via Elastic logo and home item. 

## Testing
```
feature_flags.overrides:
  core.chrome.next: true
```

https://github.com/user-attachments/assets/c6452cd9-a8ad-48c6-b49b-f678a755c853
