### PR TITLE
[9.4] [ML] Initial infrastructure for ML API integration tests Scout migration (#263066)

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -28,6 +28,7 @@ plugins:
     - lens
     - logstash
     - maps
+    - ml
     - navigation
     - observability
     - observability_onboarding

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/index.ts
@@ -48,13 +48,13 @@ export const apiServicesFixture = coreWorkerFixtures.extend<
   { apiServices: ApiServicesFixture }
 >({
   apiServices: [
-    async ({ kbnClient, log }, use) => {
+    async ({ kbnClient, esClient, log }, use) => {
       const services = {
         alerting: getAlertingApiHelper(log, kbnClient),
         cases: getCasesApiHelper(log, kbnClient),
         dataViews: getDataViewsApiHelper(log, kbnClient),
         fleet: getFleetApiHelper(log, kbnClient),
-        ml: getMlApiHelper(log, kbnClient),
+        ml: getMlApiHelper(log, kbnClient, esClient),
         sampleData: getSampleDataApiHelper(log, kbnClient),
         spaces: getSpacesApiHelper(log, kbnClient),
         streams: getStreamsApiService({ kbnClient, log }),

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/ml/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/ml/index.ts
@@ -7,9 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Client as EsClient, estypes } from '@elastic/elasticsearch';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import type { KbnClient, ScoutLogger } from '../../../../../../common';
 import { measurePerformanceAsync } from '../../../../../../common';
+
+// Model IDs that ship with Elasticsearch and must not be deleted during cleanup
+const INTERNAL_MODEL_IDS = ['lang_ident_model_1'];
+const ML_ANNOTATIONS_INDEX_ALIAS_READ = '.ml-annotations-read';
+const ML_INTERNAL_HEADERS = { [ELASTIC_HTTP_VERSION_HEADER]: '1' } as const;
+
+export interface Annotation {
+  timestamp: number;
+  annotation: string;
+  job_id: string;
+  type: 'annotation' | 'comment';
+}
 
 export interface DeleteJobsOptions {
   jobIds: string[];
@@ -17,31 +30,594 @@ export interface DeleteJobsOptions {
   deleteAlertingRules?: boolean;
 }
 
-export interface MlApiService {
-  deleteJobs: (options: DeleteJobsOptions) => Promise<void>;
+export interface MlADJobsApi {
+  /** Delete anomaly detection jobs via the Kibana API */
+  delete: (options: DeleteJobsOptions) => Promise<void>;
+  /** Get all anomaly detection jobs via the Elasticsearch API */
+  getAllJobs: () => Promise<estypes.MlJob[]>;
+  /** Wait for an anomaly detection job to exist by polling the Elasticsearch API */
+  waitForJobToExist: (jobId: string, timeout?: number) => Promise<void>;
+  /** Wait for an anomaly detection job to be deleted by polling the Elasticsearch API */
+  waitForJobNotToExist: (jobId: string, timeout?: number) => Promise<void>;
+  /** Delete all anomaly detection jobs via the Elasticsearch API */
+  deleteAllJobs: () => Promise<void>;
+  /** Delete expired ML data via the Elasticsearch API */
+  deleteExpiredData: () => Promise<void>;
+  calendars: MlCalendarsApi;
+  filters: MlFiltersApi;
+  annotations: MlAnnotationsApi;
 }
 
-export const getMlApiHelper = (log: ScoutLogger, kbnClient: KbnClient): MlApiService => {
-  return {
-    deleteJobs: async ({
+export interface MlCalendarsApi {
+  /** Get all ML calendars via the Elasticsearch API */
+  getAll: () => Promise<estypes.MlGetCalendarsCalendar[]>;
+  /** Wait for a calendar to exist by polling the Elasticsearch API */
+  waitForCalendarToExist: (calendarId: string) => Promise<void>;
+  /** Wait for a calendar to be deleted by polling the Elasticsearch API */
+  waitForCalendarNotToExist: (calendarId: string) => Promise<void>;
+  /** Delete a calendar via the Elasticsearch API */
+  delete: (calendarId: string) => Promise<void>;
+  /** Delete all calendars via the Elasticsearch API */
+  deleteAll: () => Promise<void>;
+}
+
+export interface MlFiltersApi {
+  /** Get all ML filters via the Elasticsearch API */
+  getAll: () => Promise<estypes.MlFilter[]>;
+  /** Get an ML filter by ID via the Elasticsearch API */
+  getById: (filterId: string) => Promise<estypes.MlFilter | null>;
+  /** Wait for a filter to exist by polling the Elasticsearch API */
+  waitForFilterToExist: (filterId: string) => Promise<void>;
+  /** Wait for a filter to be deleted by polling the Elasticsearch API */
+  waitForFilterToNotExist: (filterId: string) => Promise<void>;
+  /** Delete a filter via the Elasticsearch API */
+  delete: (filterId: string) => Promise<void>;
+  /** Delete all filters via the Elasticsearch API */
+  deleteAll: () => Promise<void>;
+}
+
+export interface MlAnnotationsApi {
+  /** Get all ML annotations by querying Elasticsearch directly */
+  getAll: () => Promise<Array<{ _id: string; _source: Annotation }>>;
+  /** Get an ML annotation by ID by querying Elasticsearch directly */
+  getById: (annotationId: string) => Promise<{ _id: string; _source: Annotation } | undefined>;
+  /** Wait for an annotation to exist by polling Elasticsearch directly */
+  waitForAnnotationToExist: (annotationId: string) => Promise<void>;
+  /** Wait for an annotation to be deleted by polling Elasticsearch directly */
+  waitForAnnotationNotToExist: (annotationId: string) => Promise<void>;
+  /** Delete an annotation via the Kibana API */
+  delete: (annotationId: string) => Promise<void>;
+  /** Delete all annotations via the Kibana API */
+  deleteAll: () => Promise<void>;
+}
+
+export interface MlDataFrameAnalyticsApi {
+  /** Get all data frame analytics jobs via the Elasticsearch API */
+  getAllJobs: () => Promise<estypes.MlDataframeAnalyticsSummary[]>;
+  /** Wait for a data frame analytics job to exist by polling the Elasticsearch API */
+  waitForJobToExist: (analyticsId: string, timeout?: number) => Promise<void>;
+  /** Wait for a data frame analytics job to be deleted by polling the Elasticsearch API */
+  waitForJobNotToExist: (analyticsId: string, timeout?: number) => Promise<void>;
+  /** Delete all data frame analytics jobs via the Elasticsearch API */
+  deleteAllJobs: () => Promise<void>;
+}
+
+export interface MlTrainedModelsApi {
+  /** Get all trained models via the Elasticsearch API */
+  getAll: () => Promise<estypes.MlTrainedModelConfig[]>;
+  /** Delete all trained models (excluding internal models) via the Elasticsearch API */
+  deleteAll: () => Promise<void>;
+}
+
+export interface MlIngestPipelinesApi {
+  /** Delete all ML-related ingest pipelines via the Elasticsearch API */
+  deleteAll: () => Promise<void>;
+}
+
+export interface MlSavedObjectsApi {
+  /** Initialize ML saved objects via the Kibana API */
+  init: (simulate?: boolean, space?: string) => Promise<void>;
+  /** Sync ML saved objects via the Kibana API */
+  sync: (simulate?: boolean, space?: string) => Promise<void>;
+}
+
+export interface MlIndicesApi {
+  /** Clean up all anomaly detection resources via Kibana and Elasticsearch APIs */
+  cleanAnomalyDetection: () => Promise<void>;
+  /** Clean up all data frame analytics resources via Kibana and Elasticsearch APIs */
+  cleanDataFrameAnalytics: () => Promise<void>;
+  /** Clean up all trained models and ingest pipelines via Kibana and Elasticsearch APIs */
+  cleanTrainedModels: () => Promise<void>;
+  /** Clean up all ML resources via Kibana and Elasticsearch APIs */
+  cleanAll: () => Promise<void>;
+}
+
+export interface MlApiService {
+  anomalyDetection: MlADJobsApi;
+  dataFrameAnalytics: MlDataFrameAnalyticsApi;
+  trainedModels: MlTrainedModelsApi;
+  ingestPipelines: MlIngestPipelinesApi;
+  savedObjects: MlSavedObjectsApi;
+  indices: MlIndicesApi;
+}
+
+export const getMlApiHelper = (
+  log: ScoutLogger,
+  kbnClient: KbnClient,
+  esClient: EsClient
+): MlApiService => {
+  const waitForCondition = async (
+    conditionName: string,
+    conditionFn: () => Promise<boolean>,
+    timeoutMs: number = 5000,
+    intervalMs: number = 200
+  ): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    let lastError: Error | undefined;
+
+    while (true) {
+      try {
+        if (await conditionFn()) return;
+      } catch (err) {
+        lastError = err as Error;
+      }
+      if (Date.now() >= deadline) break;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw lastError ?? new Error(`Timed out after ${timeoutMs}ms waiting for: ${conditionName}`);
+  };
+
+  const savedObjects: MlSavedObjectsApi = {
+    async init(simulate = false, space?: string) {
+      const path = `${
+        space ? `/s/${space}` : ''
+      }/internal/ml/saved_objects/initialize?simulate=${simulate}`;
+      await kbnClient.request({
+        method: 'GET',
+        path,
+        headers: ML_INTERNAL_HEADERS,
+      });
+    },
+
+    async sync(simulate = false, space?: string) {
+      const path = `${space ? `/s/${space}` : ''}/api/ml/saved_objects/sync?simulate=${simulate}`;
+      await kbnClient.request({
+        method: 'GET',
+        path,
+        headers: { [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31' },
+      });
+    },
+  };
+
+  const calendars: MlCalendarsApi = {
+    async getAll(): Promise<estypes.MlGetCalendarsCalendar[]> {
+      return measurePerformanceAsync(log, 'mlApi.calendars.getAll', async () => {
+        const response = await esClient.ml.getCalendars();
+        return response.calendars || [];
+      });
+    },
+
+    async waitForCalendarToExist(calendarId: string): Promise<void> {
+      await waitForCondition(`calendar '${calendarId}' to exist`, async () => {
+        const allCalendars = await this.getAll();
+        if (allCalendars.some((c) => c.calendar_id === calendarId)) return true;
+        throw new Error(`Calendar '${calendarId}' does not exist`);
+      });
+    },
+
+    async waitForCalendarNotToExist(calendarId: string): Promise<void> {
+      await waitForCondition(`calendar '${calendarId}' to not exist`, async () => {
+        const allCalendars = await this.getAll();
+        if (!allCalendars.some((c) => c.calendar_id === calendarId)) return true;
+        throw new Error(`Calendar '${calendarId}' still exists`);
+      });
+    },
+
+    async delete(calendarId: string): Promise<void> {
+      await measurePerformanceAsync(log, `mlApi.calendars.delete [${calendarId}]`, async () => {
+        const response = await esClient.ml.deleteCalendar({ calendar_id: calendarId });
+        if (response.acknowledged !== true) {
+          throw new Error(`Failed to delete calendar ${calendarId}`);
+        }
+        await this.waitForCalendarNotToExist(calendarId);
+      });
+    },
+
+    async deleteAll(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.calendars.deleteAll', async () => {
+        const allCalendars = await this.getAll();
+        for (const calendar of allCalendars) {
+          await this.delete(calendar.calendar_id).catch(() => {
+            /* ignore errors */
+          });
+        }
+      });
+    },
+  };
+
+  const filters: MlFiltersApi = {
+    async getAll() {
+      return measurePerformanceAsync(log, 'mlApi.filters.getAll', async () => {
+        const response = await esClient.ml.getFilters();
+        return response.filters || [];
+      });
+    },
+
+    async getById(filterId: string): Promise<estypes.MlFilter | null> {
+      return measurePerformanceAsync(log, `mlApi.filters.getById [${filterId}]`, async () => {
+        try {
+          const response = await esClient.ml.getFilters({ filter_id: filterId });
+          return response.filters?.[0] ?? null;
+        } catch {
+          return null;
+        }
+      });
+    },
+
+    async waitForFilterToExist(filterId: string): Promise<void> {
+      await waitForCondition(`filter '${filterId}' to exist`, async () => {
+        if ((await this.getById(filterId)) !== null) return true;
+        throw new Error(`Filter '${filterId}' does not exist`);
+      });
+    },
+
+    async waitForFilterToNotExist(filterId: string): Promise<void> {
+      await waitForCondition(`filter '${filterId}' to not exist`, async () => {
+        if ((await this.getById(filterId)) === null) return true;
+        throw new Error(`Filter '${filterId}' still exists`);
+      });
+    },
+
+    async delete(filterId: string): Promise<void> {
+      await measurePerformanceAsync(log, `mlApi.filters.delete [${filterId}]`, async () => {
+        const existing = await this.getById(filterId);
+        if (!existing) return;
+
+        const response = await esClient.ml.deleteFilter({ filter_id: filterId });
+        if (response.acknowledged !== true) {
+          throw new Error(`Failed to delete filter ${filterId}`);
+        }
+        await this.waitForFilterToNotExist(filterId);
+      });
+    },
+
+    async deleteAll(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.filters.deleteAll', async () => {
+        const allFilters = await this.getAll();
+        for (const filter of allFilters) {
+          await this.delete(filter.filter_id).catch(() => {
+            /* ignore errors */
+          });
+        }
+      });
+    },
+  };
+
+  const annotations: MlAnnotationsApi = {
+    async getAll(): Promise<Array<{ _id: string; _source: Annotation }>> {
+      return measurePerformanceAsync(log, 'mlApi.annotations.getAll', async () => {
+        try {
+          const annotationsResp = await esClient.search<Annotation>({
+            index: ML_ANNOTATIONS_INDEX_ALIAS_READ,
+            size: 10000,
+          });
+          return annotationsResp.hits.hits
+            .filter(
+              (hit): hit is typeof hit & { _id: string; _source: Annotation } =>
+                hit._id !== undefined && hit._source !== undefined
+            )
+            .map((hit) => ({
+              _id: hit._id,
+              _source: hit._source,
+            }));
+        } catch {
+          return [];
+        }
+      });
+    },
+
+    async getById(annotationId: string): Promise<{ _id: string; _source: Annotation } | undefined> {
+      return measurePerformanceAsync(
+        log,
+        `mlApi.annotations.getById [${annotationId}]`,
+        async () => {
+          try {
+            const resp = await esClient.search<Annotation>({
+              index: ML_ANNOTATIONS_INDEX_ALIAS_READ,
+              size: 1,
+              query: { ids: { values: [annotationId] } },
+            });
+            const hit = resp.hits.hits[0];
+            if (hit?._id === undefined || hit._source === undefined) return undefined;
+            return { _id: hit._id, _source: hit._source };
+          } catch {
+            return undefined;
+          }
+        }
+      );
+    },
+
+    async waitForAnnotationToExist(annotationId: string): Promise<void> {
+      await waitForCondition(
+        `annotation '${annotationId}' to exist`,
+        async () => {
+          if ((await this.getById(annotationId)) !== undefined) return true;
+          throw new Error(`Annotation '${annotationId}' does not exist`);
+        },
+        30 * 1000
+      );
+    },
+
+    async waitForAnnotationNotToExist(annotationId: string): Promise<void> {
+      await waitForCondition(
+        `annotation '${annotationId}' to not exist`,
+        async () => {
+          if ((await this.getById(annotationId)) === undefined) return true;
+          throw new Error(`Annotation '${annotationId}' still exists`);
+        },
+        30 * 1000
+      );
+    },
+
+    async delete(annotationId: string): Promise<void> {
+      await measurePerformanceAsync(log, `mlApi.annotations.delete [${annotationId}]`, async () => {
+        await kbnClient.request({
+          method: 'DELETE',
+          path: `/internal/ml/annotations/delete/${annotationId}`,
+          headers: ML_INTERNAL_HEADERS,
+        });
+        await this.waitForAnnotationNotToExist(annotationId);
+      });
+    },
+
+    async deleteAll(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.annotations.deleteAll', async () => {
+        const allAnnotations = await this.getAll();
+        for (const annotation of allAnnotations) {
+          await this.delete(annotation._id).catch(() => {
+            /* ignore errors */
+          });
+        }
+      });
+    },
+  };
+
+  const anomalyDetection: MlADJobsApi = {
+    async delete({
       jobIds,
       deleteUserAnnotations = false,
       deleteAlertingRules = false,
-    }: DeleteJobsOptions) => {
-      await measurePerformanceAsync(log, `mlApi.deleteJobs [${jobIds.join(', ')}]`, async () => {
-        await kbnClient.request({
-          method: 'POST',
-          path: '/internal/ml/jobs/delete_jobs',
-          headers: {
-            [ELASTIC_HTTP_VERSION_HEADER]: '1',
-          },
-          body: {
-            jobIds,
-            deleteUserAnnotations,
-            deleteAlertingRules,
-          },
+    }: DeleteJobsOptions): Promise<void> {
+      await measurePerformanceAsync(
+        log,
+        `mlApi.anomalyDetection.delete [${jobIds.join(', ')}]`,
+        async () => {
+          await kbnClient.request({
+            method: 'POST',
+            path: '/internal/ml/jobs/delete_jobs',
+            headers: ML_INTERNAL_HEADERS,
+            body: {
+              jobIds,
+              deleteUserAnnotations,
+              deleteAlertingRules,
+            },
+          });
+          for (const jobId of jobIds) {
+            await this.waitForJobNotToExist(jobId);
+          }
+        }
+      );
+    },
+
+    async getAllJobs(): Promise<estypes.MlJob[]> {
+      return measurePerformanceAsync(log, 'mlApi.anomalyDetection.getAllJobs', async () => {
+        const { jobs: adJobs } = await esClient.ml.getJobs({ job_id: '_all' });
+        return adJobs;
+      });
+    },
+
+    async waitForJobToExist(jobId: string, timeout = 5 * 1000): Promise<void> {
+      await waitForCondition(
+        `anomaly detection job '${jobId}' to exist`,
+        async () => {
+          const allJobs = await this.getAllJobs();
+          if (allJobs.some((j) => j.job_id === jobId)) return true;
+          throw new Error(`Anomaly detection job '${jobId}' does not exist`);
+        },
+        timeout
+      );
+    },
+
+    async waitForJobNotToExist(jobId: string, timeout = 5 * 1000): Promise<void> {
+      await waitForCondition(
+        `anomaly detection job '${jobId}' to not exist`,
+        async () => {
+          const allJobs = await this.getAllJobs();
+          if (!allJobs.some((j) => j.job_id === jobId)) return true;
+          throw new Error(`Anomaly detection job '${jobId}' still exists`);
+        },
+        timeout
+      );
+    },
+
+    async deleteAllJobs(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.anomalyDetection.deleteAllJobs', async () => {
+        const adJobs = await this.getAllJobs();
+        for (const job of adJobs) {
+          await esClient.ml
+            .deleteJob({ job_id: job.job_id, force: true, wait_for_completion: true })
+            .catch(() => {
+              /* ignore errors */
+            });
+        }
+      });
+    },
+
+    async deleteExpiredData(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.anomalyDetection.deleteExpiredData', async () => {
+        await esClient.transport.request({
+          method: 'DELETE',
+          path: '/_ml/_delete_expired_data',
         });
       });
     },
+
+    calendars,
+    filters,
+    annotations,
+  };
+
+  const dataFrameAnalytics: MlDataFrameAnalyticsApi = {
+    async getAllJobs(): Promise<estypes.MlDataframeAnalyticsSummary[]> {
+      return measurePerformanceAsync(log, 'mlApi.dataFrameAnalytics.getAllJobs', async () => {
+        const { data_frame_analytics: dfaJobs } = await esClient.ml.getDataFrameAnalytics({
+          id: '_all',
+          allow_no_match: true,
+        });
+        return dfaJobs;
+      });
+    },
+
+    async waitForJobToExist(analyticsId: string, timeout = 5 * 1000): Promise<void> {
+      await waitForCondition(
+        `data frame analytics job '${analyticsId}' to exist`,
+        async () => {
+          const { data_frame_analytics: dfaJobs } = await esClient.ml.getDataFrameAnalytics({
+            id: analyticsId,
+            allow_no_match: true,
+          });
+          if (dfaJobs.length > 0) return true;
+          throw new Error(`Data frame analytics job '${analyticsId}' does not exist`);
+        },
+        timeout
+      );
+    },
+
+    async waitForJobNotToExist(analyticsId: string, timeout = 5 * 1000): Promise<void> {
+      await waitForCondition(
+        `data frame analytics job '${analyticsId}' to not exist`,
+        async () => {
+          const { data_frame_analytics: dfaJobs } = await esClient.ml.getDataFrameAnalytics({
+            id: analyticsId,
+            allow_no_match: true,
+          });
+          if (dfaJobs.length === 0) return true;
+          throw new Error(`Data frame analytics job '${analyticsId}' still exists`);
+        },
+        timeout
+      );
+    },
+
+    async deleteAllJobs(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.dataFrameAnalytics.deleteAllJobs', async () => {
+        const dfaJobs = await this.getAllJobs();
+        for (const job of dfaJobs) {
+          // stop and delete are kept separate: a stop failure (e.g. job already stopped)
+          // must not prevent the subsequent delete
+          try {
+            await esClient.ml.stopDataFrameAnalytics({ id: job.id, force: true });
+          } catch {
+            /* ignore errors */
+          }
+          try {
+            await esClient.ml.deleteDataFrameAnalytics({ id: job.id });
+            await this.waitForJobNotToExist(job.id);
+          } catch {
+            /* ignore errors */
+          }
+        }
+      });
+    },
+  };
+
+  const trainedModels: MlTrainedModelsApi = {
+    async getAll(): Promise<estypes.MlTrainedModelConfig[]> {
+      return measurePerformanceAsync(log, 'mlApi.trainedModels.getAll', async () => {
+        const { trained_model_configs: models } = await esClient.ml.getTrainedModels({
+          size: 1000,
+        });
+        return models;
+      });
+    },
+
+    async deleteAll(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.trainedModels.deleteAll', async () => {
+        const models = await this.getAll();
+        for (const model of models) {
+          if (INTERNAL_MODEL_IDS.includes(model.model_id)) {
+            continue;
+          }
+          await esClient.ml
+            .deleteTrainedModel({ model_id: model.model_id, force: true })
+            .catch(() => {
+              /* ignore errors */
+            });
+        }
+      });
+    },
+  };
+
+  const ingestPipelines: MlIngestPipelinesApi = {
+    async deleteAll(): Promise<void> {
+      await measurePerformanceAsync(log, 'mlApi.ingestPipelines.deleteAll', async () => {
+        const models = await trainedModels.getAll();
+
+        for (const model of models) {
+          if (INTERNAL_MODEL_IDS.includes(model.model_id)) {
+            continue;
+          }
+
+          await esClient.ingest.deletePipeline({ id: model.model_id }).catch(() => {
+            /* ignore errors */
+          });
+        }
+      });
+    },
+  };
+
+  const indices: MlIndicesApi = {
+    async cleanAnomalyDetection() {
+      await measurePerformanceAsync(log, 'mlApi.indices.cleanAnomalyDetection', async () => {
+        await anomalyDetection.deleteAllJobs();
+        await anomalyDetection.calendars.deleteAll();
+        await anomalyDetection.filters.deleteAll();
+        await anomalyDetection.annotations.deleteAll();
+        await anomalyDetection.deleteExpiredData();
+        await savedObjects.sync();
+      });
+    },
+
+    async cleanDataFrameAnalytics() {
+      await measurePerformanceAsync(log, 'mlApi.indices.cleanDataFrameAnalytics', async () => {
+        await dataFrameAnalytics.deleteAllJobs();
+        await savedObjects.sync();
+      });
+    },
+
+    async cleanTrainedModels() {
+      await measurePerformanceAsync(log, 'mlApi.indices.cleanTrainedModels', async () => {
+        await ingestPipelines.deleteAll();
+        await trainedModels.deleteAll();
+        await savedObjects.sync();
+      });
+    },
+
+    async cleanAll() {
+      await measurePerformanceAsync(log, 'mlApi.indices.cleanAll', async () => {
+        await this.cleanAnomalyDetection();
+        await this.cleanDataFrameAnalytics();
+        await this.cleanTrainedModels();
+      });
+    },
+  };
+
+  return {
+    anomalyDetection,
+    dataFrameAnalytics,
+    trainedModels,
+    ingestPipelines,
+    savedObjects,
+    indices,
   };
 };

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/ui_settings/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/ui_settings/index.ts
@@ -29,6 +29,14 @@ export interface UiSettingsFixture {
    * @returns A Promise that resolves once the default time is set.
    */
   setDefaultTime: ({ from, to }: { from: string; to: string }) => Promise<void>;
+  /**
+   * Sets the Kibana timezone to UTC.
+   */
+  setKibanaTimeZoneToUTC: () => Promise<void>;
+  /**
+   * Resets the Kibana timezone to its default value.
+   */
+  resetKibanaTimeZone: () => Promise<void>;
 }
 
 export { uiSettingsFixture } from './single_thread';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/ui_settings/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/ui_settings/single_thread.ts
@@ -33,6 +33,14 @@ export const uiSettingsFixture = coreWorkerFixtures.extend<{}, { uiSettings: UiS
             'timepicker:timeDefaults': `{ "from": "${utcFrom}", "to": "${untcTo}"}`,
           });
         },
+
+        setKibanaTimeZoneToUTC: async () => {
+          await kbnClient.uiSettings.update({ 'dateFormat:tz': 'UTC' });
+        },
+
+        resetKibanaTimeZone: async () => {
+          await kbnClient.uiSettings.unset('dateFormat:tz');
+        },
       };
 
       log.serviceLoaded('uiSettings');

