### PR TITLE
[Search][Getting Started] Fix i18n config

### DIFF
--- a/x-pack/.i18nrc.json
+++ b/x-pack/.i18nrc.json
@@ -112,6 +112,7 @@
     "xpack.runtimeFields": "platform/plugins/private/runtime_fields",
     "xpack.screenshotting": "platform/plugins/shared/screenshotting",
     "xpack.searchSharedUI": "solutions/search/packages/shared-ui",
+    "xpack.searchGettingStarted": "solutions/search/plugins/search_getting_started",
     "xpack.searchHomepage": "solutions/search/plugins/search_homepage",
     "xpack.searchNavigation": "solutions/search/plugins/search_navigation",
     "xpack.searchNotebooks": "solutions/search/plugins/search_notebooks",

--- a/x-pack/solutions/search/plugins/search_getting_started/common/index.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/common/index.ts
@@ -8,7 +8,7 @@
 import { i18n } from '@kbn/i18n';
 
 export const PLUGIN_ID = 'searchGettingStarted';
-export const PLUGIN_NAME = i18n.translate('xpack.search.gettingStarted.plugin.name', {
+export const PLUGIN_NAME = i18n.translate('xpack.searchGettingStarted.plugin.name', {
   defaultMessage: 'Getting started',
 });
 export const PLUGIN_PATH = '/app/elasticsearch/getting_started';

--- a/x-pack/solutions/search/plugins/search_getting_started/common/prompts.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/common/prompts.ts
@@ -15,37 +15,37 @@ export interface SuggestedPrompt {
 export const DEFAULT_PROMPTS: SuggestedPrompt[] = [
   {
     id: 'chatbot_my_data',
-    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.chatbot_my_data', {
+    prompt: i18n.translate('xpack.searchGettingStarted.chat.suggestedPrompt.chatbot_my_data', {
       defaultMessage: 'I want to build a chatbot that answers questions from my data',
     }),
   },
   {
     id: 'recommendations',
-    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.recommendations', {
+    prompt: i18n.translate('xpack.searchGettingStarted.chat.suggestedPrompt.recommendations', {
       defaultMessage: "Add 'you may like' recommendations to my app",
     }),
   },
   {
     id: 'product_search',
-    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.product_search', {
+    prompt: i18n.translate('xpack.searchGettingStarted.chat.suggestedPrompt.product_search', {
       defaultMessage: 'Build product search with filters, autocomplete and facets',
     }),
   },
   {
     id: 'geo_filters',
-    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.geo_filters', {
+    prompt: i18n.translate('xpack.searchGettingStarted.chat.suggestedPrompt.geo_filters', {
       defaultMessage: "Help me build 'near me' search with geo filters",
     }),
   },
   {
     id: 'logs',
-    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.logs', {
+    prompt: i18n.translate('xpack.searchGettingStarted.chat.suggestedPrompt.logs', {
       defaultMessage: 'I need to search and analyze my applications logs',
     }),
   },
   {
     id: 'docs_search',
-    prompt: i18n.translate('xpack.gettingStarted.chat.suggestedPrompt.docs_search', {
+    prompt: i18n.translate('xpack.searchGettingStarted.chat.suggestedPrompt.docs_search', {
       defaultMessage: 'Make my docs and wiki searchable',
     }),
   },

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/agent_install/agent_install.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/agent_install/agent_install.tsx
@@ -93,10 +93,10 @@ export const AgentInstallSection = () => {
             <EuiPanel color="transparent" paddingSize="l">
               <AgentInstallPanel
                 icon="commandLine"
-                title={i18n.translate('xpack.gettingStarted.agentInstall.ide.title', {
+                title={i18n.translate('xpack.searchGettingStarted.agentInstall.ide.title', {
                   defaultMessage: 'Build in your IDE',
                 })}
-                description={i18n.translate('xpack.gettingStarted.agentInstall.ide.description', {
+                description={i18n.translate('xpack.searchGettingStarted.agentInstall.ide.description', {
                   defaultMessage: 'Code with context using Elastic-certified skills.',
                 })}
               >
@@ -108,7 +108,7 @@ export const AgentInstallSection = () => {
                       color="primary"
                       fill
                     >
-                      {i18n.translate('xpack.gettingStarted.agentInstall.userLLM.cta', {
+                      {i18n.translate('xpack.searchGettingStarted.agentInstall.userLLM.cta', {
                         defaultMessage: 'Copy prompt',
                       })}
                     </EuiButton>
@@ -125,7 +125,7 @@ export const AgentInstallSection = () => {
                           color="subdued"
                           size="m"
                           title={i18n.translate(
-                            'xpack.gettingStarted.agentInstall.anthropicIcon.title',
+                            'xpack.searchGettingStarted.agentInstall.anthropicIcon.title',
                             {
                               defaultMessage: 'Anthropic Claude Code logo',
                             }
@@ -139,7 +139,7 @@ export const AgentInstallSection = () => {
                           color="subdued"
                           size="m"
                           title={i18n.translate(
-                            'xpack.gettingStarted.agentInstall.cursorIcon.title',
+                            'xpack.searchGettingStarted.agentInstall.cursorIcon.title',
                             {
                               defaultMessage: 'Cursor AI logo',
                             }
@@ -152,7 +152,7 @@ export const AgentInstallSection = () => {
                           color="subdued"
                           size="m"
                           title={i18n.translate(
-                            'xpack.gettingStarted.agentInstall.vsCodeIcon.title',
+                            'xpack.searchGettingStarted.agentInstall.vsCodeIcon.title',
                             {
                               defaultMessage: 'Visual Studio Code logo',
                             }
@@ -171,11 +171,11 @@ export const AgentInstallSection = () => {
               <EuiPanel color="transparent" paddingSize="l">
                 <AgentInstallPanel
                   icon="productAgent"
-                  title={i18n.translate('xpack.gettingStarted.agentInstall.agentBuilder.title', {
+                  title={i18n.translate('xpack.searchGettingStarted.agentInstall.agentBuilder.title', {
                     defaultMessage: 'Build with the Elastic AI Agent',
                   })}
                   description={i18n.translate(
-                    'xpack.gettingStarted.agentInstall.agentBuilder.description',
+                    'xpack.searchGettingStarted.agentInstall.agentBuilder.description',
                     {
                       defaultMessage: 'Chat directly with our built-in agentic assistant.',
                     }
@@ -186,7 +186,7 @@ export const AgentInstallSection = () => {
                     onClick={handleOpenInAgentBuilder}
                     data-test-subj="agentInstallOpenInAgentBuilder"
                   >
-                    {i18n.translate('xpack.gettingStarted.agentInstall.agentBuilder.cta', {
+                    {i18n.translate('xpack.searchGettingStarted.agentInstall.agentBuilder.cta', {
                       defaultMessage: 'Open Elastic AI Agent',
                     })}
                   </AiButton>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/agent_install/agent_install.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/agent_install/agent_install.tsx
@@ -96,9 +96,12 @@ export const AgentInstallSection = () => {
                 title={i18n.translate('xpack.searchGettingStarted.agentInstall.ide.title', {
                   defaultMessage: 'Build in your IDE',
                 })}
-                description={i18n.translate('xpack.searchGettingStarted.agentInstall.ide.description', {
-                  defaultMessage: 'Code with context using Elastic-certified skills.',
-                })}
+                description={i18n.translate(
+                  'xpack.searchGettingStarted.agentInstall.ide.description',
+                  {
+                    defaultMessage: 'Code with context using Elastic-certified skills.',
+                  }
+                )}
               >
                 <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
                   <EuiFlexItem grow={false}>
@@ -171,9 +174,12 @@ export const AgentInstallSection = () => {
               <EuiPanel color="transparent" paddingSize="l">
                 <AgentInstallPanel
                   icon="productAgent"
-                  title={i18n.translate('xpack.searchGettingStarted.agentInstall.agentBuilder.title', {
-                    defaultMessage: 'Build with the Elastic AI Agent',
-                  })}
+                  title={i18n.translate(
+                    'xpack.searchGettingStarted.agentInstall.agentBuilder.title',
+                    {
+                      defaultMessage: 'Build with the Elastic AI Agent',
+                    }
+                  )}
                   description={i18n.translate(
                     'xpack.searchGettingStarted.agentInstall.agentBuilder.description',
                     {

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/agent_install/prompt_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/agent_install/prompt_modal.tsx
@@ -37,7 +37,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({ prompt, onClose }) => 
     <EuiModal onClose={onClose} aria-labelledby={modalTitleId} maxWidth={600}>
       <EuiModalHeader>
         <EuiModalHeaderTitle id={modalTitleId}>
-          {i18n.translate('xpack.gettingStarted.promptModal.title', {
+          {i18n.translate('xpack.searchGettingStarted.promptModal.title', {
             defaultMessage: 'Copy prompt to your coding agent',
           })}
         </EuiModalHeaderTitle>
@@ -45,7 +45,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({ prompt, onClose }) => 
       <EuiModalBody>
         <EuiText size="s" color="subdued">
           <p>
-            {i18n.translate('xpack.gettingStarted.promptModal.description', {
+            {i18n.translate('xpack.searchGettingStarted.promptModal.description', {
               defaultMessage:
                 'Paste this prompt into any coding agent to install the Elasticsearch onboarding skills.',
             })}
@@ -58,7 +58,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({ prompt, onClose }) => 
       </EuiModalBody>
       <EuiModalFooter>
         <EuiButtonEmpty onClick={onClose} data-test-subj="promptModalCloseBtn">
-          {i18n.translate('xpack.gettingStarted.promptModal.close', {
+          {i18n.translate('xpack.searchGettingStarted.promptModal.close', {
             defaultMessage: 'Close',
           })}
         </EuiButtonEmpty>
@@ -72,7 +72,7 @@ export const PromptModal: React.FC<PromptModalProps> = ({ prompt, onClose }) => 
               fill
               data-test-subj="promptModalCopyBtn"
             >
-              {i18n.translate('xpack.gettingStarted.promptModal.copy', {
+              {i18n.translate('xpack.searchGettingStarted.promptModal.copy', {
                 defaultMessage: 'Copy to clipboard',
               })}
             </EuiButton>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
@@ -21,7 +21,7 @@ export const GettingStartedAgentPrompt = () => {
         <EuiFlexItem>
           <EuiTitle size="xxs">
             <h5>
-              {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.title', {
+              {i18n.translate('xpack.searchGettingStarted.chat.agentPrompt.title', {
                 defaultMessage: 'Prompt your agent',
               })}
             </h5>
@@ -30,7 +30,7 @@ export const GettingStartedAgentPrompt = () => {
         <EuiFlexItem>
           <EuiText color="subdued" size="xs">
             <p>
-              {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.description', {
+              {i18n.translate('xpack.searchGettingStarted.chat.agentPrompt.description', {
                 defaultMessage:
                   'Set up our official optimized Elasticsearch skills in your preferred agentic code workflow.',
               })}
@@ -47,7 +47,7 @@ export const GettingStartedAgentPrompt = () => {
               size="s"
               data-test-subj="chatFirstAgentInstallBtn"
             >
-              {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.cta', {
+              {i18n.translate('xpack.searchGettingStarted.chat.agentPrompt.cta', {
                 defaultMessage: 'Copy prompt',
               })}
             </EuiButton>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_header.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_header.tsx
@@ -23,7 +23,7 @@ export const ChatHeader = () => {
           <EuiFlexItem>
             <EuiTitle size="l">
               <h1>
-                {i18n.translate('xpack.search.gettingStarted.chatPage.title', {
+                {i18n.translate('xpack.searchGettingStarted.chatPage.title', {
                   defaultMessage: 'Bring your data and start building your next search experience.',
                 })}
               </h1>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.tsx
@@ -30,7 +30,7 @@ export const ChatElasticsearchConnectionDetails = () => {
         <EuiTitle size="xxs">
           <h5>
             {i18n.translate(
-              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.serverless.title',
+              'xpack.searchGettingStarted.chat.elasticsearchConnectionDetails.serverless.title',
               {
                 defaultMessage: 'Connector to your project',
               }
@@ -42,7 +42,7 @@ export const ChatElasticsearchConnectionDetails = () => {
         <EuiBadgeGroup
           role="group"
           aria-label={i18n.translate(
-            'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadgeGroup.aria',
+            'xpack.searchGettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadgeGroup.aria',
             {
               defaultMessage: 'Select endpoint type',
             }
@@ -53,14 +53,14 @@ export const ChatElasticsearchConnectionDetails = () => {
             onClick={() => setUrlView(UrlView.elasticsearch)}
             data-test-subj="viewElasticsearchUrlBtn"
             onClickAriaLabel={i18n.translate(
-              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.elasticsearch.aria',
+              'xpack.searchGettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.elasticsearch.aria',
               {
                 defaultMessage: 'View the elasticsearch endpoint url',
               }
             )}
           >
             {i18n.translate(
-              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.elasticsearch',
+              'xpack.searchGettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.elasticsearch',
               {
                 defaultMessage: 'Elasticsearch',
               }
@@ -71,14 +71,14 @@ export const ChatElasticsearchConnectionDetails = () => {
             onClick={() => setUrlView(UrlView.mcp)}
             data-test-subj="viewMCPUrlBtn"
             onClickAriaLabel={i18n.translate(
-              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp.aria',
+              'xpack.searchGettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp.aria',
               {
                 defaultMessage: 'View the model context protocol server url',
               }
             )}
           >
             {i18n.translate(
-              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp',
+              'xpack.searchGettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp',
               {
                 defaultMessage: 'MCP',
               }

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -39,11 +39,11 @@ export const ConversationPrompt = () => {
         name="searchGettingStartedChatPromptInput"
         data-test-subj="searchGettingStartedChatPromptInput"
         placeholder={i18n.translate(
-          'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
+          'xpack.searchGettingStarted.chat.conversationPrompt.placeholder',
           { defaultMessage: 'How can I help you get started today?' }
         )}
         aria-label={i18n.translate(
-          'xpack.search.gettingStarted.chat.conversationPrompt.input.aria',
+          'xpack.searchGettingStarted.chat.conversationPrompt.input.aria',
           {
             defaultMessage: 'Ask the AI assistant a question to get started',
           }
@@ -56,7 +56,7 @@ export const ConversationPrompt = () => {
       <div css={NewConversationSendButton}>
         <EuiToolTip
           content={i18n.translate(
-            'xpack.search.gettingStarted.chat.conversationPrompt.send.tooltip',
+            'xpack.searchGettingStarted.chat.conversationPrompt.send.tooltip',
             {
               defaultMessage: 'Open the AI assistant chat',
             }
@@ -69,7 +69,7 @@ export const ConversationPrompt = () => {
             size="m"
             disabled={initialMessage.trim().length === 0}
             onClick={openConversation}
-            aria-label={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
+            aria-label={i18n.translate('xpack.searchGettingStarted.chat.conversationPrompt.send', {
               defaultMessage: 'Open the AI assistant chat',
             })}
             data-test-subj="searchGettingStartedChatPromptSend"

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/index.tsx
@@ -31,10 +31,10 @@ export const SearchGettingStartedConnectCode = () => {
       <EuiFlexGroup alignItems="center">
         <SearchGettingStartedSectionHeading
           icon="plugs"
-          title={i18n.translate('xpack.search.gettingStarted.page.codeExample.title', {
+          title={i18n.translate('xpack.searchGettingStarted.page.codeExample.title', {
             defaultMessage: 'Connect to your application',
           })}
-          description={i18n.translate('xpack.search.gettingStarted.page.codeExample.description', {
+          description={i18n.translate('xpack.searchGettingStarted.page.codeExample.description', {
             defaultMessage: 'Choose a language client and connect your application.',
           })}
         />

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/language_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/language_selector.tsx
@@ -34,13 +34,16 @@ export const LanguageSelector = ({
     () =>
       options.map((lang) => ({
         value: lang.id as AvailableLanguages,
-        'aria-label': i18n.translate('xpack.gettingStarted.codeLanguage.selectChangeAriaLabel', {
-          defaultMessage:
-            'Change language of code examples to {language} for every instance on this page',
-          values: {
-            language: lang.title,
-          },
-        }),
+        'aria-label': i18n.translate(
+          'xpack.searchGettingStarted.codeLanguage.selectChangeAriaLabel',
+          {
+            defaultMessage:
+              'Change language of code examples to {language} for every instance on this page',
+            values: {
+              language: lang.title,
+            },
+          }
+        ),
         'data-test-subj': `lang-option-${lang.id}`,
         inputDisplay: (
           <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -55,12 +58,12 @@ export const LanguageSelector = ({
     <EuiSuperSelect<AvailableLanguages>
       prepend={
         showLabel
-          ? i18n.translate('xpack.gettingStarted.codeLanguage.selectLabel', {
+          ? i18n.translate('xpack.searchGettingStarted.codeLanguage.selectLabel', {
               defaultMessage: 'Language',
             })
           : undefined
       }
-      aria-label={i18n.translate('xpack.gettingStarted.codeLanguage.selectLabel', {
+      aria-label={i18n.translate('xpack.searchGettingStarted.codeLanguage.selectLabel', {
         defaultMessage: 'Select a programming language for the code examples',
       })}
       options={languageOptions}

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/language_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/connect_code/language_selector.tsx
@@ -47,7 +47,7 @@ export const LanguageSelector = ({
         'data-test-subj': `lang-option-${lang.id}`,
         inputDisplay: (
           <EuiFlexGroup gutterSize="s" alignItems="center">
-            <EuiIcon type={`${assetBasePath}/${lang.icon}`} />
+            <EuiIcon type={`${assetBasePath}/${lang.icon}`} aria-hidden={true} />
             <EuiText>{lang.title}</EuiText>
           </EuiFlexGroup>
         ),

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/elasticsearch_connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/elasticsearch_connection_details.tsx
@@ -25,7 +25,7 @@ export const ElasticsearchConnectionDetails = () => {
             <EuiTitle size="xxxs">
               <h3>
                 {i18n.translate(
-                  'xpack.search.gettingStarted.elasticsearchConnectionDetails.endpointLabel',
+                  'xpack.searchGettingStarted.elasticsearchConnectionDetails.endpointLabel',
                   {
                     defaultMessage: 'Elasticsearch endpoint:',
                   }
@@ -36,7 +36,7 @@ export const ElasticsearchConnectionDetails = () => {
           <EuiFlexItem grow={false}>
             <EuiIconTip
               content={i18n.translate(
-                'xpack.search.gettingStarted.elasticsearchConnectionDetails.endpointTooltip',
+                'xpack.searchGettingStarted.elasticsearchConnectionDetails.endpointTooltip',
                 {
                   defaultMessage:
                     'The Elasticsearch endpoint is the URL for your Elasticsearch cluster.',
@@ -70,14 +70,14 @@ export const ElasticsearchConnectionDetails = () => {
                 onClick={() => openWiredConnectionDetails()}
                 color="text"
                 aria-label={i18n.translate(
-                  'xpack.search.gettingStarted.elasticsearchConnectionDetails.viewDetails',
+                  'xpack.searchGettingStarted.elasticsearchConnectionDetails.viewDetails',
                   {
                     defaultMessage: 'View connection details',
                   }
                 )}
               >
                 {i18n.translate(
-                  'xpack.search.gettingStarted.elasticsearchConnectionDetails.viewDetails',
+                  'xpack.searchGettingStarted.elasticsearchConnectionDetails.viewDetails',
                   {
                     defaultMessage: 'View connection details',
                   }

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/footer/index.tsx
@@ -32,14 +32,14 @@ export const GettingStartedFooter = () => {
   const footerLinks: DocLinkItem[] = [
     {
       id: 'searchLabs',
-      title: i18n.translate('xpack.gettingStarted.searchLabs.title', {
+      title: i18n.translate('xpack.searchGettingStarted.searchLabs.title', {
         defaultMessage: 'Search Labs',
       }),
-      description: i18n.translate('xpack.gettingStarted.searchLabs.description', {
+      description: i18n.translate('xpack.searchGettingStarted.searchLabs.description', {
         defaultMessage:
           'Explore the latest articles and tutorials on using Elasticsearch for AI/ML-powered search experiences.',
       }),
-      buttonLabel: i18n.translate('xpack.gettingStarted.searchLabs.buttonText', {
+      buttonLabel: i18n.translate('xpack.searchGettingStarted.searchLabs.buttonText', {
         defaultMessage: 'Visit Elasticsearch Labs',
       }),
       buttonHref: docLinks.visitSearchLabs,
@@ -47,14 +47,14 @@ export const GettingStartedFooter = () => {
     },
     {
       id: 'elasticTraining',
-      title: i18n.translate('xpack.gettingStarted.elasticTraining.title', {
+      title: i18n.translate('xpack.searchGettingStarted.elasticTraining.title', {
         defaultMessage: 'Elastic training',
       }),
-      description: i18n.translate('xpack.gettingStarted.elasticTraining.description', {
+      description: i18n.translate('xpack.searchGettingStarted.elasticTraining.description', {
         defaultMessage:
           'Access expert-led trainings, interactive labs, comprehensive certification programs, and flexible self-paced learning courses.',
       }),
-      buttonLabel: i18n.translate('xpack.gettingStarted.elasticTraining.buttonText', {
+      buttonLabel: i18n.translate('xpack.searchGettingStarted.elasticTraining.buttonText', {
         defaultMessage: 'Learn Elasticsearch',
       }),
       buttonHref: docLinks.elasticTraining,
@@ -62,16 +62,22 @@ export const GettingStartedFooter = () => {
     },
     {
       id: 'elasticsearchDocs',
-      title: i18n.translate('xpack.gettingStarted.elasticsearchDocs.title', {
+      title: i18n.translate('xpack.searchGettingStarted.elasticsearchDocs.title', {
         defaultMessage: 'Elasticsearch documentation',
       }),
-      description: i18n.translate('xpack.gettingStarted.elasticsearchDocumentation.description', {
-        defaultMessage:
-          'Comprehensive reference material to help you learn, build, and deploy search solutions with Elasticsearch.',
-      }),
-      buttonLabel: i18n.translate('xpack.gettingStarted.elasticsearchDocumentation.buttonText', {
-        defaultMessage: 'View documentation',
-      }),
+      description: i18n.translate(
+        'xpack.searchGettingStarted.elasticsearchDocumentation.description',
+        {
+          defaultMessage:
+            'Comprehensive reference material to help you learn, build, and deploy search solutions with Elasticsearch.',
+        }
+      ),
+      buttonLabel: i18n.translate(
+        'xpack.searchGettingStarted.elasticsearchDocumentation.buttonText',
+        {
+          defaultMessage: 'View documentation',
+        }
+      ),
       buttonHref: docLinks.elasticsearchDocs,
       dataTestSubj: 'gettingStartedViewDocumentation',
     },

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
@@ -36,7 +36,7 @@ export const AddDataButton: React.FC = () => {
         application.navigateToApp('home', { path: '#/tutorial_directory/fileDataViz' });
       }}
     >
-      {i18n.translate('xpack.search.gettingStarted.addDataButton.uploadFile', {
+      {i18n.translate('xpack.searchGettingStarted.addDataButton.uploadFile', {
         defaultMessage: 'Upload a file',
       })}
     </EuiContextMenuItem>,
@@ -49,7 +49,7 @@ export const AddDataButton: React.FC = () => {
         application.navigateToApp('home', { path: '#/tutorial_directory/sampleData' });
       }}
     >
-      {i18n.translate('xpack.search.gettingStarted.addDataButton.browseSampleData', {
+      {i18n.translate('xpack.searchGettingStarted.addDataButton.browseSampleData', {
         defaultMessage: 'Browse sample datasets',
       })}
     </EuiContextMenuItem>,
@@ -66,7 +66,7 @@ export const AddDataButton: React.FC = () => {
               });
             }}
           >
-            {i18n.translate('xpack.search.gettingStarted.addDataButton.createEmptyIndex', {
+            {i18n.translate('xpack.searchGettingStarted.addDataButton.createEmptyIndex', {
               defaultMessage: 'Create an empty index',
             })}
           </EuiContextMenuItem>,
@@ -83,7 +83,7 @@ export const AddDataButton: React.FC = () => {
       onClick={onButtonClick}
       data-test-subj="gettingStartedAddDataButton"
     >
-      {i18n.translate('xpack.search.gettingStarted.addDataButton.label', {
+      {i18n.translate('xpack.searchGettingStarted.addDataButton.label', {
         defaultMessage: 'Add data',
       })}
     </EuiButton>
@@ -91,7 +91,7 @@ export const AddDataButton: React.FC = () => {
 
   return (
     <EuiPopover
-      aria-label={i18n.translate('xpack.search.gettingStarted.addDataButton.popover.ariaLabel', {
+      aria-label={i18n.translate('xpack.searchGettingStarted.addDataButton.popover.ariaLabel', {
         defaultMessage: 'Add data options',
       })}
       button={button}

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/deployment_status_badges.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/deployment_status_badges.tsx
@@ -42,7 +42,7 @@ export const DeploymentStatusBadges: React.FC = () => {
           kibanaVersion={
             !cloud?.isServerlessEnabled
               ? `v${kibanaVersion}`
-              : i18n.translate('xpack.search.gettingStarted.changelog', {
+              : i18n.translate('xpack.searchGettingStarted.changelog', {
                   defaultMessage: 'Changelog',
                 })
           }

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/index.tsx
@@ -36,7 +36,7 @@ export const SearchGettingStartedHeader: React.FC = () => {
         <EuiFlexItem>
           <EuiTitle size="l">
             <h1>
-              {i18n.translate('xpack.search.gettingStarted.page.title', {
+              {i18n.translate('xpack.searchGettingStarted.page.title', {
                 defaultMessage: 'Get started with Elasticsearch.',
               })}
             </h1>
@@ -44,7 +44,7 @@ export const SearchGettingStartedHeader: React.FC = () => {
           <EuiSpacer size="s" />
           <EuiText grow={false} color="subdued" size="m">
             <p>
-              {i18n.translate('xpack.search.gettingStarted.page.description', {
+              {i18n.translate('xpack.searchGettingStarted.page.description', {
                 defaultMessage:
                   'Connect your deployment and start building modern search for products, docs, chatbots, recommenders, and more.',
               })}

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
@@ -45,7 +45,7 @@ export const SearchGettingStartedPage: React.FC = () => {
                 <EuiText size="s" color="subdued">
                   <p>
                     {i18n.translate(
-                      'xpack.search.gettingStarted.searchGettingStartedPage.description',
+                      'xpack.searchGettingStarted.searchGettingStartedPage.description',
                       { defaultMessage: 'Start with some sample data:' }
                     )}
                   </p>
@@ -66,7 +66,7 @@ export const SearchGettingStartedPage: React.FC = () => {
                       }}
                     >
                       {i18n.translate(
-                        'xpack.search.gettingStarted.searchGettingStartedPage.uploadFilesBtn',
+                        'xpack.searchGettingStarted.searchGettingStartedPage.uploadFilesBtn',
                         { defaultMessage: 'Upload files' }
                       )}
                     </EuiButtonEmpty>
@@ -86,7 +86,7 @@ export const SearchGettingStartedPage: React.FC = () => {
                       }}
                     >
                       {i18n.translate(
-                        'xpack.search.gettingStarted.searchGettingStartedPage.viewSampleDataButton',
+                        'xpack.searchGettingStarted.searchGettingStartedPage.viewSampleDataButton',
                         { defaultMessage: 'View sample data' }
                       )}
                     </EuiButtonEmpty>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -79,10 +79,13 @@ export const ConsoleTutorialsGroup = () => {
           defaultMessage: 'ES|QL fundamentals',
         }),
         dataTestSubj: 'console_tutorials_esql',
-        description: i18n.translate('xpack.searchGettingStarted.consoleTutorials.esqlDescription', {
-          defaultMessage:
-            "Learn how to use Elastic's piped query language to simplify and speed up data investigations.",
-        }),
+        description: i18n.translate(
+          'xpack.searchGettingStarted.consoleTutorials.esqlDescription',
+          {
+            defaultMessage:
+              "Learn how to use Elastic's piped query language to simplify and speed up data investigations.",
+          }
+        ),
         request: consoleTutorials.esql,
         publishedAt: new Date('2025-10-31'),
       },
@@ -106,10 +109,13 @@ export const ConsoleTutorialsGroup = () => {
           defaultMessage: 'Time series data streams',
         }),
         dataTestSubj: 'console_tutorials_tsds',
-        description: i18n.translate('xpack.searchGettingStarted.consoleTutorials.tsdsDescription', {
-          defaultMessage:
-            'Learn how to use a time series data stream (TSDS) to store timestamped metrics data.',
-        }),
+        description: i18n.translate(
+          'xpack.searchGettingStarted.consoleTutorials.tsdsDescription',
+          {
+            defaultMessage:
+              'Learn how to use a time series data stream (TSDS) to store timestamped metrics data.',
+          }
+        ),
         request: consoleTutorials.timeSeriesDataStreams,
         publishedAt: new Date('2026-02-04'),
       },

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -79,13 +79,10 @@ export const ConsoleTutorialsGroup = () => {
           defaultMessage: 'ES|QL fundamentals',
         }),
         dataTestSubj: 'console_tutorials_esql',
-        description: i18n.translate(
-          'xpack.searchGettingStarted.consoleTutorials.esqlDescription',
-          {
-            defaultMessage:
-              "Learn how to use Elastic's piped query language to simplify and speed up data investigations.",
-          }
-        ),
+        description: i18n.translate('xpack.searchGettingStarted.consoleTutorials.esqlDescription', {
+          defaultMessage:
+            "Learn how to use Elastic's piped query language to simplify and speed up data investigations.",
+        }),
         request: consoleTutorials.esql,
         publishedAt: new Date('2025-10-31'),
       },
@@ -109,13 +106,10 @@ export const ConsoleTutorialsGroup = () => {
           defaultMessage: 'Time series data streams',
         }),
         dataTestSubj: 'console_tutorials_tsds',
-        description: i18n.translate(
-          'xpack.searchGettingStarted.consoleTutorials.tsdsDescription',
-          {
-            defaultMessage:
-              'Learn how to use a time series data stream (TSDS) to store timestamped metrics data.',
-          }
-        ),
+        description: i18n.translate('xpack.searchGettingStarted.consoleTutorials.tsdsDescription', {
+          defaultMessage:
+            'Learn how to use a time series data stream (TSDS) to store timestamped metrics data.',
+        }),
         request: consoleTutorials.timeSeriesDataStreams,
         publishedAt: new Date('2026-02-04'),
       },


### PR DESCRIPTION
## Summary

Normalized all translation ids to prefix with `xpack.searchGettingStarted`, added the getting started plugin to the x-pack `i18nrc.json`

## Release Note

Fixes translations for the Elasticsearch solution getting started page.