### PR TITLE
[8.19] [UII] Optimize agent count retrieval on get agent policies request (#272429)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -7,8 +7,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import type { KibanaRequest, RequestHandler, ResponseHeaders } from '@kbn/core/server';
-import { escapeQuotes } from '@kbn/es-query';
-import pMap from 'p-map';
+import { escapeQuotes, fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { dump } from 'js-yaml';
 
 import { isEmpty, uniq } from 'lodash';
@@ -63,35 +62,67 @@ import { getLatestAgentAvailableDockerImageVersion } from '../../services/agents
 
 const deduplicateIds = (ids: string[]) => uniq(ids);
 
+interface AssignedAgentsCountAggregation {
+  buckets: Record<
+    string,
+    {
+      doc_count: number;
+      unprivileged?: { doc_count: number };
+    }
+  >;
+}
+
 export async function populateAssignedAgentsCount(
   agentClient: AgentClient,
   agentPolicies: AgentPolicy[]
 ) {
-  await pMap(
-    agentPolicies,
-    (agentPolicy: GetAgentPoliciesResponseItem) => {
-      const totalAgents = agentClient
-        .listAgents({
-          showInactive: true,
-          perPage: 0,
-          page: 1,
-          kuery: `${AGENTS_PREFIX}.policy_id:"${escapeQuotes(agentPolicy.id)}"`,
-        })
-        .then(({ total }) => (agentPolicy.agents = total));
-      const unprivilegedAgents = agentClient
-        .listAgents({
-          showInactive: true,
-          perPage: 0,
-          page: 1,
-          kuery: `${AGENTS_PREFIX}.policy_id:"${escapeQuotes(
-            agentPolicy.id
-          )}" and ${UNPRIVILEGED_AGENT_KUERY}`,
-        })
-        .then(({ total }) => (agentPolicy.unprivileged_agents = total));
-      return Promise.all([totalAgents, unprivilegedAgents]);
-    },
-    { concurrency: 10 }
+  if (agentPolicies.length === 0) {
+    return;
+  }
+
+  // Compute the per-policy agent counts with a single bucketed aggregation rather than issuing
+  // several agent searches per policy. A `filters` aggregation produces one bucket per policy
+  // (keyed by policy id), each with a sub-aggregation for the unprivileged count. This keeps the
+  // work to one ES request regardless of page size.
+  const policyKueryById = new Map(
+    agentPolicies.map((agentPolicy) => [
+      agentPolicy.id,
+      `${AGENTS_PREFIX}.policy_id:"${escapeQuotes(agentPolicy.id)}"`,
+    ])
   );
+
+  const { aggregations } = await agentClient.listAgents({
+    showInactive: true,
+    perPage: 0,
+    page: 1,
+    kuery: [...policyKueryById.values()].join(' or '),
+    aggregations: {
+      policies: {
+        filters: {
+          filters: Object.fromEntries(
+            [...policyKueryById].map(([id, kuery]) => [
+              id,
+              toElasticsearchQuery(fromKueryExpression(kuery)),
+            ])
+          ),
+        },
+        aggs: {
+          unprivileged: {
+            filter: toElasticsearchQuery(fromKueryExpression(UNPRIVILEGED_AGENT_KUERY)),
+          },
+        },
+      },
+    },
+  });
+
+  const buckets =
+    (aggregations?.policies as AssignedAgentsCountAggregation | undefined)?.buckets ?? {};
+
+  for (const agentPolicy of agentPolicies as GetAgentPoliciesResponseItem[]) {
+    const bucket = buckets[agentPolicy.id];
+    agentPolicy.agents = bucket?.doc_count ?? 0;
+    agentPolicy.unprivileged_agents = bucket?.unprivileged?.doc_count ?? 0;
+  }
 }
 
 function sanitizeItemForReadAgentOnly(item: AgentPolicy): AgentPolicy {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -18,7 +18,7 @@ import { HTTPAuthorizationHeader } from '../../../common/http_authorization_head
 
 import { fullAgentPolicyToYaml } from '../../../common/services';
 import { appContextService, agentPolicyService, licenseService } from '../../services';
-import { AGENTS_PREFIX, UNPRIVILEGED_AGENT_KUERY } from '../../constants';
+import { UNPRIVILEGED_AGENT_KUERY } from '../../constants';
 import { type AgentClient } from '../../services/agents';
 import type {
   GetAgentPoliciesRequestSchema,
@@ -87,7 +87,7 @@ export async function populateAssignedAgentsCount(
   const policyKueryById = new Map(
     agentPolicies.map((agentPolicy) => [
       agentPolicy.id,
-      `${AGENTS_PREFIX}.policy_id:"${escapeQuotes(agentPolicy.id)}"`,
+      `policy_id:"${escapeQuotes(agentPolicy.id)}"`,
     ])
   );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[UII] Optimize agent count retrieval on get agent policies request (#272429)](https://github.com/elastic/kibana/pull/272429)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-06-03T23:54:07Z","message":"[UII] Optimize agent count retrieval on get agent policies request (#272429)","sha":"8466e610bbe54cf0c0d5741f21857166c43139f5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:all-open","v9.5.0"],"title":"[UII] Optimize agent count retrieval on get agent policies request","number":272429,"url":"https://github.com/elastic/kibana/pull/272429","mergeCommit":{"message":"[UII] Optimize agent count retrieval on get agent policies request (#272429)","sha":"8466e610bbe54cf0c0d5741f21857166c43139f5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272429","number":272429,"mergeCommit":{"message":"[UII] Optimize agent count retrieval on get agent policies request (#272429)","sha":"8466e610bbe54cf0c0d5741f21857166c43139f5"}}]}] BACKPORT-->