### PR TITLE
[Alerting v2] Switch to DSL from ILM

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.test.ts
@@ -29,22 +29,7 @@ describe('DatastreamInitializer', () => {
         '@timestamp': { type: 'date' },
       },
     },
-    ilmPolicy: {
-      name: '.alerting-test-ilm-policy',
-      policy: {
-        _meta: { managed: true },
-        phases: {
-          hot: {
-            actions: {
-              rollover: {
-                max_age: '30d',
-                max_primary_shard_size: '50gb',
-              },
-            },
-          },
-        },
-      },
-    },
+    lifecycle: {},
   };
 
   beforeEach(() => {
@@ -52,25 +37,27 @@ describe('DatastreamInitializer', () => {
     mockLogger = loggerMock.create();
     // data streams uses the esClient internally
     esClient = elasticsearchServiceMock.createElasticsearchClient();
-    esClient.ilm.putLifecycle.mockResolvedValue({ acknowledged: true });
     esClient.indices.getDataStream.mockResolvedValue({ data_streams: [] });
     esClient.indices.getIndexTemplate.mockResolvedValue({ index_templates: [] });
     esClient.indices.putIndexTemplate.mockResolvedValue({ acknowledged: true });
     esClient.indices.createDataStream.mockResolvedValue({ acknowledged: true });
   });
 
-  it('installs ILM policy, index template, then creates the data stream', async () => {
+  it('installs the index template with DSL lifecycle, then creates the data stream', async () => {
     const initializer = new DatastreamInitializer(mockLogger, esClient, resourceDefinition);
 
     await initializer.initialize();
 
-    expect(esClient.ilm.putLifecycle).toHaveBeenCalledWith({
-      name: resourceDefinition.ilmPolicy.name,
-      policy: resourceDefinition.ilmPolicy.policy,
-    });
+    // No `_ilm` API call — incompatible with serverless. DSL is configured
+    // entirely through the index template's `lifecycle` field.
+    expect(esClient.ilm.putLifecycle).not.toHaveBeenCalled();
+
     expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
       expect.objectContaining({
         name: resourceDefinition.dataStreamName,
+        template: expect.objectContaining({
+          lifecycle: resourceDefinition.lifecycle,
+        }),
       })
     );
     expect(esClient.indices.createDataStream).toHaveBeenCalledWith({

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.test.ts
@@ -48,10 +48,6 @@ describe('DatastreamInitializer', () => {
 
     await initializer.initialize();
 
-    // No `_ilm` API call — incompatible with serverless. DSL is configured
-    // entirely through the index template's `lifecycle` field.
-    expect(esClient.ilm.putLifecycle).not.toHaveBeenCalled();
-
     expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
       expect.objectContaining({
         name: resourceDefinition.dataStreamName,
@@ -60,6 +56,7 @@ describe('DatastreamInitializer', () => {
         }),
       })
     );
+
     expect(esClient.indices.createDataStream).toHaveBeenCalledWith({
       name: resourceDefinition.dataStreamName,
     });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.test.ts
@@ -62,6 +62,24 @@ describe('DatastreamInitializer', () => {
     });
   });
 
+  it('installs the expected index template settings', async () => {
+    const initializer = new DatastreamInitializer(mockLogger, esClient, resourceDefinition);
+
+    await initializer.initialize();
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          settings: expect.objectContaining({
+            'index.mapping.total_fields.limit': 2500,
+            'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+            'index.lifecycle.prefer_ilm': false,
+          }),
+        }),
+      })
+    );
+  });
+
   it('ignores 409 errors when creating the data stream', async () => {
     esClient.indices.createDataStream.mockRejectedValueOnce(
       new errors.ResponseError({ statusCode: 409 } as DiagnosticResult)

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
@@ -34,13 +34,11 @@ export class DatastreamInitializer implements IResourceInitializer {
         aliases: {},
         priority: 500,
         mappings: this.resourceDefinition.mappings,
-        // Data Stream Lifecycle (DSL) instead of ILM so this works on both
-        // stateful and serverless. `DataStreamClient` handles both initial
-        // template install and lifecycle migrations on version bumps.
         lifecycle: this.resourceDefinition.lifecycle,
         settings: {
           'index.mapping.total_fields.limit': TOTAL_FIELDS_LIMIT,
           'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
+          'index.lifecycle.prefer_ilm': false,
         },
         _meta: {
           managed: true,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/resource_service/datastream_initializer.ts
@@ -26,11 +26,6 @@ export class DatastreamInitializer implements IResourceInitializer {
   ) {}
 
   public async initialize(): Promise<void> {
-    await this.esClient.ilm.putLifecycle({
-      name: this.resourceDefinition.ilmPolicy.name,
-      policy: this.resourceDefinition.ilmPolicy.policy,
-    });
-
     const dataStreamDefinition: DataStreamDefinition<typeof this.resourceDefinition.mappings> = {
       name: this.resourceDefinition.dataStreamName,
       hidden: true,
@@ -39,8 +34,11 @@ export class DatastreamInitializer implements IResourceInitializer {
         aliases: {},
         priority: 500,
         mappings: this.resourceDefinition.mappings,
+        // Data Stream Lifecycle (DSL) instead of ILM so this works on both
+        // stateful and serverless. `DataStreamClient` handles both initial
+        // template install and lifecycle migrations on version bumps.
+        lifecycle: this.resourceDefinition.lifecycle,
         settings: {
-          'index.lifecycle.name': this.resourceDefinition.ilmPolicy.name,
           'index.mapping.total_fields.limit': TOTAL_FIELDS_LIMIT,
           'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
         },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_actions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_actions.ts
@@ -5,29 +5,15 @@
  * 2.0.
  */
 
-import type { IlmPolicy } from '@elastic/elasticsearch/lib/api/types';
 import type { MappingsDefinition } from '@kbn/es-mappings';
 import { z } from '@kbn/zod/v4';
 import type { ResourceDefinition } from './types';
 
 export const ALERT_ACTIONS_DATA_STREAM = '.alert-actions';
-export const ALERT_ACTIONS_DATA_STREAM_VERSION = 2;
+// Version bumped from 2 to 3 to swap the ILM policy (incompatible with
+// serverless `_ilm` APIs) for a Data Stream Lifecycle (DSL) configuration.
+export const ALERT_ACTIONS_DATA_STREAM_VERSION = 3;
 export const ALERT_ACTIONS_BACKING_INDEX = '.ds-.alert-actions-*';
-export const ALERT_ACTIONS_ILM_POLICY_NAME = '.alert-actions-ilm-policy';
-
-export const ALERT_ACTIONS_ILM_POLICY: IlmPolicy = {
-  _meta: { managed: true },
-  phases: {
-    hot: {
-      actions: {
-        rollover: {
-          max_age: '30d',
-          max_primary_shard_size: '50gb',
-        },
-      },
-    },
-  },
-};
 
 const mappings: MappingsDefinition = {
   dynamic: false,
@@ -75,5 +61,8 @@ export const getAlertActionsResourceDefinition = (): ResourceDefinition => ({
   dataStreamName: ALERT_ACTIONS_DATA_STREAM,
   version: ALERT_ACTIONS_DATA_STREAM_VERSION,
   mappings,
-  ilmPolicy: { name: ALERT_ACTIONS_ILM_POLICY_NAME, policy: ALERT_ACTIONS_ILM_POLICY },
+  // Empty lifecycle enables DSL with cluster defaults: automatic rollover,
+  // no document retention (data is kept indefinitely, matching the previous
+  // ILM policy which only declared a `hot` rollover phase).
+  lifecycle: {},
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_actions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_actions.ts
@@ -10,8 +10,6 @@ import { z } from '@kbn/zod/v4';
 import type { ResourceDefinition } from './types';
 
 export const ALERT_ACTIONS_DATA_STREAM = '.alert-actions';
-// Version bumped from 2 to 3 to swap the ILM policy (incompatible with
-// serverless `_ilm` APIs) for a Data Stream Lifecycle (DSL) configuration.
 export const ALERT_ACTIONS_DATA_STREAM_VERSION = 3;
 export const ALERT_ACTIONS_BACKING_INDEX = '.ds-.alert-actions-*';
 
@@ -61,8 +59,5 @@ export const getAlertActionsResourceDefinition = (): ResourceDefinition => ({
   dataStreamName: ALERT_ACTIONS_DATA_STREAM,
   version: ALERT_ACTIONS_DATA_STREAM_VERSION,
   mappings,
-  // Empty lifecycle enables DSL with cluster defaults: automatic rollover,
-  // no document retention (data is kept indefinitely, matching the previous
-  // ILM policy which only declared a `hot` rollover phase).
   lifecycle: {},
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
@@ -5,29 +5,15 @@
  * 2.0.
  */
 
-import type { IlmPolicy } from '@elastic/elasticsearch/lib/api/types';
 import type { MappingsDefinition } from '@kbn/es-mappings';
 import { z } from '@kbn/zod/v4';
 import type { ResourceDefinition } from './types';
 
 export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
-export const ALERT_EVENTS_DATA_STREAM_VERSION = 3;
+// Version bumped from 3 to 4 to swap the ILM policy (incompatible with
+// serverless `_ilm` APIs) for a Data Stream Lifecycle (DSL) configuration.
+export const ALERT_EVENTS_DATA_STREAM_VERSION = 4;
 export const ALERT_EVENTS_BACKING_INDEX = '.ds-.rule-events-*';
-export const ALERT_EVENTS_ILM_POLICY_NAME = '.rule-events-ilm-policy';
-
-export const ALERT_EVENTS_ILM_POLICY: IlmPolicy = {
-  _meta: { managed: true },
-  phases: {
-    hot: {
-      actions: {
-        rollover: {
-          max_age: '30d',
-          max_primary_shard_size: '50gb',
-        },
-      },
-    },
-  },
-};
 
 const mappings: MappingsDefinition = {
   dynamic: false,
@@ -105,5 +91,8 @@ export const getAlertEventsResourceDefinition = (): ResourceDefinition => ({
   dataStreamName: ALERT_EVENTS_DATA_STREAM,
   version: ALERT_EVENTS_DATA_STREAM_VERSION,
   mappings,
-  ilmPolicy: { name: ALERT_EVENTS_ILM_POLICY_NAME, policy: ALERT_EVENTS_ILM_POLICY },
+  // Empty lifecycle enables DSL with cluster defaults: automatic rollover,
+  // no document retention (data is kept indefinitely, matching the previous
+  // ILM policy which only declared a `hot` rollover phase).
+  lifecycle: {},
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/alert_events.ts
@@ -10,8 +10,6 @@ import { z } from '@kbn/zod/v4';
 import type { ResourceDefinition } from './types';
 
 export const ALERT_EVENTS_DATA_STREAM = '.rule-events';
-// Version bumped from 3 to 4 to swap the ILM policy (incompatible with
-// serverless `_ilm` APIs) for a Data Stream Lifecycle (DSL) configuration.
 export const ALERT_EVENTS_DATA_STREAM_VERSION = 4;
 export const ALERT_EVENTS_BACKING_INDEX = '.ds-.rule-events-*';
 
@@ -91,8 +89,5 @@ export const getAlertEventsResourceDefinition = (): ResourceDefinition => ({
   dataStreamName: ALERT_EVENTS_DATA_STREAM,
   version: ALERT_EVENTS_DATA_STREAM_VERSION,
   mappings,
-  // Empty lifecycle enables DSL with cluster defaults: automatic rollover,
-  // no document retention (data is kept indefinitely, matching the previous
-  // ILM policy which only declared a `hot` rollover phase).
   lifecycle: {},
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { IlmPolicy } from '@elastic/elasticsearch/lib/api/types';
+import type { IndicesDataStreamLifecycleWithRollover } from '@elastic/elasticsearch/lib/api/types';
 import type { MappingsDefinition } from '@kbn/es-mappings';
 
 export interface ResourceDefinition {
@@ -13,8 +13,15 @@ export interface ResourceDefinition {
   dataStreamName: string;
   version: number;
   mappings: MappingsDefinition;
-  ilmPolicy: {
-    name: string;
-    policy: IlmPolicy;
-  };
+  /**
+   * Data Stream Lifecycle (DSL) configuration applied to the data stream's
+   * index template. Use DSL instead of ILM so the same definition works on
+   * both stateful and serverless deployments (`_ilm` APIs are not available
+   * on serverless).
+   *
+   * An empty object enables DSL with cluster defaults (rollover only,
+   * no retention). Set `data_retention` to auto-delete documents after
+   * a duration.
+   */
+  lifecycle: IndicesDataStreamLifecycleWithRollover;
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/types.ts
@@ -13,15 +13,5 @@ export interface ResourceDefinition {
   dataStreamName: string;
   version: number;
   mappings: MappingsDefinition;
-  /**
-   * Data Stream Lifecycle (DSL) configuration applied to the data stream's
-   * index template. Use DSL instead of ILM so the same definition works on
-   * both stateful and serverless deployments (`_ilm` APIs are not available
-   * on serverless).
-   *
-   * An empty object enables DSL with cluster defaults (rollover only,
-   * no retention). Set `data_retention` to auto-delete documents after
-   * a duration.
-   */
   lifecycle: IndicesDataStreamLifecycleWithRollover;
 }


### PR DESCRIPTION
## Summary

This PR switches from ILM policies to Data stream lifecycle (DSL) because ILM is not supported in Serverless.

Fixes: https://github.com/elastic/rna-program/issues/535

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios