### PR TITLE
[ResponseOps][Connectors] add HTML escaping for messageHTML email parameter

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/mustache_renderer.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/mustache_renderer.test.ts
@@ -154,6 +154,27 @@ describe('mustache_renderer', () => {
       expect(renderMustacheString(logger, '{{ul}}', variables, 'json')).toBe(variables.ul);
     });
 
+    it('handles escape:html with commonly escaped strings', () => {
+      expect(renderMustacheString(logger, '{{lt}}', variables, 'html')).toBe('&lt;');
+      expect(renderMustacheString(logger, '{{gt}}', variables, 'html')).toBe('&gt;');
+      expect(renderMustacheString(logger, '{{amp}}', variables, 'html')).toBe('&amp;');
+      expect(renderMustacheString(logger, '{{nl}}', variables, 'html')).toBe(variables.nl);
+      expect(renderMustacheString(logger, '{{dq}}', variables, 'html')).toBe('&quot;');
+      // backtick is also escaped by Mustache's built-in HTML escaper
+      expect(renderMustacheString(logger, '{{bt}}', variables, 'html')).toBe('&#x60;');
+      expect(renderMustacheString(logger, '{{bs}}', variables, 'html')).toBe(variables.bs);
+      expect(renderMustacheString(logger, '{{st}}', variables, 'html')).toBe(variables.st);
+      expect(renderMustacheString(logger, '{{ul}}', variables, 'html')).toBe(variables.ul);
+      expect(renderMustacheString(logger, '{{sq}}', { sq: "'" }, 'html')).toBe('&#39;');
+    });
+
+    it('handles triple escapes for html mode', () => {
+      expect(renderMustacheString(logger, '{{{lt}}}', variables, 'html')).toBe(variables.lt);
+      expect(renderMustacheString(logger, '{{{gt}}}', variables, 'html')).toBe(variables.gt);
+      expect(renderMustacheString(logger, '{{{amp}}}', variables, 'html')).toBe(variables.amp);
+      expect(renderMustacheString(logger, '{{{dq}}}', variables, 'html')).toBe(variables.dq);
+    });
+
     it('handles errors', () => {
       expect(renderMustacheString(logger, '{{a}', variables, 'none')).toMatchInlineSnapshot(
         `"error rendering mustache template \\"{{a}\\": Unclosed tag at 4"`

--- a/x-pack/platform/plugins/shared/actions/server/lib/mustache_renderer.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/mustache_renderer.ts
@@ -10,7 +10,11 @@ import { isString, isPlainObject, cloneDeepWith, merge } from 'lodash';
 import type { Logger } from '@kbn/core/server';
 import { getMustacheLambdas } from './mustache_lambdas';
 
-export type Escape = 'markdown' | 'slack' | 'json' | 'none';
+export type Escape = 'markdown' | 'slack' | 'json' | 'none' | 'html';
+
+// Capture Mustache's built-in HTML escape before any render calls can change it.
+// This is the default Mustache.escape: it escapes &, <, >, ", ', /, `, and =.
+const mustacheEscapeHtml = Mustache.escape;
 
 type Variables = Record<string, unknown>;
 
@@ -142,6 +146,7 @@ function getEscape(escape: Escape): (value: unknown) => string {
   if (escape === 'markdown') return escapeMarkdown;
   if (escape === 'slack') return escapeSlack;
   if (escape === 'json') return escapeJSON;
+  if (escape === 'html') return mustacheEscapeHtml;
   return escapeNone;
 }
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.ts
@@ -290,6 +290,10 @@ function renderParameterTemplates(
     ...renderMustacheObject(logger, params, variables),
     // message however, needs to escaped as markdown
     message: renderMustacheString(logger, params.message, variables, 'markdown'),
+    messageHTML:
+      params.messageHTML != null
+        ? renderMustacheString(logger, params.messageHTML, variables, 'html')
+        : null,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds an `'html'` escape mode to Kibana's Mustache renderer and applies it to the email connector's `messageHTML` parameter so that template variables are HTML-escaped before being injected into the HTML body.

Previously, `messageHTML` was rendered via `renderMustacheObject` with `'none'` escaping — meaning a variable like `{{rogue}}` with value `<script>alert(1)</script>` would be injected into the HTML body verbatim. This change ensures such values are safely escaped to `&lt;script&gt;alert(1)&lt;/script&gt;`.

### Changes

- **`mustache_renderer.ts`**: Adds `'html'` to the `Escape` type. Captures `Mustache.escape` at module load time (Mustache's built-in HTML escaper, which escapes `&`, `<`, `>`, `"`, `'`, `/`, `` ` ``, `=`) and wires it into `getEscape()` for the new mode. Uses the library's own implementation rather than reimplementing it.

- **`email/index.ts`**: Overrides `messageHTML` explicitly in `renderParameterTemplates` with `'html'` escaping, guarded for the `null` default, following the same pattern used for `message` with `'markdown'`.

- **`mustache_renderer.test.ts`**: Adds tests for the new `'html'` escape mode covering all HTML-significant characters and verifying that `{{{triple}}}` syntax bypasses escaping as expected.

## Testing

```bash
node scripts/jest x-pack/platform/plugins/shared/actions/server/lib/mustache_renderer.test.ts
node scripts/jest x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
```

Closes #272512

Made with [Cursor](https://cursor.com)