### PR TITLE
[9.4] [Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.ts
@@ -11,7 +11,11 @@ import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { ESQLCommandOption, ESQLAstCommand } from '@elastic/esql/types';
 import { Parser, isOptionNode, isColumn, isFunctionExpression } from '@elastic/esql';
 import { getArgsFromRenameFunction } from '@kbn/esql-utils';
-import type { EsqlEsqlShardFailure } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  EsqlEsqlShardFailure,
+  EsqlQueryResponse,
+  FieldValue,
+} from '@elastic/elasticsearch/lib/api/types';
 import { ActionGroupId } from './constants';
 
 type EsqlDocument = Record<string, string | null>;
@@ -57,16 +61,21 @@ export interface EsqlTable {
 export const ALERT_ID_COLUMN = 'Alert ID';
 export const ALERT_ID_SUGGESTED_MAX = 10;
 
-export const rowToDocument = (columns: EsqlResultColumn[], row: EsqlResultRow): EsqlDocument => {
+export const rowToDocument = (
+  columns: EsqlQueryResponse['columns'],
+  row: FieldValue[]
+): EsqlDocument => {
   const doc: EsqlDocument = {};
   for (let i = 0; i < columns.length; ++i) {
-    doc[columns[i].name] = row[i];
+    doc[columns[i].name] = row[i]?.toString() || null;
   }
   return doc;
 };
 
+// The union type "EsqlTable | EsqlQueryResponse" is needed in this file to support both the UI test query funtionality and the server side execution of the rule.
+// The UI uses the data plugin to fetch results and while the server side execution calls the esClient directly.
 export const getEsqlQueryHits = async (
-  table: EsqlTable,
+  table: EsqlTable | EsqlQueryResponse,
   query: string,
   isGroupAgg: boolean,
   isPreview: boolean = false
@@ -79,7 +88,7 @@ export const getEsqlQueryHits = async (
 };
 
 export const toEsqlQueryHits = async (
-  table: EsqlTable,
+  table: EsqlTable | EsqlQueryResponse,
   isPreview: boolean = false,
   chunkSize: number = CHUNK_SIZE
 ): Promise<EsqlQueryHits> => {
@@ -124,7 +133,7 @@ export const toEsqlQueryHits = async (
 };
 
 export const toGroupedEsqlQueryHits = async (
-  table: EsqlTable,
+  table: EsqlTable | EsqlQueryResponse,
   alertIdFields: string[],
   isPreview: boolean = false,
   chunkSize: number = CHUNK_SIZE

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.test.ts
@@ -16,7 +16,10 @@ import { publicRuleResultServiceMock } from '@kbn/alerting-plugin/server/monitor
 import { getEsqlQueryHits } from '../../../../common';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
-import type { EsqlEsqlShardFailure } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  EsqlEsqlClusterInfo,
+  EsqlEsqlShardFailure,
+} from '@elastic/elasticsearch/lib/api/types';
 
 const getTimeRange = () => {
   const date = Date.now();
@@ -50,6 +53,7 @@ jest.mock('../../../../common', () => {
 
 const logger = loggingSystemMock.create().get();
 const mockRuleResultService = publicRuleResultServiceMock.create();
+const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
 
 describe('fetchEsqlQuery', () => {
   afterAll(() => {
@@ -69,9 +73,7 @@ describe('fetchEsqlQuery', () => {
 
   describe('fetch', () => {
     it('should throw a user error when the error is a verification_exception error', async () => {
-      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-
-      scopedClusterClient.asCurrentUser.transport.request.mockRejectedValueOnce(
+      scopedClusterClient.asCurrentUser.esql.query.mockRejectedValueOnce(
         new Error(
           'verification_exception: Found 1 problem line 1:23: Unknown column [user_agent.original]'
         )
@@ -114,18 +116,17 @@ describe('fetchEsqlQuery', () => {
         index: 'test-index',
       };
 
-      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-      scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({
+      scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce({
         columns: [],
         values: [],
-        is_partial: true, // is_partial is true
+        is_partial: true,
         _clusters: {
           details: {
             'cluster-1': {
               failures: [shardFailure],
             },
           },
-        },
+        } as unknown as EsqlEsqlClusterInfo,
       });
 
       (getEsqlQueryHits as jest.Mock).mockReturnValue({
@@ -174,14 +175,13 @@ describe('fetchEsqlQuery', () => {
     });
 
     it('should add a warning when is_partial is true but there is no shard failure', async () => {
-      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-      scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({
+      scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce({
         columns: [],
         values: [],
-        is_partial: true, // is_partial is true
+        is_partial: true,
         _clusters: {
           details: {},
-        },
+        } as unknown as EsqlEsqlClusterInfo,
       });
 
       (getEsqlQueryHits as jest.Mock).mockReturnValue({
@@ -230,11 +230,10 @@ describe('fetchEsqlQuery', () => {
     });
 
     it('should not add a warning when is_partial is false', async () => {
-      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-      scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({
+      scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce({
         columns: [],
         values: [],
-        is_partial: false, // is_partial is true
+        is_partial: false,
       });
 
       (getEsqlQueryHits as jest.Mock).mockReturnValue({
@@ -383,8 +382,7 @@ describe('fetchEsqlQuery', () => {
   });
 
   it('should bubble up warnings if there are duplicate alerts', async () => {
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({
+    scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce({
       columns: [],
       values: [],
     });

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
@@ -16,9 +16,8 @@ import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/se
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
 import { i18n } from '@kbn/i18n';
-import type { EsqlEsqlShardFailure } from '@elastic/elasticsearch/lib/api/types';
+import type { EsqlEsqlShardFailure, EsqlQueryResponse } from '@elastic/elasticsearch/lib/api/types';
 import { hasStartEndParams, appendLimitToQuery } from '@kbn/esql-utils';
-import type { EsqlTable } from '../../../../common';
 import { getEsqlQueryHits } from '../../../../common';
 import type { OnlyEsqlQueryRuleParams, EsQuerySourceFields } from '../types';
 
@@ -55,13 +54,9 @@ export async function fetchEsqlQuery({
 
   logger.debug(() => `ES|QL query rule (${ruleId}) query: ${JSON.stringify(query)}`);
 
-  let response: EsqlTable;
+  let response: EsqlQueryResponse;
   try {
-    response = await esClient.transport.request<EsqlTable>({
-      method: 'POST',
-      path: '/_query',
-      body: query,
-    });
+    response = await esClient.esql.query(query);
   } catch (e) {
     if (e.message?.includes('verification_exception')) {
       throw createTaskRunError(e, TaskErrorSource.USER);
@@ -112,7 +107,7 @@ export const getEsqlQuery = (
   dateStart: string,
   dateEnd: string
 ) => {
-  const rangeFilter: unknown[] = [
+  const rangeFilter = [
     {
       range: {
         [params.timeField]: {
@@ -158,7 +153,7 @@ export function generateLink(
   return redirectUrl;
 }
 
-function getPartialResultsWarning(response: EsqlTable) {
+function getPartialResultsWarning(response: EsqlQueryResponse) {
   const clusters = response?._clusters?.details ?? {};
   const shardFailures: EsqlEsqlShardFailure[] = [];
   for (const cluster of Object.keys(clusters)) {

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
@@ -16,7 +16,11 @@ import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/se
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
 import { i18n } from '@kbn/i18n';
-import type { EsqlEsqlShardFailure, EsqlQueryResponse } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  EsqlEsqlShardFailure,
+  EsqlQueryRequest,
+  EsqlQueryResponse,
+} from '@elastic/elasticsearch/lib/api/types';
 import { hasStartEndParams, appendLimitToQuery } from '@kbn/esql-utils';
 import { getEsqlQueryHits } from '../../../../common';
 import type { OnlyEsqlQueryRuleParams, EsQuerySourceFields } from '../types';
@@ -127,7 +131,12 @@ export const getEsqlQuery = (
       },
     },
     ...(hasStartEndParams(params.esqlQuery.esql)
-      ? { params: [{ _tstart: dateStart }, { _tend: dateEnd }] }
+      ? {
+          params: [
+            { _tstart: dateStart },
+            { _tend: dateEnd },
+          ] as unknown as EsqlQueryRequest['params'],
+        }
       : {}),
   };
   return query;

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/rule_type.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/rule_type.test.ts
@@ -821,9 +821,7 @@ describe('ruleType', () => {
         ],
         values: [],
       };
-      ruleServices.scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce(
-        searchResult
-      );
+      ruleServices.scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce(searchResult);
 
       await invokeExecutor({ params, ruleServices });
       expect(ruleServices.alertsClient.report).not.toHaveBeenCalled();
@@ -843,9 +841,7 @@ describe('ruleType', () => {
           ['timestamp', 'message'],
         ],
       };
-      ruleServices.scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce(
-        searchResult
-      );
+      ruleServices.scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce(searchResult);
 
       await invokeExecutor({ params, ruleServices });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)](https://github.com/elastic/kibana/pull/270014)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lu(cia)","email":"lucia.petracca@elastic.co"},"sourceCommit":{"committedDate":"2026-06-04T10:43:30Z","message":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)\n\n## Summary\n\n\nResolves: https://github.com/elastic/kibana/issues/236361\n\nThis PR changes the rule executor logic for the \"ESQL Query rule type\"\nto use the elasticsearch query api.\n\n### Changes\n- Changed `esClient.transport.request` call to `esClient.esql.query` and\ncorresponding util function types to handle response","sha":"69e3565271359c2abf4876ebb55560aab1741720","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:Alerting/RuleTypes","backport:all-open","v9.5.0"],"title":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution","number":270014,"url":"https://github.com/elastic/kibana/pull/270014","mergeCommit":{"message":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)\n\n## Summary\n\n\nResolves: https://github.com/elastic/kibana/issues/236361\n\nThis PR changes the rule executor logic for the \"ESQL Query rule type\"\nto use the elasticsearch query api.\n\n### Changes\n- Changed `esClient.transport.request` call to `esClient.esql.query` and\ncorresponding util function types to handle response","sha":"69e3565271359c2abf4876ebb55560aab1741720"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270014","number":270014,"mergeCommit":{"message":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)\n\n## Summary\n\n\nResolves: https://github.com/elastic/kibana/issues/236361\n\nThis PR changes the rule executor logic for the \"ESQL Query rule type\"\nto use the elasticsearch query api.\n\n### Changes\n- Changed `esClient.transport.request` call to `esClient.esql.query` and\ncorresponding util function types to handle response","sha":"69e3565271359c2abf4876ebb55560aab1741720"}},{"url":"https://github.com/elastic/kibana/pull/272667","number":272667,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->