### PR TITLE
[9.4] [Dashboards] Capture route and application errors in server logs and APM (#269802)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { apm } from '@elastic/apm-rum';
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
 import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
@@ -145,7 +146,14 @@ export function DashboardRenderer({
           setShowControlGroup(results.useControlsIntegration);
       })
       .catch((err) => {
-        if (!canceled) setError(err);
+        if (!canceled) {
+          apm.captureError(err, {
+            labels: {
+              error_type: 'LoadDashboardFailure',
+            },
+          });
+          setError(err);
+        }
       });
 
     return () => {

--- a/src/platform/plugins/shared/dashboard/public/share/use_sanitized_dashboard_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/share/use_sanitized_dashboard_state.ts
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { apm } from '@elastic/apm-rum';
 import type { DashboardState } from '../../server';
 import { sanitizeDashboard } from './sanitize_dashboard';
 import type { ExportJsonSanitizedState, ExportJsonStatus } from './types';
@@ -47,7 +48,13 @@ export function useSanitizedDashboardState({
       })
       .catch((e) => {
         if (!isMounted) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
+        const err = e instanceof Error ? e : new Error(String(e));
+        apm.captureError(err, {
+          labels: {
+            error_type: 'SanitizeDashboardFailure',
+          },
+        });
+        setError(err);
         setStatus('error');
       });
 

--- a/src/platform/plugins/shared/dashboard/server/api/create/register_create_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/register_create_route.ts
@@ -8,7 +8,7 @@
  */
 
 import type { VersionedRouter } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core/server';
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { once } from 'lodash';
 import { telemetryHandler } from '@kbn/as-code-shared-telemetry';
@@ -21,7 +21,8 @@ import { writeErrorHandler } from '../write_error_handler';
 export function registerCreateRoute(
   router: VersionedRouter<RequestHandlerContext>,
   usageCounter: UsageCounter | undefined,
-  isDashboardAppRequest: boolean
+  isDashboardAppRequest: boolean,
+  logger: Logger
 ) {
   const { basePath, routeConfig, routeVersion } = getRouteConfig(isDashboardAppRequest);
   const createRoute = router.post({
@@ -70,7 +71,7 @@ export function registerCreateRoute(
           );
           return res.created({ body: result });
         } catch (e) {
-          return writeErrorHandler(e, res);
+          return writeErrorHandler(e, res, logger, req);
         }
       })
   );

--- a/src/platform/plugins/shared/dashboard/server/api/delete/register_delete_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/delete/register_delete_route.ts
@@ -8,16 +8,18 @@
  */
 
 import type { VersionedRouter } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core/server';
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { telemetryHandler } from '@kbn/as-code-shared-telemetry';
 import { getRouteConfig } from '../get_route_config';
 import { deleteDashboard } from './delete';
+import { logRequest } from '../log_request';
 
 export function registerDeleteRoute(
   router: VersionedRouter<RequestHandlerContext>,
-  usageCounter: UsageCounter | undefined
+  usageCounter: UsageCounter | undefined,
+  logger: Logger
 ) {
   const { basePath, routeConfig, routeVersion } = getRouteConfig(false);
   const deleteRoute = router.delete({
@@ -50,6 +52,9 @@ export function registerDeleteRoute(
           404: {
             description: 'not found',
           },
+          500: {
+            description: 'internal server error',
+          },
         },
       },
     },
@@ -59,16 +64,22 @@ export function registerDeleteRoute(
           await deleteDashboard(ctx, req.params.id);
         } catch (e) {
           if (e.isBoom && e.output.statusCode === 404) {
+            const message = `A dashboard with ID [${req.params.id}] was not found.`;
+            logRequest(logger, req, 'debug', message);
             return res.notFound({
               body: {
-                message: `A dashboard with ID [${req.params.id}] was not found.`,
+                message,
               },
             });
           }
+
           if (e.isBoom && e.output.statusCode === 403) {
+            logRequest(logger, req, 'debug', e.message);
             return res.forbidden({ body: { message: e.message } });
           }
-          return res.badRequest({ body: { message: e.message } });
+
+          logRequest(logger, req, 'error', e.message);
+          return res.customError({ statusCode: 500, body: { message: e.message } });
         }
 
         return res.noContent();

--- a/src/platform/plugins/shared/dashboard/server/api/log_request.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/log_request.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+
+export function logRequest(
+  logger: Logger,
+  req: KibanaRequest,
+  level: 'debug' | 'warn' | 'error',
+  message: string
+) {
+  const method = req.route.method.toUpperCase();
+  const path = req.url.pathname;
+  logger[level](`${method} ${path}: ${message}`);
+}

--- a/src/platform/plugins/shared/dashboard/server/api/read/register_read_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/read/register_read_route.ts
@@ -8,7 +8,7 @@
  */
 
 import type { VersionedRouter } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core/server';
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { schema } from '@kbn/config-schema';
 import { once } from 'lodash';
@@ -17,11 +17,13 @@ import { getRouteConfig } from '../get_route_config';
 import { getReadResponseBodySchema } from './schemas';
 import { read } from './read';
 import { getDashboardStateSchema } from '../dashboard_state_schemas';
+import { logRequest } from '../log_request';
 
 export function registerReadRoute(
   router: VersionedRouter<RequestHandlerContext>,
   usageCounter: UsageCounter | undefined,
-  isDashboardAppRequest: boolean
+  isDashboardAppRequest: boolean,
+  logger: Logger
 ) {
   const { basePath, routeConfig, routeVersion } = getRouteConfig(isDashboardAppRequest);
   const readRoute = router.get({
@@ -56,11 +58,17 @@ export function registerReadRoute(
             body: () => getReadResponseBodySchema(isDashboardAppRequest),
             description: 'success',
           },
+          400: {
+            description: 'invalid response',
+          },
           403: {
             description: 'forbidden',
           },
           404: {
             description: 'not found',
+          },
+          500: {
+            description: 'internal server error',
           },
         },
       }),
@@ -80,18 +88,27 @@ export function registerReadRoute(
           });
         } catch (e) {
           if (e.isBoom && e.output.statusCode === 404) {
+            const message = `A dashboard with ID [${req.params.id}] was not found.`;
+            logRequest(logger, req, 'debug', message);
             return res.notFound({
               body: {
-                message: `A dashboard with ID [${req.params.id}] was not found.`,
+                message,
               },
             });
           }
 
           if (e.isBoom && e.output.statusCode === 403) {
+            logRequest(logger, req, 'debug', e.message);
             return res.forbidden({ body: { message: e.message } });
           }
 
-          return res.badRequest({ body: { message: e.message } });
+          if (e.isBoom && e.output.statusCode === 400) {
+            logRequest(logger, req, 'warn', e.message);
+            return res.badRequest({ body: { message: e.message } });
+          }
+
+          logRequest(logger, req, 'error', e.message);
+          return res.customError({ statusCode: 500, body: { message: e.message } });
         }
       })
   );

