### PR TITLE
[AlertingV2] Chunk oversized ES|QL IN-lists to stay under 1 MB statement cap

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.test.ts
@@ -6,9 +6,11 @@
  */
 
 import {
+  ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES,
+  chunkInClauseLiterals,
   getDispatchableAlertEventsQuery,
-  getAlertEpisodeSuppressionsQuery,
-  getLastNotifiedTimestampsQuery,
+  getAlertEpisodeSuppressionsQueries,
+  getLastNotifiedTimestampsQueries,
 } from './queries';
 import { createAlertEpisode } from './fixtures/test_utils';
 
@@ -70,6 +72,18 @@ describe('getDispatchableAlertEventsQuery', () => {
     expect(req.query).toContain('JSON_EXTRACT(_source, "$.data")');
   });
 
+  it('drops _source after JSON_EXTRACT and before INLINE STATS to keep sub-plan buffers small', () => {
+    const req = getDispatchableAlertEventsQuery();
+
+    const extractIdx = req.query.indexOf('JSON_EXTRACT(_source');
+    const dropIdx = req.query.indexOf('DROP episode.id, rule.id, episode.status, _source');
+    const inlineStatsIdx = req.query.indexOf('INLINE STATS');
+
+    expect(extractIdx).toBeGreaterThan(-1);
+    expect(dropIdx).toBeGreaterThan(extractIdx);
+    expect(inlineStatsIdx).toBeGreaterThan(dropIdx);
+  });
+
   it('aggregates data_json using LAST by timestamp', () => {
     const req = getDispatchableAlertEventsQuery();
 
@@ -99,18 +113,95 @@ describe('getDispatchableAlertEventsQuery', () => {
   });
 });
 
