### PR TITLE
[EDR Workflows][Osquery] Fix scheduled query results detail for responses without space_id

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/lib/update_global_packs.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/update_global_packs.test.ts
@@ -242,8 +242,9 @@ describe('updateGlobalPacksCreateCallback', () => {
       mockOsqueryContext
     );
 
-    // The pack-level space identifier is emitted as `default_space_id`
-    // at the pack level; per-query `space_id` is collapsed when uniform.
+    // `default_space_id` is emitted at the pack level, and `space_id` is set on
+    // each query — osquerybeat stamps scheduled responses from the per-query
+    // value, so it must be present (see https://github.com/elastic/kibana/issues/272253).
     expect(result.inputs[0].config?.osquery?.value?.packs?.['default--embedded-pack']).toEqual({
       shard: 100,
       pack_id: 'pack-so-id-4',
@@ -253,6 +254,7 @@ describe('updateGlobalPacksCreateCallback', () => {
           name: 'test-query',
           query: 'SELECT * FROM listening_ports;',
           interval: 1800,
+          space_id: 'default',
         },
       },
     });

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/utils.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/utils.test.ts
@@ -113,13 +113,13 @@ describe('Pack utils', () => {
       );
     });
 
-    test('injects space_id at the pack level (not per-query) via default_space_id', () => {
+    test('injects space_id per-query (osquerybeat reads it) and default_space_id at the pack level', () => {
       const output = convertSOQueriesToPackConfig(getTestQueries(), {
         spaceId: 'my-space',
         isRruleFeatureEnabled: true,
       });
       expect(output.default_space_id).toBe('my-space');
-      expect(output.queries).toStrictEqual(getOneLiner({}));
+      expect(output.queries).toStrictEqual(getOneLiner({ space_id: 'my-space' }));
     });
   });
 

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/utils.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/utils.ts
@@ -401,6 +401,7 @@ export const convertSOQueriesToPackConfig = (
             : {}),
           ...(platform === DEFAULT_PLATFORM || platform === undefined ? {} : { platform }),
           ...resultType,
+          ...(spaceId ? { space_id: spaceId } : {}),
         },
         isUndefined
       );

--- a/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/scheduled_action_results/query.scheduled_action_results.dsl.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/scheduled_action_results/query.scheduled_action_results.dsl.test.ts
@@ -105,6 +105,44 @@ describe('buildScheduledActionResultsQuery', () => {
     expect(mustFilters).toContainEqual({ term: { space_id: 'my-space' } });
   });
 