--- a/x-pack/platform/plugins/shared/ml/moon.yml
+++ b/x-pack/platform/plugins/shared/ml/moon.yml
@@ -148,6 +148,8 @@ dependsOn:
   - '@kbn/cps'
   - '@kbn/cps-utils'
   - '@kbn/lens-common'
+  - '@kbn/scout'
+  - '@kbn/core-http-common'
 tags:
   - plugin
   - prod
@@ -161,6 +163,7 @@ fileGroups:
     - server/**/*
     - scripts/**/*
     - __mocks__/**/*
+    - test/scout/**/*
     - common/**/*.json
     - public/**/*.json
     - server/**/*.json

--- a/x-pack/platform/plugins/shared/ml/test/scout/.meta/api/standard.json
+++ b/x-pack/platform/plugins/shared/ml/test/scout/.meta/api/standard.json
@@ -1,0 +1,4 @@
+{
+  "sha1": "c4f42589b585a44d63e5eb75ba5eb736ec4d8efa",
+  "tests": []
+}

--- a/x-pack/platform/plugins/shared/ml/test/scout/api/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/ml/test/scout/api/fixtures/constants.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
+import type { KibanaRole } from '@kbn/scout';
+
+// Base headers required by all ML API calls
+export const COMMON_HEADERS = {
+  'kbn-xsrf': 'some-xsrf-token',
+  'x-elastic-internal-origin': 'kibana',
+} as const;
+
+// Headers for internal ML endpoints (elastic-api-version: '1')
+export const INTERNAL_API_HEADERS = {
+  ...COMMON_HEADERS,
+  [ELASTIC_HTTP_VERSION_HEADER]: '1',
+} as const;
+
+// Headers for public ML endpoints (elastic-api-version: '2023-10-31')
+export const PUBLIC_API_HEADERS = {
+  ...COMMON_HEADERS,
+  [ELASTIC_HTTP_VERSION_HEADER]: '2023-10-31',
+} as const;
+
+export const ML_USERS: Record<string, KibanaRole> = {
+  // Mirrors FTR: machine_learning_admin + ft_ml_source + ft_ml_dest + ft_ml_ui_extras + ml:all
+  mlPoweruser: {
+    kibana: [
+      {
+        base: [],
+        feature: {
+          ml: ['all'],
+          savedObjectsManagement: ['all'],
+          advancedSettings: ['all'],
+          indexPatterns: ['all'],
+          discover: ['all'],
+          dashboard: ['all'],
+        },
+        spaces: ['*'],
+      },
+    ],
+    elasticsearch: {
+      cluster: ['manage_ml', 'monitor', 'manage_ingest_pipelines'],
+      indices: [
+        { names: ['*'], privileges: ['read', 'view_index_metadata'] },
+        { names: ['user-*'], privileges: ['read', 'index', 'manage'] },
+      ],
+    },
+  },
+
+  // Mirrors FTR: machine_learning_user + ft_ml_source_readonly + ml:read
+  mlViewer: {
+    kibana: [
+      {
+        base: [],
+        feature: {
+          ml: ['read'],
+          savedObjectsManagement: ['read'],
+          advancedSettings: ['read'],
+          indexPatterns: ['read'],
+          discover: ['read'],
+          dashboard: ['read'],
+        },
+        spaces: ['*'],
+      },
+    ],
+    elasticsearch: {
+      cluster: [],
+      indices: [{ names: ['*'], privileges: ['read'] }],
+    },
+  },
+
+  // Mirrors FTR: ft_ml_unauthorized — Kibana login possible, no ML feature or index write access
+  mlUnauthorized: {
+    kibana: [
+      {
+        base: [],
+        feature: {
+          discover: ['read'],
+        },
+        spaces: ['*'],
+      },
+    ],
+    elasticsearch: {
+      cluster: [],
+      indices: [{ names: ['*'], privileges: ['read'] }],
+    },
+  },
+};

