### PR TITLE
[kbn-evals] trigger on-demand evals

### DIFF
--- a/.buildkite/scripts/steps/evals/run_suite.sh
+++ b/.buildkite/scripts/steps/evals/run_suite.sh
@@ -367,6 +367,7 @@ done
 
 # Run eval suite via @kbn/evals CLI (internal executor by default).
 # If EVAL_PROJECT is set, run a single Playwright project (used by CI fanout steps).
+# If EVAL_GREP is set, pass Playwright --grep to filter tests by name/pattern.
 # Otherwise, Playwright will run all projects defined by the suite config (useful locally).
 EVAL_RUN_ARGS=()
 if [[ -n "${EVAL_GREP:-}" ]]; then

--- a/.buildkite/scripts/steps/evals/run_suite.sh
+++ b/.buildkite/scripts/steps/evals/run_suite.sh
@@ -186,6 +186,8 @@ EOF
           EVAL_FANOUT: "0"
           TEST_RUN_ID: "${TEST_RUN_ID:-}"
           EVAL_SERVER_CONFIG_SET: "${EVAL_SERVER_CONFIG_SET:-}"
+          EVAL_GREP: "${EVAL_GREP:-}"
+          EVALUATION_REPETITIONS: "${EVALUATION_REPETITIONS:-}"
         timeout_in_minutes: ${timeout_in_minutes}
         concurrency_group: "kbn-evals-${group_key_safe}"
         concurrency: ${EVAL_FANOUT_CONCURRENCY}
@@ -366,9 +368,14 @@ done
 # Run eval suite via @kbn/evals CLI (internal executor by default).
 # If EVAL_PROJECT is set, run a single Playwright project (used by CI fanout steps).
 # Otherwise, Playwright will run all projects defined by the suite config (useful locally).
+EVAL_RUN_ARGS=()
+if [[ -n "${EVAL_GREP:-}" ]]; then
+  EVAL_RUN_ARGS+=(--grep "${EVAL_GREP}")
+fi
+
 if [[ -n "${EVAL_PROJECT:-}" ]]; then
-  node scripts/evals run --suite "$EVAL_SUITE_ID" --project "$EVAL_PROJECT"
+  node scripts/evals run --suite "$EVAL_SUITE_ID" --project "$EVAL_PROJECT" "${EVAL_RUN_ARGS[@]}"
 else
-  node scripts/evals run --suite "$EVAL_SUITE_ID"
+  node scripts/evals run --suite "$EVAL_SUITE_ID" "${EVAL_RUN_ARGS[@]}"
 fi
 

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -213,7 +213,7 @@ a. **CI Stats (recommended)**
 
 b. **Buildkite directly:**
 
-1.  Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand)
+1.  Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand-llm-evals)
 2.  Click **New build**, select branch/commit
 3.  Add environment variables:
 

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -204,18 +204,11 @@ Model groups follow the pattern `eis/<modelId>` for EIS or `llm-gateway/<model>`
 
 ### 1.3 On-demand evals (Buildkite)
 
-Run a suite on any branch without a PR
+Run a suite on any branch without a PR:
 
-a. **CI Stats (recommended)**
-
-1.  Open the [on-demand evals trigger](https://ci-stats.kibana.dev/trigger_evals_runner)
-2.  In CI Stats: choose branch, suite, and model groups, then trigger.
-
-b. **Buildkite directly:**
-
-1.  Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand-llm-evals)
-2.  Click **New build**, select branch/commit
-3.  Add environment variables:
+1. Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand)
+2. Click **New build**, select branch/commit
+3. Add environment variables:
 
 | Variable                  | Required           | Description                                                                 |
 | ------------------------- | ------------------ | --------------------------------------------------------------------------- |

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -204,11 +204,18 @@ Model groups follow the pattern `eis/<modelId>` for EIS or `llm-gateway/<model>`
 
 ### 1.3 On-demand evals (Buildkite)
 
-Run a suite on any branch without a PR:
+Run a suite on any branch without a PR
 
