### PR TITLE
[Chrome Next] Make app-header title size dynamic and tidy up vertical padding

### DIFF
--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -54,6 +54,24 @@ Pass a title object when the page title can be renamed from the header:
 The header renders a normal heading until the user edits it. Pressing Enter or leaving the input
 saves, Escape cancels, and returning a string from `onSave` keeps edit mode open.
 
+## Title size
+
+The title is `xs` by default and `s` when the header has tabs (an `xs` title looks too small in the
+taller tabbed header). This is automatic — there is no size knob to set.
+
+## Padding
+
+`padding` controls the header's **horizontal** layout only. Vertical padding is standardized
+internally (independent of the `padding` prop and the title size) so the header keeps a consistent
+height — 48px for a single row, regardless of title size or whether only a back button is present.
+
+- `'none'` — no horizontal padding, no bleed.
+- `'m'` — symmetric horizontal padding (default for inline headers).
+- `{ bleed: 'm' | 'l' }` — negative margin on left/right + top, cancelling a padded container so the
+  header spans to its edges and sits flush at the top; content is auto re-inset to stay aligned with
+  the page gutter. Set `bleed` to your container's padding when rendering inline inside a padded page
+  template.
+
 ## Chrome Next flag and runtime checks
 
 Chrome layout code should use `isNextChrome(featureFlags)` from `@kbn/core-chrome-feature-flags` to

--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -56,8 +56,9 @@ saves, Escape cancels, and returning a string from `onSave` keeps edit mode open
 
 ## Title size
 
-The title is `xs` by default and `s` when the header has tabs (an `xs` title looks too small in the
-taller tabbed header). This is automatic — there is no size knob to set.
+The title is `xs` for a single-row header and `s` when the header has a second row (tabs or a
+metadata row), where an `xs` title looks too small in the taller header. This is automatic — there
+is no size knob to set.
 
 ## Padding
 

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -20,11 +20,13 @@ import type {
   AppHeaderTab,
 } from '@kbn/core-chrome-browser';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
