### PR TITLE
Increase max size of `terms.include` and `terms.exclude`

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/aggregations/aggs_types/bucket_aggs.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/aggregations/aggs_types/bucket_aggs.ts
@@ -116,8 +116,8 @@ const orderSchema = s.oneOf([
 const termsSchema = s.object({
   field: s.maybe(s.string()),
   collect_mode: s.maybe(s.string()),
-  exclude: s.maybe(s.oneOf([s.string(), s.arrayOf(s.string(), { maxSize: 100 })])),
-  include: s.maybe(s.oneOf([s.string(), s.arrayOf(s.string(), { maxSize: 100 })])),
+  exclude: s.maybe(s.oneOf([s.string(), s.arrayOf(s.string(), { maxSize: 10000 })])),
+  include: s.maybe(s.oneOf([s.string(), s.arrayOf(s.string(), { maxSize: 10000 })])),
   execution_hint: s.maybe(s.string()),
   missing: s.maybe(s.oneOf([s.number(), s.string(), s.boolean()])),
   min_doc_count: s.maybe(s.number({ min: 1 })),


### PR DESCRIPTION
## Summary

Found an issue while working with large number of Fleet objects. Sometimes we perform SO searches with >100 `terms.include` values. These queries end up erroring out due to the recent limits imposed here.

Bumping up to 10000 (standard max window size) but maybe it should be 65536 to the reflect [the ES limit](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-terms-query#field)?


<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->