### PR TITLE
[dashboard] FTR remove updating settings from save dashboard method

### DIFF
--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_save.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_save.ts
@@ -151,7 +151,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await header.waitUntilLoadingHasFinished();
 
         await dashboard.switchToEditMode();
-        await dashboard.modifyExistingDashboardDetails(dashboardNameFlyout);
+        await dashboard.modifySettings({ title: dashboardNameFlyout });
       });
     });
   });

--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_time.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_time.ts
@@ -53,8 +53,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('is saved with time', async function () {
         await dashboard.switchToEditMode();
         await timePicker.setDefaultAbsoluteRange();
-        await dashboard.saveDashboard(dashboardName, {
+        await dashboard.modifySettings({
           storeTimeWithDashboard: true,
+        });
+        await dashboard.saveDashboard(dashboardName, {
           saveAsNew: false,
         });
         await dashboard.expectUnsavedChangesListingDoesNotExist(dashboardName);

--- a/src/platform/test/functional/apps/dashboard/group6/view_edit.ts
+++ b/src/platform/test/functional/apps/dashboard/group6/view_edit.ts
@@ -76,8 +76,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'Sep 19, 2013 @ 00:00:00.000',
           'Sep 19, 2013 @ 07:00:00.000'
         );
-        await dashboard.saveDashboard(copyOfDashboardName, {
+        await dashboard.modifySettings({
           storeTimeWithDashboard: true,
+        });
+        await dashboard.saveDashboard(copyOfDashboardName, {
           saveAsNew: false,
         });
         const isViewMode = await dashboard.getIsInViewMode();

--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -544,12 +544,12 @@ export class DashboardPageObject extends FtrService {
     title,
     storeTimeWithDashboard,
     tags,
-    confirmDuplicateTitle
+    confirmDuplicateTitle,
   }: {
     title?: string;
-    storeTimeWithDashboard?: boolean
+    storeTimeWithDashboard?: boolean;
     tags?: string[];
-    confirmDuplicateTitle?: boolean
+    confirmDuplicateTitle?: boolean;
   }) {
     await this.openSettingsFlyout();
 

--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -540,36 +540,43 @@ export class DashboardPageObject extends FtrService {
   /**
    * @description opens the dashboard settings flyout to modify an existing dashboard
    */
-  public async modifyExistingDashboardDetails(
-    dashboard: string,
-    saveOptions: Pick<SaveDashboardOptions, 'storeTimeWithDashboard' | 'tags' | 'needsConfirm'> = {}
-  ) {
+  public async modifySettings({
+    title,
+    storeTimeWithDashboard,
+    tags,
+    confirmDuplicateTitle
+  }: {
+    title?: string;
+    storeTimeWithDashboard?: boolean
+    tags?: string[];
+    confirmDuplicateTitle?: boolean
+  }) {
     await this.openSettingsFlyout();
 
     await this.retry.try(async () => {
-      this.log.debug('entering new title');
-      await this.testSubjects.setValue('dashboardTitleInput', dashboard);
-
-      if (saveOptions.storeTimeWithDashboard !== undefined) {
-        await this.setStoreTimeWithDashboard(saveOptions.storeTimeWithDashboard);
+      if (title) {
+        this.log.debug('entering new title');
+        await this.testSubjects.setValue('dashboardTitleInput', title);
       }
 
-      if (saveOptions.tags) {
+      if (storeTimeWithDashboard !== undefined) {
+        await this.setStoreTimeWithDashboard(storeTimeWithDashboard);
+      }
+
+      if (tags) {
         const tagsComboBox = await this.testSubjects.find('comboBoxInput');
-        for (const tagName of saveOptions.tags) {
+        for (const tagName of tags) {
           await this.comboBox.setElement(tagsComboBox, tagName);
         }
       }
 
-      this.log.debug('DashboardPage.applyCustomization');
       await this.testSubjects.click('applyCustomizeDashboardButton');
 
-      if (saveOptions.needsConfirm) {
+      if (confirmDuplicateTitle) {
         await this.ensureDuplicateTitleCallout();
         await this.testSubjects.click('applyCustomizeDashboardButton');
       }
 
-      this.log.debug('isCustomizeDashboardLoadingIndicatorVisible');
       return await this.expectUnsavedChangesNotificationExists(1500);
     });
   }
@@ -591,7 +598,6 @@ export class DashboardPageObject extends FtrService {
       if (saveOptions.saveAsNew) {
         await this.enterDashboardSaveModalApplyUpdatesAndClickSave(dashboardName, saveOptions);
       } else {
-        await this.modifyExistingDashboardDetails(dashboardName, saveOptions);
         await this.clickQuickSave();
       }
 

--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -598,7 +598,7 @@ export class DashboardPageObject extends FtrService {
       if (saveOptions.saveAsNew) {
         await this.enterDashboardSaveModalApplyUpdatesAndClickSave(dashboardName, saveOptions);
       } else {
-        if (typeof saveOptions.storeTimeWithDashboard === 'boolean' || saveOptions.tags) {
+        if (saveOptions.storeTimeWithDashboard !== undefined || saveOptions.tags) {
           throw new Error(
             `Unable to update settings with quick save. Call 'modifySettings' before calling 'saveDashboard'.`
           );

--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -598,6 +598,11 @@ export class DashboardPageObject extends FtrService {
       if (saveOptions.saveAsNew) {
         await this.enterDashboardSaveModalApplyUpdatesAndClickSave(dashboardName, saveOptions);
       } else {
+        if (typeof saveOptions.storeTimeWithDashboard === 'boolean' || saveOptions.tags) {
+          throw new Error(
+            `Unable to update settings with quick save. Call 'modifySettings' before calling 'saveDashboard'.`
+          );
+        }
         await this.clickQuickSave();
       }
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/272379

`saveDashboard` always calls `modifyExistingDashboardDetails` when `saveAsNew === false`. This adds surface area for flakyness and slows tests down by opening settings menu and closing settings menu.

PR resolves issue by moving `modifyExistingDashboardDetails` out of `saveDashboard`.