### PR TITLE
[One Workflows] Fix alerts table scrolling in workflow execute modal

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_alert_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_alert_form.tsx
@@ -316,7 +316,7 @@ export const WorkflowExecuteAlertForm = ({
   ];
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
+    <EuiFlexGroup direction="column" gutterSize="s" css={{ flex: 1, minHeight: 0, height: '100%' }}>
       <EuiFlexItem grow={false}>
         <AlertsSearchBar
           appName="workflow_management"
@@ -367,7 +367,7 @@ export const WorkflowExecuteAlertForm = ({
         </EuiFlexItem>
       )}
 
-      <EuiFlexItem>
+      <EuiFlexItem css={{ overflow: 'auto' }}>
         <EuiBasicTable
           itemId="_id"
           rowHeader="@timestamp"

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -302,6 +302,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
         };
 
     const isFillHeightTriggerBody =
+      selectedTrigger === 'alert' ||
       selectedTrigger === 'event' ||
       selectedTrigger === 'manual' ||
       selectedTrigger === 'historical';


### PR DESCRIPTION
## Summary

This PR addresses a UI issue in the Workflows execution modal (Alerts tab) where the alerts table lacks the correct flex properties to scroll, causing it to push the boundaries of the modal indefinitely instead of internally scrolling.

### Changes

- Updated the `isFillHeightTriggerBody` flag in `workflow_execute_modal.tsx` to include the `alert` trigger. This allows the modal body to enforce a `min-height: 0` and `flex: 1` structure.
- Added `flex: 1` and `minHeight: 0` to the root `EuiFlexGroup` in `workflow_execute_alert_form.tsx`.
- Added `overflow: 'auto'` to the `EuiFlexItem` wrapping the `EuiBasicTable` to ensure it correctly scrolls internally.

## Visual Changes

### Before

<img width="1766" height="1196" alt="Screenshot 2026-06-03 at 20 33 01" src="https://github.com/user-attachments/assets/84315297-095e-45b9-be5f-76492ad5ce8f" />

### After

https://github.com/user-attachments/assets/3e870c5e-2da5-45a7-8a45-2f07009cefcb

## Verification Steps

1. Navigate to the Workflows Execute Modal and select the **Alert** trigger tab.
2. Ensure you have a substantial amount of alerts generated in the system.
3. **Verify Scrolling**: Verify that the alerts table correctly scrolls vertically within the modal body.
