### PR TITLE
[SavedObjects] Fix retrieving mappings with empty-object fields for SO check

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/snapshots/extract_mappings_from_snapshot.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/extract_mappings_from_snapshot.test.ts
@@ -80,6 +80,16 @@ const roundTripMappingFixtures: Array<{
       },
     },
   },
+  {
+    name: 'nested empty-object field',
+    mappings: {
+      dynamic: false,
+      properties: {
+        title: { type: 'text' },
+        meta: { dynamic: false, properties: {} },
+      },
+    },
+  },
 ];
 
 const flattenSnapshotMappings = (
@@ -128,6 +138,19 @@ describe('unflattenSnapshotMappings', () => {
     expect(unflattenSnapshotMappings(flattened)).toEqual({
       dynamic: false,
       properties: {},
+    });
+  });
+
+  it('restores empty properties of nested object fields omitted by flattening', () => {
+    const flattened = getFlattenedObject({
+      dynamic: false,
+      properties: { meta: { dynamic: false, properties: {} } },
+    });
+
+    expect(flattened).toEqual({ dynamic: false, 'properties.meta.dynamic': false });
+    expect(unflattenSnapshotMappings(flattened)).toEqual({
+      dynamic: false,
+      properties: { meta: { dynamic: false, properties: {} } },
     });
   });
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/extract_mappings_from_snapshot.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/extract_mappings_from_snapshot.ts
@@ -9,28 +9,41 @@
 
 import type { SavedObjectsTypeMappingDefinitions } from '@kbn/core-saved-objects-base-server-internal';
 import { unflattenObject } from '@kbn/object-utils';
+import { isPlainObject } from 'lodash';
 import type { MigrationSnapshot } from '../types';
 
 const isFlattenedMapping = (mappings: Record<string, unknown>): boolean =>
   Object.keys(mappings).some((key) => key.includes('.'));
 
-const normalizeRootMappingProperties = (
-  mappings: SavedObjectsTypeMappingDefinitions[string]
-): SavedObjectsTypeMappingDefinitions[string] => {
-  if (!Object.hasOwn(mappings, 'properties')) {
-    return { ...mappings, properties: {} };
+const normalizeMappingProperties = (node: Record<string, unknown>): Record<string, unknown> => {
+  if (!Object.hasOwn(node, 'type') && !Object.hasOwn(node, 'properties')) {
+    return { ...node, properties: {} };
   }
-  return mappings;
+
+  if (isPlainObject(node.properties)) {
+    const properties = node.properties as Record<string, Record<string, unknown>>;
+    return {
+      ...node,
+      properties: Object.fromEntries(
+        Object.entries(properties).map(([field, child]) => [
+          field,
+          normalizeMappingProperties(child),
+        ])
+      ),
+    };
+  }
+
+  return node;
 };
 
 export const unflattenSnapshotMappings = (
   mappings: Record<string, unknown>
 ): SavedObjectsTypeMappingDefinitions[string] => {
-  const nestedMappings = isFlattenedMapping(mappings)
-    ? (unflattenObject(mappings) as unknown as SavedObjectsTypeMappingDefinitions[string])
-    : (mappings as unknown as SavedObjectsTypeMappingDefinitions[string]);
+  const nestedMappings = isFlattenedMapping(mappings) ? unflattenObject(mappings) : mappings;
 
-  return normalizeRootMappingProperties(nestedMappings);
+  return normalizeMappingProperties(
+    nestedMappings
+  ) as unknown as SavedObjectsTypeMappingDefinitions[string];
 };
 
 export const extractMappingsFromSnapshot = (


### PR DESCRIPTION
## Summary

Closes #272398

`node scripts/check_saved_objects --baseline <rev>` was failing in the **Automated rollback tests** step for any saved-object type whose mappings include an empty-object field (`{ dynamic: false, properties: {} }`).

### Root cause

Snapshots store each type's mappings in flattened (dot-path) form via `getFlattenedObject`, which emits nothing for an empty `{}`. So `{ dynamic: false, properties: {} }` flattens to just `{ dynamic: false }` — the empty `properties` is dropped at **any** nesting level. When `unflattenSnapshotMappings` rebuilt the nested mappings, it only restored the omitted `properties: {}` at the **root** of a type's mappings, leaving nested object fields malformed (`{ dynamic: false }` with no `properties`). Those mappings then broke the migrator during the rollback test.

### Change

Make the normalization in `extract_mappings_from_snapshot.ts` recursive so omitted empty `properties` are restored at every nesting level. It relies on the SO-mapping invariant that a leaf field always carries a `type` while an object/type-level node never does, so a node with neither `type` nor `properties` is an object field whose empty `properties` was dropped. This subsumes the previous root-only behavior.

### Testing

- Added a `nested empty-object field` round-trip fixture (the actual regression — previously only an empty *root* was covered) plus a focused unit test for restoring nested empty properties.
- `node scripts/jest packages/kbn-check-saved-objects-cli/src/snapshots/extract_mappings_from_snapshot.test.ts` — 18/18 pass.
- Type check and ESLint clean for the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)