--- a/x-pack/platform/plugins/shared/ml/test/scout/api/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/ml/test/scout/api/fixtures/index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout';
+import type { RoleSessionCredentials, SamlAuth } from '@kbn/scout';
+import { ML_USERS } from './constants';
+
+export interface MlSamlAuthFixture extends SamlAuth {
+  asMlPoweruser: () => Promise<RoleSessionCredentials>;
+  asMlViewer: () => Promise<RoleSessionCredentials>;
+  asMlUnauthorized: () => Promise<RoleSessionCredentials>;
+}
+
+export const mlApiTest = apiTest.extend<{
+  samlAuth: MlSamlAuthFixture;
+}>({
+  samlAuth: async ({ samlAuth }, use) => {
+    const extendedSamlAuth: MlSamlAuthFixture = {
+      ...samlAuth,
+      asMlPoweruser: () => samlAuth.asInteractiveUser(ML_USERS.mlPoweruser),
+      asMlViewer: () => samlAuth.asInteractiveUser(ML_USERS.mlViewer),
+      asMlUnauthorized: () => samlAuth.asInteractiveUser(ML_USERS.mlUnauthorized),
+    };
+    await use(extendedSamlAuth);
+  },
+});
+
+export { ML_USERS, COMMON_HEADERS, INTERNAL_API_HEADERS, PUBLIC_API_HEADERS } from './constants';