--- a/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { HttpServiceSetup, RequestHandlerContext } from '@kbn/core/server';
+import type { HttpServiceSetup, Logger, RequestHandlerContext } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 
 import { registerCreateRoute } from './create';
@@ -17,7 +17,11 @@ import { registerSearchRoute } from './search';
 import { registerReadRoute } from './read';
 import { registerSanitizeRoute } from './sanitize';
 
-export function registerRoutes(http: HttpServiceSetup, usageCounter?: UsageCounter) {
+export function registerRoutes(
+  http: HttpServiceSetup,
+  usageCounter: UsageCounter | undefined,
+  logger: Logger
+) {
   const { versioned: versionedRouter } = http.createRouter<RequestHandlerContext>();
 
   //
@@ -25,12 +29,12 @@ export function registerRoutes(http: HttpServiceSetup, usageCounter?: UsageCount
   // Only allows panel.type value with registered embeddable schema
   // Validate panel.config at route level
   //
-  registerCreateRoute(versionedRouter, usageCounter, false);
-  registerReadRoute(versionedRouter, usageCounter, false);
-  registerUpdateRoute(versionedRouter, usageCounter, false);
-  registerDeleteRoute(versionedRouter, usageCounter);
-  registerSearchRoute(versionedRouter, usageCounter);
-  registerSanitizeRoute(versionedRouter);
+  registerCreateRoute(versionedRouter, usageCounter, false, logger);
+  registerReadRoute(versionedRouter, usageCounter, false, logger);
+  registerUpdateRoute(versionedRouter, usageCounter, false, logger);
+  registerDeleteRoute(versionedRouter, usageCounter, logger);
+  registerSearchRoute(versionedRouter, usageCounter, logger);
+  registerSanitizeRoute(versionedRouter, logger);
 
   //
   // Dashboard application specific routes
@@ -40,7 +44,7 @@ export function registerRoutes(http: HttpServiceSetup, usageCounter?: UsageCount
   //
   // TODO remove these routes when all embeddable schemas are registered
   //
-  registerCreateRoute(versionedRouter, undefined, true);
-  registerReadRoute(versionedRouter, undefined, true);
-  registerUpdateRoute(versionedRouter, undefined, true);
+  registerCreateRoute(versionedRouter, undefined, true, logger);
+  registerReadRoute(versionedRouter, undefined, true, logger);
+  registerUpdateRoute(versionedRouter, undefined, true, logger);
 }

--- a/src/platform/plugins/shared/dashboard/server/api/sanitize/register_sanitize_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/sanitize/register_sanitize_route.ts
@@ -8,8 +8,9 @@
  */
 
 import type { VersionedRouter } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core/server';
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
 import { once } from 'lodash';
+import { logRequest } from '../log_request';
 import { DASHBOARD_INTERNAL_API_PATH } from '../../../common/constants';
 import { getSanitizeRequestBodySchema, getSanitizeResponseBodySchema } from './schemas';
 import { getDashboardStateSchema } from '../dashboard_state_schemas';
@@ -20,7 +21,10 @@ import { sanitize } from './sanitize';
  * This route uses an internal API path because it is not intended for public use.
  * It is currently used by the dashboard app to sanitize a dashboard for the export share integration.
  */
-export function registerSanitizeRoute(router: VersionedRouter<RequestHandlerContext>) {
+export function registerSanitizeRoute(
+  router: VersionedRouter<RequestHandlerContext>,
+  logger: Logger
+) {
   const sanitizeRoute = router.post({
     path: `${DASHBOARD_INTERNAL_API_PATH}/_sanitize`,
     summary: 'Sanitize a dashboard',
@@ -60,6 +64,7 @@ export function registerSanitizeRoute(router: VersionedRouter<RequestHandlerCont
         return res.ok({ body: result });
       } catch (e) {
         const message = e instanceof Error ? e.message : 'Unknown error';
+        logRequest(logger, req, 'warn', e.message);
         return res.badRequest({
           body: { message },
         });

--- a/src/platform/plugins/shared/dashboard/server/api/search/register_search_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/register_search_route.ts
@@ -8,16 +8,18 @@
  */
 
 import type { VersionedRouter } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core/server';
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { telemetryHandler } from '@kbn/as-code-shared-telemetry';
 import { getRouteConfig } from '../get_route_config';
 import { searchRequestParamsSchema, searchResponseBodySchema } from './schemas';
 import { search } from './search';
+import { logRequest } from '../log_request';
 
 export function registerSearchRoute(
   router: VersionedRouter<RequestHandlerContext>,
-  usageCounter: UsageCounter | undefined
+  usageCounter: UsageCounter | undefined,
+  logger: Logger
 ) {
   const { basePath, routeConfig, routeVersion } = getRouteConfig(false);
   const searchRoute = router.get({
@@ -43,6 +45,9 @@ export function registerSearchRoute(
           403: {
             description: 'forbidden',
           },
+          500: {
+            description: 'internal server error',
+          },
         },
       },
     },
@@ -53,10 +58,12 @@ export function registerSearchRoute(
           return res.ok({ body: result });
         } catch (e) {
           if (e.isBoom && e.output.statusCode === 403) {
+            logRequest(logger, req, 'debug', e.message);
             return res.forbidden({ body: { message: e.message } });
           }
 
-          return res.badRequest({ body: { message: e.message } });
+          logRequest(logger, req, 'error', e.message);
+          return res.customError({ statusCode: 500, body: { message: e.message } });
         }
       })
   );

--- a/src/platform/plugins/shared/dashboard/server/api/update/register_update_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/update/register_update_route.ts
@@ -8,7 +8,7 @@
  */
 
 import type { VersionedRouter } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core/server';
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { schema } from '@kbn/config-schema';
 import { once } from 'lodash';
@@ -22,7 +22,8 @@ import { writeErrorHandler } from '../write_error_handler';
 export function registerUpdateRoute(
   router: VersionedRouter<RequestHandlerContext>,
   usageCounter: UsageCounter | undefined,
-  isDashboardAppRequest: boolean
+  isDashboardAppRequest: boolean,
+  logger: Logger
 ) {
   const { basePath, routeConfig, routeVersion } = getRouteConfig(isDashboardAppRequest);
   const updateRoute = router.put({
@@ -86,7 +87,7 @@ export function registerUpdateRoute(
             ? res.created({ body: result })
             : res.ok({ body: result });
         } catch (e) {
-          return writeErrorHandler(e, res);
+          return writeErrorHandler(e, res, logger, req);
         }
       })
   );

--- a/src/platform/plugins/shared/dashboard/server/api/write_error_handler.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/write_error_handler.ts
@@ -7,21 +7,35 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { IKibanaResponse, KibanaResponseFactory } from '@kbn/core/server';
+import type {
+  IKibanaResponse,
+  KibanaRequest,
+  KibanaResponseFactory,
+  Logger,
+} from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { logRequest } from './log_request';
 import { TransformPanelsInError } from './transforms/in/transform_panels_in_error';
 
-export function writeErrorHandler(error: any, response: KibanaResponseFactory): IKibanaResponse {
+export function writeErrorHandler(
+  error: any,
+  response: KibanaResponseFactory,
+  logger: Logger,
+  req: KibanaRequest
+): IKibanaResponse {
   if (error.isBoom && error.output.statusCode === 403) {
+    logRequest(logger, req, 'debug', error.message);
     return response.forbidden({ body: { message: error.message } });
   }
 
   if (error instanceof TransformPanelsInError) {
+    logRequest(logger, req, 'warn', error.message);
     return response.custom({
       statusCode: 400,
       bypassErrorFormat: true,
       body: {
         message: 'Bad request',
-        panel_errors: (error as TransformPanelsInError).panelErrors.map((panelError) => ({
+        panel_errors: error.panelErrors.map((panelError) => ({
           message: panelError.message,
           panel_type: panelError.type,
           panel_config: panelError.config,
@@ -30,5 +44,11 @@ export function writeErrorHandler(error: any, response: KibanaResponseFactory): 
     });
   }
 
+  if (SavedObjectsErrorHelpers.isConflictError(error)) {
+    logRequest(logger, req, 'debug', error.message);
+    return response.conflict({ body: { message: error.message } });
+  }
+
+  logRequest(logger, req, 'warn', error.message);
   return response.badRequest({ body: { message: error.message } });
 }

--- a/src/platform/plugins/shared/dashboard/server/plugin.ts
+++ b/src/platform/plugins/shared/dashboard/server/plugin.ts
@@ -129,7 +129,7 @@ export class DashboardPlugin
 
     core.uiSettings.register(getUISettings());
 
-    registerRoutes(core.http, this.apiUsageCounter);
+    registerRoutes(core.http, this.apiUsageCounter, this.logger);
 
     void registerAccessControl({
       http: core.http,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Dashboards] Capture route and application errors in server logs and APM (#269802)](https://github.com/elastic/kibana/pull/269802)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2026-05-19T14:36:40Z","message":"[Dashboards] Capture route and application errors in server logs and APM (#269802)\n\n## Summary\n\nAdds server logs for dashboard route errors and captures dashboard\napplication errors using APM.\n\nAPM logs in the Service Inventory can filtered with `label.name:\n'dashboards'` and `label.error_type: 'RenderDashboardFailure'` or\n`label.error_type: 'SanitizeDashboardFailure'`. APM logs also capture\nthe error message.\n\nDashboard endpoint errors are logged to the server logs. The log level\nis determined by the endpoint and status code.\n\n   | Dashboard server route | Status code | Log level |\n   |---|---:|---|\n   | `POST /api/dashboards` | 201 | no log |\n   | `POST /api/dashboards` | 400 | warn |\n   | `POST /api/dashboards` | 403 | debug |\n   | `POST /api/dashboards` | 409 | debug |\n   | `GET /api/dashboards/{id}` | 200 | no log |\n   | `GET /api/dashboards/{id}` | 400 | warn |\n   | `GET /api/dashboards/{id}` | 403 | debug |\n   | `GET /api/dashboards/{id}` | 404 | debug |\n   | `GET /api/dashboards/{id}` | 500 | error |\n   | `PUT /api/dashboards/{id}` | 200 | no log |\n   | `PUT /api/dashboards/{id}` | 201 | no log |\n   | `PUT /api/dashboards/{id}` | 400 | warn |\n   | `PUT /api/dashboards/{id}` | 403 | debug |\n   | `PUT /api/dashboards/{id}` | 409 | debug |\n   | `DELETE /api/dashboards/{id}` | 204 | no log |\n   | `DELETE /api/dashboards/{id}` | 403 | debug |\n   | `DELETE /api/dashboards/{id}` | 404 | debug |\n   | `DELETE /api/dashboards/{id}` | 500 | error |\n   | `GET /api/dashboards` | 200 | no log |\n   | `GET /api/dashboards` | 403 | debug |\n   | `GET /api/dashboards` | 500 | error |\n   | `POST /internal/dashboards/app` | 201 | no log |\n   | `POST /internal/dashboards/app` | 400 | warn |\n   | `POST /internal/dashboards/app` | 403 | debug |\n   | `POST /internal/dashboards/app` | 409 | debug |\n   | `GET /internal/dashboards/app/{id}` | 200 | no log |\n   | `GET /internal/dashboards/app/{id}` | 400 | warn |\n   | `GET /internal/dashboards/app/{id}` | 403 | debug |\n   | `GET /internal/dashboards/app/{id}` | 404 | debug |\n   | `GET /internal/dashboards/app/{id}` | 500 | error |\n   | `PUT /internal/dashboards/app/{id}` | 200 | no log |\n   | `PUT /internal/dashboards/app/{id}` | 201 | no log |\n   | `PUT /internal/dashboards/app/{id}` | 400 | warn |\n   | `PUT /internal/dashboards/app/{id}` | 403 | debug |\n   | `PUT /internal/dashboards/app/{id}` | 409 | debug |\n   | `POST /internal/dashboards/_sanitize` | 200 | no log |\n   | `POST /internal/dashboards/_sanitize` | 400 | warn |\n\n_Note: Parts of this code were generated or assisted by Cursor with\nmodel gpt-5.2-high. I have reviewed and validated all code for\ncorrectness, security, and compliance with Elastic’s standards._","sha":"8d66ecbbca8684b6c2fc2f8d7f69a1b971dcfb31","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","backport missing","backport:version","v9.5.0","v9.4.3"],"title":"[Dashboards] Capture route and application errors in server logs and APM","number":269802,"url":"https://github.com/elastic/kibana/pull/269802","mergeCommit":{"message":"[Dashboards] Capture route and application errors in server logs and APM (#269802)\n\n## Summary\n\nAdds server logs for dashboard route errors and captures dashboard\napplication errors using APM.\n\nAPM logs in the Service Inventory can filtered with `label.name:\n'dashboards'` and `label.error_type: 'RenderDashboardFailure'` or\n`label.error_type: 'SanitizeDashboardFailure'`. APM logs also capture\nthe error message.\n\nDashboard endpoint errors are logged to the server logs. The log level\nis determined by the endpoint and status code.\n\n   | Dashboard server route | Status code | Log level |\n   |---|---:|---|\n   | `POST /api/dashboards` | 201 | no log |\n   | `POST /api/dashboards` | 400 | warn |\n   | `POST /api/dashboards` | 403 | debug |\n   | `POST /api/dashboards` | 409 | debug |\n   | `GET /api/dashboards/{id}` | 200 | no log |\n   | `GET /api/dashboards/{id}` | 400 | warn |\n   | `GET /api/dashboards/{id}` | 403 | debug |\n   | `GET /api/dashboards/{id}` | 404 | debug |\n   | `GET /api/dashboards/{id}` | 500 | error |\n   | `PUT /api/dashboards/{id}` | 200 | no log |\n   | `PUT /api/dashboards/{id}` | 201 | no log |\n   | `PUT /api/dashboards/{id}` | 400 | warn |\n   | `PUT /api/dashboards/{id}` | 403 | debug |\n   | `PUT /api/dashboards/{id}` | 409 | debug |\n   | `DELETE /api/dashboards/{id}` | 204 | no log |\n   | `DELETE /api/dashboards/{id}` | 403 | debug |\n   | `DELETE /api/dashboards/{id}` | 404 | debug |\n   | `DELETE /api/dashboards/{id}` | 500 | error |\n   | `GET /api/dashboards` | 200 | no log |\n   | `GET /api/dashboards` | 403 | debug |\n   | `GET /api/dashboards` | 500 | error |\n   | `POST /internal/dashboards/app` | 201 | no log |\n   | `POST /internal/dashboards/app` | 400 | warn |\n   | `POST /internal/dashboards/app` | 403 | debug |\n   | `POST /internal/dashboards/app` | 409 | debug |\n   | `GET /internal/dashboards/app/{id}` | 200 | no log |\n   | `GET /internal/dashboards/app/{id}` | 400 | warn |\n   | `GET /internal/dashboards/app/{id}` | 403 | debug |\n   | `GET /internal/dashboards/app/{id}` | 404 | debug |\n   | `GET /internal/dashboards/app/{id}` | 500 | error |\n   | `PUT /internal/dashboards/app/{id}` | 200 | no log |\n   | `PUT /internal/dashboards/app/{id}` | 201 | no log |\n   | `PUT /internal/dashboards/app/{id}` | 400 | warn |\n   | `PUT /internal/dashboards/app/{id}` | 403 | debug |\n   | `PUT /internal/dashboards/app/{id}` | 409 | debug |\n   | `POST /internal/dashboards/_sanitize` | 200 | no log |\n   | `POST /internal/dashboards/_sanitize` | 400 | warn |\n\n_Note: Parts of this code were generated or assisted by Cursor with\nmodel gpt-5.2-high. I have reviewed and validated all code for\ncorrectness, security, and compliance with Elastic’s standards._","sha":"8d66ecbbca8684b6c2fc2f8d7f69a1b971dcfb31"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269802","number":269802,"mergeCommit":{"message":"[Dashboards] Capture route and application errors in server logs and APM (#269802)\n\n## Summary\n\nAdds server logs for dashboard route errors and captures dashboard\napplication errors using APM.\n\nAPM logs in the Service Inventory can filtered with `label.name:\n'dashboards'` and `label.error_type: 'RenderDashboardFailure'` or\n`label.error_type: 'SanitizeDashboardFailure'`. APM logs also capture\nthe error message.\n\nDashboard endpoint errors are logged to the server logs. The log level\nis determined by the endpoint and status code.\n\n   | Dashboard server route | Status code | Log level |\n   |---|---:|---|\n   | `POST /api/dashboards` | 201 | no log |\n   | `POST /api/dashboards` | 400 | warn |\n   | `POST /api/dashboards` | 403 | debug |\n   | `POST /api/dashboards` | 409 | debug |\n   | `GET /api/dashboards/{id}` | 200 | no log |\n   | `GET /api/dashboards/{id}` | 400 | warn |\n   | `GET /api/dashboards/{id}` | 403 | debug |\n   | `GET /api/dashboards/{id}` | 404 | debug |\n   | `GET /api/dashboards/{id}` | 500 | error |\n   | `PUT /api/dashboards/{id}` | 200 | no log |\n   | `PUT /api/dashboards/{id}` | 201 | no log |\n   | `PUT /api/dashboards/{id}` | 400 | warn |\n   | `PUT /api/dashboards/{id}` | 403 | debug |\n   | `PUT /api/dashboards/{id}` | 409 | debug |\n   | `DELETE /api/dashboards/{id}` | 204 | no log |\n   | `DELETE /api/dashboards/{id}` | 403 | debug |\n   | `DELETE /api/dashboards/{id}` | 404 | debug |\n   | `DELETE /api/dashboards/{id}` | 500 | error |\n   | `GET /api/dashboards` | 200 | no log |\n   | `GET /api/dashboards` | 403 | debug |\n   | `GET /api/dashboards` | 500 | error |\n   | `POST /internal/dashboards/app` | 201 | no log |\n   | `POST /internal/dashboards/app` | 400 | warn |\n   | `POST /internal/dashboards/app` | 403 | debug |\n   | `POST /internal/dashboards/app` | 409 | debug |\n   | `GET /internal/dashboards/app/{id}` | 200 | no log |\n   | `GET /internal/dashboards/app/{id}` | 400 | warn |\n   | `GET /internal/dashboards/app/{id}` | 403 | debug |\n   | `GET /internal/dashboards/app/{id}` | 404 | debug |\n   | `GET /internal/dashboards/app/{id}` | 500 | error |\n   | `PUT /internal/dashboards/app/{id}` | 200 | no log |\n   | `PUT /internal/dashboards/app/{id}` | 201 | no log |\n   | `PUT /internal/dashboards/app/{id}` | 400 | warn |\n   | `PUT /internal/dashboards/app/{id}` | 403 | debug |\n   | `PUT /internal/dashboards/app/{id}` | 409 | debug |\n   | `POST /internal/dashboards/_sanitize` | 200 | no log |\n   | `POST /internal/dashboards/_sanitize` | 400 | warn |\n\n_Note: Parts of this code were generated or assisted by Cursor with\nmodel gpt-5.2-high. I have reviewed and validated all code for\ncorrectness, security, and compliance with Elastic’s standards._","sha":"8d66ecbbca8684b6c2fc2f8d7f69a1b971dcfb31"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->