### PR TITLE
[9.4] [Entity Store] Add SET unmapped_fields="nullify" to local extraction queries (#272274)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`buildLogPaginationCursorProbeEsql sorts ASC, limits, then aggregates MAX(timestamp) and COUNT(*) 1`] = `
-"FROM logs-*
+"SET unmapped_fields=\\"nullify\\";
+FROM logs-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2024-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2024-01-02T00:00:00.000Z\\")

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for generic entity description 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -277,7 +278,8 @@ asset*,
 `;
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for host entity description 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -591,7 +593,8 @@ data_stream*,
 `;
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for host with pagination 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -908,7 +911,8 @@ data_stream*,
 `;
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for host with recoveryId 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1225,7 +1229,8 @@ data_stream*,
 `;
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for service entity description 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1472,7 +1477,8 @@ data_stream*,
 `;
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for user entity description 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1748,7 +1754,8 @@ host*,
 `;
 
 exports[`buildRemainingLogsCountQuery generates the expected query for generic entity type 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1757,7 +1764,8 @@ exports[`buildRemainingLogsCountQuery generates the expected query for generic e
 `;
 
 exports[`buildRemainingLogsCountQuery generates the expected query for host entity type 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1766,7 +1774,8 @@ exports[`buildRemainingLogsCountQuery generates the expected query for host enti
 `;
 
 exports[`buildRemainingLogsCountQuery generates the expected query for service entity type 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1775,7 +1784,8 @@ exports[`buildRemainingLogsCountQuery generates the expected query for service e
 `;
 
 exports[`buildRemainingLogsCountQuery generates the expected query for user entity type 1`] = `
-"FROM test-index-*
+"SET unmapped_fields=\\"nullify\\";
+FROM test-index-*
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
@@ -401,16 +401,14 @@ export class CcsLogsExtractionClient {
     maxLogsPerPage: number;
     abortController?: AbortController;
   }): Promise<LogPaginationCursor> {
-    const probeQuery =
-      `SET unmapped_fields="nullify";\n` +
-      buildLogPaginationCursorProbeEsql({
-        indexPatterns: remoteIndexPatterns,
-        type,
-        fromDateISO,
-        toDateISO,
-        logsPageCursorStart: sliceStart,
-        maxLogsPerPage,
-      });
+    const probeQuery = buildLogPaginationCursorProbeEsql({
+      indexPatterns: remoteIndexPatterns,
+      type,
+      fromDateISO,
+      toDateISO,
+      logsPageCursorStart: sliceStart,
+      maxLogsPerPage,
+    });
 
     this.logger.info(
       `CCS probe: from=${fromDateISO} to=${toDateISO}${

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.ts
@@ -23,6 +23,7 @@ import {
   extractPaginationParams,
   buildPaginationSection,
   hasFieldEvaluations,
+  NULLIFY_UNMAPPED_FIELDS_SETTING,
 } from './query_builder_commons';
 
 const CCS_FIELDS_TO_KEEP = [
@@ -69,7 +70,7 @@ export function buildCcsLogsExtractionEsqlQuery({
   const parts = [];
 
   // Because we don't have updates on remote clusters, we need to nullify the unmapped fields
-  parts.push(`SET unmapped_fields="nullify";`);
+  parts.push(NULLIFY_UNMAPPED_FIELDS_SETTING);
 
   // FROM and WHERE
   parts.push(

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
@@ -8,6 +8,7 @@
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import {
   buildLogPageProbeSourceClause,
+  NULLIFY_UNMAPPED_FIELDS_SETTING,
   TIMESTAMP_FIELD,
   type LogPageProbeSourceClauseParams,
   type LogSlicePaginationParams,
@@ -27,6 +28,7 @@ export function buildLogPaginationCursorProbeEsql(
 ): string {
   const { maxLogsPerPage, ...sourceParams } = params;
   return (
+    `${NULLIFY_UNMAPPED_FIELDS_SETTING}\n` +
     buildLogPageProbeSourceClause(sourceParams) +
     `
   | SORT ${TIMESTAMP_FIELD} ASC

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.ts
@@ -40,6 +40,7 @@ import {
   buildPaginationSection,
   hasFieldEvaluations,
   mapPostAggFilterFieldsToRecentForEsql,
+  NULLIFY_UNMAPPED_FIELDS_SETTING,
 } from './query_builder_commons';
 
 export const HASHED_ID_FIELD = 'entity.hashedId';
@@ -81,6 +82,7 @@ export function buildRemainingLogsCountQuery(params: {
   logsPageCursorStart?: LogSlicePaginationParams;
 }): string {
   return (
+    `${NULLIFY_UNMAPPED_FIELDS_SETTING}\n` +
     buildLogPageProbeSourceClause(params) +
     `
   | STATS document_count = COUNT()`
@@ -102,6 +104,8 @@ export function buildLogsExtractionEsqlQuery({
   const { fields, type, entityTypeFallback } = entityDefinition;
 
   const parts = [];
+
+  parts.push(`${NULLIFY_UNMAPPED_FIELDS_SETTING}`);
 
   // FROM and WHERE
   parts.push(

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.ts
@@ -46,6 +46,8 @@ export const ENTITY_NAME_FIELD = 'entity.name';
 export const ENTITY_TYPE_FIELD = 'entity.type';
 export const TIMESTAMP_FIELD = '@timestamp';
 
+export const NULLIFY_UNMAPPED_FIELDS_SETTING = 'SET unmapped_fields="nullify";';
+
 export interface PaginationParams {
   timestampCursor: string;
   idCursor: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Store] Add SET unmapped_fields="nullify" to local extraction queries (#272274)](https://github.com/elastic/kibana/pull/272274)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rômulo Farias","email":"romulo.farias@elastic.co"},"sourceCommit":{"committedDate":"2026-06-02T13:34:15Z","message":"[Entity Store] Add SET unmapped_fields=\"nullify\" to local extraction queries (#272274)\n\n## Summary\n\n- Adds `SET unmapped_fields=\"nullify\"` to all three local ES|QL query\nbuilders: `buildLogsExtractionEsqlQuery`,\n`buildRemainingLogsCountQuery`, and `buildLogPaginationCursorProbeEsql`\n- Removes the now-redundant manual prepend of the directive in\n`ccs_logs_extraction_client` (since it is now embedded in\n`buildLogPaginationCursorProbeEsql`)\n- Updates snapshots accordingly\n\n## Problem\n\nIn some production deployments, the entity store extraction fails with:\n\n```\nverification_exception: Found 4 problems\nline 5:23: Unknown column [event.outcome]\nline 5:103: Unknown column [user.email]\nline 5:172: Unknown column [user.id]\nline 5:235: Unknown column [user.name]\n```\n\nES|QL validates referenced fields at query parse time against the\n**actual backing index mappings** of all indices in the `FROM` clause.\nIf a field isn't explicitly mapped in any of them, the query fails. This\nhappens when:\n\n1. The `logs-*` indices use non-ECS field types (no explicit ECS field\nmappings)\n2. The updates data stream backing index was created before\n`ecs@mappings` was included in its template (e.g. an older install that\nhasn't rolled over since the template was updated)\n\nThe CCS path already applied `SET unmapped_fields=\"nullify\"` for the\nsame reason (remote clusters may not have the updates data stream). This\nPR aligns the local path with it.\n\n## Test plan\n\n- [ ] Run entity store extraction against indices with non-ECS field\nmappings (e.g. `host.id` as `long`, `user.name` as `ip`, missing\n`user.id` mapping) — extraction should complete without\n`verification_exception`\n- [ ] Snapshot tests pass (`logs_extraction_query_builder`,\n`log_pagination_probe_query_builder`,\n`ccs_logs_extraction_query_builder`)\n\n<details>\n  <summary> Manual Test Plan </summary>\n  \n  ```\n# ──────────────────────────────────────────────\n# 0. Shared ingest pipeline — injects @timestamp if missing\n# ──────────────────────────────────────────────\nPUT _ingest/pipeline/add-timestamp\n{\n  \"processors\": [\n    {\n      \"set\": {\n        \"field\": \"@timestamp\",\n        \"value\": \"{{_ingest.timestamp}}\",\n        \"override\": false\n      }\n    }\n  ]\n}\n\n\n# ──────────────────────────────────────────────\n# 1. host.id as long\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_long\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_long-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"long\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_long-default/_doc\n{ \"host\": { \"id\": 1001, \"name\": \"host-alpha\" }, \"user\": { \"name\":\n\"alice\", \"id\": \"u-001\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_long-default/_doc\n{ \"host\": { \"id\": 1002, \"name\": \"host-beta\" }, \"user\": { \"name\": \"bob\",\n\"id\": \"u-002\" }, \"event\": { \"outcome\": \"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 2. host.id as keyword\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_keyword\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_keyword-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_keyword-default/_doc\n{ \"host\": { \"id\": \"host-id-kw-001\", \"name\": \"host-gamma\" }, \"user\": {\n\"name\": \"carol\", \"id\": \"u-003\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_keyword-default/_doc\n{ \"host\": { \"id\": \"host-id-kw-002\", \"name\": \"host-delta\" }, \"user\": {\n\"name\": \"dave\", \"id\": \"u-004\" }, \"event\": { \"outcome\": \"failure\" } }\n\n\n# ──────────────────────────────────────────────\n# 3. host.id as text\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_text\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_text-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"text\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_text-default/_doc\n{ \"host\": { \"id\": \"free text host identifier alpha\", \"name\":\n\"host-epsilon\" }, \"user\": { \"name\": \"eve\", \"id\": \"u-005\" }, \"event\": {\n\"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_text-default/_doc\n{ \"host\": { \"id\": \"free text host identifier beta\", \"name\": \"host-zeta\"\n}, \"user\": { \"name\": \"frank\", \"id\": \"u-006\" }, \"event\": { \"outcome\":\n\"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 4. user.name as long\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_long\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_long-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"long\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_long-default/_doc\n{ \"host\": { \"id\": \"h-007\", \"name\": \"host-eta\" }, \"user\": { \"name\": 7001,\n\"id\": \"u-007\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_user_name_long-default/_doc\n{ \"host\": { \"id\": \"h-008\", \"name\": \"host-theta\" }, \"user\": { \"name\":\n7002, \"id\": \"u-008\" }, \"event\": { \"outcome\": \"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 5. user.name as ip\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_ip\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_ip-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"ip\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_ip-default/_doc\n{ \"host\": { \"id\": \"h-009\", \"name\": \"host-iota\" }, \"user\": { \"name\":\n\"10.0.0.9\", \"id\": \"u-009\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_user_name_ip-default/_doc\n{ \"host\": { \"id\": \"h-010\", \"name\": \"host-kappa\" }, \"user\": { \"name\":\n\"10.0.0.10\", \"id\": \"u-010\" }, \"event\": { \"outcome\": \"failure\" } }\n\n\n# ──────────────────────────────────────────────\n# 6. user.name as text\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_text\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_text-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"text\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_text-default/_doc\n{ \"host\": { \"id\": \"h-011\", \"name\": \"host-lambda\" }, \"user\": { \"name\":\n\"full text username eleven\", \"id\": \"u-011\" }, \"event\": { \"outcome\":\n\"success\" } }\n\nPOST logs-test.conflict_user_name_text-default/_doc\n{ \"host\": { \"id\": \"h-012\", \"name\": \"host-mu\" }, \"user\": { \"name\": \"full\ntext username twelve\", \"id\": \"u-012\" }, \"event\": { \"outcome\": \"success\"\n} }\n\n\n# ──────────────────────────────────────────────\n# 7. user.id missing from mapping entirely\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_id_missing\n{\n  \"index_patterns\": [\"logs-test.conflict_user_id_missing-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"dynamic\": \"false\",\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\":  { \"type\": \"keyword\" },\n            \"email\": { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_id_missing-default/_doc\n{ \"host\": { \"id\": \"h-013\", \"name\": \"host-nu\" }, \"user\": { \"name\":\n\"grace\", \"email\": \"grace@example.com\" }, \"event\": { \"outcome\": \"success\"\n} }\n\nPOST logs-test.conflict_user_id_missing-default/_doc\n{ \"host\": { \"id\": \"h-014\", \"name\": \"host-xi\" }, \"user\": { \"name\":\n\"henry\", \"email\": \"henry@example.com\" }, \"event\": { \"outcome\": \"success\"\n} }\n\n  # ──────────────────────────────────────────────\n  # 8. IDP (okta) — event.kind and event.module as text, no host\n  # ──────────────────────────────────────────────\n  PUT _index_template/logs-test.conflict_idp_okta\n  {\n    \"index_patterns\": [\"logs-test.conflict_idp_okta-*\"],\n    \"data_stream\": {},\n    \"template\": {\n      \"settings\": {\n        \"default_pipeline\": \"add-timestamp\"\n      },\n      \"mappings\": {\n        \"properties\": {\n          \"@timestamp\": { \"type\": \"date\" },\n          \"user\": {\n            \"properties\": {\n              \"name\": { \"type\": \"keyword\" }\n            }\n          },\n          \"event\": {\n            \"properties\": {\n              \"kind\":   { \"type\": \"text\" },\n              \"module\": { \"type\": \"text\" }\n            }\n          }\n        }\n      }\n    }\n  }\n\n  POST logs-test.conflict_idp_okta-default/_doc\n{ \"user\": { \"name\": \"$3c_br0k3n_username!\" }, \"event\": { \"kind\":\n\"asset\", \"module\": \"okta\" } }\n  ```\n </details>\n \n Test should create 27 entities\n Hosts (names:\n  - host-alpha\n  - host-beta\n  - host-gamma\n  - host-delta\n  - host-epsilon\n  - host-zeta\n  - host-eta\n  - host-theta\n  - host-iota\n  - host-kappa\n  - host-lambda\n  - host-mu\n  - host-nu\n  - host-xi\n\n  Users (names):\n  - alice@host-alpha\n  - bob@host-beta\n  - carol@host-gamma\n  - 7001@host-eta\n  - 7002@host-theta\n  - 10.0.0.9@host-iota\n  - grace@host-nu\n  - henry@host-xi\n  - eve@host-epsilon\n  - frank@host-zeta\n  - full text username eleven@host-lambda\n  - full text username twelve@host-mu\n  - $3c_br0k3n_username! (okta namespace)\n\n🤖 Generated with [Claude Code](https://claude.ai/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"19f5f8cbd89599fc1ab0db4fd70b3d86104d3038","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.3"],"title":"[Entity Store] Add SET unmapped_fields=\"nullify\" to local extraction queries","number":272274,"url":"https://github.com/elastic/kibana/pull/272274","mergeCommit":{"message":"[Entity Store] Add SET unmapped_fields=\"nullify\" to local extraction queries (#272274)\n\n## Summary\n\n- Adds `SET unmapped_fields=\"nullify\"` to all three local ES|QL query\nbuilders: `buildLogsExtractionEsqlQuery`,\n`buildRemainingLogsCountQuery`, and `buildLogPaginationCursorProbeEsql`\n- Removes the now-redundant manual prepend of the directive in\n`ccs_logs_extraction_client` (since it is now embedded in\n`buildLogPaginationCursorProbeEsql`)\n- Updates snapshots accordingly\n\n## Problem\n\nIn some production deployments, the entity store extraction fails with:\n\n```\nverification_exception: Found 4 problems\nline 5:23: Unknown column [event.outcome]\nline 5:103: Unknown column [user.email]\nline 5:172: Unknown column [user.id]\nline 5:235: Unknown column [user.name]\n```\n\nES|QL validates referenced fields at query parse time against the\n**actual backing index mappings** of all indices in the `FROM` clause.\nIf a field isn't explicitly mapped in any of them, the query fails. This\nhappens when:\n\n1. The `logs-*` indices use non-ECS field types (no explicit ECS field\nmappings)\n2. The updates data stream backing index was created before\n`ecs@mappings` was included in its template (e.g. an older install that\nhasn't rolled over since the template was updated)\n\nThe CCS path already applied `SET unmapped_fields=\"nullify\"` for the\nsame reason (remote clusters may not have the updates data stream). This\nPR aligns the local path with it.\n\n## Test plan\n\n- [ ] Run entity store extraction against indices with non-ECS field\nmappings (e.g. `host.id` as `long`, `user.name` as `ip`, missing\n`user.id` mapping) — extraction should complete without\n`verification_exception`\n- [ ] Snapshot tests pass (`logs_extraction_query_builder`,\n`log_pagination_probe_query_builder`,\n`ccs_logs_extraction_query_builder`)\n\n<details>\n  <summary> Manual Test Plan </summary>\n  \n  ```\n# ──────────────────────────────────────────────\n# 0. Shared ingest pipeline — injects @timestamp if missing\n# ──────────────────────────────────────────────\nPUT _ingest/pipeline/add-timestamp\n{\n  \"processors\": [\n    {\n      \"set\": {\n        \"field\": \"@timestamp\",\n        \"value\": \"{{_ingest.timestamp}}\",\n        \"override\": false\n      }\n    }\n  ]\n}\n\n\n# ──────────────────────────────────────────────\n# 1. host.id as long\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_long\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_long-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"long\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_long-default/_doc\n{ \"host\": { \"id\": 1001, \"name\": \"host-alpha\" }, \"user\": { \"name\":\n\"alice\", \"id\": \"u-001\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_long-default/_doc\n{ \"host\": { \"id\": 1002, \"name\": \"host-beta\" }, \"user\": { \"name\": \"bob\",\n\"id\": \"u-002\" }, \"event\": { \"outcome\": \"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 2. host.id as keyword\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_keyword\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_keyword-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_keyword-default/_doc\n{ \"host\": { \"id\": \"host-id-kw-001\", \"name\": \"host-gamma\" }, \"user\": {\n\"name\": \"carol\", \"id\": \"u-003\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_keyword-default/_doc\n{ \"host\": { \"id\": \"host-id-kw-002\", \"name\": \"host-delta\" }, \"user\": {\n\"name\": \"dave\", \"id\": \"u-004\" }, \"event\": { \"outcome\": \"failure\" } }\n\n\n# ──────────────────────────────────────────────\n# 3. host.id as text\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_text\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_text-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"text\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_text-default/_doc\n{ \"host\": { \"id\": \"free text host identifier alpha\", \"name\":\n\"host-epsilon\" }, \"user\": { \"name\": \"eve\", \"id\": \"u-005\" }, \"event\": {\n\"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_text-default/_doc\n{ \"host\": { \"id\": \"free text host identifier beta\", \"name\": \"host-zeta\"\n}, \"user\": { \"name\": \"frank\", \"id\": \"u-006\" }, \"event\": { \"outcome\":\n\"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 4. user.name as long\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_long\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_long-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"long\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_long-default/_doc\n{ \"host\": { \"id\": \"h-007\", \"name\": \"host-eta\" }, \"user\": { \"name\": 7001,\n\"id\": \"u-007\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_user_name_long-default/_doc\n{ \"host\": { \"id\": \"h-008\", \"name\": \"host-theta\" }, \"user\": { \"name\":\n7002, \"id\": \"u-008\" }, \"event\": { \"outcome\": \"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 5. user.name as ip\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_ip\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_ip-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"ip\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_ip-default/_doc\n{ \"host\": { \"id\": \"h-009\", \"name\": \"host-iota\" }, \"user\": { \"name\":\n\"10.0.0.9\", \"id\": \"u-009\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_user_name_ip-default/_doc\n{ \"host\": { \"id\": \"h-010\", \"name\": \"host-kappa\" }, \"user\": { \"name\":\n\"10.0.0.10\", \"id\": \"u-010\" }, \"event\": { \"outcome\": \"failure\" } }\n\n\n# ──────────────────────────────────────────────\n# 6. user.name as text\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_text\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_text-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"text\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_text-default/_doc\n{ \"host\": { \"id\": \"h-011\", \"name\": \"host-lambda\" }, \"user\": { \"name\":\n\"full text username eleven\", \"id\": \"u-011\" }, \"event\": { \"outcome\":\n\"success\" } }\n\nPOST logs-test.conflict_user_name_text-default/_doc\n{ \"host\": { \"id\": \"h-012\", \"name\": \"host-mu\" }, \"user\": { \"name\": \"full\ntext username twelve\", \"id\": \"u-012\" }, \"event\": { \"outcome\": \"success\"\n} }\n\n\n# ──────────────────────────────────────────────\n# 7. user.id missing from mapping entirely\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_id_missing\n{\n  \"index_patterns\": [\"logs-test.conflict_user_id_missing-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"dynamic\": \"false\",\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\":  { \"type\": \"keyword\" },\n            \"email\": { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_id_missing-default/_doc\n{ \"host\": { \"id\": \"h-013\", \"name\": \"host-nu\" }, \"user\": { \"name\":\n\"grace\", \"email\": \"grace@example.com\" }, \"event\": { \"outcome\": \"success\"\n} }\n\nPOST logs-test.conflict_user_id_missing-default/_doc\n{ \"host\": { \"id\": \"h-014\", \"name\": \"host-xi\" }, \"user\": { \"name\":\n\"henry\", \"email\": \"henry@example.com\" }, \"event\": { \"outcome\": \"success\"\n} }\n\n  # ──────────────────────────────────────────────\n  # 8. IDP (okta) — event.kind and event.module as text, no host\n  # ──────────────────────────────────────────────\n  PUT _index_template/logs-test.conflict_idp_okta\n  {\n    \"index_patterns\": [\"logs-test.conflict_idp_okta-*\"],\n    \"data_stream\": {},\n    \"template\": {\n      \"settings\": {\n        \"default_pipeline\": \"add-timestamp\"\n      },\n      \"mappings\": {\n        \"properties\": {\n          \"@timestamp\": { \"type\": \"date\" },\n          \"user\": {\n            \"properties\": {\n              \"name\": { \"type\": \"keyword\" }\n            }\n          },\n          \"event\": {\n            \"properties\": {\n              \"kind\":   { \"type\": \"text\" },\n              \"module\": { \"type\": \"text\" }\n            }\n          }\n        }\n      }\n    }\n  }\n\n  POST logs-test.conflict_idp_okta-default/_doc\n{ \"user\": { \"name\": \"$3c_br0k3n_username!\" }, \"event\": { \"kind\":\n\"asset\", \"module\": \"okta\" } }\n  ```\n </details>\n \n Test should create 27 entities\n Hosts (names:\n  - host-alpha\n  - host-beta\n  - host-gamma\n  - host-delta\n  - host-epsilon\n  - host-zeta\n  - host-eta\n  - host-theta\n  - host-iota\n  - host-kappa\n  - host-lambda\n  - host-mu\n  - host-nu\n  - host-xi\n\n  Users (names):\n  - alice@host-alpha\n  - bob@host-beta\n  - carol@host-gamma\n  - 7001@host-eta\n  - 7002@host-theta\n  - 10.0.0.9@host-iota\n  - grace@host-nu\n  - henry@host-xi\n  - eve@host-epsilon\n  - frank@host-zeta\n  - full text username eleven@host-lambda\n  - full text username twelve@host-mu\n  - $3c_br0k3n_username! (okta namespace)\n\n🤖 Generated with [Claude Code](https://claude.ai/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"19f5f8cbd89599fc1ab0db4fd70b3d86104d3038"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272274","number":272274,"mergeCommit":{"message":"[Entity Store] Add SET unmapped_fields=\"nullify\" to local extraction queries (#272274)\n\n## Summary\n\n- Adds `SET unmapped_fields=\"nullify\"` to all three local ES|QL query\nbuilders: `buildLogsExtractionEsqlQuery`,\n`buildRemainingLogsCountQuery`, and `buildLogPaginationCursorProbeEsql`\n- Removes the now-redundant manual prepend of the directive in\n`ccs_logs_extraction_client` (since it is now embedded in\n`buildLogPaginationCursorProbeEsql`)\n- Updates snapshots accordingly\n\n## Problem\n\nIn some production deployments, the entity store extraction fails with:\n\n```\nverification_exception: Found 4 problems\nline 5:23: Unknown column [event.outcome]\nline 5:103: Unknown column [user.email]\nline 5:172: Unknown column [user.id]\nline 5:235: Unknown column [user.name]\n```\n\nES|QL validates referenced fields at query parse time against the\n**actual backing index mappings** of all indices in the `FROM` clause.\nIf a field isn't explicitly mapped in any of them, the query fails. This\nhappens when:\n\n1. The `logs-*` indices use non-ECS field types (no explicit ECS field\nmappings)\n2. The updates data stream backing index was created before\n`ecs@mappings` was included in its template (e.g. an older install that\nhasn't rolled over since the template was updated)\n\nThe CCS path already applied `SET unmapped_fields=\"nullify\"` for the\nsame reason (remote clusters may not have the updates data stream). This\nPR aligns the local path with it.\n\n## Test plan\n\n- [ ] Run entity store extraction against indices with non-ECS field\nmappings (e.g. `host.id` as `long`, `user.name` as `ip`, missing\n`user.id` mapping) — extraction should complete without\n`verification_exception`\n- [ ] Snapshot tests pass (`logs_extraction_query_builder`,\n`log_pagination_probe_query_builder`,\n`ccs_logs_extraction_query_builder`)\n\n<details>\n  <summary> Manual Test Plan </summary>\n  \n  ```\n# ──────────────────────────────────────────────\n# 0. Shared ingest pipeline — injects @timestamp if missing\n# ──────────────────────────────────────────────\nPUT _ingest/pipeline/add-timestamp\n{\n  \"processors\": [\n    {\n      \"set\": {\n        \"field\": \"@timestamp\",\n        \"value\": \"{{_ingest.timestamp}}\",\n        \"override\": false\n      }\n    }\n  ]\n}\n\n\n# ──────────────────────────────────────────────\n# 1. host.id as long\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_long\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_long-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"long\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_long-default/_doc\n{ \"host\": { \"id\": 1001, \"name\": \"host-alpha\" }, \"user\": { \"name\":\n\"alice\", \"id\": \"u-001\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_long-default/_doc\n{ \"host\": { \"id\": 1002, \"name\": \"host-beta\" }, \"user\": { \"name\": \"bob\",\n\"id\": \"u-002\" }, \"event\": { \"outcome\": \"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 2. host.id as keyword\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_keyword\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_keyword-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_keyword-default/_doc\n{ \"host\": { \"id\": \"host-id-kw-001\", \"name\": \"host-gamma\" }, \"user\": {\n\"name\": \"carol\", \"id\": \"u-003\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_keyword-default/_doc\n{ \"host\": { \"id\": \"host-id-kw-002\", \"name\": \"host-delta\" }, \"user\": {\n\"name\": \"dave\", \"id\": \"u-004\" }, \"event\": { \"outcome\": \"failure\" } }\n\n\n# ──────────────────────────────────────────────\n# 3. host.id as text\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_host_id_text\n{\n  \"index_patterns\": [\"logs-test.conflict_host_id_text-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"text\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"keyword\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_host_id_text-default/_doc\n{ \"host\": { \"id\": \"free text host identifier alpha\", \"name\":\n\"host-epsilon\" }, \"user\": { \"name\": \"eve\", \"id\": \"u-005\" }, \"event\": {\n\"outcome\": \"success\" } }\n\nPOST logs-test.conflict_host_id_text-default/_doc\n{ \"host\": { \"id\": \"free text host identifier beta\", \"name\": \"host-zeta\"\n}, \"user\": { \"name\": \"frank\", \"id\": \"u-006\" }, \"event\": { \"outcome\":\n\"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 4. user.name as long\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_long\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_long-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"long\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_long-default/_doc\n{ \"host\": { \"id\": \"h-007\", \"name\": \"host-eta\" }, \"user\": { \"name\": 7001,\n\"id\": \"u-007\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_user_name_long-default/_doc\n{ \"host\": { \"id\": \"h-008\", \"name\": \"host-theta\" }, \"user\": { \"name\":\n7002, \"id\": \"u-008\" }, \"event\": { \"outcome\": \"success\" } }\n\n\n# ──────────────────────────────────────────────\n# 5. user.name as ip\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_ip\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_ip-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"ip\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_ip-default/_doc\n{ \"host\": { \"id\": \"h-009\", \"name\": \"host-iota\" }, \"user\": { \"name\":\n\"10.0.0.9\", \"id\": \"u-009\" }, \"event\": { \"outcome\": \"success\" } }\n\nPOST logs-test.conflict_user_name_ip-default/_doc\n{ \"host\": { \"id\": \"h-010\", \"name\": \"host-kappa\" }, \"user\": { \"name\":\n\"10.0.0.10\", \"id\": \"u-010\" }, \"event\": { \"outcome\": \"failure\" } }\n\n\n# ──────────────────────────────────────────────\n# 6. user.name as text\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_name_text\n{\n  \"index_patterns\": [\"logs-test.conflict_user_name_text-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\": { \"type\": \"text\" },\n            \"id\":   { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_name_text-default/_doc\n{ \"host\": { \"id\": \"h-011\", \"name\": \"host-lambda\" }, \"user\": { \"name\":\n\"full text username eleven\", \"id\": \"u-011\" }, \"event\": { \"outcome\":\n\"success\" } }\n\nPOST logs-test.conflict_user_name_text-default/_doc\n{ \"host\": { \"id\": \"h-012\", \"name\": \"host-mu\" }, \"user\": { \"name\": \"full\ntext username twelve\", \"id\": \"u-012\" }, \"event\": { \"outcome\": \"success\"\n} }\n\n\n# ──────────────────────────────────────────────\n# 7. user.id missing from mapping entirely\n# ──────────────────────────────────────────────\nPUT _index_template/logs-test.conflict_user_id_missing\n{\n  \"index_patterns\": [\"logs-test.conflict_user_id_missing-*\"],\n  \"data_stream\": {},\n  \"template\": {\n    \"settings\": {\n      \"default_pipeline\": \"add-timestamp\"\n    },\n    \"mappings\": {\n      \"dynamic\": \"false\",\n      \"properties\": {\n        \"@timestamp\": { \"type\": \"date\" },\n        \"host\": {\n          \"properties\": {\n            \"id\":   { \"type\": \"keyword\" },\n            \"name\": { \"type\": \"keyword\" }\n          }\n        },\n        \"user\": {\n          \"properties\": {\n            \"name\":  { \"type\": \"keyword\" },\n            \"email\": { \"type\": \"keyword\" }\n          }\n        },\n        \"event\": {\n          \"properties\": {\n            \"outcome\": { \"type\": \"keyword\" }\n          }\n        }\n      }\n    }\n  }\n}\n\nPOST logs-test.conflict_user_id_missing-default/_doc\n{ \"host\": { \"id\": \"h-013\", \"name\": \"host-nu\" }, \"user\": { \"name\":\n\"grace\", \"email\": \"grace@example.com\" }, \"event\": { \"outcome\": \"success\"\n} }\n\nPOST logs-test.conflict_user_id_missing-default/_doc\n{ \"host\": { \"id\": \"h-014\", \"name\": \"host-xi\" }, \"user\": { \"name\":\n\"henry\", \"email\": \"henry@example.com\" }, \"event\": { \"outcome\": \"success\"\n} }\n\n  # ──────────────────────────────────────────────\n  # 8. IDP (okta) — event.kind and event.module as text, no host\n  # ──────────────────────────────────────────────\n  PUT _index_template/logs-test.conflict_idp_okta\n  {\n    \"index_patterns\": [\"logs-test.conflict_idp_okta-*\"],\n    \"data_stream\": {},\n    \"template\": {\n      \"settings\": {\n        \"default_pipeline\": \"add-timestamp\"\n      },\n      \"mappings\": {\n        \"properties\": {\n          \"@timestamp\": { \"type\": \"date\" },\n          \"user\": {\n            \"properties\": {\n              \"name\": { \"type\": \"keyword\" }\n            }\n          },\n          \"event\": {\n            \"properties\": {\n              \"kind\":   { \"type\": \"text\" },\n              \"module\": { \"type\": \"text\" }\n            }\n          }\n        }\n      }\n    }\n  }\n\n  POST logs-test.conflict_idp_okta-default/_doc\n{ \"user\": { \"name\": \"$3c_br0k3n_username!\" }, \"event\": { \"kind\":\n\"asset\", \"module\": \"okta\" } }\n  ```\n </details>\n \n Test should create 27 entities\n Hosts (names:\n  - host-alpha\n  - host-beta\n  - host-gamma\n  - host-delta\n  - host-epsilon\n  - host-zeta\n  - host-eta\n  - host-theta\n  - host-iota\n  - host-kappa\n  - host-lambda\n  - host-mu\n  - host-nu\n  - host-xi\n\n  Users (names):\n  - alice@host-alpha\n  - bob@host-beta\n  - carol@host-gamma\n  - 7001@host-eta\n  - 7002@host-theta\n  - 10.0.0.9@host-iota\n  - grace@host-nu\n  - henry@host-xi\n  - eve@host-epsilon\n  - frank@host-zeta\n  - full text username eleven@host-lambda\n  - full text username twelve@host-mu\n  - $3c_br0k3n_username! (okta namespace)\n\n🤖 Generated with [Claude Code](https://claude.ai/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"19f5f8cbd89599fc1ab0db4fd70b3d86104d3038"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->