### PR TITLE
fix the about panel edit icon focus issue

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/about_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/about_panel.tsx
@@ -162,14 +162,22 @@ export function AboutPanel() {
 
           {canEditDescription && !isEditing && (
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType="pencil"
-                aria-label={i18n.translate(
+              <EuiToolTip
+                content={i18n.translate(
                   'xpack.streams.streamOverview.aboutPanel.editDescriptionAriaLabel',
                   { defaultMessage: 'Edit description' }
                 )}
-                onClick={handleClick}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  iconType="pencil"
+                  aria-label={i18n.translate(
+                    'xpack.streams.streamOverview.aboutPanel.editDescriptionAriaLabel',
+                    { defaultMessage: 'Edit description' }
+                  )}
+                  onClick={handleClick}
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/about_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/about_panel.tsx
@@ -134,7 +134,7 @@ export function AboutPanel() {
   }, [isEditing]);
 
   return (
-    <EuiFocusTrap onClickOutside={() => setIsEditing(false)}>
+    <EuiFocusTrap disabled={!isEditing} onClickOutside={() => setIsEditing(false)}>
       <EuiPanel
         hasBorder
         hasShadow={false}
@@ -146,9 +146,6 @@ export function AboutPanel() {
           &:focus {
             box-shadow: none;
             transform: translateY(0);
-          }
-          &:is(:hover, :active, :focus, :focus-within) .aboutPanel__editButton {
-            opacity: 1;
           }
         `}
       >
@@ -164,14 +161,7 @@ export function AboutPanel() {
           </EuiFlexItem>
 
           {canEditDescription && !isEditing && (
-            <EuiFlexItem
-              grow={false}
-              className="aboutPanel__editButton"
-              css={css`
-                opacity: 0;
-                transition: opacity 150ms;
-              `}
-            >
+            <EuiFlexItem grow={false}>
               <EuiButtonIcon
                 iconType="pencil"
                 aria-label={i18n.translate(


### PR DESCRIPTION
## Summary


The About panel in the Streams overview page has the edit button always focused causing some weird behaviors.

## Before

https://github.com/user-attachments/assets/f079e941-99d1-498a-b2bc-311965c62861


## After

https://github.com/user-attachments/assets/c57372e2-07a1-459b-afec-16afd227bb38


