### PR TITLE
[Alerting v2] Add episodes list locator

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_locator.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_locator.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { decode as decodeRison } from '@kbn/rison';
+import { EPISODES_LIST_LOCATOR_ID, EpisodesListLocatorDefinition } from './episodes_list_locator';
+import { EPISODES_LIST_APP_STATE_KEY, decodeEpisodesListRecord } from './episodes_list_url_state';
+
+const EPISODES_PATH = '/alertingV2/episodes';
+
+const readEpisodesListFromPath = (path: string) => {
+  const queryIndex = path.indexOf('?');
+  if (queryIndex === -1) {
+    return undefined;
+  }
+  const params = new URLSearchParams(path.slice(queryIndex + 1));
+  const a = params.get('_a');
+  if (!a) {
+    return undefined;
+  }
+  const blob = decodeRison(a) as Record<string, unknown>;
+  return decodeEpisodesListRecord(blob[EPISODES_LIST_APP_STATE_KEY]);
+};
+
+describe('EpisodesListLocatorDefinition', () => {
+  const locator = new EpisodesListLocatorDefinition();
+
+  it('exposes the stable locator id', () => {
+    expect(locator.id).toBe(EPISODES_LIST_LOCATOR_ID);
+  });
+
+  it('points at the episodes app in management with no query when params are empty', async () => {
+    const location = await locator.getLocation({});
+    expect(location).toEqual({ app: 'management', path: EPISODES_PATH, state: {} });
+  });
+
+  it('omits an unspecified status (defaults to active)', async () => {
+    const location = await locator.getLocation({ ruleId: 'rule-1' });
+    expect(location.path).toContain(`${EPISODES_PATH}?`);
+    expect(readEpisodesListFromPath(location.path)).toEqual({ ruleId: 'rule-1' });
+  });
+
+  it('encodes "all" status explicitly', async () => {
+    const location = await locator.getLocation({ status: 'all' });
+    const decoded = readEpisodesListFromPath(location.path);
+    expect(decoded && 'status' in decoded).toBe(true);
+    expect(decoded?.status).toBeUndefined();
+  });
+
+  it('round-trips filters and a custom time range through the URL', async () => {
+    const params = {
+      ruleId: 'rule-1',
+      status: 'pending',
+      queryString: 'host:web',
+      tags: ['a', 'b'],
+      assigneeUid: 'u-1',
+      timeRange: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-02T00:00:00.000Z' },
+    };
+    const location = await locator.getLocation(params);
+    expect(readEpisodesListFromPath(location.path)).toEqual({
+      ruleId: 'rule-1',
+      status: 'pending',
+      queryString: 'host:web',
+      tags: ['a', 'b'],
+      assigneeUid: 'u-1',
+      timeRange: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-02T00:00:00.000Z' },
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_locator.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_locator.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SerializableRecord } from '@kbn/utility-types';
+import type { LocatorDefinition, LocatorPublic } from '@kbn/share-plugin/common';
+import { encode as encodeRison } from '@kbn/rison';
+import {
+  DEFAULT_EPISODES_LIST_STATUS,
+  EPISODES_LIST_APP_STATE_KEY,
+  encodeEpisodesListRecord,
+} from './episodes_list_url_state';
+
+export const EPISODES_LIST_LOCATOR_ID = 'ALERTING_V2_EPISODES_LIST_LOCATOR';
+
+/**
+ * Route segments owned by this locator. These mirror the management section /
+ * app ids registered in the plugin's public setup (`public/constants.ts` /
+ * `public/index.ts`); the locator is the canonical builder of episodes-list
+ * deep links.
+ */
+const MANAGEMENT_APP_ID = 'management';
+const ALERTING_V2_SECTION_ID = 'alertingV2';
+const ALERTING_V2_EPISODES_APP_ID = 'episodes';
+
+export interface EpisodesListLocatorParams extends SerializableRecord {
+  /** Narrow the list to a single rule. */
+  ruleId?: string;
+  /**
+   * Episode status filter. `'all'` shows every status; omit for the default
+   * (active). Any other value selects that single status.
+   */
+  status?: string;
+  /** Full-text search applied to the list. */
+  queryString?: string;
+  /** Tag values — episodes matching any selected tag (OR). */
+  tags?: string[];
+  /** Last-assignee user profile UID. */
+  assigneeUid?: string;
+  /** Time range embedded in `_a.episodesList.{timeFrom,timeTo}`. */
+  timeRange?: { from: string; to: string };
+}
+
+export type EpisodesListLocator = LocatorPublic<EpisodesListLocatorParams>;
+
+export class EpisodesListLocatorDefinition implements LocatorDefinition<EpisodesListLocatorParams> {
+  public readonly id = EPISODES_LIST_LOCATOR_ID;
+
+  public readonly getLocation = async (params: EpisodesListLocatorParams) => {
+    const { ruleId, status, queryString, tags, assigneeUid, timeRange } = params;
+
+    const record = encodeEpisodesListRecord({
+      ruleId,
+      // An unspecified status means "use the list default" (active), so it is
+      // coalesced to the default and omitted from the URL. Pass `'all'`
+      // explicitly to show every status. (In page filter state, by contrast, an
+      // absent status means "all" — hence the translation here.)
+      status: status ?? DEFAULT_EPISODES_LIST_STATUS,
+      queryString,
+      tags,
+      assigneeUid,
+      timeRange,
+    });
+
+    const basePath = `/${ALERTING_V2_SECTION_ID}/${ALERTING_V2_EPISODES_APP_ID}`;
+    let path = basePath;
+    if (Object.keys(record).length > 0) {
+      const search = new URLSearchParams();
+      search.set('_a', encodeRison({ [EPISODES_LIST_APP_STATE_KEY]: record }));
+      path = `${basePath}?${search.toString()}`;
+    }
+
+    return {
+      app: MANAGEMENT_APP_ID,
+      path,
+      state: {},
+    };
+  };
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_url_state.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_url_state.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  DEFAULT_EPISODES_LIST_TIME_RANGE,
+  EPISODES_LIST_STATUS_URL_ALL,
+  decodeEpisodesListRecord,
+  encodeEpisodesListRecord,
+  type EpisodesListUrlState,
+} from './episodes_list_url_state';
+
+describe('encodeEpisodesListRecord', () => {
+  it('omits the default status (active)', () => {
+    expect(encodeEpisodesListRecord({ status: 'active' })).toEqual({});
+  });
+
+  it('encodes a nil status as the "all" sentinel', () => {
+    expect(encodeEpisodesListRecord({ status: undefined })).toEqual({
+      status: EPISODES_LIST_STATUS_URL_ALL,
+    });
+    expect(encodeEpisodesListRecord({ status: null })).toEqual({
+      status: EPISODES_LIST_STATUS_URL_ALL,
+    });
+  });
+
+  it('encodes a non-default status verbatim', () => {
+    expect(encodeEpisodesListRecord({ status: 'pending' })).toEqual({ status: 'pending' });
+  });
+
+  it('encodes ruleId, trimmed queryString, tags and assigneeUid', () => {
+    expect(
+      encodeEpisodesListRecord({
+        status: 'active',
+        ruleId: 'rule-1',
+        queryString: '  host:web  ',
+        tags: ['a', 'b'],
+        assigneeUid: 'u-1',
+      })
+    ).toEqual({
+      ruleId: 'rule-1',
+      queryString: 'host:web',
+      tags: ['a', 'b'],
+      assigneeUid: 'u-1',
+    });
+  });
+
+  it('drops empty strings and empty tag arrays', () => {
+    expect(
+      encodeEpisodesListRecord({ status: 'active', ruleId: '   ', queryString: '', tags: [] })
+    ).toEqual({});
+  });
+
+  it('omits the default time range but encodes a custom one', () => {
+    expect(
+      encodeEpisodesListRecord({ status: 'active', timeRange: DEFAULT_EPISODES_LIST_TIME_RANGE })
+    ).toEqual({});
+    expect(
+      encodeEpisodesListRecord({
+        status: 'active',
+        timeRange: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-02T00:00:00.000Z' },
+      })
+    ).toEqual({
+      timeFrom: '2026-01-01T00:00:00.000Z',
+      timeTo: '2026-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('encodes the histogram breakdown field', () => {
+    expect(
+      encodeEpisodesListRecord({ status: 'active', histogramBreakdownField: 'host.name' })
+    ).toEqual({ histBreakdown: 'host.name' });
+  });
+});
+
+describe('decodeEpisodesListRecord', () => {
+  it('returns an empty state for non-object input', () => {
+    expect(decodeEpisodesListRecord(undefined)).toEqual({});
+    expect(decodeEpisodesListRecord('nope')).toEqual({});
+  });
+
+  it('decodes the "all" sentinel to a present-but-undefined status', () => {
+    const decoded = decodeEpisodesListRecord({ status: EPISODES_LIST_STATUS_URL_ALL });
+    expect('status' in decoded).toBe(true);
+    expect(decoded.status).toBeUndefined();
+  });
+
+  it('decodes filter fields, time and histogram breakdown', () => {
+    expect(
+      decodeEpisodesListRecord({
+        status: 'pending',
+        ruleId: 'rule-1',
+        queryString: 'host:web',
+        tags: ['a'],
+        assigneeUid: 'u-1',
+        timeFrom: 'now-7d',
+        timeTo: 'now',
+        histBreakdown: 'host.name',
+      })
+    ).toEqual({
+      status: 'pending',
+      ruleId: 'rule-1',
+      queryString: 'host:web',
+      tags: ['a'],
+      assigneeUid: 'u-1',
+      timeRange: { from: 'now-7d', to: 'now' },
+      histogramBreakdownField: 'host.name',
+    });
+  });
+
+  it('ignores a partial time range', () => {
+    expect(decodeEpisodesListRecord({ timeFrom: 'now-7d' }).timeRange).toBeUndefined();
+  });
+});
+
+describe('encode/decode round-trip', () => {
+  it.each<EpisodesListUrlState>([
+    { status: 'pending', ruleId: 'rule-1' },
+    { status: undefined, tags: ['a', 'b'] },
+    {
+      status: 'recovering',
+      timeRange: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-02T00:00:00.000Z' },
+    },
+  ])('round-trips %j', (state) => {
+    expect(decodeEpisodesListRecord(encodeEpisodesListRecord(state))).toEqual(state);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_url_state.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/locators/episodes_list_url_state.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isArray, isNil, isPlainObject, isString } from 'lodash';
+
+/** Namespace for episodes list state inside the `_a` app-state blob */
+export const EPISODES_LIST_APP_STATE_KEY = 'episodesList' as const;
+
+/** Serialized in `_a` so “all statuses” survives reload (distinct from default Active) */
+export const EPISODES_LIST_STATUS_URL_ALL = 'all' as const;
+
+/** Default status; encoded entries equal to this are omitted from the URL. */
+export const DEFAULT_EPISODES_LIST_STATUS = 'active' as const;
+
+/** Default time range; encoded ranges equal to this are omitted from the URL. */
+export const DEFAULT_EPISODES_LIST_TIME_RANGE = {
+  from: 'now-24h',
+  to: 'now',
+} as const;
+
+/**
+ * Flat representation of the episodes-list state carried in
+ * `_a.episodesList`. Framework-free so it can be shared between the URL-storage
+ * codec (browser) and the locator (`getLocation`).
+ */
+export interface EpisodesListUrlState {
+  status?: string | null;
+  ruleId?: string | null;
+  queryString?: string | null;
+  tags?: string[] | null;
+  assigneeUid?: string;
+  timeRange?: { from: string; to: string };
+  histogramBreakdownField?: string;
+}
+
+const isNonEmptyString = (v: unknown): v is string => isString(v) && v.trim().length > 0;
+
+const isStringArray = (v: unknown): v is string[] =>
+  isArray(v) && v.length > 0 && v.every(isString);
+
+/**
+ * Decodes the raw `_a.episodesList` record into a flat state object.
+ *
+ * A present-but-`undefined` `status` means “all statuses” (the URL carried the
+ * {@link EPISODES_LIST_STATUS_URL_ALL} sentinel); an absent `status` key means
+ * the caller wants the default and is left for the reader to fill in.
+ */
+export function decodeEpisodesListRecord(raw: unknown): EpisodesListUrlState {
+  if (!isPlainObject(raw)) {
+    return {};
+  }
+  const o = raw as Record<string, unknown>;
+  const result: EpisodesListUrlState = {};
+
+  if (o.status === EPISODES_LIST_STATUS_URL_ALL) {
+    result.status = undefined;
+  } else if (isNonEmptyString(o.status)) {
+    result.status = o.status;
+  }
+  if (isNonEmptyString(o.ruleId)) {
+    result.ruleId = o.ruleId;
+  }
+  if (isNonEmptyString(o.queryString)) {
+    result.queryString = o.queryString.trim();
+  }
+  if (isStringArray(o.tags)) {
+    result.tags = [...o.tags];
+  }
+  if (isNonEmptyString(o.assigneeUid)) {
+    result.assigneeUid = o.assigneeUid;
+  }
+  if (isNonEmptyString(o.timeFrom) && isNonEmptyString(o.timeTo)) {
+    result.timeRange = { from: o.timeFrom, to: o.timeTo };
+  }
+  if (isNonEmptyString(o.histBreakdown)) {
+    result.histogramBreakdownField = o.histBreakdown;
+  }
+  return result;
+}
+
+/**
+ * Encodes a flat state object into the `_a.episodesList` record. Default-valued
+ * fields (status `active`, the default time range) are omitted so a pristine
+ * list produces an empty record. The returned object is the inner record only —
+ * callers wrap it under {@link EPISODES_LIST_APP_STATE_KEY}.
+ */
+export function encodeEpisodesListRecord(state: EpisodesListUrlState): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  const { status } = state;
+  if (isNil(status)) {
+    result.status = EPISODES_LIST_STATUS_URL_ALL;
+  } else if (isNonEmptyString(status) && status !== DEFAULT_EPISODES_LIST_STATUS) {
+    result.status = status;
+  }
+  if (isNonEmptyString(state.ruleId)) {
+    result.ruleId = state.ruleId;
+  }
+  if (isNonEmptyString(state.queryString)) {
+    result.queryString = state.queryString.trim();
+  }
+  if (isStringArray(state.tags)) {
+    result.tags = [...state.tags];
+  }
+  if (isNonEmptyString(state.assigneeUid)) {
+    result.assigneeUid = state.assigneeUid;
+  }
+  const { timeRange } = state;
+  if (
+    timeRange &&
+    (timeRange.from !== DEFAULT_EPISODES_LIST_TIME_RANGE.from ||
+      timeRange.to !== DEFAULT_EPISODES_LIST_TIME_RANGE.to)
+  ) {
+    result.timeFrom = timeRange.from;
+    result.timeTo = timeRange.to;
+  }
+  if (isNonEmptyString(state.histogramBreakdownField)) {
+    result.histBreakdown = state.histogramBreakdownField;
+  }
+  return result;
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/common/locators/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/locators/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EPISODES_LIST_LOCATOR_ID, EpisodesListLocatorDefinition } from './episodes_list_locator';
+export type { EpisodesListLocator, EpisodesListLocatorParams } from './episodes_list_locator';

--- a/x-pack/platform/plugins/shared/alerting_v2/moon.yml
+++ b/x-pack/platform/plugins/shared/alerting_v2/moon.yml
@@ -116,6 +116,7 @@ dependsOn:
   - '@kbn/workflows-ui'
   - '@kbn/datemath'
   - '@kbn/triggers-actions-ui-plugin'
+  - '@kbn/rison'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -17,6 +17,7 @@ import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+import type { SharePluginSetup } from '@kbn/share-plugin/public';
 import { WorkflowApi } from '@kbn/workflows-ui';
 import {
   ALERTING_V2_SECTION_ID,
@@ -25,6 +26,7 @@ import {
   ALERTING_V2_EPISODES_APP_ID,
   ALERTING_V2_EXECUTION_HISTORY_APP_ID,
 } from './constants';
+import { EpisodesListLocatorDefinition } from '../common/locators';
 import { ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID } from '../common/advanced_settings';
 import { ActionPoliciesApi } from './services/action_policies_api';
 import { ExecutionHistoryApi } from './services/execution_history_api';
@@ -54,6 +56,9 @@ export const module = new ContainerModule(({ bind }) => {
     ) as WorkflowsExtensionsPublicPluginSetup;
 
     registerTriggerDefinitions(workflowsExtensionsSetup);
+
+    const share = container.get(PluginSetup('share')) as SharePluginSetup;
+    share.url.locators.create(new EpisodesListLocatorDefinition());
 
     getStartServices().then(([coreStart]) => {
       const diContainer = coreStart.injection.getContainer();

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts
@@ -8,116 +8,27 @@
 import type { EpisodesFilterState } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
 import type { TimeRange } from '@kbn/es-query';
 import type { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
-import { isArray, isNil, isPlainObject, isString } from 'lodash';
+import {
+  DEFAULT_EPISODES_LIST_STATUS,
+  EPISODES_LIST_APP_STATE_KEY,
+  decodeEpisodesListRecord,
+  encodeEpisodesListRecord,
+} from '../../../../common/locators/episodes_list_url_state';
 
-/** Namespace for episodes list state inside the `_a` app-state blob */
-export const EPISODES_LIST_APP_STATE_KEY = 'episodesList' as const;
-
-/** Serialized in `_a` so “all statuses” survives reload (distinct from default Active) */
-export const EPISODES_LIST_STATUS_URL_ALL = 'all' as const;
+export {
+  EPISODES_LIST_APP_STATE_KEY,
+  EPISODES_LIST_STATUS_URL_ALL,
+  DEFAULT_EPISODES_LIST_TIME_RANGE,
+} from '../../../../common/locators/episodes_list_url_state';
 
 /** Default list filters (Active episodes, no rule/tags/search/assignee). */
-export const DEFAULT_EPISODES_LIST_FILTER: EpisodesFilterState = { status: 'active' };
-
-/** Matches {@link useEpisodesTimeRange} fallback when timefilter has no prior state */
-export const DEFAULT_EPISODES_LIST_TIME_RANGE: TimeRange = {
-  from: 'now-24h',
-  to: 'now',
+export const DEFAULT_EPISODES_LIST_FILTER: EpisodesFilterState = {
+  status: DEFAULT_EPISODES_LIST_STATUS,
 };
 
 type AppStateRecord = Record<string, unknown> & {
   [EPISODES_LIST_APP_STATE_KEY]?: unknown;
 };
-
-const isNonEmptyString = (v: unknown): v is string => isString(v) && v.trim().length > 0;
-
-const isStringArray = (v: unknown): v is string[] =>
-  isArray(v) && v.length > 0 && v.every(isString);
-
-function decodeFilterFields(o: Record<string, unknown>): EpisodesFilterState {
-  const result: EpisodesFilterState = {};
-  if (o.status === EPISODES_LIST_STATUS_URL_ALL) {
-    result.status = undefined;
-  } else if (isNonEmptyString(o.status)) {
-    result.status = o.status;
-  }
-  if (isNonEmptyString(o.ruleId)) {
-    result.ruleId = o.ruleId;
-  }
-  if (isNonEmptyString(o.queryString)) {
-    result.queryString = o.queryString.trim();
-  }
-  if (isStringArray(o.tags)) {
-    result.tags = [...o.tags];
-  }
-  if (isNonEmptyString(o.assigneeUid)) {
-    result.assigneeUid = o.assigneeUid;
-  }
-  return result;
-}
-
-function splitEpisodesListRaw(raw: unknown): {
-  filter: EpisodesFilterState;
-  timeRange?: TimeRange;
-  histogramBreakdownField?: string;
-} {
-  if (!isPlainObject(raw)) {
-    return { filter: {} };
-  }
-  const o = raw as Record<string, unknown>;
-  const { timeFrom, timeTo, histBreakdown, ...rest } = o;
-  const filter = decodeFilterFields(rest);
-  const result: ReturnType<typeof splitEpisodesListRaw> = { filter };
-  if (isNonEmptyString(timeFrom) && isNonEmptyString(timeTo)) {
-    result.timeRange = { from: timeFrom, to: timeTo };
-  }
-  if (isNonEmptyString(histBreakdown)) {
-    result.histogramBreakdownField = histBreakdown;
-  }
-  return result;
-}
-
-function encodeFilterFields(state: EpisodesFilterState): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  const st = state.status;
-  if (isNil(st)) {
-    result.status = EPISODES_LIST_STATUS_URL_ALL;
-  } else if (isNonEmptyString(st) && st !== DEFAULT_EPISODES_LIST_FILTER.status) {
-    result.status = st;
-  }
-  if (isNonEmptyString(state.ruleId)) {
-    result.ruleId = state.ruleId;
-  }
-  if (isNonEmptyString(state.queryString)) {
-    result.queryString = state.queryString.trim();
-  }
-  if (isStringArray(state.tags)) {
-    result.tags = [...state.tags];
-  }
-  if (isNonEmptyString(state.assigneeUid)) {
-    result.assigneeUid = state.assigneeUid;
-  }
-  return result;
-}
-
-function encodeEpisodesListRecord(
-  filter: EpisodesFilterState,
-  timeRange: TimeRange,
-  histogramBreakdownField?: string
-): Record<string, unknown> {
-  const out = encodeFilterFields(filter);
-  if (
-    timeRange.from !== DEFAULT_EPISODES_LIST_TIME_RANGE.from ||
-    timeRange.to !== DEFAULT_EPISODES_LIST_TIME_RANGE.to
-  ) {
-    out.timeFrom = timeRange.from;
-    out.timeTo = timeRange.to;
-  }
-  if (isNonEmptyString(histogramBreakdownField)) {
-    out.histBreakdown = histogramBreakdownField;
-  }
-  return out;
-}
 
 export function readEpisodesListAppStateFromUrlStorage(storage: IKbnUrlStateStorage): {
   filterState: EpisodesFilterState;
@@ -125,7 +36,7 @@ export function readEpisodesListAppStateFromUrlStorage(storage: IKbnUrlStateStor
   histogramBreakdownField?: string;
 } {
   const raw = storage.get<AppStateRecord>('_a')?.[EPISODES_LIST_APP_STATE_KEY];
-  const { filter, timeRange, histogramBreakdownField } = splitEpisodesListRaw(raw);
+  const { timeRange, histogramBreakdownField, ...filter } = decodeEpisodesListRecord(raw);
   return {
     filterState: { ...DEFAULT_EPISODES_LIST_FILTER, ...filter },
     ...(timeRange ? { timeRange } : {}),
@@ -139,7 +50,7 @@ export async function writeEpisodesListAppStateToUrlStorage(
   timeRange: TimeRange,
   histogramBreakdownField?: string
 ): Promise<void> {
-  const serialized = encodeEpisodesListRecord(filter, timeRange, histogramBreakdownField);
+  const serialized = encodeEpisodesListRecord({ ...filter, timeRange, histogramBreakdownField });
   const appState = storage.get<AppStateRecord>('_a') ?? {};
   const {
     [EPISODES_LIST_APP_STATE_KEY]: _ignoredEpisodesListState,

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -112,7 +112,8 @@
     "@kbn/workflows-yaml",
     "@kbn/workflows-ui",
     "@kbn/datemath",
-    "@kbn/triggers-actions-ui-plugin"
+    "@kbn/triggers-actions-ui-plugin",
+    "@kbn/rison"
   ],
   "exclude": ["target/**/*", ".storybook/**/*.js"]
 }


### PR DESCRIPTION
## Summary

Adds an `EpisodesListLocatorDefinition` (registered with the `share` plugin) so other surfaces can deep-link into the alerting v2 episodes list by passing typed params, instead of hand-building URLs.

The schema for the `_a.episodesList` URL blob is now owned by a single framework-free codec in `common/locators/episodes_list_url_state.ts`. Both the new locator's `getLocation` and the episodes list page's own URL-state hook delegate to it, so the **link builder and the list reader agree by construction** — no more hand-synced encode/decode in two places.

### What's included
- `common/locators/episodes_list_url_state.ts` — canonical encode/decode + constants for `_a.episodesList`.
- `common/locators/episodes_list_locator.ts` — `EpisodesListLocatorDefinition`, `EPISODES_LIST_LOCATOR_ID`, flat `EpisodesListLocatorParams` (`ruleId`, `status`, `queryString`, `tags`, `assigneeUid`, `timeRange`).
- `public/index.ts` — registers the locator via `share.url.locators.create(...)`.
- `public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts` — refactored to delegate to the common codec (public API unchanged).

### Notes
- **Status semantics:** an unspecified `status` resolves to the list default (active) and is omitted from the URL; pass `'all'` explicitly for every status. (Page filter state treats an absent status as "all", so the locator translates — documented inline.)
- Scoped to fields the episodes list reader supports today; grouping-based filters are intentionally out of scope.

## Test plan
- [x] Unit tests for the common codec (encode/decode round-trips, default omission, `all` sentinel)
- [x] Unit tests for the locator (app/path, status handling, URL round-trip via the shared decoder)
- [x] Existing episodes list URL-state codec + hook tests still pass
- [x] Plugin typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)