### PR TITLE
[Synthetics][Scout] Trim Fleet overhead in API test setup

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/services/synthetics_private_location_api_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/services/synthetics_private_location_api_service.ts
@@ -45,6 +45,20 @@ export interface SyntheticsPrivateLocationApi {
   cleanUpPrivateLocationsAndPolicies(): Promise<void>;
 }
 
+/** Shape of a Fleet `GET epm/packages/{name}` item (only the fields we read). */
+interface FleetPackageItem {
+  status?: string;
+  version?: string;
+  installationInfo?: { version?: string };
+}
+
+/** Shape of the public `GET private_locations/{id}` response (only the fields we read). */
+interface PrivateLocationContract {
+  id?: string;
+  label?: string;
+  isInvalid?: boolean;
+}
+
 export function createSyntheticsPrivateLocationApi(
   kbnClient: KbnClient,
   fleetApi: ApiServicesFixture['fleet']
@@ -67,11 +81,6 @@ export function createSyntheticsPrivateLocationApi(
   // We now install idempotently: never DELETE, short-circuit when the package
   // is already present at the target version, and tolerate concurrent installs
   // from sibling workers.
-  interface FleetPackageItem {
-    status?: string;
-    version?: string;
-    installationInfo?: { version?: string };
-  }
   const isInstalledAt = (item: FleetPackageItem | undefined, wanted: string): boolean =>
     item?.status === 'installed' && (item?.installationInfo?.version ?? item?.version) === wanted;
 
@@ -148,11 +157,6 @@ export function createSyntheticsPrivateLocationApi(
   // `isInvalid: true`. The public `GET private_locations/{id}` route combines
   // the exact same SO + agent-policy reads, so we gate setup on it until the
   // location is both found and `isInvalid: false`.
-  interface PrivateLocationContract {
-    id?: string;
-    label?: string;
-    isInvalid?: boolean;
-  }
   // Single probe of the public `GET private_locations/{id}` route, which combines
   // the same private-location SO + agent-policy reads that the monitor-save
   // validation performs. A location is "ready" only when it is found and

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/services/synthetics_private_location_api_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/services/synthetics_private_location_api_service.ts
@@ -118,10 +118,17 @@ export function createSyntheticsPrivateLocationApi(
   };
 
   const addFleetPolicy = async (name: string, spaceIds: string[] = ['default']) => {
+    // A private location only needs an agent policy to host its synthetics
+    // package policy; it never needs system monitoring. Enabling `sysMonitoring`
+    // makes Fleet create an extra `system` package policy on every agent policy
+    // — pure overhead for these tests (the suite created ~44 agent policies in a
+    // full run). The synthetics package-policy assertions all filter by
+    // `package.name: synthetics`, so the dropped system policy is invisible to
+    // the count-sensitive specs.
     const { data } = await fleetApi.agent_policies.create({
       policyName: name,
       policyNamespace: 'default',
-      sysMonitoring: true,
+      sysMonitoring: false,
       params: {
         description: '',
         monitoring_enabled: [],

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor_project_private_location.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor_project_private_location.spec.ts
@@ -19,7 +19,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { expect } from '@kbn/scout-oblt/api';
-import type { ApiClientFixture, KbnClient, KibanaRole } from '@kbn/scout-oblt';
+import type { ApiClientFixture, KbnClient, KibanaRole, ScoutLogger } from '@kbn/scout-oblt';
 import { syntheticsMonitorSavedObjectType } from '../../../../common/types/saved_objects';
 import { ConfigKey } from '../../../../common/runtime_types';
 import { PROFILE_VALUES_ENUM, PROFILES_MAP } from '../../../../common/constants/monitor_defaults';
@@ -58,6 +58,7 @@ apiTest.describe(
     let testPolicyId: string;
     let testPrivateLocationName: string;
     let kibanaServerUrl: string;
+    let log: ScoutLogger;
     const createdSpaces: string[] = [];
 
     /**
@@ -128,8 +129,16 @@ apiTest.describe(
             spaceId: spaceId === 'default' ? undefined : spaceId,
           });
         }
-      } catch {
-        // best-effort cleanup (mirrors the FTR try/catch)
+      } catch (error) {
+        // Best-effort cleanup (mirrors the FTR try/catch). The `beforeEach`
+        // `savedObjects.clean` still guarantees a clean slate for the next test,
+        // so a failure here can't leak across tests — but surface it instead of
+        // swallowing it silently so a 500/auth/network error stays diagnosable.
+        log.warning(
+          `deleteByJourney cleanup failed for journey "${journeyId}" / project "${projectId}": ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
       }
     };
 
@@ -361,30 +370,33 @@ apiTest.describe(
       spaces: ['default'],
     });
 
-    apiTest.beforeAll(async ({ requestAuth, kbnClient, apiServices, apiClient, config }) => {
-      kibanaServerUrl = config.hosts.kibana;
+    apiTest.beforeAll(
+      async ({ requestAuth, kbnClient, apiServices, apiClient, config, log: workerLog }) => {
+        kibanaServerUrl = config.hosts.kibana;
+        log = workerLog;
 
-      const { apiKeyHeader: editorKey } = await requestAuth.getApiKey('editor');
-      editorHeaders = mergeSyntheticsApiHeaders(editorKey, { Accept: 'application/json' });
-      const { apiKeyHeader: viewerKey } = await requestAuth.getApiKey('viewer');
-      viewerHeaders = mergeSyntheticsApiHeaders(viewerKey, { Accept: 'application/json' });
-      const { apiKeyHeader: adminKey } = await requestAuth.getApiKey('admin');
-      adminHeaders = mergeSyntheticsApiHeaders(adminKey, { Accept: 'application/json' });
+        const { apiKeyHeader: editorKey } = await requestAuth.getApiKey('editor');
+        editorHeaders = mergeSyntheticsApiHeaders(editorKey, { Accept: 'application/json' });
+        const { apiKeyHeader: viewerKey } = await requestAuth.getApiKey('viewer');
+        viewerHeaders = mergeSyntheticsApiHeaders(viewerKey, { Accept: 'application/json' });
+        const { apiKeyHeader: adminKey } = await requestAuth.getApiKey('admin');
+        adminHeaders = mergeSyntheticsApiHeaders(adminKey, { Accept: 'application/json' });
 
-      await kbnClient.savedObjects.clean({ types: MONITOR_SO_TYPES });
-      await deleteAllSyntheticsPackagePolicies(apiClient, adminHeaders);
+        await kbnClient.savedObjects.clean({ types: MONITOR_SO_TYPES });
+        await deleteAllSyntheticsPackagePolicies(apiClient, adminHeaders);
 
-      testPrivateLocation = await apiServices.syntheticsPrivateLocations.addTestPrivateLocation();
-      testPolicyId = testPrivateLocation.agentPolicyId;
-      testPrivateLocationName = testPrivateLocation.label;
+        testPrivateLocation = await apiServices.syntheticsPrivateLocations.addTestPrivateLocation();
+        testPolicyId = testPrivateLocation.agentPolicyId;
+        testPrivateLocationName = testPrivateLocation.label;
 
-      // Global param referenced by the lightweight `comparePolicies` test body.
-      await apiClient.post('api/synthetics/params', {
-        headers: editorHeaders,
-        body: { key: 'testGlobalParam', value: 'testGlobalParamValue' },
-        responseType: 'json',
-      });
-    });
+        // Global param referenced by the lightweight `comparePolicies` test body.
+        await apiClient.post('api/synthetics/params', {
+          headers: editorHeaders,
+          body: { key: 'testGlobalParam', value: 'testGlobalParamValue' },
+          responseType: 'json',
+        });
+      }
+    );
 
     apiTest.beforeEach(async ({ kbnClient }) => {
       apiTest.setTimeout(150_000);

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/delete_monitor_project.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/delete_monitor_project.spec.ts
@@ -32,6 +32,11 @@ const MONITOR_SO_TYPES = [
   'ingest-package-policies',
 ];
 
+// Per-test cleanup must not wipe `synthetics-private-location`: the location is
+// created once in `beforeAll` and reused as a monitor target, so removing it
+// between tests would force an agent-policy recreation on every test.
+const PER_TEST_SO_TYPES = [syntheticsMonitorSavedObjectType, 'ingest-package-policies'];
+
 apiTest.describe(
   'DeleteProjectMonitors',
   { tag: ['@local-stateful-classic', '@local-serverless-observability_complete'] },
@@ -87,17 +92,20 @@ apiTest.describe(
       const { apiKeyHeader: adminKey } = await requestAuth.getApiKey('admin');
       adminHeaders = mergeSyntheticsApiHeaders(adminKey);
       await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
-    });
-
-    apiTest.beforeEach(async ({ apiClient, kbnClient, apiServices }) => {
-      await deleteAllSyntheticsPackagePolicies(apiClient, adminHeaders);
-      await kbnClient.savedObjects.clean({ types: MONITOR_SO_TYPES });
+      // Created once and reused across tests (see PER_TEST_SO_TYPES note).
       privateLocation = await apiServices.syntheticsPrivateLocations.addTestPrivateLocation();
     });
 
-    apiTest.afterAll(async ({ apiClient, kbnClient }) => {
+    apiTest.beforeEach(async ({ apiClient, kbnClient }) => {
+      await deleteAllSyntheticsPackagePolicies(apiClient, adminHeaders);
+      await kbnClient.savedObjects.clean({ types: PER_TEST_SO_TYPES });
+    });
+
+    apiTest.afterAll(async ({ apiClient, kbnClient, apiServices }) => {
       await deleteAllSyntheticsPackagePolicies(apiClient, adminHeaders);
       await kbnClient.savedObjects.clean({ types: MONITOR_SO_TYPES });
+      // Remove the shared agent policy created in `beforeAll`.
+      await apiServices.syntheticsPrivateLocations.cleanUpPrivateLocationsAndPolicies();
     });
 
     apiTest('only allows 500 requests at a time', async ({ apiClient }) => {

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/enable_default_alerting.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/enable_default_alerting.spec.ts
@@ -80,6 +80,11 @@ apiTest.describe(
       await kbnClient.savedObjects.clean({ types: ['synthetics-monitor-multi-space'] });
       await enableSynthetics(apiClient, editorHeaders);
       await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+      // The private location is only a monitor target and is not mutated by any
+      // test, so create it once here instead of per-test in `beforeEach`. The
+      // per-test monitor cleanup below only wipes `synthetics-monitor-multi-space`,
+      // so the location survives across tests.
+      privateLocation = await apiServices.syntheticsPrivateLocations.addTestPrivateLocation();
       await apiServices.alerting.connectors.create({
         name: TEST_INDEX_CONNECTOR_NAME,
         connectorTypeId: '.index',
@@ -87,9 +92,8 @@ apiTest.describe(
       });
     });
 
-    apiTest.beforeEach(async ({ apiClient, apiServices, kbnClient }) => {
+    apiTest.beforeEach(async ({ apiClient, kbnClient }) => {
       await kbnClient.savedObjects.clean({ types: ['synthetics-monitor-multi-space'] });
-      privateLocation = await apiServices.syntheticsPrivateLocations.addTestPrivateLocation();
       const res = await putDynamicSettings(apiClient, {
         ...DYNAMIC_SETTINGS_DEFAULTS,
         defaultConnectors: [TEST_INDEX_CONNECTOR_NAME],


### PR DESCRIPTION
## Summary

Follow-up to #272287. Small, coverage-neutral cleanups that trim Fleet overhead in the Synthetics Scout API test setup.

- **`addFleetPolicy`: drop `sysMonitoring` (was `true`).** A private location's agent policy only needs to host the synthetics package policy and never needs system monitoring, so creating an extra `system` package policy on every agent policy was pure overhead (a full suite run creates ~40 agent policies). All synthetics package-policy assertions filter by `package.name: synthetics`, so the count-sensitive specs (`clean_up_extra_package_policies`, `migrate_legacy_policies`, `reset_*`) are unaffected.
- **`enable_default_alerting` / `delete_monitor_project`: create the test private location once in `beforeAll`** instead of per-test in `beforeEach`. The location is only a monitor target and is never mutated. `delete_monitor_project`'s per-test cleanup no longer wipes `synthetics-private-location` (a new `PER_TEST_SO_TYPES` excludes it), and its `afterAll` removes the shared agent policy.

## Context / expectations

Profiling (local + the flaky-runner CI build) showed the suite is dominated by real Fleet monitor save/deploy operations, **not** agent-policy/system-policy creation, and that server boot is ~1 min in CI. So these changes are intentionally modest: they speed up the two targeted specs and reduce Fleet object churn, but they do **not** materially change the ~24-min suite total. A suite-level speedup would require the larger parallelism / per-space isolation work, tracked separately.

## Test plan

- [x] `node scripts/check.js --scope branch` → **lint ✓ (3 files) · jest ✓ (1744 tests) · tsc ✓**
- [x] Full Scout API suite (`run-tests --arch stateful --domain classic`): **256 passed / 4 skipped / 0 failed**
- [x] Per-spec deltas: `enable_default_alerting` 48s→24s (−50%), `delete_monitor_project` 77s→53s (−31%); Fleet agent policies created 47→39
