### PR TITLE
[Entity Store] Fix castField missing for single-field identity EUID evaluation

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
@@ -267,7 +267,7 @@ describe('getEuidEsqlEvaluation', () => {
   it('returns raw field for generic (skipTypePrepend: no type prefix)', () => {
     const result = getEuidEsqlEvaluation('generic');
 
-    const expected = 'entity.id';
+    const expected = 'TO_STRING(entity.id)';
     expect(normalize(result)).toBe(normalize(expected));
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
@@ -352,7 +352,11 @@ export function getEuidEsqlEvaluation(
   const mustPrependTypeId = withTypeId && !identityField.skipTypePrepend;
 
   if (isSingleFieldIdentity(identityField)) {
-    return appendTypeIdIfNeeded(entityType, identityField.singleField, mustPrependTypeId);
+    return appendTypeIdIfNeeded(
+      entityType,
+      castField(identityField.singleField),
+      mustPrependTypeId
+    );
   }
 
   const { euidRanking } = identityField;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
@@ -506,7 +506,7 @@ FROM remote_cluster:logs-*
  _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
  _src_entity_source = CASE((_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\"), _src_entity_source0, (_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\"), _src_entity_source1, (_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\"), _src_entity_source2, NULL),
  entity.source = CASE((_src_entity_source IS NULL OR _src_entity_source == \\"\\"), NULL, _src_entity_source)
-| EVAL entity.id = entity.id
+| EVAL entity.id = TO_STRING(entity.id)
 | STATS
     @timestamp = MAX(@timestamp),
     entity.EngineMetadata.FirstSeenLogInPage = MIN(@timestamp),

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
@@ -12,7 +12,7 @@ FROM test-index-*
  _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
  _src_entity_source = CASE((_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\"), _src_entity_source0, (_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\"), _src_entity_source1, (_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\"), _src_entity_source2, NULL),
  entity.source = CASE((_src_entity_source IS NULL OR _src_entity_source == \\"\\"), NULL, _src_entity_source)
-| EVAL recent.entity.EngineMetadata.UntypedId = entity.id
+| EVAL recent.entity.EngineMetadata.UntypedId = TO_STRING(entity.id)
 | STATS
     entity.EngineMetadata.FirstSeenLogInPage = MIN(@timestamp),
     recent.timestamp = MAX(@timestamp),
@@ -1240,7 +1240,7 @@ FROM test-index-*
  _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
  _src_entity_source = CASE((_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\"), _src_entity_source0, (_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\"), _src_entity_source1, (_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\"), _src_entity_source2, NULL),
  entity.source = CASE((_src_entity_source IS NULL OR _src_entity_source == \\"\\"), NULL, _src_entity_source)
-| EVAL recent.entity.EngineMetadata.UntypedId = service.name
+| EVAL recent.entity.EngineMetadata.UntypedId = TO_STRING(service.name)
 | STATS
     entity.EngineMetadata.FirstSeenLogInPage = MIN(@timestamp),
     recent.timestamp = MAX(@timestamp),

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction_broken_mapping.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction_broken_mapping.spec.ts
@@ -115,6 +115,23 @@ const EXPECTED_USER_LATEST_SOURCES = [
   },
 ] as const;
 
+/**
+ * Full expected `_source` for the service entity. service.name is long in source —
+ * TO_STRING (via castField) converts 99999 → "99999" for the EUID and stored value.
+ */
+const EXPECTED_SERVICE_LATEST_SOURCES = [
+  {
+    '@timestamp': '2026-04-14T10:03:00.000Z',
+    entity: {
+      id: 'service:99999',
+      name: '99999',
+      type: 'Service',
+      EngineMetadata: { Type: 'service', UntypedId: '99999' },
+    },
+    service: { name: '99999' },
+  },
+] as const;
+
 const matchExpectedLatestSources = <T extends { entity: { id: string } }>(
   hits: ReadonlyArray<{ _source?: unknown }>,
   expectedDocuments: readonly T[]
@@ -185,6 +202,12 @@ const createBrokenMappingTemplate = async (esClient: EsClient) => {
               outcome: { type: 'text' },
               module: { type: 'text' },
               dataset: { type: 'text' }, // used in entity.source field evaluation; tests text mapping in SPLIT/MV_FIRST path
+            },
+          },
+          // Service identity field; tests long → string coercion via castField (TO_STRING)
+          service: {
+            properties: {
+              name: { type: 'long' }, // expected as keyword in entity definition
             },
           },
           data_stream: {
@@ -283,6 +306,20 @@ const cleanupBrokenMappingArtifacts = async (esClient: EsClient) => {
   await esClient.indices.deleteIndexTemplate({ name: BROKEN_MAPPING_TEMPLATE }, { ignore: [404] });
 };
 
+const ingestBrokenServiceDoc = async (esClient: EsClient) => {
+  const bulkResponse = await esClient.bulk({
+    refresh: 'wait_for',
+    operations: [
+      { create: { _index: BROKEN_MAPPING_DATA_STREAM } },
+      {
+        '@timestamp': '2026-04-14T10:03:00Z',
+        service: { name: 99999 },
+      },
+    ],
+  });
+  expect(bulkResponse.errors).toBe(false);
+};
+
 apiTest.describe('Entity Store logs extraction broken mapping', { tag: ENTITY_STORE_TAGS }, () => {
   let defaultHeaders: Record<string, string>;
   let internalHeaders: Record<string, string>;
@@ -315,6 +352,7 @@ apiTest.describe('Entity Store logs extraction broken mapping', { tag: ENTITY_ST
       { name: BROKEN_MAPPING_DATA_STREAM },
       { ignore: [400] }
     );
+
   });
 
   apiTest.afterAll(async ({ apiClient, esClient }) => {
@@ -508,6 +546,51 @@ apiTest.describe('Entity Store logs extraction broken mapping', { tag: ENTITY_ST
         },
       });
       matchExpectedLatestSources(bothUsers.hits.hits, EXPECTED_USER_LATEST_SOURCES);
+    }
+  );
+
+  apiTest(
+    'should extract service successfully when service.name is mapped as long (triggers castField ambiguity fix)',
+    async ({ apiClient, esClient }) => {
+      await ingestBrokenServiceDoc(esClient);
+
+      const extractionResponse = await apiClient.post(
+        ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('service'),
+        {
+          headers: internalHeaders,
+          responseType: 'json',
+          body: {
+            fromDateISO: FROM_DATE,
+            toDateISO: TO_DATE,
+          },
+        }
+      );
+
+      expect(extractionResponse.statusCode).toBe(200);
+      expect(extractionResponse.body).toMatchObject({
+        success: true,
+        count: 1,
+        pages: 1,
+      });
+
+      await esClient.indices.refresh({ index: LATEST_ALIAS });
+      const serviceEntities = await esClient.search({
+        index: LATEST_ALIAS,
+        size: 10,
+        query: {
+          bool: {
+            filter: [
+              { term: { 'entity.EngineMetadata.Type': 'service' } },
+              {
+                terms: {
+                  'entity.id': ['service:99999'],
+                },
+              },
+            ],
+          },
+        },
+      });
+      matchExpectedLatestSources(serviceEntities.hits.hits, EXPECTED_SERVICE_LATEST_SOURCES);
     }
   );
 });

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction_broken_mapping.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction_broken_mapping.spec.ts
@@ -352,7 +352,6 @@ apiTest.describe('Entity Store logs extraction broken mapping', { tag: ENTITY_ST
       { name: BROKEN_MAPPING_DATA_STREAM },
       { ignore: [400] }
     );
-
   });
 
   apiTest.afterAll(async ({ apiClient, esClient }) => {


### PR DESCRIPTION
## Summary

we got errors like this:

```
Logs extraction failed for service: verification_exception
    Root causes:
        verification_exception: Found 1 problem
line 12:49: Cannot use field [service.name] due to ambiguities being mapped as [2] in
```

the fix is same as in https://github.com/elastic/kibana/pull/271927 - `castField`, in this case - for `identityField.singleField`


<details><summary> Manual Test</summary>

#### Setup - conflicting mappings:
```
PUT _index_template/broken-service-template
{ "priority": 500, "index_patterns": ["logs-broken-service*"], "data_stream": {},
    "template": { "mappings": { "properties": {
      "@timestamp": { "type": "date" },
      "service": { "properties": { "name": { "type": "long" } } }
}}}}
```

```PUT _data_stream/logs-good-service```
```
POST logs-good-service/_doc
{ "@timestamp": "2026-04-14T10:00:00Z", "service": { "name": "my-svc" } }
```

 ```PUT _data_stream/logs-broken-service```
  ```
POST logs-broken-service/_doc
{ "@timestamp": "2026-04-14T10:00:00Z", "service": { "name": 12345 } }
```

#### Reproduce:
```
POST kbn:/internal/security/entity_store/service/force_log_extraction?apiVersion=2
{ "fromDateISO": "2026-04-14T00:00:00Z", "toDateISO": "2026-04-14T23:59:59Z" }
```
 
**Before**: `verification_exception` for `service.name`. **After**: `{ success: true, count: 2 }`.
</details> 

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->