### PR TITLE
[Scout] Fix event_annotation_listing entry in scout_ci_config.yml

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -25,7 +25,7 @@ plugins:
     - discover_enhanced
     - entity_store
     - error_boundary_example
-    - eventAnnotationListing
+    - event_annotation_listing
     - exploratory_view
     - fleet
     - flyoutSystemExamples


### PR DESCRIPTION
## Summary

Fixes the `check_scout_config` CI step that was failing on #272424.

The Scout config discovery script derives module names from directory paths (snake_case), so the CI config entry must use `event_annotation_listing` to match the directory `src/platform/plugins/private/event_annotation_listing/`. The previous `eventAnnotationListing` (camelCase plugin ID) caused the validation to report the plugin as unregistered.

## Testing

Validated locally:
```
node scripts/scout discover-playwright-configs --validate
```
Output: no errors, 83 modules discovered.