### PR TITLE
[Dashboard] Drop stale inline savedObjectId from legacy by-reference panels

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/transforms/out/panel_bwc.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/out/panel_bwc.test.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { transformPanelReferencesOut } from './panel_bwc';
+import type { SavedDashboardPanel } from '../../../dashboard_saved_object';
+import { panelBwc, transformPanelReferencesOut } from './panel_bwc';
 
 describe('transformPanelReferencesOut', () => {
   test('Should transform panelRefName reference name', () => {
@@ -27,5 +28,57 @@ describe('transformPanelReferencesOut', () => {
         },
       ]
     `);
+  });
+});
+
+describe('panelBwc', () => {
+  const gridData = { x: 0, y: 0, w: 24, h: 15, i: 'panel-1' };
+
+  test('strips a stale inline savedObjectId when a by-reference reference exists', () => {
+    const panel = {
+      type: 'search',
+      panelRefName: 'panel_panel-1',
+      panelIndex: 'panel-1',
+      gridData,
+      embeddableConfig: { savedObjectId: 'stale-source-space-id', description: '' },
+    } as unknown as SavedDashboardPanel;
+    const panelReferences = [
+      { name: 'panel_panel-1', type: 'search', id: 'remapped-id' },
+    ];
+
+    const { panel: result, panelReferences: resultReferences } = panelBwc(panel, panelReferences);
+
+    expect(result.embeddableConfig).not.toHaveProperty('savedObjectId');
+    expect(result.embeddableConfig).toEqual({ description: '' });
+    expect(result.type).toBe('discover_session');
+    expect(resultReferences).toEqual([{ name: 'savedObjectRef', type: 'search', id: 'remapped-id' }]);
+  });
+
+  test('keeps inline savedObjectId when there is no by-reference reference', () => {
+    const panel = {
+      type: 'search',
+      panelIndex: 'panel-1',
+      gridData,
+      embeddableConfig: { savedObjectId: 'inline-id', description: '' },
+    } as unknown as SavedDashboardPanel;
+
+    const { panel: result } = panelBwc(panel, []);
+
+    expect(result.embeddableConfig).toHaveProperty('savedObjectId', 'inline-id');
+  });
+
+  test('does not strip savedObjectId for non by-reference reference types', () => {
+    const panel = {
+      type: 'search',
+      panelRefName: 'panel_panel-1',
+      panelIndex: 'panel-1',
+      gridData,
+      embeddableConfig: { savedObjectId: 'inline-id' },
+    } as unknown as SavedDashboardPanel;
+    const panelReferences = [{ name: 'panel_panel-1', type: 'index-pattern', id: 'dv-1' }];
+
+    const { panel: result } = panelBwc(panel, panelReferences);
+
+    expect(result.embeddableConfig).toHaveProperty('savedObjectId', 'inline-id');
   });
 });

--- a/src/platform/plugins/shared/dashboard/server/api/transforms/out/panel_bwc.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/out/panel_bwc.ts
@@ -28,11 +28,25 @@ export function panelBwc(panel: SavedDashboardPanel, panelReferences: SavedObjec
     return matchingReference ? matchingReference.type : 'unknown';
   }
 
+  // Legacy by-reference panels stored the target saved object id both inline
+  // (`embeddableConfig.savedObjectId`) and as a panel reference. Only the reference is rewritten
+  // on import / copy-to-space, so a stale inline id can survive and override the (correctly
+  // remapped) reference in the embeddable transforms. When a by-reference reference exists, drop
+  // the inline id so the reference remains authoritative.
+  const hasByRefSavedObjectReference =
+    panelRefName !== undefined &&
+    panelReferences.some(
+      (reference) => reference.name === panelRefName && BY_REF_TYPES.includes(reference.type)
+    );
+  const { savedObjectId, ...embeddableConfigWithoutSavedObjectId } = panel.embeddableConfig;
+
   return {
     panel: {
       ...rest,
       embeddableConfig: {
-        ...panel.embeddableConfig,
+        ...(hasByRefSavedObjectReference
+          ? embeddableConfigWithoutSavedObjectId
+          : panel.embeddableConfig),
         // <8.19 title stored as siblings to embeddableConfig
         ...(title !== undefined && { title }),
       },


### PR DESCRIPTION
## Summary

Legacy by-reference dashboard panels (e.g. a saved search / `discover_session` panel) stored the target saved object id in **two** places:

- inline as `embeddableConfig.savedObjectId` inside `panelsJSON`, and
- as a real `references[]` entry (`<panelIndex>:panel_<panelIndex>`, type `search`).

On import / **copy-to-space**, only the `references[]` entry is remapped to the new object id — the inline id buried as a string inside `panelsJSON` is not (the importer only rewrites `references[]`, never attribute-embedded ids). The embeddable transform (`fromStoredSearchEmbeddableByRef`) then gives the inline `savedObjectId` precedence over the `savedObjectRef` reference, so the panel resolves a **stale id that doesn't exist in the destination space** and fails to load.

This only surfaces when copy-to-space mints a new id for the referenced object (e.g. `createNewCopies: true`, or an ambiguous/origin conflict — which is what happens when related/linked dashboards are dragged into the copy). When no new id is minted, the stale inline id coincidentally still matches, which is why the same dashboard can "work" in one copy and break in another.

### Fix

`panelBwc` now strips the inline `savedObjectId` from `embeddableConfig` whenever the panel has a by-reference reference (i.e. a `panelRefName` resolving to a `BY_REF_TYPES` reference). The correctly remapped reference stays authoritative, so the panel resolves regardless of whether copy-to-space kept or regenerated the id. This applies to all by-reference panel types (`links` / `search` / `visualization` / `lens` / `map`).

The fix is intentionally placed in the dashboard server BWC layer (where the stale inline id originates) rather than inverting precedence in the discover transform, because the discover transform's state-over-reference precedence is an intentional, tested contract for the runtime/API path.

## Test plan

- [x] Unit tests added to `panel_bwc.test.ts` (strip when a by-ref reference exists; keep when there is no reference; keep for non-by-ref reference types).
- [ ] Manual: import a legacy dashboard with a saved-search panel, copy it to another space with "Create new objects with random IDs", and confirm the Discover session panel loads in the destination space.

> [!NOTE]
> Repaired at read time; re-saving the dashboard through the current Dashboard API persists the modern `savedObjectRef`-only shape.

Made with [Cursor](https://cursor.com)