### PR TITLE
[kbn-storybook] Build and publish Storybook docs assets for docs-builder

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -12,6 +12,15 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import pLimit from 'p-limit';
+import {
+  buildDocsArchive,
+  buildDocsAssets,
+  buildDocsRegistry,
+} from '@kbn/storybook/src/lib/docs_assets';
+import type {
+  BuildDocsArchiveResult,
+  BuildDocsRegistryResult,
+} from '@kbn/storybook/src/lib/docs_assets';
 import { storybookAliases } from '../../../../src/dev/storybook/aliases';
 import { getKibanaDir } from '#pipeline-utils';
 
@@ -24,8 +33,53 @@ const STORYBOOK_DIRECTORY =
 const STORYBOOK_BUCKET = 'ci-artifacts.kibana.dev/storybooks';
 const STORYBOOK_BUCKET_URL = `https://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}`;
 const STORYBOOK_BASE_URL = `${STORYBOOK_BUCKET_URL}`;
+const STORYBOOK_BUILD_DIR = path.join('.', 'built_assets');
+const STORYBOOK_ASSET_DIR = path.join(STORYBOOK_BUILD_DIR, 'storybook');
+const STORYBOOK_DOCS_DIRECTORY = 'storybook-docs';
+const STORYBOOK_DOCS_BUILD_DIR = path.join(STORYBOOK_BUILD_DIR, STORYBOOK_DOCS_DIRECTORY);
+const STORYBOOK_DOCS_BASE_URL = `${STORYBOOK_BUCKET_URL}/${STORYBOOK_DOCS_DIRECTORY}`;
+const STORYBOOK_DOCS_REGISTRY_FILE = 'docs_registry.json';
+const STORYBOOK_DOCS_REGISTRY_URL = `${STORYBOOK_DOCS_BASE_URL}/${STORYBOOK_DOCS_REGISTRY_FILE}`;
+const STORYBOOK_DOCS_ARCHIVE_SHA = process.env.BUILDKITE_COMMIT || 'unknown';
+const STORYBOOK_DOCS_ARCHIVE_FILE = 'storybook-docs.tar.gz';
+const STORYBOOK_DOCS_ARCHIVE_PATH = path.join(STORYBOOK_BUILD_DIR, STORYBOOK_DOCS_ARCHIVE_FILE);
+const STORYBOOK_DOCS_ARCHIVE_URL = `${STORYBOOK_BASE_URL}/${STORYBOOK_DOCS_ARCHIVE_FILE}`;
 
 const exec = (...args: string[]) => execSync(args.join(' '), { stdio: 'inherit' });
