### PR TITLE
[CI][Scout] Skip dev webpack prebuild in Scout discovery/builder steps

### DIFF
--- a/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
@@ -15,6 +15,13 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
+
+# This step only runs Node scripts and `playwright --list` (manifest generation,
+# config discovery, flaky run-order planning); it never serves the Kibana UI, so
+# skip building the dev-mode shared webpack bundles (monaco, ui-shared-deps)
+# during bootstrap.
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 .buildkite/scripts/bootstrap.sh
 
 # `SCOUT_DISCOVERY_TARGET` is computed at pipeline-generation time from the

--- a/.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh
@@ -3,6 +3,12 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
+
+# This step only runs Node scripts and `playwright --list` (manifest generation,
+# config discovery); it never serves the Kibana UI, so skip building the
+# dev-mode shared webpack bundles (monaco, ui-shared-deps) during bootstrap.
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Update Scout Test Config Manifests'

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+# This step only runs Node scripts and `playwright --list` (manifest generation,
+# selective-testing scope resolution, config discovery, run-order planning); it
+# never serves the Kibana UI. The dev-mode shared webpack bundles (monaco,
+# ui-shared-deps) are therefore never used, so skip building them during
+# bootstrap (this also skips the moon-cache download attempt).
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 source .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/setup_es_snapshot_cache.sh
 


### PR DESCRIPTION
## Summary

The **Scout Test Run Builder** and Playwright-config **discovery** steps only run Node scripts and `playwright --list` (manifest generation, selective-testing scope resolution, config discovery, run-order planning). They never serve the Kibana UI, so the dev-mode shared webpack bundles (`monaco`, `ui-shared-deps`) built during `kbn bootstrap` are never used.

This sets `KBN_BOOTSTRAP_NO_PREBUILT=true` on these steps so bootstrap skips the shared-webpack build (and the per-build `moon-cache.tar.zst` download attempt), mirroring the existing treatment of `pick_test_group_run_order.sh`, the FTR steps (`functional/common.sh`), and the build steps.

Affected steps:
- `.buildkite/scripts/steps/test/scout/test_run_builder.sh`
- `.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh`
- `.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh`

### Why

On a recent PR build, the **Scout Test Run Builder** step spent ~97s in `yarn install and bootstrap`, of which ~54s was rebuilding `@kbn/ui-shared-deps-src` (37s), `@kbn/monaco` (13s), and `@kbn/ui-shared-deps-npm` (13s) because the per-build moon cache missed (the step bootstrapped before the "Store Cache for build" producer finished). Since this step never uses those bundles, that work is pure waste. The step gates the Scout test lanes on the critical path, so the saving shortens time-to-lanes.

## Test plan

- [ ] CI green on this PR.
- [ ] Confirm the **Scout Test Run Builder** step log shows `skipping pre-built webpack bundles (--no-prebuilt)` and no `@kbn/ui-shared-deps*/monaco build-webpack` tasks during bootstrap.
- [ ] Confirm the step's `yarn install and bootstrap` phase is meaningfully shorter (~40s vs ~97s) and that manifest generation / config discovery still succeed.

Made with [Cursor](https://cursor.com)