### PR TITLE
Skip security_disabled user-profile suite in FIPS mode

### DIFF
--- a/x-pack/platform/test/security_api_integration/tests/user_profiles/security_disabled.ts
+++ b/x-pack/platform/test/security_api_integration/tests/user_profiles/security_disabled.ts
@@ -10,7 +10,9 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  describe('Getting user profile when security is disabled in Elasticsearch', () => {
+  describe('Getting user profile when security is disabled in Elasticsearch', function () {
+    this.tags('skipFIPS');
+
     it('returns 404 for unauthenticated requests', async () => {
       await supertestWithoutAuth.get('/internal/security/user_profile').expect(404);
     });


### PR DESCRIPTION
Closes #272260

The FIPS pipeline forcibly enables security (overriding `xpack.security.enabled=false`), causing unauthenticated requests to return 401 instead of the 404 this suite asserts. The suite's premise is incompatible with FIPS. This PR adds the `skipFIPS` tag so it runs in regular CI but is skipped in the FIPS pipeline.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->