### PR TITLE
[CI] Set `cancel_intermediate_builds` on Kibana VM image builds

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
@@ -26,6 +26,7 @@ spec:
       pipeline_file: vm-images/.buildkite/pipeline.yml
       provider_settings:
         trigger_mode: none
+      cancel_intermediate_builds: true
       schedules:
         "[ubuntu24.04] Weekly Base Image Build":
           branch: main


### PR DESCRIPTION
## Summary
VM image builds, when started close to each other, will create a failure due to shared resource usage, to prevent, we can terminate running builds when a new one starts.