### PR TITLE
[8.19] Add kbn-github skill and GitHub MCP warning hook (#261065)

### DIFF
--- a/.agents/hooks/strip-review-event.mjs
+++ b/.agents/hooks/strip-review-event.mjs
@@ -1,0 +1,340 @@
+/**
+ * Shared analyzer behind the `strip-review-event` hook (Claude Code + Cursor).
+ * Keeps PR review *creation* in PENDING so a review is never published without
+ * an explicit, separate submission step.
+ *
+ * BEST-EFFORT and intentionally minimal. It catches the *accidental* publish a
+ * cooperating agent would actually type — nothing more. It is deny-only and
+ * fails OPEN, so anything it misses is a no-op (never worse than having no hook)
+ * and it can never block unrelated work or cause a bad action. The real backstop
+ * is the kbn-github skill plus the AGENTS.md human-in-the-loop publication gate.
+ *
+ * Denied (the common-case slips):
+ *   - gh pr review --approve | --request-changes | --comment  (and -a/-r/-c, and
+ *     the `--approve=true` form), with an optional `env`/`NAME=value` prefix and
+ *     a tolerated leading `gh` global flag (`-R`/`--repo`/`--hostname`), which
+ *     `gh` accepts before the subcommand (`gh -R o/r pr review --approve`).
+ *   - gh api <…/pulls/{n}/reviews> with an inline body flag (-f/-F/--field/
+ *     --raw-field, which can carry `event=…`), `--input -` (stdin), or an
+ *     `--input <file>` the hook cannot read/parse.
+ *
+ * Allowed:
+ *   - gh api <…/pulls/{n}/reviews> --input <file>: the file is read here and any
+ *     top-level `event` key is stripped on disk before `gh` runs.
+ *   - the submission endpoint (…/reviews/{id}/events) and everything else.
+ *
+ * Explicit NON-GOALS (won't-fix; shell evasion is unbounded — see PR #261065):
+ *   wrapper eval (`bash -c`, `eval`), a publish hidden in a command substitution
+ *   (`id=$(gh pr review --approve 1)`), the GraphQL `addPullRequestReview`
+ *   mutation, an endpoint/body supplied entirely by a variable, and `env` flag
+ *   tricks (`env --split-string …`). These pass through; do not chase them.
+ *
+ * The flow is: split the command into pipeline segments, turn each segment into
+ * an argv, drop any `env`/assignment prefix and leading `gh` global flags, then
+ * inspect `gh pr review` and `gh api .../reviews` calls. Helpers below are
+ * ordered as they are used.
+ *
+ * @see .claude/hooks/strip-review-event.mjs for the Claude Code wrapper.
+ * @see .cursor/hooks/strip-review-event.mjs for the Cursor wrapper.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+// --- Deny reasons -----------------------------------------------------------
+
+/** Shared explanation of the sanctioned PENDING-then-submit flow. */
+const PUBLISH_REASON =
+  'Publishing a PR review immediately is blocked. Create the review in PENDING state by writing the request body to a JSON file (no `event` key) and running `gh api repos/{owner}/{repo}/pulls/{number}/reviews --input <file>`, then submit it explicitly with `gh api repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/events -f event=APPROVE`.';
+
+const DENY_INLINE_BODY = `Passing a body via \`-f\`/\`-F\`/\`--field\`/\`--raw-field\` on the review-creation endpoint is not allowed: the value can be (or expand to) \`event=…\`, which publishes the review. Put the entire body in a JSON file (no \`event\` key) and pass it via \`--input <file>\`. ${PUBLISH_REASON}`;
+
+const DENY_STDIN_INPUT = `\`--input -\` reads the body from stdin, which the hook cannot inspect or rewrite. Write the body to a file and pass \`--input <file>\`. ${PUBLISH_REASON}`;
+
+const DENY_UNREADABLE_INPUT = `The hook cannot read or parse the \`--input\` file before \`gh\` runs, so it cannot strip a stray \`event\` key. Write a valid JSON payload file (no \`event\` key) at an absolute path in a separate, earlier command, then run \`gh api .../reviews --input <file>\`. ${PUBLISH_REASON}`;
+
+// --- Matchers ---------------------------------------------------------------
+
+/**
+ * Review-creation endpoint: `/pulls/{n}/reviews` NOT followed by another
+ * segment, so the submission endpoint `/reviews/{id}/events` is excluded. `{n}`
+ * is `[^/]+` so a literal number and a variable (`pulls/$PR/reviews`) both match
+ * — the PR number being in a variable does not change that it is the call.
+ */
+const REVIEW_CREATION_PATH = /pulls\/[^/]+\/reviews(?!\/)/;
+
+/** `gh pr review` flags that publish immediately. */
+const PR_REVIEW_PUBLISH_FLAGS = new Set(['--approve', '--request-changes', '--comment']);
+
+/** `gh api` inline body flags: a value here can be (or expand to) `event=…`. */
+const API_FIELD_FLAGS = new Set(['-f', '-F', '--field', '--raw-field']);
+
+/** `gh api` flags that consume the following argv token as their value. */
+const API_VALUE_FLAGS = new Set([
+  '-f', '-F', '--field', '--raw-field', '-H', '--header', '-X', '--method',
+  '--hostname', '-q', '--jq', '-t', '--template', '--input', '--cache',
+  '-p', '--preview',
+]);
+
+/** `gh` global flags that may precede the subcommand and consume the next token. */
+const GH_GLOBAL_VALUE_FLAGS = new Set(['-R', '--repo', '--hostname']);
+
+// --- Shell parsing (approximate; see header NON-GOALS) -----------------------
+
+/**
+ * Split a raw command into top-level pipeline segments at `;`, `|`, `&`, `&&`,
+ * `||`, and newlines, ignoring separators inside quotes. Each segment is one
+ * simple command we can inspect on its own.
+ */
+const splitSegments = (command) => {
+  const segments = [];
+  let segmentStart = 0;
+  let openQuote = null;
+  let index = 0;
+
+  while (index < command.length) {
+    const char = command[index];
+
+    if (openQuote) {
+      // A backslash inside double quotes escapes the next char, so skip both.
+      if (char === '\\' && openQuote === '"' && index + 1 < command.length) {
+        index += 2;
+        continue;
+      }
+      if (char === openQuote) openQuote = null;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      openQuote = char;
+      index += 1;
+      continue;
+    }
+
+    const isLogical = command.startsWith('&&', index) || command.startsWith('||', index);
+    const isPipeOrSemi =
+      char === ';' || char === '|' || char === '\n' || (char === '&' && command[index + 1] !== '&');
+
+    if (isLogical || isPipeOrSemi) {
+      segments.push(command.slice(segmentStart, index));
+      index += isLogical ? 2 : 1;
+      segmentStart = index;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  segments.push(command.slice(segmentStart));
+  return segments;
+};
+
+/**
+ * Turn one segment into an approximate argv, resolving single quotes, double
+ * quotes, and backslash escapes well enough that a quoted flag like `'-f'`
+ * resolves to `-f`. Deliberately not a faithful shell: expansions are kept as
+ * literal text, and inside double quotes a backslash is dropped before any
+ * character (Bash only escapes before `$`, backtick, `"`, `\`, or newline), so
+ * an exotic double-quoted path with a literal backslash can resolve differently
+ * than Bash — an explicit non-goal, like other exotic quoting shapes.
+ */
+const tokenize = (segment) => {
+  const args = [];
+  let word = '';
+  let inWord = false; // tracks empty quoted words like `""`
+  let openQuote = null;
+  let index = 0;
+
+  const endWord = () => {
+    if (inWord) args.push(word);
+    word = '';
+    inWord = false;
+  };
+
+  while (index < segment.length) {
+    const char = segment[index];
+    index += 1;
+
+    if (openQuote === "'") {
+      if (char === "'") openQuote = null;
+      else word += char;
+      continue;
+    }
+
+    if (openQuote === '"') {
+      if (char === '\\' && index < segment.length) {
+        word += segment[index];
+        index += 1;
+      } else if (char === '"') {
+        openQuote = null;
+      } else {
+        word += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      openQuote = char;
+      inWord = true;
+    } else if (char === '\\' && index < segment.length) {
+      word += segment[index];
+      index += 1;
+      inWord = true;
+    } else if (char === ' ' || char === '\t' || char === '\n') {
+      endWord();
+    } else {
+      word += char;
+      inWord = true;
+    }
+  }
+
+  endWord();
+  return args;
+};
+
+/**
+ * Drop a leading `env` and any `NAME=value` assignment prefixes (e.g. the
+ * skill-recommended `GH_PAGER=cat gh …`) so we see the real command. `env`
+ * *flag* tricks (`env --split-string …`) are a documented non-goal.
+ */
+const stripCommandPrefix = (args) => {
+  let start = 0;
+  if (args[start] === 'env') start += 1;
+  while (start < args.length && /^\w+=/.test(args[start])) start += 1;
+  return args.slice(start);
+};
+
+/**
+ * Drop a leading run of `gh` global flags (and the values they consume) so the
+ * subcommand lands at `args[1]`. `gh` (via cobra) accepts these before the
+ * subcommand, so `gh -R owner/repo pr review --approve` parses and publishes;
+ * without this the fixed `subcommand === 'pr'`/`'api'` checks would miss it.
+ * Subcommands never start with `-`, so the first non-flag token is preserved.
+ */
+const stripGhGlobalFlags = (args) => {
+  if (args[0] !== 'gh') return args;
+  let index = 1;
+  while (index < args.length && args[index].startsWith('-')) {
+    const consumesValue = !args[index].includes('=') && GH_GLOBAL_VALUE_FLAGS.has(args[index]);
+    index += consumesValue ? 2 : 1;
+  }
+  return [args[0], ...args.slice(index)];
+};
+
+// --- gh argv inspection ------------------------------------------------------
+
+/**
+ * Find the positional endpoint argument of a `gh api` call (argv is
+ * `['gh', 'api', …]`), skipping flags and the values they consume. We match the
+ * review path against this token only — not the whole command — so a review
+ * path inside a flag value (e.g. `-f body='…pulls/1/reviews…'`) is never
+ * mistaken for the call. Returns the endpoint token, or `null` if there is none.
+ */
+const findApiEndpoint = (args) => {
+  let index = 2; // skip 'gh', 'api'
+  while (index < args.length) {
+    const arg = args[index];
+    if (arg === '--') {
+      index += 1; // everything after `--` is positional
+      break;
+    }
+    if (!arg.startsWith('-')) break; // first non-flag token is the endpoint
+    const consumesValue = !arg.includes('=') && API_VALUE_FLAGS.has(arg);
+    index += consumesValue ? 2 : 1;
+  }
+  return args[index] ?? null;
+};
+
+/** Resolve the `--input <file>` / `--input=<file>` value, or `null` if absent. */
+const findInputValue = (args) => {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--input') return args[index + 1] ?? null;
+    if (arg.startsWith('--input=')) return arg.slice('--input='.length);
+  }
+  return null;
+};
+
+/** True if any argv token is an inline body flag (`-f`/`-F`/`--field`/…). */
+const hasInlineBodyFlag = (args) =>
+  args.some((arg) => API_FIELD_FLAGS.has(arg) || /^-[fF]/.test(arg) || /^--(raw-)?field=/.test(arg));
+
+/**
+ * True if a `gh pr review` argv carries a publish flag. Tolerates the
+ * `--approve=true` / `-a=1` form (strip `=value`) and bundled short flags like
+ * `-ac` (publish if any of `a`/`r`/`c` is present).
+ */
+const isPublishingPrReview = (args) =>
+  args.slice(3).some((arg) => {
+    const flag = arg.split('=', 1)[0];
+    if (PR_REVIEW_PUBLISH_FLAGS.has(flag)) return true;
+    const isBundledShortFlags = /^-[a-zA-Z]+$/.test(flag);
+    return isBundledShortFlags && /[arc]/.test(flag.slice(1));
+  });
+
+/**
+ * Strip a stray top-level `event` key from the `--input` JSON file on disk
+ * before `gh` runs. Returns `null` on success, or a deny reason if the file
+ * cannot be read, parsed, or rewritten (fail closed: we cannot vouch for it).
+ */
+const stripStrayEventKey = (filePath) => {
+  try {
+    const payload = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const isPlainObject =
+      payload !== null && typeof payload === 'object' && !Array.isArray(payload);
+    if (isPlainObject && 'event' in payload) {
+      delete payload.event;
+      writeFileSync(filePath, JSON.stringify(payload, null, 2));
+    }
+    return null;
+  } catch {
+    return DENY_UNREADABLE_INPUT;
+  }
+};
+
+/**
+ * Inspect a `gh api` argv. Returns a deny reason for a publishing
+ * review-creation call, or `null` if it is not review creation or is the
+ * sanctioned `--input <file>` shape (whose file is sanitized as a side effect).
+ */
+const analyzeApiCall = (args) => {
+  const endpoint = findApiEndpoint(args);
+  if (endpoint === null || !REVIEW_CREATION_PATH.test(endpoint)) return null;
+
+  if (hasInlineBodyFlag(args)) return DENY_INLINE_BODY;
+
+  const inputValue = findInputValue(args);
+  if (inputValue === '-') return DENY_STDIN_INPUT;
+  if (inputValue === null) return null; // no body at all: cannot publish
+
+  return stripStrayEventKey(inputValue);
+};
+
+// --- Entry point -------------------------------------------------------------
+
+/**
+ * Analyse a raw shell command. Returns `null` (allow, possibly after stripping a
+ * stray `event` key from an `--input` file) or `{ deny: <reason> }`.
+ */
+export const analyzeReviewCommand = (rawCommand) => {
+  if (typeof rawCommand !== 'string' || rawCommand === '') return null;
+  const command = rawCommand.replace(/\\\n/g, ''); // join bash line continuations
+
+  for (const segment of splitSegments(command)) {
+    const args = stripGhGlobalFlags(stripCommandPrefix(tokenize(segment)));
+    const [program, subcommand] = args;
+    if (program !== 'gh') continue;
+
+    if (subcommand === 'pr' && args[2] === 'review') {
+      if (isPublishingPrReview(args)) return { deny: PUBLISH_REASON };
+      continue;
+    }
+
+    if (subcommand === 'api') {
+      const denyReason = analyzeApiCall(args);
+      if (denyReason) return { deny: denyReason };
+    }
+  }
+
+  return null;
+};

--- a/.agents/skills/kbn-github/SKILL.md
+++ b/.agents/skills/kbn-github/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: kbn-github
+description: GitHub interactions via gh CLI for the Kibana repo. Use when performing any GitHub interaction — creating, viewing, or modifying PRs or issues, posting comments or reviews, checking CI status, applying labels, creating releases, or making any gh/API call.
+---
+
+# GitHub (gh CLI)
+
+## Defaults & Constraints
+
+- Use `gh` CLI for all GitHub interactions.
+- Set `GH_PAGER=cat` for all `gh` calls to avoid interactive pagers.
+- The repo is `elastic/kibana`; when not inside a local clone, prefer `-R elastic/kibana` for `gh` subcommands. For `gh api`, `-R` is not supported; use explicit `repos/elastic/kibana/...` endpoints or set `GH_REPO=elastic/kibana` when using `{owner}/{repo}` placeholders.
+- Follow repository merge settings (squash/rebase/merge); do not enforce a merge strategy.
+- Never merge into the base branch via CLI; merges happen via the GitHub UI.
+
+## First Actions
+
+1. Resolve the exact target repo/object (PR, issue, comment thread, release) before mutating anything.
+
+## PR Targeting
+
+- If the user uses implicit-current phrasing ("this PR", "current PR", "PR for this branch") and does not specify a PR URL/number, resolve the PR for the current branch: `gh pr view --json number -q .number`.
+- Do not assume an unspecified GitHub task targets the current branch PR unless the wording clearly implies the current PR.
+
+## PR Workflow
+
+- Always open PRs as draft: `gh pr create --draft`.
+- Check CI status: `gh pr checks`.
+- View PR details: `gh pr view`.
+- View PR diff: `gh pr diff`.
+- List PR files: `gh pr diff --name-only`.
+- Read PR review comments: `gh api repos/elastic/kibana/pulls/{number}/comments`.
+
+## PR Creation
+
+- Always ask which existing issue the PR should reference (do not invent issue numbers).
+- Ask the user whether the PR should `Closes #X` or `Addresses #X` before creating the PR.
+- If there is no existing issue, stop and ask whether to create one; do NOT create issues unless the user explicitly instructs you to.
+- PR title is a human-readable change summary (not necessarily the Conventional Commit header).
+
+## Issue Workflow
+
+- View an issue: `gh issue view {number}`.
+- Search issues: `gh issue list --search "query"`.
+- Create an issue: `gh issue create`.
+
+## Approvals
+
+- Any GitHub side effect requires explicit approval unless the user instructed otherwise. Examples (non-exhaustive): create/edit PRs or issues, post comments/reviews, apply metadata (labels/assignees/milestones/projects), merge, or create releases.
+
+## PR Reviews
+
+> **Read [references/review.md](references/review.md) before creating or modifying any PR review.** It contains mandatory instructions for comment anchoring, verification, and avoiding irreversible API mistakes.
+
+### Core Rule: Pending vs Published
+
+- Never include `event` in a review-creation payload (`POST /repos/{o}/{r}/pulls/{n}/reviews`). Without `event` the review stays `PENDING`; with it, the review is **immediately and irreversibly published**.
+- Always create reviews via `gh api repos/{o}/{r}/pulls/{n}/reviews --input <file>` with the body in a JSON file. Do not pass `-f event=...` or `-F event=...` to the review-creation endpoint — every quoting form (bare, single-quoted, double-quoted, whole-pair quoted, `$(...)`, backticks, `${VAR:-...}`) is denied by the strip-review-event hook because the only safe sanitisation is parsing the JSON file.
+- Verify the JSON file contains no top-level `"event"` key before submitting.
+- To publish a review, use the separate submission endpoint: `POST /repos/{o}/{r}/pulls/{n}/reviews/{id}/events` with `-f event=APPROVE` (or COMMENT / REQUEST_CHANGES). The hook only denies `event=` on the review-**creation** endpoint, not on submission.
+
+## Posting PR Review Comments
+
+See [references/review.md](references/review.md) for inline, file-level, threaded reply, and PR-level comment examples.
+
+## Advanced / API
+
+- For anything beyond standard `gh` subcommands, use `gh api` with the GitHub REST or GraphQL endpoints.
+- Multiline bodies/comments: use bash/zsh `$'...'` so `\n` becomes real newlines. Do NOT rely on `\\n` escapes inside normal quotes (especially `gh api -f body=...`).
+- Payloads with arrays: prefer `gh api ... --input /path/to/payload.json` over `-f`/`-F` flags to avoid shell escaping issues.
+- If you need to add query params to a GET `gh api` call, use `-X GET`. In practice, adding `-f` or `-F` without `-X GET` can cause `gh` to hit the POST schema by default.
+- zsh gotcha: avoid unquoted `?ref=...` in endpoints (triggers `no matches found`). Prefer: `gh api -X GET repos/elastic/kibana/contents/PATH -F ref=main`.
+
+## Output & Verification
+
+- Before each side effect, restate the exact target and action you are about to perform.
+- After each side effect, verify via read-back (`gh`/API) and report the URL, identifier, or resulting state.
+
+Do not add/modify repo `.github/*` templates unless the user explicitly asks.
+
+## Sub-Issues API
+
+GitHub's sub-issue API creates real parent-child relationships (not tasklists).
+
+Create hierarchy:
+
+1. Create child issues first with full descriptions.
+2. Get GraphQL IDs:
+
+   ```bash
+   gh api graphql -f query='{ repository(owner:"elastic",name:"kibana") { issue(number:N) { id } } }'
+   ```
+
+3. Link:
+
+   ```bash
+   gh api graphql -f query="mutation { addSubIssue(input:{issueId:\"PARENT_ID\",subIssueId:\"CHILD_ID\"}) { issue { number } } }"
+   ```
+
+4. Verify: `gh api repos/elastic/kibana/issues/NUM/sub_issues`
+
+Mutations: `addSubIssue`, `removeSubIssue`, `reprioritizeSubIssue`

--- a/.agents/skills/kbn-github/references/review.md
+++ b/.agents/skills/kbn-github/references/review.md
@@ -1,0 +1,108 @@
+# PR Review API Reference
+
+Detailed reference for creating, verifying, and submitting PR reviews via `gh api`. See the main skill for the core rules on pending vs published reviews.
+
+## Creating a Pending Review
+
+- Always submit the review-creation request via `--input <file>` pointing at a JSON file. The strip-review-event hook denies every `-f event=...` / `-F event=...` / `--field event=...` flag shape on the creation endpoint because the only safe sanitisation is parsing the JSON file.
+- The `--input` path must not contain `$VAR`, `$(...)`, backticks, or a leading `~`; the hook reads the literal path and cannot expand shell metacharacters. Pass an absolute or already-expanded path.
+- `--input -` (stdin) is denied — the hook can't inspect or rewrite stdin.
+- Include all inline comments in the `comments` array in the same request.
+- Every inline comment must resolve to a valid diff anchor.
+- GitHub allows only one `PENDING` review per user per PR. Pending comments are not editable via API — do not try to PATCH them or attach new comments via the PR comments endpoint (it won't accept `pull_request_review_id`). If you need to change bodies or anchors, delete the pending review and recreate it.
+- File-level review comments (`subject_type=file`) are immediately visible; they are not part of a pending review.
+- Keep the review summary body empty unless the user explicitly wants a public summary.
+
+## Comment Anchoring
+
+Prefer `line`/`side` anchoring over `position` (less error-prone):
+
+- Use `line` (the file line number on the right side) + `side: "RIGHT"`.
+- For left-side-only comments, use `side: "LEFT"` + the old-file line number.
+- For multi-line ranges, add `start_line` + `start_side`.
+- The `line`/`side` approach uses absolute file line numbers (visible in the GitHub diff UI), so there is no off-by-one math to get wrong.
+
+Avoid `position` unless `line`/`side` cannot express the anchor. GitHub's REST docs describe `position` as closing down, and say it is "the number of lines down from the first `@@` hunk header" where the line just below that header is position 1.
+
+- Fetch the file's `patch` from `GET /repos/{o}/{r}/pulls/{n}/files`.
+- Count from the first `@@` hunk header using GitHub's definition; do not treat source-file line numbers as positions.
+- If a file has multiple hunks (or repeated target lines), create separate comments and verify the correct hunk/occurrence.
+- Common trap: the patch changes when new commits are pushed. Always re-fetch the patch from the current PR head before computing positions.
+- After posting, read back the returned comment and confirm the `path`, `line`, `side`, and `position` match the intended anchor.
+
+## Verification
+
+After creating a review:
+
+- Confirm the review is PENDING: `gh api repos/elastic/kibana/pulls/NUM/reviews --jq '.[] | {id,state}'`
+- Confirm pending review has N draft comments: `gh api repos/elastic/kibana/pulls/NUM/reviews/REVIEW_ID/comments --jq 'length'`
+- Confirm visible PR review comments are still empty (until submission): `gh api repos/elastic/kibana/pulls/NUM/comments --jq 'length'`
+
+After submitting a review:
+
+- The submitted review body is whatever you submit with the final event call. If you want a summary, include it explicitly when submitting.
+- For COMMENT/REQUEST_CHANGES, treat the body as required: always include it.
+- Count posted inline comments and reconcile anything missing; if needed, post a follow-up (non-batch) comment with leftover deep links.
+
+## Posting PR Review Comments
+
+Inline review comment (line or range; supports GitHub suggestion blocks):
+
+````bash
+gh api repos/elastic/kibana/pulls/NUM/comments -f body=$'Text.\n\n```suggestion\ncode\n```' -f commit_id=SHA -f path=FILE -f side=RIGHT -f line=LINE
+````
+
+For multi-line, add: `-f start_line=START -f start_side=RIGHT`.
+
+File-level review comment (file-scoped, immediately visible):
+
+```bash
+gh api repos/elastic/kibana/pulls/NUM/comments \
+  -f body=$'Text.' \
+  -f commit_id=SHA -f path=FILE -f subject_type=file
+```
+
+Reply in an existing review thread:
+
+```bash
+gh api repos/elastic/kibana/pulls/NUM/comments \
+  -f body=$'Text.' \
+  -F in_reply_to=COMMENT_ID
+```
+
+- The request field is `in_reply_to` (integer). The response field is `in_reply_to_id`.
+- Do NOT use `in_reply_to_id` in the request; it may create a new top-level comment instead of a reply.
+- If you are posting an anchored comment that requires `commit_id`, and GitHub rejects it as "commit_id is not part of the pull request", use the `commit_id` from the target review comment you're replying to.
+
+PR-level timeline comment (use sparingly):
+
+```bash
+gh pr comment NUM -b "<text>"
+```
+
+## Example: Create a Pending Review
+
+Run payload creation and review creation as separate shell commands. The
+`strip-review-event` hook reads the `--input` file to strip any stray `event`
+key before `gh` runs, so the payload file must already exist on disk when the
+review-creation command executes.
+
+```bash
+cat > /tmp/review-payload.json <<'JSON'
+{
+  "commit_id": "HEAD_SHA",
+  "body": "",
+  "comments": [
+    { "path": "path/to/file.ts", "line": 42, "side": "RIGHT", "body": "Comment text." },
+    { "path": "path/to/file.ts", "line": 78, "side": "RIGHT", "body": "Another comment." }
+  ]
+}
+JSON
+```
+
+```bash
+gh api repos/elastic/kibana/pulls/NUM/reviews -X POST --input /tmp/review-payload.json
+
+# Submit later (include body explicitly if you want a summary):
+gh api repos/elastic/kibana/pulls/NUM/reviews/REVIEW_ID/events -X POST -f event=APPROVE -f body=$'Looks good.'
+```

--- a/.claude/hooks/strip-review-event.mjs
+++ b/.claude/hooks/strip-review-event.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook (Claude Code) that defers to the shared analyzer in
+ * `.agents/hooks/strip-review-event.mjs` and emits Claude's nested
+ * `hookSpecificOutput.permissionDecision` deny shape. See the shared module
+ * for the policy, allowed/denied shapes, and known limitations.
+ *
+ * @see .agents/hooks/strip-review-event.mjs
+ * @see .cursor/hooks/strip-review-event.mjs for the Cursor wrapper.
+ */
+
+import { json } from 'node:stream/consumers';
+import { analyzeReviewCommand } from '../../.agents/hooks/strip-review-event.mjs';
+
+let input;
+try {
+  input = await json(process.stdin);
+} catch {
+  process.exit(0);
+}
+if (!input || typeof input !== 'object') process.exit(0);
+
+const result = analyzeReviewCommand(input?.tool_input?.command ?? '');
+if (!result) process.exit(0);
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: result.deny,
+      },
+    },
+    null,
+    2
+  )
+);

