### PR TITLE
Vector DB homepage small updates

### DIFF
--- a/x-pack/platform/packages/shared/kbn-shared-components/src/cloud_links/cloud_links.tsx
+++ b/x-pack/platform/packages/shared/kbn-shared-components/src/cloud_links/cloud_links.tsx
@@ -7,14 +7,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiLink,
-  EuiLoadingSpinner,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import { CloudLinksPillStyle } from './cloud_links_styles';
@@ -31,7 +24,6 @@ interface CloudLinksProps {
 }
 
 export const CloudLinks = ({ cloud, CloudBaseOnly = false }: CloudLinksProps) => {
-  const euiThemeContext = useEuiTheme();
   const [billingUrl, setBillingUrl] = useState<string>('');
   const [isLoadingPrivilegedUrls, setIsLoadingPrivilegedUrls] = useState(true);
   useEffect(() => {
@@ -91,7 +83,7 @@ export const CloudLinks = ({ cloud, CloudBaseOnly = false }: CloudLinksProps) =>
   }
 
   return (
-    <EuiFlexGroup gutterSize="m" alignItems="center" css={CloudLinksPillStyle(euiThemeContext)}>
+    <EuiFlexGroup gutterSize="m" alignItems="center" css={CloudLinksPillStyle}>
       <EuiFlexItem grow={false}>
         <EuiLink
           href={cloud.baseUrl}

--- a/x-pack/platform/packages/shared/kbn-shared-components/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-shared-components/tsconfig.json
@@ -5,7 +5,8 @@
     "types": [
       "jest",
       "node",
-      "react"
+      "react",
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/search_homepage.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/search_homepage.tsx
@@ -6,15 +6,7 @@
  */
 
 import React, { useEffect, useMemo } from 'react';
-import { css } from '@emotion/react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiShowFor,
-  EuiTitle,
-  type UseEuiTheme,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiShowFor, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { KibanaVersionBadge } from '@kbn/search-shared-ui';
@@ -26,11 +18,7 @@ import { ConnectToElasticsearch } from './connect_to_elasticsearch';
 import { SearchHomepageBody } from './search_homepage_body';
 import { LicenseBadge } from './license_badge';
 import { docLinks } from '../../../common/doc_links';
-
-const VerticalSeparatorStyle = ({ euiTheme }: UseEuiTheme) => css`
-  border-left: ${euiTheme.border.thin};
-  height: ${euiTheme.size.l};
-`;
+import { verticalSeparatorStyle } from './search_homepage_styles';
 
 export const SearchHomepagePage = () => {
   const {
@@ -94,7 +82,7 @@ export const SearchHomepagePage = () => {
               </EuiFlexItem>
               <EuiShowFor sizes={['m', 'l', 'xl']}>
                 <EuiFlexItem grow={false}>
-                  <span css={VerticalSeparatorStyle} />
+                  <span css={verticalSeparatorStyle} />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <CloudLinks cloud={cloud} />

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/search_homepage_styles.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/search_homepage_styles.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
-export const VECTORDB_APP_ID = 'vectordb';
-export const TUTORIALS_DEEP_LINK_ID = 'tutorials';
-export const DEPLOYMENT_STATS_PATH = '/internal/serverless_vectordb/deployment_stats';
+import { type UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const verticalSeparatorStyle = ({ euiTheme }: UseEuiTheme) => css`
+  border-left: ${euiTheme.border.thin};
+  height: ${euiTheme.size.l};
+`;

--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/connection_details/endpoint_url.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/connection_details/endpoint_url.tsx
@@ -71,6 +71,7 @@ export const EndpointUrl = ({
                   aria-label={i18n.translate('vectordbOnboarding.pathSelection.copyUrlAriaLabel', {
                     defaultMessage: 'Copy Elasticsearch URL',
                   })}
+                  data-test-subj="vectordbConnectToProjectCopyUrl"
                   data-telemetry-id="vectordbOnboarding-connectToProject-copyUrl"
                 />
               </EuiToolTip>

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/documentation_quick_links.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/documentation_quick_links.tsx
@@ -61,17 +61,17 @@ export const DocumentationQuickLinks = () => {
   ];
 
   return (
-    <div>
+    <>
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiTitle size="xxxs">
-            <h4>
+            <h2>
               <EuiTextColor color="subdued">
                 {i18n.translate('xpack.serverlessVectordb.home.docs.heading', {
                   defaultMessage: 'Documentation quick links',
                 })}
               </EuiTextColor>
-            </h4>
+            </h2>
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -80,7 +80,6 @@ export const DocumentationQuickLinks = () => {
               href={docLinks.links.enterpriseSearch.knnSearch}
               target="_blank"
               external
-              rel="noopener noreferrer"
               data-test-subj="viewDocumentationLink"
               data-telemetry-id="serverlessVectordb-home-viewDocumentation"
             >
@@ -104,6 +103,6 @@ export const DocumentationQuickLinks = () => {
           </EuiFlexItem>
         ))}
       </EuiFlexGroup>
-    </div>
+    </>
   );
 };

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page.tsx
@@ -18,10 +18,13 @@ import {
   EuiSpacer,
   EuiStat,
   EuiText,
+  EuiTextColor,
+  EuiTitle,
   type UseEuiTheme,
 } from '@elastic/eui';
 import { TrialUsageBadge, CloudLinks } from '@kbn/shared-components';
 import { ConnectToProject, useOnboardingCredentials } from '@kbn/vectordb-onboarding';
+import { i18n } from '@kbn/i18n';
 import { formatBytes, formatNumber, useDeploymentStats } from '../hooks/use_deployment_stats';
 import { HomePageBanner } from './home_page_banner';
 import { DocumentationQuickLinks } from './documentation_quick_links';
@@ -45,8 +48,8 @@ const StatTile = ({ label, value, isLoading }: StatTileProps) => (
       title={isLoading ? <EuiLoadingSpinner size="m" /> : value}
       description={
         <>
-          <EuiText size="s" color="subdued">
-            <h5>{label}</h5>
+          <EuiText size="xs" color="subdued">
+            <strong>{label}</strong>
           </EuiText>
           <EuiSpacer size="s" />
         </>
@@ -139,6 +142,16 @@ export const HomePage = () => {
           </EuiFlexItem>
           <EuiSpacer size="s" />
           <EuiFlexItem>
+            <EuiTitle size="xxxs">
+              <h2>
+                <EuiTextColor color="subdued">
+                  {i18n.translate('xpack.serverlessVectordb.home.stats.heading', {
+                    defaultMessage: 'Your vector database overview',
+                  })}
+                </EuiTextColor>
+              </h2>
+            </EuiTitle>
+            <EuiSpacer size="s" />
             <EuiFlexGrid columns={3} gutterSize="m">
               {statTiles.map(({ key, label, value }) => (
                 <StatTile key={key} label={label} value={value} isLoading={isLoading} />

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page_banner.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page_banner.tsx
@@ -21,6 +21,7 @@ import { useKibana } from '../hooks/use_kibana';
 import { useLocalStorage } from '../hooks/use_local_storage';
 import searchRocketIcon from './assets/search-rocket.svg';
 import { BANNER_DISMISSED_KEY, HOME_PAGE_BANNER_COPY } from '../constants';
+import { bannerCallOutStyle, bannerButtonFlexItemStyle } from './home_page_banner_styles';
 
 interface HomePageBannerProps {
   hasData: boolean;
@@ -63,11 +64,7 @@ export const HomePageBanner = ({ hasData, isLoading }: HomePageBannerProps) => {
       <EuiSpacer size="xxl" />
       <EuiCallOut
         announceOnMount={false}
-        css={({ euiTheme }) => ({
-          backgroundColor: `${euiTheme.colors.backgroundBasePlain}`,
-          border: `${euiTheme.border.thin}`,
-          borderRadius: `${euiTheme.border.radius.medium}`,
-        })}
+        css={bannerCallOutStyle}
         onDismiss={hasData ? handleDismiss : undefined}
         data-test-subj="homePageBanner"
       >
@@ -76,19 +73,18 @@ export const HomePageBanner = ({ hasData, isLoading }: HomePageBannerProps) => {
             <EuiImage src={searchRocketIcon} alt="" size="original" />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiTitle size={'s'}>
+            <EuiTitle size="s">
               <h3>{title}</h3>
             </EuiTitle>
             <EuiText size="s" color="subdued">
               <p>{description}</p>
             </EuiText>
           </EuiFlexItem>
-          <EuiFlexItem grow={false} css={({ euiTheme }) => ({ marginRight: euiTheme.size.l })}>
+          <EuiFlexItem grow={false} css={bannerButtonFlexItemStyle}>
             {hasData ? (
               <EuiButton
                 href={docLinks.links.enterpriseSearch.elasticInferenceServiceSupportedModels}
                 target="_blank"
-                rel="noopener noreferrer"
                 data-test-subj="homePageBannerViewSupportedModelsBtn"
                 data-telemetry-id="serverlessVectordb-home-banner-viewSupportedModels-btn"
               >

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page_banner_styles.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/home_page_banner_styles.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseEuiTheme } from '@elastic/eui';
+
+export const bannerCallOutStyle = ({ euiTheme }: UseEuiTheme) => ({
+  backgroundColor: euiTheme.colors.backgroundBasePlain,
+  border: euiTheme.border.thin,
+  borderRadius: euiTheme.border.radius.medium,
+});
+
+export const bannerButtonFlexItemStyle = ({ euiTheme }: UseEuiTheme) => ({
+  marginRight: euiTheme.size.l,
+});

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/quick_link_panel.tsx
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/quick_link_panel.tsx
@@ -13,10 +13,9 @@ import {
   EuiScreenReaderOnly,
   EuiText,
   EuiTitle,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { quickLinkInnerStyle, quickLinkBoldLabelStyle } from './quick_link_panel_styles';
 
 interface QuickLinkPanelProps {
   title: string;
@@ -26,8 +25,6 @@ interface QuickLinkPanelProps {
 }
 
 export const QuickLinkPanel = ({ title, href, telemetryId, testSubj }: QuickLinkPanelProps) => {
-  const { euiTheme } = useEuiTheme();
-
   return (
     <EuiCard
       title={
@@ -48,20 +45,11 @@ export const QuickLinkPanel = ({ title, href, telemetryId, testSubj }: QuickLink
         alignItems="flexStart"
         direction="column"
         responsive={false}
-        css={css`
-          height: 100%;
-          padding: 0 ${euiTheme.size.s} ${euiTheme.size.s} ${euiTheme.size.s};
-        `}
+        css={quickLinkInnerStyle}
       >
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiIcon size="m" type="documentation" aria-hidden={true} />
-          <EuiText
-            size="xs"
-            color="subdued"
-            css={css`
-              font-weight: ${euiTheme.font.weight.bold};
-            `}
-          >
+          <EuiText size="xs" color="subdued" css={quickLinkBoldLabelStyle}>
             <FormattedMessage
               id="xpack.serverlessVectordb.quickLinkPanel.topicLabel"
               defaultMessage="Topic"
@@ -69,7 +57,7 @@ export const QuickLinkPanel = ({ title, href, telemetryId, testSubj }: QuickLink
           </EuiText>
         </EuiFlexGroup>
         <EuiTitle size="xxs">
-          <span aria-hidden="true">{title}</span>
+          <h3>{title}</h3>
         </EuiTitle>
       </EuiFlexGroup>
     </EuiCard>

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/quick_link_panel_styles.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/home/quick_link_panel_styles.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const quickLinkInnerStyle = ({ euiTheme }: UseEuiTheme) => css`
+  height: 100%;
+  padding: 0 ${euiTheme.size.s} ${euiTheme.size.s} ${euiTheme.size.s};
+`;
+
+export const quickLinkBoldLabelStyle = ({ euiTheme }: UseEuiTheme) => css`
+  font-weight: ${euiTheme.font.weight.bold};
+`;

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/hooks/use_deployment_stats.ts
@@ -7,8 +7,7 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useKibana } from './use_kibana';
-
-const DEPLOYMENT_STATS_PATH = '/internal/serverless_vectordb/deployment_stats';
+import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
 
 export interface DeploymentStats {
   indicesCount: number | null;

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/routes/deployment_stats.ts
@@ -7,6 +7,7 @@
 
 import type { IRouter, Logger } from '@kbn/core/server';
 import { AuthzDisabled } from '@kbn/core-security-server';
+import { DEPLOYMENT_STATS_PATH } from '../../common/constants';
 
 interface MappingProperty {
   type?: string;
@@ -36,7 +37,7 @@ export const containsVectorField = (properties?: Record<string, MappingProperty>
 export const registerDeploymentStatsRoute = (router: IRouter, logger: Logger) => {
   router.get(
     {
-      path: '/internal/serverless_vectordb/deployment_stats',
+      path: DEPLOYMENT_STATS_PATH,
       validate: false,
       security: {
         authz: AuthzDisabled.delegateToESClient,


### PR DESCRIPTION
## Summary

Small updates to the Vector DB and Search homepages to address feedback in https://github.com/elastic/kibana/pull/272634:

- Extract inline Emotion styles to dedicated `*_styles.ts` files for `home_page_banner`, `quick_link_panel`, `search_homepage`, and `cloud_links` components
- Replace `div` wrapper with React fragment in `DocumentationQuickLinks` and fix heading hierarchy (`h4` → `h2`)
- Remove redundant `rel="noopener noreferrer"` from external EuiLink (EUI handles this internally)
- Add `data-test-subj` attribute to the copy URL button in `endpoint_url`
- Extract `DEPLOYMENT_STATS_PATH` to a shared constant
- Fix unused `useEuiTheme` import in `cloud_links`
- Add `@kbn/ambient-ui-types` to `kbn-shared-components` tsconfig


Made with [Cursor](https://cursor.com)