### PR TITLE
Bump @elastic/transport to 9.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@aws-sdk/client-bedrock-runtime": "3.994.0",
     "@aws-sdk/client-kendra": "3.994.0",
     "@aws-sdk/credential-provider-node": "3.972.10",
-    "@elastic/elasticsearch/@elastic/transport": "9.3.5",
+    "@elastic/elasticsearch/@elastic/transport": "9.3.7",
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2567,10 +2567,10 @@
     history "^4.9.0"
     qs "^6.9.7"
 
-"@elastic/transport@9.3.5", "@elastic/transport@^9.3.5":
-  version "9.3.5"
-  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-9.3.5.tgz#c041807aa366b7bd2f861c458ca4fd427e06e519"
-  integrity sha512-hIMJbt1guqr3/N2zCN45k9hw9o78qcdsO0xietLe+Bfa+JL0YafHTgkWkM1oT3Ht5sGMJaDcJZiYomSMU6CtTA==
+"@elastic/transport@9.3.7", "@elastic/transport@^9.3.5":
+  version "9.3.7"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-9.3.7.tgz#5b81998f5b6305dd6f8d9b05da824a96c53df8b8"
+  integrity sha512-L38Ax21uF2OPUmCRWycZ/dZdMYf7gMrtClcxvVrqJVFmn8ET2M++GYmFGJpLqOHS1beATxOXLWe7y2ijSQz/ng==
   dependencies:
     "@opentelemetry/api" "1.x"
     "@opentelemetry/core" "2.x"


### PR DESCRIPTION
## Summary

Bumps the `@elastic/elasticsearch/@elastic/transport` resolution from `9.3.5` to `9.3.7`.

The pin at `9.3.5` was not a deliberate decision; it was introduced by the blanket dependency-pinning effort in #244556 (closes #243396), which pinned every loosely-specified dependency to its then-current `yarn.lock` version. `9.3.5` simply happened to be the latest release at that time.

`9.3.6` and `9.3.7` contain connection-pool recovery fixes:

- **9.3.6**: prevent false `NoLivingConnectionsError` in `WeightedConnectionPool`; mark timed-out nodes dead when `retryOnTimeout` is false
- **9.3.7**: hardening of the timed-out-node-marking fix

These are relevant to https://github.com/elastic/sdh-kibana/issues/6305, where Kibana fails to fail over to surviving Elasticsearch nodes when one node goes offline.

Note: bumping the resolution (rather than `@elastic/elasticsearch` itself) is the correct lever here — the client at `9.4.0` already declares `^9.3.5`; it's the `resolutions` override that was freezing transport at `9.3.5`.

## Test plan

- [ ] `yarn kbn bootstrap` succeeds
- [ ] CI green
- [ ] Confirm with transport maintainers (@JoshMock) that 9.3.7 covers the customer's DR/failover scenario in SDH #6305

Made with [Cursor](https://cursor.com)