### PR TITLE
[Streams] Add validation for legacy "logs" root stream name

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/query_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/query_stream.ts
@@ -10,6 +10,7 @@ import { validateQuery } from '@kbn/esql-language';
 import { Parser } from '@elastic/esql';
 import type { ESQLSource, ESQLCommand } from '@elastic/esql/types';
 import {
+  LOGS_ROOT_STREAM_NAME,
   Streams,
   getEsqlViewName,
   getParentId,
@@ -316,6 +317,14 @@ export class QueryStream extends StreamActiveRecord<Streams.QueryStream.Definiti
     }
 
     // Check for conflicts with existing streams
+    if (this._definition.name === LOGS_ROOT_STREAM_NAME) {
+      errors.push(
+        new Error(
+          `Cannot create query stream: a stream with name "${this._definition.name}" is reserved for the legacy root stream`
+        )
+      );
+    }
+
     if (existingStream && !Streams.QueryStream.Definition.is(existingStream.definition)) {
       errors.push(
         new Error(

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/query_streams.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/query_streams.ts
@@ -195,6 +195,19 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         await deleteStream(apiClient, rootQueryStreamName);
       });
 
+      it('should reject root-level query stream with legacy logs root name', async () => {
+        const response = (await putStream(
+          apiClient,
+          'logs',
+          createQueryStreamRequest('FROM logs.otel | LIMIT 10', getEsqlViewName('logs')),
+          400
+        )) as unknown as { message: string };
+
+        expect(response.message).to.contain(
+          'Cannot create query stream: a stream with name "logs" is reserved for the legacy root stream'
+        );
+      });
+
       it('should reject child referencing grandparent instead of immediate parent', async () => {
         // First create an intermediate query stream (child of wired parent)
         const intermediateChildName = `${PARENT_STREAM_NAME}.intermediate`;


### PR DESCRIPTION
## Summary

Adds a validation so that Query Streams can't be created with the name `logs` (which would conflict with the legacy `logs` root stream).

<img width="1906" height="849" alt="Screenshot 2026-06-02 at 14 20 57" src="https://github.com/user-attachments/assets/68cc58a9-4226-410a-a5ec-cc84a901bc61" />
