### PR TITLE
[Ingest Pipelines] Fix bug with multiple selection

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
@@ -244,6 +244,7 @@ export const PipelineTable: FunctionComponent<Props> = ({
 
   const tableProps: EuiInMemoryTableProps<Pipeline> = {
     'data-test-subj': 'pipelinesTable',
+    itemId: 'name',
     sorting,
     selection: {
       onSelectionChange: setSelection,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/268351

## Summary

eui uses `itemId` to determine each rows identity for verifying which rows are checked. Without it, eui cannot match the internal selection set back to specific rows.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->