### PR TITLE
chore(deps): bump react-router-dom-v5-compat from 6.30.3 to 6.30.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1516,7 +1516,7 @@
     "react-router": "5.3.4",
     "react-router-config": "5.1.1",
     "react-router-dom": "5.3.4",
-    "react-router-dom-v5-compat": "6.30.3",
+    "react-router-dom-v5-compat": "6.30.4",
     "react-shortcuts": "2.1.0",
     "react-use": "17.6.0",
     "react-virtualized": "9.22.6",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -44,7 +44,7 @@
 @mapbox/hast-util-table-cell-style@0.2.0
 @popperjs/core@2.11.8
 @reduxjs/toolkit@1.9.7
-@remix-run/router@1.23.2
+@remix-run/router@1.23.3
 @tanstack/match-sorter-utils@8.7.0
 @tanstack/query-core@4.29.11
 @tanstack/react-query-devtools@4.29.12
@@ -399,10 +399,10 @@ react-redux@8.1.3
 react-redux@9.2.0
 react-remove-scroll-bar@2.3.4
 react-remove-scroll@2.5.7
-react-router-dom-v5-compat@6.30.3
+react-router-dom-v5-compat@6.30.4
 react-router-dom@5.3.4
 react-router@5.3.4
-react-router@6.30.3
+react-router@6.30.4
 react-style-singleton@2.2.1
 react-virtualized-auto-sizer@1.0.24
 react-window@1.8.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -12798,10 +12798,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@remix-run/router@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
-  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
+"@remix-run/router@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
+  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
 "@rsbuild/plugin-check-syntax@1.6.1":
   version "1.6.1"
@@ -31478,14 +31478,14 @@ react-router-config@5.1.1:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-react-router-dom-v5-compat@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz#0bd5ccc0d9fc0e81ceabade75acc55240279aaaf"
-  integrity sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==
+react-router-dom-v5-compat@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.4.tgz#b7cad925e08120e0d33939d8fede670d853a33a9"
+  integrity sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
     history "^5.3.0"
-    react-router "6.30.3"
+    react-router "6.30.4"
 
 react-router-dom@5.3.4:
   version "5.3.4"
@@ -31515,12 +31515,12 @@ react-router@5.3.4:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
-  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+react-router@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
 
 react-select@^5.10.1:
   version "5.10.1"


### PR DESCRIPTION
## Summary

Bump `react-router-dom-v5-compat` from `6.30.3` to `6.30.4`.




<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->