### PR TITLE
[Security Solution] Fix flaky bulk-add-alerts-to-chat Scout tests

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -25,7 +25,7 @@ plugins:
     - discover_enhanced
     - entity_store
     - error_boundary_example
-    - eventAnnotationListing
+    - event_annotation_listing
     - exploratory_view
     - fleet
     - flyoutSystemExamples

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/worker/apis/detection_alerts.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/worker/apis/detection_alerts.ts
@@ -9,9 +9,15 @@ import type { EsClient, ScoutLogger, ScoutParallelWorkerFixtures } from '@kbn/sc
 import { measurePerformanceAsync } from '@kbn/scout';
 
 const DEFAULT_ALERTS_INDEX_PATTERN = '.alerts-security.alerts-';
+const WAIT_FOR_ALERTS_POLL_INTERVAL_MS = 1_000;
 
 export interface DetectionAlertsApiService {
   deleteAll: () => Promise<void>;
+  /**
+   * Polls until at least `minCount` alerts matching `ruleName` exist, or
+   * the `timeout` is exhausted.  Resolves with the matched count; rejects on timeout.
+   */
+  waitForAlerts: (ruleName: string, minCount?: number, timeout?: number) => Promise<number>;
 }
 
 export const getDetectionAlertsApiService = ({
@@ -39,6 +45,35 @@ export const getDetectionAlertsApiService = ({
           scroll_size: 10000,
           refresh: true,
         });
+      });
+    },
+
+    waitForAlerts: async (ruleName: string, minCount = 1, timeout = 120_000) => {
+      return measurePerformanceAsync(log, 'security.detectionAlerts.waitForAlerts', async () => {
+        const deadline = Date.now() + timeout;
+        const index = `${DEFAULT_ALERTS_INDEX_PATTERN}${space}`;
+
+        while (Date.now() < deadline) {
+          try {
+            await esClient.indices.refresh({ index });
+            const result = await esClient.count({
+              index,
+              query: {
+                term: { 'kibana.alert.rule.name': ruleName },
+              },
+            });
+            if (result.count >= minCount) {
+              return result.count;
+            }
+          } catch {
+            // index not yet created — keep polling
+          }
+          await new Promise((resolve) => setTimeout(resolve, WAIT_FOR_ALERTS_POLL_INTERVAL_MS));
+        }
+
+        throw new Error(
+          `waitForAlerts timed out after ${timeout}ms: expected >=${minCount} alert(s) for rule "${ruleName}" in space "${space}"`
+        );
       });
     },
   };

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/worker/apis/detection_alerts.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/worker/apis/detection_alerts.ts
@@ -13,10 +13,7 @@ const WAIT_FOR_ALERTS_POLL_INTERVAL_MS = 1_000;
 
 export interface DetectionAlertsApiService {
   deleteAll: () => Promise<void>;
-  /**
-   * Polls until at least `minCount` alerts matching `ruleName` exist, or
-   * the `timeout` is exhausted.  Resolves with the matched count; rejects on timeout.
-   */
+  /** Polls until ≥ minCount alerts for ruleName exist; rejects on timeout (default 30s). */
   waitForAlerts: (ruleName: string, minCount?: number, timeout?: number) => Promise<number>;
 }
 
@@ -48,7 +45,7 @@ export const getDetectionAlertsApiService = ({
       });
     },
 
