### PR TITLE
[ES|QL] Use EIS fast model for NL-to-ES|QL and Fix with AI routes

### DIFF
--- a/src/platform/plugins/shared/esql/kibana.jsonc
+++ b/src/platform/plugins/shared/esql/kibana.jsonc
@@ -12,7 +12,8 @@
       "cps",
       "fieldsMetadata",
       "usageCollection",
-      "licensing"
+      "licensing",
+      "searchInferenceEndpoints"
     ],
     "requiredPlugins": [
       "data",

--- a/src/platform/plugins/shared/esql/moon.yml
+++ b/src/platform/plugins/shared/esql/moon.yml
@@ -53,13 +53,13 @@ dependsOn:
   - '@kbn/inference-plugin'
   - '@kbn/actions-plugin'
   - '@kbn/core-http-server'
-  - '@kbn/management-settings-ids'
   - '@kbn/es-types'
   - '@kbn/controls-constants'
   - '@kbn/logging'
   - '@kbn/logging-mocks'
   - '@kbn/agent-builder-genai-utils'
   - '@kbn/agent-builder-server'
+  - '@kbn/agent-builder-common'
   - '@kbn/code-editor'
 tags:
   - plugin

--- a/src/platform/plugins/shared/esql/server/routes/helpers.ts
+++ b/src/platform/plugins/shared/esql/server/routes/helpers.ts
@@ -7,13 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { IUiSettingsClient } from '@kbn/core/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { ScopedModel } from '@kbn/agent-builder-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
-
-const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
+import { AGENT_BUILDER_FAST_INFERENCE_FEATURE_ID } from '@kbn/agent-builder-common/constants';
+import type { FastInferenceEndpointsProvider } from '../types';
 
 export const createScopedModel = async ({
   inference,
@@ -32,29 +30,33 @@ export const createScopedModel = async ({
 };
 
 export const resolveConnectorId = async ({
-  uiSettingsClient,
   inference,
   request,
+  searchInferenceEndpoints,
 }: {
-  uiSettingsClient: IUiSettingsClient;
   inference: InferenceServerStart;
   request: KibanaRequest;
+  searchInferenceEndpoints?: FastInferenceEndpointsProvider;
 }): Promise<string | undefined> => {
-  try {
-    const defaultSetting = await uiSettingsClient.get<string>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR);
-    if (defaultSetting && defaultSetting !== NO_DEFAULT_CONNECTOR) {
-      return defaultSetting;
+  if (searchInferenceEndpoints) {
+    try {
+      const { endpoints } = await searchInferenceEndpoints.endpoints.getForFeature(
+        AGENT_BUILDER_FAST_INFERENCE_FEATURE_ID,
+        request
+      );
+      const recommended = endpoints.find((e) => e.isRecommended);
+      if (recommended) {
+        return recommended.connectorId;
+      }
+    } catch {
+      // fall through to default connector
     }
-  } catch {
-    // UI setting may not be registered, fall through
   }
 
   try {
     const connector = await inference.getDefaultConnector(request);
     return connector?.connectorId;
   } catch {
-    // no connectors available
+    return undefined;
   }
-
-  return undefined;
 };

--- a/src/platform/plugins/shared/esql/server/routes/nl_to_esql_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/nl_to_esql_route.ts
@@ -61,18 +61,18 @@ export const registerNLtoESQLRoute = (
         const { nlInstruction, currentQuery, isCompletion } = request.body;
         const core = await requestHandlerContext.core;
         const client = core.elasticsearch.client.asCurrentUser;
-        const [, { inference }] = await getStartServices();
+        const [, { inference, searchInferenceEndpoints }] = await getStartServices();
 
         const connectorId = await resolveConnectorId({
-          uiSettingsClient: core.uiSettings.client,
           inference,
           request,
+          searchInferenceEndpoints,
         });
 
         if (!connectorId) {
           return response.badRequest({
             body: {
-              message: 'No AI connector configured. Please set up a connector to use this feature.',
+              message: 'No AI connector available.',
             },
           });
         }

--- a/src/platform/plugins/shared/esql/server/routes/suggest_fix_route.ts
+++ b/src/platform/plugins/shared/esql/server/routes/suggest_fix_route.ts
@@ -57,18 +57,18 @@ export const registerSuggestFixRoute = (
         const { queryString, errorMessage } = request.body;
         const core = await requestHandlerContext.core;
         const client = core.elasticsearch.client.asCurrentUser;
-        const [, { inference }] = await getStartServices();
+        const [, { inference, searchInferenceEndpoints }] = await getStartServices();
 
         const connectorId = await resolveConnectorId({
-          uiSettingsClient: core.uiSettings.client,
           inference,
           request,
+          searchInferenceEndpoints,
         });
 
         if (!connectorId) {
           return response.badRequest({
             body: {
-              message: 'No AI connector configured. Please set up a connector to use this feature.',
+              message: 'No AI connector available.',
             },
           });
         }

--- a/src/platform/plugins/shared/esql/server/types.ts
+++ b/src/platform/plugins/shared/esql/server/types.ts
@@ -8,13 +8,25 @@
  */
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ESQLExtensionsRegistry } from './extensions_registry';
 
 export interface EsqlServerPluginSetup {
   getExtensionsRegistry: () => ESQLExtensionsRegistry;
 }
 
+// Should be SearchInferenceEndpointsPluginStart from @kbn/search-inference-endpoints/server but I cant use it due to circular dependency.
+export interface FastInferenceEndpointsProvider {
+  endpoints: {
+    getForFeature: (
+      featureId: string,
+      request: KibanaRequest
+    ) => Promise<{ endpoints: Array<{ connectorId: string; isRecommended?: boolean }> }>;
+  };
+}
+
 export interface EsqlServerPluginStart {
   inference: InferenceServerStart;
   actions: ActionsPluginStart;
+  searchInferenceEndpoints?: FastInferenceEndpointsProvider;
 }

--- a/src/platform/plugins/shared/esql/tsconfig.json
+++ b/src/platform/plugins/shared/esql/tsconfig.json
@@ -45,7 +45,6 @@
     "@kbn/inference-plugin",
     "@kbn/actions-plugin",
     "@kbn/core-http-server",
-    "@kbn/management-settings-ids",
     "@kbn/es-types",
     "@kbn/controls-constants",
     "@kbn/logging",

--- a/src/platform/plugins/shared/esql/tsconfig.json
+++ b/src/platform/plugins/shared/esql/tsconfig.json
@@ -52,6 +52,7 @@
     "@kbn/logging-mocks",
     "@kbn/agent-builder-genai-utils",
     "@kbn/agent-builder-server",
+    "@kbn/agent-builder-common",
     "@kbn/code-editor",
   ],
   "exclude": [


### PR DESCRIPTION
## Summary

Removes the requirement for a user-configured AI connector on EIS/Serverless. The routes now automatically select the recommended fast model connector (Gemini 3.0 Flash / Claude Haiku) via searchInferenceEndpoints.getForFeature, falling back to inference.getDefaultConnector if no EIS endpoint is available. On self-managed, behavior is unchanged — users still need a connector configured.

The agent_builder plugin couldn't be used directly for model selection due to a circular dependency (agent_builder requires esql). SearchInferenceEndpointsPluginStart also couldn't be imported directly due to a TypeScript-level cycle (search_inference_endpoints → lens → esql). Both are resolved by adding searchInferenceEndpoints as an optional plugin and duck-typing only the one method we need.

