### PR TITLE
[discover-scout] remove redundant constant for scout tags

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/common/constants.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/common/constants.ts
@@ -7,14 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { tags } from '@kbn/scout';
-
-/**
- * Default tags for Discover core / platform specs that should run across all
- * stateful + serverless deployment types.
- */
-export const DISCOVER_CORE_TAGS = tags.deploymentAgnostic;
-
 /**
  * Standard `kbn_archiver/discover` archive. Loads the `logstash-*` data view
  * and the other saved objects most Discover specs rely on.

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/data_grid_doc_table.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/data_grid_doc_table.spec.ts
@@ -11,7 +11,7 @@
  * Data-grid rendering and sidebar column management.
  */
 
-import { spaceTest } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import type { ScoutPage } from '@kbn/scout';
 import { testData } from '../../fixtures/common';
@@ -28,7 +28,7 @@ const addColumnFromSidebar = async (page: ScoutPage, column: string) => {
   await page.testSubj.click(`fieldToggle-${column}`);
 };
 
-spaceTest.describe('Discover data grid - doc table', { tag: testData.DISCOVER_CORE_TAGS }, () => {
+spaceTest.describe('Discover data grid - doc table', { tag: tags.stateful.all }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     await scoutSpace.savedObjects.load(testData.DISCOVER_KBN_ARCHIVE);
     await scoutSpace.uiSettings.setDefaultIndex(testData.DEFAULT_DATA_VIEW);

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/data_grid_doc_viewer.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/data_grid_doc_viewer.spec.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ScoutPage } from '@kbn/scout';
-import { spaceTest } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { testData } from '../../fixtures/common';
 
@@ -22,7 +22,7 @@ const EXPECTED_FIRST_ROW_ID = 'AU_x3_g4GFA8no6QjkYX';
 const firstRowTimestampCell = (page: ScoutPage) =>
   page.locator('[data-grid-visible-row-index="0"] [data-gridcell-column-id="@timestamp"]');
 
-spaceTest.describe('Discover data grid - doc viewer', { tag: testData.DISCOVER_CORE_TAGS }, () => {
+spaceTest.describe('Discover data grid - doc viewer', { tag: tags.stateful.all }, () => {
   // EUI DataGrid hides/truncates inline cellActions at narrow widths. The FTR
   // equivalent ran at 1600x1200 via `browser.setWindowSize`; match that here so
   // the doc-viewer flyout has room to render its "toggle column" actions.


### PR DESCRIPTION
## Summary

This PR removes a redundant constant for scout tests tags used in Discover. We took the decision to use tags directly imported via `import { tags } from '@kbn/scout';` and use a tag you need, instead of creating constants for each case.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