--- a/.claude/hooks/warn-github-mcp.mjs
+++ b/.claude/hooks/warn-github-mcp.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook (Claude Code): warn once per install when a GitHub MCP
+ * server is active, since the Kibana repo provides a gh-based skill that
+ * covers the same functionality without the ~50k token overhead.
+ *
+ * The warning is gated by a marker file under `XDG_STATE_HOME` (or
+ * `~/.local/state`), so it is shown at most once per user on this machine.
+ * Remove the marker to re-arm the warning.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { json } from 'node:stream/consumers';
+
+let input;
+try {
+  input = await json(process.stdin);
+} catch {
+  process.exit(0);
+}
+if (!input || typeof input !== 'object') process.exit(0);
+
+const stateDir = join(
+  process.env.XDG_STATE_HOME ||
+    (process.env.HOME
+      ? join(process.env.HOME, '.local', 'state')
+      : process.env.TMPDIR || '/tmp'),
+  'kibana-claude'
+);
+const marker = join(stateDir, 'github-mcp-warned');
+
+try {
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(marker, '', { flag: 'wx' });
+} catch (error) {
+  if (error?.code === 'EEXIST') {
+    process.exit(0);
+  }
+  throw error;
+}
+
+const msg =
+  'WARNING: A GitHub MCP server is active, which adds ~50k tokens of overhead per session. The Kibana repo already provides a gh-based GitHub skill that covers the same functionality and is well-supported by all major models. Consider removing the MCP server to save context budget.';
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'ask',
+        permissionDecisionReason: msg,
+      },
+    },
+    null,
+    2
+  )
+);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/warn-github-mcp.mjs"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh *)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/strip-review-event.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/strip-review-event.mjs",
+        "matcher": "\\bgh\\b"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/strip-review-event.mjs
+++ b/.cursor/hooks/strip-review-event.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ * beforeShellExecution hook (Cursor, matcher: `\bgh\b`) that defers to the
+ * shared analyzer in `.agents/hooks/strip-review-event.mjs` and emits Cursor's
+ * native flat `{ permission, user_message, agent_message }` deny shape. The
+ * matcher keeps the hook from spawning on every shell command — it only runs
+ * for commands mentioning `gh`. A loose matcher is harmless: a false match just
+ * runs the analyzer, which returns allow for non-review commands. See the
+ * shared module for the policy, allowed/denied shapes, and known limitations.
+ *
+ * @see .agents/hooks/strip-review-event.mjs
+ * @see .claude/hooks/strip-review-event.mjs for the Claude Code wrapper.
+ */
+
+import { json } from 'node:stream/consumers';
+import { analyzeReviewCommand } from '../../.agents/hooks/strip-review-event.mjs';
+
+let input;
+try {
+  input = await json(process.stdin);
+} catch {
+  process.exit(0);
+}
+if (!input || typeof input !== 'object') process.exit(0);
+
+// `beforeShellExecution` puts the command at the top level; fall back to the
+// `preToolUse` shape so the wrapper works regardless of which event fires.
+const result = analyzeReviewCommand(input?.command ?? input?.tool_input?.command ?? '');
+if (!result) process.exit(0);
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      permission: 'deny',
+      user_message: result.deny,
+      agent_message: result.deny,
+    },
+    null,
+    2
+  )
+);

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ target
 /build
 .jruby
 .idea
