### PR TITLE
[Core] Only enforce WIP SO type allowlist on distributable builds

### DIFF
--- a/docs/extend/saved-objects/troubleshooting.md
+++ b/docs/extend/saved-objects/troubleshooting.md
@@ -223,7 +223,9 @@ Kibana cannot start because the following WIP saved object types are registered 
 
 **Problem:** A type listed in `wip_types.json` is registered by a plugin but has not been explicitly allowed in the Kibana configuration.
 
-**Fix:** Add the type name to `migrations.allowWipTypes` in `kibana.yml` for every environment where the plugin is enabled:
+This hard failure only happens on **distributable builds** (production, including Serverless). On non-distributable builds (local development and CI test harnesses), Kibana logs a warning and starts normally, so you do not need to mirror `wip_types.json` into `migrations.allowWipTypes` just to run tests or develop locally.
+
+**Fix:** Add the type name to `migrations.allowWipTypes` in `kibana.yml` for every production environment where the plugin is enabled:
 
 ```yaml
 migrations.allowWipTypes:

--- a/docs/extend/saved-objects/validate.md
+++ b/docs/extend/saved-objects/validate.md
@@ -224,12 +224,14 @@ Use this when the feature and its plugin are only enabled in dedicated dev or QA
 
 1. Open a PR adding the type name to `src/core/packages/saved-objects/server-internal/wip_types.json` (reviewed by `@elastic/kibana-core`). This file is the gate that Core team reviews.
 
-2. Add the type name to `migrations.allowWipTypes` in every `kibana.yml` where the plugin is enabled. Kibana will fail to start if the type is registered but absent from this list:
+2. Add the type name to `migrations.allowWipTypes` in every **production** `kibana.yml` where the plugin is enabled. On distributable builds Kibana will fail to start if the type is registered but absent from this list:
 
    ```yaml
    migrations.allowWipTypes:
      - my_new_type
    ```
+
+   On non-distributable builds (local development and CI test harnesses) this acknowledgement is not required: Kibana logs a warning and starts normally, so the existing CI checks and test runners pick up WIP types without any extra configuration.
 
 3. Iterate freely. The CI SO check treats the type as perpetually new on every PR — the same checks that apply when first introducing a type always apply, but history-based immutability constraints (e.g. "existing model versions cannot change") are never enforced.
 

--- a/src/core/packages/saved-objects/server-internal/src/saved_objects_service.test.ts
+++ b/src/core/packages/saved-objects/server-internal/src/saved_objects_service.test.ts
@@ -29,6 +29,7 @@ import { MAIN_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
 import { nodeServiceMock } from '@kbn/core-node-server-mocks';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
+import { loggerMock } from '@kbn/logging-mocks';
 import { httpServiceMock, httpServerMock } from '@kbn/core-http-server-mocks';
 import type {
   SavedObjectsClientFactoryProvider,
@@ -60,6 +61,9 @@ import * as SavedObjectsImportExportModule from '@kbn/core-saved-objects-import-
 
 jest.mock('./object_types');
 jest.mock('./deprecations');
+
+jest.mock('../wip_types.json', () => []);
+const mockWipTypes = jest.requireMock('../wip_types.json') as string[];
 
 // Mock the importer and exporter constructors
 jest.mock('@kbn/core-saved-objects-import-export-server-internal', () => {
@@ -1240,6 +1244,71 @@ describe('SavedObjectsService', () => {
           );
         });
       });
+    });
+  });
+
+  describe('WIP saved object types gate', () => {
+    const WIP_TYPE = 'my_wip_type';
+
+    const createContextForWipGate = ({
+      dist,
+      allowWipTypes,
+      logger,
+    }: {
+      dist: boolean;
+      allowWipTypes?: string[];
+      logger?: ReturnType<typeof loggerMock.create>;
+    }) => {
+      const configService = configServiceMock.create();
+      configService.atPath.mockImplementation((path) => {
+        if (path === 'migrations') {
+          return new BehaviorSubject({ skip: true, allowWipTypes });
+        }
+        return new BehaviorSubject({
+          maxImportPayloadBytes: new ByteSizeValue(0),
+          maxImportExportSize: 10000,
+          enableAccessControl: true,
+        });
+      });
+      const env = Env.createDefault(REPO_ROOT, getEnvOptions({ cliArgs: { dist } }));
+      return mockCoreContext.create({ configService, env, logger });
+    };
+
+    beforeEach(() => {
+      mockWipTypes.length = 0;
+      mockWipTypes.push(WIP_TYPE);
+      typeRegistryInstanceMock.getAllTypes.mockReturnValue([createType({ name: WIP_TYPE })]);
+    });
+
+    it('throws on a distributable build when a registered WIP type is not allowed', async () => {
+      const coreContext = createContextForWipGate({ dist: true, allowWipTypes: [] });
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+
+      await expect(soService.start(createStartDeps())).rejects.toThrow(
+        `The following WIP saved object types are registered but not listed in 'migrations.allowWipTypes': [${WIP_TYPE}]`
+      );
+    });
+
+    it('starts on a distributable build when the registered WIP type is allowed', async () => {
+      const coreContext = createContextForWipGate({ dist: true, allowWipTypes: [WIP_TYPE] });
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+
+      await expect(soService.start(createStartDeps())).resolves.toBeDefined();
+    });
+
+    it('warns instead of throwing on a non-distributable build when the WIP type is not allowed', async () => {
+      const logger = loggerMock.create();
+      const coreContext = createContextForWipGate({ dist: false, allowWipTypes: [], logger });
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+
+      await expect(soService.start(createStartDeps())).resolves.toBeDefined();
+      const { warn } = loggerMock.collect(logger);
+      expect(warn).toContainEqual([
+        `The following WIP saved object types are registered but not listed in 'migrations.allowWipTypes': [${WIP_TYPE}]. Add each type name to 'migrations.allowWipTypes' to acknowledge the risk.`,
+      ]);
     });
   });
 });

--- a/src/core/packages/saved-objects/server-internal/src/saved_objects_service.ts
+++ b/src/core/packages/saved-objects/server-internal/src/saved_objects_service.ts
@@ -494,11 +494,18 @@ export class SavedObjectsService
 
     const notAllowed = registeredWipTypes.filter((name) => !allowedWipTypes.has(name));
     if (notAllowed.length > 0) {
-      throw new Error(
-        `Kibana cannot start because the following WIP saved object types are registered ` +
-          `but not listed in 'migrations.allowWipTypes': [${notAllowed.join(', ')}]. ` +
-          `Add each type name to 'migrations.allowWipTypes' to acknowledge the risk.`
-      );
+      // The allowlist is a deliberate production safeguard: operators must explicitly acknowledge
+      // each WIP type. Outside of distributable builds (local dev, CI test harnesses, etc.) WIP
+      // types are expected to be registered freely, so we relax the gate to a warning to avoid
+      // forcing every harness to mirror 'wip_types.json' into 'migrations.allowWipTypes'.
+      const reason =
+        `The following WIP saved object types are registered ` +
+        `but not listed in 'migrations.allowWipTypes': [${notAllowed.join(', ')}]. ` +
+        `Add each type name to 'migrations.allowWipTypes' to acknowledge the risk.`;
+      if (this.coreContext.env.cliArgs.dist) {
+        throw new Error(reason);
+      }
+      this.logger.warn(reason);
     }
     if (registeredWipTypes.length > 0) {
       this.logger.warn(


### PR DESCRIPTION
## Summary

WIP (work-in-progress) saved object types require their name to be listed in `migrations.allowWipTypes`, otherwise Kibana refuses to start. The first real usage of a WIP type exposed that none of the CI test harnesses (OAS snapshot capture, Scout, FTR, ...) — nor local dev — populate `allowWipTypes` from `wip_types.json`, so they crash on startup as soon as a WIP type is registered.

This relaxes the gate so it only **throws on distributable builds** (production / Serverless, `cliArgs.dist === true`). On non-distributable builds (local dev and CI test harnesses) it logs a warning and starts normally, so every current and future harness picks up WIP types without any extra configuration. The production safeguard is unchanged.

### Why centralize instead of patching each harness

Mirroring `wip_types.json` into `migrations.allowWipTypes` in every harness (OAS worker, FTR/Scout configs, kbn-server test helpers, jest_integration, ...) is fragile and easy to forget for future harnesses. Gating the throw on `dist` is a single change that covers them all while preserving the production acknowledgement.

## Changes

- `saved_objects_service.ts` — `assertNoUnallowedWipTypes` throws only when `cliArgs.dist`, warns otherwise.
- `saved_objects_service.test.ts` — behavioral tests: throws on dist+unallowed, starts on dist+allowed, warns on non-dist+unallowed.
- Docs (`troubleshooting.md`, `validate.md`) — clarify the allowlist is only required for production builds.

## Out of scope

The *Check changes in Saved Objects* failure seen alongside this is a separate, legitimate validation error (`new-type/keyword-missing-ignore-above`) for the type owner to fix; it is not addressed here.

## Test plan

- [ ] `node scripts/jest src/core/packages/saved-objects/server-internal/src/saved_objects_service.test.ts`
- [ ] CI green on harnesses that boot Kibana with a registered WIP type (OAS snapshot, Scout)

Closes #272565

Made with [Cursor](https://cursor.com)