### PR TITLE
[Chrome Next] Fix app header share button click

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
@@ -113,7 +113,7 @@ export function useAppHeaderMenu(
 }
 
 export interface ShareAction {
-  onClick: () => void;
+  onClick: (triggerElement: HTMLElement) => void;
   tooltipContent?: string;
   tooltipTitle?: string;
   testId?: string;
@@ -133,7 +133,9 @@ export function useShareAction(pageAppMenu: AppMenuConfig | undefined): ShareAct
     });
 
     return {
-      onClick: () => run(),
+      onClick: (triggerElement: HTMLElement) => {
+        run({ triggerElement, returnFocus: () => triggerElement.focus() });
+      },
       tooltipContent: content,
       tooltipTitle: title,
       testId,

--- a/src/core/packages/chrome/app-header/src/app_header/title_actions.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_actions.tsx
@@ -80,7 +80,7 @@ export const TitleActions = React.memo<TitleActionsProps>(({ shareAction, favori
             css={styles.iconButton}
             aria-label={SHARE_ARIA_LABEL}
             data-test-subj={`appHeaderShare ${shareAction.testId ?? ''}`.trim()}
-            onClick={shareAction.onClick}
+            onClick={(event) => shareAction.onClick(event.currentTarget)}
           />
         </EuiToolTip>
       ) : null}

--- a/src/core/packages/chrome/app-header/src/app_header/title_actions.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_actions.tsx
@@ -10,7 +10,7 @@
 import { EuiButtonIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { ReactNode } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import React, { useMemo } from 'react';
 import type { ShareAction } from './hooks';
 
@@ -80,7 +80,9 @@ export const TitleActions = React.memo<TitleActionsProps>(({ shareAction, favori
             css={styles.iconButton}
             aria-label={SHARE_ARIA_LABEL}
             data-test-subj={`appHeaderShare ${shareAction.testId ?? ''}`.trim()}
-            onClick={(event) => shareAction.onClick(event.currentTarget)}
+            onClick={(event: ReactMouseEvent<HTMLButtonElement>) =>
+              shareAction.onClick(event.currentTarget)
+            }
           />
         </EuiToolTip>
       ) : null}


### PR DESCRIPTION
## Summary

The share button in the Chrome Next app header (`@kbn/app-header`) did nothing when clicked. `useShareAction` invoked the app-menu item's `run()` with no arguments, but Discover's `enhanceAppMenuItemWithRunAction` wraps `run` to no-op unless it receives `params` (the trigger element + return-focus callback). Every other app-menu button passes those, so only the header share path was broken.

This threads the trigger element through `ShareAction.onClick`, so `run` is called with `{ triggerElement, returnFocus }` and the share flow fires as expected.