### PR TITLE
[Entity Analytics] Add missing FTR coverage for watchlist source labels and sync idempotency

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/csv_upload.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/csv_upload.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import { WatchlistSyncUtils } from './utils/watchlist_sync_utils';
+import { EntityStoreUtils } from './utils/entity_store_utils';
+
+const userEuid = (name: string) => `user:${name}@unknown`;
+
+const WATCHLISTS_BASE_URL = '/api/entity_analytics/watchlists';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertest');
+  const entityAnalyticsApi = getService('entityAnalyticsApi');
+
+  describe('@ess @serverless @skipInServerlessMKI Watchlist CSV Upload', () => {
+    const sourceIndexName = 'watchlist-csv-upload-test-users';
+    const utils = WatchlistSyncUtils(getService, [sourceIndexName]);
+    const entityStore = EntityStoreUtils(getService);
+
+    const uploadCsv = (watchlistId: string, csvContent: string) =>
+      supertest
+        .post(`${WATCHLISTS_BASE_URL}/${watchlistId}/csv_upload`)
+        .set('kbn-xsrf', 'true')
+        .set('x-elastic-internal-origin', 'Kibana')
+        .set('elastic-api-version', '1')
+        .attach('file', Buffer.from(csvContent), {
+          filename: 'watchlist.csv',
+          contentType: 'text/csv',
+        });
+
+    before(async () => {
+      await utils.cleanWatchlistState();
+      await entityStore.install(['user']);
+    });
+
+    after(async () => {
+      await entityStore.uninstall();
+    });
+
+    afterEach(async () => {
+      await utils.deleteAllSourceIndices();
+      await entityStore.clearAllEntityStoreData();
+      await utils.cleanWatchlistState();
+    });
+
+    it('should add an entity to the watchlist with a manual source label after CSV upload', async () => {
+      const { body: watchlist } = await entityAnalyticsApi.createWatchlist({
+        body: { name: 'csv-source-label', description: '', riskModifier: 1 },
+      });
+      const watchlistId = watchlist.id;
+
+      await entityStore.createEntity('user', {
+        user: { name: 'alice' },
+        entity: { id: userEuid('alice'), type: 'user' },
+      });
+
+      const csvContent = `type,user.name\nuser,alice\n`;
+      const response = await uploadCsv(watchlistId, csvContent);
+      expect(response.status).toBe(200);
+      expect(response.body.successful).toBeGreaterThanOrEqual(1);
+
+      const docs = await utils.queryWatchlistIndex(watchlistId);
+      expect(docs).toHaveLength(1);
+
+      const doc = utils.findEntity(docs, userEuid('alice'));
+      const sources = (doc?.labels as { sources?: string[] } | undefined)?.sources ?? [];
+      expect(sources).toContain('manual');
+    });
+
+    it('should merge source labels when entity is added via CSV and later synced from an index source', async () => {
+      await utils.createSourceIndex(sourceIndexName);
+      const { watchlistId } = await utils.createWatchlistAndEntitySource(
+        'csv-index-merge',
+        sourceIndexName
+      );
+
+      await entityStore.createEntity('user', {
+        user: { name: 'alice' },
+        entity: { id: userEuid('alice'), type: 'user' },
+      });
+
+      const csvContent = `type,user.name\nuser,alice\n`;
+      const csvResponse = await uploadCsv(watchlistId, csvContent);
+      expect(csvResponse.status).toBe(200);
+      expect(csvResponse.body.successful).toBeGreaterThanOrEqual(1);
+
+      await utils.addUsersToSourceIndex(['alice'], sourceIndexName);
+      await utils.syncWatchlist(watchlistId);
+
+      const docs = await utils.queryWatchlistIndex(watchlistId);
+      expect(docs).toHaveLength(1);
+
+      const doc = utils.findEntity(docs, userEuid('alice'));
+      const sources = (doc?.labels as { sources?: string[] } | undefined)?.sources ?? [];
+      expect(sources).toContain('manual');
+      expect(sources).toContain('index');
+    });
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/index.ts
@@ -14,5 +14,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./entity_store_sync'));
     loadTestFile(require.resolve('./manual_assignment'));
     loadTestFile(require.resolve('./lifecycle'));
+    loadTestFile(require.resolve('./csv_upload'));
   });
 }

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/index_source_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/index_source_sync.ts
@@ -106,6 +106,41 @@ export default ({ getService }: FtrProviderContext) => {
       expect(await utils.queryWatchlistIndex(watchlistId)).toHaveLength(0);
     });
 
+    it('should not update timestamps when re-syncing the same entity from the same source', async () => {
+      await utils.createSourceIndex(sourceIndexName);
+      const { watchlistId } = await utils.createWatchlistAndEntitySource(
+        'sync-idempotency',
+        sourceIndexName
+      );
+
+      await entityStore.createEntity('user', {
+        user: { name: 'alice' },
+        entity: { id: userEuid('alice'), type: 'user' },
+      });
+
+      await utils.addUsersToSourceIndex(['alice'], sourceIndexName);
+      await utils.syncWatchlist(watchlistId);
+
+      const docsAfterFirstSync = await utils.queryWatchlistIndex(watchlistId);
+      const docAfterFirstSync = utils.findEntity(docsAfterFirstSync, userEuid('alice'));
+      const timestampAfterFirstSync = (docAfterFirstSync as Record<string, unknown>)['@timestamp'];
+      const ingestedAfterFirstSync = (
+        (docAfterFirstSync as Record<string, unknown>)?.event as Record<string, unknown>
+      )?.ingested;
+
+      await utils.syncWatchlist(watchlistId);
+
+      const docsAfterSecondSync = await utils.queryWatchlistIndex(watchlistId);
+      const docAfterSecondSync = utils.findEntity(docsAfterSecondSync, userEuid('alice'));
+      expect((docAfterSecondSync as Record<string, unknown>)['@timestamp']).toEqual(
+        timestampAfterFirstSync
+      );
+      expect(
+        ((docAfterSecondSync as Record<string, unknown>)?.event as Record<string, unknown>)
+          ?.ingested
+      ).toEqual(ingestedAfterFirstSync);
+    });
+
     it('should only sync documents matching the KQL filter on the entity source', async () => {
       await utils.createSourceIndex(sourceIndexName);
       const { watchlistId } = await utils.createWatchlistAndEntitySource(


### PR DESCRIPTION
## Summary

Part of [elastic/security-team#17607](https://github.com/elastic/security-team/issues/17607).

Parity analysis against the now-deleted privmon skipped suites revealed three behaviours in the watchlist sync implementation that had no FTR coverage: CSV upload creating entities with the correct source label, source label merging when the same entity is added via multiple source types, and the sync idempotency guarantee that re-syncing an unchanged entity does not bump \`@timestamp\` or \`event.ingested\`. The upsert Painless script handles all three correctly; these tests verify it.

Note: in watchlists, CSV upload uses \`sourceLabel: 'manual'\` (same as direct API assignment), not a distinct \`'csv'\` label — the source merging test reflects that.

## How to test

```bash
yarn test:ftr:server --config x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/configs/ess.config.ts
```

Run the watchlist FTR suite and verify the three new tests pass:
- `Watchlist CSV Upload` — 2 tests in `csv_upload.ts`
- `Index Source Sync` — timestamp idempotency test in `index_source_sync.ts`