### PR TITLE
[ES|QL] Small fix for empty lines with space

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/comment_to_esql/use_ghost_line_hint.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/comment_to_esql/use_ghost_line_hint.test.tsx
@@ -52,6 +52,11 @@ describe('getGhostHintKind', () => {
     expect(getGhostHintKind(model, 1)).toBeNull();
   });
 
+  it('returns null on a whitespace-only line so the hint does not clash with suggestions', () => {
+    const { model } = buildModel(['FROM logs', ' ']);
+    expect(getGhostHintKind(model, 2)).toBeNull();
+  });
+
   it('returns null in an entirely empty editor (so it does not clash with the placeholder)', () => {
     const { model } = buildModel(['']);
     expect(getGhostHintKind(model, 1)).toBeNull();

--- a/src/platform/packages/private/kbn-esql-editor/src/comment_to_esql/use_ghost_line_hint.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/comment_to_esql/use_ghost_line_hint.ts
@@ -38,7 +38,7 @@ export const getGhostHintKind = (
     return 'comment';
   }
 
-  if (trimmed === '' && model.getValueLength() > 0) {
+  if (model.getLineContent(lineNumber) === '' && model.getValueLength() > 0) {
     return 'empty';
   }
 


### PR DESCRIPTION
## Summary

When the user is in a new line and presses space, the cursor is moved after the ghost hint and looks a bit weird

<img width="1812" height="912" alt="image" src="https://github.com/user-attachments/assets/9e0a629c-56e9-4a5c-9769-0316f643ed9b" />

This PR displays the ghost text in completely empty lines

<img width="654" height="393" alt="image" src="https://github.com/user-attachments/assets/7fe74ad6-56bc-4f5e-8ebc-c6bfa6f7d0ac" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




