### PR TITLE
[9.4] [Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation (#272276)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -167,6 +167,7 @@ function renderController(services: ReturnType<typeof buildServices>['services']
 describe('AgentBuilderAnnouncementModalController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
   });
 
   it('does not render the modal when hideAnnouncements is true', async () => {
@@ -349,5 +350,39 @@ describe('AgentBuilderAnnouncementModalController', () => {
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementModal-2a')).toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
+  });
+
+  it('does not show the modal on remount when dismissed before a slow profile update completes', async () => {
+    // Simulate a slow profile update (e.g. high-latency proxy environment) that hasn't
+    // resolved by the time the user navigates to the next page and the component remounts.
+    let resolvePartialUpdate!: () => void;
+    const slowPartialUpdate = jest.fn(
+      () => new Promise<void>((resolve) => (resolvePartialUpdate = resolve))
+    );
+    const { services } = buildServices();
+    (services.userProfile as { partialUpdate: jest.Mock }).partialUpdate = slowPartialUpdate;
+
+    const { unmount } = renderController(services);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toBeInTheDocument()
+    );
+
+    // Dismiss the modal — markSeen() fires but partialUpdate is still pending.
+    await userEvent.click(screen.getByTestId('agentBuilderAnnouncementContinueButton'));
+
+    // Simulate navigation: unmount and remount before the profile update resolves.
+    unmount();
+    renderController(services);
+
+    // The modal must not reappear even though partialUpdate hasn't finished.
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('agentBuilderAnnouncementContinueButton')
+      ).not.toBeInTheDocument();
+    });
+
+    // Let the pending update resolve to avoid unhandled promise warnings.
+    resolvePartialUpdate();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
@@ -70,7 +70,8 @@ export async function getAnnouncementModalSeen(
 
 /**
  * Persists global dismissal in user profile data.
- * No-ops when user profiles are disabled.
+ * Also writes to localStorage immediately so the modal does not reappear on fast
+ * navigation before the async profile update completes.
  */
 export async function setAnnouncementModalSeen(
   userProfile: UserProfileServiceStart
@@ -79,6 +80,9 @@ export async function setAnnouncementModalSeen(
     if (localStorage.getItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY) === 'true') {
       return;
     }
+    // Write synchronously so getAnnouncementModalSeen returns true on the next
+    // page even if the profile update below hasn't finished yet.
+    localStorage.setItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY, 'true');
   } catch {
     // ignore storage access errors
   }
@@ -103,12 +107,7 @@ export async function setAnnouncementModalSeen(
       },
     });
   } catch {
-    // Fall back to localStorage when user profile updates are unavailable (e.g., reverse proxy auth).
-    try {
-      localStorage.setItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY, 'true');
-    } catch {
-      // ignore storage access errors
-    }
+    // localStorage was already written above; nothing more to do.
   }
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation (#272276)](https://github.com/elastic/kibana/pull/272276)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-06-02T15:02:56Z","message":"[Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation (#272276)\n\n## Summary\n\n### What\nFixes a race condition where the Agent Builder announcement modal could\nreappear on page navigation after the user had already dismissed it.\n\n### Why\n`markSeen()` is called fire-and-forget when the user dismisses the\nmodal. In high-latency or proxy environments (e.g. Eden, Instruqt), the\nasync `userProfile.partialUpdate()` network call may not have completed\nby the time the user navigates to the next page. The new page mounts a\nfresh component, reads the user profile (not yet updated), gets `isSeen\n= false`, and shows the modal again — explaining the \"pops up on nearly\nevery page, goes away after 1–2 times\" reports.\n\nFixes #272269\n\n### Changes\n\n- `setAnnouncementModalSeen`: write to localStorage **synchronously** at\nthe start, before the async profile update. Since\n`getAnnouncementModalSeen` checks localStorage first, any subsequent\nread on the next page hits the short-circuit and returns `true`\nimmediately — regardless of whether the profile API call has finished.\n- `setAnnouncementModalSeen`: simplified the `catch` block comment\n(localStorage is already set before the `try`, so the old fallback write\nthere was redundant).\n- Test: added `localStorage.clear()` to `beforeEach` to keep tests\nisolated.\n- Test: added a new test that simulates the race — slow `partialUpdate`,\nfast navigation (unmount + remount) — and asserts the modal does not\nreappear.\n\n## Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Identify risks\n\n**Race condition between async profile write and next page mount\n(fixed):** The root bug was that dismissal state was not immediately\navailable to the next page when the profile API was slow. Fixed by\nwriting to localStorage synchronously before the async work. Severity:\nlow post-fix — localStorage write happens before any await, so it is\natomic from JavaScript's perspective. The only remaining edge case is if\nlocalStorage itself throws (caught and ignored), in which case the user\nmay see the modal once more on the next page but the profile update will\nstill persist it server-side.\n\nNo data loss, no breaking changes, no performance impact.\n\n### Release note\n\n> Fixes an issue where the Agent Builder announcement modal could\nreappear on page navigation after being dismissed, particularly in\nhigh-latency or proxy environments.\n\n**Suggested label:** `release_note:fix`\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"3133ef4e4d91a59fb7ea307581dfb4ad64cd5467","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","backport:version","v9.5.0","v9.4.3"],"title":"[Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation","number":272276,"url":"https://github.com/elastic/kibana/pull/272276","mergeCommit":{"message":"[Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation (#272276)\n\n## Summary\n\n### What\nFixes a race condition where the Agent Builder announcement modal could\nreappear on page navigation after the user had already dismissed it.\n\n### Why\n`markSeen()` is called fire-and-forget when the user dismisses the\nmodal. In high-latency or proxy environments (e.g. Eden, Instruqt), the\nasync `userProfile.partialUpdate()` network call may not have completed\nby the time the user navigates to the next page. The new page mounts a\nfresh component, reads the user profile (not yet updated), gets `isSeen\n= false`, and shows the modal again — explaining the \"pops up on nearly\nevery page, goes away after 1–2 times\" reports.\n\nFixes #272269\n\n### Changes\n\n- `setAnnouncementModalSeen`: write to localStorage **synchronously** at\nthe start, before the async profile update. Since\n`getAnnouncementModalSeen` checks localStorage first, any subsequent\nread on the next page hits the short-circuit and returns `true`\nimmediately — regardless of whether the profile API call has finished.\n- `setAnnouncementModalSeen`: simplified the `catch` block comment\n(localStorage is already set before the `try`, so the old fallback write\nthere was redundant).\n- Test: added `localStorage.clear()` to `beforeEach` to keep tests\nisolated.\n- Test: added a new test that simulates the race — slow `partialUpdate`,\nfast navigation (unmount + remount) — and asserts the modal does not\nreappear.\n\n## Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Identify risks\n\n**Race condition between async profile write and next page mount\n(fixed):** The root bug was that dismissal state was not immediately\navailable to the next page when the profile API was slow. Fixed by\nwriting to localStorage synchronously before the async work. Severity:\nlow post-fix — localStorage write happens before any await, so it is\natomic from JavaScript's perspective. The only remaining edge case is if\nlocalStorage itself throws (caught and ignored), in which case the user\nmay see the modal once more on the next page but the profile update will\nstill persist it server-side.\n\nNo data loss, no breaking changes, no performance impact.\n\n### Release note\n\n> Fixes an issue where the Agent Builder announcement modal could\nreappear on page navigation after being dismissed, particularly in\nhigh-latency or proxy environments.\n\n**Suggested label:** `release_note:fix`\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"3133ef4e4d91a59fb7ea307581dfb4ad64cd5467"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272276","number":272276,"mergeCommit":{"message":"[Agent Builder] Fix announcement modal reappearing after dismissal on fast navigation (#272276)\n\n## Summary\n\n### What\nFixes a race condition where the Agent Builder announcement modal could\nreappear on page navigation after the user had already dismissed it.\n\n### Why\n`markSeen()` is called fire-and-forget when the user dismisses the\nmodal. In high-latency or proxy environments (e.g. Eden, Instruqt), the\nasync `userProfile.partialUpdate()` network call may not have completed\nby the time the user navigates to the next page. The new page mounts a\nfresh component, reads the user profile (not yet updated), gets `isSeen\n= false`, and shows the modal again — explaining the \"pops up on nearly\nevery page, goes away after 1–2 times\" reports.\n\nFixes #272269\n\n### Changes\n\n- `setAnnouncementModalSeen`: write to localStorage **synchronously** at\nthe start, before the async profile update. Since\n`getAnnouncementModalSeen` checks localStorage first, any subsequent\nread on the next page hits the short-circuit and returns `true`\nimmediately — regardless of whether the profile API call has finished.\n- `setAnnouncementModalSeen`: simplified the `catch` block comment\n(localStorage is already set before the `try`, so the old fallback write\nthere was redundant).\n- Test: added `localStorage.clear()` to `beforeEach` to keep tests\nisolated.\n- Test: added a new test that simulates the race — slow `partialUpdate`,\nfast navigation (unmount + remount) — and asserts the modal does not\nreappear.\n\n## Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Identify risks\n\n**Race condition between async profile write and next page mount\n(fixed):** The root bug was that dismissal state was not immediately\navailable to the next page when the profile API was slow. Fixed by\nwriting to localStorage synchronously before the async work. Severity:\nlow post-fix — localStorage write happens before any await, so it is\natomic from JavaScript's perspective. The only remaining edge case is if\nlocalStorage itself throws (caught and ignored), in which case the user\nmay see the modal once more on the next page but the profile update will\nstill persist it server-side.\n\nNo data loss, no breaking changes, no performance impact.\n\n### Release note\n\n> Fixes an issue where the Agent Builder announcement modal could\nreappear on page navigation after being dismissed, particularly in\nhigh-latency or proxy environments.\n\n**Suggested label:** `release_note:fix`\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"3133ef4e4d91a59fb7ea307581dfb4ad64cd5467"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->