### PR TITLE
[Entity Resolution] Skip basic-license suite on FIPS pipeline

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/api_feature_access.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/basic_license_essentials_tier/api_feature_access.ts
@@ -16,7 +16,8 @@ export default ({ getService }: FtrProviderContext) => {
 
   // Request bodies/queries below are placeholders — `enterpriseLicenseMiddleware`
   // fires before request validation, so any well-formed payload triggers the 403.
-  describe('@ess basic license api access', () => {
+  describe('@ess basic license api access', function () {
+    this.tags('skipFIPS');
     it('should reject link with 403', async () => {
       const { status, body } = await supertest
         .post(ENTITY_STORE_ROUTES.public.RESOLUTION_LINK)


### PR DESCRIPTION
## Summary

The `kibana-fips` CI pipeline silently rewrites `xpack.license.self_generated.type=basic` → `trial` via `applyFipsOverrides`. Since `trial` (rank 60) ≥ `enterprise` (rank 50), `enterpriseLicenseMiddleware` passes through instead of returning 403. The `link` handler then runs against placeholder entities that don't exist in the index, throws an uncaught ES error, and the test receives 500 instead of the expected 403.

Fix: add `this.tags('skipFIPS')` to the `describe` block. This matches the pattern used throughout the FTR suite for tests that depend on a non-trial license.

Fixes #272469

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risk — test-only change, one-line tag addition.