### PR TITLE
[Agent Builder] Full-width attachment header with chart-type-specific visualization dimensions

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -222,11 +222,6 @@ export interface AttachmentUIDefinition<TAttachment extends UnknownAttachment = 
    * Buttons will appear alongside or below the rendered content.
    */
   getActionButtons?: (params: GetActionButtonsParams<TAttachment>) => ActionButton[];
-  /**
-   * Optional max-width (in px) for the inline attachment panel.
-   * When provided, the outer panel will not exceed this width.
-   */
-  getMaxWidth?: (attachment: TAttachment) => number | undefined;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/attachments/visualization_attachment.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/attachments/visualization_attachment.tsx
@@ -11,7 +11,6 @@ import { i18n } from '@kbn/i18n';
 import type { VisualizationAttachment } from '@kbn/agent-builder-common/attachments';
 import { type AttachmentUIDefinition } from '@kbn/agent-builder-browser/attachments';
 import type { AgentBuilderStartDependencies } from '../../../types';
-import { getVisualizationDimensionsFromLensConfig } from '../tools/esql/shared/get_visualization_dimensions';
 
 const LazyVisualizeLens = React.lazy(() =>
   import('../tools/esql/visualize_lens').then((m) => ({ default: m.VisualizeLens }))
@@ -36,10 +35,6 @@ export const createVisualizationAttachmentDefinition = ({
           });
     },
     getIcon: () => 'lensApp',