-.cursor
+/.cursor/*
+!/.cursor/hooks.json
+!/.cursor/hooks/
 !x-pack/solutions/security/.cursor
 !x-pack/solutions/security/test/security_solution_cypress/.cursor/
 .windsurf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,4 +83,3 @@ Follow existing patterns in the target area first; below are common defaults.
 - Make focused changes; avoid unrelated refactors.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.
-- Always open PRs as draft.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add kbn-github skill and GitHub MCP warning hook (#261065)](https://github.com/elastic/kibana/pull/261065)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-06-02T12:41:50Z","message":"Add kbn-github skill and GitHub MCP warning hook (#261065)\n\n## What this PR does\n\nAdds a `kbn-github` agent skill (do GitHub via `gh`, not the heavy\nGitHub MCP) plus two small Claude/Cursor hooks: one that stops an agent\nfrom **accidentally publishing a PR review**, and one that warns when\nthe GitHub MCP server is loaded.\n\n## Changes\n\n- **`kbn-github` skill** — `gh`-based GitHub workflow guidance, with PR\nreview API detail in `references/review.md`. The “open PRs as draft”\nrule moves here from `AGENTS.md`.\n- **Review-publish guard hook** — shared analyzer in\n`.agents/hooks/strip-review-event.mjs`, with thin Claude + Cursor\nwrappers.\n- **GitHub MCP warning hook** — warns once (atomic marker file) that the\nrepo’s `gh` skill replaces the ~50k-token MCP server.\n\n## The review-publish guard, at a glance\n\nIt keeps a review in **PENDING** so publishing is always a separate,\nexplicit step.\n\n| Command | Result |\n|---|---|\n| `gh pr review --approve` / `--request-changes` / `--comment`\n(`-a`/`-r`/`-c`) | **blocked** |\n| `gh -R <repo> pr review …` (a `gh` global flag before the subcommand)\n| **blocked** |\n| `gh api …/pulls/{n}/reviews -f event=…` (inline body) | **blocked** |\n| `gh api …/pulls/{n}/reviews --input -` (stdin) | **blocked** |\n| `gh api …/pulls/{n}/reviews --input file.json` | allowed — strips any\nstray `event` key first |\n| the submit step `…/reviews/{id}/events` | allowed |\n| everything else | allowed |\n\n## Why it’s safe to ship\n\n- **It can only say no.** The hook blocks a command or strips an `event`\nkey from the review file — nothing else. It can’t edit code, merge, or\npush.\n- **It fails open.** If it has a bug or misses something, the command\njust runs — exactly as if the hook weren’t there. It never blocks\nunrelated work and never causes a bad action.\n- **Best-effort, not a security boundary.** It catches the *honest*\naccidental publish a cooperating agent would type. Deliberate evasion is\nout of scope by design (see below) — and since it fails open, a miss is\nnever worse than having no hook.\n\n<details>\n<summary>Matcher scoping & out-of-scope shapes (detail)</summary>\n\n**When each hook runs:**\n- **Cursor** — `beforeShellExecution`, matcher `\\bgh\\b` (any command\nmentioning `gh`).\n- **Claude** — `Bash`, `if: \"Bash(gh *)\"`. Claude strips leading\n`VAR=value` assignments before matching, so `GH_PAGER=cat gh …` is\ncovered.\n\n**Intentionally not caught (won’t-fix):** the shell has unbounded ways\nto spell the same call, so chasing each is an endless treadmill. These\npass through:\n- wrapper eval (`bash -c`, `eval`)\n- a publish hidden in a command substitution (`id=$(gh pr review\n--approve 1)`)\n- the GraphQL `addPullRequestReview` mutation\n- an endpoint/body supplied entirely by a variable\n- `env`-command prefixes (`env … gh …`) — the analyzer strips a leading\n`env`, so Cursor still catches these via `\\bgh\\b`; the Claude `Bash(gh\n*)` matcher does not, because the subcommand is `env`, not `gh`.\n\nThe real backstop is the skill guidance + the MCP warning + the\n`AGENTS.md` human-in-the-loop publication gate.\n\n</details>\n\n## Test plan\n\n- `node scripts/check.js --scope=branch`\n- `node scripts/eslint .agents/hooks/strip-review-event.mjs\n.claude/hooks/strip-review-event.mjs\n.cursor/hooks/strip-review-event.mjs .claude/hooks/warn-github-mcp.mjs\n.agents/skills/kbn-github/SKILL.md\n.agents/skills/kbn-github/references/review.md`\n- Local analyzer corpus covering the table above plus the out-of-scope\npass-through cases (publish flags in long/short/`=value` forms with\n`NAME=value`/`env` prefixes and a leading `gh` global flag like\n`-R`/`--repo` before the subcommand, quoted/bare field flags, `--input\n-`, unreadable/non-JSON `--input`, var-PR paths, `--input <file>`\nsanitization, and the submit endpoint / reply bodies / `addSubIssue` /\nread-only commands).\n\nAssisted with Cursor using GPT-5.5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a186006fe76e2287bd2d29a92a3c41d16c3e7e15","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","reviewer:claude","v9.5.0","reviewer:codex"],"title":"Add kbn-github skill and GitHub MCP warning hook","number":261065,"url":"https://github.com/elastic/kibana/pull/261065","mergeCommit":{"message":"Add kbn-github skill and GitHub MCP warning hook (#261065)\n\n## What this PR does\n\nAdds a `kbn-github` agent skill (do GitHub via `gh`, not the heavy\nGitHub MCP) plus two small Claude/Cursor hooks: one that stops an agent\nfrom **accidentally publishing a PR review**, and one that warns when\nthe GitHub MCP server is loaded.\n\n## Changes\n\n- **`kbn-github` skill** — `gh`-based GitHub workflow guidance, with PR\nreview API detail in `references/review.md`. The “open PRs as draft”\nrule moves here from `AGENTS.md`.\n- **Review-publish guard hook** — shared analyzer in\n`.agents/hooks/strip-review-event.mjs`, with thin Claude + Cursor\nwrappers.\n- **GitHub MCP warning hook** — warns once (atomic marker file) that the\nrepo’s `gh` skill replaces the ~50k-token MCP server.\n\n## The review-publish guard, at a glance\n\nIt keeps a review in **PENDING** so publishing is always a separate,\nexplicit step.\n\n| Command | Result |\n|---|---|\n| `gh pr review --approve` / `--request-changes` / `--comment`\n(`-a`/`-r`/`-c`) | **blocked** |\n| `gh -R <repo> pr review …` (a `gh` global flag before the subcommand)\n| **blocked** |\n| `gh api …/pulls/{n}/reviews -f event=…` (inline body) | **blocked** |\n| `gh api …/pulls/{n}/reviews --input -` (stdin) | **blocked** |\n| `gh api …/pulls/{n}/reviews --input file.json` | allowed — strips any\nstray `event` key first |\n| the submit step `…/reviews/{id}/events` | allowed |\n| everything else | allowed |\n\n## Why it’s safe to ship\n\n- **It can only say no.** The hook blocks a command or strips an `event`\nkey from the review file — nothing else. It can’t edit code, merge, or\npush.\n- **It fails open.** If it has a bug or misses something, the command\njust runs — exactly as if the hook weren’t there. It never blocks\nunrelated work and never causes a bad action.\n- **Best-effort, not a security boundary.** It catches the *honest*\naccidental publish a cooperating agent would type. Deliberate evasion is\nout of scope by design (see below) — and since it fails open, a miss is\nnever worse than having no hook.\n\n<details>\n<summary>Matcher scoping & out-of-scope shapes (detail)</summary>\n\n**When each hook runs:**\n- **Cursor** — `beforeShellExecution`, matcher `\\bgh\\b` (any command\nmentioning `gh`).\n- **Claude** — `Bash`, `if: \"Bash(gh *)\"`. Claude strips leading\n`VAR=value` assignments before matching, so `GH_PAGER=cat gh …` is\ncovered.\n\n**Intentionally not caught (won’t-fix):** the shell has unbounded ways\nto spell the same call, so chasing each is an endless treadmill. These\npass through:\n- wrapper eval (`bash -c`, `eval`)\n- a publish hidden in a command substitution (`id=$(gh pr review\n--approve 1)`)\n- the GraphQL `addPullRequestReview` mutation\n- an endpoint/body supplied entirely by a variable\n- `env`-command prefixes (`env … gh …`) — the analyzer strips a leading\n`env`, so Cursor still catches these via `\\bgh\\b`; the Claude `Bash(gh\n*)` matcher does not, because the subcommand is `env`, not `gh`.\n\nThe real backstop is the skill guidance + the MCP warning + the\n`AGENTS.md` human-in-the-loop publication gate.\n\n</details>\n\n## Test plan\n\n- `node scripts/check.js --scope=branch`\n- `node scripts/eslint .agents/hooks/strip-review-event.mjs\n.claude/hooks/strip-review-event.mjs\n.cursor/hooks/strip-review-event.mjs .claude/hooks/warn-github-mcp.mjs\n.agents/skills/kbn-github/SKILL.md\n.agents/skills/kbn-github/references/review.md`\n- Local analyzer corpus covering the table above plus the out-of-scope\npass-through cases (publish flags in long/short/`=value` forms with\n`NAME=value`/`env` prefixes and a leading `gh` global flag like\n`-R`/`--repo` before the subcommand, quoted/bare field flags, `--input\n-`, unreadable/non-JSON `--input`, var-PR paths, `--input <file>`\nsanitization, and the submit endpoint / reply bodies / `addSubIssue` /\nread-only commands).\n\nAssisted with Cursor using GPT-5.5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a186006fe76e2287bd2d29a92a3c41d16c3e7e15"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261065","number":261065,"mergeCommit":{"message":"Add kbn-github skill and GitHub MCP warning hook (#261065)\n\n## What this PR does\n\nAdds a `kbn-github` agent skill (do GitHub via `gh`, not the heavy\nGitHub MCP) plus two small Claude/Cursor hooks: one that stops an agent\nfrom **accidentally publishing a PR review**, and one that warns when\nthe GitHub MCP server is loaded.\n\n## Changes\n\n- **`kbn-github` skill** — `gh`-based GitHub workflow guidance, with PR\nreview API detail in `references/review.md`. The “open PRs as draft”\nrule moves here from `AGENTS.md`.\n- **Review-publish guard hook** — shared analyzer in\n`.agents/hooks/strip-review-event.mjs`, with thin Claude + Cursor\nwrappers.\n- **GitHub MCP warning hook** — warns once (atomic marker file) that the\nrepo’s `gh` skill replaces the ~50k-token MCP server.\n\n## The review-publish guard, at a glance\n\nIt keeps a review in **PENDING** so publishing is always a separate,\nexplicit step.\n\n| Command | Result |\n|---|---|\n| `gh pr review --approve` / `--request-changes` / `--comment`\n(`-a`/`-r`/`-c`) | **blocked** |\n| `gh -R <repo> pr review …` (a `gh` global flag before the subcommand)\n| **blocked** |\n| `gh api …/pulls/{n}/reviews -f event=…` (inline body) | **blocked** |\n| `gh api …/pulls/{n}/reviews --input -` (stdin) | **blocked** |\n| `gh api …/pulls/{n}/reviews --input file.json` | allowed — strips any\nstray `event` key first |\n| the submit step `…/reviews/{id}/events` | allowed |\n| everything else | allowed |\n\n## Why it’s safe to ship\n\n- **It can only say no.** The hook blocks a command or strips an `event`\nkey from the review file — nothing else. It can’t edit code, merge, or\npush.\n- **It fails open.** If it has a bug or misses something, the command\njust runs — exactly as if the hook weren’t there. It never blocks\nunrelated work and never causes a bad action.\n- **Best-effort, not a security boundary.** It catches the *honest*\naccidental publish a cooperating agent would type. Deliberate evasion is\nout of scope by design (see below) — and since it fails open, a miss is\nnever worse than having no hook.\n\n<details>\n<summary>Matcher scoping & out-of-scope shapes (detail)</summary>\n\n**When each hook runs:**\n- **Cursor** — `beforeShellExecution`, matcher `\\bgh\\b` (any command\nmentioning `gh`).\n- **Claude** — `Bash`, `if: \"Bash(gh *)\"`. Claude strips leading\n`VAR=value` assignments before matching, so `GH_PAGER=cat gh …` is\ncovered.\n\n**Intentionally not caught (won’t-fix):** the shell has unbounded ways\nto spell the same call, so chasing each is an endless treadmill. These\npass through:\n- wrapper eval (`bash -c`, `eval`)\n- a publish hidden in a command substitution (`id=$(gh pr review\n--approve 1)`)\n- the GraphQL `addPullRequestReview` mutation\n- an endpoint/body supplied entirely by a variable\n- `env`-command prefixes (`env … gh …`) — the analyzer strips a leading\n`env`, so Cursor still catches these via `\\bgh\\b`; the Claude `Bash(gh\n*)` matcher does not, because the subcommand is `env`, not `gh`.\n\nThe real backstop is the skill guidance + the MCP warning + the\n`AGENTS.md` human-in-the-loop publication gate.\n\n</details>\n\n## Test plan\n\n- `node scripts/check.js --scope=branch`\n- `node scripts/eslint .agents/hooks/strip-review-event.mjs\n.claude/hooks/strip-review-event.mjs\n.cursor/hooks/strip-review-event.mjs .claude/hooks/warn-github-mcp.mjs\n.agents/skills/kbn-github/SKILL.md\n.agents/skills/kbn-github/references/review.md`\n- Local analyzer corpus covering the table above plus the out-of-scope\npass-through cases (publish flags in long/short/`=value` forms with\n`NAME=value`/`env` prefixes and a leading `gh` global flag like\n`-R`/`--repo` before the subcommand, quoted/bare field flags, `--input\n-`, unreadable/non-JSON `--input`, var-PR paths, `--input <file>`\nsanitization, and the submit endpoint / reply bodies / `addSubIssue` /\nread-only commands).\n\nAssisted with Cursor using GPT-5.5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a186006fe76e2287bd2d29a92a3c41d16c3e7e15"}},{"url":"https://github.com/elastic/kibana/pull/272309","number":272309,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->