-1. Open the [on-demand evals trigger](https://ci-stats.kibana.dev/trigger_evals_runner) in CI Stats (recommended), or [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand) on Buildkite directly
-2. In CI Stats: choose branch, suite, and model groups, then trigger. In Buildkite: click **New build**, select the branch (or commit) to evaluate
-3. Add environment variables (CI Stats sets these for you when using the wizard):
+a. **CI Stats (recommended)**
+
+1.  Open the [on-demand evals trigger](https://ci-stats.kibana.dev/trigger_evals_runner)
+2.  In CI Stats: choose branch, suite, and model groups, then trigger.
+
+b. **Buildkite directly:**
+
+1.  Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand)
+2.  Click **New build**, select branch/commit
+3.  Add environment variables:
 
 | Variable                  | Required           | Description                                                                 |
 | ------------------------- | ------------------ | --------------------------------------------------------------------------- |
@@ -221,7 +228,6 @@ Run a suite on any branch without a PR:
 | `EVAL_GREP`               | no                 | Playwright test name filter (same as `node scripts/evals run --grep`)       |
 | `EVALUATION_REPETITIONS`  | no                 | Repeat each example N times (same as `--repetitions`)                       |
 
-When using Buildkite directly, under **Environment variables** (in New build options), add the required variables below — one `KEY=value` per line.
 Example:
 
 ```text

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -206,19 +206,22 @@ Model groups follow the pattern `eis/<modelId>` for EIS or `llm-gateway/<model>`
 
 Run a suite on any branch without a PR:
 
-1. Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand)
-2. Click **New build**, select branch/commit
-3. Add environment variables:
+1. Open the [on-demand evals trigger](https://ci-stats.kibana.dev/trigger_evals_runner) in CI Stats (recommended), or [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand) on Buildkite directly
+2. In CI Stats: choose branch, suite, and model groups, then trigger. In Buildkite: click **New build**, select the branch (or commit) to evaluate
+3. Add environment variables (CI Stats sets these for you when using the wizard):
 
-| Variable                  | Required           | Description                                              |
-| ------------------------- | ------------------ | -------------------------------------------------------- |
-| `EVAL_SUITE_ID`           | yes                | Suite id from `evals.suites.json`                        |
-| `EVAL_MODEL_GROUPS`       | yes                | Model group, e.g. `eis/openai-gpt-5.4`                   |
-| `EVAL_INCLUDE_EIS_MODELS` | for `eis/*` models | Set to `1` when using EIS models                         |
-| `EVALUATION_CONNECTOR_ID` | no                 | LLM-as-judge connector override                          |
-| `EVAL_SERVER_CONFIG_SET`  | some suites        | From `serverConfigSet` in `evals.suites.json`            |
-| `KIBANA_BUILD_ID`         | no                 | Reuse a Kibana build from another job (skips build step) |
+| Variable                  | Required           | Description                                                                 |
+| ------------------------- | ------------------ | --------------------------------------------------------------------------- |
+| `EVAL_SUITE_ID`           | yes                | Suite id from `evals.suites.json`                                           |
+| `EVAL_MODEL_GROUPS`       | yes                | Comma-separated model groups, e.g. `eis/openai-gpt-5.4,llm-gateway/gpt-5.2` |
+| `EVAL_INCLUDE_EIS_MODELS` | for `eis/*` models | Set to `1` when using EIS models or an EIS judge                            |
+| `EVALUATION_CONNECTOR_ID` | no                 | LLM-as-judge connector override                                             |
+| `EVAL_SERVER_CONFIG_SET`  | some suites        | From `serverConfigSet` in `evals.suites.json`                               |
+| `KIBANA_BUILD_ID`         | no                 | Reuse a Kibana build from another job (skips build step)                    |
+| `EVAL_GREP`               | no                 | Playwright test name filter (same as `node scripts/evals run --grep`)       |
+| `EVALUATION_REPETITIONS`  | no                 | Repeat each example N times (same as `--repetitions`)                       |
 
+When using Buildkite directly, under **Environment variables** (in New build options), add the required variables below — one `KEY=value` per line.
 Example:
 
 ```text


### PR DESCRIPTION
## Summary

Part of: https://github.com/elastic/observability-dev/issues/5822

Adds support for two new on-demand eval env vars, `EVAL_GREP` (test filtering) and `EVALUATION_REPETITIONS` (repetition count)

### How to test

1. Trigger an on-demand build via [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand-llm-evals) on Buildkite.
2. Set `EVAL_GREP=<partial test name>`, confirm only matching evals run.
3. Set `EVALUATION_REPETITIONS=3`, confirm each example runs 3 times in the output.




