### PR TITLE
[Alerting V2] Move dispatcher resource-readiness check into the pipeline

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/README.md
@@ -51,16 +51,17 @@ Those anchors, plus persisted action history, let the dispatcher decide which ep
 
 The pipeline then moves through these phases:
 
-1. Fetch candidate episodes
-2. Fetch suppression facts
-3. Split into dispatchable vs suppressed episodes
-4. Load rule metadata for dispatchable episodes
-5. Load enabled action policies
-6. Evaluate policy matchers
-7. Build action groups
-8. Apply throttling
-9. Dispatch eligible groups
-10. Store final actions and reasons
+1. Wait for plugin resources to be ready
+2. Fetch candidate episodes
+3. Fetch suppression facts
+4. Split into dispatchable vs suppressed episodes
+5. Load rule metadata for dispatchable episodes
+6. Load enabled action policies
+7. Evaluate policy matchers
+8. Build action groups
+9. Apply throttling
+10. Dispatch eligible groups
+11. Store final actions and reasons
 
 ### Decision outcomes written to `.alert-actions`
 
@@ -96,6 +97,7 @@ DispatcherService
    v
 DispatcherPipeline
    |
+   +--> WaitForResourcesStep
    +--> FetchEpisodesStep
    +--> FetchSuppressionsStep
    +--> ApplySuppressionStep
@@ -159,16 +161,17 @@ Step order is defined in `setup/bind_dispatcher_executor.ts`.
 
 | # | Step | Responsibility |
 | --- | --- | --- |
