### PR TITLE
[Fleet] Fix fleet view policies panel overlap with sidebar

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
@@ -17,6 +17,7 @@ import {
 import { EuiResizableButton, EuiPanel, keys } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { layoutVar } from '@kbn/core-chrome-layout-constants';
 
 const getMouseOrTouchY = (
   e: TouchEvent | MouseEvent | React.MouseEvent | React.TouchEvent
@@ -120,10 +121,12 @@ export const ResizablePanelComponent: React.FunctionComponent<{
         position: fixed;
         padding: 0;
         bottom: 0;
+        left: ${layoutVar('application.left')};
         background: ${euiTheme.euiTheme.colors.backgroundBasePlain};
       `}
     >
       {topBar}
+
       <EuiResizableButton
         css={css`
           position: absolute;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
@@ -181,38 +181,57 @@ export const ResizablePanel: React.FunctionComponent<{
         <EuiFlexGroup responsive={false} gutterSize="none">
           <EuiFlexItem grow={false}>
             {isCollapsed ? (
-              <EuiButtonIcon
-                key="chevronSingleUp"
-                iconType="chevronSingleUp"
-                aria-label={i18n.translate(
-                  'xpack.fleet.integrationsResizablePanel.collapseButton',
-                  { defaultMessage: 'Collapse panel' }
-                )}
-                color="text"
-                onClick={toggleCollpase}
-              />
+              <EuiToolTip
+                content={i18n.translate('xpack.fleet.integrationsResizablePanel.collapseButton', {
+                  defaultMessage: 'Collapse panel',
+                })}
+              >
+                <EuiButtonIcon
+                  key="chevronSingleUp"
+                  iconType="chevronSingleUp"
+                  aria-label={i18n.translate(
+                    'xpack.fleet.integrationsResizablePanel.collapseButton',
+                    { defaultMessage: 'Collapse panel' }
+                  )}
+                  color="text"
+                  onClick={toggleCollpase}
+                />
+              </EuiToolTip>
             ) : (
-              <EuiButtonIcon
-                key="chevronSingleDown"
-                iconType="chevronSingleDown"
-                aria-label={i18n.translate(
-                  'xpack.fleet.integrationsResizablePanel.collapseButton',
-                  { defaultMessage: 'Collapse panel' }
-                )}
-                color="text"
-                onClick={toggleCollpase}
-              />
+              <EuiToolTip
+                content={i18n.translate('xpack.fleet.integrationsResizablePanel.collapseButton', {
+                  defaultMessage: 'Collapse panel',
+                })}
+              >
+                <EuiButtonIcon
+                  key="chevronSingleDown"
+                  iconType="chevronSingleDown"
+                  aria-label={i18n.translate(
+                    'xpack.fleet.integrationsResizablePanel.collapseButton',
+                    { defaultMessage: 'Collapse panel' }
+                  )}
+                  color="text"
+                  onClick={toggleCollpase}
+                />
+              </EuiToolTip>
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="cross"
-              aria-label={i18n.translate('xpack.fleet.integrationsResizablePanel.closeButton', {
+            <EuiToolTip
+              content={i18n.translate('xpack.fleet.integrationsResizablePanel.closeButton', {
                 defaultMessage: 'Close panel',
               })}
-              color="text"
-              onClick={onClose}
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label={i18n.translate('xpack.fleet.integrationsResizablePanel.closeButton', {
+                  defaultMessage: 'Close panel',
+                })}
+                color="text"
+                onClick={onClose}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPortal,
+  EuiToolTip,
   useEuiPaddingCSS,
   useEuiTheme,
 } from '@elastic/eui';


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/244848

Fix fleet view policies panel overlap with sidebar, on serverless

Before 
<img width="1234" height="948" alt="image" src="https://github.com/user-attachments/assets/80c38c54-18c9-4596-b7fe-11947deaa131" />


After 

<img width="900" alt="Screenshot 2026-06-03 at 10 02 32 AM" src="https://github.com/user-attachments/assets/9162ebe4-9711-47f5-9c05-015a5a44e1ff" />
<img width="900" alt="Screenshot 2026-06-03 at 10 02 25 AM" src="https://github.com/user-attachments/assets/c0d03c08-644a-4ac0-b89f-46e27ae222b3" />


<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->