### PR TITLE
[Obs][Scout] Migrate observability_functional cases & RBAC to Scout

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/alerts_data.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/alerts_data.ts
@@ -16,7 +16,13 @@ import { ALERT_COUNTS, ALERT_TABLE_DATE_RANGE } from './constants';
  * indices are always created by Kibana on startup, so the archive would never be
  * ingested.
  */
-const OBSERVABILITY_ALERTS_INDEX = '.alerts-observability.apm.alerts-default';
+export const OBSERVABILITY_ALERTS_INDEX = '.alerts-observability.apm.alerts-default';
+
+/**
+ * `kibana.alert.uuid` of the first generated *active* alert. Useful as a stable
+ * target when attaching an alert to a case (see the cases attachment specs).
+ */
+export const FIRST_ACTIVE_ALERT_ID = 'scout-alert-active-0';
 
 // Matches the rule that produced the active alerts in the legacy archive so the
 // rendered table content (reason, rule name, category) stays representative.

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_table.ts
@@ -30,6 +30,11 @@ export class AlertsTablePage {
   public readonly flyoutViewInAppButton: Locator;
   public readonly flyoutAlertDetailsButton: Locator;
   public readonly flyoutViewRuleDetailsLink: Locator;
+  // Add-to-case row actions / dialogs
+  public readonly addToExistingCaseAction: Locator;
+  public readonly addToNewCaseAction: Locator;
+  public readonly createCaseFlyout: Locator;
+  public readonly addToExistingCaseModal: Locator;
   public readonly queryInput: Locator;
   public readonly dataGrid: EuiDataGridWrapper;
   public readonly groupSelector: Locator;
@@ -65,6 +70,10 @@ export class AlertsTablePage {
     this.flyoutViewInAppButton = this.page.testSubj.locator('alertsFlyoutViewInAppButton');
     this.flyoutAlertDetailsButton = this.page.testSubj.locator('alertsFlyoutAlertDetailsButton');
     this.flyoutViewRuleDetailsLink = this.page.testSubj.locator('viewRuleDetailsFlyout');
+    this.addToExistingCaseAction = this.page.testSubj.locator('add-to-existing-case-action');
+    this.addToNewCaseAction = this.page.testSubj.locator('add-to-new-case-action');
+    this.createCaseFlyout = this.page.testSubj.locator('create-case-flyout');
+    this.addToExistingCaseModal = this.page.testSubj.locator('all-cases-modal');
     this.queryInput = this.page.testSubj.locator('queryInput');
   }
 
@@ -186,6 +195,15 @@ export class AlertsTablePage {
 
   async clickViewRuleDetails() {
     await this.page.testSubj.click('viewRuleDetails');
+  }
+
+  // Add to case (from the row actions menu opened via `openActionsMenuForRow`)
+  async clickAddToNewCase() {
+    await this.addToNewCaseAction.click();
+  }
+
+  async clickAddToExistingCase() {
+    await this.addToExistingCaseAction.click();
   }
 
   // Date picker

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/cases_page.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/cases_page.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout-oblt';
+
+/**
+ * Drives the Observability Cases app (`/app/observability/cases`).
+ *
+ * Ported from the FTR `observability` page object cases helpers
+ * (x-pack/solutions/observability/test/functional/page_objects/observability_page.ts)
+ * and the `cases` functional service. Page objects only drive the UI and expose
+ * locators/state; assertions live in the specs.
+ */
+export class CasesPage {
+  // Cases list / landing
+  public readonly listTitle: Locator;
+  public readonly createCaseButton: Locator;
+  // Create-case form (shown after clicking the create button)
+  public readonly createCaseForm: Locator;
+  // Comment editor textarea inside the create/edit forms
+  public readonly commentTextArea: Locator;
+  // Read-only chrome badge (rendered for users without write privileges)
+  public readonly readOnlyBadge: Locator;
+  // "Kibana feature privileges required" page rendered when the user has no
+  // cases privileges at all.
+  public readonly noFeaturePermissions: Locator;
+  // Single case view
+  public readonly caseViewTitle: Locator;
+  public readonly addCommentInput: Locator;
+  public readonly submitCommentButton: Locator;
+  // Alert attachment rule link inside a case (navigates to the rule details page)
+  public readonly alertRuleLink: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.listTitle = this.page.testSubj.locator('cases-all-title');
+    this.createCaseButton = this.page.testSubj.locator('createNewCaseBtn');
+    this.createCaseForm = this.page.testSubj.locator('case-creation-form-steps');
+    this.readOnlyBadge = this.page.testSubj.locator('headerBadge');
+    this.noFeaturePermissions = this.page.testSubj.locator('noFeaturePermissions');
+    this.caseViewTitle = this.page.testSubj.locator('case-view-title');
+    this.addCommentInput = this.page.testSubj.locator('add-comment');
+    this.commentTextArea = this.page.testSubj.locator('add-comment').locator('textarea');
+    this.submitCommentButton = this.page.testSubj.locator('submit-comment');
+    // The rule link test subject is suffixed with the rule id (e.g.
+    // `alert-rule-link-<uuid>`), so match by prefix rather than an exact id.
+    this.alertRuleLink = this.page.locator('[data-test-subj*="alert-rule-link"]');
+  }
+
+  async gotoCasesList() {
+    await this.page.gotoApp('observability/cases');
+  }
+
+  async gotoCreateCase() {
+    await this.page.gotoApp('observability/cases/create');
+  }
+
+  async gotoCase(caseId: string) {
+    await this.page.gotoApp(`observability/cases/${caseId}`);
+  }
+
+  async clickCreateCase() {
+    await this.createCaseButton.click();
+  }
+
+  /**
+   * Types a comment into the single-case-view markdown editor so the
+   * "Add comment" submit button becomes enabled (it is disabled while empty).
+   */
+  async typeComment(text: string) {
+    await this.commentTextArea.fill(text);
+  }
+
+  async clickAlertRuleLink() {
+    await this.alertRuleLink.click();
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/cases_page.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/cases_page.ts
@@ -28,6 +28,11 @@ export class CasesPage {
   // "Kibana feature privileges required" page rendered when the user has no
   // cases privileges at all.
   public readonly noFeaturePermissions: Locator;
+  // In-app "Privileges required" prompt rendered in place (not a redirect) when
+  // a user lacks the privilege for a specific cases route such as create. This
+  // is distinct from `noFeaturePermissions`, which is the Kibana 403 page shown
+  // when the user has no cases feature privilege at all.
+  public readonly noPrivilegesPrompt: Locator;
   // Single case view
   public readonly caseViewTitle: Locator;
   public readonly addCommentInput: Locator;
@@ -41,6 +46,7 @@ export class CasesPage {
     this.createCaseForm = this.page.testSubj.locator('case-creation-form-steps');
     this.readOnlyBadge = this.page.testSubj.locator('headerBadge');
     this.noFeaturePermissions = this.page.testSubj.locator('noFeaturePermissions');
+    this.noPrivilegesPrompt = this.page.getByRole('heading', { name: 'Privileges required' });
     this.caseViewTitle = this.page.testSubj.locator('case-view-title');
     this.addCommentInput = this.page.testSubj.locator('add-comment');
     this.commentTextArea = this.page.testSubj.locator('add-comment').locator('textarea');

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/index.ts
@@ -13,6 +13,7 @@ import { AlertPage } from './alert_page';
 import { AlertsTablePage } from './alerts_table';
 import { AlertControls } from './alert_controls';
 import { OverviewPage } from './overview_page';
+import { CasesPage } from './cases_page';
 
 export interface TriggersActionsPageObjects extends ObltPageObjects {
   rulesPage: RulesPage;
@@ -21,6 +22,7 @@ export interface TriggersActionsPageObjects extends ObltPageObjects {
   alertsTablePage: AlertsTablePage;
   alertControls: AlertControls;
   overviewPage: OverviewPage;
+  casesPage: CasesPage;
 }
 
 export function extendPageObjects(
@@ -35,5 +37,6 @@ export function extendPageObjects(
     alertsTablePage: createLazyPageObject(AlertsTablePage, page),
     alertControls: createLazyPageObject(AlertControls, page),
     overviewPage: createLazyPageObject(OverviewPage, page),
+    casesPage: createLazyPageObject(CasesPage, page),
   };
 }

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/roles.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/roles.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRole } from '@kbn/scout-oblt';
+
+/**
+ * Custom roles used by the Observability cases / RBAC Scout suites, ported from
+ * the FTR `observability.users.defineBasicObservabilityRole` helper
+ * (x-pack/solutions/observability/test/functional/services/observability/users.ts).
+ *
+ * The FTR helper grants `cluster: ['all']` plus index privileges keyed off the
+ * requested feature set; for `{ logs: ['all'] }` that means `['filebeat-*',
+ * 'logs-*']`. We replicate the same elasticsearch + kibana feature privileges
+ * here and drive them through `browserAuth.loginWithCustomRole`.
+ */
+const LOGS_INDEX_PRIVILEGES = { names: ['filebeat-*', 'logs-*'], privileges: ['all'] };
+
+const observabilityRole = (feature: Record<string, string[]>): KibanaRole => ({
+  elasticsearch: {
+    cluster: ['all'],
+    indices: [LOGS_INDEX_PRIVILEGES],
+  },
+  kibana: [
+    {
+      base: [],
+      feature,
+      spaces: ['*'],
+    },
+  ],
+});
+
+/** `observabilityCasesV3: ['all']` + `logs: ['all']` — full cases access. */
+export const CASES_ALL_ROLE: KibanaRole = observabilityRole({
+  observabilityCasesV3: ['all'],
+  logs: ['all'],
+});
+
+/** `observabilityCasesV3: ['read']` + `logs: ['all']` — read-only cases access. */
+export const CASES_READ_ROLE: KibanaRole = observabilityRole({
+  observabilityCasesV3: ['read'],
+  logs: ['all'],
+});
+
+/**
+ * No observability privileges at all — only `discover: ['all']`. Mirrors the FTR
+ * "no observability privileges" role and is expected to hit the cases feature
+ * 403 page.
+ */
+export const NO_CASES_ROLE: KibanaRole = {
+  elasticsearch: { cluster: [], indices: [] },
+  kibana: [
+    {
+      base: [],
+      feature: { discover: ['all'] },
+      spaces: ['*'],
+    },
+  ],
+};
+
+/**
+ * Add-to-case suites need the role to also *see* the alerts table rows. The
+ * Scout alert generator (`generateObservabilityAlerts`) writes APM alerts into
+ * `.alerts-observability.apm.alerts-default`, so unlike the FTR (which restored
+ * an es_archive visible to a logs-only user) we additionally grant `apm: ['read']`
+ * so the alerts render for the custom role under test.
+ */
+export const CASES_ALL_WITH_ALERTS_ROLE: KibanaRole = observabilityRole({
+  observabilityCasesV3: ['all'],
+  apm: ['read'],
+  logs: ['all'],
+});
+
+export const CASES_READ_WITH_ALERTS_ROLE: KibanaRole = observabilityRole({
+  observabilityCasesV3: ['read'],
+  apm: ['read'],
+  logs: ['all'],
+});

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/add_to_case.all.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/add_to_case.all.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { generateObservabilityAlerts } from '../../fixtures/alerts_data';
+import { CASES_ALL_WITH_ALERTS_ROLE } from '../../fixtures/roles';
+
+// Ported from the "When user has all privileges for cases" suite in the FTR
+// pages/alerts/add_to_case.ts. A user with cases write privileges sees the
+// add-to-case row actions and can open the new/existing case dialogs.
+test.describe(
+  'Observability alerts - add to case (all privileges)',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeAll(async ({ esClient }) => {
+      await generateObservabilityAlerts(esClient);
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginWithCustomRole(CASES_ALL_WITH_ALERTS_ROLE);
+      await pageObjects.alertsTablePage.goto();
+    });
+
+    test.afterAll(async ({ apiServices }) => {
+      await apiServices.cases.cleanup.deleteAllCases();
+    });
+
+    test('renders the case options in the row actions menu', async ({ pageObjects }) => {
+      const { alertsTablePage } = pageObjects;
+      await alertsTablePage.waitForTableToLoad();
+      await alertsTablePage.openActionsMenuForRow(0);
+      await expect(alertsTablePage.addToExistingCaseAction).toBeVisible();
+      await expect(alertsTablePage.addToNewCaseAction).toBeVisible();
+    });
+
+    test('opens the create-case flyout from "Add to new case"', async ({ pageObjects }) => {
+      const { alertsTablePage } = pageObjects;
+      await alertsTablePage.waitForTableToLoad();
+      await alertsTablePage.openActionsMenuForRow(0);
+      await alertsTablePage.clickAddToNewCase();
+      await expect(alertsTablePage.createCaseFlyout).toBeVisible();
+    });
+
+    test('opens the existing-cases modal from "Add to existing case"', async ({ pageObjects }) => {
+      const { alertsTablePage } = pageObjects;
+      await alertsTablePage.waitForTableToLoad();
+      await alertsTablePage.openActionsMenuForRow(0);
+      await alertsTablePage.clickAddToExistingCase();
+      await expect(alertsTablePage.addToExistingCaseModal).toBeVisible();
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/add_to_case.read.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/add_to_case.read.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { generateObservabilityAlerts } from '../../fixtures/alerts_data';
+import { CASES_READ_WITH_ALERTS_ROLE } from '../../fixtures/roles';
+
+// Ported from the "When user has read permissions for cases" suite in the FTR
+// pages/alerts/add_to_case.ts. A user with read-only cases privileges does not
+// see the add-to-case row actions.
+test.describe(
+  'Observability alerts - add to case (read-only)',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeAll(async ({ esClient }) => {
+      await generateObservabilityAlerts(esClient);
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginWithCustomRole(CASES_READ_WITH_ALERTS_ROLE);
+      await pageObjects.alertsTablePage.goto();
+    });
+
+    test('does not render the case options in the row actions menu', async ({ pageObjects }) => {
+      const { alertsTablePage } = pageObjects;
+      await alertsTablePage.waitForTableToLoad();
+      // The actions menu still opens (other actions remain available), but the
+      // case options must be absent for a read-only cases user.
+      await alertsTablePage.openActionsMenuForRow(0);
+      await expect(alertsTablePage.actionsMenu).toBeVisible();
+      await expect(alertsTablePage.addToExistingCaseAction).toBeHidden();
+      await expect(alertsTablePage.addToNewCaseAction).toBeHidden();
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/case_details_rule_link.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/case_details_rule_link.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import {
+  FIRST_ACTIVE_ALERT_ID,
+  OBSERVABILITY_ALERTS_INDEX,
+  generateObservabilityAlerts,
+} from '../../fixtures/alerts_data';
+import { CASES_ALL_WITH_ALERTS_ROLE } from '../../fixtures/roles';
+
+// Ported from the "Case detail rule link" suite in the FTR
+// pages/cases/case_details.ts. An alert attachment in a case renders a link to
+// the rule that produced it, which navigates to the rule management page.
+test.describe(
+  'Observability cases - case detail rule link',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    let caseId: string;
+
+    test.beforeAll(async ({ esClient, apiServices }) => {
+      await generateObservabilityAlerts(esClient);
+
+      const { data } = await apiServices.cases.create({
+        title: 'Sample case',
+        description: 'Created by the Observability cases Scout suite',
+        tags: [],
+        owner: 'observability',
+        connector: { id: 'none', name: 'none', type: '.none', fields: null },
+        settings: { syncAlerts: false, extractObservables: false },
+      });
+      caseId = data.id;
+
+      await apiServices.cases.comments.create(caseId, {
+        type: 'alert',
+        owner: 'observability',
+        alertId: FIRST_ACTIVE_ALERT_ID,
+        index: OBSERVABILITY_ALERTS_INDEX,
+        rule: { id: 'rule-id', name: 'My rule name' },
+      });
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginWithCustomRole(CASES_ALL_WITH_ALERTS_ROLE);
+    });
+
+    test.afterAll(async ({ apiServices }) => {
+      await apiServices.cases.cleanup.deleteAllCases();
+    });
+
+    test('links to the observability rule page from the case detail', async ({
+      page,
+      pageObjects,
+    }) => {
+      const { casesPage } = pageObjects;
+      await casesPage.gotoCase(caseId);
+      await expect(casesPage.caseViewTitle).toBeVisible();
+
+      await casesPage.clickAlertRuleLink();
+
+      await expect(page).toHaveURL(/\/app\/management\/insightsAndAlerting\/triggersActions\/rule/);
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.all.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.all.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { CASES_ALL_ROLE } from '../../fixtures/roles';
+
+// Ported from the "observability cases all privileges" suite in the FTR
+// feature_controls/observability_security.ts. A user with
+// `observabilityCasesV3: ['all']` can list, create and edit cases.
+test.describe('Observability cases - all privileges', { tag: [...tags.stateful.classic] }, () => {
+  let caseId: string;
+
+  test.beforeAll(async ({ apiServices }) => {
+    const { data } = await apiServices.cases.create({
+      title: 'Editable case',
+      description: 'Created by the Observability cases Scout suite',
+      tags: [],
+      owner: 'observability',
+      connector: { id: 'none', name: 'none', type: '.none', fields: null },
+      settings: { syncAlerts: false, extractObservables: false },
+    });
+    caseId = data.id;
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginWithCustomRole(CASES_ALL_ROLE);
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    await apiServices.cases.cleanup.deleteAllCases();
+  });
+
+  test('shows the cases list with an enabled create button and no read-only badge', async ({
+    pageObjects,
+  }) => {
+    const { casesPage } = pageObjects;
+    await casesPage.gotoCasesList();
+    await expect(casesPage.listTitle).toBeVisible();
+    await expect(casesPage.createCaseButton).toBeVisible();
+    await expect(casesPage.createCaseButton).toBeEnabled();
+    await expect(casesPage.readOnlyBadge).toBeHidden();
+  });
+
+  test('opens the create-case form', async ({ pageObjects }) => {
+    const { casesPage } = pageObjects;
+    await casesPage.gotoCasesList();
+    await casesPage.clickCreateCase();
+    await expect(casesPage.createCaseForm).toBeVisible();
+  });
+
+  test('allows an existing case to be edited', async ({ pageObjects }) => {
+    const { casesPage } = pageObjects;
+    await casesPage.gotoCase(caseId);
+    await expect(casesPage.caseViewTitle).toBeVisible();
+    await casesPage.typeComment('A comment from the Observability cases Scout suite');
+    await expect(casesPage.submitCommentButton).toBeEnabled();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.none.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.none.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { NO_CASES_ROLE } from '../../fixtures/roles';
+
+// Ported from the "no observability privileges" suite in the FTR
+// feature_controls/observability_security.ts. A user without any cases
+// privilege hits the "Kibana feature privileges required" page.
+test.describe('Observability cases - no privileges', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginWithCustomRole(NO_CASES_ROLE);
+  });
+
+  test('returns the feature-privileges-required page', async ({ pageObjects }) => {
+    const { casesPage } = pageObjects;
+    await casesPage.gotoCasesList();
+    await expect(casesPage.noFeaturePermissions).toBeVisible();
+    await expect(casesPage.noFeaturePermissions).toContainText(
+      'Kibana feature privileges required'
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.read.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.read.spec.ts
@@ -52,10 +52,11 @@ test.describe(
 
     test('does not allow a case to be created', async ({ pageObjects }) => {
       const { casesPage } = pageObjects;
-      // Navigating straight to the create route redirects the read-only user
-      // back to the landing page, where neither the form nor the button render.
+      // Navigating straight to the create route renders the in-app "Privileges
+      // required" prompt in place (the Cases app does not redirect), so neither
+      // the create form nor the create button render.
       await casesPage.gotoCreateCase();
-      await expect(casesPage.listTitle).toBeVisible();
+      await expect(casesPage.noPrivilegesPrompt).toBeVisible();
       await expect(casesPage.createCaseForm).toBeHidden();
       await expect(casesPage.createCaseButton).toBeHidden();
     });

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.read.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/cases/cases_feature_controls.read.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { CASES_READ_ROLE } from '../../fixtures/roles';
+
+// Ported from the "observability cases read-only privileges" suite in the FTR
+// feature_controls/observability_security.ts. A user with
+// `observabilityCasesV3: ['read']` can browse cases but cannot create or edit
+// them, and sees the read-only chrome badge.
+test.describe(
+  'Observability cases - read-only privileges',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    let caseId: string;
+
+    test.beforeAll(async ({ apiServices }) => {
+      const { data } = await apiServices.cases.create({
+        title: 'Read-only case',
+        description: 'Created by the Observability cases Scout suite',
+        tags: [],
+        owner: 'observability',
+        connector: { id: 'none', name: 'none', type: '.none', fields: null },
+        settings: { syncAlerts: false, extractObservables: false },
+      });
+      caseId = data.id;
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginWithCustomRole(CASES_READ_ROLE);
+    });
+
+    test.afterAll(async ({ apiServices }) => {
+      await apiServices.cases.cleanup.deleteAllCases();
+    });
+
+    test('shows the cases list with a read-only badge and no create button', async ({
+      pageObjects,
+    }) => {
+      const { casesPage } = pageObjects;
+      await casesPage.gotoCasesList();
+      await expect(casesPage.listTitle).toBeVisible();
+      await expect(casesPage.readOnlyBadge).toBeVisible();
+      await expect(casesPage.createCaseButton).toBeHidden();
+    });
+
+    test('does not allow a case to be created', async ({ pageObjects }) => {
+      const { casesPage } = pageObjects;
+      // Navigating straight to the create route redirects the read-only user
+      // back to the landing page, where neither the form nor the button render.
+      await casesPage.gotoCreateCase();
+      await expect(casesPage.listTitle).toBeVisible();
+      await expect(casesPage.createCaseForm).toBeHidden();
+      await expect(casesPage.createCaseButton).toBeHidden();
+    });
+
+    test('does not allow an existing case to be edited', async ({ pageObjects }) => {
+      const { casesPage } = pageObjects;
+      await casesPage.gotoCase(caseId);
+      await expect(casesPage.caseViewTitle).toBeVisible();
+      await expect(casesPage.submitCommentButton).toBeHidden();
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Migrates the **cases / RBAC** suites of the legacy `observability_functional` FTR app to Scout (Playwright), continuing the `observability_functional` → Scout migration tracked in #263519. This is the **Batch 4** PR; it follows #272801 (alerts table, merged) and is independent of #272813 (alerts mutations + overview).

Ported suites:

| FTR source | Scout spec(s) |
|---|---|
| `feature_controls/observability_security.ts` | `tests/cases/cases_feature_controls.{all,read,none}.spec.ts` |
| `pages/alerts/add_to_case.ts` | `tests/cases/add_to_case.{all,read}.spec.ts` |
| `pages/cases/case_details.ts` | `tests/cases/case_details_rule_link.spec.ts` |

### What's covered
- **Cases feature-control matrix** by privilege level: list / create-button / read-only badge / edit for `observabilityCasesV3: ['all']` and `['read']`, plus the `noFeaturePermissions` 403 page for a user with no cases privileges.
- **Add-to-case row actions**: present for a cases-write user (opens the create-case flyout and the existing-cases modal), absent for a read-only cases user.
- **Case detail → rule link**: an alert attachment in a case renders a link to the producing rule that navigates to the rule management page.

### Implementation notes
- Custom roles live in `fixtures/roles.ts` (`KibanaRole`) and are applied via `browserAuth.loginWithCustomRole`, replicating the FTR `defineBasicObservabilityRole` helper. This confirms `observabilityCasesV3` parity — it is grantable as a Kibana feature privilege in a Scout custom role on stateful.
- Cases setup uses the `apiServices.cases` worker service (`create` / `comments.create` alert attachment / `cleanup.deleteAllCases`) instead of the `cases.json` kbn archive + `observability/alerts` es_archive.
- Adds a `CasesPage` page object and add-to-case locators/helpers on the existing `AlertsTablePage`.
- **Deviation from FTR**: the `add_to_case.*` and `case_details_rule_link` roles also grant `apm: ['read']`. The Scout alert generator writes APM alerts (`.alerts-observability.apm.alerts-default`), so unlike the FTR (which restored a mixed es_archive) a logs-only role would not see them in the alerts table.

## Test plan
- [ ] Validate the new specs in CI: `node scripts/scout.js run-tests --arch stateful --domain classic --config x-pack/solutions/observability/plugins/observability/test/scout/ui/playwright.config.ts` (not run against a local Scout server in this PR).
- Local gate `node scripts/check.js --scope branch`: **lint ✓, tsc ✓**. The only jest failure is a pre-existing flake — `date_picker.test.tsx` "updates the URL when the date range changes" times out at the 5s default under full-config concurrency but passes in isolation (~4.6s) — and is unrelated to this PR (it does not touch `date_picker`).

Addresses #263519