### PR TITLE
[One Workflow](fix): Reduce managed workflow startup validation

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.ts
@@ -76,6 +76,26 @@ export function generateYamlSchemaFromConnectors(
   });
 }
 
+/**
+ * Generates a schema for trusted workflow definitions that need the shared workflow envelope
+ * validation without materializing the connector-expanded step union.
+ */
+export function generateLightweightYamlSchema(triggers: string[] = []): z.ZodType {
+  // Trigger schemas are lightweight: custom IDs add literal trigger variants and do
+  // not materialize connector or step-definition schemas.
+  const triggerSchema = getTriggerSchema(triggers);
+  const workflowBaseWithTriggers = WorkflowSchemaBase.extend({
+    triggers: z.array(triggerSchema).min(1),
+  });
+
+  return workflowBaseWithTriggers.extend({
+    // WorkflowSchemaBase validates settings with step-aware fallback schemas. Keep the
+    // trusted startup path step-agnostic so it does not duplicate the step schema SOT.
+    settings: z.unknown().optional(),
+    steps: z.array(z.unknown()).min(1),
+  });
+}
+
 function createRecursiveStepSchema(
   connectors: ConnectorContractUnion[],
   loose: boolean = false

--- a/src/platform/plugins/shared/workflows_management/common/schema.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.test.ts
@@ -30,6 +30,29 @@ describe('schema', () => {
       const schema = getWorkflowZodSchema({});
       expect(schema).toBeDefined();
     });
+    it('should allow unknown steps and settings in lightweight mode', () => {
+      const schema = getWorkflowZodSchema({}, [], { lightweight: true });
+      const result = parseWorkflowYamlToJSON(
+        [
+          'name: Lightweight workflow',
+          'enabled: true',
+          'triggers:',
+          '  - type: manual',
+          'settings:',
+          '  unknown_setting:',
+          '    nested: true',
+          'steps:',
+          '  - name: custom-step',
+          '    type: custom.step',
+          '    with:',
+          '      arbitrary: true',
+        ].join('\n'),
+        schema
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+    });
     examples.forEach((example) => {
       it(`should parse ${example.name} with zod schema`, () => {
         const schema = getWorkflowZodSchema({});

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -17,6 +17,7 @@ import type {
 import {
   builtInStepDefinitions,
   DEPRECATED_STEP_METADATA,
+  generateLightweightYamlSchema,
   generateYamlSchemaFromConnectors,
   getElasticsearchConnectors,
   getKibanaConnectors,
@@ -209,6 +210,10 @@ function convertDynamicConnectorsToContractsInternal(
 // Export types for schema results
 export type WorkflowZodSchemaType = z.infer<ReturnType<typeof getWorkflowZodSchema>>;
 export type WorkflowZodSchemaLooseType = z.infer<ReturnType<typeof getWorkflowZodSchemaLoose>>;
+
+export interface WorkflowZodSchemaOptions {
+  lightweight?: boolean;
+}
 
 // NOTE: The former `WORKFLOW_ZOD_SCHEMA` / `WORKFLOW_ZOD_SCHEMA_LOOSE`
 // module-level constants were removed in favour of `getWorkflowZodSchema()` /
@@ -403,8 +408,13 @@ export function getAllConnectorsWithDynamic(
 
 export const getWorkflowZodSchema = (
   dynamicConnectorTypes: Record<string, ConnectorTypeInfo>,
-  registeredTriggerIds: string[] = []
+  registeredTriggerIds: string[] = [],
+  options: WorkflowZodSchemaOptions = {}
 ): z.ZodType => {
+  if (options.lightweight) {
+    return generateLightweightYamlSchema(registeredTriggerIds);
+  }
+
   const allConnectors = getAllConnectorsWithDynamicInternal(dynamicConnectorTypes);
   return generateYamlSchemaFromConnectors(allConnectors, registeredTriggerIds);
 };

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts
@@ -233,6 +233,11 @@ describe('ManagedWorkflowsService', () => {
 
       await service.installManagedWorkflow(WORKFLOW_ID, { spaceId: SPACE_ID }, definition.pluginId);
 
+      expect(crudService.prepareWorkflowDocumentForStorage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lightweightValidation: true,
+        })
+      );
       expect(crudService.indexWorkflowDocument).toHaveBeenCalledWith(
         WORKFLOW_ID,
         expect.objectContaining({

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
@@ -575,6 +575,7 @@ export class ManagedWorkflowsService {
       id: workflowDocumentId,
       yaml,
       actor: MANAGED_WORKFLOW_SYSTEM_USER,
+      lightweightValidation: true,
       now,
       spaceId,
     });

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.test.ts
@@ -74,7 +74,38 @@ const makeDeps = (
   return { deps, client };
 };
 
+const lightweightWorkflowYaml = [
+  'name: My Workflow',
+  'enabled: true',
+  'triggers:',
+  '  - type: manual',
+  'steps:',
+  '  - name: step-one',
+  '    type: console',
+  '    with:',
+  '      message: "hi"',
+].join('\n');
+
 describe('WorkflowCrudService', () => {
+  describe('prepareWorkflowDocumentForStorage', () => {
+    it('uses lightweight validation only when explicitly requested', async () => {
+      const { deps } = makeDeps();
+      const service = new WorkflowCrudService(deps);
+
+      await service.prepareWorkflowDocumentForStorage({
+        id: 'managed-workflow',
+        yaml: lightweightWorkflowYaml,
+        actor: 'system',
+        lightweightValidation: true,
+        now: new Date('2024-01-01T00:00:00.000Z'),
+        spaceId: 'default',
+        request: { auth: { credentials: { username: 'alice' } } } as any,
+      });
+
+      expect(deps.validationService.getWorkflowZodSchema).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getWorkflow', () => {
     it('returns WorkflowDetailDto for existing workflow', async () => {
       const source = makeSource();

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
@@ -158,8 +158,10 @@ export class WorkflowCrudService {
           params.spaceId,
           params.request
         )
-      : getWorkflowZodSchema({}, registeredTriggerIds);
-    const triggerDefinitions = this.deps.workflowsExtensions?.getAllTriggerDefinitions() ?? [];
+      : getWorkflowZodSchema({}, registeredTriggerIds, { lightweight: true });
+    const triggerDefinitions = params.request
+      ? this.deps.workflowsExtensions?.getAllTriggerDefinitions() ?? []
+      : undefined;
 
     return prepareWorkflowDocumentFromYaml({
       id: params.id,

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.ts
@@ -20,6 +20,7 @@ import { buildWorkflowFilters } from '@kbn/workflows/server';
 import type { WorkflowPartialDetailDto } from '@kbn/workflows/types/v1';
 
 import { WorkflowConflictError } from '@kbn/workflows-yaml';
+import type { z } from '@kbn/zod/v4';
 import type { WorkflowCrudDeps } from './types';
 import { getWorkflowZodSchema } from '../../common/schema';
 import { extractBulkItemError } from '../api/lib/bulk_response_helpers';
@@ -145,6 +146,7 @@ export class WorkflowCrudService {
   async prepareWorkflowDocumentForStorage(params: {
     actor: string;
     id?: string;
+    lightweightValidation?: boolean;
     now: Date;
     spaceId: string;
     request?: KibanaRequest;
@@ -152,16 +154,21 @@ export class WorkflowCrudService {
   }): Promise<{ id: string; workflowData: WorkflowProperties; definition?: WorkflowYaml }> {
     const registeredTriggerIds =
       this.deps.workflowsExtensions?.getAllTriggerDefinitions().map((t) => t.id) ?? [];
-    const zodSchema = params.request
-      ? await this.deps.validationService.getWorkflowZodSchema(
-          { loose: false },
-          params.spaceId,
-          params.request
-        )
-      : getWorkflowZodSchema({}, registeredTriggerIds, { lightweight: true });
-    const triggerDefinitions = params.request
-      ? this.deps.workflowsExtensions?.getAllTriggerDefinitions() ?? []
-      : undefined;
+    let zodSchema: z.ZodType;
+    if (params.lightweightValidation) {
+      zodSchema = getWorkflowZodSchema({}, registeredTriggerIds, { lightweight: true });
+    } else if (params.request) {
+      zodSchema = await this.deps.validationService.getWorkflowZodSchema(
+        { loose: false },
+        params.spaceId,
+        params.request
+      );
+    } else {
+      zodSchema = getWorkflowZodSchema({}, registeredTriggerIds);
+    }
+    const triggerDefinitions = params.lightweightValidation
+      ? undefined
+      : this.deps.workflowsExtensions?.getAllTriggerDefinitions() ?? [];
 
     return prepareWorkflowDocumentFromYaml({
       id: params.id,


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/272491

```
Metric                                        old 05d3bd6   new 702ed6e   PR #272491
Raw snapshot                                  857.8 MB      951.6 MB      870.3 MB
Live heap                                     567.5 MB      621.0 MB      574.7 MB
  -> delta vs old                             —             +53.6 MB      +7.2 MB
  -> delta vs new                             —             —             -46.3 MB
Heap nodes                                    6.66 M        7.35 M        6.75 M
zod (retained)                                65.7 MB       102.2 MB      67.4 MB
zod (alloc-site)                              68.8 MB       115.2 MB      72.6 MB
@kbn/workflows-management-plugin (alloc)      1.9 MB        48.8 MB       3.3 MB
--filter=zod -> workflows-management          0.1 MB        41.8 MB       0.2 MB
```