### PR TITLE
[One Workflow](feat): Support scheduled managed workflow execution

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -41,6 +41,8 @@ dependsOn:
   - '@kbn/es-errors'
   - '@kbn/spaces-plugin'
   - '@kbn/spaces-utils'
+  - '@kbn/core-http-server'
+  - '@kbn/core-http-server-utils'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.scheduled_task.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.scheduled_task.test.ts
@@ -139,4 +139,128 @@ describe('workflow:scheduled task runner', () => {
       `Workflow ${workflowId} not found in space ${spaceId}; removing orphaned scheduled task`
     );
   });
+
+  it('rejects request-less scheduled executions for user workflows', async () => {
+    const taskDefinitions: Record<string, TaskRegisterDefinition> = {};
+    const initializerContext = coreMock.createPluginInitializerContext({
+      logging: { console: false },
+      eventDriven: { enabled: true, logEvents: true, maxChainDepth: 10 },
+    });
+
+    const plugin = new WorkflowsExecutionEnginePlugin(initializerContext);
+    const coreSetup = coreMock.createSetup();
+    const coreStart = coreMock.createStart();
+    coreSetup.getStartServices.mockResolvedValue([
+      coreStart,
+      {
+        taskManager: taskManagerMock.createStart(),
+        actions: {} as never,
+        workflowsExtensions: {} as never,
+        licensing: licensingMock.createStart(),
+      },
+      {} as never,
+    ]);
+
+    const taskManagerSetup = taskManagerMock.createSetup();
+    taskManagerSetup.registerTaskDefinitions.mockImplementation((definitions) => {
+      Object.assign(taskDefinitions, definitions);
+    });
+
+    plugin.setup(coreSetup as never, {
+      taskManager: taskManagerSetup,
+      cloud: {} as never,
+      workflowsExtensions: { registerConnectorAdapter: jest.fn() } as never,
+    });
+
+    mockGetWorkflow.mockResolvedValue({
+      id: workflowId,
+      name: 'User workflow',
+      enabled: true,
+      managed: false,
+      definition: { name: 'User workflow', triggers: [], steps: [] },
+      yaml: '',
+    });
+
+    const runner = taskDefinitions[WORKFLOW_SCHEDULED_TASK_TYPE]!.createTaskRunner({
+      taskInstance: createTaskInstance(),
+      fakeRequest: undefined,
+      abortController: new AbortController(),
+    });
+
+    await expect(runner.run()).rejects.toThrow(
+      'Cannot execute a scheduled workflow without Kibana Request'
+    );
+  });
+
+  it('creates a Kibana system request for request-less managed scheduled executions', async () => {
+    const taskDefinitions: Record<string, TaskRegisterDefinition> = {};
+    const initializerContext = coreMock.createPluginInitializerContext({
+      logging: { console: false },
+      eventDriven: { enabled: true, logEvents: true, maxChainDepth: 10 },
+    });
+
+    const plugin = new WorkflowsExecutionEnginePlugin(initializerContext);
+    const coreSetup = coreMock.createSetup();
+    const coreStart = coreMock.createStart();
+    coreStart.elasticsearch.client.asInternalUser.security.createApiKey.mockResolvedValue({
+      id: 'system-key-id',
+      api_key: 'system-key',
+    });
+    coreSetup.getStartServices.mockResolvedValue([
+      coreStart,
+      {
+        taskManager: taskManagerMock.createStart(),
+        actions: {} as never,
+        workflowsExtensions: {} as never,
+        licensing: licensingMock.createStart(),
+      },
+      {} as never,
+    ]);
+
+    const taskManagerSetup = taskManagerMock.createSetup();
+    taskManagerSetup.registerTaskDefinitions.mockImplementation((definitions) => {
+      Object.assign(taskDefinitions, definitions);
+    });
+
+    plugin.setup(coreSetup as never, {
+      taskManager: taskManagerSetup,
+      cloud: {} as never,
+      workflowsExtensions: { registerConnectorAdapter: jest.fn() } as never,
+    });
+
+    mockGetWorkflow.mockResolvedValue({
+      id: workflowId,
+      name: 'Managed workflow',
+      enabled: true,
+      managed: true,
+      definition: {
+        name: 'Managed workflow',
+        settings: { timeout: '30m' },
+        triggers: [],
+        steps: [],
+      },
+      yaml: '',
+    });
+    mockCheckAndSkipIfExistingScheduledExecution.mockResolvedValueOnce(true);
+
+    const runner = taskDefinitions[WORKFLOW_SCHEDULED_TASK_TYPE]!.createTaskRunner({
+      taskInstance: createTaskInstance(),
+      fakeRequest: undefined,
+      abortController: new AbortController(),
+    });
+
+    await runner.run();
+
+    expect(coreStart.elasticsearch.client.asInternalUser.security.createApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expiration: '2100s',
+        metadata: expect.objectContaining({
+          type: 'managed_scheduled_workflow',
+          workflowId,
+        }),
+      })
+    );
+    expect(mockCheckAndSkipIfExistingScheduledExecution).toHaveBeenCalled();
+    expect(mockRunWorkflow).not.toHaveBeenCalled();
+  });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.scheduled_task.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.scheduled_task.test.ts
@@ -251,7 +251,9 @@ describe('workflow:scheduled task runner', () => {
 
     await runner.run();
 
-    expect(coreStart.elasticsearch.client.asInternalUser.security.createApiKey).toHaveBeenCalledWith(
+    expect(
+      coreStart.elasticsearch.client.asInternalUser.security.createApiKey
+    ).toHaveBeenCalledWith(
       expect.objectContaining({
         expiration: '2100s',
         metadata: expect.objectContaining({

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -17,6 +17,9 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
+import type { FakeRawRequest } from '@kbn/core-http-server';
+import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
+import { addSpaceIdToPath } from '@kbn/spaces-plugin/server';
 import { ExecutionStatus, pickManagedWorkflowFields, WorkflowRepository } from '@kbn/workflows';
 import type {
   BulkScheduleWorkflowResult,
@@ -30,6 +33,7 @@ import {
 } from '@kbn/workflows/common/errors';
 import { ConcurrencyManager } from './concurrency/concurrency_manager';
 import type { WorkflowsExecutionEngineConfig } from './config';
+import { DEFAULT_WORKFLOW_TIMEOUT } from './default_workflow_settings';
 import {
   cancelWorkflow,
   checkAndSkipIfExistingScheduledExecution,
@@ -68,7 +72,7 @@ import type {
   WorkflowsExecutionEnginePluginStart,
   WorkflowsExecutionEnginePluginStartDeps,
 } from './types';
-import { generateExecutionTaskScope } from './utils';
+import { generateExecutionTaskScope, parseDuration } from './utils';
 import { buildWorkflowContext } from './workflow_context_manager/build_workflow_context';
 import type { ContextDependencies } from './workflow_context_manager/types';
 import { WorkflowEventLoggerService } from './workflow_event_logger';
@@ -87,6 +91,79 @@ import {
 } from './workflow_task_manager/workflow_task_manager';
 import { createWorkflowTaskAbortController } from './workflow_task_shutdown';
 import { createIndexes } from '../common';
+
+const SYSTEM_WORKFLOW_API_KEY_EXPIRATION_BUFFER_MS = 5 * 60 * 1000;
+
+const getSystemWorkflowApiKeyExpiration = (workflow: WorkflowExecutionEngineModel): string => {
+  const timeout = workflow.definition?.settings?.timeout ?? DEFAULT_WORKFLOW_TIMEOUT;
+  const expirationMs = parseDuration(timeout) + SYSTEM_WORKFLOW_API_KEY_EXPIRATION_BUFFER_MS;
+  return `${Math.ceil(expirationMs / 1000)}s`;
+};
+
+const createKibanaSystemWorkflowRequest = async ({
+  coreStart,
+  workflow,
+  spaceId,
+}: {
+  coreStart: CoreStart;
+  workflow: WorkflowExecutionEngineModel;
+  spaceId: string;
+}): Promise<KibanaRequest> => {
+  const apiKey = await coreStart.elasticsearch.client.asInternalUser.security.createApiKey({
+    name: `Managed scheduled workflow: ${workflow.id}`,
+    expiration: getSystemWorkflowApiKeyExpiration(workflow),
+    role_descriptors: {},
+    metadata: {
+      managed: true,
+      type: 'managed_scheduled_workflow',
+      workflowId: workflow.id,
+    },
+  });
+
+  const encodedApiKey = Buffer.from(`${apiKey.id}:${apiKey.api_key}`).toString('base64');
+  const path = addSpaceIdToPath('/', spaceId);
+  const fakeRawRequest: FakeRawRequest = {
+    headers: {
+      authorization: `ApiKey ${encodedApiKey}`,
+      'kbn-system-request': 'true',
+    },
+    path,
+    url: new URL(`https://fake-request${path}`),
+    auth: {
+      isAuthenticated: true,
+    },
+  };
+  const request = kibanaRequestFactory(fakeRawRequest);
+  coreStart.http.basePath.set(request, path);
+
+  return request;
+};
+
+const getScheduledWorkflowExecutionRequest = async ({
+  fakeRequest,
+  coreStart,
+  workflow,
+  spaceId,
+}: {
+  fakeRequest?: KibanaRequest;
+  coreStart: CoreStart;
+  workflow: WorkflowExecutionEngineModel;
+  spaceId: string;
+}): Promise<KibanaRequest> => {
+  if (fakeRequest) {
+    return fakeRequest;
+  }
+
+  if (!workflow.managed) {
+    throw new Error('Cannot execute a scheduled workflow without Kibana Request');
+  }
+
+  return createKibanaSystemWorkflowRequest({
+    coreStart,
+    workflow,
+    spaceId,
+  });
+};
 
 /**
  * Max Task Manager attempts for `workflow:run`.
@@ -400,9 +477,6 @@ export class WorkflowsExecutionEnginePlugin
         timeout: '365d',
         maxAttempts: 3,
         createTaskRunner: ({ taskInstance, fakeRequest, abortController }) => {
-          if (!fakeRequest) {
-            throw new Error('Cannot execute a scheduled workflow without Kibana Request');
-          }
           const taskAbortController = createWorkflowTaskAbortController(abortController);
           return {
             run: async () => {
@@ -478,6 +552,13 @@ export class WorkflowsExecutionEnginePlugin
               }
               logger.debug(`Running scheduled workflow task for workflow ${workflow.id}`);
 
+              const executionRequest = await getScheduledWorkflowExecutionRequest({
+                fakeRequest,
+                coreStart,
+                workflow,
+                spaceId,
+              });
+
               // Guard check: Check&Skip only when workflow has no concurrency strategy. When strategy is
               // set, the concurrency check (later) governs the limit and strategy.
               if (!workflow.definition?.settings?.concurrency?.strategy) {
@@ -523,7 +604,7 @@ export class WorkflowsExecutionEnginePlugin
                 'execution'
               );
               const executedBy = await getAuthenticatedUser(
-                fakeRequest,
+                executionRequest,
                 coreStart.security,
                 coreStart.elasticsearch.client
               );
@@ -595,7 +676,7 @@ export class WorkflowsExecutionEnginePlugin
                 taskAbortController,
                 logger,
                 config,
-                fakeRequest,
+                fakeRequest: executionRequest,
                 dependencies,
                 workflowsExecutionEngine,
                 meteringService: this.meteringService,

--- a/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
@@ -36,7 +36,9 @@
     "@kbn/crypto",
     "@kbn/es-errors",
     "@kbn/spaces-plugin",
-    "@kbn/spaces-utils"
+    "@kbn/spaces-utils",
+    "@kbn/core-http-server",
+    "@kbn/core-http-server-utils"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -185,6 +185,7 @@ export class WorkflowsService {
     this.managedWorkflowsService = new ManagedWorkflowsService({
       crudService: this.crudService,
       workflowsExecutionEngine: this.workflowsExecutionEngine,
+      taskScheduler: this.taskScheduler,
       logger: this.logger,
     });
   }

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts
@@ -21,6 +21,7 @@ import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-executi
 import { ManagedWorkflowsService } from './managed_workflows_service';
 import type { VersionedWorkflowDocument, WorkflowCrudService } from './workflow_crud_service';
 import type { WorkflowProperties } from '../storage/workflow_storage';
+import type { WorkflowTaskScheduler } from '../tasks/workflow_task_scheduler';
 
 let mockManagedWorkflowDefinitions: ManagedWorkflowDefinition[] = [];
 
@@ -162,12 +163,15 @@ const createCrudServiceMock = () => {
         spaceId: string;
       }) => {
         const enabled = getYamlEnabled(yaml);
+        const triggers = yaml.includes('type: scheduled')
+          ? [{ type: 'scheduled' as const, with: { every: '5m' } }]
+          : [];
         return {
           workflowData: createWorkflowSource({
             name: id,
             enabled,
             yaml,
-            definition: { name: id, enabled } as WorkflowYaml,
+            definition: { name: id, enabled, triggers } as WorkflowYaml,
             createdBy: actor,
             lastUpdatedBy: actor,
             spaceId,
@@ -194,19 +198,27 @@ const createExecutionEngineMock = () =>
     executeWorkflow: jest.fn().mockResolvedValue({ workflowExecutionId: 'execution-1' }),
   } as unknown as WorkflowsExecutionEnginePluginStart);
 
+const createTaskSchedulerMock = () =>
+  ({
+    scheduleWorkflowTask: jest.fn().mockResolvedValue('task-id'),
+  } as unknown as jest.Mocked<WorkflowTaskScheduler>);
+
 const createService = () => {
   const crudService = createCrudServiceMock();
   const workflowsExecutionEngine = createExecutionEngineMock();
+  const taskScheduler = createTaskSchedulerMock();
   const logger = loggerMock.create();
   const service = new ManagedWorkflowsService({
     crudService: crudService as unknown as WorkflowCrudService,
     workflowsExecutionEngine,
+    taskScheduler,
     logger,
   });
 
   return {
     crudService,
     workflowsExecutionEngine,
+    taskScheduler,
     logger,
     service,
   };
@@ -250,6 +262,51 @@ describe('ManagedWorkflowsService', () => {
         }),
         { create: true }
       );
+    });
+
+    it('schedules enabled managed workflows with scheduled triggers without a request', async () => {
+      const definition = createDefinition({
+        yaml: `name: Managed Scheduled Workflow
+enabled: true
+triggers:
+  - type: scheduled
+    with:
+      every: 5m
+steps: []
+`,
+      });
+      mockManagedWorkflowDefinitions = [definition];
+      const { crudService, service, taskScheduler } = createService();
+      crudService.getWorkflowDocumentWithVersion.mockResolvedValue(null);
+
+      await service.installManagedWorkflow(WORKFLOW_ID, { spaceId: SPACE_ID }, definition.pluginId);
+
+      expect(taskScheduler.scheduleWorkflowTask).toHaveBeenCalledWith(
+        WORKFLOW_ID,
+        SPACE_ID,
+        expect.objectContaining({ type: 'scheduled' }),
+        undefined
+      );
+    });
+
+    it('does not schedule disabled managed workflows with scheduled triggers', async () => {
+      const definition = createDefinition({
+        yaml: `name: Managed Scheduled Workflow
+enabled: false
+triggers:
+  - type: scheduled
+    with:
+      every: 5m
+steps: []
+`,
+      });
+      mockManagedWorkflowDefinitions = [definition];
+      const { crudService, service, taskScheduler } = createService();
+      crudService.getWorkflowDocumentWithVersion.mockResolvedValue(null);
+
+      await service.installManagedWorkflow(WORKFLOW_ID, { spaceId: SPACE_ID }, definition.pluginId);
+
+      expect(taskScheduler.scheduleWorkflowTask).not.toHaveBeenCalled();
     });
 
     it('preserves the stored enabled state when enablement is restorable', async () => {

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
@@ -30,6 +30,8 @@ import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-executi
 import { updateYamlField } from '@kbn/workflows-yaml';
 import type { WorkflowCrudService } from './workflow_crud_service';
 import type { WorkflowProperties } from '../storage/workflow_storage';
+import { scheduleWorkflowTriggers } from '../task_defs/schedule_workflow_triggers';
+import type { WorkflowTaskScheduler } from '../tasks/workflow_task_scheduler';
 
 const MANAGED_WORKFLOW_SYSTEM_USER = 'elastic/kibana';
 const MAX_MANAGED_INSTALL_RETRIES = 2;
@@ -48,6 +50,7 @@ const computeDefinitionHash = (yaml: string): string => {
 interface ManagedWorkflowsServiceDeps {
   crudService: WorkflowCrudService;
   workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart;
+  taskScheduler: WorkflowTaskScheduler;
   logger: Logger;
 }
 
@@ -193,6 +196,7 @@ export class ManagedWorkflowsService {
       await this.deps.crudService.indexWorkflowDocument(workflowDocumentId, document, {
         create: true,
       });
+      await this.scheduleManagedWorkflowIfNeeded(workflowDocumentId, document, spaceId);
       return;
     }
 
@@ -233,6 +237,7 @@ export class ManagedWorkflowsService {
       ifSeqNo: existingDocument.seqNo,
       ifPrimaryTerm: existingDocument.primaryTerm,
     });
+    await this.scheduleManagedWorkflowIfNeeded(workflowDocumentId, document, spaceId);
   }
 
   public async uninstallManagedWorkflow(
@@ -547,6 +552,22 @@ export class ManagedWorkflowsService {
       storedHash: existing?.definitionHash ?? null,
       registryHash,
     };
+  }
+
+  private async scheduleManagedWorkflowIfNeeded(
+    workflowDocumentId: string,
+    document: WorkflowProperties,
+    spaceId: string
+  ): Promise<void> {
+    await scheduleWorkflowTriggers({
+      workflowId: workflowDocumentId,
+      definition: document.definition ?? undefined,
+      enabled: document.enabled,
+      valid: document.valid,
+      spaceId,
+      taskScheduler: this.deps.taskScheduler,
+      logger: this.logger,
+    });
   }
 
   private async prepareManagedWorkflowDocument(params: {

--- a/src/platform/plugins/shared/workflows_management/server/task_defs/schedule_workflow_triggers.ts
+++ b/src/platform/plugins/shared/workflows_management/server/task_defs/schedule_workflow_triggers.ts
@@ -22,7 +22,7 @@ export const scheduleWorkflowTriggers = async (params: {
   enabled: boolean;
   valid: boolean;
   spaceId: string;
-  request: KibanaRequest;
+  request?: KibanaRequest;
   taskScheduler: WorkflowTaskScheduler | null;
   logger: Logger;
 }): Promise<void> => {

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts
@@ -115,6 +115,22 @@ describe('WorkflowTaskScheduler', () => {
       );
     });
 
+    it('schedules without request options when no request is provided', async () => {
+      const mockTm = makeMockTaskManager();
+      const scheduler = new WorkflowTaskScheduler(mockLogger, mockTm);
+
+      const result = await scheduler.scheduleWorkflowTasks(makeWorkflow(), 'default');
+
+      expect(result).toEqual(['test-task-id']);
+      expect(mockTm.schedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'workflow:test-workflow:scheduled',
+          taskType: 'workflow:scheduled',
+        }),
+        undefined
+      );
+    });
+
     it('returns empty array when workflow has no scheduled triggers', async () => {
       const mockTm = makeMockTaskManager();
       const scheduler = new WorkflowTaskScheduler(mockLogger, mockTm);

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.ts
@@ -38,7 +38,7 @@ export class WorkflowTaskScheduler {
   async scheduleWorkflowTasks(
     workflow: EsWorkflow,
     spaceId: string,
-    request: KibanaRequest
+    request?: KibanaRequest
   ): Promise<string[]> {
     const scheduledTriggers = getScheduledTriggers(workflow.definition?.triggers ?? []);
     const scheduledTaskIds: string[] = [];
@@ -70,7 +70,7 @@ export class WorkflowTaskScheduler {
     workflowId: string,
     spaceId: string,
     trigger: WorkflowTrigger,
-    request: KibanaRequest
+    request?: KibanaRequest
   ): Promise<string> {
     const schedule = convertWorkflowScheduleToTaskSchedule(trigger);
     const taskId = `workflow:${workflowId}:${trigger.type}`;
@@ -106,14 +106,21 @@ export class WorkflowTaskScheduler {
     try {
       // Use Task Manager's first-class API key support by passing the request.
       // Task Manager will automatically create and manage the API key for user context.
-      const scheduledTask = await this.taskManager.schedule(taskInstance, { request });
+      const scheduledTask = await this.taskManager.schedule(
+        taskInstance,
+        request ? { request } : undefined
+      );
 
       return scheduledTask.id;
     } catch (err) {
       if ((err as { statusCode?: number }).statusCode === VERSION_CONFLICT_STATUS) {
         // Task already exists — update its schedule in place rather than failing.
         // This handles both interval and RRule schedule types.
-        const result = await this.taskManager.bulkUpdateSchedules([taskId], schedule, { request });
+        const result = await this.taskManager.bulkUpdateSchedules(
+          [taskId],
+          schedule,
+          request ? { request } : undefined
+        );
         if (result.errors.length > 0) {
           const firstError = result.errors[0].error;
           // 409 (concurrent update) and 404 (task was just removed) are non-fatal


### PR DESCRIPTION
## Summary

- Creates Task Manager scheduled tasks when enabled managed workflows with scheduled triggers are installed or updated.
- Allows request-less managed scheduled workflow tasks to execute with a temporary Kibana system API key, while preserving the existing rejection for request-less user workflows.
- Reuses the existing scheduled workflow task scheduling path and adds coverage for managed install scheduling and managed scheduled execution fallback.

## Implementation details

Managed workflow install now receives the workflow task scheduler and calls the same scheduling helper used by user-created workflows after a managed workflow document is written. The helper and scheduler accept an optional request so startup-managed workflows can create a scheduled task before any user context exists.

The scheduled workflow runner now loads the workflow before enforcing the `fakeRequest` requirement. If Task Manager did not provide a request and the workflow is managed, the runner creates a Kibana-system fake request using a temporary API key whose expiration is based on the workflow timeout plus a small buffer. Non-managed scheduled workflows still require Task Manager user credentials.

The separate user-edit credential rotation issue is intentionally not covered here and is tracked separately.

## References

Closes elastic/security-team#17431
Related: elastic/security-team#17709

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/plugin.scheduled_task.test.ts`
- [x] `ReadLints` on touched files