### PR TITLE
[UIAM OAuth] Unskip OAuth client management scout test

### DIFF
--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
@@ -50,10 +50,7 @@ apiTest.describe(
       await kbnClient.uiSettings.unset(AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID);
     });
 
-    // Temporarily skipped: Kibana now sends `project_id` in the create-client payload, but the
-    // promoted `docker.elastic.co/kibana-ci/uiam:latest-verified` image does not yet accept that
-    // field. Re-enable once a UIAM image that supports `project_id` is promoted to `latest-verified`.
-    apiTest.skip(
+    apiTest(
       'creates, reads, lists, patches (incl. redirect_uris), and revokes a client',
       async ({ apiClient }) => {
         const clientName = `scout-crud-${Date.now()}`;


### PR DESCRIPTION
## Summary

Reverts the temporary `apiTest.skip` added in #271786 now that the `kibana-ci/uiam:latest-verified` image includes `project_id` support (confirmed the latest `uiam-verify-and-promote` build succeeded).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



