### PR TITLE
[ResponseOps][Alerting V2] Expose ActionPolicyClient on the server start contract

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/index.ts
@@ -36,4 +36,4 @@ export const module = new ContainerModule((options) => {
 });
 
 export type { PluginConfig as AlertingV2Config } from './config';
-export type { AlertingServerStart, RulesClientApi } from './types';
+export type { AlertingServerStart, RulesClientApi, ActionPolicyClientApi } from './types';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_contract.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_contract.test.ts
@@ -10,6 +10,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { Start } from '@kbn/core-di';
 import { CoreStart, Request } from '@kbn/core-di-server';
 import { RulesClient } from '../lib/rules_client';
+import { ActionPolicyClient } from '../lib/action_policy_client';
 import { RequestSpaceIdToken } from '../lib/services/spaces_service/tokens';
 import type { AlertingServerStart } from '../types';
 import { bindContract } from './bind_contract';
@@ -18,13 +19,16 @@ describe('bindContract', () => {
   let container: Container;
   let scope: Container;
   let mockRulesClient: Partial<RulesClient>;
+  let mockActionPolicyClient: Partial<ActionPolicyClient>;
   let fork: jest.Mock;
 
   beforeEach(() => {
     container = new Container();
     scope = new Container();
     mockRulesClient = { getRule: jest.fn() };
+    mockActionPolicyClient = { getActionPolicy: jest.fn() };
     scope.bind(RulesClient).toConstantValue(mockRulesClient as RulesClient);
+    scope.bind(ActionPolicyClient).toConstantValue(mockActionPolicyClient as ActionPolicyClient);
 
     fork = jest.fn(() => scope);
     container.bind(CoreStart('injection')).toConstantValue({
@@ -35,11 +39,13 @@ describe('bindContract', () => {
     container.loadSync(new ContainerModule((options) => bindContract(options)));
   });
 
-  it('exposes getRulesClients on the start contract', () => {
+  it('exposes the rules and action-policy client factories on the start contract', () => {
     const start = container.get<AlertingServerStart>(Start);
     expect(start).toEqual({
       getRulesClientWithRequest: expect.any(Function),
       getRulesClientWithRequestInSpace: expect.any(Function),
+      getActionPolicyClientWithRequest: expect.any(Function),
+      getActionPolicyClientWithRequestInSpace: expect.any(Function),
     });
   });
 
@@ -61,6 +67,28 @@ describe('bindContract', () => {
     const client = await start.getRulesClientWithRequestInSpace(fakeRequest, 'my-space');
 
     expect(client).toBe(mockRulesClient);
+    expect(scope.get(Request)).toBe(fakeRequest);
+    expect(scope.get(RequestSpaceIdToken)).toBe('my-space');
+  });
+
+  it('returns the actionPolicyClient resolved with the request when getActionPolicyClientWithRequest is called', async () => {
+    const fakeRequest = { headers: {} } as unknown as KibanaRequest;
+    const start = container.get<AlertingServerStart>(Start);
+
+    const client = await start.getActionPolicyClientWithRequest(fakeRequest);
+
+    expect(client).toBe(mockActionPolicyClient);
+    expect(fork).toHaveBeenCalledTimes(1);
+    expect(scope.get(Request)).toBe(fakeRequest);
+  });
+
+  it('binds the spaceId in the scope when getActionPolicyClientWithRequestInSpace is called', async () => {
+    const fakeRequest = { headers: {} } as unknown as KibanaRequest;
+    const start = container.get<AlertingServerStart>(Start);
+
+    const client = await start.getActionPolicyClientWithRequestInSpace(fakeRequest, 'my-space');
+
+    expect(client).toBe(mockActionPolicyClient);
     expect(scope.get(Request)).toBe(fakeRequest);
     expect(scope.get(RequestSpaceIdToken)).toBe('my-space');
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_contract.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_contract.ts
@@ -11,8 +11,9 @@ import { Global } from '@kbn/core-di-internal';
 import { CoreStart, Request } from '@kbn/core-di-server';
 import type { KibanaRequest } from '@kbn/core/server';
 import { RulesClient } from '../lib/rules_client';
+import { ActionPolicyClient } from '../lib/action_policy_client';
 import { RequestSpaceIdToken } from '../lib/services/spaces_service/tokens';
-import type { AlertingServerStart, RulesClientApi } from '../types';
+import type { AlertingServerStart, RulesClientApi, ActionPolicyClientApi } from '../types';
 
 export function bindContract({ bind }: ContainerModuleLoadOptions) {
   bind(Start).toDynamicValue(({ get }) => {
@@ -38,6 +39,17 @@ export function bindContract({ bind }: ContainerModuleLoadOptions) {
         spaceId: string
       ): Promise<RulesClientApi> {
         return buildScope(request, spaceId).get(RulesClient);
+      },
+      async getActionPolicyClientWithRequest(
+        request: KibanaRequest
+      ): Promise<ActionPolicyClientApi> {
+        return buildScope(request).get(ActionPolicyClient);
+      },
+      async getActionPolicyClientWithRequestInSpace(
+        request: KibanaRequest,
+        spaceId: string
+      ): Promise<ActionPolicyClientApi> {
+        return buildScope(request, spaceId).get(ActionPolicyClient);
       },
     };
     return contract;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/types.ts
@@ -30,8 +30,11 @@ import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
 import type { AgentContextLayerPluginSetup } from '@kbn/agent-context-layer-plugin/server';
 import type { RulesClient } from './lib/rules_client';
+import type { ActionPolicyClient } from './lib/action_policy_client';
 
 export type RulesClientApi = PublicMethodsOf<RulesClient>;
+
+export type ActionPolicyClientApi = PublicMethodsOf<ActionPolicyClient>;
 
 export type AlertingServerSetup = void;
 
@@ -41,6 +44,12 @@ export interface AlertingServerStart {
     request: KibanaRequest,
     spaceId: string
   ): Promise<RulesClientApi>;
+
+  getActionPolicyClientWithRequest(request: KibanaRequest): Promise<ActionPolicyClientApi>;
+  getActionPolicyClientWithRequestInSpace(
+    request: KibanaRequest,
+    spaceId: string
+  ): Promise<ActionPolicyClientApi>;
 }
 
 export interface AlertingServerSetupDependencies {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/271092

## Summary

- Exposes request-scoped ActionPolicyClient factories on the AlertingServerStart contract
- AlertingServerStart now provides:
  - getActionPolicyClientWithRequest(request) 
  - getActionPolicyClientWithRequestInSpace(request, spaceId) 
