### PR TITLE
[APM] Fix route self-healing in APM

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/apm_error_boundary.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/apm_error_boundary.tsx
@@ -4,7 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { NotFoundRouteException } from '@kbn/typed-react-router-config';
+import {
+  InvalidRouteParamsException,
+  NotFoundRouteException,
+} from '@kbn/typed-react-router-config';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { NotFoundPrompt } from '@kbn/shared-ux-prompt-not-found';
@@ -36,8 +39,17 @@ class ErrorBoundary extends React.Component<
     return { error };
   }
 
+  componentDidCatch(error: Error) {
+    if (error instanceof InvalidRouteParamsException) {
+      throw error;
+    }
+  }
+
   render() {
     if (this.state.error) {
+      if (this.state.error instanceof InvalidRouteParamsException) {
+        return null;
+      }
       return <ErrorWithTemplate error={this.state.error} />;
     }
 


### PR DESCRIPTION
## Summary

### The Original Bug (Issue #268109)

The APM app crashes when a user opens or reloads a URL where certain query parameters are bare
keys with no value (e.g. `?kuery&serviceGroup&rangeFrom=now-30m`). `query-string` v6 parses bare
keys as `null`. The io-ts codecs on the route expect `string`, so the decode fails, `matchRoutes`
throws an unhandled error, and the React tree crashes with no recovery path. Reloading the page
repeats the crash.

---

### What PR #257245 Was Supposed to Fix

PR #257245 introduced a **two-attempt decode with selective patching** strategy in `matchRoutes`
(`create_router.ts`):

1. First decode attempt — normal. If it succeeds, continue.
2. On failure — inspect the io-ts errors to identify which query keys failed. For each failing
   key, substitute the route's declared default or delete it.
3. Retry the decode with the patched query.
4. If retry succeeds — throw `InvalidRouteParamsException` carrying the corrected query.
5. If retry also fails — throw a plain `Error` (unrecoverable, existing behavior).

A new `RouteSelfHealErrorBoundary` component catches `InvalidRouteParamsException` and calls
`history.replace` with the corrected query, healing the URL in a single redirect. For any other
error type it re-throws, leaving existing error handling untouched.

Rather than placing `RouteSelfHealErrorBoundary` as a standalone component to be added by each
consuming plugin, the PR baked it directly into `RouterProvider` so all plugins using
`RouterProvider` would get it automatically.

---

### Root Cause: Why the Fix Never Worked for APM

The fix was broken by a **last-minute review change** within the same PR
(commit `f2133af7475425f5f5fb6498662c7ad05033d423`).

In the earlier commits of the PR branch, `RouteSelfHealErrorBoundary` was placed **explicitly
inside `ApmErrorBoundary`** in `app_root/index.tsx`:

    RouterProvider  (RouteSelfHealErrorBoundary baked in — outer)
      ApmErrorBoundary
        RouteSelfHealErrorBoundary  ← explicitly added by PR, inner
          route content

With this layout, `RouteSelfHealErrorBoundary` was the **innermost** boundary. It caught
`InvalidRouteParamsException` first, handled it with `history.replace`, and `ApmErrorBoundary`
was never involved.

The "Review changes" commit removed the explicit `RouteSelfHealErrorBoundary` wrapping from
`app_root/index.tsx`, on the assumption that the version baked into `RouterProvider` would be
sufficient. This assumption was wrong for APM. The resulting tree was:

    RouterProvider  (RouteSelfHealErrorBoundary baked in — outer)
      ApmErrorBoundary  ← now the innermost boundary
        route content

Because `ApmErrorBoundary` sits **inside** `RouterProvider`'s children, it is closer to the
error source than `RouteSelfHealErrorBoundary`. React error boundaries are resolved nearest-first,
so `ApmErrorBoundary` intercepts `InvalidRouteParamsException` before `RouteSelfHealErrorBoundary`
ever sees it.

`ApmErrorBoundary` has no knowledge of `InvalidRouteParamsException`. Its
`getDerivedStateFromError` stores any error in state and its `render` presents the fatal error UI
via `ErrorWithTemplate`. The error never reaches `RouteSelfHealErrorBoundary`, and the user sees
"Unable to load page" — identical to the original bug.

---

### The Fix

Two changes to `ApmErrorBoundary`'s inner `ErrorBoundary` class:

**1. `render` returns `null` for `InvalidRouteParamsException`**

Instead of rendering the fatal error UI, the boundary renders nothing. This prevents the error
UI flash and, critically, prevents children from being re-rendered (which would cause an infinite
loop if `getDerivedStateFromError` were to return a "no error" state).

**2. `componentDidCatch` re-throws `InvalidRouteParamsException`**

When React calls `componentDidCatch` with an `InvalidRouteParamsException`, the boundary
re-throws it. React treats this boundary as failed and propagates the error upward to the next
ancestor boundary — `RouteSelfHealErrorBoundary` inside `RouterProvider`. That boundary catches
it, calls `history.replace` with the corrected query, the URL heals, and the full subtree
(including a fresh `ApmErrorBoundary` with clean state) re-renders successfully.

All other errors continue through the existing path: `getDerivedStateFromError` stores them,
`render` shows the fatal error UI, and `componentDidCatch` does not re-throw.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->