### PR TITLE
[Agent Builder] Fix tool id telemetry hashing

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -6,7 +6,7 @@
  */
 
 import type { UserIdAndName } from '../base/users';
-import type { ToolOrigin } from '../tools/definition';
+import type { ToolOrigin, ToolType } from '../tools/definition';
 import type { ToolResult } from '../tools/tool_result';
 import type { ExecutionStatus, SerializedExecutionError } from '../agents/execution_status';
 import type {
@@ -130,6 +130,12 @@ export interface ToolCallWithResult {
    */
   tool_call_group_id?: string;
   tool_origin?: ToolOrigin;
+  /**
+   * The type of the tool that was called.
+   * Used by telemetry to decide whether the tool ID can be reported verbatim
+   * (built-in tools) or must be anonymized (user-created tools).
+   */
+  tool_type?: ToolType;
 }
 
 export type ToolCallStep = ConversationRoundStepMixin<

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -130,11 +130,6 @@ export interface ToolCallWithResult {
    */
   tool_call_group_id?: string;
   tool_origin?: ToolOrigin;
-  /**
-   * The type of the tool that was called.
-   * Used by telemetry to decide whether the tool ID can be reported verbatim
-   * (built-in tools) or must be anonymized (user-created tools).
-   */
   tool_type?: ToolType;
 }
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/events.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentBuilderEvent } from '../base/events';
-import type { ToolOrigin } from '../tools/definition';
+import type { ToolOrigin, ToolType } from '../tools/definition';
 import type { ToolResult } from '../tools/tool_result';
 import type {
   ConversationInternalState,
@@ -50,6 +50,7 @@ export interface ToolCallEventData {
   params: Record<string, unknown>;
   tool_call_group_id?: string;
   tool_origin?: ToolOrigin;
+  tool_type?: ToolType;
 }
 
 export type ToolCallEvent = ChatEventBase<ChatEventType.toolCall, ToolCallEventData>;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/langchain/graph_events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/langchain/graph_events.ts
@@ -17,7 +17,7 @@ import type {
   ToolResultEvent,
   BackgroundAgentCompleteEvent,
 } from '@kbn/agent-builder-common/chat/events';
-import { ChatEventType, type ToolOrigin } from '@kbn/agent-builder-common';
+import { ChatEventType, type ToolOrigin, type ToolType } from '@kbn/agent-builder-common';
 import type { BackgroundExecutionState } from '@kbn/agent-builder-common/chat';
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type { PromptRequestSource, PromptRequest } from '@kbn/agent-builder-common/agents/prompts';
@@ -52,6 +52,7 @@ export const createToolCallEvent = (data: {
   params: Record<string, unknown>;
   toolCallGroupId?: string;
   toolOrigin?: ToolOrigin;
+  toolType?: ToolType;
 }): ToolCallEvent => {
   return {
     type: ChatEventType.toolCall,
@@ -61,6 +62,7 @@ export const createToolCallEvent = (data: {
       params: data.params,
       tool_call_group_id: data.toolCallGroupId,
       tool_origin: data.toolOrigin,
+      tool_type: data.toolType,
     },
   };
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/tool_manager.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/tool_manager.ts
@@ -81,15 +81,7 @@ export interface ToolManager {
    */
   getToolIdMapping(): Map<string, string>;
 
-  /**
-   * Returns the origin for an internal tool ID, if known.
-   */
-  getToolOrigin(toolId: string): ToolOrigin | undefined;
-
-  /**
-   * Returns the tool type for an internal tool ID, if known.
-   */
-  getToolType(toolId: string): ToolType | undefined;
+  getToolMeta(toolId: string): { origin: ToolOrigin | undefined; type: ToolType | undefined };
 
   /**
    * Gets the internal tool IDs of all dynamic tools currently in the tool manager.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/tool_manager.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/tool_manager.ts
@@ -6,7 +6,7 @@
  */
 
 import type { StructuredTool } from '@langchain/core/tools';
-import type { BrowserApiToolMetadata, ToolOrigin } from '@kbn/agent-builder-common';
+import type { BrowserApiToolMetadata, ToolOrigin, ToolType } from '@kbn/agent-builder-common';
 import type { Logger } from '@kbn/logging';
 import type { ToolReturnSummarizerFn } from '../tools/builtin';
 import type { AgentEventEmitterFn, ExecutableTool } from '..';
@@ -85,6 +85,11 @@ export interface ToolManager {
    * Returns the origin for an internal tool ID, if known.
    */
   getToolOrigin(toolId: string): ToolOrigin | undefined;
+
+  /**
+   * Returns the tool type for an internal tool ID, if known.
+   */
+  getToolType(toolId: string): ToolType | undefined;
 
   /**
    * Gets the internal tool IDs of all dynamic tools currently in the tool manager.

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.test.ts
@@ -83,8 +83,9 @@ describe('convertGraphEvents', () => {
         graphName: 'test-graph',
         toolManager: {
           getToolIdMapping: jest.fn().mockReturnValue(new Map()),
-          getToolOrigin: jest.fn().mockReturnValue(ToolOrigin.inline),
-          getToolType: jest.fn().mockReturnValue(ToolType.builtin),
+          getToolMeta: jest
+            .fn()
+            .mockReturnValue({ origin: ToolOrigin.inline, type: ToolType.builtin }),
         } as any,
         pendingRound: undefined,
         logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -142,8 +143,7 @@ describe('convertGraphEvents', () => {
           graphName: 'test-graph',
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
-            getToolOrigin: jest.fn(),
-            getToolType: jest.fn(),
+            getToolMeta: jest.fn().mockReturnValue({ origin: undefined, type: undefined }),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -193,8 +193,7 @@ describe('convertGraphEvents', () => {
           graphName: 'test-graph',
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
-            getToolOrigin: jest.fn(),
-            getToolType: jest.fn(),
+            getToolMeta: jest.fn().mockReturnValue({ origin: undefined, type: undefined }),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -261,8 +260,7 @@ describe('convertGraphEvents', () => {
             graphName: 'test-graph',
             toolManager: {
               getToolIdMapping: jest.fn().mockReturnValue(new Map()),
-              getToolOrigin: jest.fn(),
-              getToolType: jest.fn(),
+              getToolMeta: jest.fn().mockReturnValue({ origin: undefined, type: undefined }),
             } as any,
             pendingRound: undefined,
             logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -327,8 +325,7 @@ describe('convertGraphEvents', () => {
           graphName: 'test-graph',
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
-            getToolOrigin: jest.fn(),
-            getToolType: jest.fn(),
+            getToolMeta: jest.fn().mockReturnValue({ origin: undefined, type: undefined }),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -380,8 +377,7 @@ describe('convertGraphEvents', () => {
           graphName: 'test-graph',
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
-            getToolOrigin: jest.fn(),
-            getToolType: jest.fn(),
+            getToolMeta: jest.fn().mockReturnValue({ origin: undefined, type: undefined }),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { of, toArray, lastValueFrom } from 'rxjs';
-import { ToolOrigin } from '@kbn/agent-builder-common';
+import { ToolOrigin, ToolType } from '@kbn/agent-builder-common';
 import { convertGraphEvents } from './convert_graph_events';
 import { steps } from './constants';
 
@@ -28,6 +28,7 @@ jest.mock('@kbn/agent-builder-genai-utils/langchain', () => ({
       params: data.params,
       tool_call_group_id: data.toolCallGroupId,
       tool_origin: data.toolOrigin,
+      tool_type: data.toolType,
     },
   })),
   createToolResultEvent: jest.fn(),
@@ -83,6 +84,7 @@ describe('convertGraphEvents', () => {
         toolManager: {
           getToolIdMapping: jest.fn().mockReturnValue(new Map()),
           getToolOrigin: jest.fn().mockReturnValue(ToolOrigin.inline),
+          getToolType: jest.fn().mockReturnValue(ToolType.builtin),
         } as any,
         pendingRound: undefined,
         logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -106,6 +108,7 @@ describe('convertGraphEvents', () => {
           tool_call_id: 'call-1',
           tool_id: 'inline.dynamic',
           tool_origin: ToolOrigin.inline,
+          tool_type: ToolType.builtin,
         }),
       }),
     ]);
@@ -140,6 +143,7 @@ describe('convertGraphEvents', () => {
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
             getToolOrigin: jest.fn(),
+            getToolType: jest.fn(),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -190,6 +194,7 @@ describe('convertGraphEvents', () => {
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
             getToolOrigin: jest.fn(),
+            getToolType: jest.fn(),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -257,6 +262,7 @@ describe('convertGraphEvents', () => {
             toolManager: {
               getToolIdMapping: jest.fn().mockReturnValue(new Map()),
               getToolOrigin: jest.fn(),
+              getToolType: jest.fn(),
             } as any,
             pendingRound: undefined,
             logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -322,6 +328,7 @@ describe('convertGraphEvents', () => {
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
             getToolOrigin: jest.fn(),
+            getToolType: jest.fn(),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
@@ -374,6 +381,7 @@ describe('convertGraphEvents', () => {
           toolManager: {
             getToolIdMapping: jest.fn().mockReturnValue(new Map()),
             getToolOrigin: jest.fn(),
+            getToolType: jest.fn(),
           } as any,
           pendingRound: undefined,
           logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.ts
@@ -153,14 +153,15 @@ export const convertGraphEvents = ({
                     })
                   );
                 } else {
+                  const { origin: toolOrigin, type: toolType } = toolManager.getToolMeta(toolId);
                   events.push(
                     createToolCallEvent({
                       toolId,
                       toolCallId,
                       params: toolCallArgs,
                       toolCallGroupId,
-                      toolOrigin: toolManager.getToolOrigin(toolId),
-                      toolType: toolManager.getToolType(toolId),
+                      toolOrigin,
+                      toolType,
                     })
                   );
                 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/convert_graph_events.ts
@@ -160,6 +160,7 @@ export const convertGraphEvents = ({
                       params: toolCallArgs,
                       toolCallGroupId,
                       toolOrigin: toolManager.getToolOrigin(toolId),
+                      toolType: toolManager.getToolType(toolId),
                     })
                   );
                 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
@@ -440,6 +440,7 @@ const createToolCallStep = ({
     results: toolResult?.data.results ?? [],
     tool_call_group_id: toolCall.data.tool_call_group_id,
     tool_origin: toolCall.data.tool_origin,
+    tool_type: toolCall.data.tool_type,
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_tool.ts
@@ -207,6 +207,7 @@ export const runInternalTool = async <TParams = Record<string, unknown>>({
     reportToolCallTelemetry({
       parentManager,
       toolId: tool.id,
+      toolType: tool.type,
       toolCallId,
       source,
       results: resultsWithIds,
@@ -335,6 +336,7 @@ const getAgentExecutionContext = (manager: RunnerManager) => {
 const reportToolCallTelemetry = ({
   parentManager,
   toolId,
+  toolType,
   toolCallId,
   source,
   results,
@@ -342,6 +344,7 @@ const reportToolCallTelemetry = ({
 }: {
   parentManager: RunnerManager;
   toolId: string;
+  toolType: ToolType;
   toolCallId: string;
   source: string;
   results: ToolResult[];
@@ -367,6 +370,7 @@ const reportToolCallTelemetry = ({
         conversationId: agentContext?.conversationId,
         executionId: agentContext?.executionId,
         toolId,
+        toolType,
         toolCallId,
         source,
         errorType: 'tool_error',
@@ -379,6 +383,7 @@ const reportToolCallTelemetry = ({
         conversationId: agentContext?.conversationId,
         executionId: agentContext?.executionId,
         toolId,
+        toolType,
         toolCallId,
         source,
         resultTypes: results.map((r) => r.type),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/tool_manager.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/tool_manager.test.ts
@@ -661,9 +661,9 @@ describe('ToolManager', () => {
         logger: mockLogger,
       });
 
-      expect(toolManager.getToolOrigin('registry.tool')).toBe(ToolOrigin.registry);
-      expect(toolManager.getToolOrigin('inline.tool')).toBe(ToolOrigin.inline);
-      expect(toolManager.getToolOrigin('missing.tool')).toBeUndefined();
+      expect(toolManager.getToolMeta('registry.tool').origin).toBe(ToolOrigin.registry);
+      expect(toolManager.getToolMeta('inline.tool').origin).toBe(ToolOrigin.inline);
+      expect(toolManager.getToolMeta('missing.tool').origin).toBeUndefined();
     });
 
     it('overwrites existing entries when a newer origin is provided', async () => {
@@ -678,7 +678,7 @@ describe('ToolManager', () => {
         logger: mockLogger,
       });
 
-      expect(toolManager.getToolOrigin('tool.id')).toBe(ToolOrigin.registry);
+      expect(toolManager.getToolMeta('tool.id').origin).toBe(ToolOrigin.registry);
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/tool_manager.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/tool_manager.ts
@@ -13,7 +13,7 @@ import {
 } from '@kbn/agent-builder-genai-utils/langchain';
 import { reverseMap } from '@kbn/agent-builder-genai-utils/langchain/tools';
 import { LRUCache } from 'lru-cache';
-import type { ToolOrigin } from '@kbn/agent-builder-common';
+import type { ToolOrigin, ToolType } from '@kbn/agent-builder-common';
 import type { AgentEventEmitterFn, ExecutableTool } from '@kbn/agent-builder-server';
 import type { ToolReturnSummarizerFn } from '@kbn/agent-builder-server/tools/builtin';
 import type {
@@ -43,6 +43,7 @@ export class ToolManager implements IToolManager {
   private dynamicTools: LRUCache<ToolName, StructuredTool>;
   private toolIdMappings: Map<string, string>;
   private toolOrigins: Map<string, ToolOrigin>;
+  private toolTypes: Map<string, ToolType>;
   private executableTools: Map<string, ExecutableTool> = new Map<string, ExecutableTool>();
   private eventEmitter?: AgentEventEmitterFn;
 
@@ -52,6 +53,7 @@ export class ToolManager implements IToolManager {
     });
     this.toolIdMappings = new Map<string, string>();
     this.toolOrigins = new Map<string, ToolOrigin>();
+    this.toolTypes = new Map<string, ToolType>();
   }
 
   public setEventEmitter(eventEmitter: AgentEventEmitterFn): void {
@@ -74,6 +76,7 @@ export class ToolManager implements IToolManager {
       const toolsWithOrigin = Array.isArray(input.tools) ? input.tools : [input.tools];
       const tools: ExecutableTool[] = toolsWithOrigin.map(({ origin, ...tool }) => {
         this.toolOrigins.set(tool.id, origin);
+        this.toolTypes.set(tool.id, tool.type);
         this.executableTools.set(tool.id, tool);
         return tool;
       });
@@ -157,6 +160,13 @@ export class ToolManager implements IToolManager {
    */
   public getToolOrigin(toolId: string): ToolOrigin | undefined {
     return this.toolOrigins.get(toolId);
+  }
+
+  /**
+   * Returns the tool type for a given internal tool ID.
+   */
+  public getToolType(toolId: string): ToolType | undefined {
+    return this.toolTypes.get(toolId);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/tool_manager.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/utils/tool_manager.ts
@@ -155,18 +155,14 @@ export class ToolManager implements IToolManager {
     return this.toolIdMappings;
   }
 
-  /**
-   * Returns the origin metadata for a given internal tool ID.
-   */
-  public getToolOrigin(toolId: string): ToolOrigin | undefined {
-    return this.toolOrigins.get(toolId);
-  }
-
-  /**
-   * Returns the tool type for a given internal tool ID.
-   */
-  public getToolType(toolId: string): ToolType | undefined {
-    return this.toolTypes.get(toolId);
+  public getToolMeta(toolId: string): {
+    origin: ToolOrigin | undefined;
+    type: ToolType | undefined;
+  } {
+    return {
+      origin: this.toolOrigins.get(toolId),
+      type: this.toolTypes.get(toolId),
+    };
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.test.ts
@@ -14,6 +14,7 @@ import {
   ConversationRoundStatus,
   ConversationRoundStepType,
   agentBuilderDefaultAgentId,
+  ToolType,
   type ConversationRound,
 } from '@kbn/agent-builder-common';
 import { ModelProvider } from '@kbn/inference-common';
@@ -109,6 +110,37 @@ describe('AnalyticsService', () => {
         tool_call_errors: 0,
         tools_invoked: ['custom-3c9388baa67aef90'],
       });
+    });
+
+    it('keeps the real tool id in tools_invoked for built-in tools (by tool_type)', () => {
+      const roundWithBuiltinTool: ConversationRound = {
+        ...round,
+        steps: [
+          {
+            type: ConversationRoundStepType.toolCall,
+            tool_call_id: 'tool-call-1',
+            tool_id: 'platform.dashboard.manage_dashboard',
+            tool_type: ToolType.builtin,
+            params: {},
+            results: [],
+          },
+        ],
+      };
+
+      service.reportRoundComplete({
+        agentId: agentBuilderDefaultAgentId,
+        conversationId: 'conversation-1',
+        round: roundWithBuiltinTool,
+        roundCount: 2,
+        modelProvider,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(
+        AGENT_BUILDER_EVENT_TYPES.RoundComplete,
+        expect.objectContaining({
+          tools_invoked: ['platform.dashboard.manage_dashboard'],
+        })
+      );
     });
 
     it('reports a hashed agent_id for custom agents', () => {
@@ -461,6 +493,25 @@ describe('AnalyticsService', () => {
           result_types: ['resource', 'esql_results'],
           duration_ms: 150,
         }
+      );
+    });
+
+    it('keeps the real tool_id for built-in tools (by type) not on the allow-list', () => {
+      service.reportToolCallSuccess({
+        agentId: agentBuilderDefaultAgentId,
+        toolId: 'platform.dashboard.manage_dashboard',
+        toolType: ToolType.builtin,
+        toolCallId: 'tc-1',
+        source: 'agent',
+        resultTypes: ['other'],
+        duration: 10,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(
+        AGENT_BUILDER_EVENT_TYPES.ToolCallSuccess,
+        expect.objectContaining({
+          tool_id: 'platform.dashboard.manage_dashboard',
+        })
       );
     });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
@@ -275,7 +275,8 @@ export class AnalyticsService {
       // call). This allows downstream telemetry analysis to compute per-tool invocation counts by
       // aggregating over the array values.
       const toolsInvoked =
-        toolCallSteps.map((step) => normalizeToolIdForTelemetry(step.tool_id)) ?? [];
+        toolCallSteps.map((step) => normalizeToolIdForTelemetry(step.tool_id, step.tool_type)) ??
+        [];
 
       const toolCallErrors = toolCallSteps.filter(({ results }) => {
         return results.length > 0 && results.every((r) => r.type === ToolResultType.error);
@@ -354,6 +355,7 @@ export class AnalyticsService {
     conversationId,
     executionId,
     toolId,
+    toolType,
     toolCallId,
     source,
     resultTypes,
@@ -363,6 +365,7 @@ export class AnalyticsService {
     conversationId?: string;
     executionId?: string;
     toolId: string;
+    toolType?: ToolType | string;
     toolCallId: string;
     source: string;
     resultTypes: string[];
@@ -375,7 +378,7 @@ export class AnalyticsService {
           agent_id: normalizeAgentIdForTelemetry(agentId),
           conversation_id: conversationId,
           execution_id: executionId,
-          tool_id: normalizeToolIdForTelemetry(toolId),
+          tool_id: normalizeToolIdForTelemetry(toolId, toolType),
           tool_call_id: toolCallId,
           source,
           result_types: resultTypes,
@@ -392,6 +395,7 @@ export class AnalyticsService {
     conversationId,
     executionId,
     toolId,
+    toolType,
     toolCallId,
     source,
     errorType,
@@ -402,6 +406,7 @@ export class AnalyticsService {
     conversationId?: string;
     executionId?: string;
     toolId: string;
+    toolType?: ToolType | string;
     toolCallId: string;
     source: string;
     errorType: string;
@@ -415,7 +420,7 @@ export class AnalyticsService {
           agent_id: normalizeAgentIdForTelemetry(agentId),
           conversation_id: conversationId,
           execution_id: executionId,
-          tool_id: normalizeToolIdForTelemetry(toolId),
+          tool_id: normalizeToolIdForTelemetry(toolId, toolType),
           tool_call_id: toolCallId,
           source,
           error_type: sanitizeForCounterName(errorType),

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.test.ts
@@ -5,11 +5,47 @@
  * 2.0.
  */
 
+import { ToolType } from '@kbn/agent-builder-common/tools';
+import { platformCoreTools } from '@kbn/agent-builder-common/tools';
 import {
   classifySkill,
   normalizePluginIdForTelemetry,
   normalizeSkillIdForTelemetry,
+  normalizeToolIdForTelemetry,
 } from './utils';
+
+describe('normalizeToolIdForTelemetry', () => {
+  it('returns the original id for tools typed as builtin, regardless of allow-list', () => {
+    // A built-in tool registered by another plugin and NOT present in the
+    // AGENT_BUILDER_BUILTIN_TOOLS allow-list still keeps its real id.
+    expect(
+      normalizeToolIdForTelemetry('platform.dashboard.manage_dashboard', ToolType.builtin)
+    ).toBe('platform.dashboard.manage_dashboard');
+  });
+
+  it('returns the original id for allow-listed built-in tools when no type is provided', () => {
+    expect(normalizeToolIdForTelemetry(platformCoreTools.search)).toBe(platformCoreTools.search);
+  });
+
+  it('returns the original id for internal framework tools', () => {
+    expect(normalizeToolIdForTelemetry('load_skill')).toBe('load_skill');
+  });
+
+  it('hashes user-created tools as `custom-<hash>`', () => {
+    expect(normalizeToolIdForTelemetry('my-esql-tool', ToolType.esql)).toBe(
+      normalizeToolIdForTelemetry('my-esql-tool')
+    );
+    expect(normalizeToolIdForTelemetry('my-esql-tool', ToolType.esql)).toMatch(
+      /^custom-[0-9a-f]+$/
+    );
+  });
+
+  it('hashes unknown tool ids when no type is provided and not allow-listed', () => {
+    expect(normalizeToolIdForTelemetry('platform.dashboard.manage_dashboard')).toMatch(
+      /^custom-[0-9a-f]+$/
+    );
+  });
+});
 
 describe('normalizePluginIdForTelemetry', () => {
   it('returns undefined when no plugin id is provided', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
-import { isInternalTool } from '@kbn/agent-builder-common/tools';
+import { isInternalTool, ToolType } from '@kbn/agent-builder-common/tools';
 import type {
   SkillInvocationOrigin,
   SkillSolutionArea,
@@ -52,13 +52,23 @@ export function normalizeAgentIdForTelemetry(agentId?: string): string | undefin
 
 /**
  * Normalizes tool IDs for telemetry to protect user privacy.
- * Built-in tools (from AGENT_BUILDER_BUILTIN_TOOLS) are reported with their actual ID,
- * custom/user-created tools are reported as a stable hashed label (CUSTOM-<sha256_prefix>).
+ *
+ * Built-in tools (statically registered in code, `ToolType.builtin`) and internal
+ * framework tools are reported with their actual ID. User-created tools (esql,
+ * index_search, workflow, mcp) are reported as a stable hashed label
+ * (`custom-<sha256_prefix>`) since their IDs can contain user-chosen content.
+ *
+ * Prefer passing the tool `type` so any built-in tool (regardless of which plugin
+ * registers it) keeps a readable ID. When only the ID is available (e.g. round
+ * aggregates, agent tool selections), the `AGENT_BUILDER_BUILTIN_TOOLS` allow-list
+ * is used as a best-effort fallback.
  */
-export function normalizeToolIdForTelemetry(toolId: string): string {
-  return (BUILTIN_TOOL_IDS as Set<string>).has(toolId) || isInternalTool(toolId)
-    ? toolId
-    : toCustomHashedId(toolId);
+export function normalizeToolIdForTelemetry(toolId: string, toolType?: ToolType | string): string {
+  const isBuiltin =
+    toolType === ToolType.builtin ||
+    (BUILTIN_TOOL_IDS as Set<string>).has(toolId) ||
+    isInternalTool(toolId);
+  return isBuiltin ? toolId : toCustomHashedId(toolId);
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.ts
@@ -52,16 +52,8 @@ export function normalizeAgentIdForTelemetry(agentId?: string): string | undefin
 
 /**
  * Normalizes tool IDs for telemetry to protect user privacy.
- *
- * Built-in tools (statically registered in code, `ToolType.builtin`) and internal
- * framework tools are reported with their actual ID. User-created tools (esql,
- * index_search, workflow, mcp) are reported as a stable hashed label
- * (`custom-<sha256_prefix>`) since their IDs can contain user-chosen content.
- *
- * Prefer passing the tool `type` so any built-in tool (regardless of which plugin
- * registers it) keeps a readable ID. When only the ID is available (e.g. round
- * aggregates, agent tool selections), the `AGENT_BUILDER_BUILTIN_TOOLS` allow-list
- * is used as a best-effort fallback.
+ * custom/user-created tools are reported as a stable hashed label (CUSTOM-<sha256_prefix>).
+ * Pass `toolType` when available; falls back to allow-list for legacy callers that only have a tool ID string.
  */
 export function normalizeToolIdForTelemetry(toolId: string, toolType?: ToolType | string): string {
   const isBuiltin =

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -156,6 +156,7 @@ export const createToolManagerMock = (): ToolManagerMock => {
     recordToolUse: jest.fn(),
     getToolIdMapping: jest.fn(),
     getToolOrigin: jest.fn(),
+    getToolType: jest.fn(),
     getDynamicToolIds: jest.fn(),
     getSummarizer: jest.fn(),
   };

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -155,8 +155,7 @@ export const createToolManagerMock = (): ToolManagerMock => {
     list: jest.fn(),
     recordToolUse: jest.fn(),
     getToolIdMapping: jest.fn(),
-    getToolOrigin: jest.fn(),
-    getToolType: jest.fn(),
+    getToolMeta: jest.fn(),
     getDynamicToolIds: jest.fn(),
     getSummarizer: jest.fn(),
   };


### PR DESCRIPTION
## Summary

Built-in tools were being reported in EBT telemetry as anonymized `custom-<hash>` IDs instead of their real IDs, because `normalizeToolIdForTelemetry` only kept the real ID for tools in the manually-maintained `AGENT_BUILDER_BUILTIN_TOOLS` allow-list. Skill-bundled built-in tools (e.g. `platform.dashboard.manage_dashboard`, `platform.core.create_visualization`) are registered by other plugins as inline skill tools and are not on that list, so they were hashed — making them disappear from the `tool_id` field and skewing the "most invoked tool" analysis in the skills telemetry dashboard.

This makes the hashing decision **type-driven**: any tool registered as `ToolType.builtin` keeps its real ID, while user-created tools (`esql`, `index_search`, `workflow`, `mcp`) are still anonymized. The allow-list remains as a best-effort fallback for callers that only have a tool ID string (legacy persisted rounds, agent CRUD).

Related: telemetry was introduced in #264910.

### How to test

1. Start Kibana with Agent Builder enabled.
2. Converse with an agent so it loads a built-in skill and calls a skill-bundled tool (e.g. dashboard-management → `platform.dashboard.manage_dashboard`).
3. Query the `ebt-kibana-server` telemetry index for `agent_builder_tool_call_success` and `agent_builder_round_complete` events.
4. Confirm the built-in tool appears with its real `tool_id` / in `tools_invoked` (not `custom-<hash>`), while a user-created tool still shows up hashed.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Telemetry-only change.** No user-facing or runtime behavior is affected; worst case is incorrect tool-ID anonymization in EBT. Severity: low.
- **Privacy:** user-created tool IDs remain hashed (only `ToolType.builtin` IDs are emitted verbatim). Verified by unit tests.
- **Legacy data:** rounds persisted before this change carry no `tool_type` and fall back to the allow-list — same behavior as today, no regression.

### Release notes

Fix Agent Builder tool telemetry so built-in tools are reported with their real tool IDs instead of anonymized hashes.