### PR TITLE
Deprecate `elastic.apm` settings

### DIFF
--- a/src/core/packages/root/server-internal/src/root/elastic_config.ts
+++ b/src/core/packages/root/server-internal/src/root/elastic_config.ts
@@ -21,4 +21,19 @@ export type ElasticConfigType = TypeOf<typeof elasticConfig>;
 export const elasticApmConfig: ServiceConfigDescriptor<ElasticConfigType> = {
   path: 'elastic',
   schema: elasticConfig,
+  deprecations: ({ deprecate }) => [
+    deprecate('apm', '10.0.0', {
+      level: 'critical',
+      message:
+        'Elastic APM is deprecated in favor of OpenTelemetry instrumentation and will be removed in 10.0.0. Please migrate to OpenTelemetry.',
+      documentationUrl:
+        'https://www.elastic.co/docs/extend/kibana/kibana-debugging#_instrumenting_with_otel_traces',
+      correctiveActions: {
+        manualSteps: [
+          'Remove the `elastic.apm` configuration.',
+          'Use `telemetry.tracing` and `telemetry.metrics` to configure OpenTelemetry tracing and metrics.',
+        ],
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary

As we're migrating to OpenTelemetry, we decided to deprecate the `elastic.apm` settings.

We're aware that RUM still relies on Elastic APM, but we aim to complete the migration to OpenTelemetry as soon as OTel RUM is marked as production-ready (expected sometime in FY27).


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [x] OTel RUM might be delayed: in that case, we'll extend the deprecation period.

## Release note

Elastic APM instrumentation is deprecated and will be removed in future versions. Use the OpenTelemetry instrumentation when collecting traces and metrics from Kibana. Refer to [these docs](https://www.elastic.co/docs/extend/kibana/kibana-debugging#_instrumenting_with_otel_traces) for more information about how to configure it.