+  it('matches default space OR missing space_id when spaceId is "default"', () => {
+    // osquerybeat-written scheduled responses may not carry a space_id field;
+    // in the default space we must match those legacy docs too (mirrors the
+    // history aggregation in buildScheduledResponsesQuery).
+    const options: ScheduledActionResultsRequestOptions = {
+      ...defaultOptions,
+      spaceId: 'default',
+    };
+
+    const result = buildScheduledActionResultsQuery(options);
+
+    const defaultSpaceClause = {
+      bool: {
+        should: [
+          { term: { space_id: 'default' } },
+          { bool: { must_not: { exists: { field: 'space_id' } } } },
+        ],
+      },
+    };
+
+    expect(result.query).toEqual({
+      bool: {
+        filter: [
+          { term: { schedule_id: 'test-schedule-id' } },
+          { term: { schedule_execution_count: 42 } },
+          defaultSpaceClause,
+        ],
+      },
+    });
+
+    const aggs = result.aggs as Record<string, Record<string, unknown>>;
+    const globalAggs = aggs.aggs as Record<string, Record<string, unknown>>;
+    const innerAggs = globalAggs.aggs as Record<string, Record<string, unknown>>;
+    const responsesBySchedule = innerAggs.responses_by_schedule as Record<string, unknown>;
+    const mustFilters = (responsesBySchedule.filter as { bool: { must: unknown[] } }).bool.must;
+    expect(mustFilters).toContainEqual(defaultSpaceClause);
+  });
+
   it('omits space_id filter when spaceId is not provided', () => {
     const result = buildScheduledActionResultsQuery(defaultOptions);
     const filterQuery = result.query as Record<string, Record<string, TermFilter[]>>;

--- a/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/scheduled_action_results/query.scheduled_action_results.dsl.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/scheduled_action_results/query.scheduled_action_results.dsl.ts
@@ -18,14 +18,28 @@ export const buildScheduledActionResultsQuery = ({
   pagination,
   ccsEnabled,
 }: ScheduledActionResultsRequestOptions): ISearchRequestParams => {
+  // Scheduled action_responses emitted by osquerybeat may not carry a
+  // `space_id` field. Mirror the history aggregation (buildScheduledResponsesQuery):
+  // in the default space match `space_id: default` OR a missing `space_id`;
+  // in a named space match the space exactly.
+  const spaceIdFilter: Record<string, unknown> | undefined = !spaceId
+    ? undefined
+    : spaceId === 'default'
+    ? {
+        bool: {
+          should: [
+            { term: { space_id: 'default' } },
+            { bool: { must_not: { exists: { field: 'space_id' } } } },
+          ],
+        },
+      }
+    : { term: { space_id: spaceId } };
+
   const filterQuery: Array<Record<string, unknown>> = [
     { term: { schedule_id: scheduleId } },
     { term: { schedule_execution_count: executionCount } },
+    ...(spaceIdFilter ? [spaceIdFilter] : []),
   ];
-
-  if (spaceId) {
-    filterQuery.push({ term: { space_id: spaceId } });
-  }
 
   const index = prefixIndexPatternsWithCcs(
     `${ACTION_RESPONSES_DATA_STREAM_INDEX}*`,
@@ -46,7 +60,7 @@ export const buildScheduledActionResultsQuery = ({
                 must: [
                   { term: { schedule_id: scheduleId } },
                   { term: { schedule_execution_count: executionCount } },
-                  ...(spaceId ? [{ term: { space_id: spaceId } }] : []),
+                  ...(spaceIdFilter ? [spaceIdFilter] : []),
                 ],
               },
             },

--- a/x-pack/platform/test/api_integration/apis/osquery/index.ts
+++ b/x-pack/platform/test/api_integration/apis/osquery/index.ts
@@ -18,6 +18,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./live_queries'));
     loadTestFile(require.resolve('./history_tags'));
     loadTestFile(require.resolve('./unified_history'));
+    loadTestFile(require.resolve('./scheduled_results'));
     loadTestFile(require.resolve('./export_results'));
   });
 }

--- a/x-pack/platform/test/api_integration/apis/osquery/scheduled_results.ts
+++ b/x-pack/platform/test/api_integration/apis/osquery/scheduled_results.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+
+interface ScheduledHistoryRow {
+  scheduleId: string;
+  executionCount: number;
+  sourceType: string;
+  totalRows: number;
+  agentCount: number;
+  successCount: number;
+  errorCount: number;
+}
+
+interface ScheduledResultsResponse {
+  total: number;
+  aggregations: {
+    totalRowCount: number;
+    totalResponded: number;
+    successful: number;
+    failed: number;
+    pending: number;
+  };
+}
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const es = getService('es');
+
+  // Scheduled action responses are written by osquerybeat to the
+  // osquery_manager action.responses data stream (NOT the dotted live-query
+  // index). Crucially for this regression, those docs do NOT carry a
+  // `space_id` field — osquerybeat only stamps space_id from a per-query
+  // config field, which can be absent. See
+  // https://github.com/elastic/kibana/issues/272253.
+  const responsesIndex = 'logs-osquery_manager.action.responses-default';
+  const indexTemplateName = 'osquery-scheduled-results-it';
+  const scheduleId = `scheduled-results-it-${Date.now()}`;
+  const executionCount = 11;
+
+  // 2 successful responses + 1 errored response; none carry a `space_id`.
+  const successfulResponses = 2;
+  const erroredResponses = 1;
+  const rowsPerSuccess = 111;
+  const expectedTotalRows = rowsPerSuccess * successfulResponses; // errored response reports 0 rows
+  const expectedAgents = successfulResponses + erroredResponses;
+
+  // This index is owned by the stack's generic `logs-*-*` data stream template,
+  // whose ECS dynamic mappings type strings as `keyword` and disable date
+  // detection. That makes `planned_schedule_time` a keyword (breaking the
+  // history `max` aggregation) and `error` a bare keyword with no `.keyword`
+  // sub-field (breaking the detail endpoint's painless terms script). The real
+  // osquery_manager package template maps these correctly, but the package is
+  // not installed in this env — so install a higher-priority data stream
+  // template with the field types the queries rely on, then (re)create the
+  // data stream. This keeps the test deterministic.
+  const recreateResponsesIndex = async () => {
+    await es.indices.deleteDataStream({ name: responsesIndex }, { ignore: [404] });
+    await es.indices.putIndexTemplate({
+      name: indexTemplateName,
+      index_patterns: [responsesIndex],
+      data_stream: {},
+      priority: 600,
+      template: {
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            planned_schedule_time: { type: 'date' },
+            started_at: { type: 'date' },
+            completed_at: { type: 'date' },
+            schedule_id: { type: 'keyword' },
+            schedule_execution_count: { type: 'long' },
+            response_id: { type: 'keyword' },
+            pack_id: { type: 'keyword' },
+            agent_id: { type: 'keyword' },
+            action_input_type: { type: 'keyword' },
+            space_id: { type: 'keyword' },
+            count: { type: 'long' },
+            error: { type: 'text', fields: { keyword: { type: 'keyword', ignore_above: 1024 } } },
+            action_response: {
+              properties: { osquery: { properties: { count: { type: 'long' } } } },
+            },
+          },
+        },
+      },
+    });
+    await es.indices.createDataStream({ name: responsesIndex });
+  };
+
+  const seedResponses = async () => {
+    const timestamp = new Date().toISOString();
+    const base = {
+      '@timestamp': timestamp,
+      action_input_type: 'osquery_scheduled',
+      schedule_id: scheduleId,
+      schedule_execution_count: executionCount,
+      pack_id: 'scheduled-results-it-pack',
+      planned_schedule_time: timestamp,
+      started_at: timestamp,
+      completed_at: timestamp,
+      // NB: intentionally NO `space_id` — this is what real osquerybeat emits
+      // and is the exact shape that triggered the regression.
+    };
+
+    const documents = [
+      {
+        ...base,
+        response_id: `${scheduleId}-a`,
+        agent_id: 'scheduled-results-it-agent-a',
+        action_response: { osquery: { count: rowsPerSuccess } },
+        count: rowsPerSuccess,
+      },
+      {
+        ...base,
+        response_id: `${scheduleId}-b`,
+        agent_id: 'scheduled-results-it-agent-b',
+        action_response: { osquery: { count: rowsPerSuccess } },
+        count: rowsPerSuccess,
+      },
+      {
+        ...base,
+        response_id: `${scheduleId}-c`,
+        agent_id: 'scheduled-results-it-agent-c',
+        action_response: { osquery: { count: 0 } },
+        count: 0,
+        error: 'Query execution failed',
+      },
+    ];
+
+    for (const document of documents) {
+      // Data streams only accept the `create` op type.
+      await es.index({ index: responsesIndex, op_type: 'create', refresh: 'wait_for', document });
+    }
+  };
+
+  const deleteResponses = async () => {
+    await es.indices.deleteDataStream({ name: responsesIndex }, { ignore: [404] });
+    await es.indices.deleteIndexTemplate({ name: indexTemplateName }, { ignore: [404] });
+  };
+
+  describe('Scheduled query results detail', () => {
+    before(async () => {
+      await recreateResponsesIndex();
+      await seedResponses();
+    });
+    after(deleteResponses);
+
+    // Regression guard for https://github.com/elastic/kibana/issues/272253.
+    // The history aggregation and the scheduled_results detail endpoint read
+    // the same action_responses docs and must report the same counts even when
+    // those docs have no `space_id`. Before the fix, the detail endpoint's
+    // strict `space_id` term dropped every doc and returned 0 while the
+    // history row still showed the real counts.
+    it('history row counts scheduled responses that have no space_id', async () => {
+      const { body } = await supertest
+        .get('/api/osquery/history?sourceFilters=scheduled&pageSize=100')
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
+        .expect(200);
+
+      const rows = body.data as ScheduledHistoryRow[];
+      const row = rows.find(
+        (candidate) =>
+          candidate.scheduleId === scheduleId && candidate.executionCount === executionCount
+      );
+
+      expect(row).to.be.ok();
+      expect(row?.sourceType).to.be('scheduled');
+      expect(row?.totalRows).to.be(expectedTotalRows);
+      expect(row?.agentCount).to.be(expectedAgents);
+      expect(row?.successCount).to.be(successfulResponses);
+      expect(row?.errorCount).to.be(erroredResponses);
+    });
+
+    it('detail endpoint agrees with the history row for responses with no space_id', async () => {
+      const { body } = await supertest
+        .get(`/api/osquery/scheduled_results/${scheduleId}/${executionCount}`)
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
+        .expect(200);
+
+      const { total, aggregations } = body as ScheduledResultsResponse;
+
+      // Pre-fix every one of these was 0 because of the strict space_id filter.
+      expect(aggregations.totalRowCount).to.be(expectedTotalRows);
+      expect(total).to.be(expectedAgents);
+      expect(aggregations.successful).to.be(successfulResponses);
+      expect(aggregations.failed).to.be(erroredResponses);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The Osquery History → "Query results" detail view fails to load for scheduled queries: the header shows `Docs -` and `Agents 0 / 0 / 0`, the Status tab is empty, and "Export results" is disabled with a "No exportable data available"
tooltip, even though the main history table shows the correct counts.

### Root cause

Scheduled `action_responses` are written by osquerybeat, which stamps `space_id` only from a **per-query** `space_id` config field. #270639 (rrule scheduling / Fleet fan-out) removed that per-query `space_id` from the pack config and replaced it with a **pack-level** `default_space_id` that osquerybeat does not read, so scheduled response docs are now emitted **without** `space_id`.

`buildScheduledActionResultsQuery` filtered with a strict `space_id` term and dropped every such doc (→ 0 docs / 0 agents / empty Status / disabled Export). The history aggregation (`buildScheduledResponsesQuery`) already tolerated a missing `space_id` (default space → `space_id: default` OR field absent), which is why the main table kept showing the correct counts. That asymmetry is the bug.

### Changes

- Restore the per-query `space_id` in `convertSOQueriesToPackConfig` so osquerybeat stamps `space_id` again (correct for the default space and named spaces going forward).
- Tolerate a missing `space_id` in the default space in `buildScheduledActionResultsQuery`, mirroring the history aggregation, to  recover already-emitted docs and align the two queries.

### Testing

- Unit: per-query `space_id` emission (`pack/utils.test.ts`) and the default-space fallback in the scheduled-results DSL (`query.scheduled_action_results.dsl.test.ts`).
- API integration (`scheduled_results.ts`): seeds scheduled `action_responses` **without** `space_id` and asserts the history endpoint and the `scheduled_results` detail endpoint report consistent counts, the invariant that #270639 broke.

Closes https://github.com/elastic/kibana/issues/272253


Before:
<img width="1294" height="722" alt="Screenshot 2026-06-02 at 1 54 41 PM" src="https://github.com/user-attachments/assets/7262ffac-7f8a-4b92-9683-0eff5f352230" />
<img width="1493" height="657" alt="Screenshot 2026-06-02 at 1 54 50 PM" src="https://github.com/user-attachments/assets/ac189b7c-f65c-404f-a3af-83e2d670c209" />

After:
<img width="1278" height="681" alt="Screenshot 2026-06-02 at 2 27 01 PM" src="https://github.com/user-attachments/assets/85c4f965-9cb7-4852-97ab-8dd407d720d6" />

