### PR TITLE
[@kbn/scout-reporting] Index browser console errors in scout-test-events data stream

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FullConfig, Suite, TestCase, TestResult } from '@playwright/test/reporter';
+import { BROWSER_CONSOLE_ERRORS_ATTACHMENT } from '@kbn/scout-info';
+import { ScoutReportEventAction } from '../../report';
+import { ScoutPlaywrightReporter } from './playwright_reporter';
+
+jest.mock('@kbn/code-owners', () => ({
+  getCodeOwnersEntries: jest.fn(() => []),
+  getOwningTeamsForPath: jest.fn(() => []),
+  findAreaForCodeOwner: jest.fn(() => undefined),
+}));
+
+const createMockConfig = (): FullConfig =>
+  ({ configFile: undefined, fullyParallel: false } as unknown as FullConfig);
+
+const createMockSuite = (): Suite => ({} as Suite);
+
+const createMockTest = (): TestCase =>
+  ({
+    titlePath: () => ['', 'local', 'path/to/file.spec.ts', 'My Suite', 'should work'],
+    title: 'should work',
+    tags: [],
+    annotations: [],
+    expectedStatus: 'passed',
+    location: { file: '/repo-root/path/to/file.spec.ts', line: 42, column: 0 },
+    parent: {
+      title: 'My Suite',
+      type: 'describe',
+      titlePath: () => ['', 'local', 'path/to/file.spec.ts', 'My Suite'],
+    },
+  } as unknown as TestCase);
+
+const createMockResult = (
+  overrides: { attachments?: TestResult['attachments'] } = {}
+): TestResult =>
+  ({
+    status: 'failed',
+    startTime: new Date(),
+    duration: 1000,
+    attachments: overrides.attachments ?? [],
+    error: undefined,
+    stdout: [],
+    stderr: [],
+  } as unknown as TestResult);
+
+describe('ScoutPlaywrightReporter', () => {
+  let reporter: ScoutPlaywrightReporter;
+  let logEventSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    reporter = new ScoutPlaywrightReporter({ runId: 'test-run-id' });
+    logEventSpy = jest.spyOn((reporter as any).report, 'logEvent').mockImplementation(() => {});
+    reporter.onBegin(createMockConfig(), createMockSuite());
+  });
+
+  const getTestEndEvent = () =>
+    logEventSpy.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.event?.action === ScoutReportEventAction.TEST_END);
+
+  describe('onTestEnd', () => {
+    it('sets console_errors on the test-end event when the attachment is present', () => {
+      const consoleErrorText = 'Error: React state update on unmounted component';
+
+      reporter.onTestEnd(
+        createMockTest(),
+        createMockResult({
+          attachments: [
+            {
+              name: BROWSER_CONSOLE_ERRORS_ATTACHMENT,
+              body: Buffer.from(consoleErrorText),
+              contentType: 'text/plain',
+            },
+          ],
+        })
+      );
+
+      expect(getTestEndEvent()?.test?.console_errors).toBe(consoleErrorText);
+    });
+
+    it('omits console_errors from the test-end event when no attachment is present', () => {
+      reporter.onTestEnd(createMockTest(), createMockResult());
+
+      expect(getTestEndEvent()?.test?.console_errors).toBeUndefined();
+    });
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -159,11 +159,11 @@ export class ScoutPlaywrightReporter implements Reporter {
     if (result) {
       testProps.status = result.status;
       testProps.duration = result.duration;
-      const consoleErrorsAttachment = result.attachments.find(
-        (a) => a.name === BROWSER_CONSOLE_ERRORS_ATTACHMENT
-      );
-      if (consoleErrorsAttachment) {
-        testProps.console_errors = consoleErrorsAttachment.body?.toString('utf-8');
+      const consoleErrors = result.attachments
+        .find((a) => a.name === BROWSER_CONSOLE_ERRORS_ATTACHMENT)
+        ?.body?.toString('utf-8');
+      if (consoleErrors) {
+        testProps.console_errors = consoleErrors;
       }
     }
 

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -21,6 +21,7 @@ import type {
 import path from 'node:path';
 import { ToolingLog } from '@kbn/tooling-log';
 import {
+  BROWSER_CONSOLE_ERRORS_ATTACHMENT,
   SCOUT_REPORT_OUTPUT_ROOT,
   ScoutTestRunConfigCategory,
   ScoutTestTarget,
@@ -158,6 +159,12 @@ export class ScoutPlaywrightReporter implements Reporter {
     if (result) {
       testProps.status = result.status;
       testProps.duration = result.duration;
+      const consoleErrorsAttachment = result.attachments.find(
+        (a) => a.name === BROWSER_CONSOLE_ERRORS_ATTACHMENT
+      );
+      if (consoleErrorsAttachment) {
+        testProps.console_errors = consoleErrorsAttachment.body?.toString('utf-8');
+      }
     }
 
     return testProps;

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
@@ -101,6 +101,7 @@ export interface ScoutTestInfo {
   expected_status?: string;
   duration?: number;
   status?: string;
+  console_errors?: string;
   step?: {
     title: string;
     category?: string;

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
@@ -78,7 +78,7 @@ export const suiteMappings: ClusterPutComponentTemplateRequest = {
 
 export const testMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.test',
-  version: 2,
+  version: 3,
   template: {
     mappings: {
       properties: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -221,6 +221,9 @@ export const testProperties: Record<PropertyName, MappingProperty> = {
   status: {
     type: 'keyword',
   },
+  console_errors: {
+    type: 'match_only_text',
+  },
   step: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

Browser console errors are already captured per test and surfaced in HTML failure reports (via `BROWSER_CONSOLE_ERRORS_ATTACHMENT`). This PR indexes them into the `scout-test-events` data stream so they're queryable across failures.

## Changes

- **`ScoutTestInfo`**: Added `console_errors?: string` field to the event schema
- **`testProperties` mappings**: Added `console_errors` as `match_only_text` (suited for free-text search without scoring overhead)
- **`testMappings` component template**: Bumped version `2 → 3` to trigger a cluster-side update
- **`ScoutPlaywrightReporter`**: On `test-end` events, reads the `BROWSER_CONSOLE_ERRORS_ATTACHMENT` from `result.attachments` and sets `test.console_errors` — mirroring what `ScoutFailedTestReporter` already does for the HTML report

## Testing

Added unit tests for `ScoutPlaywrightReporter.onTestEnd` verifying:
- `console_errors` is set on the `test-end` event when the attachment is present
- `console_errors` is absent when no attachment exists

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->