-describe('getAlertEpisodeSuppressionsQuery', () => {
+describe('chunkInClauseLiterals', () => {
+  const PER_LITERAL_OVERHEAD = 6;
+
+  it('returns an empty array for empty input', () => {
+    expect(chunkInClauseLiterals([])).toEqual([]);
+  });
+
+  it('returns a single chunk when one literal fits the budget', () => {
+    expect(chunkInClauseLiterals(['only'])).toEqual([['only']]);
+  });
+
+  it('returns a single chunk when many small literals fit the budget', () => {
+    const literals = ['a', 'b', 'c', 'd'];
+    expect(chunkInClauseLiterals(literals)).toEqual([literals]);
+  });
+
+  it('preserves input order across chunks', () => {
+    const literalSize = 1_000;
+    const literalsPerChunk = Math.floor(
+      ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES / (literalSize + PER_LITERAL_OVERHEAD)
+    );
+    const literals = Array.from({ length: literalsPerChunk * 2 + 5 }, (_, i) =>
+      `${i}`.padStart(literalSize, '0')
+    );
+
+    const chunks = chunkInClauseLiterals(literals);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks.flat()).toEqual(literals);
+  });
+
+  it('keeps each chunk under the byte budget', () => {
+    const literalSize = 100;
+    const literals = Array.from({ length: 20_000 }, (_, i) => `${i}`.padStart(literalSize, '0'));
+
+    const chunks = chunkInClauseLiterals(literals);
+
+    for (const chunk of chunks) {
+      const chunkBytes = chunk.reduce((sum, lit) => sum + lit.length + PER_LITERAL_OVERHEAD, 0);
+      expect(chunkBytes).toBeLessThanOrEqual(ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES);
+    }
+  });
+
+  it('places a single oversized literal alone in its own chunk', () => {
+    const oversized = 'x'.repeat(ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES + 1);
+    const small = 'tiny';
+
+    const chunks = chunkInClauseLiterals([small, oversized, small]);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual([small]);
+    expect(chunks[1]).toEqual([oversized]);
+    expect(chunks[2]).toEqual([small]);
+  });
+
+  it('produces no overlap between chunks', () => {
+    const literalSize = 500;
+    const literals = Array.from({ length: 5_000 }, (_, i) => `id-${i}`.padEnd(literalSize, '_'));
+
+    const chunks = chunkInClauseLiterals(literals);
+    const seen = new Set<string>();
+    for (const chunk of chunks) {
+      for (const lit of chunk) {
+        expect(seen.has(lit)).toBe(false);
+        seen.add(lit);
+      }
+    }
+
+    expect(seen.size).toBe(literals.length);
+  });
+});
+
+describe('getAlertEpisodeSuppressionsQueries', () => {
+  it('returns an empty array for empty input', () => {
+    expect(getAlertEpisodeSuppressionsQueries([])).toEqual([]);
+  });
+
   it('uses CONCAT + IN to filter by (rule_id, group_hash) pairs', () => {
     const episodes = [
       createAlertEpisode({ rule_id: 'rule-1', group_hash: 'hash-1' }),
       createAlertEpisode({ rule_id: 'rule-2', group_hash: 'hash-2' }),
     ];
 
-    const req = getAlertEpisodeSuppressionsQuery(episodes);
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
 
-    expect(req.query).toContain('CONCAT(rule_id, "::", group_hash)');
-    expect(req.query).toContain('rule-1::hash-1');
-    expect(req.query).toContain('rule-2::hash-2');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query).toContain('CONCAT(rule_id, "::", group_hash)');
+    expect(requests[0].query).toContain('rule-1::hash-1');
+    expect(requests[0].query).toContain('rule-2::hash-2');
   });
 
   it('deduplicates episodes with the same rule_id and group_hash', () => {
@@ -120,23 +211,23 @@ describe('getAlertEpisodeSuppressionsQuery', () => {
       createAlertEpisode({ rule_id: 'rule-2', group_hash: 'hash-2', episode_id: 'ep-3' }),
     ];
 
-    const req = getAlertEpisodeSuppressionsQuery(episodes);
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
 
-    const matches = req.query.match(/rule-1::hash-1/g);
+    const matches = requests[0].query.match(/rule-1::hash-1/g);
     expect(matches).toHaveLength(1);
-    expect(req.query).toContain('rule-2::hash-2');
+    expect(requests[0].query).toContain('rule-2::hash-2');
   });
 
   it('queries the alert actions data stream', () => {
-    const req = getAlertEpisodeSuppressionsQuery([createAlertEpisode()]);
+    const requests = getAlertEpisodeSuppressionsQueries([createAlertEpisode()]);
 
-    expect(req.query).toContain('.alert-actions');
+    expect(requests[0].query).toContain('.alert-actions');
   });
 
   it('filters for suppression action types', () => {
-    const req = getAlertEpisodeSuppressionsQuery([createAlertEpisode()]);
+    const requests = getAlertEpisodeSuppressionsQueries([createAlertEpisode()]);
 
-    expect(req.query).toContain(
+    expect(requests[0].query).toContain(
       'action_type IN ("ack", "unack", "deactivate", "activate", "snooze", "unsnooze")'
     );
   });
@@ -147,17 +238,17 @@ describe('getAlertEpisodeSuppressionsQuery', () => {
       createAlertEpisode({ last_event_timestamp: '2026-01-22T08:00:00.000Z' }),
     ];
 
-    const req = getAlertEpisodeSuppressionsQuery(episodes);
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
 
-    expect(req.query).toContain('expiry > "2026-01-22T08:00:00.000Z"::DATETIME');
+    expect(requests[0].query).toContain('expiry > "2026-01-22T08:00:00.000Z"::DATETIME');
   });
 
   it('falls back to epoch when all timestamps are invalid', () => {
     const episodes = [createAlertEpisode({ last_event_timestamp: 'not-a-date' })];
 
-    const req = getAlertEpisodeSuppressionsQuery(episodes);
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
 
-    expect(req.query).toContain('expiry > "1970-01-01T00:00:00.000Z"::DATETIME');
+    expect(requests[0].query).toContain('expiry > "1970-01-01T00:00:00.000Z"::DATETIME');
   });
 
   it('skips invalid timestamps when computing minimum', () => {
@@ -166,34 +257,35 @@ describe('getAlertEpisodeSuppressionsQuery', () => {
       createAlertEpisode({ last_event_timestamp: '2026-01-22T09:00:00.000Z' }),
     ];
 
-    const req = getAlertEpisodeSuppressionsQuery(episodes);
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
 
-    expect(req.query).toContain('expiry > "2026-01-22T09:00:00.000Z"::DATETIME');
+    expect(requests[0].query).toContain('expiry > "2026-01-22T09:00:00.000Z"::DATETIME');
   });
 
   it('computes should_suppress with snooze, ack, and deactivate precedence', () => {
-    const req = getAlertEpisodeSuppressionsQuery([createAlertEpisode()]);
+    const requests = getAlertEpisodeSuppressionsQueries([createAlertEpisode()]);
 
-    expect(req.query).toContain('EVAL should_suppress = CASE(');
-    expect(req.query).toContain('last_snooze_action == "snooze", TRUE');
-    expect(req.query).toContain('last_ack_action == "ack", TRUE');
-    expect(req.query).toContain('last_deactivate_action == "deactivate", TRUE');
+    expect(requests[0].query).toContain('EVAL should_suppress = CASE(');
+    expect(requests[0].query).toContain('last_snooze_action == "snooze", TRUE');
+    expect(requests[0].query).toContain('last_ack_action == "ack", TRUE');
+    expect(requests[0].query).toContain('last_deactivate_action == "deactivate", TRUE');
   });
 
   it('keeps the expected output columns', () => {
-    const req = getAlertEpisodeSuppressionsQuery([createAlertEpisode()]);
+    const requests = getAlertEpisodeSuppressionsQueries([createAlertEpisode()]);
 
-    expect(req.query).toContain(
+    expect(requests[0].query).toContain(
       'KEEP rule_id, group_hash, episode_id, should_suppress, last_ack_action, last_deactivate_action, last_snooze_action'
     );
   });
 
   it('handles a single episode', () => {
-    const req = getAlertEpisodeSuppressionsQuery([
+    const requests = getAlertEpisodeSuppressionsQueries([
       createAlertEpisode({ rule_id: 'only-rule', group_hash: 'only-hash' }),
     ]);
 
-    expect(req.query).toContain('only-rule::only-hash');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query).toContain('only-rule::only-hash');
   });
 
   it('builds successfully with a large number of episodes', () => {
@@ -201,51 +293,110 @@ describe('getAlertEpisodeSuppressionsQuery', () => {
       createAlertEpisode({ rule_id: `rule-${i}`, group_hash: `hash-${i}` })
     );
 
-    const req = getAlertEpisodeSuppressionsQuery(episodes);
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
 
-    expect(req).toHaveProperty('query');
-    expect(req.query).toContain('CONCAT(rule_id, "::", group_hash)');
-    expect(req.query).toContain('rule-0::hash-0');
-    expect(req.query).toContain('rule-499::hash-499');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query).toContain('CONCAT(rule_id, "::", group_hash)');
+    expect(requests[0].query).toContain('rule-0::hash-0');
+    expect(requests[0].query).toContain('rule-499::hash-499');
+  });
+
+  it('splits into multiple requests when pair keys exceed the size budget', () => {
+    // pair key length = 2 * 5_000 + 2 ('::') = 10_002 bytes per literal.
+    // ~60 literals per chunk → 200 literals span at least 3 chunks.
+    const longSegment = 'x'.repeat(5_000);
+    const episodes = Array.from({ length: 200 }, (_, i) =>
+      createAlertEpisode({ rule_id: `${longSegment}-r${i}`, group_hash: `${longSegment}-g${i}` })
+    );
+
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
+
+    expect(requests.length).toBeGreaterThanOrEqual(2);
+    for (const request of requests) {
+      expect(request.query.length).toBeLessThan(1_000_000);
+    }
+    const concatenated = requests.map((r) => r.query).join('\n');
+    expect(concatenated).toContain(`${longSegment}-r0::${longSegment}-g0`);
+    expect(concatenated).toContain(`${longSegment}-r199::${longSegment}-g199`);
+  });
+
+  it('uses the same minLastEventTimestamp on every chunk', () => {
+    const longSegment = 'y'.repeat(5_000);
+    const episodes = Array.from({ length: 200 }, (_, i) =>
+      createAlertEpisode({
+        rule_id: `${longSegment}-r${i}`,
+        group_hash: `${longSegment}-g${i}`,
+        last_event_timestamp: i === 0 ? '2026-03-01T00:00:00.000Z' : '2026-03-15T00:00:00.000Z',
+      })
+    );
+
+    const requests = getAlertEpisodeSuppressionsQueries(episodes);
+
+    expect(requests.length).toBeGreaterThanOrEqual(2);
+    for (const request of requests) {
+      expect(request.query).toContain('expiry > "2026-03-01T00:00:00.000Z"::DATETIME');
+    }
   });
 });
 
-describe('getLastNotifiedTimestampsQuery', () => {
-  it('builds a query for a single action group', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+describe('getLastNotifiedTimestampsQueries', () => {
+  it('returns an empty array for empty input', () => {
+    expect(getLastNotifiedTimestampsQueries([])).toEqual([]);
+  });
 
-    expect(req.query).toContain('action_group_id IN ("group-1")');
-    expect(req.query).toContain('.alert-actions');
-    expect(req.query).toContain('last_notified = MAX(@timestamp)');
+  it('builds a query for a single action group', () => {
+    const requests = getLastNotifiedTimestampsQueries(['group-1']);
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query).toContain('action_group_id IN ("group-1")');
+    expect(requests[0].query).toContain('.alert-actions');
+    expect(requests[0].query).toContain('last_notified = MAX(@timestamp)');
   });
 
   it('builds a query for multiple action groups', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1', 'group-2']);
+    const requests = getLastNotifiedTimestampsQueries(['group-1', 'group-2']);
 
-    expect(req.query).toContain('action_group_id IN ("group-1", "group-2")');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query).toContain('action_group_id IN ("group-1", "group-2")');
   });
 
   it('filters for notified action type', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const requests = getLastNotifiedTimestampsQueries(['group-1']);
 
-    expect(req.query).toContain('action_type == "notified"');
+    expect(requests[0].query).toContain('action_type == "notified"');
   });
 
   it('keeps the expected output columns', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const requests = getLastNotifiedTimestampsQueries(['group-1']);
 
-    expect(req.query).toContain('KEEP action_group_id, last_notified, episode_status');
+    expect(requests[0].query).toContain('KEEP action_group_id, last_notified, episode_status');
   });
 
   it('aggregates episode_status using LAST by timestamp', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const requests = getLastNotifiedTimestampsQueries(['group-1']);
 
-    expect(req.query).toContain('episode_status = LAST(episode_status, @timestamp)');
+    expect(requests[0].query).toContain('episode_status = LAST(episode_status, @timestamp)');
   });
 
   it('groups by action_group_id', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const requests = getLastNotifiedTimestampsQueries(['group-1']);
 
-    expect(req.query).toContain('BY action_group_id');
+    expect(requests[0].query).toContain('BY action_group_id');
+  });
+
+  it('splits into multiple requests when ids exceed the size budget', () => {
+    const longSegment = 'z'.repeat(10_000);
+    const ids = Array.from({ length: 200 }, (_, i) => `${longSegment}-${i}`);
+
+    const requests = getLastNotifiedTimestampsQueries(ids);
+
+    expect(requests.length).toBeGreaterThanOrEqual(2);
+    for (const request of requests) {
+      expect(request.query.length).toBeLessThan(1_000_000);
+    }
+    const concatenated = requests.map((r) => r.query).join('\n');
+    for (const id of [ids[0], ids[ids.length - 1]]) {
+      expect(concatenated).toContain(id);
+    }
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -13,21 +13,12 @@ import {
 } from '../../resources/datastreams/alert_events';
 import type { AlertEpisode, ActionGroupId } from './types';
 
-/**
- * Fetches dispatchable alert events by querying both alert_events and alert_actions data streams.
- *
- * Uses field-based discrimination instead of `_index LIKE` to tell rows apart:
- *  - alert_events has a `type` field ('signal' | 'alert'); alert_actions does not (NULL in ES|QL).
- *  - alert_actions has an `action_type` field; alert_events does not (NULL in ES|QL).
- *
- * `_source` is dropped immediately after the EVAL that consumes it. The ES|QL planner does
- * not auto-prune `METADATA _source`, so without an explicit DROP it would ride through the
- * INLINE STATS hash-join buffer and push the per-shard sub-plan output past the ~16.8 MB
- * limit at production volumes (data is `flattened`, only addressable via `_source`).
- *
- * This avoids an ES|QL regression where `WHERE _index LIKE` before `STATS` in a multi-index
- * query returns 0 rows. See: https://github.com/elastic/elasticsearch/issues/146318
- */
+// Field-based discrimination (type / action_type IS NULL) instead of `_index LIKE` works around
+// an ES|QL regression where `WHERE _index LIKE` before `STATS` returns 0 rows.
+// See: https://github.com/elastic/elasticsearch/issues/146318
+//
+// `_source` is dropped after JSON_EXTRACT because ES|QL does not auto-prune METADATA fields;
+// without the explicit DROP it rides through the INLINE STATS buffer and can exceed ~16.8 MB.
 export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
   const alertEventType: AlertEventType = 'alert';
 
@@ -56,51 +47,17 @@ export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
 
 const PAIR_SEPARATOR = '::';
 
-/**
- * Maximum bytes to allocate to in-clause literals per chunked ES|QL query.
- *
- * ES|QL has a hard 1,000,000-byte cap on the statement text. The two
- * dispatcher queries that inline pipeline-state-derived inputs as quoted
- * literals inside `IN (...)` (`getAlertEpisodeSuppressionsQueries` and
- * `getLastNotifiedTimestampsQueries`) can exceed that cap at LIMIT-sized
- * batches, producing `parsing_exception: ESQL statement is too large`.
- * Because the dispatcher does not advance its watermark on `step_error`,
- * a single offending tick stalls every subsequent tick permanently.
- *
- * The 600 KB budget is intentionally well below the cap to leave room for:
- *   - the static query body (FROM/EVAL/WHERE/STATS/...) which is < 2 KB
- *     for either current query, but may grow,
- *   - escape characters added when literals contain quotes,
- *   - future ES|QL grammar/serialization changes that grow the per-literal
- *     cost,
- *   - downstream proxy/transport headers that may add fixed overhead.
- */
+// ES|QL caps statement text at 1 MB. IN-list queries exceed this at production cardinality,
+// producing `parsing_exception: ESQL statement is too large`. Without chunking the dispatcher
+// watermark never advances past the offending tick. 600 KB leaves headroom for the static
+// query body and escape overhead.
 export const ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES = 600_000;
 
-/**
- * Per-literal serialization cost in the ES|QL `IN (...)` clause.
- *
- * Each literal is rendered as `"<value>", ` — that's two surrounding quotes,
- * a comma, and a space (4 bytes) on top of the literal length. We add 2 more
- * bytes as a margin for backslash escapes when the value contains quotes,
- * for a total overhead of `length + 6` bytes per literal.
- */
+// `"<value>", ` = 2 quotes + comma + space (4 bytes) + 2 escape-margin bytes per literal.
 const PER_LITERAL_OVERHEAD_BYTES = 6;
 
-/**
- * Split a list of literal values into groups small enough to be safely
- * embedded inside an ES|QL `IN (...)` clause without exceeding the statement
- * size cap.
- *
- * Exported for unit testing of chunk boundaries; production callers should
- * use {@link getAlertEpisodeSuppressionsQueries} or
- * {@link getLastNotifiedTimestampsQueries}, which apply this helper internally.
- *
- * Pathological case: a single literal whose serialized size exceeds the
- * budget is placed alone in its own chunk. The resulting query may still
- * exceed the ES|QL cap; in practice every key passed in is a UUID/hash with
- * bounded length (≤ ~150 bytes), so this is unreachable.
- */
+// Exported for unit-testing chunk boundaries. An oversized single literal gets its own chunk;
+// at ≤150-byte keys (UUID/hash) this is unreachable in practice.
 export const chunkInClauseLiterals = (literals: readonly string[]): string[][] => {
   if (literals.length === 0) return [];
 
@@ -123,23 +80,9 @@ export const chunkInClauseLiterals = (literals: readonly string[]): string[][] =
   return chunks;
 };
 
-/**
- * Build the ES|QL request(s) that fetch suppression state for a batch of
- * alert episodes.
- *
- * Returns an array because the `WHERE _pair_key IN (...)` clause is chunked
- * to keep each emitted statement under the ES|QL 1 MB cap (see
- * {@link ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES}). Aggregation correctness is
- * preserved across chunks: the `INLINE STATS BY rule_id, group_hash` and
- * `STATS BY rule_id, group_hash, episode_id` aggregations partition by the
- * chunk key (or finer), so no row ever participates in two chunks'
- * aggregations and concatenated results are identical to a single-query
- * result.
- *
- * `minLastEventTimestamp` is computed once from the full input and reused
- * across every chunk's snooze-expiry filter so the filter semantics do not
- * shift with the chunking.
- */
+// Returns one request per chunk (see ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES). Safe to concat:
+// aggregations key on rule_id/group_hash so no row spans two chunks. minLastEventTimestamp
+// is computed from the full input so the snooze-expiry filter is consistent across chunks.
 export const getAlertEpisodeSuppressionsQueries = (
   alertEpisodes: AlertEpisode[]
 ): EsqlRequest[] => {
@@ -184,15 +127,8 @@ export const getAlertEpisodeSuppressionsQueries = (
   });
 };
 
-/**
- * Build the ES|QL request(s) that fetch last-notified timestamps for a batch
- * of action groups.
- *
- * Returns an array for the same statement-size reason as
- * {@link getAlertEpisodeSuppressionsQueries}. The query's only aggregation
- * (`STATS ... BY action_group_id`) partitions by the same key the chunks are
- * partitioned on, so concatenated results equal a single-query result.
- */
+// Returns one request per chunk (see ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES). Safe to concat:
+// STATS aggregates by action_group_id, the same key used for chunking.
 export const getLastNotifiedTimestampsQueries = (
   actionGroupIds: ActionGroupId[]
 ): EsqlRequest[] => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -20,6 +20,11 @@ import type { AlertEpisode, ActionGroupId } from './types';
  *  - alert_events has a `type` field ('signal' | 'alert'); alert_actions does not (NULL in ES|QL).
  *  - alert_actions has an `action_type` field; alert_events does not (NULL in ES|QL).
  *
+ * `_source` is dropped immediately after the EVAL that consumes it. The ES|QL planner does
+ * not auto-prune `METADATA _source`, so without an explicit DROP it would ride through the
+ * INLINE STATS hash-join buffer and push the per-shard sub-plan output past the ~16.8 MB
+ * limit at production volumes (data is `flattened`, only addressable via `_source`).
+ *
  * This avoids an ES|QL regression where `WHERE _index LIKE` before `STATS` in a multi-index
  * query returns 0 rows. See: https://github.com/elastic/elasticsearch/issues/146318
  */
@@ -33,7 +38,7 @@ export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
           episode_id = COALESCE(episode.id, episode_id),
           episode_status = episode.status,
           data_json = CASE(type IS NOT NULL, JSON_EXTRACT(_source, "$.data"), NULL)
-      | DROP episode.id, rule.id, episode.status
+      | DROP episode.id, rule.id, episode.status, _source
       | INLINE STATS last_fired = max(last_series_event_timestamp) WHERE action_type == "fire" OR action_type == "suppress" OR action_type == "unmatched" BY rule_id, group_hash
       | WHERE last_fired IS NULL OR last_fired < @timestamp
       | STATS
@@ -51,7 +56,95 @@ export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
 
 const PAIR_SEPARATOR = '::';
 
-export const getAlertEpisodeSuppressionsQuery = (alertEpisodes: AlertEpisode[]): EsqlRequest => {
+/**
+ * Maximum bytes to allocate to in-clause literals per chunked ES|QL query.
+ *
+ * ES|QL has a hard 1,000,000-byte cap on the statement text. The two
+ * dispatcher queries that inline pipeline-state-derived inputs as quoted
+ * literals inside `IN (...)` (`getAlertEpisodeSuppressionsQueries` and
+ * `getLastNotifiedTimestampsQueries`) can exceed that cap at LIMIT-sized
+ * batches, producing `parsing_exception: ESQL statement is too large`.
+ * Because the dispatcher does not advance its watermark on `step_error`,
+ * a single offending tick stalls every subsequent tick permanently.
+ *
+ * The 600 KB budget is intentionally well below the cap to leave room for:
+ *   - the static query body (FROM/EVAL/WHERE/STATS/...) which is < 2 KB
+ *     for either current query, but may grow,
+ *   - escape characters added when literals contain quotes,
+ *   - future ES|QL grammar/serialization changes that grow the per-literal
+ *     cost,
+ *   - downstream proxy/transport headers that may add fixed overhead.
+ */
+export const ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES = 600_000;
+
+/**
+ * Per-literal serialization cost in the ES|QL `IN (...)` clause.
+ *
+ * Each literal is rendered as `"<value>", ` — that's two surrounding quotes,
+ * a comma, and a space (4 bytes) on top of the literal length. We add 2 more
+ * bytes as a margin for backslash escapes when the value contains quotes,
+ * for a total overhead of `length + 6` bytes per literal.
+ */
+const PER_LITERAL_OVERHEAD_BYTES = 6;
+
+/**
+ * Split a list of literal values into groups small enough to be safely
+ * embedded inside an ES|QL `IN (...)` clause without exceeding the statement
+ * size cap.
+ *
+ * Exported for unit testing of chunk boundaries; production callers should
+ * use {@link getAlertEpisodeSuppressionsQueries} or
+ * {@link getLastNotifiedTimestampsQueries}, which apply this helper internally.
+ *
+ * Pathological case: a single literal whose serialized size exceeds the
+ * budget is placed alone in its own chunk. The resulting query may still
+ * exceed the ES|QL cap; in practice every key passed in is a UUID/hash with
+ * bounded length (≤ ~150 bytes), so this is unreachable.
+ */
+export const chunkInClauseLiterals = (literals: readonly string[]): string[][] => {
+  if (literals.length === 0) return [];
+
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentSize = 0;
+
+  for (const literal of literals) {
+    const cost = literal.length + PER_LITERAL_OVERHEAD_BYTES;
+    if (current.length > 0 && currentSize + cost > ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push(literal);
+    currentSize += cost;
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+};
+
+/**
+ * Build the ES|QL request(s) that fetch suppression state for a batch of
+ * alert episodes.
+ *
+ * Returns an array because the `WHERE _pair_key IN (...)` clause is chunked
+ * to keep each emitted statement under the ES|QL 1 MB cap (see
+ * {@link ESQL_IN_CLAUSE_LITERAL_BUDGET_BYTES}). Aggregation correctness is
+ * preserved across chunks: the `INLINE STATS BY rule_id, group_hash` and
+ * `STATS BY rule_id, group_hash, episode_id` aggregations partition by the
+ * chunk key (or finer), so no row ever participates in two chunks'
+ * aggregations and concatenated results are identical to a single-query
+ * result.
+ *
+ * `minLastEventTimestamp` is computed once from the full input and reused
+ * across every chunk's snooze-expiry filter so the filter semantics do not
+ * shift with the chunking.
+ */
+export const getAlertEpisodeSuppressionsQueries = (
+  alertEpisodes: AlertEpisode[]
+): EsqlRequest[] => {
+  if (alertEpisodes.length === 0) return [];
+
   const minLastEventTimestamp =
     alertEpisodes.reduce<string | undefined>((min, ep) => {
       const parsedTimestamp = new Date(ep.last_event_timestamp);
@@ -66,37 +159,55 @@ export const getAlertEpisodeSuppressionsQuery = (alertEpisodes: AlertEpisode[]):
   const uniquePairKeys = [
     ...new Set(alertEpisodes.map((ep) => `${ep.rule_id}${PAIR_SEPARATOR}${ep.group_hash}`)),
   ];
-  const pairValues = uniquePairKeys.map((key) => esql.str(key));
 
-  return esql`FROM ${ALERT_ACTIONS_DATA_STREAM}
-      | EVAL _pair_key = CONCAT(rule_id, ${PAIR_SEPARATOR}, group_hash)
-      | WHERE _pair_key IN (${pairValues})
-      | WHERE action_type IN ("ack", "unack", "deactivate", "activate", "snooze", "unsnooze")
-      | WHERE action_type != "snooze" OR expiry > ${minLastEventTimestamp}::datetime
-      | INLINE STATS
-          last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze")
-          BY rule_id, group_hash
-      | STATS
-          last_ack_action = LAST(action_type, @timestamp) WHERE action_type IN ("ack", "unack"),
-          last_deactivate_action = LAST(action_type, @timestamp) WHERE action_type IN ("deactivate", "activate"),
-          last_snooze_action = MAX(last_snooze_action)
-        BY rule_id, group_hash, episode_id
-      | EVAL should_suppress = CASE(
-          last_snooze_action == "snooze", true,
-          last_ack_action == "ack", true,
-          last_deactivate_action == "deactivate", true,
-          false
-        )
-      | KEEP rule_id, group_hash, episode_id, should_suppress, last_ack_action, last_deactivate_action, last_snooze_action`.toRequest();
+  return chunkInClauseLiterals(uniquePairKeys).map((chunk) => {
+    const pairValues = chunk.map((key) => esql.str(key));
+
+    return esql`FROM ${ALERT_ACTIONS_DATA_STREAM}
+        | EVAL _pair_key = CONCAT(rule_id, ${PAIR_SEPARATOR}, group_hash)
+        | WHERE _pair_key IN (${pairValues})
+        | WHERE action_type IN ("ack", "unack", "deactivate", "activate", "snooze", "unsnooze")
+        | WHERE action_type != "snooze" OR expiry > ${minLastEventTimestamp}::datetime
+        | INLINE STATS
+            last_snooze_action = LAST(action_type, @timestamp) WHERE action_type IN ("snooze", "unsnooze")
+            BY rule_id, group_hash
+        | STATS
+            last_ack_action = LAST(action_type, @timestamp) WHERE action_type IN ("ack", "unack"),
+            last_deactivate_action = LAST(action_type, @timestamp) WHERE action_type IN ("deactivate", "activate"),
+            last_snooze_action = MAX(last_snooze_action)
+          BY rule_id, group_hash, episode_id
+        | EVAL should_suppress = CASE(
+            last_snooze_action == "snooze", true,
+            last_ack_action == "ack", true,
+            last_deactivate_action == "deactivate", true,
+            false
+          )
+        | KEEP rule_id, group_hash, episode_id, should_suppress, last_ack_action, last_deactivate_action, last_snooze_action`.toRequest();
+  });
 };
 
-export const getLastNotifiedTimestampsQuery = (actionGroupIds: ActionGroupId[]): EsqlRequest => {
-  const values = actionGroupIds.map((id) => esql.str(id));
-  const whereClause = esql.exp`action_type == "notified" AND action_group_id IN (${values})`;
+/**
+ * Build the ES|QL request(s) that fetch last-notified timestamps for a batch
+ * of action groups.
+ *
+ * Returns an array for the same statement-size reason as
+ * {@link getAlertEpisodeSuppressionsQueries}. The query's only aggregation
+ * (`STATS ... BY action_group_id`) partitions by the same key the chunks are
+ * partitioned on, so concatenated results equal a single-query result.
+ */
+export const getLastNotifiedTimestampsQueries = (
+  actionGroupIds: ActionGroupId[]
+): EsqlRequest[] => {
+  if (actionGroupIds.length === 0) return [];
 
-  return esql`FROM ${ALERT_ACTIONS_DATA_STREAM}
-    | WHERE ${whereClause}
-    | STATS last_notified = MAX(@timestamp), episode_status = LAST(episode_status, @timestamp) BY action_group_id
-    | KEEP action_group_id, last_notified, episode_status
-    `.toRequest();
+  return chunkInClauseLiterals(actionGroupIds).map((chunk) => {
+    const values = chunk.map((id) => esql.str(id));
+    const whereClause = esql.exp`action_type == "notified" AND action_group_id IN (${values})`;
+
+    return esql`FROM ${ALERT_ACTIONS_DATA_STREAM}
+      | WHERE ${whereClause}
+      | STATS last_notified = MAX(@timestamp), episode_status = LAST(episode_status, @timestamp) BY action_group_id
+      | KEEP action_group_id, last_notified, episode_status
+      `.toRequest();
+  });
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -143,8 +143,6 @@ export const chunkInClauseLiterals = (literals: readonly string[]): string[][] =
 export const getAlertEpisodeSuppressionsQueries = (
   alertEpisodes: AlertEpisode[]
 ): EsqlRequest[] => {
-  if (alertEpisodes.length === 0) return [];
-
   const minLastEventTimestamp =
     alertEpisodes.reduce<string | undefined>((min, ep) => {
       const parsedTimestamp = new Date(ep.last_event_timestamp);
@@ -198,8 +196,6 @@ export const getAlertEpisodeSuppressionsQueries = (
 export const getLastNotifiedTimestampsQueries = (
   actionGroupIds: ActionGroupId[]
 ): EsqlRequest[] => {
-  if (actionGroupIds.length === 0) return [];
-
   return chunkInClauseLiterals(actionGroupIds).map((chunk) => {
     const values = chunk.map((id) => esql.str(id));
     const whereClause = esql.exp`action_type == "notified" AND action_group_id IN (${values})`;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.test.ts
@@ -5,8 +5,16 @@
  * 2.0.
  */
 
-import { applyThrottling } from './apply_throttling_step';
-import { createAlertEpisode, createActionGroup, createActionPolicy } from '../fixtures/test_utils';
+import { ApplyThrottlingStep, applyThrottling } from './apply_throttling_step';
+import { createQueryService } from '../../services/query_service/query_service.mock';
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
+import { createLastNotifiedTimestampsResponse } from '../fixtures/dispatcher';
+import {
+  createAlertEpisode,
+  createActionGroup,
+  createActionPolicy,
+  createDispatcherPipelineState,
+} from '../fixtures/test_utils';
 import type { ActionGroupId, LastNotifiedInfo } from '../types';
 
 const NOW = new Date('2026-01-22T10:00:00.000Z');
@@ -455,5 +463,65 @@ describe('applyThrottling', () => {
       expect(dispatch).toHaveLength(0);
       expect(throttled).toHaveLength(0);
     });
+  });
+});
+
+describe('ApplyThrottlingStep', () => {
+  it('issues multiple ES|QL requests and concatenates results when input exceeds the size budget', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const { loggerService } = createLoggerService();
+    const step = new ApplyThrottlingStep(queryService, loggerService);
+
+    const longSegment = 'q'.repeat(10_000);
+    const groups = Array.from({ length: 200 }, (_, i) =>
+      createActionGroup({ id: `${longSegment}-g${i}`, policyId: 'p1' })
+    );
+    const policies = new Map([
+      ['p1', createActionPolicy({ id: 'p1', throttle: { strategy: 'every_time' } })],
+    ]);
+
+    const firstId = groups[0].id;
+    const lastId = groups[groups.length - 1].id;
+
+    // A chunk that contains firstId returns its row, the chunk that contains
+    // lastId returns its row, every other chunk returns an empty result.
+    mockEsClient.esql.query.mockImplementation((args: { query: string }) => {
+      const rows: Array<{ action_group_id: string; last_notified: string }> = [];
+      if (args.query.includes(firstId)) {
+        rows.push({ action_group_id: firstId, last_notified: '2026-01-22T08:00:00.000Z' });
+      }
+      if (args.query.includes(lastId)) {
+        rows.push({ action_group_id: lastId, last_notified: '2026-01-22T08:00:00.000Z' });
+      }
+      return Promise.resolve(createLastNotifiedTimestampsResponse(rows));
+    });
+
+    const state = createDispatcherPipelineState({ groups, policies });
+    const result = await step.execute(state);
+
+    expect(mockEsClient.esql.query.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const [args] of mockEsClient.esql.query.mock.calls) {
+      expect((args.query as string).length).toBeLessThan(1_000_000);
+    }
+
+    expect(result.type).toBe('continue');
+    if (result.type !== 'continue') return;
+    // every_time strategy → all groups dispatch regardless of last_notified.
+    expect(result.data?.dispatch).toHaveLength(200);
+    expect(result.data?.throttled).toHaveLength(0);
+  });
+
+  it('returns empty dispatch and throttled when no groups', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const { loggerService } = createLoggerService();
+    const step = new ApplyThrottlingStep(queryService, loggerService);
+
+    const result = await step.execute(createDispatcherPipelineState({ groups: [] }));
+
+    expect(mockEsClient.esql.query).not.toHaveBeenCalled();
+    expect(result.type).toBe('continue');
+    if (result.type !== 'continue') return;
+    expect(result.data?.dispatch).toHaveLength(0);
+    expect(result.data?.throttled).toHaveLength(0);
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.ts
@@ -13,7 +13,7 @@ import {
 } from '../../services/logger_service/logger_service';
 import type { QueryServiceContract } from '../../services/query_service/query_service';
 import { QueryServiceInternalToken } from '../../services/query_service/tokens';
-import { getLastNotifiedTimestampsQuery } from '../queries';
+import { getLastNotifiedTimestampsQueries } from '../queries';
 import type {
   ActionGroup,
   ActionGroupId,
@@ -61,9 +61,13 @@ export class ApplyThrottlingStep implements DispatcherStep {
   private async fetchLastNotifiedTimestamps(
     actionGroupIds: ActionGroupId[]
   ): Promise<Map<ActionGroupId, LastNotifiedInfo>> {
-    const records = await this.queryService.executeQueryRows<LastNotifiedRecord>({
-      query: getLastNotifiedTimestampsQuery(actionGroupIds).query,
-    });
+    const queries = getLastNotifiedTimestampsQueries(actionGroupIds);
+    const responses = await Promise.all(
+      queries.map((request) =>
+        this.queryService.executeQueryRows<LastNotifiedRecord>({ query: request.query })
+      )
+    );
+    const records = responses.flat();
 
     return new Map<ActionGroupId, LastNotifiedInfo>(
       records.map((record) => [

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_suppressions_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_suppressions_step.test.ts
@@ -61,4 +61,59 @@ describe('FetchSuppressionsStep', () => {
     if (result.type !== 'continue') return;
     expect(result.data?.suppressions).toHaveLength(0);
   });
+
+  it('issues multiple ES|QL requests and concatenates results when input exceeds the size budget', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const step = new FetchSuppressionsStep(queryService);
+
+    // pair_key = rule_id::group_hash → ~10 KB per literal forces multiple chunks
+    // for 200 episodes against the 600 KB budget.
+    const longSegment = 'x'.repeat(5_000);
+    const episodes = Array.from({ length: 200 }, (_, i) =>
+      createAlertEpisode({
+        rule_id: `${longSegment}-r${i}`,
+        group_hash: `${longSegment}-g${i}`,
+        episode_id: `e${i}`,
+      })
+    );
+
+    mockEsClient.esql.query.mockImplementation((args: { query: string }) => {
+      const rows: Array<{
+        rule_id: string;
+        group_hash: string;
+        episode_id: string;
+        should_suppress: boolean;
+      }> = [];
+      if (args.query.includes(`${longSegment}-r0::`)) {
+        rows.push({
+          rule_id: `${longSegment}-r0`,
+          group_hash: `${longSegment}-g0`,
+          episode_id: 'e0',
+          should_suppress: true,
+        });
+      }
+      if (args.query.includes(`${longSegment}-r199::`)) {
+        rows.push({
+          rule_id: `${longSegment}-r199`,
+          group_hash: `${longSegment}-g199`,
+          episode_id: 'e199',
+          should_suppress: false,
+        });
+      }
+      return Promise.resolve(createAlertEpisodeSuppressionsResponse(rows));
+    });
+
+    const state = createDispatcherPipelineState({ episodes });
+    const result = await step.execute(state);
+
+    expect(mockEsClient.esql.query.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const [args] of mockEsClient.esql.query.mock.calls) {
+      expect((args.query as string).length).toBeLessThan(1_000_000);
+    }
+
+    expect(result.type).toBe('continue');
+    if (result.type !== 'continue') return;
+    expect(result.data?.suppressions).toHaveLength(2);
+    expect(result.data?.suppressions?.map((s) => s.episode_id)).toEqual(['e0', 'e199']);
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_suppressions_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_suppressions_step.ts
@@ -8,7 +8,7 @@
 import { inject, injectable } from 'inversify';
 import type { QueryServiceContract } from '../../services/query_service/query_service';
 import { QueryServiceInternalToken } from '../../services/query_service/tokens';
-import { getAlertEpisodeSuppressionsQuery } from '../queries';
+import { getAlertEpisodeSuppressionsQueries } from '../queries';
 import type {
   AlertEpisodeSuppression,
   DispatcherPipelineState,
@@ -30,9 +30,13 @@ export class FetchSuppressionsStep implements DispatcherStep {
       return { type: 'continue', data: { suppressions: [] } };
     }
 
-    const suppressions = await this.queryService.executeQueryRows<AlertEpisodeSuppression>({
-      query: getAlertEpisodeSuppressionsQuery(episodes).query,
-    });
+    const queries = getAlertEpisodeSuppressionsQueries(episodes);
+    const responses = await Promise.all(
+      queries.map((request) =>
+        this.queryService.executeQueryRows<AlertEpisodeSuppression>({ query: request.query })
+      )
+    );
+    const suppressions = responses.flat();
 
     return { type: 'continue', data: { suppressions } };
   }


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/rna-program/issues/434

ES|QL has a hard 1,000,000-byte cap on statement text. The two dispatcher queries that inline pipeline-state-derived inputs as `IN (...)` literals — `fetch_suppressions` (rule/group pair keys) and `apply_throttling` (action group IDs) — can exceed this cap at high cardinality, producing:

```
parsing_exception: ESQL statement is too large
```

### Changes

- **`queries.ts`**: adds `chunkInClauseLiterals` helper that splits a list of string literals into groups whose serialized size stays ≤ 600 KB (well below the 1 MB cap, with headroom for the static query body, escape overhead, and future grammar changes). `getAlertEpisodeSuppressionsQuery` and `getLastNotifiedTimestampsQuery` are renamed to the plural `…Queries` and now return `EsqlRequest[]` — one request per chunk.
- **`fetch_suppressions_step.ts`** / **`apply_throttling_step.ts`**: fan out chunk queries with `Promise.all`, then `.flat()` the results before continuing — semantically equivalent to a single query because the aggregations partition by the same keys used for chunking.
- Also drops `_source` from the `fetch_episodes` query after the `JSON_EXTRACT` EVAL; the field is redundant once consumed and was adding unnecessary transfer overhead.


🤖 Generated with [Claude Code](https://claude.com/claude-code)