### PR TITLE
[9.4] [UII] Optimize agent count retrieval on get agent policies request (#272429)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.test.ts
@@ -11,8 +11,14 @@ import { agentPolicyService } from '../../services';
 
 import type { FleetRequestHandlerContext } from '../..';
 import { xpackMocks } from '../../mocks';
+import type { AgentClient } from '../../services/agents';
+import type { AgentPolicy } from '../../types';
 
-import { bulkGetAgentPoliciesHandler, GetListAgentPolicyOutputsHandler } from './handlers';
+import {
+  bulkGetAgentPoliciesHandler,
+  GetListAgentPolicyOutputsHandler,
+  populateAssignedAgentsCount,
+} from './handlers';
 
 jest.mock('../../services/agent_policy', () => {
   return {
@@ -63,6 +69,107 @@ describe('Agent policy API handlers', () => {
         expect.anything(),
         ['1'],
         expect.anything()
+      );
+    });
+  });
+
+  describe('populateAssignedAgentsCount', () => {
+    const makeAgentClient = (
+      listAgents: jest.Mock
+    ): { agentClient: AgentClient; listAgents: jest.Mock } => ({
+      agentClient: { listAgents } as unknown as AgentClient,
+      listAgents,
+    });
+
+    it('does not query agents when there are no policies', async () => {
+      const { agentClient, listAgents } = makeAgentClient(jest.fn());
+
+      await populateAssignedAgentsCount(agentClient, []);
+
+      expect(listAgents).not.toHaveBeenCalled();
+    });
+
+    it('populates counts for every policy from a single bucketed aggregation', async () => {
+      const listAgents = jest.fn().mockResolvedValue({
+        aggregations: {
+          policies: {
+            buckets: {
+              'policy-1': {
+                doc_count: 5,
+                unprivileged: { doc_count: 2 },
+                fips: { doc_count: 1 },
+                versions: {
+                  buckets: [
+                    { key: '8.0.0', doc_count: 3 },
+                    { key: '8.1.0', doc_count: 2 },
+                  ],
+                },
+              },
+              // policy-2 has no matching agents
+              'policy-2': {
+                doc_count: 0,
+                unprivileged: { doc_count: 0 },
+                fips: { doc_count: 0 },
+                versions: { buckets: [] },
+              },
+            },
+          },
+        },
+      });
+      const { agentClient } = makeAgentClient(listAgents);
+
+      const agentPolicies = [{ id: 'policy-1' }, { id: 'policy-2' }] as AgentPolicy[];
+
+      await populateAssignedAgentsCount(agentClient, agentPolicies);
+
+      // Only a single agents query is issued regardless of the number of policies
+      expect(listAgents).toHaveBeenCalledTimes(1);
+      const listAgentsArgs = listAgents.mock.calls[0][0];
+      expect(listAgentsArgs.perPage).toBe(0);
+      // One filter bucket per policy
+      expect(Object.keys(listAgentsArgs.aggregations.policies.filters.filters)).toEqual([
+        'policy-1',
+        'policy-2',
+      ]);
+
+      expect(agentPolicies[0]).toEqual(
+        expect.objectContaining({
+          agents: 5,
+          unprivileged_agents: 2,
+          fips_agents: 1,
+          agents_per_version: [
+            { version: '8.0.0', count: 3 },
+            { version: '8.1.0', count: 2 },
+          ],
+        })
+      );
+      expect(agentPolicies[1]).toEqual(
+        expect.objectContaining({
+          agents: 0,
+          unprivileged_agents: 0,
+          fips_agents: 0,
+          agents_per_version: [],
+        })
+      );
+    });
+
+    it('defaults counts to zero when a policy has no aggregation bucket', async () => {
+      const listAgents = jest.fn().mockResolvedValue({
+        aggregations: { policies: { buckets: {} } },
+      });
+      const { agentClient } = makeAgentClient(listAgents);
+
+      const agentPolicies = [{ id: 'policy-without-bucket' }] as AgentPolicy[];
+
+      await populateAssignedAgentsCount(agentClient, agentPolicies);
+
+      expect(agentPolicies[0]).toEqual(
+        expect.objectContaining({
+          agents: 0,
+          unprivileged_agents: 0,
+          fips_agents: 0,
+          agents_per_version: [],
+        })
       );
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -8,7 +8,12 @@
 import type { TypeOf } from '@kbn/config-schema';
 import type { KibanaRequest, RequestHandler, ResponseHeaders } from '@kbn/core/server';
 import { escapeKuery, escapeQuotes } from '@kbn/es-query';
-import pMap from 'p-map';
+import {
+  escapeKuery,
+  escapeQuotes,
+  fromKueryExpression,
+  toElasticsearchQuery,
+} from '@kbn/es-query';
 import { dump } from 'js-yaml';
 
 import { isEmpty, uniq } from 'lodash';
@@ -29,10 +34,7 @@ import {
   licenseService,
 } from '../../services';
 import { type AgentClient } from '../../services/agents';
-import {
-  MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10,
-  UNPRIVILEGED_AGENT_KUERY,
-} from '../../constants';
+import { UNPRIVILEGED_AGENT_KUERY } from '../../constants';
 import type {
   GetAgentPoliciesRequestSchema,
   GetOneAgentPolicyRequestSchema,
@@ -91,67 +93,76 @@ function getPolicyOrVersionSpecificKuery(policyId: string): string {
   )}${AGENT_POLICY_VERSION_SEPARATOR}*)`;
 }
 
+interface AssignedAgentsCountAggregation {
+  buckets: Record<
+    string,
+    {
+      doc_count: number;
+      unprivileged?: { doc_count: number };
+      fips?: { doc_count: number };
+      versions?: { buckets: Array<{ key: string; doc_count: number }> };
+    }
+  >;
+}
+
 export async function populateAssignedAgentsCount(
   agentClient: AgentClient,
   agentPolicies: AgentPolicy[]
 ) {
-  await pMap(
-    agentPolicies,
-    (agentPolicy: GetAgentPoliciesResponseItem) => {
-      const policyKuery = getPolicyOrVersionSpecificKuery(agentPolicy.id);
-      const totalAgents = agentClient
-        .listAgents({
-          showInactive: true,
-          perPage: 0,
-          page: 1,
-          kuery: policyKuery,
-        })
-        .then(({ total }) => (agentPolicy.agents = total));
-      const unprivilegedAgents = agentClient
-        .listAgents({
-          showInactive: true,
-          perPage: 0,
-          page: 1,
-          kuery: `${policyKuery} and ${UNPRIVILEGED_AGENT_KUERY}`,
-        })
-        .then(({ total }) => (agentPolicy.unprivileged_agents = total));
-      const fipsAgents = agentClient
-        .listAgents({
-          showInactive: true,
-          perPage: 0,
-          page: 1,
-          kuery: `${policyKuery} and ${FIPS_AGENT_KUERY}`,
-        })
-        .then(({ total }) => (agentPolicy.fips_agents = total));
+  if (agentPolicies.length === 0) {
+    return;
+  }
 
-      const perVersionAgents = agentClient
-        .listAgents({
-          showInactive: true,
-          perPage: 0,
-          page: 1,
-          aggregations: {
-            versions: {
-              terms: {
-                field: 'agent.version',
-                size: 1000,
-              },
-            },
-          },
-          kuery: policyKuery,
-        })
-        .then(({ aggregations }) => {
-          const versions = (aggregations?.versions as any)?.buckets ?? [];
-          agentPolicy.agents_per_version = versions.map(
-            (version: { key: string; doc_count: number }) => ({
-              version: version.key,
-              count: version.doc_count,
-            })
-          );
-        });
-      return Promise.all([totalAgents, unprivilegedAgents, fipsAgents, perVersionAgents]);
-    },
-    { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10 }
+  // Compute the per-policy agent counts with a single bucketed aggregation rather than issuing
+  // several agent searches per policy. A `filters` aggregation produces one bucket per policy
+  // (keyed by policy id), each with sub-aggregations for the unprivileged/FIPS counts and the
+  // per-version breakdown. This keeps the work to one ES request regardless of page size.
+  const policyKueryById = new Map(
+    agentPolicies.map((agentPolicy) => [
+      agentPolicy.id,
+      getPolicyOrVersionSpecificKuery(agentPolicy.id),
+    ])
   );
+
+  const { aggregations } = await agentClient.listAgents({
+    showInactive: true,
+    perPage: 0,
+    page: 1,
+    kuery: [...policyKueryById.values()].join(' or '),
+    aggregations: {
+      policies: {
+        filters: {
+          filters: Object.fromEntries(
+            [...policyKueryById].map(([id, kuery]) => [
+              id,
+              toElasticsearchQuery(fromKueryExpression(kuery)),
+            ])
+          ),
+        },
+        aggs: {
+          unprivileged: {
+            filter: toElasticsearchQuery(fromKueryExpression(UNPRIVILEGED_AGENT_KUERY)),
+          },
+          fips: { filter: toElasticsearchQuery(fromKueryExpression(FIPS_AGENT_KUERY)) },
+          versions: { terms: { field: 'agent.version', size: 1000 } },
+        },
+      },
+    },
+  });
+
+  const buckets =
+    (aggregations?.policies as AssignedAgentsCountAggregation | undefined)?.buckets ?? {};
+
+  for (const agentPolicy of agentPolicies as GetAgentPoliciesResponseItem[]) {
+    const bucket = buckets[agentPolicy.id];
+    agentPolicy.agents = bucket?.doc_count ?? 0;
+    agentPolicy.unprivileged_agents = bucket?.unprivileged?.doc_count ?? 0;
+    agentPolicy.fips_agents = bucket?.fips?.doc_count ?? 0;
+    agentPolicy.agents_per_version = (bucket?.versions?.buckets ?? []).map((version) => ({
+      version: version.key,
+      count: version.doc_count,
+    }));
+  }
 }
 
 function sanitizeItemForReadAgentOnly(item: AgentPolicy): AgentPolicy {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -7,7 +7,6 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import type { KibanaRequest, RequestHandler, ResponseHeaders } from '@kbn/core/server';
-import { escapeKuery, escapeQuotes } from '@kbn/es-query';
 import {
   escapeKuery,
   escapeQuotes,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[UII] Optimize agent count retrieval on get agent policies request (#272429)](https://github.com/elastic/kibana/pull/272429)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-06-03T23:54:07Z","message":"[UII] Optimize agent count retrieval on get agent policies request (#272429)","sha":"8466e610bbe54cf0c0d5741f21857166c43139f5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:all-open","v9.5.0"],"title":"[UII] Optimize agent count retrieval on get agent policies request","number":272429,"url":"https://github.com/elastic/kibana/pull/272429","mergeCommit":{"message":"[UII] Optimize agent count retrieval on get agent policies request (#272429)","sha":"8466e610bbe54cf0c0d5741f21857166c43139f5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272429","number":272429,"mergeCommit":{"message":"[UII] Optimize agent count retrieval on get agent policies request (#272429)","sha":"8466e610bbe54cf0c0d5741f21857166c43139f5"}}]}] BACKPORT-->