### PR TITLE
fix(agent builder): attach skill to agent on creation

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/agents/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/agents/contract.ts
@@ -15,4 +15,10 @@ export interface AgentsServiceStartContract {
    * List all agents available.
    */
   list(): Promise<AgentDefinition[]>;
+
+  /**
+   * Add a skill to an agent's configuration, returning the updated agent.
+   * Idempotent: a skill already present on the agent leaves it unchanged.
+   */
+  addSkillToAgent(params: { agentId: string; skillId: string }): Promise<AgentDefinition>;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -70,6 +70,8 @@ export interface GetActionButtonsParams<TAttachment extends UnknownAttachment = 
   isSidebar: boolean;
   /** Whether the attachment is being rendered in canvas mode (expanded flyout view) */
   isCanvas: boolean;
+  /** Id of the agent the current conversation is using, when known. */
+  agentId?: string;
   /** Function to update the attachment's origin reference */
   updateOrigin: (origin: string) => Promise<UpdateOriginResponse | undefined>;
   /** Callback to open the attachment in canvas mode (expanded flyout view). Undefined when already in canvas mode. */

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
@@ -43,6 +43,7 @@ jest.mock('../../../../../hooks/use_conversation', () => ({
   useConversation: () => ({
     conversation: null,
   }),
+  useAgentId: () => 'agent-1',
 }));
 
 jest.mock('../../../../../hooks/use_agent_builder_service', () => ({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -13,6 +13,7 @@ import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationId } from '../../../../../context/conversation/use_conversation_id';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
+import { useAgentId } from '../../../../../hooks/use_conversation';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
 import { useCanvasContext } from './canvas_context';
@@ -38,6 +39,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   const { canvasState, closeCanvas, setCanvasAttachmentOrigin } = useCanvasContext();
   const conversationId = useConversationId();
   const { conversationActions } = useConversationContext();
+  const agentId = useAgentId();
   const { openSidebarConversation: openSidebarConversationInternal } = useAgentBuilderServices();
   const isNarrowViewport = useIsWithinBreakpoints(['xs', 's', 'm']);
 
@@ -102,12 +104,13 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
       uiDefinition?.getActionButtons?.({
         attachment: canvasState.attachment,
         isSidebar: canvasState.isSidebar,
+        agentId,
         updateOrigin,
         openSidebarConversation: canvasState.isSidebar ? undefined : openSidebarConversation,
         isCanvas: true,
       }) ?? [];
     return [...staticButtons, ...dynamicButtons];
-  }, [canvasState, uiDefinition, updateOrigin, openSidebarConversation, dynamicButtons]);
+  }, [canvasState, uiDefinition, agentId, updateOrigin, openSidebarConversation, dynamicButtons]);
 
   if (!canvasState || !uiDefinition?.renderCanvasContent) {
     return null;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.test.tsx
@@ -37,6 +37,10 @@ jest.mock('../../../../../context/conversation/conversation_context', () => ({
   }),
 }));
 