+
+const annotateStorybookDocsArtifacts = (
+  archive: BuildDocsArchiveResult,
+  registry: BuildDocsRegistryResult
+) => {
+  const annotation = [
+    '### Storybook docs artifacts',
+    '',
+    `* Commit: \`${STORYBOOK_DOCS_ARCHIVE_SHA}\``,
+    `* Registry: [${STORYBOOK_DOCS_REGISTRY_FILE}](${STORYBOOK_DOCS_REGISTRY_URL})`,
+    `  * Integrity: \`${registry.integrity}\``,
+    `* Tarball: [${STORYBOOK_DOCS_ARCHIVE_FILE}](${STORYBOOK_DOCS_ARCHIVE_URL})`,
+    `  * Integrity: \`${archive.integrity}\``,
+    '',
+    '```yaml',
+    'sources:',
+    '  kibana:',
+    `    registry: ${STORYBOOK_DOCS_REGISTRY_URL}`,
+    `    integrity: ${registry.integrity}`,
+    '```',
+    '',
+    '```yaml',
+    'sources:',
+    '  kibana:',
+    `    artifact: ${STORYBOOK_DOCS_ARCHIVE_URL}`,
+    `    integrity: ${archive.integrity}`,
+    '```',
+  ].join('\n');
+
+  execSync('buildkite-agent annotate --style info --context storybook-docs-artifacts', {
+    input: annotation,
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+};
 
 const buildStorybook = (storybook: string): Promise<{ logs: string }> => {
   return new Promise((resolve, reject) => {
@@ -73,7 +127,10 @@ const ghStatus = (state: string, description: string) =>
     `--silent`
   );
 
-const build = async () => {
+const build = async (): Promise<{
+  archive: BuildDocsArchiveResult;
+  registry: BuildDocsRegistryResult;
+}> => {
   console.log('--- Building Storybooks');
 
   const limit = pLimit(os.availableParallelism());
@@ -87,18 +144,66 @@ const build = async () => {
     results.forEach(({ logs }) => {
       console.log(logs);
     });
+
+    console.log('--- Generating Storybook docs assets');
+
+    const docsManifests = await Promise.all(
+      storybooks.map((storybook) =>
+        limit(() =>
+          buildDocsAssets({
+            alias: storybook,
+            storybookDir: path.join(STORYBOOK_ASSET_DIR, storybook),
+            docsOutputDir: STORYBOOK_DOCS_BUILD_DIR,
+            inlineBaseUrl: STORYBOOK_DOCS_BASE_URL,
+            iframeBaseUrl: STORYBOOK_BASE_URL,
+            renderMode: 'inline',
+            configDir: storybookAliases[storybook as keyof typeof storybookAliases],
+            buildInlineBundle: true,
+          })
+        )
+      )
+    );
+
+    const registry = await buildDocsRegistry({
+      aliases: storybooks,
+      docsRootDir: STORYBOOK_DOCS_BUILD_DIR,
+      baseUrl: STORYBOOK_DOCS_BASE_URL,
+      build: {
+        commit: process.env.BUILDKITE_COMMIT ?? '',
+        branch: process.env.BUILDKITE_BRANCH ?? '',
+        buildUrl: process.env.BUILDKITE_BUILD_URL,
+      },
+    });
+
+    const archive = await buildDocsArchive({
+      aliases: docsManifests
+        .filter((manifest) => manifest.stories.length > 0)
+        .map((manifest) => manifest.alias),
+      docsRootDir: STORYBOOK_DOCS_BUILD_DIR,
+      outputPath: STORYBOOK_DOCS_ARCHIVE_PATH,
+    });
+
+    return { archive, registry };
   } catch (error) {
     console.error(error);
     throw error;
   }
 };
 
-const upload = () => {
+const upload = (archive: BuildDocsArchiveResult, registry: BuildDocsRegistryResult) => {
   const originalDirectory = process.cwd();
+  const storybookDocsArchivePath = path.resolve(originalDirectory, STORYBOOK_DOCS_ARCHIVE_PATH);
+  const activateScriptPath = path.join(
+    getKibanaDir(),
+    '.buildkite',
+    'scripts',
+    'common',
+    'activate_service_account.sh'
+  );
   try {
     console.log('--- Generating Storybooks HTML');
 
-    process.chdir(path.join('.', 'built_assets', 'storybook'));
+    process.chdir(STORYBOOK_ASSET_DIR);
 
     const storybooks = execSync(`ls -1d */`)
       .toString()
@@ -124,15 +229,22 @@ const upload = () => {
     fs.writeFileSync('index.html', html);
 
     console.log('--- Uploading Storybooks');
-    const activateScript = path.relative(
-      process.cwd(),
-      path.join(getKibanaDir(), '.buildkite', 'scripts', 'common', 'activate_service_account.sh')
-    );
     exec(`
-      ${activateScript} gs://ci-artifacts.kibana.dev
+      ${path.relative(process.cwd(), activateScriptPath)} gs://ci-artifacts.kibana.dev
       gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" --gzip-local=js,css,html,json,map,txt,svg --recursive --no-user-output-enabled '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/'
+      gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" --no-user-output-enabled '${storybookDocsArchivePath}' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/${STORYBOOK_DOCS_ARCHIVE_FILE}'
       gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" --gzip-local=html --no-user-output-enabled 'index.html' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/latest/'
     `);
+
+    console.log('--- Uploading Storybook docs assets');
+    process.chdir(originalDirectory);
+    process.chdir(STORYBOOK_DOCS_BUILD_DIR);
+    exec(`
+      ${path.relative(process.cwd(), activateScriptPath)} gs://ci-artifacts.kibana.dev
+      gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" --gzip-local=js,css,html,json,map,txt,svg --recursive --no-user-output-enabled '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/${STORYBOOK_DOCS_DIRECTORY}/'
+    `);
+
+    annotateStorybookDocsArtifacts(archive, registry);
 
     if (process.env.BUILDKITE_PULL_REQUEST && process.env.BUILDKITE_PULL_REQUEST !== 'false') {
       exec(
@@ -147,8 +259,8 @@ const upload = () => {
 (async () => {
   try {
     ghStatus('pending', 'Building Storybooks');
-    await build();
-    upload();
+    const { archive, registry } = await build();
+    upload(archive, registry);
     ghStatus('success', 'Storybooks built');
   } catch (error) {
     ghStatus('error', 'Building Storybooks failed');

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "spec_to_console": "node scripts/spec_to_console",
     "start": "node scripts/kibana --dev",
     "storybook": "node scripts/storybook",
+    "storybook_docs": "node scripts/storybook_docs",
     "test:ftr": "node scripts/functional_tests",
     "test:ftr:runner": "node scripts/functional_test_runner",
     "test:ftr:server": "node scripts/functional_tests_server",

--- a/scripts/storybook_docs.js
+++ b/scripts/storybook_docs.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+require('@kbn/setup-node-env');
+require('../src/dev/storybook/run_storybook_docs_cli');

--- a/src/dev/storybook/run_storybook_docs_cli.ts
+++ b/src/dev/storybook/run_storybook_docs_cli.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { run } from '@kbn/dev-cli-runner';
+import { createFlagError } from '@kbn/dev-cli-errors';
+import { buildStorybookDocsArtifacts, runStorybookDocsTestServer } from '@kbn/storybook';
+import { storybookAliases } from './aliases';
+
+run(
+  async ({ flagsReader, log }) => {
+    const [alias] = flagsReader.getPositionals();
+
+    if (!alias) {
+      throw createFlagError('Missing alias');
+    }
+
+    if (!Object.hasOwn(storybookAliases, alias)) {
+      throw createFlagError(`Unknown alias [${alias}]`);
+    }
+
+    const build = flagsReader.boolean('build');
+    const dev = flagsReader.boolean('dev');
+    const serve = flagsReader.boolean('serve');
+
+    if ([build, dev, serve].filter(Boolean).length !== 1) {
+      throw createFlagError('Pass exactly one of --build, --dev, or --serve');
+    }
+
+    const port = flagsReader.number('port') ?? 6007;
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      throw createFlagError('Expected --port to be a valid port');
+    }
+
+    const configDir = storybookAliases[alias as keyof typeof storybookAliases];
+    const baseUrl = flagsReader.string('base-url') ?? `http://127.0.0.1:${port}`;
+    const skipStorybookBuild = flagsReader.boolean('skip-storybook-build');
+    const includeAllStories = flagsReader.boolean('include-all-stories');
+
+    if (serve) {
+      await runStorybookDocsTestServer({
+        alias,
+        configDir,
+        port,
+        baseUrl,
+        skipStorybookBuild,
+        includeAllStories,
+        log,
+      });
+      return;
+    }
+
+    const { archive, assetDir, registryUrl, manifest } = await buildStorybookDocsArtifacts({
+      alias,
+      configDir,
+      baseUrl,
+      skipStorybookBuild,
+      includeAllStories,
+      writeArchive: build,
+      log,
+    });
+
+    log.info(`Docs asset directory: ${assetDir}`);
+    log.info(`Docs registry: ${registryUrl}`);
+    if (archive) {
+      log.info(`Docs archive: ${archive.outputPath}`);
+      log.info(`Docs archive integrity: ${archive.integrity}`);
+      log.info(`Storybook sources manifest snippet:
+sources:
+  kibana:
+    artifact: ${archive.outputPath}
+    integrity: ${archive.integrity}`);
+    }
+    log.info(`Embeddable stories: ${manifest.stories.length}`);
+  },
+  {
+    usage: `node scripts/storybook_docs <alias> (--build | --dev | --serve)`,
+    description: `
+      Build Storybook docs artifacts for an alias.
+
+      Available aliases:
+        ${Object.keys(storybookAliases)
+          .map((alias) => `📕 ${alias}`)
+          .join('\n        ')}
+    `,
+    flags: {
+      string: ['base-url', 'port'],
+      boolean: ['build', 'dev', 'include-all-stories', 'serve', 'skip-storybook-build'],
+      help: `
+      --build            Build docs registry, inline assets, and tarball.
+      --dev              Build docs registry and inline assets without creating a tarball.
+      --serve            Build docs artifacts and serve built_assets with CORS.
+      --base-url         Base URL written into docs_registry.json. Defaults to http://127.0.0.1:<port>.
+      --port             Local docs asset server port for --serve. Defaults to 6007.
+      --include-all-stories
+                         Include untagged stories in the generated docs registry.
+      --skip-storybook-build
+                         Reuse the existing static Storybook build.
+    `,
+    },
+  }
+);

--- a/src/platform/packages/shared/kbn-storybook/README.md
+++ b/src/platform/packages/shared/kbn-storybook/README.md
@@ -46,6 +46,27 @@ This package provides ability to add [Storybook](https://storybook.js.org/) to a
 
 - Launch Storybook with `yarn storybook <plugin>`, or build a static site with `yarn storybook --site <plugin>`.
 
+- Tag stories that are safe to consume outside Storybook with `embeddable`. Use the `EmbeddableStoryObj` type (imported as a type, so no runtime code is pulled into the story bundle) to require the tag and strongly type `parameters.embeddable`:
+
+  ```tsx
+  import type { EmbeddableStoryObj } from '@kbn/storybook';
+
+  export const Basic: EmbeddableStoryObj<StoryArgs> = {
+    tags: ['embeddable'],
+    parameters: { embeddable: { height: 96 } },
+  };
+  ```
+
+  `parameters.embeddable.height` is an optional initial-height hint (in pixels) that reserves space and reduces layout shift before the embed measures itself. Sizing is otherwise derived at runtime: the inline embed observes the rendered container and the iframe fallback `postMessage`s its height, both reported via the `kbn-storybook-docs:resize` event (`EMBEDDABLE_RESIZE_EVENT`) for the host to auto-size the embed.
+
+- Build inline docs assets and serve them locally with CORS enabled:
+
+  ```sh
+  yarn storybook_docs <plugin> --serve
+  ```
+
+  The docs assets are written to a dedicated `built_assets/storybook-docs/` tree, kept separate from the Storybook static site under `built_assets/storybook/`. This writes `built_assets/storybook-docs/docs_registry.json` and a per-alias `built_assets/storybook-docs/<alias>/` directory (manifest plus the inline registry bundle), writes a `built_assets/storybook-docs-<alias>-<sha>.tar.gz` archive with `sha256` integrity, serves `built_assets` at `http://127.0.0.1:6007` (so the registry resolves at `http://127.0.0.1:6007/storybook-docs/docs_registry.json` and the iframe fallback at `http://127.0.0.1:6007/storybook/<alias>/iframe.html`), and prints the `docs-builder` `storybook.registry` snippet to use in a local docset. To generate the same files without serving them, run `yarn storybook_docs <plugin> --build`. To generate only the unpacked asset directory without a tarball, run `yarn storybook_docs <plugin> --dev`. Only `embeddable` stories are included by default. Use `--skip-storybook-build` to reuse an existing static Storybook build, or `--include-all-stories` to include untagged stories for local debugging.
+
 ## Customizing configuration
 
 The `defaultConfig` object provided by the `@kbn/storybook` package should be all you need to get running, but you can

--- a/src/platform/packages/shared/kbn-storybook/index.ts
+++ b/src/platform/packages/shared/kbn-storybook/index.ts
@@ -14,3 +14,37 @@ export type { StorybookConfig };
 export { runStorybookCli } from './src/lib/run_storybook_cli';
 export { default as WebpackConfig } from './src/webpack.config';
 export { DEFAULT_THEME, THEMES } from './src/lib/themes';
+export {
+  buildInlineRegistryBundle,
+  buildDocsArchive,
+  buildDocsAssets,
+  buildDocsRegistry,
+  createDocsManifest,
+  createDocsRegistry,
+  createInlineRegistryWebpackConfig,
+  createInlineRegistryEntrySource,
+} from './src/lib/docs_assets';
+export { EMBEDDABLE_STORYBOOK_TAG, EMBEDDABLE_RESIZE_EVENT } from './src/lib/embeddable';
+export type {
+  EmbeddableParameters,
+  EmbeddableParametersForTags,
+  EmbeddableResizePayload,
+  EmbeddableStoryObj,
+  EmbeddableStoryParameters,
+} from './src/lib/embeddable';
+export type { DocsRegistry, MountStoryOptions } from './src/lib/embed_runtime';
+export type {
+  BuildDocsArchiveResult,
+  BuildDocsArchiveOptions,
+  BuildDocsRegistryOptions,
+  BuildDocsRegistryResult,
+  BuildDocsAssetsOptions,
+  CreateInlineRegistryWebpackConfigOptions,
+  StorybookDocsBootstrap,
+  StorybookDocsBundleParameters,
+  StorybookDocsFilterOptions,
+  StorybookDocsManifest,
+  StorybookDocsManifestStory,
+  StorybookDocsMetadata,
+  StorybookDocsRegistry,
+} from './src/lib/docs_assets';

--- a/src/platform/packages/shared/kbn-storybook/index.ts
+++ b/src/platform/packages/shared/kbn-storybook/index.ts
@@ -12,6 +12,7 @@ import { defaultConfig } from './src/lib/default_config';
 export { defaultConfig };
 export type { StorybookConfig };
 export { runStorybookCli } from './src/lib/run_storybook_cli';
+export { buildStorybookDocsArtifacts, runStorybookDocsTestServer } from './src/lib/docs_test';
 export { default as WebpackConfig } from './src/webpack.config';
 export { DEFAULT_THEME, THEMES } from './src/lib/themes';
 export {
@@ -52,6 +53,11 @@ export type {
   StorybookDocsMetadata,
   StorybookDocsRegistry,
 } from './src/lib/docs_assets';
+export type {
+  BuildStorybookDocsArtifactsOptions,
+  BuildStorybookDocsArtifactsResult,
+  RunStorybookDocsTestServerOptions,
+} from './src/lib/docs_test';
 export type {
   StorybookDocsReference,
   ValidateStorybookDocsReferencesResult,

--- a/src/platform/packages/shared/kbn-storybook/index.ts
+++ b/src/platform/packages/shared/kbn-storybook/index.ts
@@ -33,6 +33,10 @@ export type {
   EmbeddableStoryParameters,
 } from './src/lib/embeddable';
 export type { DocsRegistry, MountStoryOptions } from './src/lib/embed_runtime';
+export {
+  extractStorybookDocsReferences,
+  validateStorybookDocsReferences,
+} from './src/lib/docs_references';
 export type {
   BuildDocsArchiveResult,
   BuildDocsArchiveOptions,
@@ -48,3 +52,7 @@ export type {
   StorybookDocsMetadata,
   StorybookDocsRegistry,
 } from './src/lib/docs_assets';
+export type {
+  StorybookDocsReference,
+  ValidateStorybookDocsReferencesResult,
+} from './src/lib/docs_references';

--- a/src/platform/packages/shared/kbn-storybook/jest.config.js
+++ b/src/platform/packages/shared/kbn-storybook/jest.config.js
@@ -7,9 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { resolve } from 'path';
-import { REPO_ROOT as KIBANA_ROOT } from '@kbn/repo-info';
-
-export const REPO_ROOT = KIBANA_ROOT;
-export const ASSET_DIR = resolve(KIBANA_ROOT, 'built_assets/storybook');
-export const DOCS_ASSET_DIR = resolve(KIBANA_ROOT, 'built_assets/storybook-docs');
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/src/platform/packages/shared/kbn-storybook'],
+};

--- a/src/platform/packages/shared/kbn-storybook/src/lib/decorators.tsx
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/decorators.tsx
@@ -22,6 +22,7 @@ import { KibanaRootContextProvider } from '@kbn/react-kibana-context-root';
 import { i18n } from '@kbn/i18n';
 
 import { DEFAULT_THEME, getKibanaTheme } from './themes';
+import { EMBEDDABLE_RESIZE_EVENT, EMBEDDABLE_STORYBOOK_TAG } from './embeddable';
 
 const theme$ = new BehaviorSubject<CoreTheme>(getKibanaTheme(DEFAULT_THEME));
 const userProfile = { getUserProfile$: () => of(null) };
@@ -56,4 +57,41 @@ const KibanaContextDecorator: Decorator = (storyFn, { globals }) => {
   );
 };
 
-export const decorators = [KibanaContextDecorator];
+/**
+ * When an embeddable story renders inside an iframe (the docs-builder fallback),
+ * report the measured height to the parent via {@link EMBEDDABLE_RESIZE_EVENT}
+ * so the host can auto-size the iframe.
+ */
+const EmbeddableResize: React.FC<{ storyId: string; children: React.ReactNode }> = ({
+  storyId,
+  children,
+}) => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || window.parent === window) {
+      return;
+    }
+
+    const root = document.documentElement;
+    const post = () => {
+      const height = Math.ceil(root.getBoundingClientRect().height);
+      window.parent.postMessage({ type: EMBEDDABLE_RESIZE_EVENT, storyId, height }, '*');
+    };
+    const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(post) : undefined;
+
+    observer?.observe(root);
+    post();
+
+    return () => observer?.disconnect();
+  }, [storyId]);
+
+  return <>{children}</>;
+};
+
+const EmbeddableResizeDecorator: Decorator = (storyFn, { id, tags }) =>
+  tags?.includes(EMBEDDABLE_STORYBOOK_TAG) ? (
+    <EmbeddableResize storyId={id}>{storyFn()}</EmbeddableResize>
+  ) : (
+    storyFn()
+  );
+
+export const decorators = [KibanaContextDecorator, EmbeddableResizeDecorator];

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.test.ts
@@ -1,0 +1,569 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  buildDocsAssets,
+  buildDocsArchive,
+  buildDocsRegistry,
+  createDocsManifest,
+  createDocsRegistry,
+  createInlineRegistryEntrySource,
+  createInlineRegistryWebpackConfig,
+} from './docs_assets';
+import type { StorybookIndex } from './docs_assets';
+import { EMBEDDABLE_STORYBOOK_TAG } from './embeddable';
+
+const INLINE_BASE_URL = 'https://ci-artifacts.kibana.dev/storybooks/pr-1/storybook-docs';
+const IFRAME_BASE_URL = 'https://ci-artifacts.kibana.dev/storybooks/pr-1';
+
+const storybookIndex: StorybookIndex = {
+  entries: {
+    'components-button--regular': {
+      title: 'Components/Button',
+      name: 'Regular',
+      type: 'story',
+      importPath: './src/button.stories.tsx',
+      componentPath: './src/button.tsx',
+      tags: [EMBEDDABLE_STORYBOOK_TAG],
+    },
+    'components-button--docs': {
+      title: 'Components/Button',
+      name: 'Docs',
+      type: 'docs',
+      importPath: './src/button.mdx',
+    },
+    'components-input--custom': {
+      id: 'components-input--custom',
+      title: 'Components/Input',
+      name: 'Custom',
+      type: 'story',
+      importPath: './src/input.stories.tsx',
+    },
+  },
+};
+
+describe('createDocsManifest', () => {
+  it('keeps only embeddable story entries and maps storybook fields into docs manifest stories', () => {
+    const manifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: `${INLINE_BASE_URL}/`,
+      iframeBaseUrl: `${IFRAME_BASE_URL}/`,
+      index: storybookIndex,
+    });
+
+    expect(manifest).toEqual({
+      schemaVersion: 1,
+      producer: 'kibana-storybook-docs-manifest',
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      stories: [
+        {
+          alias: 'shared_ux',
+          docsId: 'components-button--regular',
+          storybookId: 'components-button--regular',
+          title: 'Components/Button',
+          name: 'Regular',
+          importPath: './src/button.stories.tsx',
+          componentPath: './src/button.tsx',
+          tags: [EMBEDDABLE_STORYBOOK_TAG],
+          type: 'story',
+          renderMode: 'iframe',
+          iframe: {
+            url: `${IFRAME_BASE_URL}/shared_ux/iframe.html?id=components-button--regular&viewMode=story`,
+          },
+        },
+      ],
+    });
+  });
+
+  it('can include all story entries for local debugging', () => {
+    const manifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: storybookIndex,
+      filter: {
+        includeAllStories: true,
+      },
+    });
+
+    expect(manifest.stories.map(({ storybookId }) => storybookId)).toEqual([
+      'components-button--regular',
+      'components-input--custom',
+    ]);
+  });
+
+  it('encodes storybook IDs in iframe URLs rooted at the static site', () => {
+    const manifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: {
+        entries: {
+          'components/button--regular variant': {
+            title: 'Components/Button',
+            name: 'Regular variant',
+            type: 'story',
+            importPath: './src/button.stories.tsx',
+            tags: [EMBEDDABLE_STORYBOOK_TAG],
+          },
+        },
+      },
+    });
+
+    expect(manifest.stories[0].iframe.url).toBe(
+      `${IFRAME_BASE_URL}/shared_ux/iframe.html?id=components%2Fbutton--regular%20variant&viewMode=story`
+    );
+  });
+
+  it('roots inline entries at the docs subpath and bootstrap at the static site', () => {
+    const manifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: {
+        entries: {
+          'components-button--regular': {
+            title: 'Components/Button',
+            name: 'Regular',
+            type: 'story',
+            importPath: './src/button.stories.tsx',
+            tags: [EMBEDDABLE_STORYBOOK_TAG],
+          },
+        },
+      },
+      renderMode: 'inline',
+    });
+
+    expect(manifest.stories[0]).toMatchObject({
+      renderMode: 'inline',
+      inline: {
+        entry: `${INLINE_BASE_URL}/shared_ux/registry.js`,
+        bundleId: 'shared_ux',
+        bootstrap: {
+          publicPath: `${IFRAME_BASE_URL}/shared_ux/`,
+          scripts: [
+            `${IFRAME_BASE_URL}/shared_ux/kbn-ui-shared-deps-npm.dll.js`,
+            `${IFRAME_BASE_URL}/shared_ux/kbn-ui-shared-deps-src.js`,
+          ],
+          styles: [
+            `${IFRAME_BASE_URL}/shared_ux/kbn-ui-shared-deps-src.css`,
+            'https://fonts.googleapis.com/css2?family=Inter:wght@300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap',
+          ],
+        },
+      },
+    });
+  });
+
+  it('uses docs metadata for stable docs IDs and default heights', () => {
+    const manifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: storybookIndex,
+      docsMetadata: {
+        'components-button--regular': {
+          id: 'button-regular',
+          height: 240,
+        },
+      },
+    });
+
+    expect(manifest.stories[0]).toMatchObject({
+      docsId: 'button-regular',
+      storybookId: 'components-button--regular',
+      height: 240,
+      iframe: {
+        url: `${IFRAME_BASE_URL}/shared_ux/iframe.html?id=components-button--regular&viewMode=story`,
+      },
+    });
+    expect(manifest.stories).toHaveLength(1);
+  });
+
+  it('fails on duplicate docs IDs within an alias', () => {
+    expect(() =>
+      createDocsManifest({
+        alias: 'shared_ux',
+        inlineBaseUrl: INLINE_BASE_URL,
+        iframeBaseUrl: IFRAME_BASE_URL,
+        index: storybookIndex,
+        docsMetadata: {
+          'components-button--regular': {
+            id: 'duplicate',
+          },
+          'components-input--custom': {
+            id: 'duplicate',
+          },
+        },
+        filter: {
+          includeAllStories: true,
+        },
+      })
+    ).toThrowError('Duplicate Storybook docs ID [duplicate] in alias [shared_ux]');
+  });
+});
+
+describe('buildDocsAssets', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kbn-storybook-docs-assets-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads Storybook index.json and writes the docs manifest into the docs output tree', async () => {
+    const docsOutputDir = join(tempDir, 'docs-output');
+    await mkdir(tempDir, { recursive: true });
+    await writeFile(join(tempDir, 'index.json'), JSON.stringify(storybookIndex), 'utf8');
+
+    const manifest = await buildDocsAssets({
+      alias: 'shared_ux',
+      storybookDir: tempDir,
+      docsOutputDir,
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      docsMetadata: {
+        'components-button--regular': {
+          id: 'button-regular',
+          height: 240,
+        },
+      },
+    });
+    const manifestJson = await readFile(join(docsOutputDir, 'shared_ux', 'manifest.json'), 'utf8');
+
+    expect(JSON.parse(manifestJson)).toEqual(manifest);
+    expect(manifest.stories.map(({ docsId }) => docsId)).toEqual(['button-regular']);
+    expect(manifest.stories[0].height).toBe(240);
+  });
+
+  it('writes a generated registry entry source for inline assets', async () => {
+    const docsOutputDir = join(tempDir, 'docs-output');
+    await mkdir(tempDir, { recursive: true });
+    await writeFile(join(tempDir, 'index.json'), JSON.stringify(storybookIndex), 'utf8');
+
+    const manifest = await buildDocsAssets({
+      alias: 'shared_ux',
+      storybookDir: tempDir,
+      docsOutputDir,
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      renderMode: 'inline',
+      configDir: join(tempDir, '.storybook'),
+    });
+    const registryEntrySource = await readFile(
+      join(docsOutputDir, 'shared_ux', 'registry_entry.js'),
+      'utf8'
+    );
+
+    expect(manifest.stories.every(({ renderMode }) => renderMode === 'inline')).toBe(true);
+    expect(registryEntrySource).toContain(
+      `import * as previewAnnotations from "${join(tempDir, '.storybook', 'preview')}";`
+    );
+    expect(registryEntrySource).toContain(
+      `"components-button--regular": () => import("${join(
+        process.cwd(),
+        'src/button.stories.tsx'
+      )}"),`
+    );
+    expect(registryEntrySource).not.toContain(
+      `"components-input--custom": () => import("${join(process.cwd(), 'src/input.stories.tsx')}"),`
+    );
+  });
+
+  it('requires preview annotations when writing inline assets', async () => {
+    const docsOutputDir = join(tempDir, 'docs-output');
+    await mkdir(tempDir, { recursive: true });
+    await writeFile(join(tempDir, 'index.json'), JSON.stringify(storybookIndex), 'utf8');
+
+    await expect(
+      buildDocsAssets({
+        alias: 'shared_ux',
+        storybookDir: tempDir,
+        docsOutputDir,
+        inlineBaseUrl: INLINE_BASE_URL,
+        iframeBaseUrl: IFRAME_BASE_URL,
+        renderMode: 'inline',
+      })
+    ).rejects.toThrowError(
+      'Inline Storybook docs assets require previewAnnotationsImportPath or configDir.'
+    );
+  });
+
+  it('skips inline source generation when no stories are embeddable', async () => {
+    const docsOutputDir = join(tempDir, 'docs-output');
+    await mkdir(tempDir, { recursive: true });
+    await writeFile(
+      join(tempDir, 'index.json'),
+      JSON.stringify({
+        entries: {
+          'components-input--custom': storybookIndex.entries['components-input--custom'],
+        },
+      }),
+      'utf8'
+    );
+
+    const manifest = await buildDocsAssets({
+      alias: 'shared_ux',
+      storybookDir: tempDir,
+      docsOutputDir,
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      renderMode: 'inline',
+    });
+
+    expect(manifest.stories).toEqual([]);
+    await expect(
+      readFile(join(docsOutputDir, 'shared_ux', 'registry_entry.js'), 'utf8')
+    ).rejects.toThrow();
+  });
+});
+
+describe('createInlineRegistryEntrySource', () => {
+  it('generates the dynamic story-import map and delegates to the embed runtime', () => {
+    const source = createInlineRegistryEntrySource({
+      alias: 'shared_ux',
+      index: storybookIndex,
+      previewAnnotationsImportPath: '../.storybook/preview',
+    });
+
+    expect(source).toContain('import * as previewAnnotations from "../.storybook/preview";');
+    expect(source).toContain('import { createDocsRegistry } from "');
+    expect(source).toContain('embed_runtime');
+    expect(source).toContain(
+      '"components-button--regular": () => import("./src/button.stories.tsx"),'
+    );
+    expect(source).not.toContain(
+      '"components-input--custom": () => import("./src/input.stories.tsx"),'
+    );
+    expect(source).toContain(
+      'export const { mountStory, unmountStory, getStoryParameters } = createDocsRegistry({'
+    );
+    expect(source).toContain('alias: "shared_ux",');
+    expect(source).toContain('projectAnnotations: previewAnnotations,');
+    expect(source).not.toContain('() => import("./src/button.mdx")');
+  });
+});
+
+describe('createInlineRegistryWebpackConfig', () => {
+  it('targets an ESM docs registry bundle with lazy chunks beside it', () => {
+    const config = createInlineRegistryWebpackConfig({
+      entryPath: '/storybook-docs/shared_ux/registry_entry.js',
+      docsDir: '/storybook-docs/shared_ux',
+    });
+
+    expect(config.entry).toEqual({
+      registry: '/storybook-docs/shared_ux/registry_entry.js',
+    });
+    expect(config.output).toMatchObject({
+      path: '/storybook-docs/shared_ux',
+      filename: 'registry.js',
+      chunkFilename: '[name].[contenthash].registry.js',
+      publicPath: 'auto',
+      module: true,
+      library: {
+        type: 'module',
+      },
+    });
+    expect(config.experiments).toMatchObject({
+      outputModule: true,
+    });
+  });
+});
+
+describe('createDocsRegistry', () => {
+  it('aggregates manifests into namespaced story records', () => {
+    const sharedUxManifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: storybookIndex,
+    });
+    const observabilityManifest = createDocsManifest({
+      alias: 'observability',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: {
+        entries: {
+          'components-button--regular': {
+            title: 'Components/Button',
+            name: 'Regular',
+            type: 'story',
+            importPath: './src/observability_button.stories.tsx',
+            tags: [EMBEDDABLE_STORYBOOK_TAG],
+          },
+        },
+      },
+    });
+
+    const registry = createDocsRegistry({
+      baseUrl: `${INLINE_BASE_URL}/`,
+      build: {
+        commit: 'abc123',
+        branch: 'main',
+        buildUrl: 'https://buildkite.example/builds/1',
+      },
+      manifests: [sharedUxManifest, observabilityManifest],
+    });
+
+    expect(registry.schemaVersion).toBe(1);
+    expect(registry.producer).toBe('kibana-storybook');
+    expect(registry.baseUrl).toBe(INLINE_BASE_URL);
+    expect(registry.build).toEqual({
+      commit: 'abc123',
+      branch: 'main',
+      buildUrl: 'https://buildkite.example/builds/1',
+    });
+    expect(Object.keys(registry.stories)).toEqual([
+      'kibana:shared_ux:components-button--regular',
+      'kibana:observability:components-button--regular',
+    ]);
+    expect(registry.stories['kibana:shared_ux:components-button--regular'].importPath).toBe(
+      './src/button.stories.tsx'
+    );
+    expect(registry.stories['kibana:observability:components-button--regular'].importPath).toBe(
+      './src/observability_button.stories.tsx'
+    );
+  });
+
+  it('fails on duplicate docs IDs within an alias', () => {
+    const manifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: storybookIndex,
+    });
+
+    expect(() =>
+      createDocsRegistry({
+        baseUrl: INLINE_BASE_URL,
+        build: {
+          commit: 'abc123',
+          branch: 'main',
+        },
+        manifests: [manifest, manifest],
+      })
+    ).toThrowError('Duplicate Storybook docs ID [kibana:shared_ux:components-button--regular]');
+  });
+});
+
+describe('buildDocsRegistry', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kbn-storybook-docs-registry-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads alias manifests, writes the root docs registry, and reports integrity', async () => {
+    const sharedUxDir = join(tempDir, 'shared_ux');
+    const observabilityDir = join(tempDir, 'observability');
+    const sharedUxManifest = createDocsManifest({
+      alias: 'shared_ux',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: storybookIndex,
+    });
+    const observabilityManifest = createDocsManifest({
+      alias: 'observability',
+      inlineBaseUrl: INLINE_BASE_URL,
+      iframeBaseUrl: IFRAME_BASE_URL,
+      index: {
+        entries: {
+          'app-alerts--severity': {
+            title: 'App/Alerts',
+            name: 'Severity',
+            type: 'story',
+            importPath: './src/alert_severity_badge.stories.tsx',
+            tags: [EMBEDDABLE_STORYBOOK_TAG],
+          },
+        },
+      },
+    });
+
+    await mkdir(sharedUxDir, { recursive: true });
+    await mkdir(observabilityDir, { recursive: true });
+    await writeFile(join(sharedUxDir, 'manifest.json'), JSON.stringify(sharedUxManifest), 'utf8');
+    await writeFile(
+      join(observabilityDir, 'manifest.json'),
+      JSON.stringify(observabilityManifest),
+      'utf8'
+    );
+
+    const result = await buildDocsRegistry({
+      aliases: ['shared_ux', 'observability'],
+      docsRootDir: tempDir,
+      baseUrl: INLINE_BASE_URL,
+      build: {
+        commit: 'abc123',
+        branch: 'main',
+      },
+    });
+    const registryPath = join(tempDir, 'docs_registry.json');
+    const registryJson = await readFile(registryPath, 'utf8');
+    const registryStats = await stat(registryPath);
+
+    expect(JSON.parse(registryJson)).toEqual(result.registry);
+    expect(Object.keys(result.registry.stories)).toEqual([
+      'kibana:shared_ux:components-button--regular',
+      'kibana:observability:app-alerts--severity',
+    ]);
+    expect(result.outputPath).toBe(registryPath);
+    expect(result.size).toBe(registryStats.size);
+    expect(result.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.integrity).toBe(`sha256-${result.sha256}`);
+  });
+});
+
+describe('buildDocsArchive', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kbn-storybook-docs-archive-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes a tarball containing the root registry and selected alias docs assets', async () => {
+    const sharedUxDir = join(tempDir, 'shared_ux');
+    const archivePath = join(tempDir, 'storybook-docs-test.tar.gz');
+
+    await mkdir(sharedUxDir, { recursive: true });
+    await writeFile(join(tempDir, 'docs_registry.json'), '{}\n', 'utf8');
+    await writeFile(join(sharedUxDir, 'registry.js'), 'export {};\n', 'utf8');
+
+    const archive = await buildDocsArchive({
+      aliases: ['shared_ux'],
+      docsRootDir: tempDir,
+      outputPath: archivePath,
+    });
+
+    const archiveStats = await stat(archivePath);
+
+    expect(archiveStats.isFile()).toBe(true);
+    expect(archiveStats.size).toBeGreaterThan(0);
+    expect(archive).toEqual({
+      integrity: `sha256-${archive.sha256}`,
+      outputPath: archivePath,
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      size: archiveStats.size,
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.ts
@@ -1,0 +1,645 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createHash } from 'crypto';
+import { createReadStream, createWriteStream } from 'fs';
+import { mkdir, readFile, stat, writeFile } from 'fs/promises';
+import { dirname, join, resolve } from 'path';
+import archiver from 'archiver';
+import webpack from 'webpack';
+import type { Configuration, StatsError } from 'webpack';
+import { default as WebpackConfig } from '../webpack.config';
+import { EMBEDDABLE_STORYBOOK_TAG } from './embeddable';
+
+export interface StorybookIndexEntry {
+  id?: string;
+  title: string;
+  name: string;
+  type: string;
+  importPath: string;
+  exportName?: string;
+  componentPath?: string;
+  tags?: string[];
+}
+
+export interface StorybookIndex {
+  entries: Record<string, StorybookIndexEntry>;
+}
+
+export interface StorybookDocsBootstrap {
+  publicPath: string;
+  scripts: string[];
+  styles: string[];
+}
+
+export interface StorybookDocsManifestStory {
+  alias: string;
+  docsId: string;
+  storybookId: string;
+  title: string;
+  name: string;
+  importPath: string;
+  componentPath?: string;
+  tags?: string[];
+  height?: number;
+  type: 'story';
+  renderMode: 'inline' | 'iframe';
+  inline?: {
+    entry: string;
+    bundleId: string;
+    bootstrap: StorybookDocsBootstrap;
+  };
+  iframe: {
+    url: string;
+  };
+}
+
+export interface StorybookDocsManifest {
+  schemaVersion: 1;
+  producer: 'kibana-storybook-docs-manifest';
+  alias: string;
+  inlineBaseUrl: string;
+  iframeBaseUrl: string;
+  stories: StorybookDocsManifestStory[];
+}
+
+export interface StorybookDocsRegistry {
+  schemaVersion: 1;
+  producer: 'kibana-storybook';
+  baseUrl: string;
+  build: {
+    commit: string;
+    branch: string;
+    buildUrl?: string;
+  };
+  stories: Record<`kibana:${string}:${string}`, StorybookDocsManifestStory>;
+}
+
+export interface StorybookDocsBundleParameters {
+  id?: string;
+  height?: number;
+}
+
+export type StorybookDocsMetadata = Record<string, StorybookDocsBundleParameters>;
+
+export interface StorybookDocsFilterOptions {
+  includeAllStories?: boolean;
+  includeTags?: string[];
+}
+
+export interface BuildDocsAssetsOptions {
+  alias: string;
+  storybookDir: string;
+  docsOutputDir: string;
+  inlineBaseUrl: string;
+  iframeBaseUrl: string;
+  renderMode?: StorybookDocsManifestStory['renderMode'];
+  previewAnnotationsImportPath?: string;
+  configDir?: string;
+  buildInlineBundle?: boolean;
+  docsMetadata?: StorybookDocsMetadata;
+  filter?: StorybookDocsFilterOptions;
+}
+
+export interface BuildDocsRegistryOptions {
+  aliases: string[];
+  docsRootDir: string;
+  baseUrl: string;
+  build: StorybookDocsRegistry['build'];
+}
+
+export interface BuildDocsRegistryResult {
+  registry: StorybookDocsRegistry;
+  integrity: `sha256-${string}`;
+  outputPath: string;
+  sha256: string;
+  size: number;
+}
+
+export interface BuildDocsArchiveOptions {
+  aliases: string[];
+  docsRootDir: string;
+  outputPath: string;
+}
+
+export interface BuildDocsArchiveResult {
+  integrity: `sha256-${string}`;
+  outputPath: string;
+  sha256: string;
+  size: number;
+}
+
+export interface CreateInlineRegistryWebpackConfigOptions {
+  entryPath: string;
+  docsDir: string;
+}
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+
+const joinUrl = (...parts: string[]): string =>
+  parts
+    .filter(Boolean)
+    .map((part, index) => {
+      if (index === 0) {
+        return trimTrailingSlash(part);
+      }
+      return part.replace(/^\/+|\/+$/g, '');
+    })
+    .join('/');
+
+const createIframeUrl = (aliasBaseUrl: string, storybookId: string): string =>
+  `${joinUrl(aliasBaseUrl, 'iframe.html')}?id=${encodeURIComponent(storybookId)}&viewMode=story`;
+
+const createBootstrap = (aliasBaseUrl: string): StorybookDocsBootstrap => ({
+  publicPath: `${trimTrailingSlash(aliasBaseUrl)}/`,
+  scripts: [
+    joinUrl(aliasBaseUrl, 'kbn-ui-shared-deps-npm.dll.js'),
+    joinUrl(aliasBaseUrl, 'kbn-ui-shared-deps-src.js'),
+  ],
+  styles: [
+    joinUrl(aliasBaseUrl, 'kbn-ui-shared-deps-src.css'),
+    'https://fonts.googleapis.com/css2?family=Inter:wght@300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap',
+  ],
+});
+
+const stringify = (value: string): string => JSON.stringify(value);
+
+const shouldIncludeStory = (
+  entry: StorybookIndexEntry,
+  {
+    includeAllStories = false,
+    includeTags = [EMBEDDABLE_STORYBOOK_TAG],
+  }: StorybookDocsFilterOptions
+): boolean => {
+  if (entry.type !== 'story') {
+    return false;
+  }
+
+  if (includeAllStories) {
+    return true;
+  }
+
+  return includeTags.some((tag) => entry.tags?.includes(tag));
+};
+
+const getStoryEntries = (
+  index: StorybookIndex,
+  filter: StorybookDocsFilterOptions = {}
+): Array<[string, StorybookIndexEntry]> =>
+  Object.entries(index.entries).filter(([, entry]) => shouldIncludeStory(entry, filter));
+
+export const createInlineRegistryEntrySource = ({
+  alias,
+  index,
+  previewAnnotationsImportPath,
+  storyImportRoot,
+  filter,
+}: {
+  alias: string;
+  index: StorybookIndex;
+  previewAnnotationsImportPath: string;
+  storyImportRoot?: string;
+  filter?: StorybookDocsFilterOptions;
+}): string => {
+  const storyLoaders = getStoryEntries(index, filter)
+    .map(([entryId, entry]) => {
+      const storybookId = entry.id ?? entryId;
+      const importPath =
+        storyImportRoot?.startsWith('/') && entry.importPath.startsWith('.')
+          ? resolve(storyImportRoot, entry.importPath)
+          : entry.importPath;
+      return `  ${stringify(storybookId)}: () => import(${stringify(importPath)}),`;
+    })
+    .join('\n');
+  const runtimeImportPath = resolve(__dirname, 'embed_runtime');
+
+  return `import * as previewAnnotations from ${stringify(previewAnnotationsImportPath)};
+import { createDocsRegistry } from ${stringify(runtimeImportPath)};
+
+const storyModules = {
+${storyLoaders}
+};
+
+export const { mountStory, unmountStory, getStoryParameters } = createDocsRegistry({
+  alias: ${stringify(alias)},
+  storyModules,
+  projectAnnotations: previewAnnotations,
+});
+`;
+};
+
+export const createInlineRegistryWebpackConfig = ({
+  entryPath,
+  docsDir,
+}: CreateInlineRegistryWebpackConfigOptions): Configuration =>
+  WebpackConfig({
+    config: {
+      mode: 'production',
+      target: 'web',
+      entry: {
+        registry: resolve(entryPath),
+      },
+      output: {
+        path: resolve(docsDir),
+        filename: 'registry.js',
+        chunkFilename: '[name].[contenthash].registry.js',
+        publicPath: 'auto',
+        module: true,
+        library: {
+          type: 'module',
+        },
+      },
+      experiments: {
+        outputModule: true,
+      },
+      externalsType: 'var',
+      devtool: 'source-map',
+      module: {
+        rules: [
+          {
+            test: /\.(js|jsx|ts|tsx|mjs)$/,
+            exclude: /node_modules/,
+            use: {
+              loader: require.resolve('babel-loader'),
+              options: {
+                presets: [
+                  require.resolve('@kbn/babel-preset/common_preset'),
+                  [
+                    require.resolve('@emotion/babel-preset-css-prop'),
+                    {
+                      autoLabel: 'always',
+                      labelFormat: '[filename]--[local]',
+                    },
+                  ],
+                ],
+              },
+            },
+          },
+          {
+            test: /\.css$/,
+            use: ['style-loader', 'css-loader'],
+          },
+          {
+            test: /\.mdx?$/,
+            type: 'asset/source',
+          },
+          {
+            test: /\.(woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|webp)(\?|$)/,
+            type: 'asset/resource',
+            generator: {
+              filename: 'assets/[name].[contenthash][ext]',
+            },
+          },
+          {
+            test: /\.scss$/,
+            exclude: /\.module.(s(a|c)ss)$/,
+            use: [
+              { loader: 'style-loader' },
+              { loader: 'css-loader', options: { importLoaders: 2 } },
+              {
+                loader: 'postcss-loader',
+                options: {
+                  postcssOptions: {
+                    config: require.resolve('@kbn/optimizer/postcss.config'),
+                  },
+                },
+              },
+              {
+                loader: 'sass-loader',
+                options: {
+                  additionalData: (content: string): string => {
+                    const globalsPath = stringify(
+                      resolve(
+                        __dirname,
+                        '../../../../../../core/public/styles/core_app/_globals_borealislight.scss'
+                      )
+                    );
+                    return `@import ${globalsPath};\n${content}`;
+                  },
+                  implementation: require('sass-embedded'),
+                  sassOptions: {
+                    includePaths: [resolve(__dirname, '../../../../../../../node_modules')],
+                    quietDeps: true,
+                    silenceDeprecations: ['import', 'legacy-js-api'],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      plugins: [
+        new webpack.DefinePlugin({
+          'process.env.NODE_ENV': JSON.stringify('production'),
+        }),
+      ],
+      resolve: {
+        extensions: ['.js', '.mjs', '.ts', '.tsx', '.json', '.mdx'],
+      },
+      optimization: {
+        runtimeChunk: false,
+      },
+      stats: 'errors-only',
+    },
+  });
+
+const formatWebpackError = (error: StatsError): string => {
+  if (error.message) {
+    return error.message;
+  }
+
+  return JSON.stringify(error);
+};
+
+export const buildInlineRegistryBundle = async ({
+  entryPath,
+  docsDir,
+}: CreateInlineRegistryWebpackConfigOptions): Promise<void> => {
+  const config = createInlineRegistryWebpackConfig({ entryPath, docsDir });
+
+  await new Promise<void>((resolvePromise, reject) => {
+    const compiler = webpack(config);
+
+    compiler.run((runError, stats) => {
+      compiler.close((closeError) => {
+        if (runError) {
+          reject(runError);
+          return;
+        }
+
+        if (closeError) {
+          reject(closeError);
+          return;
+        }
+
+        const errors = stats?.toJson({ errors: true }).errors ?? [];
+
+        if (errors.length) {
+          reject(new Error(errors.map(formatWebpackError).join('\n\n')));
+          return;
+        }
+
+        resolvePromise();
+      });
+    });
+  });
+};
+
+export const createDocsManifest = ({
+  alias,
+  inlineBaseUrl,
+  iframeBaseUrl,
+  index,
+  renderMode = 'iframe',
+  docsMetadata = {},
+  filter,
+}: {
+  alias: string;
+  inlineBaseUrl: string;
+  iframeBaseUrl: string;
+  index: StorybookIndex;
+  renderMode?: StorybookDocsManifestStory['renderMode'];
+  docsMetadata?: StorybookDocsMetadata;
+  filter?: StorybookDocsFilterOptions;
+}): StorybookDocsManifest => {
+  const aliasInlineBaseUrl = joinUrl(inlineBaseUrl, alias);
+  const aliasIframeBaseUrl = joinUrl(iframeBaseUrl, alias);
+  const inlineEntry = joinUrl(aliasInlineBaseUrl, 'registry.js');
+  // Shared deps and the iframe fallback are served from the Storybook static site, not the docs subpath.
+  const bootstrap = createBootstrap(aliasIframeBaseUrl);
+  const docsIds = new Set<string>();
+
+  const stories = getStoryEntries(index, filter).map(([entryId, entry]) => {
+    const storybookId = entry.id ?? entryId;
+    const metadata = docsMetadata[storybookId];
+    const docsId = metadata?.id ?? storybookId;
+
+    if (docsIds.has(docsId)) {
+      throw new Error(`Duplicate Storybook docs ID [${docsId}] in alias [${alias}]`);
+    }
+
+    docsIds.add(docsId);
+
+    return {
+      alias,
+      docsId,
+      storybookId,
+      title: entry.title,
+      name: entry.name,
+      importPath: entry.importPath,
+      ...(entry.componentPath ? { componentPath: entry.componentPath } : {}),
+      ...(entry.tags ? { tags: entry.tags } : {}),
+      ...(typeof metadata?.height === 'number' ? { height: metadata.height } : {}),
+      type: 'story' as const,
+      renderMode,
+      ...(renderMode === 'inline'
+        ? {
+            inline: {
+              entry: inlineEntry,
+              bundleId: alias,
+              bootstrap,
+            },
+          }
+        : {}),
+      iframe: {
+        url: createIframeUrl(aliasIframeBaseUrl, storybookId),
+      },
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    producer: 'kibana-storybook-docs-manifest',
+    alias,
+    inlineBaseUrl: trimTrailingSlash(inlineBaseUrl),
+    iframeBaseUrl: trimTrailingSlash(iframeBaseUrl),
+    stories,
+  };
+};
+
+export const buildDocsAssets = async ({
+  alias,
+  storybookDir,
+  docsOutputDir,
+  inlineBaseUrl,
+  iframeBaseUrl,
+  renderMode,
+  previewAnnotationsImportPath,
+  configDir,
+  buildInlineBundle,
+  docsMetadata,
+  filter,
+}: BuildDocsAssetsOptions): Promise<StorybookDocsManifest> => {
+  const indexPath = join(storybookDir, 'index.json');
+  const docsDir = join(docsOutputDir, alias);
+  const manifestPath = join(docsDir, 'manifest.json');
+  const registryEntryPath = join(docsDir, 'registry_entry.js');
+  const index = JSON.parse(await readFile(indexPath, 'utf8')) as StorybookIndex;
+  const manifest = createDocsManifest({
+    alias,
+    inlineBaseUrl,
+    iframeBaseUrl,
+    index,
+    renderMode,
+    docsMetadata,
+    filter,
+  });
+
+  await mkdir(docsDir, { recursive: true });
+
+  if (renderMode === 'inline' && manifest.stories.length > 0) {
+    const resolvedPreviewAnnotationsImportPath =
+      previewAnnotationsImportPath ?? (configDir ? resolve(configDir, 'preview') : undefined);
+
+    if (!resolvedPreviewAnnotationsImportPath) {
+      throw new Error(
+        'Inline Storybook docs assets require previewAnnotationsImportPath or configDir.'
+      );
+    }
+
+    await writeFile(
+      registryEntryPath,
+      createInlineRegistryEntrySource({
+        alias,
+        index,
+        previewAnnotationsImportPath: resolvedPreviewAnnotationsImportPath,
+        storyImportRoot: process.cwd(),
+        filter,
+      }),
+      'utf8'
+    );
+
+    if (buildInlineBundle) {
+      await buildInlineRegistryBundle({ entryPath: registryEntryPath, docsDir });
+    }
+  }
+
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+  return manifest;
+};
+
+export const createDocsRegistry = ({
+  baseUrl,
+  build,
+  manifests,
+}: {
+  baseUrl: string;
+  build: StorybookDocsRegistry['build'];
+  manifests: StorybookDocsManifest[];
+}): StorybookDocsRegistry => {
+  const stories: StorybookDocsRegistry['stories'] = {};
+
+  manifests.forEach((manifest) => {
+    manifest.stories.forEach((story) => {
+      const registryId = `kibana:${manifest.alias}:${story.docsId}` as const;
+
+      if (stories[registryId]) {
+        throw new Error(`Duplicate Storybook docs ID [${registryId}]`);
+      }
+
+      stories[registryId] = story;
+    });
+  });
+
+  return {
+    schemaVersion: 1,
+    producer: 'kibana-storybook',
+    baseUrl: trimTrailingSlash(baseUrl),
+    build,
+    stories,
+  };
+};
+
+const hashFile = async (filePath: string): Promise<{ sha256: string; size: number }> => {
+  const stats = await stat(filePath);
+
+  if (!stats.isFile() || stats.size === 0) {
+    throw new Error(`Expected a non-empty file at [${filePath}]`);
+  }
+
+  const sha256 = await new Promise<string>((resolvePromise, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolvePromise(hash.digest('hex')));
+  });
+
+  return { sha256, size: stats.size };
+};
+
+export const buildDocsRegistry = async ({
+  aliases,
+  docsRootDir,
+  baseUrl,
+  build,
+}: BuildDocsRegistryOptions): Promise<BuildDocsRegistryResult> => {
+  const manifests = await Promise.all(
+    aliases.map(async (alias) => {
+      const manifestPath = join(docsRootDir, alias, 'manifest.json');
+      return JSON.parse(await readFile(manifestPath, 'utf8')) as StorybookDocsManifest;
+    })
+  );
+  const registry = createDocsRegistry({ baseUrl, build, manifests });
+  const outputPath = join(docsRootDir, 'docs_registry.json');
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+
+  const { sha256, size } = await hashFile(outputPath);
+
+  return {
+    registry,
+    integrity: `sha256-${sha256}`,
+    outputPath,
+    sha256,
+    size,
+  };
+};
+
+export const buildDocsArchive = async ({
+  aliases,
+  docsRootDir,
+  outputPath,
+}: BuildDocsArchiveOptions): Promise<BuildDocsArchiveResult> => {
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  await new Promise<void>((resolvePromise, reject) => {
+    const output = createWriteStream(outputPath);
+    const archive = archiver('tar', {
+      gzip: true,
+      gzipOptions: {
+        level: 9,
+      },
+    });
+
+    output.on('close', resolvePromise);
+    output.on('error', reject);
+    archive.on('error', reject);
+    archive.pipe(output);
+    archive.file(join(docsRootDir, 'docs_registry.json'), { name: 'docs_registry.json' });
+
+    aliases.forEach((alias) => {
+      archive.directory(join(docsRootDir, alias), alias);
+    });
+
+    archive.finalize().catch(reject);
+  });
+
+  const { sha256, size } = await hashFile(outputPath);
+
+  return {
+    integrity: `sha256-${sha256}`,
+    outputPath,
+    sha256,
+    size,
+  };
+};

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_references.test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_references.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { extractStorybookDocsReferences, validateStorybookDocsReferences } from './docs_references';
+import type { StorybookDocsRegistry } from './docs_assets';
+
+describe('extractStorybookDocsReferences', () => {
+  it('extracts IDs from indented storybook directives', () => {
+    const references = extractStorybookDocsReferences({
+      file: 'guide.md',
+      markdown: [
+        ':id: outside-block',
+        '  ::::{storybook}',
+        '  :id: kibana:shared_ux:button-regular',
+        '  :height: 240',
+        '  ::::',
+        '',
+        ':::{storybook}',
+        ':id: kibana:observability:alert-severity',
+        ':::',
+      ].join('\n'),
+    });
+
+    expect(references).toEqual([
+      {
+        file: 'guide.md',
+        id: 'kibana:shared_ux:button-regular',
+        line: 3,
+      },
+      {
+        file: 'guide.md',
+        id: 'kibana:observability:alert-severity',
+        line: 8,
+      },
+    ]);
+  });
+});
+
+describe('validateStorybookDocsReferences', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kbn-storybook-docs-references-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports storybook directive IDs missing from the registry', async () => {
+    const docsRoot = join(tempDir, 'docs');
+    const nestedDocsRoot = join(docsRoot, 'nested');
+    const registryPath = join(tempDir, 'docs_registry.json');
+    const registry: StorybookDocsRegistry = {
+      schemaVersion: 1,
+      producer: 'kibana-storybook',
+      baseUrl: 'https://ci-artifacts.kibana.dev/storybooks/pr-1',
+      build: {
+        commit: 'abc123',
+        branch: 'main',
+      },
+      stories: {
+        'kibana:shared_ux:button-regular': {
+          alias: 'shared_ux',
+          docsId: 'button-regular',
+          storybookId: 'components-button--regular',
+          title: 'Components/Button',
+          name: 'Regular',
+          importPath: './src/button.stories.tsx',
+          type: 'story',
+          renderMode: 'iframe',
+          iframe: {
+            url: 'https://ci-artifacts.kibana.dev/storybooks/pr-1/shared_ux/iframe.html?id=components-button--regular&viewMode=story',
+          },
+        },
+      },
+    };
+
+    await mkdir(nestedDocsRoot, { recursive: true });
+    await writeFile(registryPath, JSON.stringify(registry), 'utf8');
+    await writeFile(
+      join(docsRoot, 'guide.md'),
+      [':::{storybook}', ':id: kibana:shared_ux:button-regular', ':::'].join('\n'),
+      'utf8'
+    );
+    await writeFile(
+      join(nestedDocsRoot, 'missing.md'),
+      [':::{storybook}', ':id: kibana:shared_ux:missing', ':::'].join('\n'),
+      'utf8'
+    );
+    await writeFile(
+      join(nestedDocsRoot, 'ignored.txt'),
+      [':::{storybook}', ':id: kibana:shared_ux:ignored', ':::'].join('\n'),
+      'utf8'
+    );
+
+    const result = await validateStorybookDocsReferences({ docsRoot, registryPath });
+
+    expect(result.references.map(({ id }) => id).sort()).toEqual([
+      'kibana:shared_ux:button-regular',
+      'kibana:shared_ux:missing',
+    ]);
+    expect(result.missing).toEqual([
+      {
+        file: join(nestedDocsRoot, 'missing.md'),
+        id: 'kibana:shared_ux:missing',
+        line: 2,
+      },
+    ]);
+  });
+});

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_references.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_references.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import type { StorybookDocsRegistry } from './docs_assets';
+
+export interface StorybookDocsReference {
+  file: string;
+  id: string;
+  line: number;
+}
+
+export interface ValidateStorybookDocsReferencesResult {
+  references: StorybookDocsReference[];
+  missing: StorybookDocsReference[];
+}
+
+const directiveStartRegex = /^\s*:{3,}\s*(?:\{storybook\}|storybook)(?:\s|$)/;
+const directiveEndRegex = /^\s*:{3,}\s*$/;
+const idRegex = /^\s*:id:\s*(\S+)/;
+
+export const extractStorybookDocsReferences = ({
+  markdown,
+  file = '<inline>',
+}: {
+  markdown: string;
+  file?: string;
+}): StorybookDocsReference[] => {
+  const references: StorybookDocsReference[] = [];
+  let inStorybookDirective = false;
+
+  markdown.split(/\r?\n/).forEach((line, index) => {
+    if (directiveStartRegex.test(line)) {
+      inStorybookDirective = true;
+      return;
+    }
+
+    if (!inStorybookDirective) {
+      return;
+    }
+
+    const idMatch = line.match(idRegex);
+
+    if (idMatch) {
+      references.push({
+        file,
+        id: idMatch[1],
+        line: index + 1,
+      });
+    }
+
+    if (directiveEndRegex.test(line)) {
+      inStorybookDirective = false;
+    }
+  });
+
+  return references;
+};
+
+const getMarkdownFiles = async (dir: string): Promise<string[]> => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const nestedFiles = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return getMarkdownFiles(entryPath);
+      }
+
+      if (entry.isFile() && entry.name.endsWith('.md')) {
+        return [entryPath];
+      }
+
+      return [];
+    })
+  );
+
+  return nestedFiles.flat();
+};
+
+export const validateStorybookDocsReferences = async ({
+  docsRoot,
+  registryPath,
+}: {
+  docsRoot: string;
+  registryPath: string;
+}): Promise<ValidateStorybookDocsReferencesResult> => {
+  const registry = JSON.parse(await readFile(registryPath, 'utf8')) as StorybookDocsRegistry;
+  const registryIds = new Set(Object.keys(registry.stories));
+  const markdownFiles = await getMarkdownFiles(docsRoot);
+  const references = (
+    await Promise.all(
+      markdownFiles.map(async (file) =>
+        extractStorybookDocsReferences({
+          file,
+          markdown: await readFile(file, 'utf8'),
+        })
+      )
+    )
+  ).flat();
+
+  return {
+    references,
+    missing: references.filter(({ id }) => !registryIds.has(id)),
+  };
+};

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_test.ts
@@ -1,0 +1,294 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { execFileSync } from 'child_process';
+import { createReadStream, statSync } from 'fs';
+import { createServer, type ServerResponse } from 'http';
+import { extname, join, resolve, sep } from 'path';
+import { buildDocsArchive, buildDocsAssets, buildDocsRegistry } from './docs_assets';
+import type { BuildDocsArchiveResult, StorybookDocsManifest } from './docs_assets';
+import { buildStorybook } from './run_storybook_cli';
+import { ASSET_DIR, DOCS_ASSET_DIR } from './constants';
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+
+interface StorybookDocsTestLog {
+  info(message: string): void;
+}
+
+export interface RunStorybookDocsTestServerOptions {
+  alias: string;
+  configDir: string;
+  port: number;
+  baseUrl: string;
+  skipStorybookBuild?: boolean;
+  includeAllStories?: boolean;
+  log: StorybookDocsTestLog;
+}
+
+export interface BuildStorybookDocsArtifactsOptions {
+  alias: string;
+  configDir: string;
+  baseUrl: string;
+  skipStorybookBuild?: boolean;
+  includeAllStories?: boolean;
+  writeArchive?: boolean;
+  log: StorybookDocsTestLog;
+}
+
+export interface BuildStorybookDocsArtifactsResult {
+  archive?: BuildDocsArchiveResult;
+  assetDir: string;
+  registryUrl: string;
+  manifest: StorybookDocsManifest;
+}
+
+const mimeTypes: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+const getGitValue = (args: string[]): string => {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+  } catch {
+    return 'local';
+  }
+};
+
+const sendNotFound = (response: ServerResponse) => {
+  response.writeHead(404, corsHeaders({ 'Content-Type': 'text/plain; charset=utf-8' }));
+  response.end('Not found');
+};
+
+const corsHeaders = (headers: Record<string, string> = {}) => ({
+  ...headers,
+  'Access-Control-Allow-Headers': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Origin': '*',
+});
+
+const isSubPath = (root: string, filePath: string): boolean =>
+  filePath === root || filePath.startsWith(`${root}${sep}`);
+
+const serveDirectory = async ({
+  directory,
+  port,
+  registryUrl,
+  log,
+}: {
+  directory: string;
+  port: number;
+  registryUrl: string;
+  log: StorybookDocsTestLog;
+}): Promise<void> => {
+  const root = resolve(directory);
+
+  await new Promise<void>((resolvePromise, reject) => {
+    const server = createServer((request, response) => {
+      if (request.method === 'OPTIONS') {
+        response.writeHead(204, corsHeaders());
+        response.end();
+        return;
+      }
+
+      if (request.method !== 'GET' && request.method !== 'HEAD') {
+        response.writeHead(405, corsHeaders({ Allow: 'GET, HEAD, OPTIONS' }));
+        response.end();
+        return;
+      }
+
+      let pathname: string;
+      try {
+        pathname = decodeURIComponent(new URL(request.url ?? '/', 'http://127.0.0.1').pathname);
+      } catch {
+        sendNotFound(response);
+        return;
+      }
+      const requestedPath = resolve(root, pathname.replace(/^\/+/, ''));
+
+      if (!isSubPath(root, requestedPath)) {
+        sendNotFound(response);
+        return;
+      }
+
+      let filePath = requestedPath;
+
+      try {
+        const stats = statSync(filePath);
+        if (stats.isDirectory()) {
+          filePath = join(filePath, 'index.html');
+        }
+      } catch {
+        sendNotFound(response);
+        return;
+      }
+
+      try {
+        const stats = statSync(filePath);
+        if (!stats.isFile()) {
+          sendNotFound(response);
+          return;
+        }
+
+        response.writeHead(
+          200,
+          corsHeaders({
+            'Content-Length': String(stats.size),
+            'Content-Type': mimeTypes[extname(filePath)] ?? 'application/octet-stream',
+          })
+        );
+
+        if (request.method === 'HEAD') {
+          response.end();
+          return;
+        }
+
+        createReadStream(filePath).pipe(response);
+      } catch {
+        sendNotFound(response);
+      }
+    });
+
+    server.on('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      log.info(`Serving Storybook docs assets at http://127.0.0.1:${port}`);
+      log.info(`Registry URL: ${registryUrl}`);
+    });
+
+    const shutdown = () => {
+      server.close(() => resolvePromise());
+    };
+
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
+};
+
+export const buildStorybookDocsArtifacts = async ({
+  alias,
+  configDir,
+  baseUrl,
+  skipStorybookBuild,
+  includeAllStories,
+  writeArchive = true,
+  log,
+}: BuildStorybookDocsArtifactsOptions): Promise<BuildStorybookDocsArtifactsResult> => {
+  const storybookDir = join(ASSET_DIR, alias);
+  const root = trimTrailingSlash(baseUrl);
+  // The static Storybook site (shared deps + iframe fallback) and the docs assets are served from
+  // sibling subpaths so their URL contracts stay independent.
+  const iframeBaseUrl = `${root}/storybook`;
+  const inlineBaseUrl = `${root}/storybook-docs`;
+  const registryUrl = `${inlineBaseUrl}/docs_registry.json`;
+
+  if (!skipStorybookBuild) {
+    log.info(`Building static Storybook for [${alias}]`);
+    process.env.STORYBOOK_BASE_URL = iframeBaseUrl;
+    await buildStorybook({ configDir, name: alias, site: true });
+  }
+
+  log.info(`Generating inline Storybook docs assets for [${alias}]`);
+  const manifest = await buildDocsAssets({
+    alias,
+    storybookDir,
+    docsOutputDir: DOCS_ASSET_DIR,
+    inlineBaseUrl,
+    iframeBaseUrl,
+    renderMode: 'inline',
+    configDir,
+    buildInlineBundle: true,
+    filter: {
+      includeAllStories,
+    },
+  });
+
+  await buildDocsRegistry({
+    aliases: [alias],
+    docsRootDir: DOCS_ASSET_DIR,
+    baseUrl: inlineBaseUrl,
+    build: {
+      commit: getGitValue(['rev-parse', 'HEAD']),
+      branch: getGitValue(['branch', '--show-current']),
+    },
+  });
+  let archive: BuildDocsArchiveResult | undefined;
+
+  if (writeArchive) {
+    const archivePath = resolve(
+      DOCS_ASSET_DIR,
+      '..',
+      `storybook-docs-${alias}-${getGitValue(['rev-parse', '--short', 'HEAD'])}.tar.gz`
+    );
+
+    archive = await buildDocsArchive({
+      aliases: manifest.stories.length > 0 ? [alias] : [],
+      docsRootDir: DOCS_ASSET_DIR,
+      outputPath: archivePath,
+    });
+  }
+
+  return {
+    archive,
+    assetDir: resolve(DOCS_ASSET_DIR),
+    registryUrl,
+    manifest,
+  };
+};
+
+export const runStorybookDocsTestServer = async ({
+  alias,
+  configDir,
+  port,
+  baseUrl,
+  skipStorybookBuild,
+  includeAllStories,
+  log,
+}: RunStorybookDocsTestServerOptions): Promise<void> => {
+  const { archive, registryUrl, manifest } = await buildStorybookDocsArtifacts({
+    alias,
+    configDir,
+    baseUrl,
+    skipStorybookBuild,
+    includeAllStories,
+    log,
+  });
+
+  log.info(`Docs-builder docset.yml snippet:
+storybook:
+  registry: ${registryUrl}`);
+  if (archive) {
+    log.info(`Docs archive: ${archive.outputPath}`);
+    log.info(`Docs archive integrity: ${archive.integrity}`);
+    log.info(`Storybook sources manifest snippet:
+sources:
+  kibana:
+    registry: ${registryUrl}
+    integrity: ${archive.integrity}`);
+  }
+  log.info(`Markdown smoke test:
+:::{storybook}
+:id: kibana:${alias}:${manifest.stories[0]?.docsId ?? '<docsId>'}
+:::`);
+
+  await serveDirectory({ directory: resolve(ASSET_DIR, '..'), port, registryUrl, log });
+};

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime.test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createDocsRegistry } from './embed_runtime';
+import { EMBEDDABLE_RESIZE_EVENT } from './embeddable';
+
+jest.mock('react-dom/client', () => ({
+  createRoot: jest.fn(() => ({ render: jest.fn(), unmount: jest.fn() })),
+}));
+
+jest.mock('@storybook/react', () => ({
+  setProjectAnnotations: (annotations: unknown) => annotations,
+  composeStories: (storyModule: { stories: Record<string, unknown> }) => storyModule.stories,
+}));
+
+const composeStory = (id: string, parameters?: Record<string, unknown>) =>
+  Object.assign(() => null, { id, parameters });
+
+const storyModuleFor = (story: ReturnType<typeof composeStory>) => () =>
+  Promise.resolve({ stories: { Default: story } });
+
+// jsdom is unavailable under the Node jest preset, so stand in a minimal EventTarget-backed element.
+class FakeContainer extends EventTarget {
+  public style: Record<string, string> = {};
+  public getBoundingClientRect = () => ({ height: 40 } as DOMRect);
+}
+
+const makeContainer = () => new FakeContainer() as unknown as HTMLElement;
+
+describe('createDocsRegistry', () => {
+  it('registers the alias on the window registry map', () => {
+    (global as unknown as { window?: object }).window = {};
+    try {
+      const registry = createDocsRegistry({
+        alias: 'shared_ux',
+        storyModules: {},
+        projectAnnotations: {},
+      });
+
+      expect(window.__kbnStorybookDocsRegistries__?.shared_ux).toBe(registry);
+    } finally {
+      delete (global as unknown as { window?: object }).window;
+    }
+  });
+
+  it('exposes embeddable parameters via getStoryParameters', async () => {
+    const registry = createDocsRegistry({
+      alias: 'shared_ux',
+      storyModules: {
+        'button--default': storyModuleFor(
+          composeStory('button--default', { embeddable: { height: 120 } })
+        ),
+      },
+      projectAnnotations: {},
+    });
+
+    await expect(registry.getStoryParameters('button--default')).resolves.toEqual({ height: 120 });
+  });
+
+  it('defaults to empty parameters when a story declares none', async () => {
+    const registry = createDocsRegistry({
+      alias: 'shared_ux',
+      storyModules: { 'button--default': storyModuleFor(composeStory('button--default')) },
+      projectAnnotations: {},
+    });
+
+    await expect(registry.getStoryParameters('button--default')).resolves.toEqual({});
+  });
+
+  it('throws for an unknown story id', async () => {
+    const registry = createDocsRegistry({
+      alias: 'shared_ux',
+      storyModules: {},
+      projectAnnotations: {},
+    });
+
+    await expect(registry.getStoryParameters('missing--story')).rejects.toThrow(
+      'Unknown Storybook docs story [missing--story]'
+    );
+  });
+
+  it('applies the height hint and reports a measured size on mount', async () => {
+    const registry = createDocsRegistry({
+      alias: 'shared_ux',
+      storyModules: {
+        'button--default': storyModuleFor(
+          composeStory('button--default', { embeddable: { height: 96 } })
+        ),
+      },
+      projectAnnotations: {},
+    });
+    const container = makeContainer();
+    const onResize = jest.fn();
+    const heights: number[] = [];
+
+    container.addEventListener(EMBEDDABLE_RESIZE_EVENT, (event) => {
+      heights.push((event as CustomEvent<{ height: number }>).detail.height);
+    });
+
+    await registry.mountStory('button--default', container, { onResize });
+
+    // jsdom lacks ResizeObserver, so the runtime falls back to a single synchronous report.
+    expect(container.style.minHeight).toBe('96px');
+    expect(onResize).toHaveBeenCalledWith({ height: 40 });
+    expect(heights).toEqual([40]);
+  });
+
+  it('is idempotent across unmount', async () => {
+    const registry = createDocsRegistry({
+      alias: 'shared_ux',
+      storyModules: { 'button--default': storyModuleFor(composeStory('button--default')) },
+      projectAnnotations: {},
+    });
+    const container = makeContainer();
+
+    await registry.mountStory('button--default', container);
+
+    expect(() => registry.unmountStory(container)).not.toThrow();
+    expect(() => registry.unmountStory(container)).not.toThrow();
+  });
+});

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { composeStories, setProjectAnnotations } from '@storybook/react';
+import { EMBEDDABLE_RESIZE_EVENT } from './embeddable';
+import type { EmbeddableResizePayload, EmbeddableStoryParameters } from './embeddable';
+
+/**
+ * Browser runtime backing the per-alias inline registry bundle. The generated
+ * `registry_entry.js` supplies the dynamic story-import map and calls
+ * {@link createDocsRegistry}; all embed logic lives here so it stays typed,
+ * linted, and unit-tested rather than hand-written into a string.
+ */
+
+type StoryModuleLoader = () => Promise<Record<string, unknown>>;
+type StoryModules = Record<string, StoryModuleLoader>;
+
+// A composed story is renderable as a component and carries Storybook metadata.
+type ComposedStory = React.ComponentType & {
+  id: string;
+  parameters?: { embeddable?: EmbeddableStoryParameters };
+};
+
+export interface MountStoryOptions {
+  onResize?: (size: { height: number }) => void;
+}
+
+export interface DocsRegistry {
+  mountStory: (
+    storybookId: string,
+    container: HTMLElement,
+    options?: MountStoryOptions
+  ) => Promise<void>;
+  unmountStory: (container: HTMLElement) => void;
+  getStoryParameters: (storybookId: string) => Promise<EmbeddableStoryParameters>;
+}
+
+export interface CreateDocsRegistryOptions {
+  alias: string;
+  storyModules: StoryModules;
+  projectAnnotations: Parameters<typeof setProjectAnnotations>[0];
+}
+
+declare global {
+  interface Window {
+    __kbnStorybookDocsRegistries__?: Record<string, DocsRegistry>;
+  }
+}
+
+const getEmbeddableParameters = (story: ComposedStory): EmbeddableStoryParameters =>
+  story.parameters?.embeddable ?? {};
+
+export const createDocsRegistry = ({
+  alias,
+  storyModules,
+  projectAnnotations,
+}: CreateDocsRegistryOptions): DocsRegistry => {
+  const roots = new WeakMap<HTMLElement, ReturnType<typeof createRoot>>();
+  const observers = new WeakMap<HTMLElement, ResizeObserver>();
+  const annotations = setProjectAnnotations(projectAnnotations);
+
+  const getComposedStory = async (storybookId: string): Promise<ComposedStory> => {
+    const loadStoryModule = storyModules[storybookId];
+
+    if (!loadStoryModule) {
+      throw new Error(`Unknown Storybook docs story [${storybookId}]`);
+    }
+
+    const storyModule = await loadStoryModule();
+    const stories = composeStories(
+      storyModule as Parameters<typeof composeStories>[0],
+      annotations as Parameters<typeof composeStories>[1]
+    );
+    const Story = Object.values(stories).find(
+      (story) => (story as ComposedStory).id === storybookId
+    );
+
+    if (!Story) {
+      throw new Error(`Storybook module did not compose story [${storybookId}]`);
+    }
+
+    return Story as unknown as ComposedStory;
+  };
+
+  const reportSize = (
+    container: HTMLElement,
+    storyId: string,
+    onResize: MountStoryOptions['onResize']
+  ): void => {
+    const height = Math.ceil(container.getBoundingClientRect().height);
+
+    onResize?.({ height });
+
+    container.dispatchEvent(
+      new CustomEvent<EmbeddableResizePayload>(EMBEDDABLE_RESIZE_EVENT, {
+        detail: { storyId, height },
+        bubbles: true,
+      })
+    );
+  };
+
+  const observeSize = (
+    container: HTMLElement,
+    storyId: string,
+    onResize: MountStoryOptions['onResize']
+  ): void => {
+    if (typeof ResizeObserver === 'undefined') {
+      reportSize(container, storyId, onResize);
+      return;
+    }
+
+    const observer = new ResizeObserver(() => reportSize(container, storyId, onResize));
+    observer.observe(container);
+    observers.set(container, observer);
+  };
+
+  const unmountStory = (container: HTMLElement): void => {
+    observers.get(container)?.disconnect();
+    observers.delete(container);
+
+    const root = roots.get(container);
+
+    if (!root) {
+      return;
+    }
+
+    root.unmount();
+    roots.delete(container);
+  };
+
+  const mountStory = async (
+    storybookId: string,
+    container: HTMLElement,
+    options: MountStoryOptions = {}
+  ): Promise<void> => {
+    const Story = await getComposedStory(storybookId);
+
+    unmountStory(container);
+
+    const { height } = getEmbeddableParameters(Story);
+
+    if (typeof height === 'number') {
+      container.style.minHeight = `${height}px`;
+    }
+
+    const root = createRoot(container);
+    roots.set(container, root);
+    root.render(React.createElement(Story as React.ComponentType));
+    observeSize(container, storybookId, options.onResize);
+  };
+
+  const getStoryParameters = async (storybookId: string): Promise<EmbeddableStoryParameters> =>
+    getEmbeddableParameters(await getComposedStory(storybookId));
+
+  const registry: DocsRegistry = { mountStory, unmountStory, getStoryParameters };
+
+  if (typeof window !== 'undefined') {
+    window.__kbnStorybookDocsRegistries__ = window.__kbnStorybookDocsRegistries__ ?? {};
+    window.__kbnStorybookDocsRegistries__[alias] = registry;
+  }
+
+  return registry;
+};

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embeddable.test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embeddable.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EMBEDDABLE_RESIZE_EVENT, EMBEDDABLE_STORYBOOK_TAG } from './embeddable';
+import type { EmbeddableParametersForTags, EmbeddableStoryObj } from './embeddable';
+
+describe('embeddable', () => {
+  it('exposes stable tag and resize event identifiers', () => {
+    expect(EMBEDDABLE_STORYBOOK_TAG).toBe('embeddable');
+    expect(EMBEDDABLE_RESIZE_EVENT).toBe('kbn-storybook-docs:resize');
+  });
+
+  // Type-level coverage: these assignments only compile when `parameters.embeddable`
+  // is strongly typed and the embeddable tag is required.
+  it('strongly types parameters.embeddable on an embeddable story', () => {
+    const story: EmbeddableStoryObj<{ label: string }> = {
+      tags: [EMBEDDABLE_STORYBOOK_TAG],
+      parameters: { embeddable: { height: 96 }, layout: 'centered' },
+      args: { label: 'AI' },
+    };
+
+    expect(story.parameters?.embeddable?.height).toBe(96);
+  });
+
+  it('keys parameter typing off the presence of the embeddable tag', () => {
+    const embeddable: EmbeddableParametersForTags<['embeddable']> = {
+      embeddable: { height: 120 },
+    };
+    const plain: EmbeddableParametersForTags<['other']> = { anything: true };
+
+    expect(embeddable.embeddable?.height).toBe(120);
+    expect(plain.anything).toBe(true);
+  });
+});

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embeddable.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embeddable.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { StoryObj } from '@storybook/react';
+
+/** Tag that opts a story into docs embedding (inline registry + iframe fallback). */
+export const EMBEDDABLE_STORYBOOK_TAG = 'embeddable';
+
+/**
+ * Event the embed runtime emits with the measured story height. Dispatched as a
+ * `CustomEvent` on the inline container and `postMessage`d from the iframe
+ * fallback. Consumers (docs-builder) listen for it to auto-size the embed.
+ */
+export const EMBEDDABLE_RESIZE_EVENT = 'kbn-storybook-docs:resize';
+
+/** Payload shared by the inline `CustomEvent` and the iframe `postMessage`. */
+export interface EmbeddableResizePayload {
+  /** Storybook ID of the measured story. */
+  storyId: string;
+  /** Measured content height in pixels. */
+  height: number;
+}
+
+/**
+ * Typed `parameters.embeddable` namespace. Runtime auto-sizing stays
+ * authoritative; everything here is an optional authoring hint.
+ */
+export interface EmbeddableStoryParameters {
+  /** Initial render height in pixels, used to reserve space and reduce layout shift before the embed measures itself. */
+  height?: number;
+}
+
+/** Storybook `parameters` extended with the typed {@link EmbeddableStoryParameters} namespace. */
+export interface EmbeddableParameters {
+  embeddable?: EmbeddableStoryParameters;
+}
+
+// `EmbeddableStoryParameters & unknown` collapses to `EmbeddableStoryParameters`, so the named
+// `embeddable` key stays strongly typed while arbitrary sibling parameters remain permitted.
+type StoryParametersWithEmbeddable = EmbeddableParameters & Record<string, unknown>;
+
+/**
+ * Resolves to {@link StoryParametersWithEmbeddable} only when the
+ * {@link EMBEDDABLE_STORYBOOK_TAG} is present in `TTags`, so a story's
+ * `parameters` typing keys off its `tags` collection.
+ */
+export type EmbeddableParametersForTags<TTags extends readonly string[]> =
+  typeof EMBEDDABLE_STORYBOOK_TAG extends TTags[number]
+    ? StoryParametersWithEmbeddable
+    : Record<string, unknown>;
+
+/**
+ * `StoryObj` for an embeddable story: requires the {@link EMBEDDABLE_STORYBOOK_TAG}
+ * and strongly types `parameters.embeddable`. Prefer importing this as a type
+ * (`import type`) from story files so no runtime code is pulled into the bundle.
+ *
+ * @example
+ * export const Default: EmbeddableStoryObj<StoryArgs> = {
+ *   tags: ['embeddable'],
+ *   parameters: { embeddable: { height: 96 } },
+ *   render: () => <Button />,
+ * };
+ */
+export type EmbeddableStoryObj<TArgs = unknown> = Omit<StoryObj<TArgs>, 'tags' | 'parameters'> & {
+  tags: readonly [typeof EMBEDDABLE_STORYBOOK_TAG, ...string[]];
+  parameters?: StoryParametersWithEmbeddable;
+};

