### PR TITLE
[UIAM OAuth] Application connections UX updates

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -72,8 +72,8 @@ describe('ApplicationConnections', () => {
 
     const { findByText, findByTestId, getByTestId, getByPlaceholderText } = renderPage(coreStart);
 
-    expect(await findByText(/No MCP clients \(OAuth\)/)).toBeInTheDocument();
-    expect(await findByText(/Get started with MCP clients/)).toBeInTheDocument();
+    expect(await findByText(/No application connections/)).toBeInTheDocument();
+    expect(await findByText(/Get started by creating MCP clients/)).toBeInTheDocument();
     const addButton = await findByTestId('applicationConnectionsEmptyPromptAddButton');
     expect(addButton).toBeInTheDocument();
     expect(addButton).toHaveAttribute(
@@ -111,7 +111,7 @@ describe('ApplicationConnections', () => {
 
     const { findByText, queryByText, queryByTestId } = renderPage(coreStart);
 
-    expect(await findByText(/No MCP clients \(OAuth\)/)).toBeInTheDocument();
+    expect(await findByText(/No application connections/)).toBeInTheDocument();
     expect(queryByText('Unused MCP app')).not.toBeInTheDocument();
     expect(
       queryByTestId('applicationConnectionsListRow-client-without-conn')

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.tsx
@@ -6,11 +6,10 @@
  */
 
 import type { UseEuiTheme } from '@elastic/eui';
-import { EuiLink, EuiSpacer } from '@elastic/eui';
+import { EuiButton, EuiCallOut } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React from 'react';
 
-import { FormattedMessage } from '@kbn/i18n-react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { ApplicationConnectionsTable } from './application_connections_table';
@@ -22,33 +21,30 @@ const headerStyles = ({ euiTheme }: UseEuiTheme) => css`
   border-style: none;
 `;
 
+const callOutStyles = ({ euiTheme }: UseEuiTheme) => css`
+  margin-block: ${euiTheme.size.m};
+`;
+
 export const ApplicationConnections = () => {
   const { mcpClientsListUrl } = useNavigation();
-
   return (
     <>
       <KibanaPageTemplate.Header
         css={headerStyles}
         pageTitle={labels.page.title}
-        description={
-          <FormattedMessage
-            id="xpack.security.management.applicationConnections.subtitle"
-            defaultMessage="Manage connections for OAuth-based applications. Currently, only MCP clients are supported. {manageClientsLink}"
-            values={{
-              manageClientsLink: (
-                <EuiLink
-                  href={mcpClientsListUrl}
-                  data-test-subj="applicationConnectionsManageClientsLink"
-                >
-                  {labels.page.manageClientsLink}
-                </EuiLink>
-              ),
-            }}
-          />
-        }
+        rightSideItems={[
+          <EuiButton
+            color="text"
+            iconType="gear"
+            href={mcpClientsListUrl}
+            data-test-subj="applicationConnectionsManageClientsLink"
+          >
+            {labels.page.manageClientsLink}
+          </EuiButton>,
+        ]}
       />
       <KibanaPageTemplate.Section paddingSize="none">
-        <EuiSpacer size="l" />
+        <EuiCallOut size="s" title={labels.page.pageCallout} iconType="info" css={callOutStyles} />
         <ApplicationConnectionsTable />
       </KibanaPageTemplate.Section>
     </>

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
@@ -12,6 +12,10 @@ export const labels = {
     title: i18n.translate('xpack.security.management.applicationConnectionsTitle', {
       defaultMessage: 'Application connections',
     }),
+    pageCallout: i18n.translate('xpack.security.management.applicationConnectionsPageCallout', {
+      defaultMessage:
+        'Manage connections for OAuth-based applications. Currently, only MCP clients are supported.',
+    }),
     manageClientsLink: i18n.translate(
       'xpack.security.management.applicationConnections.manageClientsLink',
       { defaultMessage: 'Manage MCP clients' }
@@ -183,11 +187,11 @@ export const labels = {
   emptyPrompt: {
     title: i18n.translate(
       'xpack.security.management.applicationConnectionsEmptyPrompt.emptyTitle',
-      { defaultMessage: 'No MCP clients (OAuth)' }
+      { defaultMessage: 'No application connections' }
     ),
     message: i18n.translate(
       'xpack.security.management.applicationConnectionsEmptyPrompt.emptyMessage',
-      { defaultMessage: 'Get started with MCP clients (OAuth).' }
+      { defaultMessage: 'Get started by creating MCP clients (OAuth).' }
     ),
     addButton: i18n.translate(
       'xpack.security.management.applicationConnectionsEmptyPrompt.addButton',


### PR DESCRIPTION
## Summary

Minor UX updates to the Application connections page:
- Moves the "Manage MCP clients" action from an inline description link into a header button
- Replaces the page description with a callout
- Updates the empty-state copy to "No application connections" / "Get started by creating MCP clients (OAuth)."

### Demo
<img width="1778" height="979" alt="Screenshot 2026-06-04 at 10 25 28" src="https://github.com/user-attachments/assets/6bab98bf-0b6c-4677-a733-9a1c40fbec33" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
