### PR TITLE
[9.4] [Entity Analytics] Fix entities table default sort to show highest risk entities first (#272234)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/fetch_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/fetch_utils.ts
@@ -8,6 +8,11 @@
 import type { RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
 import { ENTITY_FIELDS } from '../constants';
 
+const fieldsRequiringSortMissingLast: string[] = [
+  ENTITY_FIELDS.ENTITY_RISK,
+  ENTITY_FIELDS.RESOLUTION_RISK_SCORE,
+];
+
 export const getRuntimeMappingsFromSort = (fields: string[], sort: string[][]) => {
   return sort
     .filter(([field]) => fields.includes(field))
@@ -45,6 +50,9 @@ const getSortField = ({ field, direction }: { field: string; direction: string }
         },
       },
     };
+  }
+  if (fieldsRequiringSortMissingLast.includes(field)) {
+    return { [field]: { order: direction, missing: '_last' } };
   }
   return { [field]: direction };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.ts
@@ -53,11 +53,16 @@ export interface EntityURLStateResult {
   getRowsFromPages: (data: Array<{ page: DataTableRecord[] }> | undefined) => DataTableRecord[];
 }
 
+export const DEFAULT_ENTITIES_TABLE_SORT: Array<[string, string]> = [
+  ['entity.risk.calculated_score_norm', 'desc'],
+  ['@timestamp', 'desc'],
+];
+
 const getDefaultQuery = ({ query, filters }: EntitiesBaseURLQuery) => ({
   query,
   filters,
   pageFilters: [],
-  sort: { field: '@timestamp', direction: 'desc' },
+  sort: DEFAULT_ENTITIES_TABLE_SORT,
   pageIndex: 0,
 });
 export const useEntityURLState = ({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/index.ts
@@ -20,6 +20,7 @@ export const DataViewContext = createContext<DataViewContextValue>({} as DataVie
 export { EntitiesTableSection } from './entities_table_section';
 export {
   useEntityURLState,
+  DEFAULT_ENTITIES_TABLE_SORT,
   type EntityURLStateResult,
   type EntitiesBaseURLQuery,
   type URLQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -47,6 +47,7 @@ import {
   EntitiesTableSection,
   DataViewContext,
   useEntityURLState,
+  DEFAULT_ENTITIES_TABLE_SORT,
   type EntitiesBaseURLQuery,
   type URLQuery,
 } from '../components/home/entities_table';
@@ -74,7 +75,7 @@ const getDefaultQuery = ({ query, filters }: EntitiesBaseURLQuery): URLQuery => 
   query,
   filters,
   pageFilters: [],
-  sort: [['@timestamp', 'desc']],
+  sort: DEFAULT_ENTITIES_TABLE_SORT,
   pageIndex: 0,
 });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout/resolution_section.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout/resolution_section.cy.ts
@@ -79,15 +79,17 @@ describe(
     },
   },
   () => {
-    before(() => {
-      cy.task('esArchiverLoad', { archiveName: ARCHIVE_NAME });
-    });
-
     after(() => {
       cy.task('esArchiverUnload', { archiveName: ARCHIVE_NAME });
     });
 
+    // Reload the archive before every test (and on every Cypress retry) so each
+    // test starts from the seeded resolution state. The link / unlink tests
+    // mutate shared entities via the resolution API; without a per-test reset a
+    // retried test would observe leftover groups created during its own first
+    // attempt (e.g. a seeded group of 3 appearing as 4) and fail spuriously.
     beforeEach(() => {
+      cy.task('esArchiverLoad', { archiveName: ARCHIVE_NAME });
       interceptEntityStoreStatus('running');
       interceptResolutionGroup();
       interceptResolutionMutations();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_analytics/entity_flyout_resolution.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_analytics/entity_flyout_resolution.ts
@@ -9,6 +9,8 @@ import {
   EXPAND_ROW_BUTTON,
   dataGridRowCellByColumn,
 } from '../../screens/entity_analytics/entity_analytics_home';
+import { GLOBAL_KQL_INPUT, GLOBAL_SEARCH_BAR_SUBMIT_BUTTON } from '../../screens/search_bar';
+import { fillKqlQueryBar } from '../search_bar';
 import {
   ADD_ENTITIES_ACCORDION,
   ADD_ENTITIES_SEARCH,
@@ -51,11 +53,32 @@ export const interceptResolutionMutations = () => {
 };
 
 /**
+ * Filter the home entities grid to a single entity by typing an exact
+ * `entity.name` match into the global KQL search bar. This narrows the
+ * server-side result so the target row is always rendered on the first page,
+ * independent of the table's default sort order or how many entities exist.
+ */
+export const filterHomeEntitiesByName = (entityName: string) => {
+  cy.get(GLOBAL_KQL_INPUT).clear();
+  fillKqlQueryBar(`entity.name: "${entityName}"`);
+  cy.get(GLOBAL_SEARCH_BAR_SUBMIT_BUTTON).click();
+};
+
+/**
  * Click the row-expand button on the entity-analytics flat data grid for the
- * row whose `entity.name` cell matches `entityName`. Targets the row via
- * a non-positional selector chain: name cell → containing role=row → expand button.
+ * row whose `entity.name` cell matches `entityName`. Filters the grid to that
+ * entity first so the lookup does not depend on default sort or virtualization,
+ * then targets the row via a non-positional selector chain: name cell →
+ * containing role=row → expand button.
  */
 export const openEntityFlyoutFromHomeByName = (entityName: string) => {
+  filterHomeEntitiesByName(entityName);
+  // Wait for the filtered refetch to render the matching row before acting on
+  // it. The assertion retries the `cy.contains` query, so it also re-resolves
+  // the subject if the grid re-renders, avoiding a detached-element click.
+  cy.contains(dataGridRowCellByColumn('entity.name'), entityName, { timeout: 20000 }).should(
+    'be.visible'
+  );
   cy.contains(dataGridRowCellByColumn('entity.name'), entityName)
     .parents('[role="row"]')
     .find(EXPAND_ROW_BUTTON)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] Fix entities table default sort to show highest risk entities first (#272234)](https://github.com/elastic/kibana/pull/272234)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abhishek Bhatia","email":"117628830+abhishekbhatia1710@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-04T13:06:14Z","message":"[Entity Analytics] Fix entities table default sort to show highest risk entities first (#272234)\n\n## Summary\n\nThe entities table on the Entity Analytics homepage was defaulting to\nsort by `@timestamp` (last seen) instead of risk score. This caused\nentities with no risk score to appear at the top when they were recently\nactive, pushing high-risk entities down.\n\nTwo changes:\n\n1. Changed the default sort to `entity.risk.calculated_score_norm`\ndescending, with `@timestamp` as a tiebreaker for entities with the same\nscore.\n2. Added explicit `missing: _last` to the Elasticsearch sort clause for\nrisk score fields so entities without a risk score always appear at the\nbottom, regardless of sort direction.\n\n## How to verify\n\n1. Checkout this branch\n2. Seed some data which has NA risk scores for certain entities\n3. Then open the Entity Analytics homepage. Entities should now be\nordered highest risk first, with NA entities at the bottom.\n\nCloses : https://github.com/elastic/security-team/issues/17666\n\nScreen recording for ref : \n\n\nhttps://github.com/user-attachments/assets/57458c4d-d8f6-4418-a6e9-d71c0a1d2317","sha":"0cc966d18410a40c731ee486d9630c9867184c03","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Entity Analytics","backport:version","v9.4.0","v9.5.0"],"title":"[Entity Analytics] Fix entities table default sort to show highest risk entities first","number":272234,"url":"https://github.com/elastic/kibana/pull/272234","mergeCommit":{"message":"[Entity Analytics] Fix entities table default sort to show highest risk entities first (#272234)\n\n## Summary\n\nThe entities table on the Entity Analytics homepage was defaulting to\nsort by `@timestamp` (last seen) instead of risk score. This caused\nentities with no risk score to appear at the top when they were recently\nactive, pushing high-risk entities down.\n\nTwo changes:\n\n1. Changed the default sort to `entity.risk.calculated_score_norm`\ndescending, with `@timestamp` as a tiebreaker for entities with the same\nscore.\n2. Added explicit `missing: _last` to the Elasticsearch sort clause for\nrisk score fields so entities without a risk score always appear at the\nbottom, regardless of sort direction.\n\n## How to verify\n\n1. Checkout this branch\n2. Seed some data which has NA risk scores for certain entities\n3. Then open the Entity Analytics homepage. Entities should now be\nordered highest risk first, with NA entities at the bottom.\n\nCloses : https://github.com/elastic/security-team/issues/17666\n\nScreen recording for ref : \n\n\nhttps://github.com/user-attachments/assets/57458c4d-d8f6-4418-a6e9-d71c0a1d2317","sha":"0cc966d18410a40c731ee486d9630c9867184c03"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272234","number":272234,"mergeCommit":{"message":"[Entity Analytics] Fix entities table default sort to show highest risk entities first (#272234)\n\n## Summary\n\nThe entities table on the Entity Analytics homepage was defaulting to\nsort by `@timestamp` (last seen) instead of risk score. This caused\nentities with no risk score to appear at the top when they were recently\nactive, pushing high-risk entities down.\n\nTwo changes:\n\n1. Changed the default sort to `entity.risk.calculated_score_norm`\ndescending, with `@timestamp` as a tiebreaker for entities with the same\nscore.\n2. Added explicit `missing: _last` to the Elasticsearch sort clause for\nrisk score fields so entities without a risk score always appear at the\nbottom, regardless of sort direction.\n\n## How to verify\n\n1. Checkout this branch\n2. Seed some data which has NA risk scores for certain entities\n3. Then open the Entity Analytics homepage. Entities should now be\nordered highest risk first, with NA entities at the bottom.\n\nCloses : https://github.com/elastic/security-team/issues/17666\n\nScreen recording for ref : \n\n\nhttps://github.com/user-attachments/assets/57458c4d-d8f6-4418-a6e9-d71c0a1d2317","sha":"0cc966d18410a40c731ee486d9630c9867184c03"}}]}] BACKPORT-->