### PR TITLE
[kbn-evals] Fix stop command not stopping EDOT Docker container and orphaned Scout children

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/doctor.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/doctor.ts
@@ -116,7 +116,8 @@ export const doctorCmd: Command<void> = {
       '--format',
       '{{.Names}}',
     ]);
-    const edotDockerAlive = dockerPs !== null && dockerPs.length > 0;
+    const edotDockerAlive =
+      dockerPs !== null && dockerPs.split('\n').some((name) => name.trim() === EDOT_CONTAINER_NAME);
 
     if (edotManagedAlive || edotDockerAlive) {
       const source = edotManagedAlive ? 'managed' : 'docker';
@@ -143,7 +144,10 @@ export const doctorCmd: Command<void> = {
             '--format',
             '{{.Names}}',
           ]);
-          if (edotUpAfterFix && edotUpAfterFix.length > 0) {
+          if (
+            edotUpAfterFix &&
+            edotUpAfterFix.split('\n').some((n) => n.trim() === EDOT_CONTAINER_NAME)
+          ) {
             log.info('EDOT collector started successfully');
           } else {
             log.warning(

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/doctor.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/doctor.ts
@@ -11,7 +11,13 @@ import { spawn } from 'child_process';
 import inquirer from 'inquirer';
 import type { Command } from '@kbn/dev-cli-runner';
 import { parseConnectorsFromEnv, isTTY } from '../prompts';
-import { isServiceRunning, readState, startService, tailLog } from '../services';
+import {
+  isServiceRunning,
+  readState,
+  startService,
+  tailLog,
+  EDOT_CONTAINER_NAME,
+} from '../services';
 import { safeExec } from '../utils';
 import { defaultExportProfile, readVaultConfigFromFile, resolveVaultConfigPath } from '../profiles';
 
@@ -106,7 +112,7 @@ export const doctorCmd: Command<void> = {
     const dockerPs = safeExec('docker', [
       'ps',
       '--filter',
-      'name=kibana-edot-collector',
+      `name=${EDOT_CONTAINER_NAME}`,
       '--format',
       '{{.Names}}',
     ]);
@@ -133,7 +139,7 @@ export const doctorCmd: Command<void> = {
           const edotUpAfterFix = safeExec('docker', [
             'ps',
             '--filter',
-            'name=kibana-edot-collector',
+            `name=${EDOT_CONTAINER_NAME}`,
             '--format',
             '{{.Names}}',
           ]);

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -29,9 +29,8 @@ import {
   stopService,
   connectorsHash,
   tailLog,
-  EDOT_CONTAINER_NAME,
+  isEdotDockerRunning,
 } from '../services';
-import { safeExec } from '../utils';
 import { readCachedEisConnectors } from '../eis_connectors_cache';
 import {
   defaultExportProfile,
@@ -48,17 +47,6 @@ import { runConfigInit, runConnectorSetup, ensureVaultAuth, ensureLocalConfig } 
 const SCOUT_LOCAL_CONFIG = '.scout/servers/local.json';
 const SCOUT_READY_POLL_INTERVAL_MS = 3000;
 const SCOUT_READY_TIMEOUT_MS = 180_000;
-
-const isEdotRunningViaDocker = (): boolean => {
-  const result = safeExec('docker', [
-    'ps',
-    '--filter',
-    `name=${EDOT_CONTAINER_NAME}`,
-    '--format',
-    '{{.Names}}',
-  ]);
-  return result !== null && result.length > 0;
-};
 
 const waitForScoutReady = async (repoRoot: string, log: ToolingLog): Promise<void> => {
   const configPath = Path.join(repoRoot, SCOUT_LOCAL_CONFIG);
@@ -439,7 +427,7 @@ export const startCmd: Command<void> = {
 
     if (!skipServer) {
       // --- Step 1: EDOT collector (exports traces to configured ES) ---
-      if (isServiceRunning(repoRoot, 'edot') || isEdotRunningViaDocker()) {
+      if (isServiceRunning(repoRoot, 'edot') || isEdotDockerRunning()) {
         log.info('[1/4] EDOT collector already running -- reusing');
       } else {
         log.info('[1/4] Starting EDOT collector (backgrounded)...');
@@ -456,7 +444,7 @@ export const startCmd: Command<void> = {
         await new Promise((r) => setTimeout(r, 5000));
         stopTail();
 
-        if (!isEdotRunningViaDocker()) {
+        if (!isEdotDockerRunning()) {
           log.warning(
             'EDOT collector may not have started. Check logs: node scripts/evals logs --service edot'
           );

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -29,6 +29,7 @@ import {
   stopService,
   connectorsHash,
   tailLog,
+  EDOT_CONTAINER_NAME,
 } from '../services';
 import { safeExec } from '../utils';
 import { readCachedEisConnectors } from '../eis_connectors_cache';
@@ -52,7 +53,7 @@ const isEdotRunningViaDocker = (): boolean => {
   const result = safeExec('docker', [
     'ps',
     '--filter',
-    'name=kibana-edot-collector',
+    `name=${EDOT_CONTAINER_NAME}`,
     '--format',
     '{{.Names}}',
   ]);

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Command } from '@kbn/dev-cli-runner';
-import { stopAll, stopService, readState, isAlive, type ServiceName } from '../services';
+import { stopAll, stopService, type ServiceName } from '../services';
 
 export const stopCmd: Command<void> = {
   name: 'stop',
@@ -34,17 +34,9 @@ export const stopCmd: Command<void> = {
       }
       await stopService(repoRoot, serviceName, log);
     } else {
-      const state = readState(repoRoot);
-      const edotAlive = state.edot && isAlive(state.edot.pid);
-      const scoutAlive = state.scout && isAlive(state.scout.pid);
-
-      if (!edotAlive && !scoutAlive) {
-        log.info('No managed services are running.');
-        return;
-      }
-
+      // Always run stopAll — Docker containers and orphaned child processes
+      // can outlive the tracked PIDs recorded in services.json.
       await stopAll(repoRoot, log);
-      log.info('All eval services stopped.');
     }
   },
 };

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
@@ -37,6 +37,7 @@ export const stopCmd: Command<void> = {
       // Always run stopAll — Docker containers and orphaned child processes
       // can outlive the tracked PIDs recorded in services.json.
       await stopAll(repoRoot, log);
+      log.info('All eval services stopped.');
     }
   },
 };

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
@@ -37,7 +37,7 @@ export const stopCmd: Command<void> = {
       // Always run stopAll — Docker containers and orphaned child processes
       // can outlive the tracked PIDs recorded in services.json.
       await stopAll(repoRoot, log);
-      log.info('All eval services stopped.');
+      log.info('All eval services have been shut down.');
     }
   },
 };

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/stop.ts
@@ -36,8 +36,12 @@ export const stopCmd: Command<void> = {
     } else {
       // Always run stopAll — Docker containers and orphaned child processes
       // can outlive the tracked PIDs recorded in services.json.
-      await stopAll(repoRoot, log);
-      log.info('All eval services have been shut down.');
+      const didStop = await stopAll(repoRoot, log);
+      if (didStop) {
+        log.info('All eval services have been shut down.');
+      } else {
+        log.info('No managed services were running.');
+      }
     }
   },
 };

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -156,7 +156,7 @@ export const startService = (
   return pid;
 };
 
-const isEdotDockerRunning = (): boolean => {
+export const isEdotDockerRunning = (): boolean => {
   try {
     const result = execFileSync(
       'docker',
@@ -190,10 +190,15 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
       return;
     }
   } catch (err) {
-    const isTimeout =
-      err instanceof Error && (err as unknown as { signal?: string }).signal != null;
-    if (isTimeout) {
+    const signal = (err as Record<string, unknown>).signal;
+    if (signal != null) {
       log.warning('[edot] docker compose down timed out, falling back to docker stop');
+    } else {
+      log.warning(
+        `[edot] docker compose down failed (${
+          err instanceof Error ? err.message : err
+        }), falling back to docker stop`
+      );
     }
   }
 
@@ -296,33 +301,17 @@ export const stopService = async (
   log.info(`[${name}] stopping (PID ${entry.pid})...`);
 
   // Kill the process group (negative PID) so Scout's child ES/Kibana processes also die
-  try {
-    process.kill(-entry.pid, 'SIGTERM');
-  } catch {
-    try {
-      process.kill(entry.pid, 'SIGTERM');
-    } catch {
-      // already dead
-    }
-  }
+  killProcessGroup(entry.pid, 'SIGTERM');
 
-  // Wait up to 10s for graceful shutdown
+  // Wait up to 10s for the entire process group to exit
   const deadline = Date.now() + 10_000;
-  while (isAlive(entry.pid) && Date.now() < deadline) {
+  while (isProcessGroupAlive(entry.pid) && Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, 500));
   }
 
-  if (isAlive(entry.pid)) {
+  if (isProcessGroupAlive(entry.pid)) {
     log.warning(`[${name}] did not stop gracefully, sending SIGKILL`);
-    try {
-      process.kill(-entry.pid, 'SIGKILL');
-    } catch {
-      try {
-        process.kill(entry.pid, 'SIGKILL');
-      } catch {
-        // already dead
-      }
-    }
+    killProcessGroup(entry.pid, 'SIGKILL');
   }
 
   if (name === 'edot') {

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -8,12 +8,14 @@
 import Fs from 'fs';
 import Path from 'path';
 import { createHash } from 'crypto';
-import { spawn, type SpawnOptions } from 'child_process';
+import { execFileSync, spawn, type SpawnOptions } from 'child_process';
 import type { ToolingLog } from '@kbn/tooling-log';
 
 const EVALS_DIR = 'target/evals';
 const STATE_FILE = 'target/evals/services.json';
 const DEFAULT_SERVER_CONFIG_SET = 'evals_tracing';
+const EDOT_DOCKER_COMPOSE_FILE = 'data/edot_collector/docker-compose.yaml';
+export const EDOT_CONTAINER_NAME = 'kibana-edot-collector';
 
 export type ServiceName = 'edot' | 'scout';
 
@@ -155,7 +157,51 @@ export const startService = (
 };
 
 /**
+ * Stop the EDOT Docker container. The container runs independently of the
+ * tracked node process, so killing the PID alone is not enough.
+ */
+const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
+  const composePath = Path.join(repoRoot, EDOT_DOCKER_COMPOSE_FILE);
+
+  try {
+    if (Fs.existsSync(composePath)) {
+      execFileSync('docker', ['compose', '-f', composePath, 'down'], {
+        stdio: 'ignore',
+        timeout: 15_000,
+      });
+      log.info('[edot] Docker container stopped via compose');
+      return;
+    }
+  } catch {
+    // fall through to docker stop
+  }
+
+  try {
+    execFileSync('docker', ['stop', EDOT_CONTAINER_NAME], {
+      stdio: 'ignore',
+      timeout: 15_000,
+    });
+    log.info('[edot] Docker container stopped');
+  } catch {
+    // container not running or docker unavailable
+  }
+};
+
+/**
+ * Best-effort kill of a process group. Useful when the group leader (tracked
+ * PID) has exited but children (ES, Kibana) may still be running.
+ */
+const killProcessGroup = (pid: number, signal: NodeJS.Signals): void => {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    // no remaining group members
+  }
+};
+
+/**
  * Stop a service by PID. Sends SIGTERM, waits briefly, then SIGKILL if needed.
+ * For EDOT, also tears down the Docker container.
  */
 export const stopService = async (
   repoRoot: string,
@@ -166,12 +212,23 @@ export const stopService = async (
   const entry = state[name];
 
   if (!entry) {
+    if (name === 'edot') {
+      stopEdotDockerContainer(repoRoot, log);
+    }
     log.info(`[${name}] no tracked process`);
     return false;
   }
 
   if (!isAlive(entry.pid)) {
-    log.info(`[${name}] already stopped (PID ${entry.pid})`);
+    log.info(`[${name}] tracked process already exited (PID ${entry.pid})`);
+
+    // Children (ES/Kibana) may outlive the process group leader
+    killProcessGroup(entry.pid, 'SIGTERM');
+
+    if (name === 'edot') {
+      stopEdotDockerContainer(repoRoot, log);
+    }
+
     delete state[name];
     writeState(repoRoot, state);
     return false;
@@ -207,6 +264,10 @@ export const stopService = async (
         // already dead
       }
     }
+  }
+
+  if (name === 'edot') {
+    stopEdotDockerContainer(repoRoot, log);
   }
 
   log.info(`[${name}] stopped`);

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -156,11 +156,28 @@ export const startService = (
   return pid;
 };
 
+const isEdotDockerRunning = (): boolean => {
+  try {
+    const result = execFileSync(
+      'docker',
+      ['ps', '--filter', `name=${EDOT_CONTAINER_NAME}`, '--format', '{{.Names}}'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5_000 }
+    ).trim();
+    return result.length > 0;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Stop the EDOT Docker container. The container runs independently of the
  * tracked node process, so killing the PID alone is not enough.
  */
 const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
+  if (!isEdotDockerRunning()) {
+    return;
+  }
+
   const composePath = Path.join(repoRoot, EDOT_DOCKER_COMPOSE_FILE);
 
   try {
@@ -172,8 +189,11 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
       log.info('[edot] Docker container stopped via compose');
       return;
     }
-  } catch {
-    // fall through to docker stop
+  } catch (err) {
+    const isTimeout = err instanceof Error && 'killed' in err;
+    if (isTimeout) {
+      log.warning('[edot] docker compose down timed out, falling back to docker stop');
+    }
   }
 
   try {
@@ -190,12 +210,51 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
 /**
  * Best-effort kill of a process group. Useful when the group leader (tracked
  * PID) has exited but children (ES, Kibana) may still be running.
+ * Returns true if any process in the group was signalled.
  */
-const killProcessGroup = (pid: number, signal: NodeJS.Signals): void => {
+const killProcessGroup = (pid: number, signal: NodeJS.Signals): boolean => {
   try {
     process.kill(-pid, signal);
+    return true;
   } catch {
-    // no remaining group members
+    return false;
+  }
+};
+
+/**
+ * Returns true if any process in the given process group is still alive.
+ */
+const isProcessGroupAlive = (pid: number): boolean => {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Send SIGTERM to a process group, wait up to {@link timeoutMs} for all
+ * members to exit, then SIGKILL any survivors.
+ */
+const terminateProcessGroup = async (
+  pid: number,
+  log: ToolingLog,
+  label: string,
+  timeoutMs = 10_000
+): Promise<void> => {
+  if (!killProcessGroup(pid, 'SIGTERM')) {
+    return;
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessGroupAlive(pid) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  if (isProcessGroupAlive(pid)) {
+    log.warning(`[${label}] orphaned children did not stop gracefully, sending SIGKILL`);
+    killProcessGroup(pid, 'SIGKILL');
   }
 };
 
@@ -212,18 +271,17 @@ export const stopService = async (
   const entry = state[name];
 
   if (!entry) {
+    log.info(`[${name}] no tracked process`);
     if (name === 'edot') {
       stopEdotDockerContainer(repoRoot, log);
     }
-    log.info(`[${name}] no tracked process`);
     return false;
   }
 
   if (!isAlive(entry.pid)) {
     log.info(`[${name}] tracked process already exited (PID ${entry.pid})`);
 
-    // Children (ES/Kibana) may outlive the process group leader
-    killProcessGroup(entry.pid, 'SIGTERM');
+    await terminateProcessGroup(entry.pid, log, name);
 
     if (name === 'edot') {
       stopEdotDockerContainer(repoRoot, log);

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -163,7 +163,7 @@ export const isEdotDockerRunning = (): boolean => {
       ['ps', '--filter', `name=${EDOT_CONTAINER_NAME}`, '--format', '{{.Names}}'],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5_000 }
     ).trim();
-    return result.length > 0;
+    return result.split('\n').some((name) => name.trim() === EDOT_CONTAINER_NAME);
   } catch {
     return false;
   }
@@ -218,11 +218,14 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
  * PID) has exited but children (ES, Kibana) may still be running.
  * Returns true if any process in the group was signalled.
  */
-const killProcessGroup = (pid: number, signal: NodeJS.Signals): boolean => {
+const killProcessGroup = (pid: number, signal: NodeJS.Signals, log?: ToolingLog): boolean => {
   try {
     process.kill(-pid, signal);
     return true;
-  } catch {
+  } catch (err) {
+    if (log && (err as NodeJS.ErrnoException).code !== 'ESRCH') {
+      log.warning(`Failed to signal process group ${pid}: ${(err as Error).message}`);
+    }
     return false;
   }
 };
@@ -249,7 +252,7 @@ const terminateProcessGroup = async (
   label: string,
   timeoutMs = 10_000
 ): Promise<void> => {
-  if (!killProcessGroup(pid, 'SIGTERM')) {
+  if (!killProcessGroup(pid, 'SIGTERM', log)) {
     return;
   }
 
@@ -259,8 +262,8 @@ const terminateProcessGroup = async (
   }
 
   if (isProcessGroupAlive(pid)) {
-    log.warning(`[${label}] orphaned children did not stop gracefully, sending SIGKILL`);
-    killProcessGroup(pid, 'SIGKILL');
+    log.warning(`[${label}] did not stop gracefully, sending SIGKILL`);
+    killProcessGroup(pid, 'SIGKILL', log);
   }
 };
 
@@ -300,19 +303,7 @@ export const stopService = async (
 
   log.info(`[${name}] stopping (PID ${entry.pid})...`);
 
-  // Kill the process group (negative PID) so Scout's child ES/Kibana processes also die
-  killProcessGroup(entry.pid, 'SIGTERM');
-
-  // Wait up to 10s for the entire process group to exit
-  const deadline = Date.now() + 10_000;
-  while (isProcessGroupAlive(entry.pid) && Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 500));
-  }
-
-  if (isProcessGroupAlive(entry.pid)) {
-    log.warning(`[${name}] did not stop gracefully, sending SIGKILL`);
-    killProcessGroup(entry.pid, 'SIGKILL');
-  }
+  await terminateProcessGroup(entry.pid, log, name);
 
   if (name === 'edot') {
     stopEdotDockerContainer(repoRoot, log);

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -183,22 +183,20 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
   try {
     if (Fs.existsSync(composePath)) {
       execFileSync('docker', ['compose', '-f', composePath, 'down'], {
-        stdio: 'ignore',
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
         timeout: 15_000,
       });
       log.info('[edot] Docker container stopped via compose');
       return;
     }
   } catch (err) {
-    const signal = (err as Record<string, unknown>).signal;
+    const { signal, stderr } = err as Record<string, unknown>;
     if (signal != null) {
       log.warning('[edot] docker compose down timed out, falling back to docker stop');
     } else {
-      log.warning(
-        `[edot] docker compose down failed (${
-          err instanceof Error ? err.message : err
-        }), falling back to docker stop`
-      );
+      const detail = typeof stderr === 'string' && stderr.trim() ? stderr.trim() : String(err);
+      log.warning(`[edot] docker compose down failed (${detail}), falling back to docker stop`);
     }
   }
 
@@ -264,6 +262,11 @@ const terminateProcessGroup = async (
   if (isProcessGroupAlive(pid)) {
     log.warning(`[${label}] did not stop gracefully, sending SIGKILL`);
     killProcessGroup(pid, 'SIGKILL', log);
+
+    const killDeadline = Date.now() + 2_000;
+    while (isProcessGroupAlive(pid) && Date.now() < killDeadline) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
   }
 };
 

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -179,10 +179,8 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
 
   const composePath = Path.join(repoRoot, 'data/edot_collector/docker-compose.yaml');
 
-  try {
-    if (!Fs.existsSync(composePath)) {
-      log.info('[edot] compose file not found, using docker stop');
-    } else {
+  if (Fs.existsSync(composePath)) {
+    try {
       execFileSync('docker', ['compose', '-f', composePath, 'down'], {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -190,15 +188,17 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
       });
       log.info('[edot] Docker container stopped via compose');
       return;
+    } catch (err) {
+      const { signal, stderr } = err as Record<string, unknown>;
+      if (signal != null) {
+        log.warning('[edot] docker compose down timed out, falling back to docker stop');
+      } else {
+        const detail = typeof stderr === 'string' && stderr.trim() ? stderr.trim() : String(err);
+        log.warning(`[edot] docker compose down failed (${detail}), falling back to docker stop`);
+      }
     }
-  } catch (err) {
-    const { signal, stderr } = err as Record<string, unknown>;
-    if (signal != null) {
-      log.warning('[edot] docker compose down timed out, falling back to docker stop');
-    } else {
-      const detail = typeof stderr === 'string' && stderr.trim() ? stderr.trim() : String(err);
-      log.warning(`[edot] docker compose down failed (${detail}), falling back to docker stop`);
-    }
+  } else {
+    log.info('[edot] compose file not found, using docker stop');
   }
 
   try {
@@ -306,7 +306,7 @@ export const stopService = async (
 
     delete state[name];
     writeState(repoRoot, state);
-    return false;
+    return true;
   }
 
   log.info(`[${name}] stopping (PID ${entry.pid})...`);

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -190,7 +190,8 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
       return;
     }
   } catch (err) {
-    const isTimeout = err instanceof Error && 'killed' in err;
+    const isTimeout =
+      err instanceof Error && (err as unknown as { signal?: string }).signal != null;
     if (isTimeout) {
       log.warning('[edot] docker compose down timed out, falling back to docker stop');
     }

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -181,7 +181,9 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
   const composePath = Path.join(repoRoot, EDOT_DOCKER_COMPOSE_FILE);
 
   try {
-    if (Fs.existsSync(composePath)) {
+    if (!Fs.existsSync(composePath)) {
+      log.info('[edot] compose file not found, using docker stop');
+    } else {
       execFileSync('docker', ['compose', '-f', composePath, 'down'], {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -267,6 +269,10 @@ const terminateProcessGroup = async (
     while (isProcessGroupAlive(pid) && Date.now() < killDeadline) {
       await new Promise((r) => setTimeout(r, 100));
     }
+
+    if (isProcessGroupAlive(pid)) {
+      log.warning(`[${label}] process group ${pid} still alive after SIGKILL`);
+    }
   }
 };
 
@@ -312,16 +318,21 @@ export const stopService = async (
     stopEdotDockerContainer(repoRoot, log);
   }
 
-  log.info(`[${name}] stopped`);
+  if (isProcessGroupAlive(entry.pid)) {
+    log.warning(`[${name}] may not have fully stopped (PID ${entry.pid})`);
+  } else {
+    log.info(`[${name}] stopped`);
+  }
   delete state[name];
   writeState(repoRoot, state);
   return true;
 };
 
-export const stopAll = async (repoRoot: string, log: ToolingLog): Promise<void> => {
+export const stopAll = async (repoRoot: string, log: ToolingLog): Promise<boolean> => {
   // Stop Scout first (it has child processes), then EDOT
-  await stopService(repoRoot, 'scout', log);
-  await stopService(repoRoot, 'edot', log);
+  const scoutStopped = await stopService(repoRoot, 'scout', log);
+  const edotStopped = await stopService(repoRoot, 'edot', log);
+  return scoutStopped || edotStopped;
 };
 
 /**

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/services.ts
@@ -14,7 +14,6 @@ import type { ToolingLog } from '@kbn/tooling-log';
 const EVALS_DIR = 'target/evals';
 const STATE_FILE = 'target/evals/services.json';
 const DEFAULT_SERVER_CONFIG_SET = 'evals_tracing';
-const EDOT_DOCKER_COMPOSE_FILE = 'data/edot_collector/docker-compose.yaml';
 export const EDOT_CONTAINER_NAME = 'kibana-edot-collector';
 
 export type ServiceName = 'edot' | 'scout';
@@ -178,7 +177,7 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
     return;
   }
 
-  const composePath = Path.join(repoRoot, EDOT_DOCKER_COMPOSE_FILE);
+  const composePath = Path.join(repoRoot, 'data/edot_collector/docker-compose.yaml');
 
   try {
     if (!Fs.existsSync(composePath)) {
@@ -208,8 +207,8 @@ const stopEdotDockerContainer = (repoRoot: string, log: ToolingLog): void => {
       timeout: 15_000,
     });
     log.info('[edot] Docker container stopped');
-  } catch {
-    // container not running or docker unavailable
+  } catch (err) {
+    log.warning(`[edot] docker stop failed (${err instanceof Error ? err.message : err})`);
   }
 };
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/272348

## Summary

Fixes `node scripts/evals stop` failing to actually stop the EDOT collector and Scout server (ES/Kibana) in two scenarios:

- **EDOT**: The stop command only killed the tracked node process, but the Docker container (`kibana-edot-collector`) runs independently and was never torn down. Now calls `docker compose down` (or `docker stop` as fallback) when stopping EDOT.
- **Scout**: When the tracked Scout process exited while ES/Kibana children were still running, the stop command bailed early with "No managed services are running" without attempting to kill the orphaned process group. Now always attempts a process group kill even when the leader PID is dead.

Also consolidates the hardcoded `kibana-edot-collector` container name into a shared `EDOT_CONTAINER_NAME` constant.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