+import type { AppHeaderPadding } from '../types';
 import { AppHeaderView } from './app_header';
 
 interface ComposedHeaderStoryProps {
   title: string;
   editable: boolean;
+  padding: 'none' | 'm' | 'bleed-l';
   width: number;
   showBack: boolean;
   showTabs: boolean;
@@ -65,6 +67,7 @@ const menu: AppMenuConfig = {
 const ComposedHeader = ({
   title: initialTitle,
   editable,
+  padding,
   width,
   showBack,
   showTabs,
@@ -83,6 +86,8 @@ const ComposedHeader = ({
       setTitle(nextTitle);
     },
   };
+
+  const paddingProp: AppHeaderPadding = padding === 'bleed-l' ? { bleed: 'l' } : padding;
 
   return (
     <ChromeServiceProvider value={{ chrome }}>
@@ -110,7 +115,7 @@ const ComposedHeader = ({
             ) : undefined
           }
           sticky={false}
-          padding="m"
+          padding={paddingProp}
         />
       </div>
     </ChromeServiceProvider>
@@ -137,9 +142,17 @@ const meta: Meta<ComposedHeaderStoryProps> = {
       },
     },
   },
+  argTypes: {
+    padding: {
+      control: 'inline-radio',
+      options: ['none', 'm', 'bleed-l'],
+      description: "Horizontal padding. `bleed-l` cancels a padded container (`{ bleed: 'l' }`).",
+    },
+  },
   args: {
     title: 'System Shells via Services',
     editable: true,
+    padding: 'm',
     width: 900,
     showBack: true,
     showTabs: true,

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
@@ -125,13 +125,22 @@ describe('AppHeaderView', () => {
     expect(screen.getByText('Technical preview')).toBeInTheDocument();
   });
 
-  it('renders an xs title by default and an s title when tabs are present', () => {
-    const { unmount } = renderAppHeader(<AppHeaderView title="Dashboard" />);
+  it('renders an xs title for a single row and an s title when a second row is present', () => {
+    const { unmount: unmountSingle } = renderAppHeader(<AppHeaderView title="Dashboard" />);
     expect(screen.getByRole('heading', { level: 1 }).className).toMatch(/euiTitle-xs/);
-    unmount();
+    unmountSingle();
+
+    const { unmount: unmountTabs } = renderAppHeader(
+      <AppHeaderView title="Dashboard" tabs={[{ id: 'overview', label: 'Overview' }]} />
+    );
+    expect(screen.getByRole('heading', { level: 1 }).className).toMatch(/euiTitle-s/);
+    unmountTabs();
 
     renderAppHeader(
-      <AppHeaderView title="Dashboard" tabs={[{ id: 'overview', label: 'Overview' }]} />
+      <AppHeaderView
+        title="Dashboard"
+        metadata={[{ type: 'text', label: 'Created by: analyst' }]}
+      />
     );
     expect(screen.getByRole('heading', { level: 1 }).className).toMatch(/euiTitle-s/);
   });

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.test.tsx
@@ -125,6 +125,17 @@ describe('AppHeaderView', () => {
     expect(screen.getByText('Technical preview')).toBeInTheDocument();
   });
 
+  it('renders an xs title by default and an s title when tabs are present', () => {
+    const { unmount } = renderAppHeader(<AppHeaderView title="Dashboard" />);
+    expect(screen.getByRole('heading', { level: 1 }).className).toMatch(/euiTitle-xs/);
+    unmount();
+
+    renderAppHeader(
+      <AppHeaderView title="Dashboard" tabs={[{ id: 'overview', label: 'Overview' }]} />
+    );
+    expect(screen.getByRole('heading', { level: 1 }).className).toMatch(/euiTitle-s/);
+  });
+
   it('renders tab badge and test subject metadata', () => {
     renderAppHeader(
       <AppHeaderView

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -60,6 +60,10 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
     const hasLegacyActionMenu = useHasLegacyActionMenu();
     const shareAction = useShareAction(menu);
     const resolvedBadges = useResolvedBadges(badges);
+
+    // Tabs make a taller header where an `xs` title looks too small, so default to `s` there.
+    const titleSize = tabs?.length ? 's' : 'xs';
+
     const show =
       title !== undefined ||
       back !== undefined ||
@@ -79,7 +83,7 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
 
     return (
       <AppHeaderShell
-        title={<TitleArea title={title} back={back} />}
+        title={<TitleArea title={title} back={back} size={titleSize} />}
         badges={<AppBadges badges={resolvedBadges} />}
         titleActions={<TitleActions shareAction={shareAction} favorite={favorite} />}
         trailing={

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -61,8 +61,10 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
     const shareAction = useShareAction(menu);
     const resolvedBadges = useResolvedBadges(badges);
 
-    // Tabs make a taller header where an `xs` title looks too small, so default to `s` there.
-    const titleSize = tabs?.length ? 's' : 'xs';
+    // A second row (tabs or metadata) makes a taller, multi-line header where an `xs` title looks
+    // too small, so bump the title to `s` there; single-row headers stay `xs`.
+    const isMultiRow = !!tabs?.length || !!metadata?.length;
+    const titleSize = isMultiRow ? 's' : 'xs';
 
     const show =
       title !== undefined ||

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
@@ -13,7 +13,10 @@ import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
 import type { AppHeaderPadding } from '../types';
 
-export const APPLICATION_TOP_BAR_MIN_HEIGHT_PX = 48;
+// Single-row bar height, applied to every header (title, tabbed, or back-button-only) so the bar
+// stays a consistent 48px. The symmetric size.s padding leaves a 32px content area, enough for the
+// trailing controls (buttons) to fit without pushing the row past 48px.
+const APPLICATION_TOP_BAR_MIN_HEIGHT_PX = 48;
 
 export interface AppHeaderShellProps {
   title?: ReactNode;
@@ -26,7 +29,9 @@ export interface AppHeaderShellProps {
   padding?: AppHeaderPadding;
 }
 
-const resolveLayoutProps = (
+// Resolves the horizontal-only padding contract. Vertical padding is standardized internally
+// (see `useHeaderStyles`) so the header keeps a consistent height regardless of this prop.
+const resolveHorizontalPadding = (
   sticky: boolean,
   padding: AppHeaderPadding | undefined,
   euiTheme: ReturnType<typeof useEuiTheme>['euiTheme']
@@ -34,31 +39,17 @@ const resolveLayoutProps = (
   const resolved = padding ?? (sticky ? 'm' : 'none');
 
   if (resolved === 'none') {
-    return { paddingInline: undefined, paddingBlock: undefined, bleedMargin: undefined };
+    return { paddingInline: undefined, bleedMargin: undefined };
   }
 
   if (resolved === 'm') {
-    return {
-      paddingInline: euiTheme.size.m,
-      paddingBlock: euiTheme.size.m,
-      bleedMargin: undefined,
-    };
+    return { paddingInline: euiTheme.size.m, bleedMargin: undefined };
   }
 
-  const bleedMargin = resolved.bleed === 'l' ? euiTheme.size.l : euiTheme.size.m;
-  const size = resolved.size ?? resolved.bleed;
-
-  let paddingInline: string | undefined;
-  let paddingBlock: string | undefined;
-  if (size === 'l') {
-    paddingInline = euiTheme.size.base;
-    paddingBlock = euiTheme.size.base;
-  } else if (size === 'm') {
-    paddingInline = euiTheme.size.m;
-    paddingBlock = euiTheme.size.m;
-  }
-
-  return { paddingInline, paddingBlock, bleedMargin };
+  // `{ bleed }`: pull the header out to its padded container's edges (negative margin) and
+  // re-inset the content by the same amount so it stays aligned with the page gutter.
+  const value = resolved.bleed === 'l' ? euiTheme.size.l : euiTheme.size.m;
+  return { paddingInline: value, bleedMargin: value };
 };
 
 const useHeaderStyles = (
@@ -70,11 +61,14 @@ const useHeaderStyles = (
   const { euiTheme } = useEuiTheme();
 
   return useMemo(() => {
-    const { paddingInline, paddingBlock, bleedMargin } = resolveLayoutProps(
-      sticky,
-      padding,
-      euiTheme
-    );
+    const { paddingInline, bleedMargin } = resolveHorizontalPadding(sticky, padding, euiTheme);
+
+    // Vertical padding is internal (independent of the `padding` prop). The primary row floors at a
+    // consistent 48px regardless of title size; content is centered within it.
+    const paddingBlock = euiTheme.size.s;
+    // A row followed by another collapses its bottom gap so the next row sits close (and tabs stay
+    // flush with the header's bottom border); otherwise it uses the symmetric vertical padding.
+    const bottomPad = (followed: boolean) => (followed ? euiTheme.size.xs : paddingBlock);
 
     const root = css`
       ${sticky &&
@@ -87,7 +81,6 @@ const useHeaderStyles = (
       display: flex;
       flex-direction: column;
       min-width: 0;
-      min-height: ${APPLICATION_TOP_BAR_MIN_HEIGHT_PX}px;
       box-sizing: border-box;
       padding: 0;
       ${paddingInline &&
@@ -116,11 +109,8 @@ const useHeaderStyles = (
       gap: ${euiTheme.size.m};
       min-width: 0;
       min-height: ${APPLICATION_TOP_BAR_MIN_HEIGHT_PX}px;
-      ${paddingBlock &&
-      css`
-        padding-block-start: ${paddingBlock};
-        padding-block-end: ${hasTabs || hasMetadata ? euiTheme.size.xs : paddingBlock};
-      `}
+      padding-block-start: ${paddingBlock};
+      padding-block-end: ${bottomPad(hasTabs || hasMetadata)};
     `;
 
     const titleCluster = css`
@@ -156,10 +146,7 @@ const useHeaderStyles = (
       column-gap: ${euiTheme.size.m};
       row-gap: ${euiTheme.size.xs};
       min-width: 0;
-      ${paddingBlock &&
-      css`
-        padding-block-end: ${hasTabs ? euiTheme.size.xs : paddingBlock};
-      `}
+      padding-block-end: ${bottomPad(hasTabs)};
     `;
 
     const titleActionsReveal = css`

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
@@ -7,7 +7,8 @@ user can rename inline.
 - `title_area.tsx` — `TitleArea`: thin layout orchestrator (back button + title in a
   flex row). Holds no edit state.
 - `title.tsx` — `Title`: the editable/read-only title itself. All the styling, width
-  model, save flow, and a11y live here. Also exports the `isEditableTitle` type guard.
+  model, save flow, and a11y live here. Takes a `size` (`xs` | `s`) for the `EuiTitle`.
+  Also exports the `isEditableTitle` type guard.
 - `title_area.stories.tsx` — every scenario, rendered inside the full app header.
 - `title.test.tsx` — behavior/a11y tests for the save, validation, and cancel flows.
 - `index.ts` — public barrel (`TitleArea`, `TitleAreaProps`).
@@ -33,6 +34,10 @@ A `string` title renders as a non-editable heading. An object title renders the
 inline editor. `onSave` returns nothing on success, or an **error string** to reject
 the value (also thrown errors are caught and surfaced). The component owns all edit
 state (`draft`, `error`, `isSaving`); the caller only owns the committed `text`.
+
+The `size` (`xs` | `s`) is decided upstream in `AppHeaderView`: `s` when tabs are
+present, otherwise `xs`. The size applies uniformly to read and edit, so it does not
+affect the pixel-parity below.
 
 ## The one hard requirement: read and edit must be pixel-identical
 

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
@@ -35,9 +35,9 @@ inline editor. `onSave` returns nothing on success, or an **error string** to re
 the value (also thrown errors are caught and surfaced). The component owns all edit
 state (`draft`, `error`, `isSaving`); the caller only owns the committed `text`.
 
-The `size` (`xs` | `s`) is decided upstream in `AppHeaderView`: `s` when tabs are
-present, otherwise `xs`. The size applies uniformly to read and edit, so it does not
-affect the pixel-parity below.
+The `size` (`xs` | `s`) is decided upstream in `AppHeaderView`: `s` when the header
+has a second row (tabs or metadata), otherwise `xs`. The size applies uniformly to
+read and edit, so it does not affect the pixel-parity below.
 
 ## The one hard requirement: read and edit must be pixel-identical
 

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/title.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/title.tsx
@@ -18,7 +18,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import type { AppHeaderEditableTitle, AppHeaderTitle } from '../../types';
+import type { AppHeaderEditableTitle } from '../../types';
 
 // The bundled lib.dom `FocusOptions` does not yet include `focusVisible`, which lets us
 // force the focus ring on/off when restoring focus programmatically.
@@ -48,8 +48,9 @@ const invalidTitleErrorMessage = i18n.translate(
   }
 );
 
-export const isEditableTitle = (title: AppHeaderTitle): title is AppHeaderEditableTitle =>
-  typeof title !== 'string';
+export const isEditableTitle = (
+  title: string | AppHeaderEditableTitle
+): title is AppHeaderEditableTitle => typeof title !== 'string';
 
 // All of the title's layout/visual contract lives here, isolated from the behavior in
 // `Title`. The comments record the hard-won invariants behind read/edit pixel parity --
@@ -258,246 +259,250 @@ const useTitleStyles = () => {
   }, [euiTheme]);
 };
 
-export const Title = React.memo<{ title: AppHeaderTitle; titleOffset?: boolean }>(
-  ({ title, titleOffset }) => {
-    const editable = isEditableTitle(title);
-    const text = editable ? title.text : title;
-    const placeholder = editable ? title.placeholder : undefined;
-    const ariaLabel = editable ? title.ariaLabel : undefined;
-    const onSave = editable ? title.onSave : undefined;
+interface TitleProps {
+  title: string | AppHeaderEditableTitle;
+  titleOffset?: boolean;
+  size?: 'xs' | 's';
+}
 
-    const [isEditing, setIsEditing] = useState(false);
-    const [draft, setDraft] = useState(text);
-    const [error, setError] = useState<string | undefined>();
-    const [isSaving, setIsSaving] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
-    const titleRef = useRef<HTMLButtonElement>(null);
-    // Whether the current edit was opened via keyboard, so the focus ring only returns for
-    // keyboard users when focus is restored to the title.
-    const enteredViaKeyboardRef = useRef(false);
-    // Marks that an edit was resolved by an explicit action (Enter/Escape) so the trailing
-    // blur from unmounting the focused input does not re-enter save().
-    const resolvingRef = useRef(false);
-    const errorId = useGeneratedHtmlId({ prefix: 'appHeaderEditableTitleError' });
-    const instructionsId = useGeneratedHtmlId({ prefix: 'appHeaderEditableTitleInstructions' });
+export const Title = React.memo<TitleProps>(({ title, titleOffset, size = 's' }) => {
+  const editable = isEditableTitle(title);
+  const text = editable ? title.text : title;
+  const placeholder = editable ? title.placeholder : undefined;
+  const ariaLabel = editable ? title.ariaLabel : undefined;
+  const onSave = editable ? title.onSave : undefined;
 
-    const styles = useTitleStyles();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(text);
+  const [error, setError] = useState<string | undefined>();
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleRef = useRef<HTMLButtonElement>(null);
+  // Whether the current edit was opened via keyboard, so the focus ring only returns for
+  // keyboard users when focus is restored to the title.
+  const enteredViaKeyboardRef = useRef(false);
+  // Marks that an edit was resolved by an explicit action (Enter/Escape) so the trailing
+  // blur from unmounting the focused input does not re-enter save().
+  const resolvingRef = useRef(false);
+  const errorId = useGeneratedHtmlId({ prefix: 'appHeaderEditableTitleError' });
+  const instructionsId = useGeneratedHtmlId({ prefix: 'appHeaderEditableTitleInstructions' });
 
-    useEffect(() => {
-      if (!isEditing) {
+  const styles = useTitleStyles();
+
+  useEffect(() => {
+    if (!isEditing) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      const input = inputRef.current;
+      if (!input) {
         return;
       }
+      input.focus();
+      // Select the whole title on entry so the I-beam never lands the caret in a surprising
+      // spot; the user can click again within the now-real input to position it.
+      input.select();
+    });
+  }, [isEditing]);
 
-      requestAnimationFrame(() => {
-        const input = inputRef.current;
-        if (!input) {
-          return;
-        }
-        input.focus();
-        // Select the whole title on entry so the I-beam never lands the caret in a surprising
-        // spot; the user can click again within the now-real input to position it.
-        input.select();
-      });
-    }, [isEditing]);
+  const returnFocusToTitle = () => {
+    const options: FocusOptionsWithVisible = { focusVisible: enteredViaKeyboardRef.current };
+    requestAnimationFrame(() => {
+      titleRef.current?.focus(options);
+    });
+  };
 
-    const returnFocusToTitle = () => {
-      const options: FocusOptionsWithVisible = { focusVisible: enteredViaKeyboardRef.current };
-      requestAnimationFrame(() => {
-        titleRef.current?.focus(options);
-      });
-    };
+  const startEditing = (viaKeyboard = false) => {
+    if (!editable) {
+      return;
+    }
 
-    const startEditing = (viaKeyboard = false) => {
-      if (!editable) {
-        return;
-      }
+    enteredViaKeyboardRef.current = viaKeyboard;
+    resolvingRef.current = false;
+    setDraft(text);
+    setError(undefined);
+    setIsEditing(true);
+  };
 
-      enteredViaKeyboardRef.current = viaKeyboard;
-      resolvingRef.current = false;
-      setDraft(text);
-      setError(undefined);
-      setIsEditing(true);
-    };
+  const save = async (restoreFocus = true) => {
+    if (!onSave || isSaving) {
+      return;
+    }
 
-    const save = async (restoreFocus = true) => {
-      if (!onSave || isSaving) {
-        return;
-      }
+    const nextTitle = draft.trim();
 
-      const nextTitle = draft.trim();
-
-      // No change -> exit without calling onSave (also covers leaving an empty title empty).
-      if (nextTitle === text.trim()) {
-        resolvingRef.current = true;
-        setError(undefined);
-        setIsEditing(false);
-        if (restoreFocus) {
-          returnFocusToTitle();
-        }
-        return;
-      }
-
-      if (!nextTitle) {
-        setError(emptyTitleErrorMessage);
-        return;
-      }
-
-      setIsSaving(true);
-      let result: string | void;
-      try {
-        result = await onSave(nextTitle);
-      } catch {
-        setIsSaving(false);
-        setError(invalidTitleErrorMessage);
-        return;
-      }
-
-      const saveError = typeof result === 'string' ? result : undefined;
-      setIsSaving(false);
-
-      if (saveError) {
-        setError(saveError);
-        return;
-      }
-
+    // No change -> exit without calling onSave (also covers leaving an empty title empty).
+    if (nextTitle === text.trim()) {
       resolvingRef.current = true;
       setError(undefined);
       setIsEditing(false);
       if (restoreFocus) {
         returnFocusToTitle();
       }
-    };
+      return;
+    }
 
-    const cancel = () => {
-      resolvingRef.current = true;
-      setDraft(text);
-      setError(undefined);
-      setIsEditing(false);
+    if (!nextTitle) {
+      setError(emptyTitleErrorMessage);
+      return;
+    }
+
+    setIsSaving(true);
+    let result: string | void;
+    try {
+      result = await onSave(nextTitle);
+    } catch {
+      setIsSaving(false);
+      setError(invalidTitleErrorMessage);
+      return;
+    }
+
+    const saveError = typeof result === 'string' ? result : undefined;
+    setIsSaving(false);
+
+    if (saveError) {
+      setError(saveError);
+      return;
+    }
+
+    resolvingRef.current = true;
+    setError(undefined);
+    setIsEditing(false);
+    if (restoreFocus) {
       returnFocusToTitle();
-    };
+    }
+  };
 
-    const displayText = text || placeholder || '';
-    const isPlaceholder = !text && !!placeholder;
+  const cancel = () => {
+    resolvingRef.current = true;
+    setDraft(text);
+    setError(undefined);
+    setIsEditing(false);
+    returnFocusToTitle();
+  };
 
-    // The hidden sizer is the single source of the frame width in both modes: its intrinsic
-    // width sets the grid track while the visible text/input truncates or scrolls within it,
-    // so read and edit share identical geometry. Read mode sizes to the shown text (or the
-    // placeholder when empty); edit mode sizes to the draft (or placeholder while empty) so
-    // the input grows in lockstep as you type and the placeholder shows in full.
-    const renderSizer = (sizerText: string) => (
-      <span aria-hidden="true" css={styles.titleSizer}>
-        {sizerText}
+  const displayText = text || placeholder || '';
+  const isPlaceholder = !text && !!placeholder;
+
+  // The hidden sizer is the single source of the frame width in both modes: its intrinsic
+  // width sets the grid track while the visible text/input truncates or scrolls within it,
+  // so read and edit share identical geometry. Read mode sizes to the shown text (or the
+  // placeholder when empty); edit mode sizes to the draft (or placeholder while empty) so
+  // the input grows in lockstep as you type and the placeholder shows in full.
+  const renderSizer = (sizerText: string) => (
+    <span aria-hidden="true" css={styles.titleSizer}>
+      {sizerText}
+    </span>
+  );
+
+  // Shared read view: the sizer drives the frame width while the visible span truncates
+  // within it, so editable and non-editable titles have identical geometry.
+  const readContent = (
+    <>
+      {renderSizer(displayText)}
+      <span css={[styles.titleText, isPlaceholder ? styles.placeholderText : undefined]}>
+        {displayText}
       </span>
-    );
+    </>
+  );
 
-    // Shared read view: the sizer drives the frame width while the visible span truncates
-    // within it, so editable and non-editable titles have identical geometry.
-    const readContent = (
-      <>
-        {renderSizer(displayText)}
-        <span css={[styles.titleText, isPlaceholder ? styles.placeholderText : undefined]}>
-          {displayText}
-        </span>
-      </>
-    );
+  return (
+    <div
+      css={[styles.titleWrapper, titleOffset ? styles.titleOffsetStyle : undefined]}
+      data-test-subj="appHeaderTitle"
+    >
+      <EuiTitle size={size}>
+        <h1>
+          {isEditing ? (
+            <div css={[styles.editingTitleFrame, error ? styles.invalidTitleFrame : undefined]}>
+              {renderSizer(draft || placeholder || '')}
+              <input
+                ref={inputRef}
+                // `size={1}` keeps the input's intrinsic width from inflating the grid track,
+                // so the sizer span alone determines the frame width.
+                size={1}
+                data-test-subj="appHeaderTitleInput"
+                css={styles.input}
+                value={draft}
+                placeholder={placeholder}
+                disabled={isSaving}
+                aria-busy={isSaving}
+                aria-invalid={!!error}
+                aria-label={ariaLabel ?? defaultAriaLabel}
+                aria-describedby={error ? errorId : undefined}
+                onChange={(event) => {
+                  setDraft(event.target.value);
+                  setError(undefined);
+                }}
+                onBlur={() => {
+                  // Ignore the trailing blur from an Enter/Escape that already closed the
+                  // field; a genuine click-away still commits.
+                  if (resolvingRef.current) {
+                    return;
+                  }
+                  void save(false);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    void save();
+                  }
 
-    return (
-      <div
-        css={[styles.titleWrapper, titleOffset ? styles.titleOffsetStyle : undefined]}
-        data-test-subj="appHeaderTitle"
-      >
-        <EuiTitle size="s">
-          <h1>
-            {isEditing ? (
-              <div css={[styles.editingTitleFrame, error ? styles.invalidTitleFrame : undefined]}>
-                {renderSizer(draft || placeholder || '')}
-                <input
-                  ref={inputRef}
-                  // `size={1}` keeps the input's intrinsic width from inflating the grid track,
-                  // so the sizer span alone determines the frame width.
-                  size={1}
-                  data-test-subj="appHeaderTitleInput"
-                  css={styles.input}
-                  value={draft}
-                  placeholder={placeholder}
-                  disabled={isSaving}
-                  aria-busy={isSaving}
-                  aria-invalid={!!error}
-                  aria-label={ariaLabel ?? defaultAriaLabel}
-                  aria-describedby={error ? errorId : undefined}
-                  onChange={(event) => {
-                    setDraft(event.target.value);
-                    setError(undefined);
-                  }}
-                  onBlur={() => {
-                    // Ignore the trailing blur from an Enter/Escape that already closed the
-                    // field; a genuine click-away still commits.
-                    if (resolvingRef.current) {
-                      return;
-                    }
-                    void save(false);
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') {
-                      event.preventDefault();
-                      void save();
-                    }
-
-                    if (event.key === 'Escape') {
-                      event.preventDefault();
-                      cancel();
-                    }
-                  }}
-                />
-                {error && (
-                  <EuiScreenReaderOnly>
-                    <span id={errorId} role="alert" data-test-subj="appHeaderTitleError">
-                      {error}
-                    </span>
-                  </EuiScreenReaderOnly>
-                )}
-                {(isSaving || error) && (
-                  <span css={[styles.statusIcon]}>
-                    {isSaving ? (
-                      <EuiLoadingSpinner size="m" />
-                    ) : (
-                      <EuiIconTip type="warning" color="danger" content={error} position="top" />
-                    )}
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    cancel();
+                  }
+                }}
+              />
+              {error && (
+                <EuiScreenReaderOnly>
+                  <span id={errorId} role="alert" data-test-subj="appHeaderTitleError">
+                    {error}
                   </span>
-                )}
-              </div>
-            ) : editable ? (
-              // Accessible name comes from the visible title text (the sizer span is
-              // aria-hidden), so the heading reads as the title itself; editability is
-              // conveyed via the screen-reader instructions referenced below.
-              <button
-                ref={titleRef}
-                type="button"
-                data-test-subj="appHeaderTitleButton"
-                css={styles.readModeTrigger}
-                aria-describedby={instructionsId}
-                // `event.detail === 0` marks a keyboard activation (Enter/Space) vs a mouse
-                // click, so the ring only returns to keyboard users after editing.
-                onClick={(event) => startEditing(event.detail === 0)}
-              >
-                {readContent}
-              </button>
-            ) : (
-              // Non-editable title: shares the same frame as the editable read view (its
-              // transparent overlay simply never activates) so geometry/alignment is identical.
-              <span css={styles.titleFrame}>{readContent}</span>
-            )}
-          </h1>
-        </EuiTitle>
-        {/* Kept outside the h1 so it never feeds the heading's name-from-content. */}
-        {editable && !isEditing && (
-          <EuiScreenReaderOnly>
-            <span id={instructionsId}>{editInstructions}</span>
-          </EuiScreenReaderOnly>
-        )}
-      </div>
-    );
-  }
-);
+                </EuiScreenReaderOnly>
+              )}
+              {(isSaving || error) && (
+                <span css={[styles.statusIcon]}>
+                  {isSaving ? (
+                    <EuiLoadingSpinner size="m" />
+                  ) : (
+                    <EuiIconTip type="warning" color="danger" content={error} position="top" />
+                  )}
+                </span>
+              )}
+            </div>
+          ) : editable ? (
+            // Accessible name comes from the visible title text (the sizer span is
+            // aria-hidden), so the heading reads as the title itself; editability is
+            // conveyed via the screen-reader instructions referenced below.
+            <button
+              ref={titleRef}
+              type="button"
+              data-test-subj="appHeaderTitleButton"
+              css={styles.readModeTrigger}
+              aria-describedby={instructionsId}
+              // `event.detail === 0` marks a keyboard activation (Enter/Space) vs a mouse
+              // click, so the ring only returns to keyboard users after editing.
+              onClick={(event) => startEditing(event.detail === 0)}
+            >
+              {readContent}
+            </button>
+          ) : (
+            // Non-editable title: shares the same frame as the editable read view (its
+            // transparent overlay simply never activates) so geometry/alignment is identical.
+            <span css={styles.titleFrame}>{readContent}</span>
+          )}
+        </h1>
+      </EuiTitle>
+      {/* Kept outside the h1 so it never feeds the heading's name-from-content. */}
+      {editable && !isEditing && (
+        <EuiScreenReaderOnly>
+          <span id={instructionsId}>{editInstructions}</span>
+        </EuiScreenReaderOnly>
+      )}
+    </div>
+  );
+});
 
 Title.displayName = 'Title';

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/title_area.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/title_area.tsx
@@ -10,17 +10,18 @@
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
-import type { AppHeaderBack, AppHeaderTitle } from '../../types';
+import type { AppHeaderBack, AppHeaderEditableTitle } from '../../types';
 import { useBackNavTargets } from '../hooks';
 import { BackButton } from '../back_button';
 import { Title, isEditableTitle } from './title';
 
 export interface TitleAreaProps {
-  title?: AppHeaderTitle;
+  title?: string | AppHeaderEditableTitle;
   back?: AppHeaderBack | AppHeaderBack[];
+  size?: 'xs' | 's';
 }
 
-export const TitleArea = React.memo<TitleAreaProps>(({ title, back }) => {
+export const TitleArea = React.memo<TitleAreaProps>(({ title, back, size }) => {
   const { euiTheme } = useEuiTheme();
   const backTargets = useBackNavTargets(back);
   const hasBack = backTargets.length > 0;
@@ -45,7 +46,7 @@ export const TitleArea = React.memo<TitleAreaProps>(({ title, back }) => {
   return (
     <div css={wrapper}>
       {hasBack && <BackButton targets={backTargets} />}
-      {title && <Title title={title} titleOffset={!hasBack} />}
+      {title && <Title title={title} titleOffset={!hasBack} size={size} />}
     </div>
   );
 });

--- a/src/core/packages/chrome/app-header/src/types.ts
+++ b/src/core/packages/chrome/app-header/src/types.ts
@@ -38,10 +38,17 @@ export type AppHeaderTab = CoreAppHeaderTab;
 export type AppHeaderTitle = CoreAppHeaderTitle;
 export type AppHeaderTitleSaveResult = CoreAppHeaderTitleSaveResult;
 
+// Controls the header's HORIZONTAL layout only. Vertical padding is standardized internally so
+// the header keeps a consistent height regardless of this value.
 export type AppHeaderPadding =
-  | 'none'
-  | 'm'
+  | 'none' // no horizontal padding, no bleed
+  | 'm' // symmetric horizontal padding
   | {
+      /**
+       * Negative margin on left/right + top: cancels a padded container so the header spans to
+       * its edges and sits flush at the top. Set this to your container's padding when rendering
+       * the header inline inside a padded page template. Content is auto re-inset to match, so it
+       * stays aligned with the page gutter.
+       */
       bleed: 'm' | 'l';
-      size?: 'none' | 'm' | 'l';
     };

--- a/src/core/packages/chrome/browser-components/src/project/chrome_app_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/chrome_app_header.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { Suspense, useMemo, useState, useLayoutEffect } from 'react';
+import { css } from '@emotion/react';
 import type { ChromeBreadcrumb, AppHeaderBack, AppHeaderConfig } from '@kbn/core-chrome-browser';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { useObservable } from '@kbn/use-observable';
@@ -20,6 +21,12 @@ const AppHeaderViewLazy = React.lazy(async () => {
   const { AppHeaderView } = await import('@kbn/app-header');
   return { default: AppHeaderView };
 });
+
+// Reserve the app-header's single-row height while the lazy chunk loads so the layout reserves the
+// space from the first paint and content doesn't jump down (0 → 48px) once the header renders.
+// Must stay in sync with the single-row bar height in @kbn/app-header (kept local to avoid eagerly
+// bundling that package and defeating the lazy import above).
+const RESERVED_APP_HEADER_MIN_HEIGHT_PX = 48;
 
 function getBreadcrumbText(crumb: ChromeBreadcrumb): string | undefined {
   if (typeof crumb.text === 'string') return crumb.text;
@@ -130,7 +137,12 @@ export const ChromeAppHeaderRenderer = React.memo(() => {
   if (!hasContent) return null;
 
   return (
-    <div ref={measureRef}>
+    <div
+      ref={measureRef}
+      css={css`
+        min-height: ${RESERVED_APP_HEADER_MIN_HEIGHT_PX}px;
+      `}
+    >
       <Suspense fallback={null}>
         <AppHeaderViewLazy
           title={config?.title}


### PR DESCRIPTION
## Summary

Polishes the Chrome Next app-header title sizing and vertical spacing.

- **Dynamic title size**: the title is `xs` by default and `s` when the header has tabs or metadata row (an `xs` title looks too small in the taller header). The size is resolved internally in `AppHeaderView` and threaded down to the title — there is no public size knob, so the API surface stays minimal.
- **Consistent height**: vertical padding is standardized internally to a consistent 48px single-row height, independent of the title size or whether only a back button is present.
- **No load-time shift**: the layout reserves the 48px header height while the header chunk lazy-loads, so content no longer jumps (0 → 48px) on first paint.
- **Simpler padding API**: `AppHeaderPadding` now controls horizontal layout only; vertical spacing is internal.

<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 21" src="https://github.com/user-attachments/assets/b235e113-7a23-4d93-8f97-4d90eef58072" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 24" src="https://github.com/user-attachments/assets/eebfc28c-0a67-4de1-9fcf-26b355761f5a" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 29" src="https://github.com/user-attachments/assets/b784f6fa-4985-4c56-ba58-23223a257e22" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 31" src="https://github.com/user-attachments/assets/0499d83f-ee6b-4e0a-a468-a47c0c4f4d0e" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 37" src="https://github.com/user-attachments/assets/adee7182-372b-49ec-b742-70841e9598c7" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 38" src="https://github.com/user-attachments/assets/76ea1cf5-d368-488e-9a26-511a54bb2e45" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 45" src="https://github.com/user-attachments/assets/c28d90c7-bb41-48bd-b793-96e77ab31f1c" />
<img width="1600" height="1011" alt="Screenshot 2026-06-05 at 16 21 46" src="https://github.com/user-attachments/assets/f6af5feb-3e8c-4758-be8f-58bb9763b642" />
