### PR TITLE
[Fleet] Fix cloud connector to match integration policy template

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.test.ts
@@ -509,6 +509,36 @@ describe('AgentlessConnectorsInfraService', () => {
 
       expect(result).toBe(fakeAgentPolicy);
     });
+
+    test.each([
+      ['microsoft_teams', 'teams'],
+      ['mssql', 'microsoft_sql'],
+      ['s3', 'amazon_s3'],
+    ])(
+      'maps service_type "%s" to policy_template "%s" (issue #266539)',
+      async (serviceType, expectedPolicyTemplate) => {
+        const testConnector = {
+          id: '000000006',
+          name: 'Test Agentless Connector',
+          service_type: serviceType,
+          is_deleted: false,
+        };
+
+        const fakeAgentPolicy = { id: 'agent-policy-006' } as AgentPolicy;
+        agentlessPoliciesService.createAgentlessPolicy.mockResolvedValue(fakeAgentPolicy);
+
+        await service.deployConnector(testConnector);
+
+        expect(agentlessPoliciesService.createAgentlessPolicy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            policy_template: expectedPolicyTemplate,
+            inputs: expect.objectContaining({
+              [`${expectedPolicyTemplate}-connectors-py`]: expect.anything(),
+            }),
+          })
+        );
+      }
+    );
   });
   describe('removeDeployment', () => {
     const packagePolicyId = 'this-is-package-policy-id';

--- a/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/services/index.ts
@@ -49,6 +49,17 @@ const connectorsInputName = 'connectors-py';
 const pkgName = 'elastic_connectors';
 const pkgTitle = 'Elastic Connectors';
 
+// A few native connector `service_type` values don't match their `policy_template`
+// name in the `elastic_connectors` package manifest (see issue #266539).
+const SERVICE_TYPE_TO_POLICY_TEMPLATE: Record<string, string> = {
+  microsoft_teams: 'teams',
+  mssql: 'microsoft_sql',
+  s3: 'amazon_s3',
+};
+
+const getPolicyTemplateName = (serviceType: string): string =>
+  SERVICE_TYPE_TO_POLICY_TEMPLATE[serviceType] ?? serviceType;
+
 export class AgentlessConnectorsInfraService {
   private logger: Logger;
   private soClient: SavedObjectsClientContract;
@@ -185,6 +196,8 @@ export class AgentlessConnectorsInfraService {
     const pkgVersion = await this.getPackageVersion();
     this.logger.debug(`Latest package version for ${pkgName} is ${pkgVersion}`);
 
+    const policyTemplate = getPolicyTemplateName(connector.service_type);
+
     const packagePolicyToCreate = {
       package: {
         title: pkgTitle,
@@ -195,9 +208,9 @@ export class AgentlessConnectorsInfraService {
       description: '',
       namespace: '',
       enabled: true,
-      policy_template: connector.service_type,
+      policy_template: policyTemplate,
       inputs: {
-        [`${connector.service_type}-${connectorsInputName}`]: {
+        [`${policyTemplate}-${connectorsInputName}`]: {
           enabled: true,
           vars: {
             connector_id: connector.id,


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/266539 

 `deployConnector()` used a connector's `service_type` directly as the `elastic_connectors` `policy_template` name. A few service types don't match the manifest's template names, so deployment failed (Errors: `Input not
  found` on 9.3+, `not allowed for deployment mode 'agentless'` retry loop on 9.2).

That PR fix this by adding a service_type to policy_template mapping used when building the package policy; all other service types pass through unchanged.

  | `service_type` | `policy_template` |
  |---|---|
  | `microsoft_teams` | `teams` |
  | `mssql` | `microsoft_sql` |
  | `s3` | `amazon_s3` |


## How to test?

Create a content connector and verify the agentless policy is well created

<img width="1509" height="699" alt="Screenshot 2026-06-02 at 11 06 15 AM" src="https://github.com/user-attachments/assets/df1d9b63-dc44-47d1-9278-f8ab7f96ad5c" />



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->