### PR TITLE
[Obs][Scout] Migrate observability_functional alerts mutations + overview to Scout

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
@@ -229,4 +229,53 @@ export class AlertsTablePage {
     const text = (await statTitle.innerText()).trim();
     return Number.parseInt(text, 10);
   }
+
+  // Bulk actions
+  /**
+   * Toggles the table header "select all" checkbox and waits for the bulk
+   * actions button to appear.
+   */
+  async selectAllVisibleAlerts() {
+    await this.page.testSubj.click('bulk-actions-header');
+    await this.page.testSubj.locator('selectedShowBulkActionsButton').waitFor({ state: 'visible' });
+  }
+
+  async bulkMuteSelected() {
+    await this.page.testSubj.click('selectedShowBulkActionsButton');
+    await this.page.testSubj.click('bulk-mute');
+  }
+
+  async bulkUnmuteSelected() {
+    await this.page.testSubj.click('selectedShowBulkActionsButton');
+    await this.page.testSubj.click('bulk-unmute');
+  }
+
+  /**
+   * Reads the title of the most recent toast and dismisses all visible toasts.
+   * `waitFor` tolerates multiple matches (waits for the first), and
+   * `allInnerTexts` returns every title so we can pick the most recently
+   * rendered one without a positional locator method.
+   */
+  async readAndDismissLatestToastTitle(): Promise<string> {
+    const titles = this.page.testSubj.locator('euiToastHeader__title');
+    await titles.waitFor({ state: 'visible' });
+    const allTitles = await titles.allInnerTexts();
+    for (const button of await this.page.testSubj.locator('toastCloseButton').all()) {
+      await button.click().catch(() => {});
+    }
+    return (allTitles[allTitles.length - 1] ?? '').trim();
+  }
+
+  /**
+   * Re-runs the query bar with `query` and returns the resulting total alert
+   * count. Used to poll for server-side updates that the table only reflects on
+   * a fresh search (e.g. the muted field, written via a fire-and-forget
+   * `updateByQuery`).
+   */
+  async countForQuery(query: string): Promise<number> {
+    await this.clearQueryBar();
+    await this.submitQuery(query);
+    await this.waitForTableToLoad();
+    return this.getRowCount();
+  }
 }

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
@@ -115,8 +115,15 @@ export class AlertsTablePage {
    * data grid's `aria-rowcount` (set by EuiDataGrid to the full alert count)
    * rather than counting rendered cells, which would undercount because the grid
    * virtualizes rows outside the viewport.
+   *
+   * When a query matches no alerts the page renders the empty state instead of
+   * the data grid, so short-circuit to 0 rather than waiting for a grid body
+   * that will never appear (which would otherwise time out).
    */
   async getRowCount(): Promise<number> {
+    if (await this.noDataState.isVisible()) {
+      return 0;
+    }
     const grid = this.page.locator(
       '[data-test-subj="alertsTableIsLoaded"] [data-test-subj="euiDataGridBody"]'
     );

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/index.ts
@@ -12,6 +12,7 @@ import { RuleDetailsPage } from './rule_details_page';
 import { AlertPage } from './alert_page';
 import { AlertsTablePage } from './alerts_table';
 import { AlertControls } from './alert_controls';
+import { OverviewPage } from './overview_page';
 
 export interface TriggersActionsPageObjects extends ObltPageObjects {
   rulesPage: RulesPage;
@@ -19,6 +20,7 @@ export interface TriggersActionsPageObjects extends ObltPageObjects {
   alertPage: AlertPage;
   alertsTablePage: AlertsTablePage;
   alertControls: AlertControls;
+  overviewPage: OverviewPage;
 }
 
 export function extendPageObjects(
@@ -32,5 +34,6 @@ export function extendPageObjects(
     alertPage: createLazyPageObject(AlertPage, page),
     alertsTablePage: createLazyPageObject(AlertsTablePage, page),
     alertControls: createLazyPageObject(AlertControls, page),
+    overviewPage: createLazyPageObject(OverviewPage, page),
   };
 }

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/overview_page.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/overview_page.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiDataGridWrapper, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import { ALERTS_TABLE_TEST_SUBJECTS as SUBJ } from '../constants';
+
+/**
+ * Time window that contains the generated Observability alerts (mirrors
+ * `DATE_WITH_DATA` from the FTR overview common service).
+ */
+const DATE_WITH_DATA = {
+  rangeFrom: '2021-10-18T13:36:22.109Z',
+  rangeTo: '2021-10-20T13:36:22.109Z',
+} as const;
+
+/**
+ * Time window a month before the generated alerts (mirrors `DATE_WITHOUT_DATA`).
+ * Note the overview "no data" prompt is driven by whether any Observability
+ * rules/indices exist, not by the selected range, so this is only used to mirror
+ * the FTR navigation.
+ */
+const DATE_WITHOUT_DATA = {
+  rangeFrom: '2021-09-18T13:36:22.109Z',
+  rangeTo: '2021-09-20T13:36:22.109Z',
+} as const;
+
+/**
+ * Drives the Observability overview page (`/app/observability/overview`).
+ *
+ * Ported from the FTR `observability.overview.common` service
+ * (x-pack/solutions/observability/test/functional/services/observability/overview/common.ts).
+ * Page objects only drive the UI and return state; assertions live in the specs.
+ */
+export class OverviewPage {
+  public readonly noDataPrompt: Locator;
+  public readonly addDataButton: Locator;
+  public readonly alertsSection: Locator;
+  public readonly alertsTable: Locator;
+  public readonly alertsDataGrid: EuiDataGridWrapper;
+
+  constructor(private readonly page: ScoutPage) {
+    this.noDataPrompt = this.page.testSubj.locator('obltOverviewNoDataPrompt');
+    this.addDataButton = this.page.testSubj.locator('o11yOverviewPageAddDataButton');
+    this.alertsSection = this.page.testSubj.locator('accordion-Alerts');
+    this.alertsTable = this.page.testSubj.locator(SUBJ.TABLE_LOADED);
+    this.alertsDataGrid = new EuiDataGridWrapper(this.page, SUBJ.TABLE_LOADED);
+  }
+
+  /** Navigates to the overview using the time window that contains alerts. */
+  async gotoWithAlerts() {
+    await this.page.gotoApp('observability/overview', { params: { ...DATE_WITH_DATA } });
+  }
+
+  /** Navigates to the overview using a time window before any alerts exist. */
+  async gotoWithoutAlerts() {
+    await this.page.gotoApp('observability/overview', { params: { ...DATE_WITHOUT_DATA } });
+  }
+
+  /** Waits for the alerts accordion (open by default) to render its table. */
+  async waitForAlertsSection() {
+    await this.alertsSection.waitFor({ state: 'visible' });
+    await this.alertsTable.scrollIntoViewIfNeeded();
+    await this.alertsTable.waitFor({ state: 'visible' });
+  }
+
+  /** Returns the number of alert rows rendered in the overview alerts table. */
+  async getAlertsRowCount(): Promise<number> {
+    return this.alertsDataGrid.getRowsCount();
+  }
+
+  /** Clicks the empty-state "Add data" CTA that links to onboarding. */
+  async clickAddData() {
+    await this.addDataButton.click();
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/mute_unmute.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/mute_unmute.spec.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+
+// Ported from the FTR `Mute and Unmute alerts` suite
+// (x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/mute_unmute.ts).
+//
+// A grouped `.es-query` rule is created and left to fire (>= 2 alert instances),
+// then the table's bulk mute/unmute actions are exercised. The FTR split this
+// into a sequence of dependent `it`s sharing one browser session; here they are
+// one journey with `test.step`s. The mute field is written server-side via a
+// fire-and-forget `updateByQuery` (alertsService `_updateMuteState`), so every
+// post-action assertion polls by re-running the query bar (the FTR used
+// `retry.try` for the same reason).
+const TEST_INDEX = 'mute-test-data';
+const STACK_ALERTS_INDEX = '.alerts-stack.alerts-default';
+const MIN_ALERTS = 2;
+const ASYNC_POLL = { timeout: 60_000, intervals: [3_000] } as const;
+
+async function countActiveAlerts(esClient: Client, ruleId: string): Promise<number> {
+  const response = await esClient.count({
+    index: STACK_ALERTS_INDEX,
+    ignore_unavailable: true,
+    query: {
+      bool: {
+        must: [
+          { term: { 'kibana.alert.rule.uuid': ruleId } },
+          { term: { 'kibana.alert.status': 'active' } },
+        ],
+      },
+    },
+  });
+  return response.count;
+}
+
+test.describe(
+  'Observability alerts - bulk mute / unmute',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    let ruleId: string;
+
+    test.beforeAll(async ({ esClient, apiServices, log }) => {
+      await apiServices.alerting.cleanup.deleteAllRules();
+
+      await esClient.indices.create({
+        index: TEST_INDEX,
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            host: { type: 'keyword' },
+            message: { type: 'text' },
+          },
+        },
+      });
+
+      const now = new Date().toISOString();
+      await esClient.bulk({
+        refresh: 'wait_for',
+        operations: [
+          { index: { _index: TEST_INDEX } },
+          { '@timestamp': now, host: 'host-a', message: 'test message 1' },
+          { index: { _index: TEST_INDEX } },
+          { '@timestamp': now, host: 'host-b', message: 'test message 2' },
+          { index: { _index: TEST_INDEX } },
+          { '@timestamp': now, host: 'host-a', message: 'test message 3' },
+          { index: { _index: TEST_INDEX } },
+          { '@timestamp': now, host: 'host-b', message: 'test message 4' },
+        ],
+      });
+
+      const { data } = await apiServices.alerting.rules.create({
+        name: 'Mute test rule',
+        consumer: 'logs',
+        ruleTypeId: '.es-query',
+        schedule: { interval: '1m' },
+        params: {
+          size: 100,
+          thresholdComparator: '>',
+          threshold: [0],
+          index: [TEST_INDEX],
+          timeField: '@timestamp',
+          esQuery: JSON.stringify({ query: { match_all: {} } }),
+          timeWindowSize: 5,
+          timeWindowUnit: 'm',
+          groupBy: 'top',
+          termSize: 10,
+          termField: 'host',
+        },
+        actions: [],
+      });
+      ruleId = data.id;
+      log.info(`Created mute test rule ${ruleId}`);
+
+      // Let the rule fire and produce the grouped alert instances.
+      await apiServices.alerting.waiting.waitForRuleStatus(ruleId, 'active', undefined, 120_000);
+      await expect
+        .poll(() => countActiveAlerts(esClient, ruleId), { timeout: 120_000, intervals: [3_000] })
+        .toBeGreaterThanOrEqual(MIN_ALERTS);
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
+    test.afterAll(async ({ esClient, apiServices }) => {
+      await apiServices.alerting.cleanup.deleteAllRules();
+      await esClient.indices.delete({ index: TEST_INDEX, ignore_unavailable: true });
+    });
+
+    test('bulk mutes and unmutes the rule alerts', async ({ pageObjects }) => {
+      const { alertsTablePage } = pageObjects;
+      const ruleQuery = `kibana.alert.rule.uuid: "${ruleId}"`;
+      let totalAlerts = 0;
+
+      await alertsTablePage.goto({ withoutFilter: true });
+      await alertsTablePage.submitQuery(ruleQuery);
+      await alertsTablePage.waitForTableToLoad();
+
+      await test.step('finds at least two alerts for the rule', async () => {
+        await expect.poll(() => alertsTablePage.getRowCount()).toBeGreaterThanOrEqual(MIN_ALERTS);
+        totalAlerts = await alertsTablePage.getRowCount();
+      });
+
+      await test.step('bulk mutes all selected alerts and shows a success toast', async () => {
+        await alertsTablePage.selectAllVisibleAlerts();
+        await alertsTablePage.bulkMuteSelected();
+        const toast = await alertsTablePage.readAndDismissLatestToastTitle();
+        expect(toast).toContain('Muted');
+        expect(toast).toContain('alert instance');
+        expect(toast).toContain('rule');
+      });
+
+      await test.step('reports every alert as muted', async () => {
+        await expect
+          .poll(
+            () => alertsTablePage.countForQuery(`${ruleQuery} AND kibana.alert.muted: true`),
+            ASYNC_POLL
+          )
+          .toBe(totalAlerts);
+        await expect
+          .poll(
+            () => alertsTablePage.countForQuery(`${ruleQuery} AND kibana.alert.muted: false`),
+            ASYNC_POLL
+          )
+          .toBe(0);
+      });
+
+      await test.step('bulk unmutes all selected alerts and shows a success toast', async () => {
+        await alertsTablePage.countForQuery(ruleQuery);
+        await alertsTablePage.selectAllVisibleAlerts();
+        await alertsTablePage.bulkUnmuteSelected();
+        const toast = await alertsTablePage.readAndDismissLatestToastTitle();
+        expect(toast).toContain('Unmuted');
+        expect(toast).toContain('alert instance');
+        expect(toast).toContain('rule');
+      });
+
+      await test.step('reports every alert as unmuted', async () => {
+        await expect
+          .poll(
+            () => alertsTablePage.countForQuery(`${ruleQuery} AND kibana.alert.muted: false`),
+            ASYNC_POLL
+          )
+          .toBe(totalAlerts);
+        await expect
+          .poll(
+            () => alertsTablePage.countForQuery(`${ruleQuery} AND kibana.alert.muted: true`),
+            ASYNC_POLL
+          )
+          .toBe(0);
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/mute_unmute.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/mute_unmute.spec.ts
@@ -23,7 +23,12 @@ import { test } from '../../fixtures';
 const TEST_INDEX = 'mute-test-data';
 const STACK_ALERTS_INDEX = '.alerts-stack.alerts-default';
 const MIN_ALERTS = 2;
-const ASYNC_POLL = { timeout: 60_000, intervals: [3_000] } as const;
+// Not `as const`: `expect.poll` expects `intervals?: number[]`, and `as const`
+// would widen it to a readonly tuple that isn't assignable.
+const ASYNC_POLL: { timeout: number; intervals: number[] } = {
+  timeout: 60_000,
+  intervals: [3_000],
+};
 
 async function countActiveAlerts(esClient: Client, ruleId: string): Promise<number> {
   const response = await esClient.count({

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/overview_alert_table.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/overview_alert_table.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { generateObservabilityAlerts } from '../../fixtures/alerts_data';
+
+// Ported from the FTR `Observability overview` suite
+// (x-pack/solutions/observability/test/observability_functional/apps/observability/pages/overview/alert_table.ts).
+//
+// The overview "no data" prompt and the alerts section are both driven by
+// whether any Observability rule exists (the `alert` data section calls
+// `/api/alerting/rules/_find` and treats a rule with an allowed consumer as
+// "has data"), not by the selected time range. So the "Without data" case
+// clears all rules and the "With data" case creates one rule before navigating.
+const ALERTS_FIRST_PAGE = 10;
+
+test.describe(
+  'Observability alerts - overview alert table',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeAll(async ({ esClient }) => {
+      await generateObservabilityAlerts(esClient);
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
+    test.afterAll(async ({ apiServices }) => {
+      await apiServices.alerting.cleanup.deleteAllRules();
+    });
+
+    test('navigates to onboarding from the no-data "Add data" CTA', async ({
+      apiServices,
+      page,
+      pageObjects,
+    }) => {
+      // No Observability rules => the overview reports no data and shows the CTA.
+      await apiServices.alerting.cleanup.deleteAllRules();
+
+      await pageObjects.overviewPage.gotoWithoutAlerts();
+      await expect(pageObjects.overviewPage.noDataPrompt).toBeVisible();
+
+      await pageObjects.overviewPage.clickAddData();
+      await expect.poll(() => page.url()).toContain('observabilityOnboarding');
+    });
+
+    test('renders the alerts section with alerts once a rule exists', async ({
+      apiServices,
+      pageObjects,
+    }) => {
+      // Any rule with an allowed consumer flips the overview to the "with data"
+      // layout that renders the alerts section.
+      await apiServices.alerting.rules.create({
+        name: 'Overview alerts section test',
+        consumer: 'logs',
+        ruleTypeId: '.es-query',
+        params: {
+          size: 100,
+          thresholdComparator: '>',
+          threshold: [-1],
+          index: ['alert-test-data'],
+          timeField: 'date',
+          esQuery: JSON.stringify({ query: { match_all: {} } }),
+          timeWindowSize: 20,
+          timeWindowUnit: 's',
+        },
+        schedule: { interval: '1m' },
+      });
+
+      await pageObjects.overviewPage.gotoWithAlerts();
+      await pageObjects.overviewPage.waitForAlertsSection();
+
+      await expect.poll(() => pageObjects.overviewPage.getAlertsRowCount()).toBe(ALERTS_FIRST_PAGE);
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/overview_alert_table.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/overview_alert_table.spec.ts
@@ -42,7 +42,17 @@ test.describe(
       pageObjects,
     }) => {
       // No Observability rules => the overview reports no data and shows the CTA.
+      // The overview's `hasData.alert` flag is driven by `/api/alerting/rules/_find`,
+      // so wait until no rules remain before navigating: `deleteAllRules` issues
+      // async deletes and a stale rule would keep the page in its "has data"
+      // layout, in which case the no-data prompt never renders.
       await apiServices.alerting.cleanup.deleteAllRules();
+      await expect
+        .poll(async () => (await apiServices.alerting.rules.find({ per_page: 1 })).data.total, {
+          timeout: 30_000,
+          intervals: [1_000],
+        })
+        .toBe(0);
 
       await pageObjects.overviewPage.gotoWithoutAlerts();
       await expect(pageObjects.overviewPage.noDataPrompt).toBeVisible();

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/rule_stats.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/alerts/rule_stats.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+
+// Ported from the FTR `Observability rules / Stat counters` suite
+// (x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/rule_stats.ts).
+//
+// Six `apm.anomaly` rules are created via the API; one is disabled and one is
+// muted, then the alerts page rule-stat widgets are asserted. Rules are cleared
+// before each run so the space-wide counts are deterministic regardless of the
+// order this spec runs in relative to the other alerts specs.
+const RULE_NAMES = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+const ANOMALY_RULE_PARAMS = {
+  windowSize: 30,
+  windowUnit: 'm',
+  anomalySeverityType: 'critical',
+  anomalyDetectorTypes: ['txLatency', 'txThroughput', 'txFailureRate'],
+  environment: 'ENVIRONMENT_ALL',
+};
+
+test.describe('Observability alerts - rule stats', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ apiServices, browserAuth }) => {
+    await apiServices.alerting.cleanup.deleteAllRules();
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    await apiServices.alerting.cleanup.deleteAllRules();
+  });
+
+  test('shows the expected rule, disabled, muted and error counts', async ({
+    apiServices,
+    pageObjects,
+  }) => {
+    const ids: string[] = [];
+    for (const name of RULE_NAMES) {
+      const { data } = await apiServices.alerting.rules.create({
+        name,
+        ruleTypeId: 'apm.anomaly',
+        consumer: 'alerts',
+        params: ANOMALY_RULE_PARAMS,
+        schedule: { interval: '1m' },
+        actions: [],
+      });
+      ids.push(data.id);
+    }
+
+    await apiServices.alerting.rules.disable(ids[1]);
+    await apiServices.alerting.rules.muteAll(ids[5]);
+
+    await pageObjects.alertsTablePage.goto();
+
+    const { alertsTablePage } = pageObjects;
+    await expect.poll(() => alertsTablePage.getRuleStatValue('statRuleCount')).toBe(6);
+    await expect.poll(() => alertsTablePage.getRuleStatValue('statDisabled')).toBe(1);
+    await expect.poll(() => alertsTablePage.getRuleStatValue('statMuted')).toBe(1);
+    await expect.poll(() => alertsTablePage.getRuleStatValue('statErrors')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Second PR in the `observability_functional` → **Scout** migration, **stacked on #272801** (alerts table / Batch 0+2). Ports the remaining alerts **mutation + overview** specs.

> Stacked PR: until #272801 merges, the diff here includes that PR's commit. Review only the top commit (`[Obs][Scout] Migrate observability_functional alerts mutations + overview to Scout`), or use the compare view against `#272801`'s branch. Once #272801 merges, rebase shrinks this to the Batch 3 diff.

### What's included (3 specs)
- **`rule_stats.spec.ts`** — creates 6 `apm.anomaly` rules via the alerting API (one disabled, one muted), then asserts the alerts-page rule-stat widgets (`statRuleCount`/`statDisabled`/`statMuted`/`statErrors`). Rules are cleared in `beforeEach`/`afterAll` for deterministic, order-independent counts.
- **`mute_unmute.spec.ts`** — creates a grouped `.es-query` rule and lets it fire to ≥ 2 alert instances, then exercises the table's **bulk mute / unmute** as one `test.step` journey. The muted field is written server-side via a fire-and-forget `updateByQuery`, so each post-action assertion polls by re-running the query bar (mirrors the FTR `retry.try`).
- **`overview_alert_table.spec.ts`** — the overview "no data" prompt → onboarding CTA (no rules), and the alerts section rendering 10 rows once a rule with an allowed consumer exists. The overview "has data" state is rule-driven (via `/api/alerting/rules/_find`), not time-range-driven.

### Page objects
- New **`OverviewPage`** (ports `observability.overview.common`).
- **`AlertsTablePage`** gains bulk-action helpers (`selectAllVisibleAlerts` / `bulkMuteSelected` / `bulkUnmuteSelected`), a toast reader (`readAndDismissLatestToastTitle`, using `allInnerTexts` to stay clear of `playwright/no-nth-methods`), and `countForQuery`.

### Validation status
- [x] Lint clean.
- [x] `tsc` clean (`node scripts/type_check --project …/observability/tsconfig.json` → exit 0).
- [x] jest: the only failure on `--scope branch` was a pre-existing flaky timeout in `public/pages/overview/components/date_picker/date_picker.test.tsx` (passes in 617ms in isolation; outside this PR's diff, which is entirely under `test/scout/ui/`).
- [ ] **Scout run pending** — the 3 specs have **not yet been run against a Scout server locally**; relying on CI (or a follow-up local run) before un-drafting. `mute_unmute` in particular depends on async rule firing and is the highest flake risk.

### Relates to
Addresses #263519 — continues the `observability_functional` (`with_rac_write.config.ts`) migration after #272801. Batch 1 (drop skipped/orphan FTR specs) remains as a separate follow-up.
