### PR TITLE
Dispatch action policy workflow payload under a payload field

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/completion/payload_completion_provider.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/completion/payload_completion_provider.test.ts
@@ -28,7 +28,7 @@ const makePosition = (column: number) => ({
 describe('createPayloadCompletionProvider', () => {
   const provider = createPayloadCompletionProvider();
 
-  it('returns inputs.-prefixed variables at top level inside an empty template', () => {
+  it('returns inputs.payload.-prefixed variables at top level inside an empty template', () => {
     const line = '{{ ';
     const result = provider.provideCompletionItems!(
       makeModel(line) as any,
@@ -39,16 +39,28 @@ describe('createPayloadCompletionProvider', () => {
 
     expect(result.suggestions).toHaveLength(DISPATCH_PAYLOAD_VARIABLES.length);
     expect(result.suggestions.map((s) => s.label)).toEqual(
-      DISPATCH_PAYLOAD_VARIABLES.map((v) => `inputs.${v.path}`)
+      DISPATCH_PAYLOAD_VARIABLES.map((v) => `inputs.payload.${v.path}`)
     );
     // insertText must match the label so accepting a suggestion doesn't double the prefix
     expect(result.suggestions.map((s) => s.insertText)).toEqual(
-      DISPATCH_PAYLOAD_VARIABLES.map((v) => `inputs.${v.path}`)
+      DISPATCH_PAYLOAD_VARIABLES.map((v) => `inputs.payload.${v.path}`)
     );
   });
 
-  it('returns bare inputs children inside {{ inputs.', () => {
+  it('returns the payload wrapper inside {{ inputs.', () => {
     const line = '{{ inputs.';
+    const result = provider.provideCompletionItems!(
+      makeModel(line) as any,
+      makePosition(line.length + 1) as any,
+      {} as any,
+      {} as any
+    ) as { suggestions: Array<{ label: string }> };
+
+    expect(result.suggestions.map((s) => s.label)).toEqual(['payload']);
+  });
+
+  it('returns bare payload children inside {{ inputs.payload.', () => {
+    const line = '{{ inputs.payload.';
     const result = provider.provideCompletionItems!(
       makeModel(line) as any,
       makePosition(line.length + 1) as any,
@@ -62,8 +74,8 @@ describe('createPayloadCompletionProvider', () => {
     );
   });
 
-  it('returns episode fields when cursor is inside inputs.episodes[N].', () => {
-    const line = 'to: "{{ inputs.episodes[0].';
+  it('returns episode fields when cursor is inside inputs.payload.episodes[N].', () => {
+    const line = 'to: "{{ inputs.payload.episodes[0].';
     const result = provider.provideCompletionItems!(
       makeModel(line) as any,
       makePosition(line.length + 1) as any,
@@ -99,8 +111,8 @@ describe('createPayloadCompletionProvider', () => {
     expect(result.suggestions).toHaveLength(0);
   });
 
-  it('returns bare inputs children for the second template on the same line', () => {
-    const line = '{{ inputs.id }} text {{ inputs.poli';
+  it('returns bare payload children for the second template on the same line', () => {
+    const line = '{{ inputs.payload.id }} text {{ inputs.payload.poli';
     const result = provider.provideCompletionItems!(
       makeModel(line) as any,
       makePosition(line.length + 1) as any,
@@ -113,7 +125,7 @@ describe('createPayloadCompletionProvider', () => {
   });
 
   it('returns no suggestions inside a Liquid filter context', () => {
-    const line = '{{ inputs.id | upc';
+    const line = '{{ inputs.payload.id | upc';
     const result = provider.provideCompletionItems!(
       makeModel(line) as any,
       makePosition(line.length + 1) as any,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/completion/payload_completion_provider.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/completion/payload_completion_provider.ts
@@ -10,8 +10,17 @@ import { parseLineForCompletion } from '@kbn/workflows-yaml';
 import type { PayloadVariable } from '../registry';
 import { DISPATCH_PAYLOAD_VARIABLES, ALERT_EPISODE_FIELDS } from '../registry';
 
-// All dispatcher payload variables are nested under `context.inputs` at render time.
-const TOP_LEVEL_PREFIX = 'inputs.';
+// All dispatcher payload variables are nested under `context.inputs.payload` at render time.
+const TOP_LEVEL_PREFIX = 'inputs.payload.';
+
+// The single wrapper key exposed directly under `inputs`.
+const PAYLOAD_WRAPPER: readonly PayloadVariable[] = [
+  {
+    path: 'payload',
+    detail: 'object',
+    documentation: 'Dispatcher payload for the action group.',
+  },
+];
 
 const buildItem = (
   variable: PayloadVariable,
@@ -34,10 +43,14 @@ const getParentPath = (pathSegments: string[] | null, lastPathSegment: string | 
 };
 
 const isEpisodeContext = (parent: string[]): boolean =>
-  parent.length >= 3 &&
+  parent.length >= 4 &&
   parent[0] === 'inputs' &&
-  parent[1] === 'episodes' &&
-  /^\d+$/.test(parent[2]);
+  parent[1] === 'payload' &&
+  parent[2] === 'episodes' &&
+  /^\d+$/.test(parent[3]);
+
+const isPayloadContext = (parent: string[]): boolean =>
+  parent.length === 2 && parent[0] === 'inputs' && parent[1] === 'payload';
 
 const isInputsContext = (parent: string[]): boolean =>
   parent.length === 1 && parent[0] === 'inputs';
@@ -72,8 +85,10 @@ export const createPayloadCompletionProvider = (): monaco.languages.CompletionIt
     let prefix = '';
     if (isEpisodeContext(parent)) {
       candidates = ALERT_EPISODE_FIELDS;
-    } else if (isInputsContext(parent)) {
+    } else if (isPayloadContext(parent)) {
       candidates = DISPATCH_PAYLOAD_VARIABLES;
+    } else if (isInputsContext(parent)) {
+      candidates = PAYLOAD_WRAPPER;
     } else if (parent.length === 0) {
       candidates = DISPATCH_PAYLOAD_VARIABLES;
       prefix = TOP_LEVEL_PREFIX;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/components/params_editor.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/components/params_editor.tsx
@@ -38,9 +38,9 @@ export const ParamsEditor = ({ value, onChange, height = 200 }: ParamsEditorProp
         'Use {syntax} to reference dispatcher payload values such as {policyId}, {groupKey}, or {episodes}.',
       values: {
         syntax: '{{ ... }}',
-        policyId: '{{ inputs.policyId }}',
-        groupKey: '{{ inputs.groupKey }}',
-        episodes: '{{ inputs.episodes }}',
+        policyId: '{{ inputs.payload.policyId }}',
+        groupKey: '{{ inputs.payload.groupKey }}',
+        episodes: '{{ inputs.payload.episodes }}',
       },
     })}
     fullWidth

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/registry/payload_variables.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/registry/payload_variables.ts
@@ -8,8 +8,8 @@
 import type { PayloadVariable } from './types';
 
 // Mirrors `ActionPolicyWorkflowPayload` from server/lib/dispatcher/types.ts.
-// These are the children of `context.inputs` at workflow render time — scheduleWorkflow
-// wraps non-`event` payload fields under `inputs`, so templates use `{{ inputs.policyId }}`, etc.
+// These are the children of `context.inputs.payload` at workflow render time — the dispatcher
+// schedules the workflow with `{ payload }`, so templates use `{{ inputs.payload.policyId }}`, etc.
 // Keep in sync when the dispatcher payload changes.
 export const DISPATCH_PAYLOAD_VARIABLES: readonly PayloadVariable[] = [
   {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/single_step_workflow_form.stories.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/single_step_workflow_form/single_step_workflow_form.stories.tsx
@@ -73,7 +73,7 @@ export const CreateNewFilled: Story = {
       typeId: 'email',
       connectorId: 'email-ops',
       params:
-        'to: "{{ inputs.policyId }}@example.com"\nsubject: "Alert for {{ inputs.id }}"\nmessage: "{{ inputs.episodes }} episodes"\n',
+        'to: "{{ inputs.payload.policyId }}@example.com"\nsubject: "Alert for {{ inputs.payload.id }}"\nmessage: "{{ inputs.payload.episodes }} episodes"\n',
     },
   },
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -342,11 +342,11 @@ steps:
     with:
       to:
         - <user-provided-email>
-      subject: "Alert: <rule-name> — {{ inputs.episodes | size }} episode(s)"
+      subject: "Alert: <rule-name> — {{ inputs.payload.episodes | size }} episode(s)"
       message: >
-        Rule "<rule-name>" triggered {{ inputs.episodes | size }} alert episode(s).
+        Rule "<rule-name>" triggered {{ inputs.payload.episodes | size }} alert episode(s).
 
-        {% for ep in inputs.episodes %}
+        {% for ep in inputs.payload.episodes %}
         - Host: {{ ep.data.host.name | default: "unknown" }}
           Errors: {{ ep.data.error_count | default: "n/a" }}
           Status: {{ ep.episode_status }}
@@ -373,14 +373,14 @@ steps:
 
 | Variable | Description |
 |---|---|
-| \`inputs.episodes\` | Array of alert episodes |
-| \`inputs.episodes[].episode_status\` | \`active\`, \`pending\`, \`recovering\`, or \`inactive\` |
-| \`inputs.episodes[].rule_id\` | The rule's saved object ID |
-| \`inputs.episodes[].episode_id\` | The episode UUID |
-| \`inputs.episodes[].data.*\` | ES|QL output row fields (populated for active/pending) |
-| \`inputs.policyId\` | The action policy ID |
-| \`inputs.id\` | The action group ID |
-| \`inputs.groupKey\` | The grouping key object |
+| \`inputs.payload.episodes\` | Array of alert episodes |
+| \`inputs.payload.episodes[].episode_status\` | \`active\`, \`pending\`, \`recovering\`, or \`inactive\` |
+| \`inputs.payload.episodes[].rule_id\` | The rule's saved object ID |
+| \`inputs.payload.episodes[].episode_id\` | The episode UUID |
+| \`inputs.payload.episodes[].data.*\` | ES|QL output row fields (populated for active/pending) |
+| \`inputs.payload.policyId\` | The action policy ID |
+| \`inputs.payload.id\` | The action group ID |
+| \`inputs.payload.groupKey\` | The grouping key object |
 | \`triggeredBy\` | Always \`"action_policy"\` |
 | \`spaceId\` | The Kibana space |
 | \`execution.url\` | Direct link to the workflow execution in Kibana |

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/dispatch_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/dispatch_step.test.ts
@@ -81,10 +81,12 @@ describe('DispatchStep', () => {
       expect.objectContaining({ id: 'workflow-1', name: 'Test Workflow' }),
       'default',
       expect.objectContaining({
-        id: 'g1',
-        policyId: 'p1',
-        groupKey: group.groupKey,
-        episodes: group.episodes,
+        payload: expect.objectContaining({
+          id: 'g1',
+          policyId: 'p1',
+          groupKey: group.groupKey,
+          episodes: group.episodes,
+        }),
       }),
       expect.objectContaining({
         headers: expect.objectContaining({
@@ -329,7 +331,9 @@ describe('DispatchStep', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({
-        rules: { 'rule-1': { name: 'CPU spike monitor' } },
+        payload: expect.objectContaining({
+          rules: { 'rule-1': { name: 'CPU spike monitor' } },
+        }),
       }),
       expect.anything(),
       expect.anything()
@@ -364,7 +368,7 @@ describe('DispatchStep', () => {
     expect(mockWfm.scheduleWorkflow).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ rules: {} }),
+      expect.objectContaining({ payload: expect.objectContaining({ rules: {} }) }),
       expect.anything(),
       expect.anything()
     );

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/dispatch_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/dispatch_step.ts
@@ -176,7 +176,7 @@ export class DispatchStep implements DispatcherStep {
     const executionId = await this.workflowsManagement.scheduleWorkflow(
       model,
       group.spaceId,
-      payload,
+      { payload },
       request,
       ACTION_POLICY_TRIGGER
     );


### PR DESCRIPTION
## Summary

The workflow team is introducing a `$ref` system for input properties, which requires the dispatcher to nest the action-policy payload under a dedicated field rather than spreading it at the top level.

This change schedules workflows with `{ payload }` instead of the bare payload object, so payload values are now exposed to workflow templates under `inputs.payload.*` (e.g. `{{ inputs.payload.policyId }}`) instead of `inputs.*`.

### Changes
- `dispatch_step.ts`: schedule workflows with `{ payload }`.
- Updated the public single-step workflow form to match the new template paths:
  - autocomplete provider now suggests `inputs.payload.*` (with an intermediate `payload` wrapper suggestion).
  - default params editor examples and registry sync comment.
- Updated docs/examples in the agent-builder rule-management skill and the Storybook story.
- Updated unit tests for the dispatcher and completion provider.

## Test plan
- [x] `node scripts/jest` for `dispatch_step.test.ts` and `payload_completion_provider.test.ts`
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/alerting_v2/tsconfig.json`

Closes elastic/rna-program#496

Made with [Cursor](https://cursor.com)