### PR TITLE
[Synthetics] Hide space filter when user can access only one space

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/show_all_spaces.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/show_all_spaces.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '../../../utils/testing/rtl_helpers';
+import { ShowAllSpaces } from './show_all_spaces';
+import { useHasMultipleSpaces } from '../../../../../hooks/use_has_multiple_spaces';
+import { useKibanaSpace } from '../../../../../hooks/use_kibana_space';
+
+jest.mock('../../../../../hooks/use_has_multiple_spaces');
+jest.mock('../../../../../hooks/use_kibana_space');
+
+describe('ShowAllSpaces', () => {
+  const useHasMultipleSpacesMock = useHasMultipleSpaces as jest.Mock;
+  const useKibanaSpaceMock = useKibanaSpace as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useKibanaSpaceMock.mockReturnValue({
+      space: { id: 'default', name: 'Default' },
+      loading: false,
+    });
+  });
+
+  it('renders the spaces filter when the user can access multiple spaces', () => {
+    useHasMultipleSpacesMock.mockReturnValue({ hasMultipleSpaces: true, loading: false });
+
+    const { getByText } = render(<ShowAllSpaces />);
+
+    expect(getByText('Spaces')).toBeTruthy();
+  });
+
+  it('hides the spaces filter when the user can access only one space', () => {
+    useHasMultipleSpacesMock.mockReturnValue({ hasMultipleSpaces: false, loading: false });
+
+    const { queryByText } = render(<ShowAllSpaces />);
+
+    expect(queryByText('Spaces')).toBeNull();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/show_all_spaces.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/show_all_spaces.tsx
@@ -24,9 +24,17 @@ import {
   updateManagementPageStateAction,
 } from '../../../state';
 import { useKibanaSpace } from '../../../../../hooks/use_kibana_space';
+import { useHasMultipleSpaces } from '../../../../../hooks/use_has_multiple_spaces';
 
 export const ShowAllSpaces: React.FC = () => {
   const { space } = useKibanaSpace();
+  const { hasMultipleSpaces } = useHasMultipleSpaces();
+
+  // With access to a single space, toggling between "current" and "all
+  // permitted" spaces is a no-op, so the filter is hidden entirely.
+  if (!hasMultipleSpaces) {
+    return null;
+  }
 
   return (
     <EuiFlexGroup gutterSize="xs" alignItems="center">

--- a/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_has_multiple_spaces.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/hooks/use_has_multiple_spaces.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useFetcher } from '@kbn/observability-shared-plugin/public';
+import type { Space } from '@kbn/spaces-plugin/common';
+import { API_VERSIONS } from '@kbn/spaces-plugin/common';
+import type { ClientPluginsStart } from '../plugin';
+
+export const useHasMultipleSpaces = () => {
+  const { services } = useKibana<ClientPluginsStart>();
+  const { spaces, http } = services;
+
+  const { data, loading } = useFetcher(async () => {
+    // When the Spaces plugin is disabled or the instance only supports the
+    // default space there is nothing to switch between, so skip the request.
+    if (!spaces || spaces.hasOnlyDefaultSpace) {
+      return [] as Space[];
+    }
+    return http?.get<Space[]>('/api/spaces/space', { version: API_VERSIONS.public.v1 });
+  }, [spaces, http]);
+
+  return {
+    hasMultipleSpaces: (data?.length ?? 0) > 1,
+    loading,
+  };
+};


### PR DESCRIPTION
## Summary

The monitors page **Spaces** filter (`ShowAllSpaces`) lets users switch between the current space and all permitted spaces. When the user can only reach a single space the toggle is a no-op and just adds clutter, so this hides it entirely.

- Adds a `useHasMultipleSpaces` hook that reuses the existing public `GET /api/spaces/space` endpoint (which already returns only the spaces the user is authorized to access). It short-circuits **without** a request when the Spaces plugin is disabled or the instance only supports the default space (`hasOnlyDefaultSpace`), so there is no new server route.
- The shared `ShowAllSpaces` component early-returns `null` when fewer than two spaces are accessible — a single change that covers both the overview grid and the management list header.
- While the spaces list is loading the control stays hidden and then appears for multi-space users, avoiding a flash-then-remove for single-space users.

### Testing

- Added `show_all_spaces.test.tsx` covering both the show and hide paths.
- `node scripts/type_check`, `node scripts/eslint`, and the new Jest suite pass locally.
