### PR TITLE
[Entity Analytics] Fixing filtering for `Unknown` risk level from donut chart

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
@@ -13,7 +13,7 @@ import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
 import { useRiskLevelsEsqlQuery } from '../watchlists/components/hooks/use_risk_levels_esql_query';
 import { useKibana } from '../../../common/lib/kibana';
 import { RiskSeverity } from '../../../../common/search_strategy';
-import { ENTITY_RISK_LEVEL_FIELD } from './risk_level_breakdown_table';
+import { ENTITY_RISK_LEVEL_FIELD, RiskLevelBreakdownTable } from './risk_level_breakdown_table';
 import { RiskScoreDonutChart } from '../risk_score_donut_chart';
 
 jest.mock('./use_combined_risk_score_kpi');
@@ -27,10 +27,16 @@ jest.mock('../risk_score_donut_chart', () => ({
   RiskScoreDonutChart: jest.fn(() => <div data-test-subj="mock-risk-score-donut-chart" />),
 }));
 
+jest.mock('./risk_level_breakdown_table', () => ({
+  ...jest.requireActual('./risk_level_breakdown_table'),
+  RiskLevelBreakdownTable: jest.fn(() => <div data-test-subj="mock-risk-level-breakdown-table" />),
+}));
+
 const mockUseCombinedRiskScoreKpi = useCombinedRiskScoreKpi as jest.Mock;
 const mockUseRiskLevelsEsqlQuery = useRiskLevelsEsqlQuery as jest.Mock;
 const mockUseKibana = useKibana as jest.Mock;
 const mockRiskScoreDonutChart = RiskScoreDonutChart as unknown as jest.Mock;
+const mockRiskLevelBreakdownTable = RiskLevelBreakdownTable as unknown as jest.Mock;
 
 const buildKibanaServices = (addFilters: jest.Mock, isV2Enabled: boolean) => ({
   services: {
@@ -138,6 +144,44 @@ describe('DynamicRiskLevelPanel', () => {
           negate: false,
         },
         query: { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: RiskSeverity.Critical } },
+      },
+    ]);
+  });
+
+  it('applies custom filter for Unknown entity.risk.calculated_level', () => {
+    const addFilters = jest.fn();
+    mockUseKibana.mockReturnValue(buildKibanaServices(addFilters, false));
+
+    render(
+      <TestProviders>
+        <DynamicRiskLevelPanel />
+      </TestProviders>
+    );
+
+    expect(mockRiskScoreDonutChart).toHaveBeenCalled();
+    const donutProps = mockRiskScoreDonutChart.mock.calls[0][0];
+    expect(typeof donutProps.onPartitionClick).toBe('function');
+
+    donutProps.onPartitionClick(RiskSeverity.Unknown);
+
+    expect(addFilters).toHaveBeenCalledTimes(1);
+    expect(addFilters).toHaveBeenCalledWith([
+      {
+        meta: {
+          alias: 'Risk level: Unknown',
+          disabled: false,
+          negate: false,
+          key: 'entity.risk.calculated_level',
+        },
+        query: {
+          bool: {
+            should: [
+              { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: 'Unknown' } },
+              { bool: { must_not: { exists: { field: ENTITY_RISK_LEVEL_FIELD } } } },
+            ],
+            minimum_should_match: 1,
+          },
+        },
       },
     ]);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
@@ -13,7 +13,7 @@ import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
 import { useRiskLevelsEsqlQuery } from '../watchlists/components/hooks/use_risk_levels_esql_query';
 import { useKibana } from '../../../common/lib/kibana';
 import { RiskSeverity } from '../../../../common/search_strategy';
-import { ENTITY_RISK_LEVEL_FIELD, RiskLevelBreakdownTable } from './risk_level_breakdown_table';
+import { ENTITY_RISK_LEVEL_FIELD } from './risk_level_breakdown_table';
 import { RiskScoreDonutChart } from '../risk_score_donut_chart';
 
 jest.mock('./use_combined_risk_score_kpi');
@@ -27,16 +27,10 @@ jest.mock('../risk_score_donut_chart', () => ({
   RiskScoreDonutChart: jest.fn(() => <div data-test-subj="mock-risk-score-donut-chart" />),
 }));
 
-jest.mock('./risk_level_breakdown_table', () => ({
-  ...jest.requireActual('./risk_level_breakdown_table'),
-  RiskLevelBreakdownTable: jest.fn(() => <div data-test-subj="mock-risk-level-breakdown-table" />),
-}));
-
 const mockUseCombinedRiskScoreKpi = useCombinedRiskScoreKpi as jest.Mock;
 const mockUseRiskLevelsEsqlQuery = useRiskLevelsEsqlQuery as jest.Mock;
 const mockUseKibana = useKibana as jest.Mock;
 const mockRiskScoreDonutChart = RiskScoreDonutChart as unknown as jest.Mock;
-const mockRiskLevelBreakdownTable = RiskLevelBreakdownTable as unknown as jest.Mock;
 
 const buildKibanaServices = (addFilters: jest.Mock, isV2Enabled: boolean) => ({
   services: {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.tsx
@@ -10,8 +10,7 @@ import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import type { RiskSeverity } from '../../../../common/search_strategy';
-import { EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
+import { RiskSeverity, EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { RiskScoreDonutChart } from '../risk_score_donut_chart';
 import { ENTITY_RISK_LEVEL_FIELD, RiskLevelBreakdownTable } from './risk_level_breakdown_table';
@@ -83,18 +82,40 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
 
   const handlePartitionClick = useCallback(
     (level: RiskSeverity) => {
-      filterManager.addFilters([
-        {
-          meta: {
-            alias: null,
-            disabled: false,
-            negate: false,
-          },
-          query: { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: level } },
-        },
-      ]);
+      const filter =
+        level === RiskSeverity.Unknown
+          ? {
+              meta: {
+                alias: i18n.translate(
+                  'xpack.securitySolution.entityAnalytics.dynamicRiskLevel.unknownFilterAlias',
+                  { defaultMessage: 'Risk level: Unknown' }
+                ),
+                index: entityDataView?.id,
+                key: ENTITY_RISK_LEVEL_FIELD,
+                disabled: false,
+                negate: false,
+              },
+              query: {
+                bool: {
+                  should: [
+                    { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: level } },
+                    { bool: { must_not: { exists: { field: ENTITY_RISK_LEVEL_FIELD } } } },
+                  ],
+                  minimum_should_match: 1,
+                },
+              },
+            }
+          : {
+              meta: {
+                alias: null,
+                disabled: false,
+                negate: false,
+              },
+              query: { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: level } },
+            };
+      filterManager.addFilters([filter]);
     },
-    [filterManager]
+    [filterManager, entityDataView?.id]
   );
 
   const title = i18n.translate(


### PR DESCRIPTION
## Summary

Adding custom filter for `Unknown` risk level filter that properly captures the risk_level: null condition.

Note: This does not fix the cell actions on the aggregated risk table. Intercepting the cell actions to add a custom filter is a much larger change and is not addressed by this PR

**Before:**
Donut chart shows 3 entities. Applying filter shows 1 entity
https://github.com/user-attachments/assets/c061bef7-2707-47a7-97b7-ca9aaacea5c5

**After:**
Donut chart shows 3 entities. Applying filter shows 3 entities. Filter is a custom filter with alias

https://github.com/user-attachments/assets/86e81cac-0966-46c9-8858-d1e447a5c4e2