--- a/x-pack/platform/plugins/shared/ml/test/scout/api/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/ml/test/scout/api/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/ml/test/scout/api/services/ml_common_configs.ts
+++ b/x-pack/platform/plugins/shared/ml/test/scout/api/services/ml_common_configs.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+
+/**
+ * Returns a single-metric AD job config for the farequote dataset.
+ * Source: FTR x-pack/platform/test/api_integration/services/ml/common_config.ts (FQ_SM_JOB_CONFIG)
+ */
+export const getADFqSingleMetricJobConfig = (jobId: string): Partial<estypes.MlJob> => ({
+  job_id: jobId,
+  description: 'mean(responsetime) on farequote dataset with 15m bucket span',
+  groups: ['farequote', 'automated', 'single-metric'],
+  analysis_config: {
+    bucket_span: '15m',
+    influencers: [],
+    detectors: [{ function: 'mean', field_name: 'responsetime' }],
+  },
+  data_description: { time_field: '@timestamp' },
+  analysis_limits: { model_memory_limit: '10mb' },
+  model_plot_config: { enabled: true },
+});
+
+/**
+ * Returns a multi-metric AD job config for the farequote dataset.
+ * Source: FTR x-pack/platform/test/api_integration/services/ml/common_config.ts (FQ_MM_JOB_CONFIG)
+ */
+export const getADFqMultiMetricJobConfig = (jobId: string): Partial<estypes.MlJob> => ({
+  job_id: jobId,
+  description:
+    'mean/min/max(responsetime) partition=airline on farequote dataset with 1h bucket span',
+  groups: ['farequote', 'automated', 'multi-metric'],
+  analysis_config: {
+    bucket_span: '1h',
+    influencers: ['airline'],
+    detectors: [
+      { function: 'mean', field_name: 'responsetime', partition_field_name: 'airline' },
+      { function: 'min', field_name: 'responsetime', partition_field_name: 'airline' },
+      { function: 'max', field_name: 'responsetime', partition_field_name: 'airline' },
+    ],
+  },
+  data_description: { time_field: '@timestamp' },
+  analysis_limits: { model_memory_limit: '20mb' },
+  model_plot_config: { enabled: true },
+});
+
+/**
+ * Returns a datafeed config targeting the ft_farequote index for the given AD job.
+ * Source: FTR x-pack/platform/test/api_integration/services/ml/common_config.ts (FQ_DATAFEED_CONFIG)
+ */
+export const getADFqDatafeedConfig = (jobId: string): Partial<estypes.MlDatafeed> => ({
+  datafeed_id: `datafeed-${jobId}`,
+  job_id: jobId,
+  indices: ['ft_farequote'],
+  query: { bool: { must: [{ match_all: {} }] } },
+});

