### PR TITLE
[Agent Builder] Restore padding for DataTable container

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
@@ -25,12 +25,15 @@ export const visualizationWrapperStyles = ({ euiTheme }: UseEuiTheme) =>
       marginInlineStart: 0,
     },
 
-    p: {
+    '.echMetricText__subtitle': {
       margin: 0,
     },
 
     '.expExpressionRenderer__expression': {
       padding: `${euiTheme.size.s} 0`,
+      '[class*="datatableContainerStyles"]': {
+        padding: `${euiTheme.size.s} ${euiTheme.size.s}`,
+      },
     },
   });
 


### PR DESCRIPTION
Resolves #272502

Previously, we removed horizontal padding from visualizations following the approach introduced in the referenced [PR](https://github.com/elastic/kibana/pull/261909).

However, `DataTable` visualizations require horizontal padding to render correctly and maintain proper spacing. This change carefully restores the horizontal padding only for the `DataTable` container (`datatableContainerStyles`) without affecting other visualization types.

Before:
<img width="819" height="502" alt="Screenshot 2026-06-03 at 14 57 30" src="https://github.com/user-attachments/assets/6be32dba-7ae5-4a52-aaa7-a13796169e38" />

After:
<img width="819" height="502" alt="Screenshot 2026-06-03 at 14 57 04" src="https://github.com/user-attachments/assets/6377e810-7695-40ec-9271-90f1fca91f59" />
