### PR TITLE
[User Storage] namespace-aware document ids

### DIFF
--- a/src/core/packages/user-storage/server-internal/src/routes/index.ts
+++ b/src/core/packages/user-storage/server-internal/src/routes/index.ts
@@ -8,48 +8,27 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { Logger } from '@kbn/logging';
-import type { IRouter } from '@kbn/core-http-server';
+import type { IRouter, KibanaRequest } from '@kbn/core-http-server';
 import { AuthzDisabled } from '@kbn/core-security-server';
-import type {
-  CoreRequestHandlerContext,
-  RequestHandlerContext,
-} from '@kbn/core-http-request-handler-context-server';
-import type { UserStorageDefinition } from '@kbn/core-user-storage-common';
-import { USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE } from '../saved_objects';
-import { UserStorageClient } from '../user_storage_client';
+import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
+import type { IUserStorageClient } from '@kbn/core-user-storage-common';
 
 const FORBIDDEN_MESSAGE = 'User profile not available';
 
 const isUnregisteredKeyError = (err: unknown): err is Error =>
   err instanceof Error && err.message.includes('is not registered');
 
-interface RegisterRoutesParams {
+export interface RegisterRoutesParams {
   router: IRouter<RequestHandlerContext>;
-  definitions: ReadonlyMap<string, UserStorageDefinition>;
-  logger: Logger;
+  /**
+   * Returns a scoped client for the given request, or `null` when the request
+   * has no user profile (e.g. API-key auth). Supplied by the service at start
+   * time so that namespace resolution is handled in one place.
+   */
+  getClient: (request: KibanaRequest) => IUserStorageClient | null;
 }
 
-const getSoClient = (coreCtx: CoreRequestHandlerContext) =>
-  coreCtx.savedObjects.getClient({
-    includedHiddenTypes: [USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE],
-  });
-
-const createClientOrNull = (
-  coreCtx: CoreRequestHandlerContext,
-  params: { definitions: ReadonlyMap<string, UserStorageDefinition>; logger: Logger }
-): UserStorageClient | null => {
-  const profileUid = coreCtx.security.authc.getCurrentUser()?.profile_uid;
-  if (!profileUid) return null;
-  return new UserStorageClient({
-    savedObjectsClient: getSoClient(coreCtx),
-    profileUid,
-    definitions: params.definitions,
-    logger: params.logger,
-  });
-};
-
-export const registerRoutes = ({ router, definitions, logger }: RegisterRoutesParams) => {
+export const registerRoutes = ({ router, getClient }: RegisterRoutesParams) => {
   router.get(
     {
       path: '/internal/user_storage/{key}',
@@ -60,9 +39,8 @@ export const registerRoutes = ({ router, definitions, logger }: RegisterRoutesPa
         authz: AuthzDisabled.delegateToSOClient,
       },
     },
-    async (requestHandlerContext, request, response) => {
-      const coreCtx = await requestHandlerContext.core;
-      const client = createClientOrNull(coreCtx, { definitions, logger });
+    async (_requestHandlerContext, request, response) => {
+      const client = getClient(request);
       if (!client) return response.forbidden({ body: { message: FORBIDDEN_MESSAGE } });
 
       const { key } = request.params;
@@ -90,9 +68,8 @@ export const registerRoutes = ({ router, definitions, logger }: RegisterRoutesPa
         authz: AuthzDisabled.delegateToSOClient,
       },
     },
-    async (requestHandlerContext, request, response) => {
-      const coreCtx = await requestHandlerContext.core;
-      const client = createClientOrNull(coreCtx, { definitions, logger });
+    async (_requestHandlerContext, request, response) => {
+      const client = getClient(request);
       if (!client) return response.forbidden({ body: { message: FORBIDDEN_MESSAGE } });
 
       const { key } = request.params;
@@ -125,9 +102,8 @@ export const registerRoutes = ({ router, definitions, logger }: RegisterRoutesPa
         authz: AuthzDisabled.delegateToSOClient,
       },
     },
-    async (requestHandlerContext, request, response) => {
-      const coreCtx = await requestHandlerContext.core;
-      const client = createClientOrNull(coreCtx, { definitions, logger });
+    async (_requestHandlerContext, request, response) => {
+      const client = getClient(request);
       if (!client) return response.forbidden({ body: { message: FORBIDDEN_MESSAGE } });
 
       const { key } = request.params;

--- a/src/core/packages/user-storage/server-internal/src/user_storage_client.test.ts
+++ b/src/core/packages/user-storage/server-internal/src/user_storage_client.test.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
 import type { UserStorageDefinition } from '@kbn/core-user-storage-common';
 import { UserStorageClient } from './user_storage_client';
@@ -16,17 +17,27 @@ import { USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE } from './saved_objec
 
 const PROFILE_UID = 'profile-uid';
 
-const buildClient = (definitions: Map<string, UserStorageDefinition>) => {
+// Document ids produced by the client under each namespace.
+const DEFAULT_SPACE_DOC_ID = `default:${PROFILE_UID}`;
+const SECURITY_SPACE_DOC_ID = `security-space:${PROFILE_UID}`;
+
+const buildClient = (
+  definitions: Map<string, UserStorageDefinition>,
+  namespace?: string | undefined
+) => {
   const savedObjectsClient = savedObjectsClientMock.create();
   const logger: MockedLogger = loggerMock.create();
   const client = new UserStorageClient({
     savedObjectsClient,
     profileUid: PROFILE_UID,
+    namespace,
     definitions,
     logger,
   });
   return { client, savedObjectsClient, logger };
 };
+
+// ─── getForInjection ──────────────────────────────────────────────────────────
 
 describe('UserStorageClient.getForInjection()', () => {
   it('returns empty object when no definitions have preload: true', async () => {
@@ -51,10 +62,13 @@ describe('UserStorageClient.getForInjection()', () => {
     savedObjectsClient.bulkGet.mockResolvedValue({
       saved_objects: [
         {
-          id: PROFILE_UID,
+          id: DEFAULT_SPACE_DOC_ID,
           type: USER_STORAGE_SO_TYPE,
           references: [],
-          attributes: { userId: PROFILE_UID, data: { 'space:a': 'hello', 'space:b': 'world' } },
+          attributes: {
+            userId: PROFILE_UID,
+            data: { 'space:a': 'hello', 'space:b': 'world' },
+          },
         },
       ] as any,
     });
@@ -74,7 +88,7 @@ describe('UserStorageClient.getForInjection()', () => {
     savedObjectsClient.bulkGet.mockResolvedValue({
       saved_objects: [
         {
-          id: PROFILE_UID,
+          id: DEFAULT_SPACE_DOC_ID,
           type: USER_STORAGE_SO_TYPE,
           references: [],
           attributes: { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
@@ -92,11 +106,35 @@ describe('UserStorageClient.getForInjection()', () => {
 
     expect(savedObjectsClient.bulkGet).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
-      { type: USER_STORAGE_SO_TYPE, id: PROFILE_UID },
+      { type: USER_STORAGE_SO_TYPE, id: DEFAULT_SPACE_DOC_ID },
       { type: USER_STORAGE_GLOBAL_SO_TYPE, id: PROFILE_UID },
     ]);
     expect(savedObjectsClient.get).not.toHaveBeenCalled();
     expect(result).toEqual({ 'space:a': 'hello', 'global:b': 7 });
+  });
+
+  it('uses the namespaced id when the client is scoped to a non-default space', async () => {
+    const definitions = new Map<string, UserStorageDefinition>([
+      ['space:a', { schema: z.string(), defaultValue: 'a-default', scope: 'space', preload: true }],
+    ]);
+    const { client, savedObjectsClient } = buildClient(definitions, 'security-space');
+
+    savedObjectsClient.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: SECURITY_SPACE_DOC_ID,
+          type: USER_STORAGE_SO_TYPE,
+          references: [],
+          attributes: { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
+        },
+      ] as any,
+    });
+
+    await client.getForInjection();
+
+    expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
+      { type: USER_STORAGE_SO_TYPE, id: SECURITY_SPACE_DOC_ID },
+    ]);
   });
 
   it('only requests the scope(s) used by injectable keys', async () => {
@@ -109,7 +147,7 @@ describe('UserStorageClient.getForInjection()', () => {
     savedObjectsClient.bulkGet.mockResolvedValue({
       saved_objects: [
         {
-          id: PROFILE_UID,
+          id: DEFAULT_SPACE_DOC_ID,
           type: USER_STORAGE_SO_TYPE,
           references: [],
           attributes: { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
@@ -120,7 +158,7 @@ describe('UserStorageClient.getForInjection()', () => {
     await client.getForInjection();
 
     expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
-      { type: USER_STORAGE_SO_TYPE, id: PROFILE_UID },
+      { type: USER_STORAGE_SO_TYPE, id: DEFAULT_SPACE_DOC_ID },
     ]);
   });
 
@@ -134,13 +172,13 @@ describe('UserStorageClient.getForInjection()', () => {
     savedObjectsClient.bulkGet.mockResolvedValue({
       saved_objects: [
         {
-          id: PROFILE_UID,
+          id: DEFAULT_SPACE_DOC_ID,
           type: USER_STORAGE_SO_TYPE,
           references: [],
           attributes: {} as any,
           error: {
             error: 'Not Found',
-            message: 'Saved object [user-storage/profile-uid] not found',
+            message: `Saved object [user-storage/${DEFAULT_SPACE_DOC_ID}] not found`,
             statusCode: 404,
           },
         },
@@ -167,7 +205,7 @@ describe('UserStorageClient.getForInjection()', () => {
     savedObjectsClient.bulkGet.mockResolvedValue({
       saved_objects: [
         {
-          id: PROFILE_UID,
+          id: DEFAULT_SPACE_DOC_ID,
           type: USER_STORAGE_SO_TYPE,
           references: [],
           attributes: { userId: PROFILE_UID, data: { 'space:a': 123 } },
@@ -194,16 +232,114 @@ describe('UserStorageClient.getForInjection()', () => {
   });
 });
 
+// ─── set() ────────────────────────────────────────────────────────────────────
+
 describe('UserStorageClient.set()', () => {
-  it('returns the schema-validated value', async () => {
-    const definitions = new Map<string, UserStorageDefinition>([
+  const spaceDefinitions = () =>
+    new Map<string, UserStorageDefinition>([
       ['space:a', { schema: z.string().trim(), defaultValue: '', scope: 'space' }],
     ]);
-    const { client, savedObjectsClient } = buildClient(definitions);
+
+  it('returns the schema-validated value', async () => {
+    const { client, savedObjectsClient } = buildClient(spaceDefinitions());
     savedObjectsClient.update.mockResolvedValue({} as any);
 
     const result = await client.set('space:a', '  hello  ');
 
     expect(result).toBe('hello');
+  });
+
+  it('uses a namespaced document id for space-scoped keys', async () => {
+    const { client, savedObjectsClient } = buildClient(spaceDefinitions(), 'security-space');
+    savedObjectsClient.update.mockResolvedValue({} as any);
+
+    await client.set('space:a', 'hello');
+
+    expect(savedObjectsClient.update).toHaveBeenCalledWith(
+      USER_STORAGE_SO_TYPE,
+      SECURITY_SPACE_DOC_ID,
+      expect.any(Object)
+    );
+  });
+
+  it('creates the document when it does not exist yet', async () => {
+    const { client, savedObjectsClient } = buildClient(spaceDefinitions());
+    savedObjectsClient.update.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError(
+        USER_STORAGE_SO_TYPE,
+        DEFAULT_SPACE_DOC_ID
+      )
+    );
+    savedObjectsClient.create.mockResolvedValue({} as any);
+
+    const result = await client.set('space:a', 'hello');
+
+    expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
+    expect(savedObjectsClient.create).toHaveBeenCalledWith(
+      USER_STORAGE_SO_TYPE,
+      { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
+      { id: DEFAULT_SPACE_DOC_ID }
+    );
+    expect(result).toBe('hello');
+  });
+
+  it('recovers from a same-space concurrent create by retrying the update', async () => {
+    const { client, savedObjectsClient } = buildClient(spaceDefinitions());
+    savedObjectsClient.update
+      .mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(
+          USER_STORAGE_SO_TYPE,
+          DEFAULT_SPACE_DOC_ID
+        )
+      )
+      .mockResolvedValueOnce({} as any);
+    savedObjectsClient.create.mockRejectedValue(
+      SavedObjectsErrorHelpers.createConflictError(USER_STORAGE_SO_TYPE, DEFAULT_SPACE_DOC_ID)
+    );
+
+    const result = await client.set('space:a', 'hello');
+
+    expect(savedObjectsClient.update).toHaveBeenCalledTimes(2);
+    expect(result).toBe('hello');
+  });
+
+  it('succeeds in a second space because each space has its own document id', async () => {
+    // Regression: previously this failed with a 500 because the globally-unique
+    // profile_uid was used as the SO id, so a doc in one space conflicted with
+    // create in another space, and the conflict retry-update then got a NotFound.
+    // Now each space uses "{space}:{profile_uid}" so writes are fully independent.
+    const { client: securityClient, savedObjectsClient: securitySo } = buildClient(
+      spaceDefinitions(),
+      'security-space'
+    );
+    // First write in the security space finds no document → creates one.
+    securitySo.update.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError(
+        USER_STORAGE_SO_TYPE,
+        SECURITY_SPACE_DOC_ID
+      )
+    );
+    securitySo.create.mockResolvedValue({} as any);
+
+    const result = await securityClient.set('space:a', 'hello');
+
+    expect(result).toBe('hello');
+    expect(securitySo.create).toHaveBeenCalledWith(
+      USER_STORAGE_SO_TYPE,
+      { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
+      { id: SECURITY_SPACE_DOC_ID }
+    );
+    // The security-space doc id must differ from the default-space one.
+    expect(SECURITY_SPACE_DOC_ID).not.toBe(DEFAULT_SPACE_DOC_ID);
+  });
+
+  it('logs and rethrows unexpected errors from the initial update', async () => {
+    const { client, savedObjectsClient, logger } = buildClient(spaceDefinitions());
+    savedObjectsClient.update.mockRejectedValue(new Error('transport boom'));
+
+    await expect(client.set('space:a', 'hello')).rejects.toThrow('transport boom');
+
+    expect(savedObjectsClient.create).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/packages/user-storage/server-internal/src/user_storage_client.ts
+++ b/src/core/packages/user-storage/server-internal/src/user_storage_client.ts
@@ -13,14 +13,27 @@ import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import type { UserStorageDefinition, IUserStorageClient } from '@kbn/core-user-storage-common';
 import { USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE } from './saved_objects';
 
+/** Converts a namespace id to a stable string — mirrors `SavedObjectsUtils.namespaceIdToString`. */
+const namespaceToString = (namespace: string | undefined): string => namespace ?? 'default';
+
 interface UserStorageAttributes {
   userId: string;
   data?: Record<string, unknown>;
 }
 
+const getErrorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
+
 interface UserStorageClientOpts {
   savedObjectsClient: SavedObjectsClientContract;
   profileUid: string;
+  /**
+   * The active namespace (space id) for this request, or `undefined` for the
+   * default space. Used to build a per-space SO document id for space-scoped
+   * keys, so that writes in different spaces never collide on the same
+   * `multiple-isolated` document.
+   */
+  namespace: string | undefined;
   definitions: ReadonlyMap<string, UserStorageDefinition>;
   logger: Logger;
 }
@@ -29,12 +42,20 @@ interface UserStorageClientOpts {
 export class UserStorageClient implements IUserStorageClient {
   private readonly soClient: SavedObjectsClientContract;
   private readonly profileUid: string;
+  private readonly namespace: string | undefined;
   private readonly definitions: ReadonlyMap<string, UserStorageDefinition>;
   private readonly logger: Logger;
 
-  constructor({ savedObjectsClient, profileUid, definitions, logger }: UserStorageClientOpts) {
+  constructor({
+    savedObjectsClient,
+    profileUid,
+    namespace,
+    definitions,
+    logger,
+  }: UserStorageClientOpts) {
     this.soClient = savedObjectsClient;
     this.profileUid = profileUid;
+    this.namespace = namespace;
     this.definitions = definitions;
     this.logger = logger;
   }
@@ -44,7 +65,7 @@ export class UserStorageClient implements IUserStorageClient {
     const soType = this.getSoType(definition);
 
     try {
-      const doc = await this.soClient.get<UserStorageAttributes>(soType, this.profileUid);
+      const doc = await this.soClient.get<UserStorageAttributes>(soType, this.getSoId(definition));
       const raw = doc.attributes.data?.[key];
       if (raw != null) {
         const parsed = definition.schema.safeParse(raw);
@@ -77,7 +98,7 @@ export class UserStorageClient implements IUserStorageClient {
     }
 
     const objectsToFetch: Array<{ type: string; id: string }> = [];
-    if (hasSpace) objectsToFetch.push({ type: USER_STORAGE_SO_TYPE, id: this.profileUid });
+    if (hasSpace) objectsToFetch.push({ type: USER_STORAGE_SO_TYPE, id: this.spaceDocId() });
     if (hasGlobal) objectsToFetch.push({ type: USER_STORAGE_GLOBAL_SO_TYPE, id: this.profileUid });
 
     let spaceData: Record<string, unknown> | undefined;
@@ -122,31 +143,61 @@ export class UserStorageClient implements IUserStorageClient {
     const validated = definition.schema.parse(value) as T;
     const soType = this.getSoType(definition);
 
+    const soId = this.getSoId(definition);
+
     this.logger.debug(`Setting userStorage key [${key}] (scope: ${definition.scope})`);
 
     const dataUpdate = { data: { [key]: validated } };
 
     try {
-      await this.soClient.update(soType, this.profileUid, dataUpdate);
+      await this.soClient.update(soType, soId, dataUpdate);
     } catch (err) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
-        try {
-          await this.soClient.create(
-            soType,
-            { userId: this.profileUid, data: { [key]: validated } },
-            { id: this.profileUid }
-          );
-        } catch (createErr) {
-          // Conflict means a concurrent first-write for this user beat us to create().
-          // The doc now exists but our key isn't in it yet — retry as update().
-          if (SavedObjectsErrorHelpers.isConflictError(createErr)) {
-            await this.soClient.update(soType, this.profileUid, dataUpdate);
-          } else {
-            throw createErr;
-          }
-        }
-      } else {
+      if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
+        this.logger.error(
+          `Failed to update userStorage key [${key}] for user [${this.profileUid}] ` +
+            `(type: ${soType}, id: ${soId}, scope: ${definition.scope}): ${getErrorMessage(err)}`
+        );
         throw err;
+      }
+
+      this.logger.debug(
+        `No existing userStorage document [${soType}/${soId}]; creating one for key [${key}].`
+      );
+
+      try {
+        await this.soClient.create(
+          soType,
+          { userId: this.profileUid, data: { [key]: validated } },
+          {
+            id: soId,
+          }
+        );
+      } catch (createErr) {
+        // Conflict means a concurrent first-write for this user beat us to create().
+        // The doc now exists but our key isn't in it yet — retry as update().
+        if (!SavedObjectsErrorHelpers.isConflictError(createErr)) {
+          this.logger.error(
+            `Failed to create userStorage document [${soType}/${soId}] for key [${key}] ` +
+              `(scope: ${definition.scope}): ${getErrorMessage(createErr)}`
+          );
+          throw createErr;
+        }
+
+        this.logger.debug(
+          `Conflict creating userStorage document [${soType}/${soId}] for key [${key}]; ` +
+            `retrying as update.`
+        );
+
+        try {
+          await this.soClient.update(soType, soId, dataUpdate);
+        } catch (retryErr) {
+          this.logger.error(
+            `Failed to persist userStorage key [${key}] for user [${this.profileUid}] ` +
+              `(type: ${soType}, id: ${soId}, scope: ${definition.scope}) after create-conflict retry: ` +
+              `${getErrorMessage(retryErr)}`
+          );
+          throw retryErr;
+        }
       }
     }
 
@@ -160,7 +211,7 @@ export class UserStorageClient implements IUserStorageClient {
     this.logger.debug(`Removing userStorage key [${key}] (scope: ${definition.scope})`);
 
     try {
-      await this.soClient.update(soType, this.profileUid, { data: { [key]: null } });
+      await this.soClient.update(soType, this.getSoId(definition), { data: { [key]: null } });
     } catch (err) {
       if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
         throw err;
@@ -178,5 +229,27 @@ export class UserStorageClient implements IUserStorageClient {
 
   private getSoType(definition: UserStorageDefinition): string {
     return definition.scope === 'space' ? USER_STORAGE_SO_TYPE : USER_STORAGE_GLOBAL_SO_TYPE;
+  }
+
+  /**
+   * Returns the saved object document id for the given definition.
+   *
+   * - **Global** (`scope: 'global'`): `profile_uid` — one agnostic doc per user.
+   * - **Space** (`scope: 'space'`): `{space}:{profile_uid}` — `user-storage` is
+   *   `namespaceType: 'multiple-isolated'`, which means the raw ES `_id` does NOT
+   *   include a namespace prefix (unlike `single` types). Without application-level
+   *   namespacing the same profile_uid becomes a globally-unique id, causing cross-
+   *   space writes to conflict. Embedding the space in the id gives each space its
+   *   own document while preserving the access-control capabilities of the
+   *   `multiple-isolated` namespace type.
+   */
+  private getSoId(definition: UserStorageDefinition): string {
+    if (definition.scope === 'global') return this.profileUid;
+    return this.spaceDocId();
+  }
+
+  /** Space-scoped document id for this request: `{space}:{profile_uid}`. */
+  private spaceDocId(): string {
+    return `${namespaceToString(this.namespace)}:${this.profileUid}`;
   }
 }

--- a/src/core/packages/user-storage/server-internal/src/user_storage_service.ts
+++ b/src/core/packages/user-storage/server-internal/src/user_storage_service.ts
@@ -18,6 +18,7 @@ import type { InternalSecurityServiceStart } from '@kbn/core-security-server-int
 import type {
   UserStorageDefinition,
   UserStorageRegistrations,
+  IUserStorageClient,
 } from '@kbn/core-user-storage-common';
 import type {
   UserStorageServiceSetup,
@@ -46,6 +47,14 @@ export interface UserStorageStartDeps {
 export class UserStorageService {
   private readonly definitions = new Map<string, UserStorageDefinition>();
   private readonly logger: Logger;
+  /**
+   * Populated in `start()`; routes call this to get a scoped client. Using a
+   * mutable reference avoids a hard dependency between the route setup (which
+   * runs during `setup()`) and the start-time dependencies (savedObjects,
+   * security) that are only available once `start()` fires.
+   */
+  private scopedClientFactory: ((request: KibanaRequest) => IUserStorageClient | null) | null =
+    null;
 
   constructor(coreContext: CoreContext) {
     this.logger = coreContext.logger.get('user-storage');
@@ -58,7 +67,18 @@ export class UserStorageService {
     savedObjects.registerType(userStorageGlobalType);
 
     const router = http.createRouter<RequestHandlerContext>('');
-    registerRoutes({ router, definitions: this.definitions, logger: this.logger });
+    registerRoutes({
+      router,
+      getClient: (request) => {
+        if (!this.scopedClientFactory) {
+          this.logger.error(
+            'userStorage.getClient called before start() completed; returning null.'
+          );
+          return null;
+        }
+        return this.scopedClientFactory(request);
+      },
+    });
 
     return {
       register: (registrations: UserStorageRegistrations) => {
@@ -96,26 +116,42 @@ export class UserStorageService {
   public start({ savedObjects, security }: UserStorageStartDeps): UserStorageServiceStart {
     this.logger.debug('Starting user storage service');
 
-    return {
-      asScoped: (request: KibanaRequest) => {
-        const profileUid = security.authc.getCurrentUser(request)?.profile_uid;
-        if (!profileUid) return null;
+    const asScoped = (request: KibanaRequest): IUserStorageClient | null => {
+      const profileUid = security.authc.getCurrentUser(request)?.profile_uid;
+      if (!profileUid) return null;
 
-        const savedObjectsClient = savedObjects.getScopedClient(request, {
-          includedHiddenTypes: [USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE],
-        });
+      const savedObjectsClient = savedObjects.getScopedClient(request, {
+        includedHiddenTypes: [USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE],
+      });
 
-        return new UserStorageClient({
-          savedObjectsClient,
-          profileUid,
-          definitions: this.definitions,
-          logger: this.logger,
-        });
-      },
+      // Resolve the active space namespace so that space-scoped document ids are
+      // namespaced (e.g. `<space>:<profile_uid>`), preventing cross-space id
+      // collisions on the `multiple-isolated` SO type.
+      //
+      // This must be read from the scoped client (not a bare
+      // `createScopedRepository`): `getScopedClient` applies the spaces extension
+      // via the client provider, so `getCurrentNamespace()` reflects the request's
+      // space. A repository built directly from `createScopedRepository` without
+      // extensions has no spaces extension and always returns `undefined`.
+      const namespace = savedObjectsClient.getCurrentNamespace();
+
+      return new UserStorageClient({
+        savedObjectsClient,
+        profileUid,
+        namespace,
+        definitions: this.definitions,
+        logger: this.logger,
+      });
     };
+
+    // Make the factory available to the routes registered during setup().
+    this.scopedClientFactory = asScoped;
+
+    return { asScoped };
   }
 
   public stop() {
     this.logger.debug('Stopping user storage service');
+    this.scopedClientFactory = null;
   }
 }

--- a/src/core/server/integration_tests/user_storage/remove.test.ts
+++ b/src/core/server/integration_tests/user_storage/remove.test.ts
@@ -54,6 +54,7 @@ describe('UserStorage remove() / null-merge behavior', () => {
     userStorage = new UserStorageClient({
       savedObjectsClient,
       profileUid: PROFILE_UID,
+      namespace: undefined,
       definitions,
       logger: kbn.root.logger.get('user-storage-test'),
     });


### PR DESCRIPTION
## Summary

The `user-storage` SO namespaceType is `multiple-isolated`, which means its raw ES `_id` is not namespace-prefixed by core. This made every user's space-scoped doc globally unique under `user-storage:<profile_uid>`, causing cross-space writes to conflict and ultimately 500.

The fix is applied at the application layer: space-scoped keys now use `{space}:{profile_uid}` as the SO document id instead of the bare profile_uid. Each space owns an independent document; no cross-space collision is possible. The `multiple-isolated` type is preserved (and with it, the security team's future access-control capability).

| Module | Changes
|-|-
| `user_storage_client.ts` | <ul><li>`UserStorageClientOpts` gains a `namespace: string \| undefined` field. <li>`getSoId(definition)` returns `{space}:{profileUid}` for space scope and bare `profileUid` for global; a `spaceDocId()` helper builds the `{space}:{profileUid}` id and is also used directly by the `bulkGet` in `getForInjection`. <li>All SO read/write calls now address the doc via `getSoId`/`spaceDocId` rather than the bare profile_uid. <li>Error logging in `set()` reports the resolved `type`/`id`/`scope` on update/create/retry failures; the "different space" case is no longer reachable. <li>The conflict-retry path remains for legitimate same-space concurrent first-writes.</ul>
| `user_storage_service.ts` | <ul><li>`start().asScoped()` resolves the active namespace via `savedObjects.getScopedClient(request, { includedHiddenTypes }).getCurrentNamespace()` and passes it to the client. The namespace **must** come from the scoped client — `getScopedClient` applies the spaces extension via the client provider<li>A `scopedClientFactory` reference (set in `start`, cleared in `stop`) is exposed to the routes via `registerRoutes({ getClient })`, eliminating the duplicate inline client construction that previously had no namespace.</ul>
| `routes/index.ts` | <ul><li>`RegisterRoutesParams` now takes a `getClient: (request) => IUserStorageClient \| null` factory instead of `definitions + logger`. <li>Route handlers call `getClient(request)` and `forbidden()` when it returns `null`. No more direct `UserStorageClient` construction in route handlers.</ul>
| `remove.test.ts` | <ul><li>Added the now-required `namespace: undefined` field to the one place that constructs `UserStorageClient` directly.</ul>
| `user_storage_client.test.ts` | <ul><li>Updated all `get` / `bulkGet` / `update` / `create` assertions to use namespaced ids. <li>Added tests for the namespaced-id behavior and the regression ("succeeds in a second space"), which previously would have hit the cross-space conflict path.</ul>



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



