### PR TITLE
[9.4] [transform] move loadIfNeeded in index file, remove unloading and afterAll hook on finish (#271265)

### DIFF
--- a/x-pack/platform/test/functional/apps/transform/actions/deleting.ts
+++ b/x-pack/platform/test/functional/apps/transform/actions/deleting.ts
@@ -11,7 +11,6 @@ import type { FtrProviderContext } from '../../../ftr_provider_context';
 import { getLatestTransformConfig, getPivotTransformConfig } from '../helpers';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('deleting', function () {
@@ -64,7 +63,6 @@ export default function ({ getService }: FtrProviderContext) {
     ];
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {

--- a/x-pack/platform/test/functional/apps/transform/actions/index.ts
+++ b/x-pack/platform/test/functional/apps/transform/actions/index.ts
@@ -17,19 +17,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     before(async () => {
       await transform.securityCommon.createTransformRoles();
       await transform.securityCommon.createTransformUsers();
-    });
-
-    after(async () => {
-      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-      await transform.securityUI.logout();
-
-      await transform.securityCommon.cleanTransformUsers();
-      await transform.securityCommon.cleanTransformRoles();
-
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-
-      await transform.testResources.resetKibanaTimeZone();
+      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
     });
 
     loadTestFile(require.resolve('./deleting'));

--- a/x-pack/platform/test/functional/apps/transform/actions/reauthorizing.ts
+++ b/x-pack/platform/test/functional/apps/transform/actions/reauthorizing.ts
@@ -54,7 +54,6 @@ function generateHeaders(apiKey: SecurityCreateApiKeyResponse, version?: string)
 }
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   const apiKeysForTransformUsers = new Map<USER, SecurityCreateApiKeyResponse>();
@@ -137,7 +136,6 @@ export default function ({ getService }: FtrProviderContext) {
         apiKeysForTransformUsers.set(user.name as USER, apiKey)
       );
 
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {

--- a/x-pack/platform/test/functional/apps/transform/actions/resetting.ts
+++ b/x-pack/platform/test/functional/apps/transform/actions/resetting.ts
@@ -11,7 +11,6 @@ import type { FtrProviderContext } from '../../../ftr_provider_context';
 import { getLatestTransformConfig, getPivotTransformConfig } from '../helpers';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('resetting', function () {
@@ -66,7 +65,6 @@ export default function ({ getService }: FtrProviderContext) {
     ];
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {

--- a/x-pack/platform/test/functional/apps/transform/actions/starting.ts
+++ b/x-pack/platform/test/functional/apps/transform/actions/starting.ts
@@ -45,7 +45,6 @@ interface TestDataLatest {
 type TestData = TestDataPivot | TestDataLatest;
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('starting', function () {
@@ -109,7 +108,6 @@ export default function ({ getService }: FtrProviderContext) {
     ];
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {

--- a/x-pack/platform/test/functional/apps/transform/creation/index_pattern/creation_index_pattern.ts
+++ b/x-pack/platform/test/functional/apps/transform/creation/index_pattern/creation_index_pattern.ts
@@ -13,13 +13,11 @@ import { isLatestTransformTestData, isPivotTransformTestData } from '../../helpe
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const canvasElement = getService('canvasElement');
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
   const pageObjects = getPageObjects(['discover']);
 
   describe('creation_index_pattern', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await transform.testResources.setKibanaTimeZoneToUTC();
 

--- a/x-pack/platform/test/functional/apps/transform/creation/index_pattern/index.ts
+++ b/x-pack/platform/test/functional/apps/transform/creation/index_pattern/index.ts
@@ -17,19 +17,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     before(async () => {
       await transform.securityCommon.createTransformRoles();
       await transform.securityCommon.createTransformUsers();
-    });
-
-    after(async () => {
-      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-      await transform.securityUI.logout();
-
-      await transform.securityCommon.cleanTransformUsers();
-      await transform.securityCommon.cleanTransformRoles();
-
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-
-      await transform.testResources.resetKibanaTimeZone();
+      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
     });
 
     loadTestFile(require.resolve('./creation_index_pattern'));

--- a/x-pack/platform/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_runtime_mappings.ts
+++ b/x-pack/platform/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_runtime_mappings.ts
@@ -14,7 +14,6 @@ import type { GroupByEntry, LatestTransformTestData, PivotTransformTestData } fr
 import { isLatestTransformTestData, isPivotTransformTestData } from '../../helpers';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   const runtimeMappings = {
@@ -30,7 +29,6 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('creation with runtime mappings', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/farequote');
       await transform.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await transform.testResources.setKibanaTimeZoneToUTC();
 

--- a/x-pack/platform/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_saved_search.ts
+++ b/x-pack/platform/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_saved_search.ts
@@ -12,12 +12,10 @@ import type { GroupByEntry, LatestTransformTestData, PivotTransformTestData } fr
 import { isLatestTransformTestData, isPivotTransformTestData } from '../../helpers';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('creation_saved_search', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/farequote');
       await transform.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await transform.testResources.createSavedSearchFarequoteFilterIfNeeded();
       await transform.testResources.setKibanaTimeZoneToUTC();

--- a/x-pack/platform/test/functional/apps/transform/creation/runtime_mappings_saved_search/index.ts
+++ b/x-pack/platform/test/functional/apps/transform/creation/runtime_mappings_saved_search/index.ts
@@ -17,19 +17,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     before(async () => {
       await transform.securityCommon.createTransformRoles();
       await transform.securityCommon.createTransformUsers();
-    });
-
-    after(async () => {
-      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-      await transform.securityUI.logout();
-
-      await transform.securityCommon.cleanTransformUsers();
-      await transform.securityCommon.cleanTransformRoles();
-
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-
-      await transform.testResources.resetKibanaTimeZone();
+      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/farequote');
     });
 
     loadTestFile(require.resolve('./creation_saved_search'));

--- a/x-pack/platform/test/functional/apps/transform/edit_clone/cloning.ts
+++ b/x-pack/platform/test/functional/apps/transform/edit_clone/cloning.ts
@@ -183,7 +183,6 @@ function getTransformConfigWithBoolFilterAgg(): TransformPivotConfig {
 }
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   // Failing: See https://github.com/elastic/kibana/issues/165883
@@ -195,7 +194,6 @@ export default function ({ getService }: FtrProviderContext) {
     const transformConfigWithLatest = getLatestTransformConfig('cloning');
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await transform.api.createAndRunTransform(
         transformConfigWithPivot.id,

--- a/x-pack/platform/test/functional/apps/transform/edit_clone/editing.ts
+++ b/x-pack/platform/test/functional/apps/transform/edit_clone/editing.ts
@@ -15,7 +15,6 @@ import type { FtrProviderContext } from '../../../ftr_provider_context';
 import { getLatestTransformConfig, getPivotTransformConfig } from '../helpers';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('editing', function () {
@@ -26,7 +25,6 @@ export default function ({ getService }: FtrProviderContext) {
     };
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
       await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       await transform.api.createAndRunTransform(

--- a/x-pack/platform/test/functional/apps/transform/edit_clone/index.ts
+++ b/x-pack/platform/test/functional/apps/transform/edit_clone/index.ts
@@ -17,19 +17,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     before(async () => {
       await transform.securityCommon.createTransformRoles();
       await transform.securityCommon.createTransformUsers();
-    });
-
-    after(async () => {
-      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-      await transform.securityUI.logout();
-
-      await transform.securityCommon.cleanTransformUsers();
-      await transform.securityCommon.cleanTransformRoles();
-
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-
-      await transform.testResources.resetKibanaTimeZone();
+      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
     });
 
     loadTestFile(require.resolve('./cloning'));

--- a/x-pack/platform/test/functional/apps/transform/feature_controls/index.ts
+++ b/x-pack/platform/test/functional/apps/transform/feature_controls/index.ts
@@ -8,7 +8,6 @@
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('transform - feature controls', function () {
@@ -17,19 +16,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     before(async () => {
       await transform.securityCommon.createTransformRoles();
       await transform.securityCommon.createTransformUsers();
-    });
-
-    after(async () => {
-      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-      await transform.securityUI.logout();
-
-      await transform.securityCommon.cleanTransformUsers();
-      await transform.securityCommon.cleanTransformRoles();
-
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-
-      await transform.testResources.resetKibanaTimeZone();
     });
 
     loadTestFile(require.resolve('./transform_security'));

--- a/x-pack/platform/test/functional/apps/transform/permissions/full_transform_access.ts
+++ b/x-pack/platform/test/functional/apps/transform/permissions/full_transform_access.ts
@@ -10,7 +10,6 @@ import { getPivotTransformConfig } from '../helpers';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('for user with full transform access', function () {
@@ -54,7 +53,6 @@ export default function ({ getService }: FtrProviderContext) {
       const transformConfigWithPivot = getPivotTransformConfig(PREFIX, false);
 
       before(async () => {
-        await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
         await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
         await transform.api.createAndRunTransform(

--- a/x-pack/platform/test/functional/apps/transform/permissions/index.ts
+++ b/x-pack/platform/test/functional/apps/transform/permissions/index.ts
@@ -17,19 +17,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     before(async () => {
       await transform.securityCommon.createTransformRoles();
       await transform.securityCommon.createTransformUsers();
-    });
-
-    after(async () => {
-      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
-      await transform.securityUI.logout();
-
-      await transform.securityCommon.cleanTransformUsers();
-      await transform.securityCommon.cleanTransformRoles();
-
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-
-      await transform.testResources.resetKibanaTimeZone();
+      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
     });
 
     loadTestFile(require.resolve('./full_transform_access'));

--- a/x-pack/platform/test/functional/apps/transform/permissions/read_transform_access.ts
+++ b/x-pack/platform/test/functional/apps/transform/permissions/read_transform_access.ts
@@ -10,7 +10,6 @@ import { getPivotTransformConfig } from '../helpers';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
   describe('for user with read only transform access', function () {
@@ -54,7 +53,6 @@ export default function ({ getService }: FtrProviderContext) {
       const transformConfigWithPivot = getPivotTransformConfig(PREFIX, false);
 
       before(async () => {
-        await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
         await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
         await transform.api.createAndRunTransform(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[transform] move loadIfNeeded in index file, remove unloading and afterAll hook on finish (#271265)](https://github.com/elastic/kibana/pull/271265)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-27T03:59:27Z","message":"[transform] move loadIfNeeded in index file, remove unloading and afterAll hook on finish (#271265)\n\n## Summary\n\nDoing the same changes over each Transform FTR config to cut CI runtime:\n\n- Add one await `esArchiver.loadIfNeeded('X')` in the index file's\nbefore hook.\n- Delete the per-child `loadIfNeeded('X')` calls.\n- Delete any `esArchiver.unload('X')` in the index after hook.\n\nSince we stop servers after each FTR config is finished, unloading data\nis wasted time.\n\nSome numbers:\n\n- `loadIfNeeded` calls eliminated per CI run: 12 (hoisted once per suite\ninstead of once per child)\n- `esArchiver.unload(...)` calls removed: 12 (2 per index file × 6\nsuites)\n- Total esArchiver ops eliminated per CI run: ~24\n\nSince each FTR config gets its own fresh ES+Kibana instance, none of the\ntop-level after hooks have any effect on subsequent configs. Saving time\nby removing them and related calls across all 6 suites:\n\n- `transform.securityUI.logout()` — browser session is killed with the\nserver anyway\n- `transform.securityCommon.cleanTransformUsers/Roles()` — ES security\nobjects destroyed with the server\n- `transform.testResources.resetKibanaTimeZone()` — Kibana instance\ndestroyed with the server","sha":"0e225a385b99fafe0d57932c9a5ac96d1c7e5cf5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.5.0"],"title":"[transform] move loadIfNeeded in index file, remove unloading and afterAll hook on finish","number":271265,"url":"https://github.com/elastic/kibana/pull/271265","mergeCommit":{"message":"[transform] move loadIfNeeded in index file, remove unloading and afterAll hook on finish (#271265)\n\n## Summary\n\nDoing the same changes over each Transform FTR config to cut CI runtime:\n\n- Add one await `esArchiver.loadIfNeeded('X')` in the index file's\nbefore hook.\n- Delete the per-child `loadIfNeeded('X')` calls.\n- Delete any `esArchiver.unload('X')` in the index after hook.\n\nSince we stop servers after each FTR config is finished, unloading data\nis wasted time.\n\nSome numbers:\n\n- `loadIfNeeded` calls eliminated per CI run: 12 (hoisted once per suite\ninstead of once per child)\n- `esArchiver.unload(...)` calls removed: 12 (2 per index file × 6\nsuites)\n- Total esArchiver ops eliminated per CI run: ~24\n\nSince each FTR config gets its own fresh ES+Kibana instance, none of the\ntop-level after hooks have any effect on subsequent configs. Saving time\nby removing them and related calls across all 6 suites:\n\n- `transform.securityUI.logout()` — browser session is killed with the\nserver anyway\n- `transform.securityCommon.cleanTransformUsers/Roles()` — ES security\nobjects destroyed with the server\n- `transform.testResources.resetKibanaTimeZone()` — Kibana instance\ndestroyed with the server","sha":"0e225a385b99fafe0d57932c9a5ac96d1c7e5cf5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271265","number":271265,"mergeCommit":{"message":"[transform] move loadIfNeeded in index file, remove unloading and afterAll hook on finish (#271265)\n\n## Summary\n\nDoing the same changes over each Transform FTR config to cut CI runtime:\n\n- Add one await `esArchiver.loadIfNeeded('X')` in the index file's\nbefore hook.\n- Delete the per-child `loadIfNeeded('X')` calls.\n- Delete any `esArchiver.unload('X')` in the index after hook.\n\nSince we stop servers after each FTR config is finished, unloading data\nis wasted time.\n\nSome numbers:\n\n- `loadIfNeeded` calls eliminated per CI run: 12 (hoisted once per suite\ninstead of once per child)\n- `esArchiver.unload(...)` calls removed: 12 (2 per index file × 6\nsuites)\n- Total esArchiver ops eliminated per CI run: ~24\n\nSince each FTR config gets its own fresh ES+Kibana instance, none of the\ntop-level after hooks have any effect on subsequent configs. Saving time\nby removing them and related calls across all 6 suites:\n\n- `transform.securityUI.logout()` — browser session is killed with the\nserver anyway\n- `transform.securityCommon.cleanTransformUsers/Roles()` — ES security\nobjects destroyed with the server\n- `transform.testResources.resetKibanaTimeZone()` — Kibana instance\ndestroyed with the server","sha":"0e225a385b99fafe0d57932c9a5ac96d1c7e5cf5"}}]}] BACKPORT-->