+jest.mock('../../../../../hooks/use_conversation', () => ({
+  useAgentId: () => 'agent-1',
+}));
+
 jest.mock('../../../../../hooks/use_agent_builder_service', () => ({
   useAgentBuilderServices: () => ({
     openSidebarConversation: mockOpenSidebarConversation,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -15,6 +15,7 @@ import { EuiSplitPanel } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
+import { useAgentId } from '../../../../../hooks/use_conversation';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
 import { getAttachmentPreviewKey, useCanvasContext } from './canvas_context';
@@ -49,6 +50,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
     setPreviewedAttachmentKey,
   } = useCanvasContext();
   const { conversationActions } = useConversationContext();
+  const agentId = useAgentId();
   const { openSidebarConversation: openSidebarConversationInternal } = useAgentBuilderServices();
 
   const openCanvas = useCallback(() => {
@@ -87,6 +89,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
       uiDefinition?.getActionButtons?.({
         attachment,
         isSidebar,
+        agentId,
         updateOrigin,
         openCanvas,
         openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
@@ -101,6 +104,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
       uiDefinition,
       attachment,
       isSidebar,
+      agentId,
       updateOrigin,
       openCanvas,
       setPreviewedAttachmentKey,

--- a/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
@@ -35,6 +35,7 @@ export type AgentBuilderPluginStartMock = jest.Mocked<AgentBuilderPluginStart> &
 const createAgentStartMock = (): AgentsServiceStartContractMock => {
   return {
     list: jest.fn(),
+    addSkillToAgent: jest.fn(),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/agents/create_public_agents_contract.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/agents/create_public_agents_contract.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentDefinition } from '@kbn/agent-builder-common';
+import type { AgentService } from './agents_service';
+import { createPublicAgentsContract } from './create_public_agents_contract';
+
+const buildAgent = (skillIds?: string[]): AgentDefinition =>
+  ({
+    id: 'agent-1',
+    configuration: { tools: [], skill_ids: skillIds },
+  } as unknown as AgentDefinition);
+
+describe('createPublicAgentsContract - addSkillToAgent', () => {
+  it('appends the skill id to the existing skill_ids and updates the agent', async () => {
+    const agentService = {
+      get: jest.fn().mockResolvedValue(buildAgent(['a'])),
+      update: jest.fn().mockResolvedValue(buildAgent(['a', 'b'])),
+    } as unknown as AgentService;
+    const contract = createPublicAgentsContract({ agentService });
+
+    await contract.addSkillToAgent({ agentId: 'agent-1', skillId: 'b' });
+
+    expect(agentService.get).toHaveBeenCalledWith('agent-1');
+    expect(agentService.update).toHaveBeenCalledWith('agent-1', {
+      configuration: { skill_ids: ['a', 'b'] },
+    });
+  });
+
+  it('treats missing skill_ids as an empty list', async () => {
+    const agentService = {
+      get: jest.fn().mockResolvedValue(buildAgent(undefined)),
+      update: jest.fn().mockResolvedValue(buildAgent(['b'])),
+    } as unknown as AgentService;
+    const contract = createPublicAgentsContract({ agentService });
+
+    await contract.addSkillToAgent({ agentId: 'agent-1', skillId: 'b' });
+
+    expect(agentService.update).toHaveBeenCalledWith('agent-1', {
+      configuration: { skill_ids: ['b'] },
+    });
+  });
+
+  it('is idempotent when the skill is already attached', async () => {
+    const existing = buildAgent(['a', 'b']);
+    const agentService = {
+      get: jest.fn().mockResolvedValue(existing),
+      update: jest.fn(),
+    } as unknown as AgentService;
+    const contract = createPublicAgentsContract({ agentService });
+
+    const result = await contract.addSkillToAgent({ agentId: 'agent-1', skillId: 'b' });
+
+    expect(agentService.update).not.toHaveBeenCalled();
+    expect(result).toBe(existing);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/agents/create_public_agents_contract.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/agents/create_public_agents_contract.ts
@@ -17,5 +17,15 @@ export const createPublicAgentsContract = ({
     list: async () => {
       return agentService.list();
     },
+    addSkillToAgent: async ({ agentId, skillId }) => {
+      const agent = await agentService.get(agentId);
+      const currentSkillIds = agent.configuration.skill_ids ?? [];
+      if (currentSkillIds.includes(skillId)) {
+        return agent;
+      }
+      return agentService.update(agentId, {
+        configuration: { skill_ids: [...currentSkillIds, skillId] },
+      });
+    },
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder_platform/jest.config.js
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/jest.config.js
@@ -8,7 +8,11 @@
 module.exports = {
   preset: '@kbn/test',
   rootDir: '../../../../..',
-  roots: ['<rootDir>/x-pack/platform/plugins/shared/agent_builder_platform/server'],
+  roots: [
+    '<rootDir>/x-pack/platform/plugins/shared/agent_builder_platform/public',
+    '<rootDir>/x-pack/platform/plugins/shared/agent_builder_platform/server',
+    '<rootDir>/x-pack/platform/plugins/shared/agent_builder_platform/common',
+  ],
   setupFiles: [],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/index.tsx
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import type { AttachmentServiceStartContract } from '@kbn/agent-builder-browser';
+import type {
+  AgentsServiceStartContract,
+  AttachmentServiceStartContract,
+} from '@kbn/agent-builder-browser';
 import type { ILocatorClient } from '@kbn/share-plugin/common/url_service';
 import type { CoreStart } from '@kbn/core/public';
 import { AttachmentType } from '@kbn/agent-builder-common/attachments';
@@ -18,10 +21,12 @@ import { createSkillAttachmentDefinition } from './skill_attachment/skill_attach
 
 export const registerAttachmentUiDefinitions = ({
   attachments,
+  agents,
   locators,
   core,
 }: {
   attachments: AttachmentServiceStartContract;
+  agents: AgentsServiceStartContract;
   locators: ILocatorClient;
   core: CoreStart;
 }) => {
@@ -35,6 +40,7 @@ export const registerAttachmentUiDefinitions = ({
       http: core.http,
       notifications: core.notifications,
       application: core.application,
+      agents,
     })
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, HttpStart } from '@kbn/core/public';
+import type { AgentsServiceStartContract } from '@kbn/agent-builder-browser';
+import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
+import { SKILL_ATTACHMENT_TYPE, type SkillAttachment } from '../../../common/attachments';
+import { createSkillAttachmentDefinition } from './skill_attachment';
+
+jest.mock('@kbn/agent-builder-plugin/public', () => ({
+  SKILLS_API_PATH: '/api/agent_builder/skills',
+  AGENTBUILDER_APP_ID: 'agent_builder',
+}));
+
+const CREATE_BUTTON_LABEL = 'Create skill';
+const NEW_SKILL_ID = 'track-purchases';
+
+const buildAttachment = (): SkillAttachment =>
+  ({
+    id: 'attachment-1',
+    type: SKILL_ATTACHMENT_TYPE,
+    data: {
+      id: NEW_SKILL_ID,
+      name: 'Track purchases',
+      description: 'Tracks small purchases',
+      content: 'instructions',
+      tool_ids: [],
+      referenced_content: [],
+    },
+    // version === versionCount marks the draft as the latest, which is the
+    // condition under which the "Create skill" button is rendered.
+    version: 1,
+    versionCount: 1,
+  } as unknown as SkillAttachment);
+
+const setup = () => {
+  const post = jest.fn().mockResolvedValue({ id: NEW_SKILL_ID });
+  const addSuccess = jest.fn();
+  const addError = jest.fn();
+  const addSkillToAgent = jest.fn().mockResolvedValue({});
+  const updateOrigin = jest.fn().mockResolvedValue(undefined);
+
+  const http = { post } as unknown as HttpStart;
+  const notifications = {
+    toasts: { addSuccess, addError },
+  } as unknown as CoreStart['notifications'];
+  const application = {
+    capabilities: { agentBuilder: { manageSkills: true } },
+    getUrlForApp: jest.fn(),
+  } as unknown as CoreStart['application'];
+  const agents = { list: jest.fn(), addSkillToAgent } as unknown as AgentsServiceStartContract;
+
+  const definition = createSkillAttachmentDefinition({ http, notifications, application, agents });
+
+  const getCreateHandler = (agentId?: string) => {
+    const buttons: ActionButton[] =
+      definition.getActionButtons?.({
+        attachment: buildAttachment(),
+        agentId,
+        isSidebar: false,
+        isCanvas: false,
+        updateOrigin,
+      }) ?? [];
+    const createButton = buttons.find((button) => button.label === CREATE_BUTTON_LABEL);
+    if (!createButton) {
+      throw new Error('Create skill button not found');
+    }
+    return createButton.handler;
+  };
+
+  return { post, addSuccess, addError, addSkillToAgent, updateOrigin, getCreateHandler };
+};
+
+describe('createSkillAttachmentDefinition - Create skill', () => {
+  it('creates the skill and adds it to the current agent', async () => {
+    const { post, addSuccess, addError, addSkillToAgent, updateOrigin, getCreateHandler } = setup();
+
+    await getCreateHandler('agent-1')();
+
+    expect(post).toHaveBeenCalledWith('/api/agent_builder/skills', expect.any(Object));
+    expect(updateOrigin).toHaveBeenCalledWith(NEW_SKILL_ID);
+    expect(addSkillToAgent).toHaveBeenCalledWith({ agentId: 'agent-1', skillId: NEW_SKILL_ID });
+    expect(addSuccess).toHaveBeenCalledTimes(1);
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('creates the skill without attaching when there is no current agent', async () => {
+    const { addSkillToAgent, addSuccess, addError, getCreateHandler } = setup();
+
+    await getCreateHandler(undefined)();
+
+    expect(addSkillToAgent).not.toHaveBeenCalled();
+    expect(addSuccess).toHaveBeenCalledTimes(1);
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('keeps the created skill and reports separately when attaching to the agent fails', async () => {
+    const { addSkillToAgent, addSuccess, addError, updateOrigin, getCreateHandler } = setup();
+    addSkillToAgent.mockRejectedValueOnce(new Error('forbidden'));
+
+    await getCreateHandler('agent-1')();
+
+    expect(updateOrigin).toHaveBeenCalledWith(NEW_SKILL_ID);
+    expect(addSkillToAgent).toHaveBeenCalledWith({ agentId: 'agent-1', skillId: NEW_SKILL_ID });
+    expect(addError).toHaveBeenCalledTimes(1);
+    expect(addSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt to attach when skill creation fails', async () => {
+    const { post, addSkillToAgent, addSuccess, addError, getCreateHandler } = setup();
+    post.mockRejectedValueOnce(new Error('boom'));
+
+    await getCreateHandler('agent-1')();
+
+    expect(addSkillToAgent).not.toHaveBeenCalled();
+    expect(addSuccess).not.toHaveBeenCalled();
+    expect(addError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.tsx
@@ -19,6 +19,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import type { CoreStart, HttpStart } from '@kbn/core/public';
+import type { AgentsServiceStartContract } from '@kbn/agent-builder-browser';
 import type { HeaderBadge } from '@kbn/agent-builder-browser/attachments';
 import {
   ActionButtonType,
@@ -241,16 +242,11 @@ interface CreateSkillDeps {
   http: HttpStart;
   notifications: CoreStart['notifications'];
   application: CoreStart['application'];
+  agents: AgentsServiceStartContract;
 }
 
 /**
  * Factory for the `skill` UI definition.
- *
- * Why a factory: `getActionButtons` runs every render but lives in module
- * scope, so it can't use React hooks. We close over `core.http` /
- * `core.notifications` / `core.application` captured at registration time
- * and use them directly. This mirrors the pattern used by the ESQL and
- * dashboard attachment definitions.
  *
  * The Create button:
  * 1. Disables when the user lacks the `manageSkills` capability.
@@ -258,12 +254,16 @@ interface CreateSkillDeps {
  * 3. On success, calls the framework-provided `updateOrigin(skillId)` so the
  *    same attachment now references the persisted skill (the card flips to
  *    a "Created" badge and the button disables).
- * 4. On failure, surfaces the agent_builder error message via core toasts.
+ * 4. Adds the new skill to the current conversation's agent (`agentId`) so it
+ *    is immediately usable; a failure here is reported separately and does not
+ *    undo the skill creation.
+ * 5. On failure, surfaces the agent_builder error message via core toasts.
  */
 export const createSkillAttachmentDefinition = ({
   http,
   notifications,
   application,
+  agents,
 }: CreateSkillDeps): AttachmentUIDefinition<SkillAttachment> => {
   const canCreate = application.capabilities.agentBuilder?.manageSkills === true;
   const isLatest = ({
@@ -319,7 +319,7 @@ export const createSkillAttachmentDefinition = ({
     },
     renderInlineContent: (props) => <SkillInlineContent {...props} />,
     renderCanvasContent: (props) => <SkillCanvasContent {...props} />,
-    getActionButtons: ({ attachment, updateOrigin, openCanvas, isCanvas }) => {
+    getActionButtons: ({ attachment, agentId, updateOrigin, openCanvas, isCanvas }) => {
       const { version, versionCount } = attachment;
       const isCreated = Boolean(attachment.origin);
 
@@ -330,6 +330,24 @@ export const createSkillAttachmentDefinition = ({
             body: JSON.stringify(attachment.data satisfies SkillAttachmentData),
           });
           await updateOrigin(response.id);
+          if (agentId) {
+            try {
+              await agents.addSkillToAgent({ agentId, skillId: response.id });
+            } catch (error) {
+              notifications.toasts.addError(error as Error, {
+                title: i18n.translate(
+                  'xpack.agentBuilderPlatform.attachments.skill.addToAgentErrorToast',
+                  {
+                    defaultMessage:
+                      'Skill "{skillId}" created, but could not be added to this agent',
+                    values: { skillId: response.id },
+                  }
+                ),
+              });
+              return;
+            }
+          }
+
           notifications.toasts.addSuccess({
             title: i18n.translate(
               'xpack.agentBuilderPlatform.attachments.skill.createSuccessToast',

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/plugin.tsx
@@ -35,6 +35,7 @@ export class AgentBuilderPlatformPlugin
 
     registerAttachmentUiDefinitions({
       attachments: agentBuilder.attachments,
+      agents: agentBuilder.agents,
       locators: share.url.locators,
       core: coreStart,
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/search-team/issues/14717

## Summary

Fixes a bug where skills created via chat, when created were not correctly added to the current agent. 