--- a/src/platform/packages/shared/kbn-storybook/src/lib/run_storybook_cli.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/run_storybook_cli.ts
@@ -18,7 +18,7 @@ import * as constants from './constants';
 type StorybookCliOptions = CLIOptions & BuilderOptions & LoadOptions & { mode: 'dev' | 'static' };
 
 // Convert the flags to a Storybook loglevel
-function getLogLevelFromFlags(flags: Flags) {
+export function getLogLevelFromFlags(flags: Flags) {
   if (flags.debug) {
     return 'silly';
   }
@@ -34,34 +34,53 @@ function getLogLevelFromFlags(flags: Flags) {
   return 'info';
 }
 
+export async function buildStorybook({
+  configDir,
+  name,
+  site = false,
+  loglevel = 'info',
+}: {
+  configDir: string;
+  name: string;
+  site?: boolean;
+  loglevel?: StorybookCliOptions['loglevel'];
+}) {
+  const config: StorybookCliOptions = {
+    configDir,
+    mode: site ? 'static' : 'dev',
+    port: 9001,
+    loglevel,
+  };
+
+  if (site) {
+    config.outputDir = join(constants.ASSET_DIR, name);
+    process.env.NODE_ENV = 'production';
+  } else {
+    // required for react refresh
+    process.env.NODE_ENV = 'development';
+  }
+
+  try {
+    // Some transitive deps of addon-docs are ESM and not loading properly
+    // See: https://github.com/storybookjs/storybook/issues/29467
+    require('fix-esm').require('react-docgen');
+    await build(config);
+  } finally {
+    require('fix-esm').unregister();
+  }
+}
+
 export function runStorybookCli({ configDir, name }: { configDir: string; name: string }) {
   run(
     async ({ flags, log }) => {
       log.debug('Global config:\n', constants);
 
-      const config: StorybookCliOptions = {
+      await buildStorybook({
         configDir,
-        mode: flags.site ? 'static' : 'dev',
-        port: 9001,
+        name,
+        site: Boolean(flags.site),
         loglevel: getLogLevelFromFlags(flags),
-      };
-
-      if (flags.site) {
-        config.outputDir = join(constants.ASSET_DIR, name);
-        process.env.NODE_ENV = 'production';
-      } else {
-        // required for react refresh
-        process.env.NODE_ENV = 'development';
-      }
-
-      try {
-        // Some transitive deps of addon-docs are ESM and not loading properly
-        // See: https://github.com/storybookjs/storybook/issues/29467
-        require('fix-esm').require('react-docgen');
-        await build(config);
-      } finally {
-        require('fix-esm').unregister();
-      }
+      });
 
       // Line is only reached when building the static version
       if (flags.site) process.exit();

--- a/src/platform/packages/shared/kbn-storybook/tsconfig.json
+++ b/src/platform/packages/shared/kbn-storybook/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "jest",
       "node",
       "@kbn/ambient-storybook-types"
     ]


### PR DESCRIPTION
## Summary

Adds the ability to build, validate, and publish **embeddable Storybook docs assets** so [`docs-builder`](https://github.com/elastic/docs-builder) can render live, interactive Kibana stories inside documentation via a `{storybook}` directive.

Stories opt in with an `embeddable` tag. For each per-alias static Storybook build, CI now also:

- Generates a per-alias docs manifest and an aggregate `docs_registry.json` mapping namespaced `kibana:<alias>:<docsId>` IDs to an inline registry bundle entry and an iframe fallback URL.
- Builds an inline registry JS bundle using the existing Kibana Storybook webpack config (no new bundler).
- Emits everything into a dedicated `storybook-docs` output tree and uploads it alongside the static site.
- Advertises the registry and tarball URLs with their `sha256` integrity in the Buildkite annotation, so a docs-builder docset can pin a specific build.

Inline entries and the iframe fallback carry independent base URLs: the inline registry roots at the new `storybook-docs` subpath, while the iframe fallback and shared-deps bootstrap root at the existing static site.

### What's included

- **Core build** (`@kbn/storybook`): manifest + `docs_registry.json` + inline bundle generation, with `sha256` integrity and a slim tarball.
- **Reference validation**: a standalone utility to extract `{storybook}` directive IDs from Markdown and validate them against a `docs_registry.json` (usable from both Kibana and docs-builder CI).
- **Local tooling**: `yarn storybook_docs <alias> (--build | --dev | --serve)` to build the registry/bundle locally, optionally package a tarball, and serve `built_assets` over a local CORS-enabled HTTP server for docs-builder consumption.
- **CI wiring**: docs asset generation + upload in `build_and_upload.ts`.
- **First adopter**: the AI button `Default` story tagged `embeddable`.

## Why draft

Opening as draft to run a full CI build and produce the docs assets so we can wire up and test the docs-builder side end-to-end.

## Test plan

- [ ] CI build produces the `storybook-docs` subtree and `docs_registry.json`.
- [ ] Buildkite annotation shows the registry + tarball URLs with `sha256` integrity.
- [ ] docs-builder can fetch the registry and embed the AI button story (inline + iframe fallback).
- [ ] `yarn storybook_docs shared_ux --serve` serves the registry locally with CORS.
- [ ] Reference validation flags unknown `{storybook}` IDs.