### PR TITLE
[Security Solution] Fix change tracking for snooze and API key in bulk edit

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/bulk_edit_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/bulk_edit_rules.test.ts
@@ -3674,5 +3674,93 @@ describe('bulkEdit()', () => {
       // Negative assertion is exercised at the helper level.
       expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalled();
     });
+
+    test('logs action "rule_update_api_key" for a single apiKey operation', async () => {
+      const changeTrackingService = createChangeTrackingService();
+      const trackingClient = new RulesClient({ ...rulesClientParams, changeTrackingService });
+      setRuleType();
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [updatedRuleSO('1')],
+      });
+
+      await trackingClient.bulkEdit({
+        filter: '',
+        operations: [{ field: 'apiKey', operation: 'set' }],
+      });
+
+      expect(changeTrackingService.logBulk).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ action: 'rule_update_api_key' })
+      );
+    });
+
+    test('logs action "rule_snooze" for a single snoozeSchedule set operation', async () => {
+      const changeTrackingService = createChangeTrackingService();
+      const trackingClient = new RulesClient({ ...rulesClientParams, changeTrackingService });
+      setRuleType();
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [updatedRuleSO('1')],
+      });
+
+      await trackingClient.bulkEdit({
+        filter: '',
+        operations: [
+          {
+            field: 'snoozeSchedule',
+            operation: 'set',
+            value: {
+              duration: 28800000,
+              rRule: { dtstart: '2010-09-19T11:49:59.329Z', count: 1, tzid: 'UTC' },
+            },
+          },
+        ],
+      });
+
+      expect(changeTrackingService.logBulk).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ action: 'rule_snooze' })
+      );
+    });
+
+    test('logs action "rule_unsnooze" for a single snoozeSchedule delete operation', async () => {
+      const changeTrackingService = createChangeTrackingService();
+      const trackingClient = new RulesClient({ ...rulesClientParams, changeTrackingService });
+      setRuleType();
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [updatedRuleSO('1')],
+      });
+
+      await trackingClient.bulkEdit({
+        filter: '',
+        operations: [{ field: 'snoozeSchedule', operation: 'delete', value: [] }],
+      });
+
+      expect(changeTrackingService.logBulk).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ action: 'rule_unsnooze' })
+      );
+    });
+
+    test('falls back to "rule_update" when multiple operations are provided', async () => {
+      const changeTrackingService = createChangeTrackingService();
+      const trackingClient = new RulesClient({ ...rulesClientParams, changeTrackingService });
+      setRuleType();
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [updatedRuleSO('1')],
+      });
+
+      await trackingClient.bulkEdit({
+        filter: '',
+        operations: [
+          { field: 'tags', operation: 'add', value: ['test-1'] },
+          { field: 'apiKey', operation: 'set' },
+        ],
+      });
+
+      expect(changeTrackingService.logBulk).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ action: 'rule_update' })
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/bulk_edit_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_edit/bulk_edit_rules.ts
@@ -67,7 +67,10 @@ export async function bulkEditRules<Params extends RuleParams>(
     auditAction,
     requiredAuthOperation,
     shouldInvalidateApiKeys,
-    changeTracking: { action: RuleChangeTrackingAction.ruleUpdate, ...options.changeTracking },
+    changeTracking: {
+      action: deriveChangeTrackingAction(options.operations),
+      ...options.changeTracking,
+    },
     shouldValidateSchedule: options.operations.some((operation) => operation.field === 'schedule'),
     updateFn: (opts: UpdateOperationOpts) =>
       updateRuleAttributesAndParamsInMemory<Params>({
@@ -468,4 +471,19 @@ async function attemptToMigrateLegacyFrequency<Params extends RuleParams>(
     actions,
   });
   return rule;
+}
+
+// Only emit a specific action when the batch is unambiguous (single operation); mixed batches fall back to ruleUpdate.
+function deriveChangeTrackingAction(operations: BulkEditOperation[]): RuleChangeTrackingAction {
+  if (operations.length === 1 && operations[0].field === 'apiKey') {
+    return RuleChangeTrackingAction.ruleUpdateApiKey;
+  }
+
+  if (operations.length === 1 && operations[0].field === 'snoozeSchedule') {
+    return operations[0].operation === 'set'
+      ? RuleChangeTrackingAction.ruleSnooze
+      : RuleChangeTrackingAction.ruleUnsnooze;
+  }
+
+  return RuleChangeTrackingAction.ruleUpdate;
 }


### PR DESCRIPTION
**Related to: #262490**

## Summary

`rulesClient.bulkEdit` was recording all bulk edit operations as a generic `ruleUpdate` change-tracking event, even when the operation was specifically an API key rotation or a snooze/unsnooze. This adds a `deriveChangeTrackingAction` helper that emits the correct action for unambiguous single-operation batches. Mixed-operation batches fall back to `ruleUpdate`.

## Details

- **Backend (`bulk_edit_rules.ts`)**: Replace the hardcoded `RuleChangeTrackingAction.ruleUpdate` with `deriveChangeTrackingAction(operations)` which maps:
  - Single `apiKey` operation → `ruleUpdateApiKey`
  - Single `snoozeSchedule` `set` operation → `ruleSnooze`
  - Single `snoozeSchedule` unset operation → `ruleUnsnooze`
  - Mixed or multi-operation batch → `ruleUpdate`

## How to test

- Rotate the API key for a rule via bulk edit and confirm the change history event type is `ruleUpdateApiKey`.
- Snooze a rule via bulk edit and confirm the change history event type is `ruleSnooze`.
- Unsnooze a rule via bulk edit and confirm the change history event type is `ruleUnsnooze`.

## Release note

skip

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Low risk: only the change-tracking action enum value is affected; no behavioral change to the rule operations themselves.