### PR TITLE
[Discover][Traces] Remove temporary workaround for popovers in waterfall document details flyout

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -19,7 +19,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { FullTraceWaterfallOnErrorClick } from '@kbn/apm-types';
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDocViewerViewedEvent } from '@kbn/unified-doc-viewer';
 import { css } from '@emotion/react';
 import { getUnifiedDocViewerServices } from '../../../../../plugin';
@@ -84,39 +84,6 @@ export const FullScreenWaterfall = ({
     contentId: FlyoutContentId.TRACE_TIMELINE,
     skipNextReport: skipNextEventReport,
   });
-
-  /*
-   * Temporary workaround: add a native <style> tag to fix the z-index of EuiDataGrid cell popovers
-   * rendered inside nested flyouts.
-   *
-   * EuiDataGrid popovers use EuiPortal, which inserts content at the document root. When nested
-   * flyouts unmount, Emotion's style cleanup can target portals that have already been removed
-   * from the DOM, resulting in a white screen crash.
-   *
-   * By injecting a plain <style> element into document.head, we bypass Emotion entirely,
-   * avoiding the cleanup race condition while still ensuring the popover renders
-   * above the flyout layers.
-   *
-   * TODO: Remove this workaround once EUI provides a proper fix for popover z-index handling
-   * inside nested flyouts (see: https://github.com/elastic/eui/issues/8801).
-   */
-
-  useEffect(() => {
-    const style = document.createElement('style');
-
-    style.id = 'flyout-datagrid-popover-z-index-fix';
-    style.textContent = `
-      .euiDataGridRowCell__popover {
-        z-index: ${euiTheme.levels.menu} !important;
-      }
-    `;
-
-    document.head.appendChild(style);
-
-    return () => {
-      style.remove();
-    };
-  }, [euiTheme.levels.menu]);
 
   const traceWaterfallTitleId = useGeneratedHtmlId({
     prefix: 'traceWaterfallTitle',

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/trace_waterfall_flyout.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/trace_waterfall_flyout.ts
@@ -19,6 +19,10 @@ export interface TraceWaterfallFlyout {
       readonly section: Locator;
     };
     readonly logMessage: Locator;
+    readonly cellPopover: Locator;
+    expandFirstValueCell(): Promise<void>;
+    ensureCellPopoverOnTop(): Promise<void>;
+    closeCellPopover(): Promise<void>;
     close(): Promise<void>;
   };
   open(): Promise<void>;
@@ -30,6 +34,8 @@ export interface TraceWaterfallFlyout {
 export function createTraceWaterfallFlyout(page: ScoutPage): TraceWaterfallFlyout {
   const dialog = page.getByRole('dialog', { name: 'Full trace waterfall flyout' });
   const spanDetailFlyout = page.getByTestId('apmTraceWaterfallSpanDetailFlyout');
+  const aboutTableGrid = spanDetailFlyout.locator('.kbnDocViewer__fieldsGrid');
+  const cellPopover = page.locator('.euiDataGridRowCell__popover');
 
   return {
     dialog,
@@ -43,6 +49,30 @@ export function createTraceWaterfallFlyout(page: ScoutPage): TraceWaterfallFlyou
         section: spanDetailFlyout.getByTestId('unifiedDocViewerErrorsAccordion'),
       },
       logMessage: spanDetailFlyout.getByTestId('unifiedDocViewLogsOverviewMessage'),
+      cellPopover,
+
+      async expandFirstValueCell() {
+        await aboutTableGrid.waitFor({ state: 'visible' });
+
+        const valueCell = aboutTableGrid.locator(
+          '[data-gridcell-column-id="value"][data-gridcell-row-index="0"]'
+        );
+        await valueCell.scrollIntoViewIfNeeded();
+        await valueCell.hover();
+
+        const expandButton = valueCell.getByTestId('euiDataGridCellExpandButton');
+        await expandButton.click();
+      },
+
+      async ensureCellPopoverOnTop() {
+        await cellPopover.click({ trial: true });
+      },
+
+      async closeCellPopover() {
+        await page.keyboard.press('Escape');
+        await cellPopover.waitFor({ state: 'hidden' });
+      },
+
       async close() {
         await page.keyboard.press('Escape');
         await spanDetailFlyout.waitFor({ state: 'hidden' });

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/trace_waterfall_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/trace_waterfall_flyout.spec.ts
@@ -63,7 +63,15 @@ test.describe(
       await test.step('Clicking a span row opens the span detail flyout', async () => {
         await traceWaterfallFlyout.clickSpan(testData.WATERFALL_NODE_DB_SPAN_NAME);
         await expect(traceWaterfallFlyout.spanDetailFlyout).toBeVisible();
-        await traceWaterfallFlyout.childDocFlyout.close();
+      });
+
+      await test.step('Expanding an About field cell shows the popover above the nested flyout', async () => {
+        const { childDocFlyout } = traceWaterfallFlyout;
+        await childDocFlyout.expandFirstValueCell();
+        await expect(childDocFlyout.cellPopover).toBeVisible();
+        await childDocFlyout.ensureCellPopoverOnTop();
+        await childDocFlyout.closeCellPopover();
+        await childDocFlyout.close();
       });
 
       await test.step('Clicking "View error" on a transaction with one error opens the error detail flyout', async () => {


### PR DESCRIPTION
## Summary

Closes #252119

Removing temporary workaround for popovers in waterfall document details flyout, where the popover would be hidden. This solution was intentionally short-term and is now being removed since an official fix is already available in the current EUI version.

Workaround PR: https://github.com/elastic/kibana/pull/251434
Related EUI fix: https://github.com/elastic/eui/issues/8801
EUI package upgrade PR: #269821

### Demo

https://github.com/user-attachments/assets/451eaa8d-e2c2-47fb-bf1c-667cf94b26e1


