### PR TITLE
[9.3] [ftr] replace UI login with cookie session (#271520)

### DIFF
--- a/src/platform/packages/private/kbn-journeys/services/auth.ts
+++ b/src/platform/packages/private/kbn-journeys/services/auth.ts
@@ -8,8 +8,8 @@
  */
 
 import Url from 'url';
-import { format } from 'util';
 
+import { fetchSessionCookie } from '@kbn/ftr-common-functional-services';
 import { FtrService } from './ftr_context_provider';
 
 export interface Credentials {
@@ -17,78 +17,26 @@ export interface Credentials {
   password: string;
 }
 
-function extractCookieValue(headers: Headers) {
-  // Headers.getSetCookie() is the Node 22 / undici API; fall back to Headers.get for
-  // older runtimes (jsdom in the test config).
-  const headersWithGetSetCookie = headers as Headers & { getSetCookie?: () => string[] };
-  const firstSetCookie = headersWithGetSetCookie.getSetCookie
-    ? headersWithGetSetCookie.getSetCookie()[0]
-    : headers.get('set-cookie');
-  return firstSetCookie?.split(';')[0].split('sid=')[1] ?? '';
-}
 export class AuthService extends FtrService {
   private readonly config = this.ctx.getService('config');
   private readonly log = this.ctx.getService('log');
   private readonly kibanaServer = this.ctx.getService('kibanaServer');
 
   public async login(credentials?: Credentials) {
-    const baseUrl = new URL(
-      Url.format({
-        protocol: this.config.get('servers.kibana.protocol'),
-        hostname: this.config.get('servers.kibana.hostname'),
-        port: this.config.get('servers.kibana.port'),
-      })
-    );
-    const loginUrl = new URL('/internal/security/login', baseUrl);
-    const provider = this.isCloud() ? 'cloud-basic' : 'basic';
-
-    const version = await this.kibanaServer.version.get();
-
-    this.log.info('fetching auth cookie from', loginUrl.href);
-    const authResponse = await fetch(loginUrl, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'kbn-version': version,
-        'sec-fetch-mode': 'cors',
-        'sec-fetch-site': 'same-origin',
-        'x-elastic-internal-origin': 'Kibana',
-      },
-      body: JSON.stringify({
-        providerType: 'basic',
-        providerName: provider,
-        currentURL: new URL('/login?next=%2F', baseUrl).href,
-        params: credentials ?? { username: this.getUsername(), password: this.getPassword() },
-      }),
-      redirect: 'manual',
+    const baseUrl = Url.format({
+      protocol: this.config.get('servers.kibana.protocol'),
+      hostname: this.config.get('servers.kibana.hostname'),
+      port: this.config.get('servers.kibana.port'),
     });
+    const provider = this.isCloud() ? 'cloud-basic' : 'basic';
+    const kbnVersion = await this.kibanaServer.version.get();
+    const username = credentials?.username ?? this.getUsername();
+    const password = credentials?.password ?? this.getPassword();
 
-    if (authResponse.status !== 200) {
-      throw new Error(
-        `Kibana auth failed: code: ${authResponse.status}, message: ${authResponse.statusText}`
-      );
-    }
-
-    const cookie = extractCookieValue(authResponse.headers);
-    if (cookie) {
-      this.log.info('captured auth cookie');
-    } else {
-      this.log.error(
-        format('unable to determine auth cookie from response', {
-          status: `${authResponse.status} ${authResponse.statusText}`,
-          body: await authResponse.text(),
-          headers: Object.fromEntries(authResponse.headers.entries()),
-        })
-      );
-
-      throw new Error(`failed to determine auth cookie`);
-    }
-
-    return {
-      name: 'sid',
-      value: cookie,
-      url: baseUrl.href,
-    };
+    this.log.info(`fetching auth cookie from ${baseUrl}/internal/security/login`);
+    const cookie = await fetchSessionCookie({ baseUrl, username, password, kbnVersion, provider });
+    this.log.info('captured auth cookie');
+    return cookie;
   }
 
   public getUsername() {

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/index.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/index.ts
@@ -47,3 +47,5 @@ export { RandomnessService } from './services/randomness';
 export { KibanaSupertestProvider, ElasticsearchSupertestProvider } from './services/supertest';
 export { retryForSuccess } from './services/retry/retry_for_success';
 export { SecurityService } from './services/security';
+export { fetchSessionCookie } from './services/cookie_auth';
+export type { SessionCookie, FetchSessionCookieParams } from './services/cookie_auth';

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/all.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/all.ts
@@ -22,6 +22,8 @@ import { SupertestWithoutAuthProvider } from './supertest_without_auth';
 import { SamlAuthProvider } from './saml_auth';
 import { KibanaSupertestProvider, ElasticsearchSupertestProvider } from './supertest';
 import { SecurityServiceProvider } from './security';
+import { CookieAuthService } from './cookie_auth';
+import { BrowserAuthService } from './browser_auth';
 
 export const services = {
   es: EsProvider,
@@ -40,4 +42,6 @@ export const services = {
   esSupertest: ElasticsearchSupertestProvider,
   supertestWithoutAuth: SupertestWithoutAuthProvider,
   security: SecurityServiceProvider,
+  cookieAuth: CookieAuthService,
+  browserAuth: BrowserAuthService,
 };

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/browser_auth/browser_auth_service.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/browser_auth/browser_auth_service.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FtrService } from '../ftr_provider_context';
+import type { Cookie } from '../cookie_auth';
+
+export interface LoginByCookieOptions {
+  /** When provided, verifies GET /internal/security/me returns this username. */
+  expectedUsername?: string;
+  /** Whether to assert the userMenuButton test-subject is rendered after login. Defaults to true. */
+  expectUserMenuButton?: boolean;
+  /**
+   * Where to navigate after injecting the cookie. Defaults to the Kibana root (`/`).
+   * Pass the actual target app URL to avoid a second navigation in the caller.
+   */
+  targetUrl?: string;
+}
+
+/**
+ * Browser-side cookie injection service.
+ *
+ * Mirrors the pattern used by the serverless `svl_common_page.loginWithRole()`:
+ *   1. Navigate to /bootstrap-anonymous.js (no-auth endpoint to enter the Kibana origin)
+ *   2. Clean all browser state (cookies, session storage, local storage)
+ *   3. Set the `sid` cookie
+ *   4. Navigate to Kibana home and optionally verify identity
+ *
+ * Consumed by SecurityPageObject.login() and TestUser.setRoles() when
+ * `security.cookieLogin: true` is set in the FTR config.
+ *
+ * Note: `browser` and `testSubjects` are not part of the common FTR provider context type —
+ * they come from @kbn/ftr-common-functional-ui-services, which functional test configs spread
+ * on top. We use `hasService` + `as any` (same pattern as TestUser) to access them safely.
+ */
+export class BrowserAuthService extends FtrService {
+  private readonly log = this.ctx.getService('log');
+  private readonly deployment = this.ctx.getService('deployment');
+  private readonly supertestWithoutAuth = this.ctx.getService('supertestWithoutAuth');
+
+  // Browser-specific services — only present in functional (UI) test contexts.
+
+  private readonly browser: any = this.ctx.hasService('browser')
+    ? this.ctx.getService('browser' as any)
+    : undefined;
+
+  private readonly testSubjects: any = this.ctx.hasService('testSubjects')
+    ? this.ctx.getService('testSubjects' as any)
+    : undefined;
+
+  /**
+   * Clears all browser state (cookies, session storage, local storage).
+   *
+   * Navigates to `/bootstrap-anonymous.js` first only when the browser is not already on the
+   * Kibana origin — e.g. when starting from `about:blank`. If the browser is already on a
+   * Kibana page (e.g. `/login` after a redirect) the extra navigation is skipped.
+   */
+  async cleanBrowserState(): Promise<void> {
+    if (!this.browser) {
+      throw new Error(
+        '[browserAuth] browser service is not available — ' +
+          'cleanBrowserState() can only be called from functional UI test configs.'
+      );
+    }
+
+    const hostPort = this.deployment.getHostPort();
+    const currentUrl: string = await this.browser.getCurrentUrl();
+
+    if (!currentUrl.startsWith(hostPort)) {
+      // Not on the Kibana origin yet — navigate to a lightweight no-auth endpoint
+      // so cookie operations target the correct domain.
+      this.log.debug('[browserAuth] navigating to /bootstrap-anonymous.js for cookie domain');
+      await this.browser.get(hostPort + '/bootstrap-anonymous.js');
+      const alert = await this.browser.getAlert();
+      if (alert) await alert.accept();
+    }
+
+    this.log.debug('[browserAuth] deleting all cookies and clearing storage');
+    await this.browser.deleteAllCookies();
+    await this.browser.clearSessionStorage();
+    await this.browser.clearLocalStorage();
+  }
+
+  /**
+   * Injects a Kibana `sid` session cookie into the browser context and navigates to
+   * `options.targetUrl` (defaults to Kibana root `/`), verifying login succeeded.
+   *
+   * Pass `targetUrl` equal to the final app URL to avoid a second navigation in the caller.
+   */
+  async loginByCookie(cookie: Cookie, options: LoginByCookieOptions = {}): Promise<void> {
+    if (!this.browser || !this.testSubjects) {
+      throw new Error(
+        '[browserAuth] browser services are not available — ' +
+          'loginByCookie() can only be called from functional UI test configs.'
+      );
+    }
+
+    const { expectUserMenuButton = true, targetUrl } = options;
+
+    await this.cleanBrowserState();
+
+    // cleanBrowserState() wipes localStorage. Restore the flag that suppresses the
+    // welcome screen so it does not overlay the UI after the first navigation.
+    await this.browser.setLocalStorageItem('home:welcome:show', 'false');
+
+    this.log.debug(`[browserAuth] injecting 'sid' cookie`);
+    await this.browser.setCookie('sid', cookie.value);
+
+    const destination = targetUrl ?? this.deployment.getHostPort();
+    this.log.debug(`[browserAuth] navigating to ${destination}`);
+    await this.browser.get(destination);
+
+    if (options.expectedUsername) {
+      const cookies = await this.browser.getCookies();
+      const sidValue = (cookies as Array<{ name: string; value: string }>).find(
+        (c) => c.name === 'sid'
+      )?.value;
+
+      if (sidValue) {
+        const { body } = await this.supertestWithoutAuth
+          .get('/internal/security/me')
+          .set('kbn-xsrf', 'xxx')
+          .set('Cookie', `sid=${sidValue}`)
+          .expect(200);
+
+        if (body.username !== options.expectedUsername) {
+          throw new Error(
+            `[browserAuth] expected username '${options.expectedUsername}' but got '${body.username}'`
+          );
+        }
+        this.log.debug(`[browserAuth] verified session for '${options.expectedUsername}'`);
+      }
+    }
+
+    if (expectUserMenuButton) {
+      await this.testSubjects.existOrFail('userMenuButton', { timeout: 10_000 });
+      this.log.debug('[browserAuth] login confirmed via userMenuButton');
+    }
+  }
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/browser_auth/index.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/browser_auth/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { BrowserAuthService } from './browser_auth_service';
+export type { LoginByCookieOptions } from './browser_auth_service';

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/cookie_auth/cookie_auth_service.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/cookie_auth/cookie_auth_service.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Url from 'url';
+import { FtrService } from '../ftr_provider_context';
+import { fetchSessionCookie } from './fetch_session_cookie';
+
+export type { SessionCookie as Cookie } from './fetch_session_cookie';
+
+const TEST_USER_NAME = 'test_user';
+const TEST_USER_PASSWORD = 'changeme';
+
+/**
+ * Generates a Kibana session cookie (`sid`) by posting to the internal basic-auth login endpoint.
+ * Works for both local (`basic` provider) and Cloud (`cloud-basic` provider) deployments.
+ *
+ * This is purely HTTP — no browser dependency. Consumed by BrowserAuthService (browser-side
+ * cookie injection) and directly by API-level test helpers.
+ */
+export class CookieAuthService extends FtrService {
+  private readonly config = this.ctx.getService('config');
+  private readonly log = this.ctx.getService('log');
+  private readonly kibanaServer = this.ctx.getService('kibanaServer');
+
+  private getBaseUrl(): string {
+    return Url.format({
+      protocol: this.config.get('servers.kibana.protocol'),
+      hostname: this.config.get('servers.kibana.hostname'),
+      port: this.config.get('servers.kibana.port'),
+    });
+  }
+
+  isCloud(): boolean {
+    return this.config.get('servers.kibana.hostname') !== 'localhost';
+  }
+
+  async getCookieForUser(username: string, password: string) {
+    const baseUrl = this.getBaseUrl();
+    const provider = this.isCloud() ? 'cloud-basic' : 'basic';
+    const kbnVersion = await this.kibanaServer.version.get();
+
+    this.log.info(
+      `[cookieAuth] fetching auth cookie for '${username}' from ${baseUrl}/internal/security/login`
+    );
+    const cookie = await fetchSessionCookie({ baseUrl, username, password, kbnVersion, provider });
+    this.log.info(`[cookieAuth] captured auth cookie for '${username}'`);
+    return cookie;
+  }
+
+  /** Cookie for the shared FTR test_user (username: test_user, password: changeme). */
+  async getCookieForTestUser() {
+    return this.getCookieForUser(TEST_USER_NAME, TEST_USER_PASSWORD);
+  }
+
+  /** Cookie for the Kibana server user configured in `servers.kibana.username/password`. */
+  async getCookieForKibanaUser() {
+    return this.getCookieForUser(
+      this.config.get('servers.kibana.username'),
+      this.config.get('servers.kibana.password')
+    );
+  }
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/cookie_auth/fetch_session_cookie.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/cookie_auth/fetch_session_cookie.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { format } from 'util';
+
+export interface SessionCookie {
+  name: string;
+  value: string;
+  url: string;
+}
+
+export interface FetchSessionCookieParams {
+  baseUrl: string;
+  username: string;
+  password: string;
+  /** Kibana version string, obtained from GET /api/status. */
+  kbnVersion: string;
+  /** Use 'cloud-basic' on Cloud, 'basic' for local. */
+  provider?: 'basic' | 'cloud-basic';
+}
+
+function extractCookieValue(headers: Headers): string {
+  const headersWithGetSetCookie = headers as Headers & { getSetCookie?: () => string[] };
+  const firstSetCookie = headersWithGetSetCookie.getSetCookie
+    ? headersWithGetSetCookie.getSetCookie()[0]
+    : headers.get('set-cookie');
+  return firstSetCookie?.split(';')[0].split('sid=')[1] ?? '';
+}
+
+/**
+ * Pure HTTP utility — no FTR service dependency.
+ * POSTs to Kibana's internal basic-auth login endpoint and returns the `sid` session cookie.
+ * Used by CookieAuthService (FTR service) and @kbn/journeys AuthService.
+ */
+export async function fetchSessionCookie(params: FetchSessionCookieParams): Promise<SessionCookie> {
+  const { baseUrl, username, password, kbnVersion, provider = 'basic' } = params;
+  const loginUrl = new URL('/internal/security/login', baseUrl);
+
+  const authResponse = await fetch(loginUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'kbn-version': kbnVersion,
+      'sec-fetch-mode': 'cors',
+      'sec-fetch-site': 'same-origin',
+      'x-elastic-internal-origin': 'Kibana',
+    },
+    body: JSON.stringify({
+      providerType: 'basic',
+      providerName: provider,
+      currentURL: new URL('/login?next=%2F', baseUrl).href,
+      params: { username, password },
+    }),
+    redirect: 'manual',
+  });
+
+  if (authResponse.status !== 200) {
+    throw new Error(
+      `[fetchSessionCookie] Kibana auth failed for '${username}': ` +
+        `code ${authResponse.status}, message: ${authResponse.statusText}`
+    );
+  }
+
+  const cookieValue = extractCookieValue(authResponse.headers);
+  if (!cookieValue) {
+    throw new Error(
+      format(
+        `[fetchSessionCookie] unable to determine auth cookie for '${username}'`,
+        Object.fromEntries(authResponse.headers.entries())
+      )
+    );
+  }
+
+  return { name: 'sid', value: cookieValue, url: baseUrl };
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/cookie_auth/index.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/cookie_auth/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { CookieAuthService } from './cookie_auth_service';
+export type { Cookie } from './cookie_auth_service';
+export { fetchSessionCookie } from './fetch_session_cookie';
+export type { SessionCookie, FetchSessionCookieParams } from './fetch_session_cookie';

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/security/test_user.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/security/test_user.ts
@@ -72,11 +72,14 @@ export class TestUser extends FtrService {
       full_name: 'test user',
     });
 
-    if (this.browser && this.testSubjects && !options?.skipBrowserRefresh) {
+    if (!options?.skipBrowserRefresh && this.browser && this.testSubjects) {
       if (
         (await this.browser.hasOpenWindow()) &&
         (await this.testSubjects.exists('kibanaChrome', { allowHidden: true }))
       ) {
+        // Reload the current page so Kibana fetches fresh capabilities for the updated roles.
+        // We do NOT use cookie injection here: the existing session remains valid after a role
+        // change and a browser.refresh() is sufficient — and faster — than creating a new session.
         await this.browser.refresh();
         // accept alert if it pops up
         const alert = await this.browser.getAlert();

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -353,6 +353,7 @@ export const schema = Joi.object()
           })
           .default(['superuser']),
         disableTestUser: Joi.boolean(),
+        cookieLogin: Joi.boolean().default(true),
       })
       .default(),
 

--- a/src/platform/test/functional/page_objects/common_page.ts
+++ b/src/platform/test/functional/page_objects/common_page.ts
@@ -30,6 +30,14 @@ export class CommonPageObject extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly loginPage = this.ctx.getPageObject('login');
   private readonly kibanaServer = this.ctx.getService('kibanaServer');
+  // cookieAuth / browserAuth are only registered in stateful functional configs.
+  // Use hasService guards so this page object remains safe in serverless configs too.
+  private readonly cookieAuth = this.ctx.hasService('cookieAuth')
+    ? this.ctx.getService('cookieAuth')
+    : undefined;
+  private readonly browserAuth = this.ctx.hasService('browserAuth')
+    ? this.ctx.getService('browserAuth')
+    : undefined;
 
   private readonly defaultTryTimeout = this.config.get('timeouts.try');
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
@@ -83,24 +91,37 @@ export class CommonPageObject extends FtrService {
 
     if (loginPage && !wantedLoginPage) {
       this.log.debug('Found login page');
-      if (this.config.get('security.disableTestUser')) {
-        await this.loginPage.login(
-          this.config.get('servers.kibana.username'),
-          this.config.get('servers.kibana.password')
-        );
+      if (this.config.get('security.cookieLogin') && this.cookieAuth && this.browserAuth) {
+        // Cookie-login path: generate a session via the login API and inject the sid cookie
+        // directly, bypassing the Selenium form fill entirely.
+        // Pass appUrl as targetUrl so loginByCookie navigates there in one step.
+        const cookie = this.config.get('security.disableTestUser')
+          ? await this.cookieAuth.getCookieForKibanaUser()
+          : await this.cookieAuth.getCookieForTestUser();
+        await this.browserAuth.loginByCookie(cookie, {
+          expectUserMenuButton: false,
+          targetUrl: appUrl,
+        });
       } else {
-        await this.loginPage.login('test_user', 'changeme');
-      }
+        if (this.config.get('security.disableTestUser')) {
+          await this.loginPage.login(
+            this.config.get('servers.kibana.username'),
+            this.config.get('servers.kibana.password')
+          );
+        } else {
+          await this.loginPage.login('test_user', 'changeme');
+        }
 
-      if (appUrl.includes('/status')) {
-        await this.testSubjects.find('statusPageRoot');
-      } else {
-        await this.find.byCssSelector(
-          '[data-test-subj="kibanaChrome"] nav:not(.ng-hide)',
-          6 * this.defaultFindTimeout
-        );
+        if (appUrl.includes('/status')) {
+          await this.testSubjects.find('statusPageRoot');
+        } else {
+          await this.find.byCssSelector(
+            '[data-test-subj="kibanaChrome"] nav:not(.ng-hide)',
+            6 * this.defaultFindTimeout
+          );
+        }
+        await this.browser.get(appUrl, insertTimestamp);
       }
-      await this.browser.get(appUrl, insertTimestamp);
       currentUrl = await this.browser.getCurrentUrl();
       this.log.debug(`Finished login process currentUrl = ${currentUrl}`);
     }

--- a/x-pack/platform/test/accessibility/apps/group1/config.ts
+++ b/x-pack/platform/test/accessibility/apps/group1/config.ts
@@ -22,6 +22,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     pageObjects,
     services,
 
+    security: {
+      ...functionalConfig.get('security'),
+      cookieLogin: false, // login_page.ts audits the login form UI itself
+    },
+
     junit: {
       reportName: 'X-Pack Patform Accessibility Tests - Group 1',
     },

--- a/x-pack/platform/test/functional/apps/security/config.ts
+++ b/x-pack/platform/test/functional/apps/security/config.ts
@@ -16,5 +16,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     esTestCluster: {
       ...functionalConfig.get('esTestCluster'),
     },
+    security: {
+      ...functionalConfig.get('security'),
+      cookieLogin: false, // these tests verify the login form itself
+    },
   };
 }

--- a/x-pack/platform/test/functional/config_security_basic.ts
+++ b/x-pack/platform/test/functional/config_security_basic.ts
@@ -70,5 +70,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     junit: {
       reportName: 'Chrome X-Pack UI Functional Tests (Security Basic)',
     },
+    security: {
+      cookieLogin: false, // these tests verify the login form itself
+    },
   };
 }

--- a/x-pack/platform/test/functional/page_objects/security_page.ts
+++ b/x-pack/platform/test/functional/page_objects/security_page.ts
@@ -44,6 +44,14 @@ export class SecurityPageObject extends FtrService {
   private readonly header = this.ctx.getPageObject('header');
   private readonly monacoEditor = this.ctx.getService('monacoEditor');
   private readonly es = this.ctx.getService('es');
+  // cookieAuth / browserAuth are only registered in stateful functional configs.
+  // Use hasService guards so SecurityPageObject remains safe in serverless configs too.
+  private readonly cookieAuth = this.ctx.hasService('cookieAuth')
+    ? this.ctx.getService('cookieAuth')
+    : undefined;
+  private readonly browserAuth = this.ctx.hasService('browserAuth')
+    ? this.ctx.getService('browserAuth')
+    : undefined;
 
   delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -264,6 +272,22 @@ export class SecurityPageObject extends FtrService {
   }
 
   async login(username?: string, password?: string, options: LoginOptions = {}) {
+    // When the cookie-login flag is on and we're not testing edge cases that require the
+    // real login form (space-selector or forbidden redirects), bypass form fill entirely.
+    if (
+      this.config.get('security.cookieLogin') &&
+      this.cookieAuth &&
+      this.browserAuth &&
+      !options.expectSpaceSelector &&
+      !options.expectForbidden
+    ) {
+      const resolvedUsername = username || adminTestUser.username;
+      const resolvedPassword = password || adminTestUser.password;
+      const cookie = await this.cookieAuth.getCookieForUser(resolvedUsername, resolvedPassword);
+      await this.browserAuth.loginByCookie(cookie, { expectedUsername: resolvedUsername });
+      return;
+    }
+
     await this.loginPage.login(username, password, options);
 
     if (options.expectSpaceSelector || options.expectForbidden) {
@@ -309,6 +333,17 @@ export class SecurityPageObject extends FtrService {
     this.log.debug('SecurityPage.forceLogout');
     if (await this.isLoginFormVisible()) {
       this.log.debug('Already on the login page, not forcing anything');
+      return;
+    }
+
+    // When cookie-login is active, skip the /logout server round-trip entirely.
+    // Clearing browser state is sufficient for test isolation — the next navigateToApp
+    // will redirect to /login and loginIfPrompted will inject a fresh cookie.
+    if (this.config.get('security.cookieLogin') && this.browserAuth) {
+      this.log.debug(
+        '[security] cookieLogin: clearing browser state instead of navigating to /logout'
+      );
+      await this.browserAuth.cleanBrowserState();
       return;
     }
 

--- a/x-pack/platform/test/functional_embedded/config.ts
+++ b/x-pack/platform/test/functional_embedded/config.ts
@@ -44,6 +44,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       reportName: 'Kibana Embedded in iframe with X-Pack Security',
     },
 
+    security: {
+      cookieLogin: false, // HTTPS with self-signed cert — native fetch() rejects it
+    },
+
     esTestCluster: kibanaFunctionalConfig.get('esTestCluster'),
     apps: {
       ...kibanaFunctionalConfig.get('apps'),

--- a/x-pack/platform/test/serverless/shared/config.base.ts
+++ b/x-pack/platform/test/serverless/shared/config.base.ts
@@ -187,7 +187,10 @@ export default async () => {
       ],
     },
 
-    security: { disableTestUser: true },
+    security: {
+      disableTestUser: true,
+      cookieLogin: false, // serverless uses SAML-based auth, not basic-auth cookie login
+    },
 
     // Used by FTR to recognize serverless project and change its behavior accordingly
     serverless: true,

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/data_views/config.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/data_views/config.ts
@@ -22,6 +22,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     pageObjects,
     services,
     testFiles: [resolve(__dirname, './data_views')],
+    security: {
+      ...xpackFunctionalConfig.get('security'),
+      cookieLogin: false,
+    },
     junit: {
       reportName: 'X-Pack Cloud Security Posture Functional Tests',
     },

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group1/config.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group1/config.ts
@@ -45,6 +45,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     },
     pageObjects,
     testFiles: [resolve(__dirname, './pages')],
+    security: {
+      ...xpackFunctionalConfig.get('security'),
+      cookieLogin: false,
     junit: {
       reportName: 'X-Pack Cloud Security Posture Functional Tests - Group 1',
     },

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group1/config.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group1/config.ts
@@ -48,6 +48,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     security: {
       ...xpackFunctionalConfig.get('security'),
       cookieLogin: false,
+    },
     junit: {
       reportName: 'X-Pack Cloud Security Posture Functional Tests - Group 1',
     },

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group2/config.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group2/config.ts
@@ -13,6 +13,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseConfig.getAll(),
     testFiles: [resolve(__dirname, './pages')],
+    security: {
+      ...baseConfig.get('security'),
+      cookieLogin: false, // tests rely on localStorage column state between steps; loginByCookie clears it
+    },
     junit: {
       reportName: 'X-Pack Cloud Security Posture Functional Tests - Group 2',
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ftr] replace UI login with cookie session (#271520)](https://github.com/elastic/kibana/pull/271520)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T21:10:22Z","message":"[ftr] replace UI login with cookie session (#271520)\n\n## Summary\n\n\n### Cookie-based browser login for stateful FTR tests\n\nInstead of driving the Kibana login form through Selenium (type\nusername, type password, click submit, wait for redirect), the test\ninfrastructure now acquires a session cookie via a direct HTTP POST\n`/internal/security/login` call and injects it into the browser. This\nbypasses all form interaction entirely.\n\nThree files changed in `@kbn/ftr-common-functional-services`:\n\n- `CookieAuthService` — makes the HTTP login call and returns the sid\ncookie value\n- `BrowserAuthService` — clears browser state and injects the cookie,\nthen navigates directly to the target app URL\n- `fetchSessionCookie` — shared utility also consumed by @kbn/journeys\n(deduplicates existing logic there)\n\nThree existing login entry-points updated to branch on a config flag:\n- `SecurityPageObject.login()` — takes the cookie path unless the test\nexplicitly expects expectSpaceSelector or expectForbidden (those still\nneed the real form)\n- `CommonPageObject.loginIfPrompted()` — same; fires on first\n`navigateToApp` when no session exists\n- `SecurityPageObject.forceLogout()` — instead of navigating to\n`/logout` and waiting for the server redirect, just clears browser\ncookies/storage directly\n- Rollout is opt-in per config via `security.cookieLogin`, which\ndefaults to `true` in the schema. Only 5 configs opt out with\n`cookieLogin: false`: (e.g. `apps/security` suite and\n`config_security_basic`, because those tests deliberately verify the\nlogin form UI itself) + serverless default config - it uses it's own\nhelper for SAML Auth + Cookie injection\n\n\n### Approximate time saving:\n\nEvent | Count | Avg saved | Total\n-- | -- | -- | --\n`loginIfPrompted` (1 per config, 155 eligible configs) | 155 | 4s | 620s\nStandalone `security.login()` (no preceding forceLogout) | ~20 | 4s |\n80s\n`forceLogout()` + `security.login()` pairs | ~40 | 7s | 280s\nStandalone `forceLogout()` in after() cleanup hooks | ~60 | 2.5s | 150s\nTotal serialized |   |   | ~1130s ≈ 19 min\n\n**155** FTR configs are running the cookie path","sha":"cedc2787ed7106644b64c32ef1b1670db6b5f9a1","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","reviewer:claude","v9.5.0","v9.4.2"],"title":"[ftr] replace UI login with cookie session","number":271520,"url":"https://github.com/elastic/kibana/pull/271520","mergeCommit":{"message":"[ftr] replace UI login with cookie session (#271520)\n\n## Summary\n\n\n### Cookie-based browser login for stateful FTR tests\n\nInstead of driving the Kibana login form through Selenium (type\nusername, type password, click submit, wait for redirect), the test\ninfrastructure now acquires a session cookie via a direct HTTP POST\n`/internal/security/login` call and injects it into the browser. This\nbypasses all form interaction entirely.\n\nThree files changed in `@kbn/ftr-common-functional-services`:\n\n- `CookieAuthService` — makes the HTTP login call and returns the sid\ncookie value\n- `BrowserAuthService` — clears browser state and injects the cookie,\nthen navigates directly to the target app URL\n- `fetchSessionCookie` — shared utility also consumed by @kbn/journeys\n(deduplicates existing logic there)\n\nThree existing login entry-points updated to branch on a config flag:\n- `SecurityPageObject.login()` — takes the cookie path unless the test\nexplicitly expects expectSpaceSelector or expectForbidden (those still\nneed the real form)\n- `CommonPageObject.loginIfPrompted()` — same; fires on first\n`navigateToApp` when no session exists\n- `SecurityPageObject.forceLogout()` — instead of navigating to\n`/logout` and waiting for the server redirect, just clears browser\ncookies/storage directly\n- Rollout is opt-in per config via `security.cookieLogin`, which\ndefaults to `true` in the schema. Only 5 configs opt out with\n`cookieLogin: false`: (e.g. `apps/security` suite and\n`config_security_basic`, because those tests deliberately verify the\nlogin form UI itself) + serverless default config - it uses it's own\nhelper for SAML Auth + Cookie injection\n\n\n### Approximate time saving:\n\nEvent | Count | Avg saved | Total\n-- | -- | -- | --\n`loginIfPrompted` (1 per config, 155 eligible configs) | 155 | 4s | 620s\nStandalone `security.login()` (no preceding forceLogout) | ~20 | 4s |\n80s\n`forceLogout()` + `security.login()` pairs | ~40 | 7s | 280s\nStandalone `forceLogout()` in after() cleanup hooks | ~60 | 2.5s | 150s\nTotal serialized |   |   | ~1130s ≈ 19 min\n\n**155** FTR configs are running the cookie path","sha":"cedc2787ed7106644b64c32ef1b1670db6b5f9a1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271520","number":271520,"mergeCommit":{"message":"[ftr] replace UI login with cookie session (#271520)\n\n## Summary\n\n\n### Cookie-based browser login for stateful FTR tests\n\nInstead of driving the Kibana login form through Selenium (type\nusername, type password, click submit, wait for redirect), the test\ninfrastructure now acquires a session cookie via a direct HTTP POST\n`/internal/security/login` call and injects it into the browser. This\nbypasses all form interaction entirely.\n\nThree files changed in `@kbn/ftr-common-functional-services`:\n\n- `CookieAuthService` — makes the HTTP login call and returns the sid\ncookie value\n- `BrowserAuthService` — clears browser state and injects the cookie,\nthen navigates directly to the target app URL\n- `fetchSessionCookie` — shared utility also consumed by @kbn/journeys\n(deduplicates existing logic there)\n\nThree existing login entry-points updated to branch on a config flag:\n- `SecurityPageObject.login()` — takes the cookie path unless the test\nexplicitly expects expectSpaceSelector or expectForbidden (those still\nneed the real form)\n- `CommonPageObject.loginIfPrompted()` — same; fires on first\n`navigateToApp` when no session exists\n- `SecurityPageObject.forceLogout()` — instead of navigating to\n`/logout` and waiting for the server redirect, just clears browser\ncookies/storage directly\n- Rollout is opt-in per config via `security.cookieLogin`, which\ndefaults to `true` in the schema. Only 5 configs opt out with\n`cookieLogin: false`: (e.g. `apps/security` suite and\n`config_security_basic`, because those tests deliberately verify the\nlogin form UI itself) + serverless default config - it uses it's own\nhelper for SAML Auth + Cookie injection\n\n\n### Approximate time saving:\n\nEvent | Count | Avg saved | Total\n-- | -- | -- | --\n`loginIfPrompted` (1 per config, 155 eligible configs) | 155 | 4s | 620s\nStandalone `security.login()` (no preceding forceLogout) | ~20 | 4s |\n80s\n`forceLogout()` + `security.login()` pairs | ~40 | 7s | 280s\nStandalone `forceLogout()` in after() cleanup hooks | ~60 | 2.5s | 150s\nTotal serialized |   |   | ~1130s ≈ 19 min\n\n**155** FTR configs are running the cookie path","sha":"cedc2787ed7106644b64c32ef1b1670db6b5f9a1"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/271795","number":271795,"state":"MERGED","mergeCommit":{"sha":"91faad9eaf9730b1e6e32cb6b65e1732635362d5","message":"[9.4] [ftr] replace UI login with cookie session (#271520) (#271795)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[ftr] replace UI login with cookie session\n(#271520)](https://github.com/elastic/kibana/pull/271520)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/271794","number":271794,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->