-| 1 | `FetchEpisodesStep` | Load episodes that should be considered in this run. |
-| 2 | `FetchSuppressionsStep` | Load alert-action facts needed for suppression decisions. |
-| 3 | `ApplySuppressionStep` | Mark each episode as dispatchable or suppressed, preserving reasons. |
-| 4 | `FetchRulesStep` | Load rule metadata for the remaining dispatchable set. |
-| 5 | `FetchPoliciesStep` | Load enabled action policies for the space. |
-| 6 | `EvaluateMatchersStep` | Evaluate each policy matcher against each episode context. |
-| 7 | `BuildGroupsStep` | Build `ActionGroup` objects based on policy grouping settings. |
-| 8 | `ApplyThrottlingStep` | Compare candidate groups with action history and split them into dispatch vs throttled. |
-| 9 | `DispatchStep` | Perform delivery side effects for eligible groups. |
-| 10 | `StoreActionsStep` | Persist the execution outcome to `.alert-actions`. |
+| 1 | `WaitForResourcesStep` | Block the run until the dispatcher's required plugin resources are ready. |
+| 2 | `FetchEpisodesStep` | Load episodes that should be considered in this run. |
+| 3 | `FetchSuppressionsStep` | Load alert-action facts needed for suppression decisions. |
+| 4 | `ApplySuppressionStep` | Mark each episode as dispatchable or suppressed, preserving reasons. |
+| 5 | `FetchRulesStep` | Load rule metadata for the remaining dispatchable set. |
+| 6 | `FetchPoliciesStep` | Load enabled action policies for the space. |
+| 7 | `EvaluateMatchersStep` | Evaluate each policy matcher against each episode context. |
+| 8 | `BuildGroupsStep` | Build `ActionGroup` objects based on policy grouping settings. |
+| 9 | `ApplyThrottlingStep` | Compare candidate groups with action history and split them into dispatch vs throttled. |
+| 10 | `DispatchStep` | Perform delivery side effects for eligible groups. |
+| 11 | `StoreActionsStep` | Persist the execution outcome to `.alert-actions`. |
 
 ## Halt reasons
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.test.ts
@@ -6,29 +6,15 @@
  */
 
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
-import { createMockResourceManager } from '../services/resource_service/resource_manager.mock';
 import { INTERVAL, scheduleDispatcherTask } from './schedule_task';
 import { DISPATCHER_TASK_ID, DISPATCHER_TASK_TYPE } from './constants';
 
 describe('scheduleDispatcherTask', () => {
   let taskManager: jest.Mocked<Pick<TaskManagerStartContract, 'ensureScheduled'>>;
-  let resourceManager: ReturnType<typeof createMockResourceManager>;
-  let callOrder: string[];
 
   beforeEach(() => {
-    callOrder = [];
-
-    resourceManager = createMockResourceManager();
-    resourceManager.waitUntilReady.mockImplementation(() => {
-      callOrder.push('waitUntilReady');
-      return Promise.resolve();
-    });
-
     taskManager = {
-      ensureScheduled: jest.fn().mockImplementation(() => {
-        callOrder.push('ensureScheduled');
-        return Promise.resolve();
-      }),
+      ensureScheduled: jest.fn().mockResolvedValue(undefined),
     };
   });
 
@@ -36,33 +22,17 @@ describe('scheduleDispatcherTask', () => {
     jest.clearAllMocks();
   });
 
-  it('waits for resources before scheduling the task', async () => {
+  it('schedules the dispatcher task', async () => {
     await scheduleDispatcherTask({
       taskManager: taskManager as unknown as TaskManagerStartContract,
-      resourceManager,
     });
 
-    expect(callOrder).toEqual(['waitUntilReady', 'ensureScheduled']);
-  });
-
-  it('does not schedule when resources fail to initialize', async () => {
-    const error = new Error('resource init failed');
-    resourceManager.waitUntilReady.mockRejectedValue(error);
-
-    await expect(
-      scheduleDispatcherTask({
-        taskManager: taskManager as unknown as TaskManagerStartContract,
-        resourceManager,
-      })
-    ).rejects.toThrow(error);
-
-    expect(taskManager.ensureScheduled).not.toHaveBeenCalled();
+    expect(taskManager.ensureScheduled).toHaveBeenCalledTimes(1);
   });
 
   it('passes the correct task configuration to ensureScheduled', async () => {
     await scheduleDispatcherTask({
       taskManager: taskManager as unknown as TaskManagerStartContract,
-      resourceManager,
     });
 
     expect(taskManager.ensureScheduled).toHaveBeenCalledWith({

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.ts
@@ -6,20 +6,15 @@
  */
 
 import type { AlertingServerStartDependencies } from '../../types';
-import type { ResourceManagerContract } from '../services/resource_service/resource_manager';
 import { DISPATCHER_TASK_ID, DISPATCHER_TASK_TYPE } from './constants';
 
 export const INTERVAL = '5s';
 
 export async function scheduleDispatcherTask({
   taskManager,
-  resourceManager,
 }: {
   taskManager: AlertingServerStartDependencies['taskManager'];
-  resourceManager: ResourceManagerContract;
 }): Promise<void> {
-  await resourceManager.waitUntilReady();
-
   await taskManager.ensureScheduled({
     id: DISPATCHER_TASK_ID,
     taskType: DISPATCHER_TASK_TYPE,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+export { WaitForResourcesStep } from './wait_for_resources_step';
 export { FetchEpisodesStep } from './fetch_episodes_step';
 export { FetchSuppressionsStep } from './fetch_suppressions_step';
 export { ApplySuppressionStep } from './apply_suppression_step';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/wait_for_resources_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/wait_for_resources_step.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
+import { createMockResourceManager } from '../../services/resource_service/resource_manager.mock';
+import { createDispatcherPipelineState } from '../fixtures/test_utils';
+import { WaitForResourcesStep } from './wait_for_resources_step';
+
+describe('WaitForResourcesStep', () => {
+  let step: WaitForResourcesStep;
+  let resourceManager: ReturnType<typeof createMockResourceManager>;
+
+  beforeEach(() => {
+    const { loggerService } = createLoggerService();
+    resourceManager = createMockResourceManager();
+    step = new WaitForResourcesStep(loggerService, resourceManager);
+  });
+
+  it('waits for resources and continues execution', async () => {
+    resourceManager.waitUntilReady.mockResolvedValue(undefined);
+
+    const state = createDispatcherPipelineState();
+    const result = await step.execute(state);
+
+    expect(result).toEqual({ type: 'continue' });
+    expect(resourceManager.waitUntilReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors from resource manager', async () => {
+    const error = new Error('Resource initialization failed');
+    resourceManager.waitUntilReady.mockRejectedValue(error);
+
+    const state = createDispatcherPipelineState();
+
+    await expect(step.execute(state)).rejects.toThrow('Resource initialization failed');
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/wait_for_resources_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/wait_for_resources_step.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { inject, injectable } from 'inversify';
+import {
+  LoggerServiceToken,
+  type LoggerServiceContract,
+} from '../../services/logger_service/logger_service';
+import {
+  ResourceManager,
+  type ResourceManagerContract,
+} from '../../services/resource_service/resource_manager';
+import type { DispatcherPipelineState, DispatcherStep, DispatcherStepOutput } from '../types';
+
+@injectable()
+export class WaitForResourcesStep implements DispatcherStep {
+  public readonly name = 'wait_for_resources';
+
+  constructor(
+    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
+    @inject(ResourceManager) private readonly resourceManager: ResourceManagerContract
+  ) {}
+
+  public async execute(_state: Readonly<DispatcherPipelineState>): Promise<DispatcherStepOutput> {
+    this.logger.debug({ message: `[${this.name}] Waiting for resources to be ready` });
+
+    await this.resourceManager.waitUntilReady();
+
+    this.logger.debug({ message: `[${this.name}] Resources ready` });
+
+    return { type: 'continue' };
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_dispatcher_executor.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_dispatcher_executor.ts
@@ -9,6 +9,7 @@ import type { ContainerModuleLoadOptions } from 'inversify';
 import { DispatcherPipeline } from '../lib/dispatcher/execution_pipeline';
 import { DispatcherExecutionStepsToken } from '../lib/dispatcher/steps/tokens';
 import {
+  WaitForResourcesStep,
   FetchEpisodesStep,
   FetchSuppressionsStep,
   ApplySuppressionStep,
@@ -28,6 +29,7 @@ export const bindDispatcherExecutionServices = ({ bind }: ContainerModuleLoadOpt
    * Dispatcher execution steps via multi-injection.
    * Binding order defines execution order.
    */
+  bind(DispatcherExecutionStepsToken).to(WaitForResourcesStep).inSingletonScope();
   bind(DispatcherExecutionStepsToken).to(FetchEpisodesStep).inSingletonScope();
   bind(DispatcherExecutionStepsToken).to(FetchSuppressionsStep).inSingletonScope();
   bind(DispatcherExecutionStepsToken).to(ApplySuppressionStep).inSingletonScope();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_start.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_start.ts
@@ -39,7 +39,7 @@ export function bindOnStart({ bind }: ContainerModuleLoadOptions) {
 
     initSubscribers(container);
 
-    scheduleDispatcherTask({ taskManager, resourceManager }).catch((error) => {
+    scheduleDispatcherTask({ taskManager }).catch((error) => {
       logger.error(error as Error, {
         error: {
           code: 'DISPATCHER_TASK_SCHEDULE_FAILURE',


### PR DESCRIPTION
## Summary

Previously, `scheduleDispatcherTask` awaited `resourceManager.waitUntilReady()` before calling `taskManager.ensureScheduled`. If resource initialization permanently failed, the dispatcher task was never scheduled, and the dispatcher would stay silent for the lifetime of the Kibana process.

This PR decouples scheduling from resource readiness:

- `scheduleDispatcherTask` now just schedules the task and returns. It no longer takes a `ResourceManager` parameter.
- A new `WaitForResourcesStep` is added as the first step of the `DispatcherPipeline`. It awaits `ResourceManager.waitUntilReady()` on every run, mirroring the pattern already used by the rule executor.
- The dispatcher task is always scheduled at startup. Resource failures fail the individual run (fast and visibly), but no longer block the task from being scheduled in the first place. Once resources eventually become ready, subsequent runs continue normally.

Fixes: https://github.com/elastic/kibana/issues/272836

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios