### PR TITLE
[Synthetics] Bound remoteName schema in network_events route (CCS)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/network_events/get_network_events.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/network_events/get_network_events.ts
@@ -17,7 +17,7 @@ export const createNetworkEventsRoute: SyntheticsRestApiRouteFactory = () => ({
     query: schema.object({
       checkGroup: schema.string(),
       stepIndex: schema.number(),
-      remoteName: schema.maybe(schema.string()),
+      remoteName: schema.maybe(schema.string({ maxLength: 256 })),
     }),
   },
   handler: async ({ syntheticsEsClient, request }): Promise<any> => {


### PR DESCRIPTION
## Summary

Follow-up to #270590. Adds `maxLength: 256` to the `remoteName` query
parameter in the Synthetics network-events route so it matches every
other CCS route (`get_pings`, `journeys`, `journey_screenshots`,
`ping_heatmap`, `last_successful_check`, `get_monitor_summary_stats`,
…), all of which already bound `remoteName` to 256 chars.

This resolves the high-severity CodeQL **"Unbounded string in schema
validation"** alert that landed on `main` with #270590:

```
x-pack/solutions/observability/plugins/synthetics/server/routes/network_events/get_network_events.ts
```

No behavior change for valid requests — a remote cluster alias is well
under 256 chars; the bound only rejects abusive oversized input (the DoS
vector CodeQL flags).

### Checklist

- [x] Lint clean (`node scripts/eslint`)
- [x] Type-check clean (`node scripts/type_check --project .../synthetics/tsconfig.json`)
