### PR TITLE
[Inference Connectors] Move deprecation badge to connector type

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -374,6 +374,7 @@ const ActionsConnectorsList = ({
                 tooltipContent={DEPRECATED_CONNECTOR_TOOLTIP_CONTENT}
                 color="warning"
                 size="s"
+                alignment="middle"
               />
             </EuiFlexItem>
             {isLLMConnectorTypeId(item.actionTypeId) && (

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -368,15 +368,6 @@ const ActionsConnectorsList = ({
         return (
           <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>{actionType}</EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBetaBadge
-                label={DEPRECATED_LABEL}
-                tooltipContent={DEPRECATED_CONNECTOR_TOOLTIP_CONTENT}
-                color="warning"
-                size="s"
-                alignment="middle"
-              />
-            </EuiFlexItem>
             {isLLMConnectorTypeId(item.actionTypeId) && (
               <EuiFlexItem grow={false}>
                 <EuiIconTip
@@ -387,6 +378,15 @@ const ActionsConnectorsList = ({
                 />
               </EuiFlexItem>
             )}
+            <EuiFlexItem grow={false}>
+              <EuiBetaBadge
+                label={DEPRECATED_LABEL}
+                tooltipContent={DEPRECATED_CONNECTOR_TOOLTIP_CONTENT}
+                color="warning"
+                size="s"
+                alignment="middle"
+              />
+            </EuiFlexItem>
           </EuiFlexGroup>
         );
       },

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -236,10 +236,6 @@ const ActionsConnectorsList = ({
     setConnectorsToDelete(itemIds);
     setDeleteConnectorWarning(itemIds);
   }
-  const hasDeprecatedConnectors = useMemo(() => {
-    return actionConnectorTableItems.some((item) => item.isConnectorTypeDeprecated);
-  }, [actionConnectorTableItems]);
-
   const actionsTableColumns = [
     {
       field: 'name',
@@ -356,38 +352,6 @@ const ActionsConnectorsList = ({
         );
       },
     },
-    ...(hasDeprecatedConnectors
-      ? [
-          {
-            name: '',
-            render: (item: ActionConnectorTableItem) => {
-              if (!item.isConnectorTypeDeprecated) return null;
-              return (
-                <EuiFlexGroup gutterSize="xs" alignItems="center" justifyContent="center">
-                  <EuiFlexItem grow={false}>
-                    <EuiBetaBadge
-                      label={DEPRECATED_LABEL}
-                      tooltipContent={DEPRECATED_CONNECTOR_TOOLTIP_CONTENT}
-                      color="warning"
-                      size="s"
-                    />
-                  </EuiFlexItem>
-                  {isLLMConnectorTypeId(item.actionTypeId) && (
-                    <EuiFlexItem grow={false}>
-                      <EuiIconTip
-                        type="info"
-                        color="subdued"
-                        content={DEPRECATED_LLM_CONNECTOR_INFO}
-                        data-test-subj={`deprecatedLLMConnectorInfo-${item.id}`}
-                      />
-                    </EuiFlexItem>
-                  )}
-                </EuiFlexGroup>
-              );
-            },
-          },
-        ]
-      : []),
     {
       field: 'actionType',
       'data-test-subj': 'connectorsTableCell-actionType',
@@ -399,6 +363,32 @@ const ActionsConnectorsList = ({
       ),
       sortable: false,
       truncateText: true,
+      render: (actionType: string, item: ActionConnectorTableItem) => {
+        if (!item.isConnectorTypeDeprecated) return actionType;
+        return (
+          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>{actionType}</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBetaBadge
+                label={DEPRECATED_LABEL}
+                tooltipContent={DEPRECATED_CONNECTOR_TOOLTIP_CONTENT}
+                color="warning"
+                size="s"
+              />
+            </EuiFlexItem>
+            {isLLMConnectorTypeId(item.actionTypeId) && (
+              <EuiFlexItem grow={false}>
+                <EuiIconTip
+                  type="info"
+                  color="subdued"
+                  content={DEPRECATED_LLM_CONNECTOR_INFO}
+                  data-test-subj={`deprecatedLLMConnectorInfo-${item.id}`}
+                />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        );
+      },
     },
     {
       field: 'compatibility',


### PR DESCRIPTION
## Summary

Moves the deprecation badge from the connector name to the connector type, as the type is the thing that's deprecated, not the specific connector.


<img width="1264" height="402" alt="Screenshot 2026-06-04 at 16 41 54" src="https://github.com/user-attachments/assets/e6bc7e5b-ff21-4530-be48-9e01cc754d3b" />