-    waitForAlerts: async (ruleName: string, minCount = 1, timeout = 120_000) => {
+    waitForAlerts: async (ruleName: string, minCount = 1, timeout = 30_000) => {
       return measurePerformanceAsync(log, 'security.detectionAlerts.waitForAlerts', async () => {
         const deadline = Date.now() + timeout;
         const index = `${DEFAULT_ALERTS_INDEX_PATTERN}${space}`;

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/common/roles.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/common/roles.ts
@@ -33,7 +33,10 @@ export const FULL_KIBANA_SECURITY_ROLE: KibanaRole = {
           '.lists*',
           '.items*',
         ],
-        privileges: ['read', 'write'],
+        // The Security alerts page checks for all four of these privileges and shows
+        // an "Insufficient privileges" callout if any are missing, preventing the
+        // alerts table from rendering.
+        privileges: ['read', 'write', 'view_index_metadata', 'manage'],
       },
     ],
   },

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/bulk_add_alerts_to_chat.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/bulk_add_alerts_to_chat.spec.ts
@@ -21,7 +21,9 @@ spaceTest.describe(
     // One rule name per created rule; the first is used as the anchor to wait for page readiness.
     const ruleNames: string[] = [];
 
-    spaceTest.beforeEach(async ({ browserAuth, apiServices, scoutSpace }) => {
+    spaceTest.beforeEach(async ({ browserAuth, apiServices, scoutSpace }, testInfo) => {
+      // Rule execution can take up to ~90s under load; extend beyond Playwright's 60s default.
+      testInfo.setTimeout(testInfo.timeout + 90_000);
       // Defensive cleanup from any prior failed run.
       // Note: cleanStandardList() is intentionally omitted here — it deletes saved objects
       // of type 'action', which would destroy the .gen-ai connector created by the
@@ -43,7 +45,9 @@ spaceTest.describe(
       // Wait for the task manager to execute each rule and produce at least one alert before
       // opening the browser. Without this, waitForRuleAlert races against the task manager's
       // first-run scheduling (which can take up to ~90s under load) and times out.
-      await Promise.all(ruleNames.map((name) => apiServices.detectionAlerts.waitForAlerts(name)));
+      await Promise.all(
+        ruleNames.map((name) => apiServices.detectionAlerts.waitForAlerts(name, 1, 60_000))
+      );
 
       await browserAuth.loginWithCustomRole(FULL_KIBANA_SECURITY_ROLE);
     });

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/bulk_add_alerts_to_chat.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/bulk_add_alerts_to_chat.spec.ts
@@ -39,6 +39,12 @@ spaceTest.describe(
           rule_id: `scout-bulk-chat-${scoutSpace.id}-${i}`,
         });
       }
+
+      // Wait for the task manager to execute each rule and produce at least one alert before
+      // opening the browser. Without this, waitForRuleAlert races against the task manager's
+      // first-run scheduling (which can take up to ~90s under load) and times out.
+      await Promise.all(ruleNames.map((name) => apiServices.detectionAlerts.waitForAlerts(name)));
+
       await browserAuth.loginWithCustomRole(FULL_KIBANA_SECURITY_ROLE);
     });
 


### PR DESCRIPTION
## Summary

### What
Fixes two intermittently failing Scout UI tests in `bulk_add_alerts_to_chat.spec.ts` by adding missing index privileges to the test role, pre-warming alert documents before opening the browser, extending the `beforeEach` timeout, and fixing a plugin name casing typo in the CI config.

### Why
Issue #272445 identified two root causes for the flakiness:

1. The `FULL_KIBANA_SECURITY_ROLE` test role was missing `view_index_metadata` and `manage` index privileges. The Security alerts page checks for all four index privileges and shows an "Insufficient privileges" callout — preventing the alerts table from rendering — if any are absent.
2. Tests were opening the browser before the task manager had a chance to execute the detection rules and produce alert documents. Task manager's first-run scheduling can take up to ~90s under load, causing `waitForRuleAlert` to race and time out.

Fixes #272445

### Changes

- `test/scout/ui/common/roles.ts`: Add `view_index_metadata` and `manage` to `FULL_KIBANA_SECURITY_ROLE` index privileges so the Security alerts page renders correctly
- `test/scout/ui/fixtures/worker/apis/detection_alerts.ts`: Add `waitForAlerts` API helper that polls until the expected number of alert documents exist
- `test/scout/ui/parallel_tests/investigations/bulk_add_alerts_to_chat.spec.ts`: Call `waitForAlerts` in `beforeEach` to ensure alerts exist before opening the browser; extend timeout by 90s to accommodate task manager latency
- `.buildkite/scout_ci_config.yml`: Fix plugin name casing (`eventAnnotationListing` → `event_annotation_listing`)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

All changes are test-only and do not affect production code.

- **Adding index privileges to the test role** (low): The role is only used in Scout test setup. Adding `view_index_metadata` and `manage` brings it closer to a realistic security analyst role; it does not mask any production permission boundary.
- **Pre-warming alerts in `beforeEach`** (low): Adds up to 60s of polling before each test, which slightly increases total suite duration under load but eliminates the race condition that caused flakiness. Timeout budget is explicitly extended to accommodate this.

No significant risks to production behaviour.

### Release note

> No user-facing changes — fixes intermittently failing Scout UI tests for the bulk-add-alerts-to-chat feature.

**Suggested label:** `release_note:skip`