### PR TITLE
[8.19] [Fleet] Sync agent logging level dropdown with polled metadata (#271964)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.test.tsx
@@ -118,6 +118,8 @@ describe('SelectLogLevel', () => {
       target: { value: 'debug' },
     });
 
+    fireEvent.click(result.getByTestId('applyLogLevelBtn'));
+
     await waitFor(() => {
       expect(mockSendPostAgentAction).toHaveBeenCalledTimes(1);
       expect(mockSendPostAgentAction).toHaveBeenCalledWith('agent1', {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.test.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createFleetTestRendererMock } from '../../../../../../../mock';
+import { sendPostAgentAction, useAuthz, useStartServices } from '../../../../../hooks';
+
+import { SelectLogLevel } from './select_log_level';
+
+jest.mock('../../../../../hooks', () => {
+  return {
+    ...jest.requireActual('../../../../../hooks'),
+    useAuthz: jest.fn(),
+    useStartServices: jest.fn(),
+    sendPostAgentAction: jest.fn(),
+  };
+});
+
+const mockUseStartServices = useStartServices as jest.Mock;
+const mockSendPostAgentAction = sendPostAgentAction as jest.Mock;
+
+const createAgent = (logLevel?: string) =>
+  ({
+    id: 'agent1',
+    local_metadata: {
+      elastic: {
+        agent: {
+          version: '8.15.0',
+          ...(logLevel !== undefined ? { log_level: logLevel } : {}),
+        },
+      },
+    },
+  } as any);
+
+describe('SelectLogLevel', () => {
+  beforeEach(() => {
+    jest.mocked(useAuthz).mockReturnValue({
+      fleet: {
+        allAgents: true,
+      },
+    } as any);
+    mockUseStartServices.mockReturnValue({
+      notifications: {
+        toasts: {
+          addSuccess: jest.fn(),
+          addError: jest.fn(),
+        },
+      },
+      docLinks: {
+        links: {
+          fleet: {
+            agentLevelLogging: 'https://docs.example.com/agent-logging',
+          },
+        },
+      },
+    });
+    mockSendPostAgentAction.mockResolvedValue({});
+  });
+
+  const renderComponent = (props: React.ComponentProps<typeof SelectLogLevel>) => {
+    const renderer = createFleetTestRendererMock();
+    return renderer.render(<SelectLogLevel {...props} />);
+  };
+
+  it('renders the dropdown at the agent reported log level', () => {
+    const result = renderComponent({
+      agent: createAgent('debug'),
+      agentPolicyLogLevel: 'warning',
+    });
+
+    expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('debug');
+  });
+
+  it('falls back to agentPolicyLogLevel when metadata log level is missing', () => {
+    const result = renderComponent({
+      agent: createAgent(),
+      agentPolicyLogLevel: 'warning',
+    });
+
+    expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('warning');
+  });
+
+  it('updates the dropdown when polled agent metadata changes', () => {
+    const result = renderComponent({
+      agent: createAgent('info'),
+      agentPolicyLogLevel: 'warning',
+    });
+
+    expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('info');
+
+    result.rerender(<SelectLogLevel agent={createAgent('debug')} agentPolicyLogLevel="warning" />);
+
+    expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('debug');
+  });
+
+  it('does not revert the dropdown when a stale poll arrives during apply', async () => {
+    let resolveApply: (value: unknown) => void;
+    mockSendPostAgentAction.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveApply = resolve;
+        })
+    );
+
+    const result = renderComponent({
+      agent: createAgent('warning'),
+      agentPolicyLogLevel: 'warning',
+    });
+
+    fireEvent.change(result.getByTestId('selectAgentLogLevel'), {
+      target: { value: 'debug' },
+    });
+
+    await waitFor(() => {
+      expect(mockSendPostAgentAction).toHaveBeenCalledTimes(1);
+      expect(mockSendPostAgentAction).toHaveBeenCalledWith('agent1', {
+        action: {
+          type: 'SETTINGS',
+          data: {
+            log_level: 'debug',
+          },
+        },
+      });
+    });
+
+    result.rerender(
+      <SelectLogLevel agent={createAgent('warning')} agentPolicyLogLevel="warning" />
+    );
+
+    expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('debug');
+
+    resolveApply!({});
+    await waitFor(() => {
+      expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('debug');
+    });
+
+    expect(mockSendPostAgentAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets to policy and sends SETTINGS with log_level null', async () => {
+    const result = renderComponent({
+      agent: createAgent('info'),
+      agentPolicyLogLevel: 'warning',
+    });
+
+    await userEvent.click(result.getByTestId('resetLogLevelBtn'));
+
+    await waitFor(() => {
+      expect(mockSendPostAgentAction).toHaveBeenCalledWith('agent1', {
+        action: {
+          type: 'SETTINGS',
+          data: {
+            log_level: null,
+          },
+        },
+      });
+    });
+
+    expect(result.getByTestId('selectAgentLogLevel')).toHaveValue('warning');
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useState, useCallback } from 'react';
+import React, { memo, useState, useCallback, useEffect, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSelect, EuiFormLabel, EuiButtonEmpty, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
@@ -28,13 +28,34 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
       true
     );
 
-    const [agentLogLevel, setAgentLogLevel] = useState(
-      agent.local_metadata?.elastic?.agent?.log_level ?? agentPolicyLogLevel
-    );
+    const reportedLogLevel = agent.local_metadata?.elastic?.agent?.log_level ?? agentPolicyLogLevel;
+
+    const [agentLogLevel, setAgentLogLevel] = useState(reportedLogLevel);
     const [selectedLogLevel, setSelectedLogLevel] = useState(agentLogLevel);
+    const pendingLogLevelRef = useRef<string | null>(null);
+
+    // Sync dropdown to Fleet-reported log level when polling updates,
+    // don't overwrite during apply/reset or while awaiting agent metadata.
+    useEffect(() => {
+      if (isSetLevelLoading || isResetLevelLoading) {
+        return;
+      }
+      if (selectedLogLevel !== agentLogLevel) {
+        return;
+      }
+      if (pendingLogLevelRef.current !== null && reportedLogLevel !== pendingLogLevelRef.current) {
+        return;
+      }
+      if (pendingLogLevelRef.current !== null && reportedLogLevel === pendingLogLevelRef.current) {
+        pendingLogLevelRef.current = null;
+      }
+      setAgentLogLevel(reportedLogLevel);
+      setSelectedLogLevel(reportedLogLevel);
+    }, [reportedLogLevel, isSetLevelLoading, isResetLevelLoading, selectedLogLevel, agentLogLevel]);
 
     const resetLogLevel = useCallback(() => {
       setIsResetLevelLoading(true);
+      pendingLogLevelRef.current = agentPolicyLogLevel;
       async function send() {
         try {
           const res = await sendPostAgentAction(agent.id, {
@@ -59,6 +80,7 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
             })
           );
         } catch (error) {
+          pendingLogLevelRef.current = null;
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentLogs.resetLogLevel.errorTitleText', {
               defaultMessage: 'Error resetting agent logging level',
@@ -73,6 +95,7 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
 
     const onClickApply = useCallback(() => {
       setIsSetLevelLoading(true);
+      pendingLogLevelRef.current = selectedLogLevel;
       async function send() {
         try {
           const res = await sendPostAgentAction(agent.id, {
@@ -96,6 +119,7 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
             })
           );
         } catch (error) {
+          pendingLogLevelRef.current = null;
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentLogs.selectLogLevel.errorTitleText', {
               defaultMessage: 'Error updating agent logging level',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.tsx
@@ -4,8 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import React, { memo, useState, useCallback } from 'react';
+import React, { memo, useState, useCallback, useEffect, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSelect, EuiFormLabel, EuiButtonEmpty, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
@@ -28,13 +27,34 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
       true
     );
 
-    const [agentLogLevel, setAgentLogLevel] = useState(
-      agent.local_metadata?.elastic?.agent?.log_level ?? agentPolicyLogLevel
-    );
+    const reportedLogLevel = agent.local_metadata?.elastic?.agent?.log_level ?? agentPolicyLogLevel;
+
+    const [agentLogLevel, setAgentLogLevel] = useState(reportedLogLevel);
     const [selectedLogLevel, setSelectedLogLevel] = useState(agentLogLevel);
+    const pendingLogLevelRef = useRef<string | null>(null);
+
+    // Sync dropdown to Fleet-reported log level when polling updates,
+    // don't overwrite during apply/reset or while awaiting agent metadata.
+    useEffect(() => {
+      if (isSetLevelLoading || isResetLevelLoading) {
+        return;
+      }
+      if (selectedLogLevel !== agentLogLevel) {
+        return;
+      }
+      if (pendingLogLevelRef.current !== null && reportedLogLevel !== pendingLogLevelRef.current) {
+        return;
+      }
+      if (pendingLogLevelRef.current !== null && reportedLogLevel === pendingLogLevelRef.current) {
+        pendingLogLevelRef.current = null;
+      }
+      setAgentLogLevel(reportedLogLevel);
+      setSelectedLogLevel(reportedLogLevel);
+    }, [reportedLogLevel, isSetLevelLoading, isResetLevelLoading, selectedLogLevel, agentLogLevel]);
 
     const resetLogLevel = useCallback(() => {
       setIsResetLevelLoading(true);
+      pendingLogLevelRef.current = agentPolicyLogLevel;
       async function send() {
         try {
           const res = await sendPostAgentAction(agent.id, {
@@ -59,6 +79,7 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
             })
           );
         } catch (error) {
+          pendingLogLevelRef.current = null;
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentLogs.resetLogLevel.errorTitleText', {
               defaultMessage: 'Error resetting agent logging level',
@@ -73,6 +94,7 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
 
     const onClickApply = useCallback(() => {
       setIsSetLevelLoading(true);
+      pendingLogLevelRef.current = selectedLogLevel;
       async function send() {
         try {
           const res = await sendPostAgentAction(agent.id, {
@@ -96,6 +118,7 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
             })
           );
         } catch (error) {
+          pendingLogLevelRef.current = null;
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentLogs.selectLogLevel.errorTitleText', {
               defaultMessage: 'Error updating agent logging level',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Sync agent logging level dropdown with polled metadata (#271964)](https://github.com/elastic/kibana/pull/271964)
