### PR TITLE
[CSP][Graph] Fix flaky CSP graph ESQL tests (CASE guard for origin predicates, supersedes #269060)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.ts
@@ -433,14 +433,14 @@ ${buildPinnedEsql(pinnedIds)}
 // Origin event and alerts allow us to identify the start position of graph traversal
 | EVAL isOrigin = ${
     originEventIds.length > 0
-      ? `COALESCE(event.id in (${originEventIds
+      ? `CASE (event.id IS NOT NULL AND event.id != "", event.id in (${originEventIds
           .map((_id, idx) => `?og_id${idx}`)
           .join(', ')}), false)`
       : 'false'
   }
 | EVAL isOriginAlert = ${
     originAlertIds.length > 0
-      ? `COALESCE(isOrigin AND event.id in (${originAlertIds
+      ? `CASE (event.id IS NOT NULL AND event.id != "", isOrigin AND event.id in (${originAlertIds
           .map((_id, idx) => `?og_alrt_id${idx}`)
           .join(', ')}), false)`
       : 'false'


### PR DESCRIPTION
## Summary

Replaces #269060 

Stabilizes the 6-issue Graph API flaky-test cluster in `x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts`:

- #267867 — pin event by doc id
- #267901 — Pinning: ignore non-existent pinnedIds
- #268111 — pinned actors from grouped nodes
- #268237 — events with null event.id
- #268321 — Pinning: empty pinnedIds same as missing
- #268890 — v2 index without lookup mode

### What changed

In `fetch_events_graph.ts`, the `isOrigin`/`isOriginAlert` ESQL evaluations replace `COALESCE(event.id IN (...), false)` with `CASE(event.id IS NOT NULL AND event.id != "", event.id IN (...), false)`. This guards against rows where `event.id` is `null` or `""` reaching the `IN` operator and tripping the ES|QL optimizer's nullable-propagation rules.

### Context

**1. Upstream ES PropagateNullable bug.** Confirmed:

- ES issue [#141579](https://github.com/elastic/elasticsearch/issues/141579) (original NPE in `PropagateNullable.rule(And and, ...)`)
- ES PR [#148277](https://github.com/elastic/elasticsearch/pull/148277) — first attempt, turned NPE into `IllegalStateException [#141579]`
- ES issue [#148944](https://github.com/elastic/elasticsearch/issues/148944) — "PropagateNullable still fails after #148277" (closed)
- ES PR [#149592](https://github.com/elastic/elasticsearch/pull/149592) "[ESQL] Per-query partition column nullability" — **merged 2026-05-21 to ES `main` with label `v9.5.0`**

Kibana `main` is `9.5.0` and bundles ES `main` snapshots, so the ES fix is in the snapshot Kibana CI runs against.

**2. Cluster is not self-resolving.** Despite ES #149592 merging, 4 of the 6 issues continued to fail after that date:

| Issue | Last `kibanamachine` failure | Post-ES-fix? |
|---|---|---|
| #267867 | 2026-05-26 | yes (+5d) |
| #267901 | 2026-05-14 | before |
| #268111 | **2026-06-02** | yes (+12d) |
| #268237 | 2026-05-28 | yes (+7d) |
| #268321 | 2026-06-01 | yes (+11d) |
| #268890 | 2026-05-18 | before |

The most recent failure (#268111, 2026-06-02) shows a **different** ES NPE — `Cannot invoke "java.util.Set.isEmpty()" because "nullExpressions" is null` — not the original `pattern is null`. This is a sibling optimizer bug that ES #149592 didn't address (no public ES tracker for it yet). Kibana-side defense remains required.

**3. AND-operator concern (acknowledged risk).** The fix's `CASE(event.id IS NOT NULL AND event.id != "", ...)` still uses `AND`. If a future optimizer regression hits a sibling rule, it could fire here. The `/flaky` run on this PR is the empirical check. If still flaky, the structural alternative is `COALESCE(event.id, "") IN (...)` — eliminates the nullable input to `IN` without using `AND`.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed (100× run dispatched on this PR)
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

