### PR TITLE
[Synthetics] Migrate add_monitor & synthetics_enablement API tests to Scout

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/add_monitor_private_location.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/add_monitor_private_location.spec.ts
@@ -16,7 +16,7 @@ import {
   SYNTHETICS_MONITOR_SO_TYPES,
 } from '../fixtures';
 import type { ScoutPrivateLocation } from '../services/synthetics_private_location_api_service';
-import { deleteMonitors } from '../fixtures/monitors';
+import { deleteMonitors, omitMonitorKeys, parseMonitorResponse } from '../fixtures/monitors';
 import { getPackagePolicyForMonitor } from '../fixtures/fleet';
 import { httpMonitorFixture } from '../fixtures/data/http_monitor';
 import { browserMonitorFixture } from '../fixtures/data/browser_monitor';
@@ -25,6 +25,7 @@ interface ServiceLocation {
   id: string;
   isInvalid?: boolean;
   isServiceManaged?: boolean;
+  spaces?: string[];
 }
 
 /**
@@ -75,6 +76,11 @@ apiTest.describe('PrivateLocationAddMonitor', { tag: ['@local-stateful-classic']
     const added = locations.find((location) => location.id === privateLocation.id);
     expect(added).toBeDefined();
     expect(added?.isInvalid).toBe(false);
+    // The location was created in both the default space and the test space; the
+    // service-locations response reflects both (FTR asserted the exact
+    // `spaces: ['default', SPACE_ID]` membership on the listed location).
+    expect(added?.spaces).toContain('default');
+    expect(added?.spaces).toContain(spaceId);
     // A service-managed (public) location is still listed alongside private ones.
     expect(locations.some((location) => location.isServiceManaged)).toBe(true);
   });
@@ -132,9 +138,29 @@ apiTest.describe('PrivateLocationAddMonitor', { tag: ['@local-stateful-classic']
       responseType: 'json',
     });
     expect(res).toHaveStatusCode(200);
-    const created = res.body as { id: string; namespace: string; spaces: string[] };
+    const created = res.body as {
+      id: string;
+      namespace: string;
+      spaces: string[];
+      created_at: string;
+      updated_at: string;
+    };
     expect(created.namespace).toBe(formatKibanaNamespace(spaceId));
     expect(created.spaces).toStrictEqual([spaceId]);
+
+    // Server-generated timestamps are present and parseable (FTR asserted both).
+    expect(Number.isNaN(Date.parse(created.created_at))).toBe(false);
+    expect(Number.isNaN(Date.parse(created.updated_at))).toBe(false);
+
+    // Full body parity: the created monitor round-trips to the submitted config
+    // with the Kibana-space namespace applied and scoped to the test space.
+    expect(parseMonitorResponse(res.body as Record<string, unknown>)).toStrictEqual(
+      omitMonitorKeys({
+        ...monitor,
+        namespace: formatKibanaNamespace(spaceId),
+        spaces: [spaceId],
+      })
+    );
 
     // The Fleet package policy is generated with the current spaceless id
     // (`${monitorId}-${locationId}`) and named `${monitorName}-${locationLabel}`.

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/synthetics_enablement.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/synthetics_enablement.spec.ts
@@ -278,6 +278,44 @@ apiTest.describe(
       );
     });
 
+    // A user with the full synthetics-writer ES privileges plus `uptime: all`
+    // but WITHOUT any api-key management cluster privilege can still *enable*
+    // synthetics, reporting `canManageApiKeys: false`. Ported from the FTR
+    // `returns response for an admin with privilege` case (which used a bespoke
+    // ES role without `manage_*`). The created key's privileges are asserted via
+    // the cross-target-safe `expectSyntheticsWriterPrivileges` helper rather than
+    // an exact `role_descriptors` match, consistent with the rest of this suite.
+    apiTest(
+      '[PUT] enables synthetics for a writer user without api-key management privileges',
+      async ({ apiClient, samlAuth, config }) => {
+        // `canEnable` requires the user to hold the synthetics-writer cluster
+        // privileges for the *current* target. Mirror `getServiceApiKeyPrivileges`:
+        // `read_ilm` is required on stateful but rejected by ES on serverless.
+        const writerCluster = config.serverless
+          ? COMMON_SYNTHETICS_WRITER_CLUSTER_PRIVS
+          : [...COMMON_SYNTHETICS_WRITER_CLUSTER_PRIVS, 'read_ilm'];
+        const { cookieHeader } = await samlAuth.asInteractiveUser({
+          elasticsearch: {
+            cluster: writerCluster,
+            indices: SYNTHETICS_SERVICE_WRITER_INDICES,
+          },
+          kibana: [{ base: [], feature: { uptime: ['all'] }, spaces: ['*'] }],
+        });
+        const res = await putEnablement(apiClient, { ...KIBANA_HEADERS, ...cookieHeader });
+        expect(res).toHaveStatusCode(200);
+        expect(res.body).toMatchObject({
+          areApiKeysEnabled: true,
+          canManageApiKeys: false,
+          canEnable: true,
+          isEnabled: true,
+          isValidApiKey: true,
+        });
+        const validApiKeys = await getApiKeys(apiClient);
+        expect(validApiKeys).toHaveLength(1);
+        expectSyntheticsWriterPrivileges(validApiKeys[0]);
+      }
+    );
+
     apiTest(
       '[PUT] auto re-enables the api key when the existing key has invalid permissions',
       async ({ apiClient, esClient, kbnClient }) => {


### PR DESCRIPTION
## Summary

**Stacked on #272696.** Completes the FTR→Scout migration of the synthetics `api_integration` suite for the `add_monitor` and `synthetics_enablement` specs.

- Augment `add_monitor_private_location.spec.ts`: service-locations space-membership assertion + create-in-space body parity & timestamp checks (FTR `add a test private location` / `handles spaces`).
- Augment `synthetics_enablement.spec.ts`: the writer-without-api-key-management path (`canManageApiKeys: false`, `canEnable: true`) — the one behavioural path the Scout spec did not already cover.
- Delete `add_monitor.ts` (covered by `add_monitor_permissions.spec.ts`) and `synthetics_enablement.ts` (covered by `synthetics_enablement.spec.ts`); drop both from `index.ts`.
- Move the shared `omitMonitorKeys`/`keyToOmitList` helpers out of the removed `add_monitor.ts` into `helper/monitor_keys.ts` so `sync_global_params*` and `add_monitor_private_location` keep compiling.

`add_monitor_private_location.ts` is **intentionally retained**: its `handles spaces` `comparePolicies` assertion for UI monitors is blocked by #258046 (same blocker as the skipped `create_monitor_private_location.spec.ts` / `sync_global_params*`).

> This PR is stacked on #272696 and currently includes that PR's commit too. Once #272696 merges it will be rebased onto `main` and reduce to the single migration commit.

## Test plan

- [ ] CI green (Scout API tests: synthetics)
- [ ] `add_monitor_private_location.spec.ts` and `synthetics_enablement.spec.ts` pass on `@local-stateful-classic` and `@local-serverless-observability_complete`
