### PR TITLE
feat(action_policies): restrict action policy quick filters to alert-kind rules

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -401,6 +401,13 @@ export const findRulesResponseSchema = z
 
 export type FindRulesResponse = z.infer<typeof findRulesResponseSchema>;
 
+/** Query parameters for the rule tags API. */
+export const ruleTagsParamsSchema = z.object({
+  filter: z.string().optional().describe('The filter to apply when aggregating rule tags.'),
+});
+
+export type RuleTagsParams = z.infer<typeof ruleTagsParamsSchema>;
+
 /** Rule tags response schema. */
 export const ruleTagsResponseSchema = z
   .object({

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -403,7 +403,11 @@ export type FindRulesResponse = z.infer<typeof findRulesResponseSchema>;
 
 /** Query parameters for the rule tags API. */
 export const ruleTagsParamsSchema = z.object({
-  filter: z.string().optional().describe('The filter to apply when aggregating rule tags.'),
+  filter: z
+    .string()
+    .max(1024)
+    .optional()
+    .describe('The filter to apply when aggregating rule tags.'),
 });
 
 export type RuleTagsParams = z.infer<typeof ruleTagsParamsSchema>;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/constants.ts
@@ -12,6 +12,12 @@ export interface QuickFiltersProps {
 
 export const POPOVER_PANEL_STYLE = { maxWidth: 360 };
 
+/**
+ * Action policies only target alert-kind rules, so the quick filters restrict
+ * the rules and tags they surface to `kind: 'alert'`.
+ */
+export const ALERT_KIND_FILTER = 'kind:alert';
+
 export const SELECTABLE_LIST_PROPS = {
   isVirtualized: false as const,
   textWrap: 'wrap' as const,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/quick_filters.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/quick_filters.test.tsx
@@ -99,6 +99,14 @@ describe('RuleFilter', () => {
     expect(mockUseFetchRules).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: true }));
   });
 
+  it('restricts fetched rules to kind:alert', () => {
+    renderWithI18n(<RuleFilter matcher="" onChange={jest.fn()} />);
+
+    expect(mockUseFetchRules).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: 'kind:alert' })
+    );
+  });
+
   it('displays rules from API', async () => {
     renderWithI18n(<RuleFilter matcher="" onChange={jest.fn()} />);
 
@@ -301,6 +309,14 @@ describe('TagsFilter', () => {
 
     expect(mockUseFetchRuleTags).toHaveBeenLastCalledWith(
       expect.objectContaining({ enabled: true })
+    );
+  });
+
+  it('restricts fetched tags to kind:alert', () => {
+    renderWithI18n(<TagsFilter matcher="" onChange={jest.fn()} />);
+
+    expect(mockUseFetchRuleTags).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: 'kind:alert' })
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/rule_filter.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/rule_filter.tsx
@@ -27,7 +27,12 @@ import { useDebouncedValue } from '@kbn/react-hooks';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
 import { useFetchRules } from '../../../../../hooks/use_fetch_rules';
 import { mergeRuleIdsIntoMatcher, parseRuleIdsFromMatcher } from '../../matcher_quick_filter_utils';
-import { POPOVER_PANEL_STYLE, SELECTABLE_LIST_PROPS, type QuickFiltersProps } from './constants';
+import {
+  ALERT_KIND_FILTER,
+  POPOVER_PANEL_STYLE,
+  SELECTABLE_LIST_PROPS,
+  type QuickFiltersProps,
+} from './constants';
 
 interface RuleSelectableMeta {
   value: string;
@@ -54,6 +59,7 @@ export const RuleFilter = ({ matcher, onChange }: QuickFiltersProps) => {
     perPage: 50,
     search: debouncedSearch || undefined,
     enabled: isOpen,
+    filter: ALERT_KIND_FILTER,
   });
   const items = data?.items;
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/tags_filter.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/action_policy/form/components/quick_filters/tags_filter.tsx
@@ -24,7 +24,12 @@ import {
   mergeRuleTagsIntoMatcher,
   parseRuleTagsFromMatcher,
 } from '../../matcher_quick_filter_utils';
-import { POPOVER_PANEL_STYLE, SELECTABLE_LIST_PROPS, type QuickFiltersProps } from './constants';
+import {
+  ALERT_KIND_FILTER,
+  POPOVER_PANEL_STYLE,
+  SELECTABLE_LIST_PROPS,
+  type QuickFiltersProps,
+} from './constants';
 
 interface TagSelectableMeta {
   value: string;
@@ -37,6 +42,7 @@ export const TagsFilter = ({ matcher, onChange }: QuickFiltersProps) => {
 
   const { data: apiTags = [], isLoading } = useFetchRuleTags({
     enabled: isOpen,
+    filter: ALERT_KIND_FILTER,
   });
   const selectedTags = useMemo(() => parseRuleTagsFromMatcher(matcher), [matcher]);
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
@@ -20,7 +20,7 @@ export const ruleKeys = {
   }) => [...ruleKeys.lists(), filters] as const,
   details: () => [...ruleKeys.all, 'details'] as const,
   detail: (id: string) => [...ruleKeys.details(), id] as const,
-  tags: () => [...ruleKeys.all, 'tags'] as const,
+  tags: (filter?: string) => [...ruleKeys.all, 'tags', { filter }] as const,
 };
 
 export const workflowKeys = {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_rule_tags.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_rule_tags.ts
@@ -12,13 +12,16 @@ import { ruleKeys } from './query_key_factory';
 
 const TAGS_STALE_TIME = 30_000;
 
-export const useFetchRuleTags = ({ enabled = true }: { enabled?: boolean } = {}) => {
+export const useFetchRuleTags = ({
+  filter,
+  enabled = true,
+}: { filter?: string; enabled?: boolean } = {}) => {
   const rulesApi = useService(RulesApi);
 
   return useQuery({
-    queryKey: ruleKeys.tags(),
+    queryKey: ruleKeys.tags(filter),
     queryFn: async () => {
-      const { tags } = await rulesApi.listTags();
+      const { tags } = await rulesApi.listTags({ filter });
       return tags;
     },
     enabled,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
@@ -37,8 +37,10 @@ export type { BulkOperationParams, BulkOperationResponse };
 export class RulesApi {
   constructor(@inject(CoreStart('http')) private readonly http: HttpStart) {}
 
-  public async listTags() {
-    return this.http.get<{ tags: string[] }>(`${ALERTING_V2_RULE_API_PATH}/_tags`);
+  public async listTags(params: { filter?: string } = {}) {
+    return this.http.get<{ tags: string[] }>(`${ALERTING_V2_RULE_API_PATH}/_tags`, {
+      query: { filter: params.filter },
+    });
   }
 
   public async listRules(params: ListRulesParams) {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -1392,6 +1392,53 @@ describe('RulesClient', () => {
     });
   });
 
+  describe('getTags', () => {
+    const findResponseWithTags = (tags: string[]) => ({
+      saved_objects: [],
+      total: 0,
+      page: 1,
+      per_page: 0,
+      aggregations: {
+        tags: { buckets: tags.map((key) => ({ key })) },
+      },
+    });
+
+    it('returns the aggregated tags without a filter', async () => {
+      const client = createClient();
+
+      mockSavedObjectsClient.find.mockResolvedValueOnce(findResponseWithTags(['cpu', 'memory']));
+
+      const tags = await client.getTags();
+
+      expect(tags).toEqual(['cpu', 'memory']);
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: RULE_SAVED_OBJECT_TYPE,
+          perPage: 0,
+        })
+      );
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith(
+        expect.not.objectContaining({ filter: expect.anything() })
+      );
+    });
+
+    it('translates a clean API filter to an SO filter before aggregating', async () => {
+      const client = createClient();
+
+      mockSavedObjectsClient.find.mockResolvedValueOnce(findResponseWithTags(['cpu']));
+
+      await client.getTags({ filter: 'kind:alert' });
+
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: RULE_SAVED_OBJECT_TYPE,
+          perPage: 0,
+          filter: `${RULE_SAVED_OBJECT_TYPE}.attributes.kind: alert`,
+        })
+      );
+    });
+  });
+
   describe('bulkDeleteRules', () => {
     it('removes tasks and deletes saved objects for all ids', async () => {
       const client = createClient();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -395,8 +395,9 @@ export class RulesClient {
   }
 
   @withApm
-  public async getTags(): Promise<string[]> {
-    return this.rulesSavedObjectService.findTags();
+  public async getTags(params: { filter?: string } = {}): Promise<string[]> {
+    const soFilter = params.filter ? buildRuleSoFilter(params.filter) : undefined;
+    return this.rulesSavedObjectService.findTags({ filter: soFilter });
   }
 
   @withApm

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/rules_saved_object_service/rules_saved_object_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/rules_saved_object_service/rules_saved_object_service.ts
@@ -77,7 +77,7 @@ export interface RulesSavedObjectServiceContract {
     saved_objects: Array<{ id: string; attributes: RuleSavedObjectAttributes; version?: string }>;
     total: number;
   }>;
-  findTags(): Promise<string[]>;
+  findTags(params?: { filter?: string }): Promise<string[]>;
 }
 
 @injectable()
@@ -268,10 +268,11 @@ export class RulesSavedObjectService implements RulesSavedObjectServiceContract 
     });
   }
 
-  public async findTags(): Promise<string[]> {
+  public async findTags({ filter }: { filter?: string } = {}): Promise<string[]> {
     const result = await this.client.find<RuleSavedObjectAttributes>({
       type: RULE_SAVED_OBJECT_TYPE,
       perPage: 0,
+      ...(filter ? { filter } : {}),
       aggs: {
         tags: {
           terms: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rule_tags_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rule_tags_route.ts
@@ -5,9 +5,15 @@
  * 2.0.
  */
 
-import type { RouteSecurity } from '@kbn/core-http-server';
+import type { KibanaRequest, RouteSecurity } from '@kbn/core-http-server';
 import { inject, injectable } from 'inversify';
-import { errorResponseSchema, ruleTagsResponseSchema } from '@kbn/alerting-v2-schemas';
+import { Request } from '@kbn/core-di-server';
+import type { z } from '@kbn/zod/v4';
+import {
+  errorResponseSchema,
+  ruleTagsParamsSchema,
+  ruleTagsResponseSchema,
+} from '@kbn/alerting-v2-schemas';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
@@ -28,6 +34,9 @@ export class GetRuleTagsRoute extends BaseAlertingRoute {
     summary: 'Get rule tags',
   } as const;
   static schemas = {
+    request: {
+      query: ruleTagsParamsSchema,
+    },
     response: {
       200: {
         body: () => ruleTagsResponseSchema,
@@ -44,13 +53,15 @@ export class GetRuleTagsRoute extends BaseAlertingRoute {
 
   constructor(
     @inject(AlertingRouteContext) ctx: AlertingRouteContext,
+    @inject(Request)
+    private readonly request: KibanaRequest<unknown, z.infer<typeof ruleTagsParamsSchema>, unknown>,
     @inject(RulesClient) private readonly rulesClient: RulesClient
   ) {
     super(ctx);
   }
 
   protected async execute() {
-    const tags = await this.rulesClient.getTags();
+    const tags = await this.rulesClient.getTags({ filter: this.request.query.filter });
     return this.ctx.response.ok({ body: { tags } });
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rule_tags.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/get_rule_tags.spec.ts
@@ -18,6 +18,15 @@ import {
 
 const TAGS_URL = `${testData.RULE_API_PATH}/_tags`;
 
+const tagsUrl = (params: Record<string, string | undefined> = {}): string => {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(key, value);
+  }
+  const qs = search.toString();
+  return qs ? `${TAGS_URL}?${qs}` : TAGS_URL;
+};
+
 apiTest.describe('Get rule tags API', { tag: '@local-stateful-classic' }, () => {
   let readerCredentials: RoleApiCredentials;
   let readerHeaders: Record<string, string>;
@@ -94,6 +103,57 @@ apiTest.describe('Get rule tags API', { tag: '@local-stateful-classic' }, () => 
       expect(response.body.tags).not.toContain(undefined);
       expect(response.body.tags).not.toContain(null);
       expect(response.body.tags).not.toContain('');
+    }
+  );
+
+  apiTest(
+    'filter: should only return tags from rules matching the filter',
+    async ({ apiClient, apiServices }) => {
+      // Seed an alert-kind rule and a signal-kind rule with disjoint tags so a
+      // `kind:alert` filter must exclude the signal rule's tags entirely.
+      await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({
+          kind: 'alert',
+          metadata: { name: 'alert-rule', tags: ['alert-tag'] },
+        })
+      );
+      await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({
+          kind: 'signal',
+          state_transition: undefined,
+          metadata: { name: 'signal-rule', tags: ['signal-tag'] },
+        })
+      );
+
+      const filtered = await apiClient.get(tagsUrl({ filter: 'kind:alert' }), {
+        headers: readerHeaders,
+      });
+
+      expect(filtered).toHaveStatusCode(200);
+      expect(filtered.body).toStrictEqual({ tags: ['alert-tag'] });
+
+      // Without a filter both rules' tags are returned.
+      const unfiltered = await apiClient.get(TAGS_URL, {
+        headers: readerHeaders,
+      });
+
+      expect(unfiltered).toHaveStatusCode(200);
+      expect(unfiltered.body).toStrictEqual({ tags: ['alert-tag', 'signal-tag'] });
+    }
+  );
+
+  apiTest(
+    'filter: should return 400 for an invalid filter field',
+    async ({ apiClient, apiServices }) => {
+      await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({ metadata: { name: 'alert-rule', tags: ['alert-tag'] } })
+      );
+
+      const response = await apiClient.get(tagsUrl({ filter: 'not_a_field:alert' }), {
+        headers: readerHeaders,
+      });
+
+      expect(response).toHaveStatusCode(400);
     }
   );
 


### PR DESCRIPTION
## Summary

resolves elastic/rna-program#512

Action policies only target rules of `kind: 'alert'`, but the **Rule** and **Tags** quick filters in the action policy form surfaced data from every rule kind. This scopes both filters to alert-kind rules.

## testing

- [ ] Create two rules (one signal, one alert) with tags
- [ ] Go to action policies create form and check rule quick filter and tags quick filter shows only the ones from the alert rule.