### PR TITLE
[8.19] [Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.ts
@@ -12,10 +12,7 @@ import type { ESQLCommandOption } from '@kbn/esql-ast';
 import { type ESQLAstCommand, parse } from '@kbn/esql-ast';
 import { isOptionItem, isColumnItem, isFunctionItem } from '@kbn/esql-validation-autocomplete';
 import { getArgsFromRenameFunction } from '@kbn/esql-utils';
-import type {
-  EsqlQueryResponse,
-  FieldValue
-} from '@elastic/elasticsearch/lib/api/types';
+import type { EsqlQueryResponse, FieldValue } from '@elastic/elasticsearch/lib/api/types';
 import { ActionGroupId } from './constants';
 
 type EsqlDocument = Record<string, string | null>;

--- a/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.ts
@@ -12,6 +12,10 @@ import type { ESQLCommandOption } from '@kbn/esql-ast';
 import { type ESQLAstCommand, parse } from '@kbn/esql-ast';
 import { isOptionItem, isColumnItem, isFunctionItem } from '@kbn/esql-validation-autocomplete';
 import { getArgsFromRenameFunction } from '@kbn/esql-utils';
+import type {
+  EsqlQueryResponse,
+  FieldValue
+} from '@elastic/elasticsearch/lib/api/types';
 import { ActionGroupId } from './constants';
 
 type EsqlDocument = Record<string, string | null>;
@@ -48,16 +52,21 @@ export interface EsqlTable {
 export const ALERT_ID_COLUMN = 'Alert ID';
 export const ALERT_ID_SUGGESTED_MAX = 10;
 
-export const rowToDocument = (columns: EsqlResultColumn[], row: EsqlResultRow): EsqlDocument => {
-  return columns.reduce<Record<string, string | null>>((acc, column, i) => {
-    acc[column.name] = row[i];
-
-    return acc;
-  }, {});
+export const rowToDocument = (
+  columns: EsqlQueryResponse['columns'],
+  row: FieldValue[]
+): EsqlDocument => {
+  const doc: EsqlDocument = {};
+  for (let i = 0; i < columns.length; ++i) {
+    doc[columns[i].name] = row[i]?.toString() || null;
+  }
+  return doc;
 };
 
+// The union type "EsqlTable | EsqlQueryResponse" is needed in this file to support both the UI test query funtionality and the server side execution of the rule.
+// The UI uses the data plugin to fetch results and while the server side execution calls the esClient directly.
 export const getEsqlQueryHits = (
-  table: EsqlTable,
+  table: EsqlTable | EsqlQueryResponse,
   query: string,
   isGroupAgg: boolean
 ): EsqlQueryHits => {
@@ -68,7 +77,7 @@ export const getEsqlQueryHits = (
   return toEsqlQueryHits(table);
 };
 
-export const toEsqlQueryHits = (table: EsqlTable): EsqlQueryHits => {
+export const toEsqlQueryHits = (table: EsqlTable | EsqlQueryResponse): EsqlQueryHits => {
   const hits: EsqlHit[] = [];
   const rows: EsqlDocument[] = [];
   for (const row of table.values) {
@@ -101,7 +110,7 @@ export const toEsqlQueryHits = (table: EsqlTable): EsqlQueryHits => {
 };
 
 export const toGroupedEsqlQueryHits = (
-  table: EsqlTable,
+  table: EsqlTable | EsqlQueryResponse,
   alertIdFields: string[]
 ): EsqlQueryHits => {
   const duplicateAlertIds: Set<string> = new Set<string>();

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../../../common', () => {
 
 const logger = loggingSystemMock.create().get();
 const mockRuleResultService = publicRuleResultServiceMock.create();
+const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
 
 describe('fetchEsqlQuery', () => {
   afterAll(() => {
@@ -64,9 +65,7 @@ describe('fetchEsqlQuery', () => {
 
   describe('fetch', () => {
     it('should throw a user error when the error is a verification_exception error', async () => {
-      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-
-      scopedClusterClient.asCurrentUser.transport.request.mockRejectedValueOnce(
+      scopedClusterClient.asCurrentUser.esql.query.mockRejectedValueOnce(
         new Error(
           'verification_exception: Found 1 problem line 1:23: Unknown column [user_agent.original]'
         )
@@ -185,8 +184,7 @@ describe('fetchEsqlQuery', () => {
   });
 
   it('should bubble up warnings if there are duplicate alerts', async () => {
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({
+    scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce({
       columns: [],
       values: [],
     });

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
@@ -17,7 +17,7 @@ import { ecsFieldMap, alertFieldMap } from '@kbn/alerts-as-data-utils';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
-import type { EsqlTable } from '../../../../common';
+import type { EsqlQueryResponse } from '@elastic/elasticsearch/lib/api/types';
 import { getEsqlQueryHits } from '../../../../common';
 import type { OnlyEsqlQueryRuleParams } from '../types';
 
@@ -52,13 +52,9 @@ export async function fetchEsqlQuery({
 
   logger.debug(() => `ES|QL query rule (${ruleId}) query: ${JSON.stringify(query)}`);
 
-  let response: EsqlTable;
+  let response: EsqlQueryResponse;
   try {
-    response = await esClient.transport.request<EsqlTable>({
-      method: 'POST',
-      path: '/_query',
-      body: query,
-    });
+    response = await esClient.esql.query(query);
   } catch (e) {
     if (e.message?.includes('verification_exception')) {
       throw createTaskRunError(e, TaskErrorSource.USER);
@@ -102,7 +98,7 @@ export const getEsqlQuery = (
   dateStart: string,
   dateEnd: string
 ) => {
-  const rangeFilter: unknown[] = [
+  const rangeFilter = [
     {
       range: {
         [params.timeField]: {
@@ -125,7 +121,7 @@ export const getEsqlQuery = (
   return query;
 };
 
-export const getSourceFields = (results: EsqlTable) => {
+export const getSourceFields = (results: EsqlQueryResponse) => {
   const resultFields = results.columns.map((c) => ({
     label: c.name,
     searchPath: c.name,

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/rule_type.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/rule_type.test.ts
@@ -821,9 +821,7 @@ describe('ruleType', () => {
         ],
         values: [],
       };
-      ruleServices.scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce(
-        searchResult
-      );
+      ruleServices.scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce(searchResult);
 
       await invokeExecutor({ params, ruleServices });
       expect(ruleServices.alertsClient.report).not.toHaveBeenCalled();
@@ -843,9 +841,7 @@ describe('ruleType', () => {
           ['timestamp', 'message'],
         ],
       };
-      ruleServices.scopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce(
-        searchResult
-      );
+      ruleServices.scopedClusterClient.asCurrentUser.esql.query.mockResolvedValueOnce(searchResult);
 
       await invokeExecutor({ params, ruleServices });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)](https://github.com/elastic/kibana/pull/270014)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lu(cia)","email":"lucia.petracca@elastic.co"},"sourceCommit":{"committedDate":"2026-06-04T10:43:30Z","message":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)\n\n## Summary\n\n\nResolves: https://github.com/elastic/kibana/issues/236361\n\nThis PR changes the rule executor logic for the \"ESQL Query rule type\"\nto use the elasticsearch query api.\n\n### Changes\n- Changed `esClient.transport.request` call to `esClient.esql.query` and\ncorresponding util function types to handle response","sha":"69e3565271359c2abf4876ebb55560aab1741720","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:Alerting/RuleTypes","backport:all-open","v9.5.0"],"title":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution","number":270014,"url":"https://github.com/elastic/kibana/pull/270014","mergeCommit":{"message":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)\n\n## Summary\n\n\nResolves: https://github.com/elastic/kibana/issues/236361\n\nThis PR changes the rule executor logic for the \"ESQL Query rule type\"\nto use the elasticsearch query api.\n\n### Changes\n- Changed `esClient.transport.request` call to `esClient.esql.query` and\ncorresponding util function types to handle response","sha":"69e3565271359c2abf4876ebb55560aab1741720"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270014","number":270014,"mergeCommit":{"message":"[Response Ops][Alerting] feat: use esClient query method for esql query rule execution (#270014)\n\n## Summary\n\n\nResolves: https://github.com/elastic/kibana/issues/236361\n\nThis PR changes the rule executor logic for the \"ESQL Query rule type\"\nto use the elasticsearch query api.\n\n### Changes\n- Changed `esClient.transport.request` call to `esClient.esql.query` and\ncorresponding util function types to handle response","sha":"69e3565271359c2abf4876ebb55560aab1741720"}},{"url":"https://github.com/elastic/kibana/pull/272667","number":272667,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->