### PR TITLE
[Entity Analytics] Pin entity store searches to origin project to prevent duplicate entity display in CPS environments

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.test.ts
@@ -5,8 +5,40 @@
  * 2.0.
  */
 
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { of } from 'rxjs';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { EntityType } from '../../../../../../common/entity_analytics/types';
-import { parseTargetMetadataHits } from './use_fetch_grouped_data';
+import {
+  getGroupedEntitiesQuery,
+  parseTargetMetadataHits,
+  useFetchTargetMetadata,
+  type EntitiesGroupingQuery,
+} from './use_fetch_grouped_data';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { DataViewContext, type DataViewContextValue } from '..';
+
+jest.mock('../../../../../common/lib/kibana');
+
+const mockSearch = jest.fn();
+
+const createWrapper = (
+  indexPattern = 'entities-latest-default'
+): React.FC<{ children: React.ReactNode }> => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const dataView = {
+      getIndexPattern: () => indexPattern,
+    } as unknown as DataViewContextValue['dataView'];
+    return React.createElement(
+      QueryClientProvider,
+      { client },
+      React.createElement(DataViewContext.Provider, { value: { dataView } }, children)
+    );
+  };
+  return Wrapper;
+};
 
 describe('parseTargetMetadataHits', () => {
   it('extracts name, type, and riskScore from well-formed hits', () => {
@@ -195,5 +227,50 @@ describe('parseTargetMetadataHits', () => {
     const result = parseTargetMetadataHits([]);
 
     expect(result.size).toBe(0);
+  });
+});
+
+describe('getGroupedEntitiesQuery', () => {
+  const minimalQuery = { size: 0 } as EntitiesGroupingQuery;
+
+  it('pins the grouped query to the origin entity store via project_routing', () => {
+    const result = getGroupedEntitiesQuery(minimalQuery, 'entities-latest-default');
+
+    expect(result).toHaveProperty('project_routing', '_alias:_origin');
+  });
+
+  it('targets the provided index pattern', () => {
+    const result = getGroupedEntitiesQuery(minimalQuery, 'entities-latest-default');
+
+    expect(result.index).toBe('entities-latest-default');
+  });
+});
+
+describe('useFetchTargetMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearch.mockReturnValue(of({ rawResponse: { hits: { hits: [] } } }));
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: { search: { search: mockSearch } },
+        notifications: { toasts: { addError: jest.fn() } },
+      },
+    });
+  });
+
+  it('pins the target-metadata query to the origin entity store', async () => {
+    renderHook(() => useFetchTargetMetadata(['host:cps-host-id-001']), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalled());
+
+    expect(mockSearch.mock.calls[0][0].params).toHaveProperty('project_routing', '_alias:_origin');
+  });
+
+  it('does not fire when entityIds is empty', () => {
+    renderHook(() => useFetchTargetMetadata([]), { wrapper: createWrapper() });
+
+    expect(mockSearch).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -82,6 +82,7 @@ export const getGroupedEntitiesQuery = (query: EntitiesGroupingQuery, indexPatte
   return {
     ...query,
     index: indexPattern,
+    project_routing: '_alias:_origin',
     ignore_unavailable: true,
     size: 0,
   };
@@ -150,6 +151,7 @@ export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap =
         searchService.search<{}, IKibanaSearchResponse<SearchResponse>>({
           params: {
             index: indexPattern,
+            project_routing: '_alias:_origin',
             ignore_unavailable: true,
             size: entityIds.length,
             _source: [

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { buildInspectData } from './use_fetch_grid_data';
+import { buildInspectData, getEntitiesQuery } from './use_fetch_grid_data';
 
 describe('buildInspectData', () => {
   const queryParams = {
@@ -44,5 +44,32 @@ describe('buildInspectData', () => {
     const inspect = buildInspectData(queryParams, rawResponse);
 
     expect(inspect.dsl[0]).toBe(JSON.stringify(queryParams));
+  });
+});
+
+describe('getEntitiesQuery', () => {
+  const options = {
+    query: undefined,
+    sort: [['entity.name', 'asc']] as Array<[string, string]>,
+    enabled: true,
+    pageSize: 25,
+  };
+
+  it('throws when no index pattern is provided', () => {
+    expect(() => getEntitiesQuery(options, undefined, undefined)).toThrow(
+      'Index pattern is required'
+    );
+  });
+
+  it('pins the query to the origin entity store via project_routing', () => {
+    const params = getEntitiesQuery(options, undefined, 'entities-latest-default');
+
+    expect(params).toHaveProperty('project_routing', '_alias:_origin');
+  });
+
+  it('targets the provided index pattern', () => {
+    const params = getEntitiesQuery(options, undefined, 'entities-latest-default');
+
+    expect(params.index).toEqual(['entities-latest-default']);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_fetch_grid_data.ts
@@ -37,7 +37,7 @@ const ENTITY_TABLE_RUNTIME_MAPPING_FIELDS: string[] = [
   ENTITY_FIELDS.ENTITY_NAME,
 ];
 
-const getEntitiesQuery = (
+export const getEntitiesQuery = (
   { query, sort }: UseEntitiesOptions,
   pageParam: unknown,
   indexPattern?: string
@@ -48,6 +48,7 @@ const getEntitiesQuery = (
 
   return {
     index: [indexPattern],
+    project_routing: '_alias:_origin',
     sort: getMultiFieldsSort(sort),
     runtime_mappings: getRuntimeMappingsFromSort(ENTITY_TABLE_RUNTIME_MAPPING_FIELDS, sort),
     size: MAX_ENTITIES_TO_LOAD,


### PR DESCRIPTION
## Summary

In Kibana Serverless environments with Cross-Product Search (CPS) enabled, the Entity Analytics page shows the same entity multiple times - once per linked project. In a staging environment with 20 linked projects, each entity appeared 20 times in the entities table.

This PR fixes that by pinning the three search calls that power the entities table to the origin project only.

## Root Cause

Kibana's client-side search interceptor (`search_interceptor.ts:338`) automatically injects `project_routing: "_alias:*"` into every `data.search.search()` call, based on the active space's NPRE setting. In the default CPS space, that NPRE is `_alias:*`, which tells Elasticsearch to fan out the query across every linked project.

The Entity Store on each linked project contains the same entity records (same source data). So a query for host entities returns one copy from the origin plus one copy from each of the 20 linked projects, for a total of 20 duplicates per entity.

## Fix

Added `project_routing: '_alias:_origin'` directly in the body of each of the three search calls:

1. `getEntitiesQuery` in `use_fetch_grid_data.ts` - powers the main entity table rows
2. `getGroupedEntitiesQuery` in `use_fetch_grouped_data.ts` - powers the grouped view aggregations
3. `useFetchTargetMetadata` in `use_fetch_grouped_data.ts` - fetches metadata for grouped entity targets

This works because the Elasticsearch search strategy (`es_search_strategy.ts:73-74`) spreads the options-derived routing value before the request params, so a `project_routing` value in the body overrides the space default. The CPS request handler middleware also preserves existing body values and only injects when none is present (`cps_request_handler.ts:139`).

## Safety in Non-CPS Environments

This change is safe to ship without CPS. When `cpsEnabled` is false (which is the default for all stateful, ESS, and single-project serverless deployments), the CPS request handler strips `project_routing` from the request body before it reaches Elasticsearch (`cps_request_handler.ts:70-77`). So non-CPS environments see a byte-for-byte identical request to today. There is no risk of a 400 error or behavior change for any non-CPS customer.

## Dependency

This fix works correctly only when the origin project entity store is populated with entities from linked projects. That population is handled by elastic/kibana#268007 (Or Ouziel). Without that PR, pinning to `_alias:_origin` would return an empty table in a multi-project CPS environment, because the origin store would not yet contain any cross-project entity data.

This PR is opened as a draft and should be held until elastic/kibana#268007 is merged.

## Testing

Because the local Scout CPS environment (Docker-based) does not replicate the multi-cluster fan-out of a real staging environment, verification used a combination of:

1. **Unit tests for query builders (Approach 1):** `getEntitiesQuery` and `getGroupedEntitiesQuery` are tested directly to assert the presence of `project_routing: '_alias:_origin'` in the returned params. `getEntitiesQuery` was also exported to enable this (it was previously module-private).

2. **Mock-based hook test for `useFetchTargetMetadata` (Approach 2):** This call site has no extractable function, so `data.search.search` is mocked and the test asserts the exact params passed to it. This is the only way to cover site 3. The pattern follows the existing `use_fetch_chart_data.test.ts` in the asset inventory area.

3. **Staging evidence:** The `_clusters` section of the raw Elasticsearch response on the staging environment shows 21 shards queried (1 origin + 20 linked), confirming the fan-out is real. Each entity had `doc_count: 20`.

4. **Code path tracing:** Confirmed end-to-end that `search_interceptor.ts:338` injects space routing, that `es_search_strategy.ts:73-74` allows body to override it, and that `cps_request_handler.ts:139` preserves existing body values.

All 20 tests pass locally with zero lint errors.

## Related

- Staging validation issue: elastic/security-team#17397
- Companion PR (populate origin store): elastic/kibana#268007