### PR TITLE
[OTel Logger] Send ECS-compliant structured body when json layout

### DIFF
--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.test.mocks.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.test.mocks.ts
@@ -99,14 +99,3 @@ jest.mock('@kbn/tracing', () => ({
 jest.mock('@kbn/metrics', () => ({
   initMetrics: jest.fn(),
 }));
-
-export const mockLayoutFormat = jest.fn((record: { message: string }) => record.message);
-export const mockLayoutsCreate = jest.fn(() => ({ format: mockLayoutFormat }));
-
-jest.mock('../../layouts/layouts', () => ({
-  Layouts: {
-    // Use the real configSchema so that schema validation tests work correctly.
-    configSchema: jest.requireActual('../../layouts/layouts').Layouts.configSchema,
-    create: mockLayoutsCreate,
-  },
-}));

--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.test.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.test.ts
@@ -12,8 +12,6 @@ import {
   mockDetectResources,
   mockEmit,
   mockGetConfiguration,
-  mockLayoutFormat,
-  mockLayoutsCreate,
   mockLoggerProvider,
   mockMergeResource,
   mockOTLPLogExporter,
@@ -21,10 +19,13 @@ import {
   mockShutdown,
 } from './otel_appender.test.mocks';
 
+import { set } from '@kbn/safer-lodash-set';
 import { trace } from '@opentelemetry/api';
 import { LogLevel } from '@kbn/logging';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { OtelAppender } from './otel_appender';
+import { Layouts } from '../../layouts/layouts';
+import { JsonLayout } from '../../layouts/json_layout';
 
 const validConfig = {
   type: 'otel' as const,
@@ -42,570 +43,589 @@ const makeRecord = (overrides = {}) => ({
   ...overrides,
 });
 
-beforeEach(() => {
-  mockEmit.mockReset();
-  mockShutdown.mockReset();
-  mockLoggerProvider.mockClear();
-  mockBatchLogRecordProcessor.mockClear();
-  mockOTLPLogExporter.mockClear();
-  mockResourceFromAttributes.mockClear();
-  mockDetectResources.mockClear();
-  mockMergeResource.mockClear();
-  mockGetConfiguration.mockClear();
-  mockLayoutsCreate.mockClear();
-  mockLayoutFormat.mockClear();
-  jest.mocked(trace.setSpanContext).mockClear();
-});
+describe('OtelAppender', () => {
+  let mockLayoutFormat: jest.SpyInstance;
+  let mockLayoutsCreate: jest.SpyInstance;
 
-describe('OtelAppender.configSchema', () => {
-  it('validates a minimal config (url only required)', () => {
-    const result = OtelAppender.configSchema.validate({
-      type: 'otel',
-      url: 'http://collector:4318/v1/logs',
+  beforeEach(() => {
+    mockEmit.mockReset();
+    mockShutdown.mockReset();
+    mockLoggerProvider.mockClear();
+    mockBatchLogRecordProcessor.mockClear();
+    mockOTLPLogExporter.mockClear();
+    mockResourceFromAttributes.mockClear();
+    mockDetectResources.mockClear();
+    mockMergeResource.mockClear();
+    mockGetConfiguration.mockClear();
+    const originalLayoutsCreate = Layouts.create;
+    mockLayoutsCreate = jest.spyOn(Layouts, 'create').mockImplementation((opts) => {
+      const layout = originalLayoutsCreate(opts);
+      mockLayoutFormat = jest.spyOn(layout, 'format');
+      return layout;
     });
-    expect(result.url).toBe('http://collector:4318/v1/logs');
-    expect(result.headers).toEqual({});
-    expect(result.layout).toBeUndefined();
-    expect(result.attributes).toBeUndefined();
+    jest.mocked(trace.setSpanContext).mockClear();
   });
 
-  it('accepts a json layout config', () => {
-    const result = OtelAppender.configSchema.validate({
-      ...validConfig,
-      layout: { type: 'json' },
+  afterEach(() => {
+    mockLayoutsCreate.mockRestore();
+  });
+
+  describe('configSchema', () => {
+    it('validates a minimal config (url only required)', () => {
+      const result = OtelAppender.configSchema.validate({
+        type: 'otel',
+        url: 'http://collector:4318/v1/logs',
+      });
+      expect(result.url).toBe('http://collector:4318/v1/logs');
+      expect(result.headers).toEqual({});
+      expect(result.layout).toBeUndefined();
+      expect(result.attributes).toBeUndefined();
     });
-    expect(result.layout).toEqual({ type: 'json' });
-  });
 
-  it('accepts a pattern layout config', () => {
-    const result = OtelAppender.configSchema.validate({
-      ...validConfig,
-      layout: { type: 'pattern', pattern: '[%p] %m' },
-    });
-    expect(result.layout).toEqual({ type: 'pattern', pattern: '[%p] %m' });
-  });
-
-  it('accepts optional user-provided attributes to override defaults', () => {
-    const result = OtelAppender.configSchema.validate({
-      ...validConfig,
-      attributes: { 'service.name': 'my-kibana' },
-    });
-    expect(result.attributes).toEqual({ 'service.name': 'my-kibana' });
-  });
-
-  it('rejects config without url', () => {
-    expect(() => OtelAppender.configSchema.validate({ type: 'otel' })).toThrow();
-  });
-
-  it('rejects config with wrong type', () => {
-    expect(() => OtelAppender.configSchema.validate({ ...validConfig, type: 'console' })).toThrow();
-  });
-
-  it('rejects ssl.certificate without ssl.key', () => {
-    expect(() =>
-      OtelAppender.configSchema.validate({
+    it('accepts a json layout config', () => {
+      const result = OtelAppender.configSchema.validate({
         ...validConfig,
-        ssl: { certificate: '/path/to/cert.pem' },
-      })
-    ).toThrow(/ssl\.key/);
-  });
+        layout: { type: 'json' },
+      });
+      expect(result.layout).toEqual({ type: 'json' });
+    });
 
-  it('rejects ssl.key without ssl.certificate', () => {
-    expect(() =>
-      OtelAppender.configSchema.validate({
+    it('accepts a pattern layout config', () => {
+      const result = OtelAppender.configSchema.validate({
         ...validConfig,
-        ssl: { key: '/path/to/key.pem' },
-      })
-    ).toThrow(/ssl\.certificate/);
-  });
+        layout: { type: 'pattern', pattern: '[%p] %m' },
+      });
+      expect(result.layout).toEqual({ type: 'pattern', pattern: '[%p] %m' });
+    });
 
-  it('rejects ssl.keyPassphrase without ssl.key', () => {
-    expect(() =>
-      OtelAppender.configSchema.validate({
+    it('accepts optional user-provided attributes to override defaults', () => {
+      const result = OtelAppender.configSchema.validate({
         ...validConfig,
-        ssl: { keyPassphrase: 'secret' },
-      })
-    ).toThrow(/ssl\.key/);
+        attributes: { 'service.name': 'my-kibana' },
+      });
+      expect(result.attributes).toEqual({ 'service.name': 'my-kibana' });
+    });
+
+    it('rejects config without url', () => {
+      expect(() => OtelAppender.configSchema.validate({ type: 'otel' })).toThrow();
+    });
+
+    it('rejects config with wrong type', () => {
+      expect(() =>
+        OtelAppender.configSchema.validate({ ...validConfig, type: 'console' })
+      ).toThrow();
+    });
+
+    it('rejects ssl.certificate without ssl.key', () => {
+      expect(() =>
+        OtelAppender.configSchema.validate({
+          ...validConfig,
+          ssl: { certificate: '/path/to/cert.pem' },
+        })
+      ).toThrow(/ssl\.key/);
+    });
+
+    it('rejects ssl.key without ssl.certificate', () => {
+      expect(() =>
+        OtelAppender.configSchema.validate({
+          ...validConfig,
+          ssl: { key: '/path/to/key.pem' },
+        })
+      ).toThrow(/ssl\.certificate/);
+    });
+
+    it('rejects ssl.keyPassphrase without ssl.key', () => {
+      expect(() =>
+        OtelAppender.configSchema.validate({
+          ...validConfig,
+          ssl: { keyPassphrase: 'secret' },
+        })
+      ).toThrow(/ssl\.key/);
+    });
+
+    it('accepts optional ssl.tls settings', () => {
+      const result = OtelAppender.configSchema.validate({
+        ...validConfig,
+        ssl: {
+          verificationMode: 'full',
+          certificateAuthorities: '/etc/ssl/custom-ca.pem',
+          certificate: '/etc/ssl/client.crt',
+          key: '/etc/ssl/client.key',
+        },
+      });
+      expect(result.ssl?.verificationMode).toBe('full');
+      expect(result.ssl?.certificateAuthorities).toBe('/etc/ssl/custom-ca.pem');
+    });
   });
 
-  it('accepts optional ssl.tls settings', () => {
-    const result = OtelAppender.configSchema.validate({
-      ...validConfig,
-      ssl: {
-        verificationMode: 'full',
-        certificateAuthorities: '/etc/ssl/custom-ca.pem',
-        certificate: '/etc/ssl/client.crt',
-        key: '/etc/ssl/client.key',
-      },
-    });
-    expect(result.ssl?.verificationMode).toBe('full');
-    expect(result.ssl?.certificateAuthorities).toBe('/etc/ssl/custom-ca.pem');
-  });
-});
+  describe('OtelAppender constructor', () => {
+    it('creates OTLPLogExporter with url and headers from config', () => {
+      new OtelAppender(validConfig);
 
-describe('OtelAppender constructor', () => {
-  it('creates OTLPLogExporter with url and headers from config', () => {
-    new OtelAppender(validConfig);
-
-    expect(mockOTLPLogExporter).toHaveBeenCalledWith({
-      url: validConfig.url,
-      headers: validConfig.headers,
-    });
-  });
-
-  it('passes httpAgentOptions when ssl is set (HTTP exporter)', () => {
-    new OtelAppender({
-      ...validConfig,
-      ssl: { verificationMode: 'none' },
+      expect(mockOTLPLogExporter).toHaveBeenCalledWith({
+        url: validConfig.url,
+        headers: validConfig.headers,
+      });
     });
 
-    expect(mockOTLPLogExporter).toHaveBeenCalledWith({
-      url: validConfig.url,
-      headers: validConfig.headers,
-      httpAgentOptions: expect.objectContaining({ rejectUnauthorized: false }),
-    });
-  });
+    it('passes httpAgentOptions when ssl is set (HTTP exporter)', () => {
+      new OtelAppender({
+        ...validConfig,
+        ssl: { verificationMode: 'none' },
+      });
 
-  it('passes httpAgentOptions for proto protocol when ssl is set', () => {
-    new OtelAppender({
-      ...validConfig,
-      protocol: 'proto',
-      ssl: { verificationMode: 'full' },
-    });
-
-    expect(mockOTLPLogExporter).toHaveBeenCalledWith({
-      url: validConfig.url,
-      headers: validConfig.headers,
-      httpAgentOptions: expect.objectContaining({ rejectUnauthorized: true }),
-    });
-  });
-
-  it('passes grpc channel credentials when ssl is set', () => {
-    new OtelAppender({
-      type: 'otel',
-      protocol: 'grpc',
-      url: 'https://collector:4317',
-      ssl: { verificationMode: 'none' },
+      expect(mockOTLPLogExporter).toHaveBeenCalledWith({
+        url: validConfig.url,
+        headers: validConfig.headers,
+        httpAgentOptions: expect.objectContaining({ rejectUnauthorized: false }),
+      });
     });
 
-    expect(mockOTLPLogExporter).toHaveBeenCalledWith(
-      expect.objectContaining({
+    it('passes httpAgentOptions for proto protocol when ssl is set', () => {
+      new OtelAppender({
+        ...validConfig,
+        protocol: 'proto',
+        ssl: { verificationMode: 'full' },
+      });
+
+      expect(mockOTLPLogExporter).toHaveBeenCalledWith({
+        url: validConfig.url,
+        headers: validConfig.headers,
+        httpAgentOptions: expect.objectContaining({ rejectUnauthorized: true }),
+      });
+    });
+
+    it('passes grpc channel credentials when ssl is set', () => {
+      new OtelAppender({
+        type: 'otel',
+        protocol: 'grpc',
         url: 'https://collector:4317',
-        metadata: expect.anything(),
-        credentials: expect.anything(),
-      })
+        ssl: { verificationMode: 'none' },
+      });
+
+      expect(mockOTLPLogExporter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://collector:4317',
+          metadata: expect.anything(),
+          credentials: expect.anything(),
+        })
+      );
+    });
+
+    it('defaults to empty headers when none are provided', () => {
+      new OtelAppender({ type: 'otel', url: validConfig.url, protocol: 'http' });
+
+      expect(mockOTLPLogExporter).toHaveBeenCalledWith({
+        url: validConfig.url,
+        headers: {},
+      });
+    });
+
+    it('creates a pattern layout with the OTel-specific default pattern when no layout is configured', () => {
+      new OtelAppender(validConfig);
+
+      expect(mockLayoutsCreate).toHaveBeenCalledWith({
+        type: 'pattern',
+        pattern: '%message %error',
+      });
+    });
+
+    it('uses the OTel-specific "%message %error" pattern when pattern type is requested without a custom string', () => {
+      new OtelAppender({ ...validConfig, layout: { type: 'pattern' } });
+
+      expect(mockLayoutsCreate).toHaveBeenCalledWith({
+        type: 'pattern',
+        pattern: '%message %error',
+      });
+    });
+
+    it('preserves an explicit custom pattern string provided by the user', () => {
+      new OtelAppender({ ...validConfig, layout: { type: 'pattern', pattern: '%m' } });
+
+      expect(mockLayoutsCreate).toHaveBeenCalledWith({ type: 'pattern', pattern: '%m' });
+    });
+
+    it('creates a JSON layout when explicitly configured', () => {
+      new OtelAppender({ ...validConfig, layout: { type: 'json' } });
+
+      expect(mockLayoutsCreate).toHaveBeenCalledWith({ type: 'json' });
+    });
+
+    it('always includes telemetry.sdk.language: nodejs in derived attributes', () => {
+      mockGetConfiguration.mockReturnValue(undefined);
+
+      new OtelAppender(validConfig);
+
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({ 'telemetry.sdk.language': 'nodejs' })
+      );
+    });
+
+    it('derives service.name, service.version and deployment.environment from the APM config singleton', () => {
+      mockGetConfiguration.mockReturnValue({
+        serviceName: 'kibana',
+        serviceVersion: '9.4.0',
+        environment: 'production',
+      });
+
+      new OtelAppender(validConfig);
+
+      expect(mockGetConfiguration).toHaveBeenCalledWith('kibana');
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith({
+        'telemetry.sdk.language': 'nodejs',
+        'service.name': 'kibana',
+        'service.version': '9.4.0',
+        'deployment.environment.name': 'production',
+      });
+    });
+
+    it('derives service.instance.id from kibana_uuid in APM global labels', () => {
+      mockGetConfiguration.mockReturnValue({
+        serviceName: 'kibana',
+        globalLabels: { kibana_uuid: 'test-uuid-123' },
+      });
+
+      new OtelAppender(validConfig);
+
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({ 'service.instance.id': 'test-uuid-123' })
+      );
+    });
+
+    it('omits service.instance.id when kibana_uuid is absent from global labels', () => {
+      mockGetConfiguration.mockReturnValue({ serviceName: 'kibana', globalLabels: {} });
+
+      new OtelAppender(validConfig);
+
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith(
+        expect.not.objectContaining({ 'service.instance.id': expect.anything() })
+      );
+    });
+
+    it('omits APM-derived service attributes whose config value is falsy', () => {
+      mockGetConfiguration.mockReturnValue({ serviceName: 'kibana' }); // no version, environment or uuid
+
+      new OtelAppender(validConfig);
+
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith({
+        'telemetry.sdk.language': 'nodejs',
+        'service.name': 'kibana',
+      });
+    });
+
+    it('only emits telemetry.sdk.language when the APM config singleton is not initialised', () => {
+      mockGetConfiguration.mockReturnValue(undefined);
+
+      new OtelAppender(validConfig);
+
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith({
+        'telemetry.sdk.language': 'nodejs',
+      });
+    });
+
+    it('user-provided attributes override the APM-derived ones', () => {
+      mockGetConfiguration.mockReturnValue({ serviceName: 'kibana', environment: 'development' });
+
+      new OtelAppender({
+        ...validConfig,
+        attributes: { 'service.name': 'custom-kibana', 'deployment.environment': 'staging' },
+      });
+
+      // The user override is passed as the last merge layer.
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith({
+        'service.name': 'custom-kibana',
+        'deployment.environment': 'staging',
+      });
+    });
+
+    it('auto-detects host/process/OS/env attributes via resource detectors', () => {
+      new OtelAppender(validConfig);
+
+      expect(mockDetectResources).toHaveBeenCalledWith({
+        detectors: expect.arrayContaining([
+          'envDetector',
+          'hostDetector',
+          'osDetector',
+          'processDetector',
+        ]),
+      });
+    });
+  });
+
+  describe('append() — severity mapping', () => {
+    it.each([
+      {
+        name: 'trace',
+        level: LogLevel.Trace,
+        severityNumber: SeverityNumber.TRACE,
+        severityText: 'TRACE',
+      },
+      {
+        name: 'debug',
+        level: LogLevel.Debug,
+        severityNumber: SeverityNumber.DEBUG,
+        severityText: 'DEBUG',
+      },
+      {
+        name: 'info',
+        level: LogLevel.Info,
+        severityNumber: SeverityNumber.INFO,
+        severityText: 'INFO',
+      },
+      {
+        name: 'warn',
+        level: LogLevel.Warn,
+        severityNumber: SeverityNumber.WARN,
+        severityText: 'WARN',
+      },
+      {
+        name: 'error',
+        level: LogLevel.Error,
+        severityNumber: SeverityNumber.ERROR,
+        severityText: 'ERROR',
+      },
+      {
+        name: 'fatal',
+        level: LogLevel.Fatal,
+        severityNumber: SeverityNumber.FATAL,
+        severityText: 'FATAL',
+      },
+    ])(
+      'maps log level $name to severityNumber $severityNumber and severityText $severityText',
+      ({ level, severityNumber, severityText }) => {
+        const appender = new OtelAppender(validConfig);
+        appender.append(makeRecord({ level }));
+
+        expect(mockEmit).toHaveBeenCalledWith(
+          expect.objectContaining({ severityNumber, severityText })
+        );
+      }
     );
-  });
 
-  it('defaults to empty headers when none are provided', () => {
-    new OtelAppender({ type: 'otel', url: validConfig.url, protocol: 'http' });
-
-    expect(mockOTLPLogExporter).toHaveBeenCalledWith({
-      url: validConfig.url,
-      headers: {},
-    });
-  });
-
-  it('creates a pattern layout with the OTel-specific default pattern when no layout is configured', () => {
-    new OtelAppender(validConfig);
-
-    expect(mockLayoutsCreate).toHaveBeenCalledWith({ type: 'pattern', pattern: '%message %error' });
-  });
-
-  it('uses the OTel-specific "%message %error" pattern when pattern type is requested without a custom string', () => {
-    new OtelAppender({ ...validConfig, layout: { type: 'pattern' } });
-
-    expect(mockLayoutsCreate).toHaveBeenCalledWith({ type: 'pattern', pattern: '%message %error' });
-  });
-
-  it('preserves an explicit custom pattern string provided by the user', () => {
-    new OtelAppender({ ...validConfig, layout: { type: 'pattern', pattern: '%m' } });
-
-    expect(mockLayoutsCreate).toHaveBeenCalledWith({ type: 'pattern', pattern: '%m' });
-  });
-
-  it('creates a JSON layout when explicitly configured', () => {
-    new OtelAppender({ ...validConfig, layout: { type: 'json' } });
-
-    expect(mockLayoutsCreate).toHaveBeenCalledWith({ type: 'json' });
-  });
-
-  it('always includes telemetry.sdk.language: nodejs in derived attributes', () => {
-    mockGetConfiguration.mockReturnValue(undefined);
-
-    new OtelAppender(validConfig);
-
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith(
-      expect.objectContaining({ 'telemetry.sdk.language': 'nodejs' })
-    );
-  });
-
-  it('derives service.name, service.version and deployment.environment from the APM config singleton', () => {
-    mockGetConfiguration.mockReturnValue({
-      serviceName: 'kibana',
-      serviceVersion: '9.4.0',
-      environment: 'production',
-    });
-
-    new OtelAppender(validConfig);
-
-    expect(mockGetConfiguration).toHaveBeenCalledWith('kibana');
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith({
-      'telemetry.sdk.language': 'nodejs',
-      'service.name': 'kibana',
-      'service.version': '9.4.0',
-      'deployment.environment.name': 'production',
-    });
-  });
-
-  it('derives service.instance.id from kibana_uuid in APM global labels', () => {
-    mockGetConfiguration.mockReturnValue({
-      serviceName: 'kibana',
-      globalLabels: { kibana_uuid: 'test-uuid-123' },
-    });
-
-    new OtelAppender(validConfig);
-
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith(
-      expect.objectContaining({ 'service.instance.id': 'test-uuid-123' })
-    );
-  });
-
-  it('omits service.instance.id when kibana_uuid is absent from global labels', () => {
-    mockGetConfiguration.mockReturnValue({ serviceName: 'kibana', globalLabels: {} });
-
-    new OtelAppender(validConfig);
-
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith(
-      expect.not.objectContaining({ 'service.instance.id': expect.anything() })
-    );
-  });
-
-  it('omits APM-derived service attributes whose config value is falsy', () => {
-    mockGetConfiguration.mockReturnValue({ serviceName: 'kibana' }); // no version, environment or uuid
-
-    new OtelAppender(validConfig);
-
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith({
-      'telemetry.sdk.language': 'nodejs',
-      'service.name': 'kibana',
-    });
-  });
-
-  it('only emits telemetry.sdk.language when the APM config singleton is not initialised', () => {
-    mockGetConfiguration.mockReturnValue(undefined);
-
-    new OtelAppender(validConfig);
-
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith({
-      'telemetry.sdk.language': 'nodejs',
-    });
-  });
-
-  it('user-provided attributes override the APM-derived ones', () => {
-    mockGetConfiguration.mockReturnValue({ serviceName: 'kibana', environment: 'development' });
-
-    new OtelAppender({
-      ...validConfig,
-      attributes: { 'service.name': 'custom-kibana', 'deployment.environment': 'staging' },
-    });
-
-    // The user override is passed as the last merge layer.
-    expect(mockResourceFromAttributes).toHaveBeenCalledWith({
-      'service.name': 'custom-kibana',
-      'deployment.environment': 'staging',
-    });
-  });
-
-  it('auto-detects host/process/OS/env attributes via resource detectors', () => {
-    new OtelAppender(validConfig);
-
-    expect(mockDetectResources).toHaveBeenCalledWith({
-      detectors: expect.arrayContaining([
-        'envDetector',
-        'hostDetector',
-        'osDetector',
-        'processDetector',
-      ]),
-    });
-  });
-});
-
-describe('OtelAppender.append() — severity mapping', () => {
-  it.each([
-    {
-      name: 'trace',
-      level: LogLevel.Trace,
-      severityNumber: SeverityNumber.TRACE,
-      severityText: 'TRACE',
-    },
-    {
-      name: 'debug',
-      level: LogLevel.Debug,
-      severityNumber: SeverityNumber.DEBUG,
-      severityText: 'DEBUG',
-    },
-    {
-      name: 'info',
-      level: LogLevel.Info,
-      severityNumber: SeverityNumber.INFO,
-      severityText: 'INFO',
-    },
-    {
-      name: 'warn',
-      level: LogLevel.Warn,
-      severityNumber: SeverityNumber.WARN,
-      severityText: 'WARN',
-    },
-    {
-      name: 'error',
-      level: LogLevel.Error,
-      severityNumber: SeverityNumber.ERROR,
-      severityText: 'ERROR',
-    },
-    {
-      name: 'fatal',
-      level: LogLevel.Fatal,
-      severityNumber: SeverityNumber.FATAL,
-      severityText: 'FATAL',
-    },
-  ])(
-    'maps log level $name to severityNumber $severityNumber and severityText $severityText',
-    ({ level, severityNumber, severityText }) => {
+    it.each([
+      ['off', LogLevel.Off],
+      ['all', LogLevel.All],
+    ])('emits records with filter-only level %s as severityNumber UNSPECIFIED', (_name, level) => {
       const appender = new OtelAppender(validConfig);
       appender.append(makeRecord({ level }));
 
       expect(mockEmit).toHaveBeenCalledWith(
-        expect.objectContaining({ severityNumber, severityText })
+        expect.objectContaining({ severityNumber: SeverityNumber.UNSPECIFIED })
       );
-    }
-  );
-
-  it.each([
-    ['off', LogLevel.Off],
-    ['all', LogLevel.All],
-  ])('emits records with filter-only level %s as severityNumber UNSPECIFIED', (_name, level) => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord({ level }));
-
-    expect(mockEmit).toHaveBeenCalledWith(
-      expect.objectContaining({ severityNumber: SeverityNumber.UNSPECIFIED })
-    );
-  });
-});
-
-describe('OtelAppender.append() — body', () => {
-  it('with pattern layout (default): passes the formatted string as body.text', () => {
-    mockLayoutFormat.mockReturnValue('hello world');
-    const appender = new OtelAppender(validConfig);
-    const record = makeRecord({ message: 'hello world' });
-    appender.append(record);
-
-    expect(mockLayoutFormat).toHaveBeenCalledWith(record);
-    // Formatted string is indexed as body.text, aliased to the ECS `message` field.
-    expect(mockEmit).toHaveBeenCalledWith(expect.objectContaining({ body: 'hello world' }));
-  });
-
-  it('with explicit pattern layout: passes the formatted string as body.text', () => {
-    mockLayoutFormat.mockReturnValue('formatted: hello world');
-    const appender = new OtelAppender({ ...validConfig, layout: { type: 'pattern' } });
-    const record = makeRecord({ message: 'hello world' });
-    appender.append(record);
-
-    expect(mockLayoutFormat).toHaveBeenCalledWith(record);
-    expect(mockEmit).toHaveBeenCalledWith(
-      expect.objectContaining({ body: 'formatted: hello world' })
-    );
-  });
-
-  it('with JSON layout: passes a sanitised LogRecord as structured body - strips level and null fields', () => {
-    const appender = new OtelAppender({ ...validConfig, layout: { type: 'json' } });
-    // Simulate runtime null values that can appear for missing trace identifiers.
-    const record = makeRecord({ message: 'hello world', spanId: null, traceId: null });
-    appender.append(record as unknown as ReturnType<typeof makeRecord>);
-
-    const { body } = mockEmit.mock.calls[0][0];
-    // level is a LogLevel object - redundant given severity_text/severity_number
-    expect(body).not.toHaveProperty('level');
-    // null fields are stripped to avoid empty entries in Elasticsearch
-    expect(body).not.toHaveProperty('spanId');
-    expect(body).not.toHaveProperty('traceId');
-    // non-null fields are preserved
-    expect(body).toMatchObject({
-      message: 'hello world',
-      context: record.context,
-      pid: record.pid,
     });
-    // The layout's format() method is NOT invoked for JSON layout
-    expect(mockLayoutFormat).not.toHaveBeenCalled();
-  });
-});
-
-describe('OtelAppender.append() — trace context', () => {
-  it('passes trace context via OTel context API when traceId and spanId are present', () => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord({ traceId: 'abc123', spanId: 'def456' }));
-
-    expect(trace.setSpanContext).toHaveBeenCalledWith('root-context', {
-      traceId: 'abc123',
-      spanId: 'def456',
-      traceFlags: 0, // TraceFlags.NONE
-    });
-    const emittedContext = mockEmit.mock.calls[0][0].context;
-    expect(emittedContext).toBeDefined();
   });
 
-  it('omits context when the record has no trace identifiers', () => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord());
-
-    expect(trace.setSpanContext).not.toHaveBeenCalled();
-    expect(mockEmit.mock.calls[0][0].context).toBeUndefined();
-  });
-
-  it('does not include trace.id or span.id in log record attributes', () => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord({ traceId: 'abc123', spanId: 'def456' }));
-
-    const { attributes } = mockEmit.mock.calls[0][0];
-    expect(attributes).not.toHaveProperty('trace.id');
-    expect(attributes).not.toHaveProperty('span.id');
-  });
-});
-
-describe('OtelAppender.append() — attributes', () => {
-  it('emits the correct timestamp and log.logger attribute', () => {
-    const appender = new OtelAppender(validConfig);
-    const timestamp = new Date('2024-06-15T12:00:00Z');
-    appender.append(makeRecord({ timestamp, context: 'my.plugin' }));
-
-    expect(mockEmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        timestamp,
-        attributes: expect.objectContaining({ 'log.logger': 'my.plugin' }),
-      })
-    );
-  });
-
-  it('does not include process.pid in log record attributes (it lives in the resource)', () => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord({ pid: 9999 }));
-
-    const { attributes } = mockEmit.mock.calls[0][0];
-    expect(attributes).not.toHaveProperty('process.pid');
-  });
-
-  it('maps error to OTel exception semantic convention attributes', () => {
-    const appender = new OtelAppender(validConfig);
-    const error = new Error('something went wrong');
-    appender.append(makeRecord({ error }));
-
-    expect(mockEmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attributes: expect.objectContaining({
-          'exception.type': 'Error',
-          'exception.message': 'something went wrong',
-          'exception.stacktrace': error.stack,
-        }),
-      })
-    );
-  });
-
-  it('omits exception attributes when no error is present', () => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord());
-
-    const { attributes } = mockEmit.mock.calls[0][0];
-    expect(attributes).not.toHaveProperty('exception.type');
-    expect(attributes).not.toHaveProperty('exception.message');
-    expect(attributes).not.toHaveProperty('exception.stacktrace');
-  });
-
-  it('includes transactionId as transaction.id attribute', () => {
-    const appender = new OtelAppender(validConfig);
-    appender.append(makeRecord({ transactionId: 'txn-123' }));
-
-    expect(mockEmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attributes: expect.objectContaining({ 'transaction.id': 'txn-123' }),
-      })
-    );
-  });
-
-  describe('log.meta', () => {
-    it('with pattern layout (default): flattens meta fields into kibana.log.meta.* attributes', () => {
+  describe('append() — body', () => {
+    it('with pattern layout (default): passes the formatted string as body.text', () => {
       const appender = new OtelAppender(validConfig);
-      const meta = { http: { method: 'GET' }, tags: ['api'] };
-      appender.append(makeRecord({ meta }));
+      mockLayoutFormat.mockReturnValue('hello world');
+      const record = makeRecord({ message: 'hello world' });
+      appender.append(record);
+
+      expect(mockLayoutFormat).toHaveBeenCalledWith(record);
+      // Formatted string is indexed as body.text, aliased to the ECS `message` field.
+      expect(mockEmit).toHaveBeenCalledWith(expect.objectContaining({ body: 'hello world' }));
+    });
+
+    it('with explicit pattern layout: passes the formatted string as body.text', () => {
+      const appender = new OtelAppender({ ...validConfig, layout: { type: 'pattern' } });
+      mockLayoutFormat.mockReturnValue('formatted: hello world');
+      const record = makeRecord({ message: 'hello world' });
+      appender.append(record);
+
+      expect(mockLayoutFormat).toHaveBeenCalledWith(record);
+      expect(mockEmit).toHaveBeenCalledWith(
+        expect.objectContaining({ body: 'formatted: hello world' })
+      );
+    });
+
+    it('with JSON layout: passes a sanitised LogRecord as structured body - strips level and null fields', () => {
+      const appender = new OtelAppender({ ...validConfig, layout: { type: 'json' } });
+      // Simulate runtime null values that can appear for missing trace identifiers.
+      const record = makeRecord({ message: 'hello world', spanId: null, traceId: null });
+      appender.append(record as unknown as ReturnType<typeof makeRecord>);
+
+      const { body } = mockEmit.mock.calls[0][0];
+      // level is a LogLevel object - redundant given severity_text/severity_number
+      expect(body).not.toHaveProperty('level');
+      // null fields are stripped to avoid empty entries in Elasticsearch
+      expect(body).not.toHaveProperty('spanId');
+      expect(body).not.toHaveProperty('traceId');
+      // non-null fields are preserved
+      expect(body).toMatchObject(
+        set(JsonLayout.ecsRecord(record), 'process.uptime', expect.any(Number))
+      );
+      // The layout's format() method is NOT invoked for JSON layout
+      expect(mockLayoutFormat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('append() — trace context', () => {
+    it('passes trace context via OTel context API when traceId and spanId are present', () => {
+      const appender = new OtelAppender(validConfig);
+      appender.append(makeRecord({ traceId: 'abc123', spanId: 'def456' }));
+
+      expect(trace.setSpanContext).toHaveBeenCalledWith('root-context', {
+        traceId: 'abc123',
+        spanId: 'def456',
+        traceFlags: 0, // TraceFlags.NONE
+      });
+      const emittedContext = mockEmit.mock.calls[0][0].context;
+      expect(emittedContext).toBeDefined();
+    });
+
+    it('omits context when the record has no trace identifiers', () => {
+      const appender = new OtelAppender(validConfig);
+      appender.append(makeRecord());
+
+      expect(trace.setSpanContext).not.toHaveBeenCalled();
+      expect(mockEmit.mock.calls[0][0].context).toBeUndefined();
+    });
+
+    it('does not include trace.id or span.id in log record attributes', () => {
+      const appender = new OtelAppender(validConfig);
+      appender.append(makeRecord({ traceId: 'abc123', spanId: 'def456' }));
+
+      const { attributes } = mockEmit.mock.calls[0][0];
+      expect(attributes).not.toHaveProperty('trace.id');
+      expect(attributes).not.toHaveProperty('span.id');
+    });
+  });
+
+  describe('append() — attributes', () => {
+    it('emits the correct timestamp and log.logger attribute', () => {
+      const appender = new OtelAppender(validConfig);
+      const timestamp = new Date('2024-06-15T12:00:00Z');
+      appender.append(makeRecord({ timestamp, context: 'my.plugin' }));
+
+      expect(mockEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timestamp,
+          attributes: expect.objectContaining({ 'log.logger': 'my.plugin' }),
+        })
+      );
+    });
+
+    it('does not include process.pid in log record attributes (it lives in the resource)', () => {
+      const appender = new OtelAppender(validConfig);
+      appender.append(makeRecord({ pid: 9999 }));
+
+      const { attributes } = mockEmit.mock.calls[0][0];
+      expect(attributes).not.toHaveProperty('process.pid');
+    });
+
+    it('maps error to OTel exception semantic convention attributes', () => {
+      const appender = new OtelAppender(validConfig);
+      const error = new Error('something went wrong');
+      appender.append(makeRecord({ error }));
 
       expect(mockEmit).toHaveBeenCalledWith(
         expect.objectContaining({
           attributes: expect.objectContaining({
-            'kibana.log.meta.http.method': 'GET',
-            'kibana.log.meta.tags': ['api'],
+            'exception.type': 'Error',
+            'exception.message': 'something went wrong',
+            'exception.stacktrace': error.stack,
           }),
         })
       );
     });
 
-    it('with pattern layout: omits log.meta when meta is not present', () => {
+    it('omits exception attributes when no error is present', () => {
       const appender = new OtelAppender(validConfig);
       appender.append(makeRecord());
 
       const { attributes } = mockEmit.mock.calls[0][0];
-      expect(attributes).not.toHaveProperty('log.meta');
+      expect(attributes).not.toHaveProperty('exception.type');
+      expect(attributes).not.toHaveProperty('exception.message');
+      expect(attributes).not.toHaveProperty('exception.stacktrace');
     });
 
-    it('with JSON layout: does not include log.meta in attributes (meta is part of the structured body)', () => {
-      const appender = new OtelAppender({ ...validConfig, layout: { type: 'json' } });
-      const meta = { http: { method: 'GET' }, tags: ['api'] };
-      appender.append(makeRecord({ meta }));
+    it('includes transactionId as transaction.id attribute', () => {
+      const appender = new OtelAppender(validConfig);
+      appender.append(makeRecord({ transactionId: 'txn-123' }));
 
-      const { attributes } = mockEmit.mock.calls[0][0];
-      expect(attributes).not.toHaveProperty('log.meta');
+      expect(mockEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({ 'transaction.id': 'txn-123' }),
+        })
+      );
+    });
+
+    describe('log.meta', () => {
+      it('with pattern layout (default): flattens meta fields into kibana.log.meta.* attributes', () => {
+        const appender = new OtelAppender(validConfig);
+        const meta = { http: { method: 'GET' }, tags: ['api'] };
+        appender.append(makeRecord({ meta }));
+
+        expect(mockEmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attributes: expect.objectContaining({
+              'kibana.log.meta.http.method': 'GET',
+              'kibana.log.meta.tags': ['api'],
+            }),
+          })
+        );
+      });
+
+      it('with pattern layout: omits log.meta when meta is not present', () => {
+        const appender = new OtelAppender(validConfig);
+        appender.append(makeRecord());
+
+        const { attributes } = mockEmit.mock.calls[0][0];
+        expect(attributes).not.toHaveProperty('log.meta');
+      });
+
+      it('with JSON layout: does not include log.meta in attributes (meta is part of the structured body)', () => {
+        const appender = new OtelAppender({ ...validConfig, layout: { type: 'json' } });
+        const meta = { http: { method: 'GET' }, tags: ['api'] };
+        appender.append(makeRecord({ meta }));
+
+        const { attributes } = mockEmit.mock.calls[0][0];
+        expect(attributes).not.toHaveProperty('log.meta');
+      });
     });
   });
-});
 
-describe('OtelAppender.dispose()', () => {
-  it('shuts down the logger provider', async () => {
-    mockShutdown.mockResolvedValue(undefined);
-    const appender = new OtelAppender(validConfig);
-    await appender.dispose();
+  describe('dispose()', () => {
+    it('shuts down the logger provider', async () => {
+      mockShutdown.mockResolvedValue(undefined);
+      const appender = new OtelAppender(validConfig);
+      await appender.dispose();
 
-    expect(mockShutdown).toHaveBeenCalledTimes(1);
-  });
+      expect(mockShutdown).toHaveBeenCalledTimes(1);
+    });
 
-  it('resolves even if shutdown hangs (timeout guard)', async () => {
-    jest.useFakeTimers();
-    mockShutdown.mockReturnValue(new Promise(() => {})); // never resolves
-    const appender = new OtelAppender(validConfig);
+    it('resolves even if shutdown hangs (timeout guard)', async () => {
+      jest.useFakeTimers();
+      mockShutdown.mockReturnValue(new Promise(() => {})); // never resolves
+      const appender = new OtelAppender(validConfig);
 
-    const disposePromise = appender.dispose();
-    jest.runAllTimers();
-    await expect(disposePromise).resolves.toBeUndefined();
+      const disposePromise = appender.dispose();
+      jest.runAllTimers();
+      await expect(disposePromise).resolves.toBeUndefined();
 
-    jest.useRealTimers();
-  });
+      jest.useRealTimers();
+    });
 
-  it('does not produce an unhandled rejection when shutdown rejects after the timeout', async () => {
-    jest.useFakeTimers();
-    let rejectShutdown!: (err: Error) => void;
-    mockShutdown.mockReturnValue(
-      new Promise<void>((_, rej) => {
-        rejectShutdown = rej;
-      })
-    );
-    const appender = new OtelAppender(validConfig);
+    it('does not produce an unhandled rejection when shutdown rejects after the timeout', async () => {
+      jest.useFakeTimers();
+      let rejectShutdown!: (err: Error) => void;
+      mockShutdown.mockReturnValue(
+        new Promise<void>((_, rej) => {
+          rejectShutdown = rej;
+        })
+      );
+      const appender = new OtelAppender(validConfig);
 
-    const disposePromise = appender.dispose();
-    jest.runAllTimers();
-    await expect(disposePromise).resolves.toBeUndefined();
+      const disposePromise = appender.dispose();
+      jest.runAllTimers();
+      await expect(disposePromise).resolves.toBeUndefined();
 
-    // Rejecting the shutdown promise after dispose() has already returned should not
-    // surface as an unhandled rejection because .catch(() => {}) is attached.
-    expect(() => rejectShutdown(new Error('late shutdown failure'))).not.toThrow();
+      // Rejecting the shutdown promise after dispose() has already returned should not
+      // surface as an unhandled rejection because .catch(() => {}) is attached.
+      expect(() => rejectShutdown(new Error('late shutdown failure'))).not.toThrow();
 
-    jest.useRealTimers();
+      jest.useRealTimers();
+    });
   });
 });

--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.test.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.test.ts
@@ -446,15 +446,21 @@ describe('OtelAppender', () => {
       appender.append(record as unknown as ReturnType<typeof makeRecord>);
 
       const { body } = mockEmit.mock.calls[0][0];
-      // level is a LogLevel object - redundant given severity_text/severity_number
-      expect(body).not.toHaveProperty('level');
       // null fields are stripped to avoid empty entries in Elasticsearch
-      expect(body).not.toHaveProperty('spanId');
-      expect(body).not.toHaveProperty('traceId');
+      expect(body).not.toHaveProperty('span');
+      expect(body).not.toHaveProperty('trace');
+      expect(body).not.toHaveProperty('transaction');
+      expect(body).not.toHaveProperty('error');
       // non-null fields are preserved
-      expect(body).toMatchObject(
-        set(JsonLayout.ecsRecord(record), 'process.uptime', expect.any(Number))
-      );
+      const {
+        // Undefined fields are stripped
+        span,
+        trace: _trace,
+        transaction: _transaction,
+        error: _error,
+        ...ecsRecord
+      } = JsonLayout.ecsRecord(record);
+      expect(body).toMatchObject(set(ecsRecord, 'process.uptime', expect.any(Number)));
       // The layout's format() method is NOT invoked for JSON layout
       expect(mockLayoutFormat).not.toHaveBeenCalled();
     });

--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.ts
@@ -28,6 +28,7 @@ import type { OtelAppenderConfig, LayoutConfigType } from '@kbn/core-logging-ser
 import { buildOtelResources } from '@kbn/telemetry';
 import { getFlattenedObject } from '@kbn/std';
 import { Layouts } from '../../layouts/layouts';
+import { JsonLayout } from '../../layouts/json_layout';
 import {
   buildGrpcVerifyOptions,
   buildHttpsAgentTlsOptions,
@@ -78,22 +79,6 @@ const toTraceContext = (record: LogRecord): Context | undefined => {
     traceFlags: TraceFlags.NONE,
   });
 };
-
-/**
- * Builds a sanitised copy of a `LogRecord` for use as `body.structured`.
- *
- * The raw record is stripped of:
- * - `level`: a Kibana-internal `LogLevel` object that is redundant given the
- *   top-level `severity_number` / `severity_text` OTLP fields.
- * - Fields with `null` or `undefined` values (e.g. `spanId`/`traceId` when no
- *   trace context is present) to avoid noisy empty entries in Elasticsearch.
- */
-const toStructuredBody = (record: LogRecord): AnyValueMap =>
-  Object.fromEntries(
-    Object.entries(record as unknown as Record<string, unknown>).filter(
-      ([key, v]) => key !== 'level' && v != null
-    )
-  ) as AnyValueMap;
 
 /**
  * Resolves the effective layout config for the OTel appender.
@@ -277,13 +262,15 @@ export class OtelAppender implements DisposableAppender {
       timestamp: record.timestamp,
       severityNumber,
       severityText: record.level.id.toUpperCase(),
-      // JSON layout: send a sanitised LogRecord as a structured object.
-      // Elastic's OTel ingest indexes this as body.structured. Note that the ECS
-      // `message` field will be empty because it aliases body.text, not body.structured.
+      // JSON layout: send a ECS record as a structured object.
+      // Elastic's OTel ingest indexes this as body.structured.
       //
       // Pattern layout (default): format the record to a human-readable string.
       // Elastic indexes this as body.text, aliased to the ECS `message` field.
-      body: this.useStructuredBody ? toStructuredBody(record) : this.layout.format(record),
+      body:
+        this.layout instanceof JsonLayout
+          ? (JsonLayout.ecsRecord(record) as unknown as AnyValueMap)
+          : this.layout.format(record),
       context: toTraceContext(record),
       // log.meta is omitted from attributes when using JSON layout because it
       // is already part of the structured body.

--- a/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/otel/otel_appender.ts
@@ -7,6 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { isNil } from 'lodash';
+import { set } from '@kbn/safer-lodash-set';
+import type { Ecs } from '@elastic/ecs';
 import type { OTLPLogExporter as OTLPLogExporterHTTP } from '@opentelemetry/exporter-logs-otlp-http';
 import type { OTLPLogExporter as OTLPLogExporterGRPC } from '@opentelemetry/exporter-logs-otlp-grpc';
 import type { OTLPLogExporter as OTLPLogExporterPROTO } from '@opentelemetry/exporter-logs-otlp-proto';
@@ -269,7 +272,7 @@ export class OtelAppender implements DisposableAppender {
       // Elastic indexes this as body.text, aliased to the ECS `message` field.
       body:
         this.layout instanceof JsonLayout
-          ? (JsonLayout.ecsRecord(record) as unknown as AnyValueMap)
+          ? omitDeepNilValues(JsonLayout.ecsRecord(record))
           : this.layout.format(record),
       context: toTraceContext(record),
       // log.meta is omitted from attributes when using JSON layout because it
@@ -290,6 +293,14 @@ export class OtelAppender implements DisposableAppender {
     ]);
   }
 }
+
+const omitDeepNilValues = (obj: Ecs) => {
+  const result: AnyValueMap = {};
+  Object.entries(getFlattenedObject(obj))
+    .filter(([_, value]) => !isNil(value))
+    .forEach(([key, value]) => set(result, key, value));
+  return result;
+};
 
 const createExporter = (
   config: OtelAppenderConfig

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
@@ -670,7 +670,7 @@ fcTest.prop([nonObjectToJsonReturnArb])(
         level: 'DEBUG',
         logger: 'bar',
       },
-      error: String(toJsonValue),
+      error: { message: String(toJsonValue) },
       process: {
         pid: 3,
         uptime: 10,

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
@@ -27,7 +27,7 @@ const jsonLayoutSchema = object({
 export class JsonLayout implements Layout {
   public static configSchema = jsonLayoutSchema;
 
-  public format(record: LogRecord): string {
+  public static ecsRecord(record: LogRecord): Ecs {
     const spanId = record.meta?.span?.id ?? record.spanId;
     const traceId = record.meta?.trace?.id ?? record.traceId;
     const transactionId = record.meta?.transaction?.id ?? record.transactionId;
@@ -58,6 +58,12 @@ export class JsonLayout implements Layout {
       }
       output = merge(serializedMeta, log);
     }
+
+    return output;
+  }
+
+  public format(record: LogRecord): string {
+    const output = JsonLayout.ecsRecord(record);
 
     return JSON.stringify(output);
   }

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
@@ -84,7 +84,7 @@ function metaToSerializableObject(meta: unknown): Record<string, unknown> {
     typeof serializedMeta !== 'object' ||
     Array.isArray(serializedMeta)
   ) {
-    return { error: String(serializedMeta) };
+    return { error: { message: String(serializedMeta) } };
   }
 
   return serializedMeta as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/270476


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