--- a/x-pack/platform/plugins/shared/ml/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ml/tsconfig.json
@@ -9,6 +9,7 @@
     "server/**/*",
     "scripts/**/*",
     "__mocks__/**/*",
+    "test/scout/**/*",
     "../../../../../typings/**/*",
     // have to declare *.json explicitly due to https://github.com/microsoft/TypeScript/issues/25636
     "common/**/*.json",
@@ -149,5 +150,7 @@
     "@kbn/cps",
     "@kbn/cps-utils",
     "@kbn/lens-common",
+    "@kbn/scout",
+    "@kbn/core-http-common",
   ]
 }

--- a/x-pack/solutions/observability/plugins/uptime/test/scout_uptime_legacy/.meta/ui/standard.json
+++ b/x-pack/solutions/observability/plugins/uptime/test/scout_uptime_legacy/.meta/ui/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "5a50349c536e802d7cc89f631a059cefc83bc835",
+  "sha1": "b17506960fab4d2142608f27b3987b39cd1ecc0a",
   "tests": [
     {
       "id": "b84b07d0bf27e66-b0ce2da86af09e0",

--- a/x-pack/solutions/observability/plugins/uptime/test/scout_uptime_legacy/ui/tests/monitor_alerts.spec.ts
+++ b/x-pack/solutions/observability/plugins/uptime/test/scout_uptime_legacy/ui/tests/monitor_alerts.spec.ts
@@ -18,7 +18,7 @@ const mlJobId = '0000_intermittent_high_latency_by_geo';
 
 test.describe('MonitorAlerts', { tag: '@local-stateful-classic' }, () => {
   test.afterAll(async ({ apiServices }) => {
-    await apiServices.ml.deleteJobs({
+    await apiServices.ml.anomalyDetection.delete({
       jobIds: [mlJobId],
       deleteUserAnnotations: true,
       deleteAlertingRules: true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ML] Initial infrastructure for ML API integration tests Scout migration (#263066)](https://github.com/elastic/kibana/pull/263066)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Krasocki","email":"104936644+KodeRad@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-07T12:23:55Z","message":"[ML] Initial infrastructure for ML API integration tests Scout migration (#263066)\n\n## Summary\n\nThis PR wires up the ML plugin for Scout API testing by:\n1. Expanding the shared MlApiService in @kbn/scout from a single\ndeleteJobs method into a rich\nnested API (jobs, calendars, filters, annotations, dataFrameAnalytics,\ntrainedModels,\ningestPipelines, savedObjects, indices)\n2. Adding the ML plugin's Scout scaffold (playwright.config.ts,\nfixtures, role definitions)\n3. Adding timezone helpers to the shared UiSettingsFixture\n  4. Registering ML in Buildkite Scout CI config    \n\n**Service architecture decisions:**\n\n- The plugin-local `ml_api_service.ts` was removed and its ML-specific\nhelpers (clean indicies, manage saved objects) were consolidated into a\nshared `MlApiService` in `@kbn/scout` — exposed via `apiServices.ml`,\nconsistent with how other shared services (e.g. `apiServices.dataViews`)\nwork.\n- The plugin-local `MlTestResourcesService` (data view helpers, timezone\nhelpers, index patterns) was removed entirely — tests can use\n`apiServices.dataViews` and `apiServices.uiSettings` from the shared\nScout fixtures instead of plugin-local wrappers. Timezone helpers were\nmoved to `UiSettingsFixture`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"79e24e49f868fa0594e69834838c075639d3dd65","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":[":ml","release_note:skip","Team:ML","backport:version","test:scout","v9.5.0","v9.4.3","v9.3.6"],"title":"[ML] Initial infrastructure for ML API integration tests Scout migration","number":263066,"url":"https://github.com/elastic/kibana/pull/263066","mergeCommit":{"message":"[ML] Initial infrastructure for ML API integration tests Scout migration (#263066)\n\n## Summary\n\nThis PR wires up the ML plugin for Scout API testing by:\n1. Expanding the shared MlApiService in @kbn/scout from a single\ndeleteJobs method into a rich\nnested API (jobs, calendars, filters, annotations, dataFrameAnalytics,\ntrainedModels,\ningestPipelines, savedObjects, indices)\n2. Adding the ML plugin's Scout scaffold (playwright.config.ts,\nfixtures, role definitions)\n3. Adding timezone helpers to the shared UiSettingsFixture\n  4. Registering ML in Buildkite Scout CI config    \n\n**Service architecture decisions:**\n\n- The plugin-local `ml_api_service.ts` was removed and its ML-specific\nhelpers (clean indicies, manage saved objects) were consolidated into a\nshared `MlApiService` in `@kbn/scout` — exposed via `apiServices.ml`,\nconsistent with how other shared services (e.g. `apiServices.dataViews`)\nwork.\n- The plugin-local `MlTestResourcesService` (data view helpers, timezone\nhelpers, index patterns) was removed entirely — tests can use\n`apiServices.dataViews` and `apiServices.uiSettings` from the shared\nScout fixtures instead of plugin-local wrappers. Timezone helpers were\nmoved to `UiSettingsFixture`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"79e24e49f868fa0594e69834838c075639d3dd65"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263066","number":263066,"mergeCommit":{"message":"[ML] Initial infrastructure for ML API integration tests Scout migration (#263066)\n\n## Summary\n\nThis PR wires up the ML plugin for Scout API testing by:\n1. Expanding the shared MlApiService in @kbn/scout from a single\ndeleteJobs method into a rich\nnested API (jobs, calendars, filters, annotations, dataFrameAnalytics,\ntrainedModels,\ningestPipelines, savedObjects, indices)\n2. Adding the ML plugin's Scout scaffold (playwright.config.ts,\nfixtures, role definitions)\n3. Adding timezone helpers to the shared UiSettingsFixture\n  4. Registering ML in Buildkite Scout CI config    \n\n**Service architecture decisions:**\n\n- The plugin-local `ml_api_service.ts` was removed and its ML-specific\nhelpers (clean indicies, manage saved objects) were consolidated into a\nshared `MlApiService` in `@kbn/scout` — exposed via `apiServices.ml`,\nconsistent with how other shared services (e.g. `apiServices.dataViews`)\nwork.\n- The plugin-local `MlTestResourcesService` (data view helpers, timezone\nhelpers, index patterns) was removed entirely — tests can use\n`apiServices.dataViews` and `apiServices.uiSettings` from the shared\nScout fixtures instead of plugin-local wrappers. Timezone helpers were\nmoved to `UiSettingsFixture`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"79e24e49f868fa0594e69834838c075639d3dd65"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->