-    getMaxWidth: (attachment) =>
-      getVisualizationDimensionsFromLensConfig(
-        attachment.data.visualization as Record<string, unknown>
-      ).width,
     renderInlineContent: ({ attachment, screenContext }, callbacks) => {
       const timeRange = attachment.data.time_range ?? screenContext?.time_range;
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -132,7 +132,6 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
 
   const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
   const header = uiDefinition?.getHeader?.({ attachment });
-  const maxWidth = uiDefinition?.getMaxWidth?.(attachment);
 
   return (
     <EuiSplitPanel.Outer
@@ -141,7 +140,6 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
       hasBorder={true}
       css={css`
         overflow: visible; // allow vis actions to overflow
-        ${maxWidth !== undefined ? `max-width: ${maxWidth}px;` : ''}
       `}
     >
       <AttachmentHeader

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/get_visualization_dimensions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/get_visualization_dimensions.ts
@@ -19,7 +19,7 @@ export interface VisualizationDimensions {
 export const DEFAULT_VISUALIZATION_HEIGHT = 240;
 
 const METRIC_DIMENSIONS: VisualizationDimensions = {
-  height: 130,
+  height: 158,
   width: 260,
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
@@ -12,27 +12,39 @@ export const visualizationActionsClassName = 'agentBuilderVisualizationActions';
 export const visualizationTimePickerContainerClassName =
   'agentBuilderVisualizationTimePickerContainer';
 
-export const visualizationWrapperStyles = ({ euiTheme }: UseEuiTheme) =>
-  css({
-    position: 'relative',
-    overflow: 'visible',
-    display: 'flex',
-    flexDirection: 'column',
-    [`.${visualizationActionsClassName} + .${visualizationTimePickerContainerClassName}`]: {
-      width: `calc(100% - ${euiTheme.base * 4}px)`,
-    },
-    '.echChart ul': {
-      marginInlineStart: 0,
-    },
+export const visualizationWrapperStyles =
+  (dimensions?: { width?: number }) =>
+  ({ euiTheme }: UseEuiTheme) =>
+    css({
+      position: 'relative',
+      overflow: 'visible',
+      display: 'flex',
+      flexDirection: 'column',
+      ...(dimensions?.width !== undefined
+        ? {
+            maxWidth: dimensions.width,
+            '.echMetric': {
+              border: euiTheme.border.thin,
+              borderRadius: euiTheme.border.radius.small,
+              overflow: 'hidden',
+            },
+          }
+        : {}),
+      [`.${visualizationActionsClassName} + .${visualizationTimePickerContainerClassName}`]: {
+        width: `calc(100% - ${euiTheme.base * 4}px)`,
+      },
+      '.echChart ul': {
+        marginInlineStart: 0,
+      },
 
-    p: {
-      margin: 0,
-    },
+      p: {
+        margin: 0,
+      },
 
-    '.expExpressionRenderer__expression': {
-      padding: `${euiTheme.size.s} 0`,
-    },
-  });
+      '.expExpressionRenderer__expression': {
+        padding: `${euiTheme.size.s} 0`,
+      },
+    });
 
 export const visualizationHeaderStyles = ({ euiTheme }: UseEuiTheme) =>
   css({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
@@ -26,7 +26,6 @@ export const visualizationWrapperStyles =
             '.echMetric': {
               border: euiTheme.border.thin,
               borderRadius: euiTheme.border.radius.small,
-              overflow: 'hidden',
             },
           }
         : {}),
@@ -34,6 +33,7 @@ export const visualizationWrapperStyles =
         width: `calc(100% - ${euiTheme.base * 4}px)`,
       },
       '.echChart ul': {
+        listStyleType: 'none',
         marginInlineStart: 0,
       },
 
@@ -43,6 +43,9 @@ export const visualizationWrapperStyles =
 
       '.expExpressionRenderer__expression': {
         padding: `${euiTheme.size.s} 0`,
+        '[class*="metric_vis_renderer"]': {
+          paddingLeft: euiTheme.size.base,
+        },
       },
     });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_esql/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_esql/index.tsx
@@ -60,8 +60,7 @@ export function VisualizeESQL({
       hasShadow={false}
       hasBorder={true}
       css={[
-        visualizationWrapperStyles,
-        width !== undefined ? css({ maxWidth: width }) : undefined,
+        visualizationWrapperStyles({ width }),
         ({ euiTheme }: UseEuiTheme) =>
           css({
             marginBlockEnd: euiTheme.size.m,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_lens/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_lens/index.tsx
@@ -10,7 +10,6 @@ import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
 import React, { useCallback, useState } from 'react';
 import { EuiCallOut } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import {
   type ActionButton,
@@ -73,7 +72,7 @@ export function VisualizeLens({
   return (
     <div
       data-test-subj="lensVisualization"
-      css={[visualizationWrapperStyles, width !== undefined ? css({ maxWidth: width }) : undefined]}
+      css={visualizationWrapperStyles({ width })}
     >
       {shouldRenderLocalActionButtons && (
         <FallbackVisualizationActions buttons={localActionButtons} />


### PR DESCRIPTION
Resolves #272437

Reworks how inline visualization sizing is applied in Agent Builder chat attachments.
Previously (#271710), `maxWidth` was applied at the outer attachment panel level - this constrained the `AttachmentHeader` to the chart's width (e.g. 260 px for metric), making the header look cut off.

This PR changes the approach so that:
- The **outer attachment panel and header always span the full chat width**
- The **`maxWidth` is applied only to the inner visualization wrapper** (`VisualizeLens` / `VisualizeESQL`), keeping chart content at its intended size

Metric viz after changes:
<img width="819" height="502" alt="Screenshot 2026-06-03 at 16 46 14" src="https://github.com/user-attachments/assets/532a6bd8-94a1-40a2-94b0-382a8a1bddce" />

### Changes
- **`contract.ts`** — removed `getMaxWidth` from `AttachmentUIDefinition`; sizing is now handled entirely within the visualization components
- **`visualization_attachment.tsx`** — removed `getMaxWidth` implementation
- **`inline_attachment_with_actions.tsx`** — removed `maxWidth` from the outer `EuiSplitPanel.Outer` so the header renders at full width
- **`styles.ts`** — refactored `visualizationWrapperStyles` to a curried function `(dimensions?) => (theme) => css(...)` that applies `maxWidth` on the inner chart wrapper when a width is defined
- **Metric chart polish:**
  - Dimensions updated to **260×158 px**
  - Added **`border`** (`euiTheme.border.thin`) and **4 px rounded corners** (`euiTheme.border.radius.small`) on `.echMetric` to match the visual style of standard dashboard panels
### Before / After
| | Before | After |
|---|---|---|
| Header | Constrained to chart width (e.g. 260 px) | Full chat width |
| Metric chart | No visual boundary | Border + rounded corners matching dashboard panels |
| Metric size | 260×130 px | 260×158 px |
