### PR TITLE
[Home App] Fix flaky test

### DIFF
--- a/src/platform/test/functional/page_objects/home_page.ts
+++ b/src/platform/test/functional/page_objects/home_page.ts
@@ -70,12 +70,15 @@ export class HomePageObject extends FtrService {
     // hence we setup a delay so the interstitial has enough time to fade in
     const animSpeedExtraSlow = 500;
     await new Promise((resolve) => setTimeout(resolve, animSpeedExtraSlow));
-    return this.retry.try(async () => {
-      return await this.testSubjects.isDisplayed(
-        'homeWelcomeInterstitial',
-        animSpeedExtraSlow * 16
-      );
-    });
+    // Use waitForWithTimeout (retries on false) rather than retry.try (only retries on thrown errors).
+    // In slower environments (e.g. FIPS builds) isDisplayed can return false before the interstitial
+    // finishes fading in, and retry.try would return that false result immediately without retrying.
+    await this.retry.waitForWithTimeout(
+      'homeWelcomeInterstitial to be displayed',
+      animSpeedExtraSlow * 30, // 15s — generous for slow FIPS builds
+      async () => await this.testSubjects.isDisplayed('homeWelcomeInterstitial', animSpeedExtraSlow)
+    );
+    return true;
   }
 
   async isGuidedOnboardingLandingDisplayed() {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/229498

**Bug**: `retry.try` uses `retryForSuccess` with `accept = returnTrue` (the default), which means it accepts the *first result* regardless of whether it's `true` or `false`. It only retries when the block *throws*. Since `testSubjects.isDisplayed()` returns `false` (doesn't throw) when the element isn't visible yet, `retry.try` returned `false` immediately — no retries ever happened.

In FIPS mode the page loads slower, so the welcome interstitial was still covered by a loading overlay or hadn't faded in yet when the check ran. The single 8-second timeout on `isDisplayed` to find the element in the DOM helped, but once found the element wasn't visible yet and false was returned with no retry.

**Fix**
- Retries `isDisplayed` for up to 15s (via `waitForWithTimeout`, which retries on `false`).
- Returns `true` once the interstitial is visible.
- Throws a descriptive `timed out waiting for homeWelcomeInterstitial to be displayed` error if it never appears — more informative than the old `expected false to equal true`.
