### PR TITLE
[9.4] [SecuritySolution][Navigation] Fix `Security` category link on global side nav (#272155)

### DIFF
--- a/src/core/packages/chrome/browser-components/src/classic/collapsible_nav.tsx
+++ b/src/core/packages/chrome/browser-components/src/classic/collapsible_nav.tsx
@@ -69,7 +69,9 @@ const getCollapsibleNavStyles = (euiThemeContext: UseEuiTheme) => {
   };
 };
 
-function getAllCategories(allCategorizedLinks: Record<string, ChromeNavLink[]>) {
+function getAllCategories(
+  allCategorizedLinks: Record<string, ChromeNavLink[]>
+): Record<string, AppCategory | undefined> {
   const allCategories = {} as Record<string, AppCategory | undefined>;
 
   for (const [key, value] of Object.entries(allCategorizedLinks)) {
@@ -111,16 +113,11 @@ interface Props {
   button: EuiCollapsibleNavProps['button'];
 }
 
-const overviewIDsToHide = [
-  'kibanaOverview',
-  'securitySolutionUI:get_started',
-  'securitySolutionUI:ai_value',
-  'securitySolutionUI:siem_migrations',
-  'securitySolutionUI:siem_readiness',
-];
+const overviewIDsToHide = ['kibanaOverview'];
 const overviewIDs = [
-  ...overviewIDsToHide,
+  'kibanaOverview',
   'observability-overview',
+  'securitySolutionUI:launchpad',
   'management',
   'enterpriseSearch',
 ];
@@ -136,17 +133,19 @@ export function CollapsibleNav({
   const navigateToUrl = useNavigateToUrl();
   const homeHref = useHomeHref();
   const allLinks = useNavLinks();
+
   const allowedLinks = useMemo(
     () =>
       allLinks.filter(
         (link) =>
-          // Filterting out hidden links,
+          // Filtering out hidden links,
           link.visibleIn.includes('sideNav') &&
           // and non-data overview pages
           !overviewIDsToHide.includes(link.id)
       ),
     [allLinks]
   );
+
   // Find just the integrations link
   const integrationsLink = useMemo(
     () => allLinks.find((link) => link.id === 'integrations'),
@@ -157,13 +156,17 @@ export function CollapsibleNav({
     () => allLinks.filter((link) => overviewIDs.includes(link.id)),
     [allLinks]
   );
+
   const recentlyAccessed = useRecentlyAccessed();
   const customNavLink = useCustomNavLink();
   const appId = useCurrentAppId();
+
   const groupedNavLinks = groupBy(allowedLinks, (link) => link?.category?.id);
   const { undefined: unknowns = [], ...allCategorizedLinks } = groupedNavLinks;
-  const categoryDictionary = getAllCategories(allCategorizedLinks);
-  const orderedCategories = getOrderedCategories(allCategorizedLinks, categoryDictionary);
+  const categoryDictionary: Record<string, AppCategory | undefined> =
+    getAllCategories(allCategorizedLinks);
+  const orderedCategories: string[] = getOrderedCategories(allCategorizedLinks, categoryDictionary);
+
   const readyForEUI = (link: ChromeNavLink, needsIcon: boolean = false) => {
     return createEuiListItem({
       link,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.test.tsx
@@ -17,6 +17,7 @@ import type { NavigationLink } from '../../../links/types';
 import { track } from '../../../lib/telemetry';
 import { useKibana } from '../../../lib/kibana';
 import { getNavCategories } from './categories';
+import { SecurityGroupName } from '@kbn/security-solution-navigation';
 
 const settingsNavLink: NavigationLink = {
   id: SecurityPageName.administration,
@@ -32,6 +33,24 @@ const settingsNavLink: NavigationLink = {
     },
   ],
 };
+
+const launchpadNavLink: NavigationLink = {
+  id: SecurityPageName.launchpad,
+  title: 'Launchpad',
+  description: 'Launchpad',
+  categories: [{ label: 'Launchpad category', linkIds: [] }],
+  links: [
+    {
+      id: SecurityPageName.landing,
+      title: 'Get started',
+    },
+    {
+      id: SecurityPageName.siemReadiness,
+      title: 'SIEM Readiness',
+    },
+  ],
+};
+
 const alertsNavLink: NavigationLink = {
   id: SecurityPageName.alerts,
   title: 'alerts',
@@ -176,20 +195,75 @@ describe('SecuritySideNav', () => {
     );
   });
 
-  it('should render launchpad item', () => {
-    mockUseNavLinks.mockReturnValue([
-      { id: SecurityPageName.launchpad, title: 'Launchpad', sideNavIcon: 'rocket' },
-    ]);
+  it('should render launchpad item in footer', () => {
+    mockUseNavLinks.mockReturnValue([alertsNavLink, launchpadNavLink, settingsNavLink]);
     renderNav();
     expect(mockSolutionSideNav).toHaveBeenCalledWith(
       expect.objectContaining({
         items: [
           expect.objectContaining({
-            id: SecurityPageName.launchpad,
-            label: 'Launchpad',
+            id: SecurityGroupName.launchpad,
+            position: 'bottom',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should place administration item in footer', () => {
+    mockUseNavLinks.mockReturnValue([alertsNavLink, launchpadNavLink, settingsNavLink]);
+    renderNav();
+    expect(mockSolutionSideNav).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            id: SecurityPageName.administration,
+            position: 'bottom',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should not include administration item in body', () => {
+    mockUseNavLinks.mockReturnValue([settingsNavLink, alertsNavLink]);
+    renderNav();
+    const calls = mockSolutionSideNav.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    const items = lastCall[0].items;
+    const administrationItemsInBody = items.filter(
+      (item) => item.id === SecurityPageName.administration && item.position !== 'bottom'
+    );
+    expect(administrationItemsInBody).toHaveLength(0);
+  });
+
+  it('should select launchpad when landing page is selected', () => {
+    mockUseRouteSpy.mockReturnValueOnce([{ pageName: SecurityPageName.landing }]);
+    const landingNavLink: NavigationLink = {
+      id: SecurityPageName.landing,
+      title: 'Get started',
+      description: 'Get started description',
+    };
+    mockUseNavLinks.mockReturnValue([alertsNavLink, landingNavLink, settingsNavLink]);
+    renderNav();
+    expect(mockSolutionSideNav).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedId: 'securityGroup:launchpad',
+      })
+    );
+  });
+
+  it('should maintain top position for most items', () => {
+    mockUseNavLinks.mockReturnValue([alertsNavLink]);
+    renderNav();
+    expect(mockSolutionSideNav).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            id: SecurityPageName.alerts,
             position: 'top',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.test.tsx
@@ -200,7 +200,7 @@ describe('SecuritySideNav', () => {
     renderNav();
     expect(mockSolutionSideNav).toHaveBeenCalledWith(
       expect.objectContaining({
-        items: [
+        items: expect.arrayContaining([
           expect.objectContaining({
             id: SecurityGroupName.launchpad,
             position: 'bottom',
@@ -368,63 +368,5 @@ describe('SecuritySideNav', () => {
         })
       );
     });
-  });
-
-  it('should place administration item in footer', () => {
-    mockUseNavLinks.mockReturnValue([alertsNavLink, settingsNavLink]);
-    renderNav();
-    expect(mockSolutionSideNav).toHaveBeenCalledWith(
-      expect.objectContaining({
-        items: expect.arrayContaining([
-          expect.objectContaining({
-            id: SecurityPageName.administration,
-            position: 'bottom',
-          }),
-        ]),
-      })
-    );
-  });
-
-  it('should not include administration item in body', () => {
-    mockUseNavLinks.mockReturnValue([settingsNavLink, alertsNavLink]);
-    renderNav();
-    const calls = mockSolutionSideNav.mock.calls;
-    const lastCall = calls[calls.length - 1];
-    const items = lastCall[0].items;
-    const administrationItemsInBody = items.filter(
-      (item) => item.id === SecurityPageName.administration && item.position !== 'bottom'
-    );
-    expect(administrationItemsInBody).toHaveLength(0);
-  });
-
-  it('should select launchpad when landing page is selected', () => {
-    mockUseRouteSpy.mockReturnValue([{ pageName: SecurityPageName.landing }]);
-    const landingNavLink: NavigationLink = {
-      id: SecurityPageName.landing,
-      title: 'Get started',
-      description: 'Get started description',
-    };
-    mockUseNavLinks.mockReturnValue([landingNavLink, alertsNavLink, settingsNavLink]);
-    renderNav();
-    expect(mockSolutionSideNav).toHaveBeenCalledWith(
-      expect.objectContaining({
-        selectedId: 'securityGroup:launchpad',
-      })
-    );
-  });
-
-  it('should maintain top position for most items', () => {
-    mockUseNavLinks.mockReturnValue([alertsNavLink]);
-    renderNav();
-    expect(mockSolutionSideNav).toHaveBeenCalledWith(
-      expect.objectContaining({
-        items: [
-          expect.objectContaining({
-            id: SecurityPageName.alerts,
-            position: 'top',
-          }),
-        ],
-      })
-    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.tsx
@@ -205,7 +205,10 @@ const useSolutionSideNavItems = (): SolutionSideNavItem<string>[] | undefined =>
         return navItems;
       }
 
-      if (navLink.id === SecurityPageName.administration) {
+      if (
+        navLink.id === SecurityPageName.launchpad ||
+        navLink.id === SecurityPageName.administration
+      ) {
         return navItems;
       }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/links.ts
@@ -39,6 +39,5 @@ export const aiValueLinks: LinkItem = {
       defaultMessage: 'Value report',
     }),
   ],
-  globalNavPosition: 12,
   hideTimeline: true,
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[SecuritySolution][Navigation] Fix `Security` category link on global side nav (#272155)](https://github.com/elastic/kibana/pull/272155)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ash","email":"1849116+ashokaditya@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-04T14:27:38Z","message":"[SecuritySolution][Navigation] Fix `Security` category link on global side nav (#272155)\n\n## Summary\n\nFixes the issue where Security category link on the global classic\nsidenav was pointing to value report instead of the get started page.\nThe fix targer for next patch release `9.4.3`.\n\n<img width=\"254\" height=\"798\" alt=\"Screenshot 2026-06-01 at 16 59 27\"\nsrc=\"https://github.com/user-attachments/assets/6f751df6-62db-4cf8-a2f0-6066f6edc769\"\n/>\n\nregression introduced in https://github.com/elastic/kibana/pull/262358/\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"9d766a49f366b41fec805a1abc358d1e2bc4e6ff","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.5.0","Team:Security Deployment","v9.4.3","security-pds:current-sprint"],"title":"[SecuritySolution][Navigation] Fix `Security` category link on global side nav","number":272155,"url":"https://github.com/elastic/kibana/pull/272155","mergeCommit":{"message":"[SecuritySolution][Navigation] Fix `Security` category link on global side nav (#272155)\n\n## Summary\n\nFixes the issue where Security category link on the global classic\nsidenav was pointing to value report instead of the get started page.\nThe fix targer for next patch release `9.4.3`.\n\n<img width=\"254\" height=\"798\" alt=\"Screenshot 2026-06-01 at 16 59 27\"\nsrc=\"https://github.com/user-attachments/assets/6f751df6-62db-4cf8-a2f0-6066f6edc769\"\n/>\n\nregression introduced in https://github.com/elastic/kibana/pull/262358/\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"9d766a49f366b41fec805a1abc358d1e2bc4e6ff"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272155","number":272155,"mergeCommit":{"message":"[SecuritySolution][Navigation] Fix `Security` category link on global side nav (#272155)\n\n## Summary\n\nFixes the issue where Security category link on the global classic\nsidenav was pointing to value report instead of the get started page.\nThe fix targer for next patch release `9.4.3`.\n\n<img width=\"254\" height=\"798\" alt=\"Screenshot 2026-06-01 at 16 59 27\"\nsrc=\"https://github.com/user-attachments/assets/6f751df6-62db-4cf8-a2f0-6066f6edc769\"\n/>\n\nregression introduced in https://github.com/elastic/kibana/pull/262358/\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"9d766a49f366b41fec805a1abc358d1e2bc4e6ff"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->