### PR TITLE
[9.4] [ResponseOps][Alerts] Fix stack alerts page double loading with filter controls (#271441)

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.test.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.test.ts
@@ -112,6 +112,31 @@ describe('utils', () => {
         exclude: panelObj.exclude,
       });
     });
+
+    it('should omit the title key for untitled panels so rison round-trips do not cause false diffs', () => {
+      // Simulates a user-added control with no title (title is absent from localStorage state)
+      const untitledInputData = {
+        initialChildControlState: {
+          '0': {
+            ...initialInputData.initialChildControlState['0'],
+            title: undefined,
+          },
+        },
+      } as unknown as typeof initialInputData;
+
+      const [item] = getFilterItemObjListFromControlState(untitledInputData);
+
+      // Must NOT have a `title` key at all — not even `title: undefined`
+      expect(Object.prototype.hasOwnProperty.call(item, 'title')).toBe(false);
+
+      // Simulates what rison decodes back from the URL (no `title` key)
+      const urlDecoded: FilterControlConfig[] = [{ field_name: item.field_name }];
+      const fromStorage: FilterControlConfig[] = [item];
+
+      // The comparator used by FilterGroup to decide whether to show the "controls changed" banner
+      const comparator = getFilterControlsComparator('field_name', 'title');
+      expect(isEqualWith(fromStorage, urlDecoded, comparator)).toBe(true);
+    });
   });
 
   describe('mergeControls', () => {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
@@ -26,7 +26,10 @@ export const getFilterItemObjListFromControlState = (controlState: ControlGroupR
     return {
       field_name,
       selected_options,
-      title,
+      // Without this check, adding new field filters (that don't have a title) causes the "Filters
+      // changed" banner to show up indefinitely on every reload because rison strips `undefined`
+      // values, causing a mismatch with the localStorage-derived config under lodash `isEqual`.
+      ...(title !== undefined && { title }),
       exists_selected,
       exclude,
       display_settings: {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.test.tsx
@@ -23,11 +23,30 @@ const mockLoadRuleTypes = jest
 jest.mock('@kbn/alerts-ui-shared/src/common/apis/fetch_alerts_fields');
 jest.mocked(fetchAlertsFields).mockResolvedValue({ browserFields: {}, fields: [] });
 
-jest.mock('../../alerts_search_bar/url_synced_alerts_search_bar', () => ({
-  UrlSyncedAlertsSearchBar: () => (
-    <div data-test-subj="urlSyncedAlertsSearchBar">{'UrlSyncedAlertsSearchBar'}</div>
-  ),
-}));
+jest.mock('../../alerts_search_bar/url_synced_alerts_search_bar', () => {
+  const ReactLib = jest.requireActual('react');
+  return {
+    // Simulate the real search bar: invoke the readiness callbacks once mounted, so the
+    // page's `hasInitialControlLoadingFinished` gate flips to `true`.
+    UrlSyncedAlertsSearchBar: ({
+      onFilterControlsChange,
+      onControlApiAvailable,
+    }: {
+      onFilterControlsChange?: (filters: unknown[]) => void;
+      onControlApiAvailable?: (api: unknown) => void;
+    }) => {
+      ReactLib.useEffect(() => {
+        onControlApiAvailable?.({});
+        onFilterControlsChange?.([]);
+      }, [onControlApiAvailable, onFilterControlsChange]);
+      return ReactLib.createElement(
+        'div',
+        { 'data-test-subj': 'urlSyncedAlertsSearchBar' },
+        'UrlSyncedAlertsSearchBar'
+      );
+    },
+  };
+});
 
 // Not using `jest.mocked` here because the `AlertsTable` component is manually typed to ensure
 // correct type inference, but it's actually a `memo(forwardRef())` component, which is hard to mock

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.tsx
@@ -28,6 +28,7 @@ import type {
   AlertsTableSupportedConsumers,
 } from '@kbn/response-ops-alerts-table/types';
 import { useGetRuleTypesPermissions } from '@kbn/alerts-ui-shared';
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared/src/alert_filter_controls/types';
 import { ALERTS_PAGE_ID } from '../../../../common/constants';
 import type { QuickFiltersMenuItem } from '../../alerts_search_bar/quick_filters';
 import { NoPermissionPrompt } from '../../../components/prompts/no_permission_prompt';
@@ -140,6 +141,12 @@ const PageContentComponent: React.FC<PageContentProps> = ({
   );
 
   const [consumers, setConsumers] = useState<string[]>(NON_SIEM_CONSUMERS);
+  const [filterControls, setFilterControls] = useState<Filter[]>();
+  const [controlApi, setControlApi] = useState<FilterGroupHandler | undefined>();
+  const hasInitialControlLoadingFinished = useMemo(
+    () => Boolean(controlApi) && Array.isArray(filterControls),
+    [controlApi, filterControls]
+  );
 
   const [selectedFilters, setSelectedFilters] = useState<AlertsFeatureIdsFilter[]>([]);
   const ruleStats = useRuleStats({ ruleTypeIds });
@@ -282,35 +289,39 @@ const PageContentComponent: React.FC<PageContentProps> = ({
             showFilterControls
             showFilterBar
             quickFilters={quickFilters}
+            filterControls={filterControls}
+            onFilterControlsChange={setFilterControls}
+            onControlApiAvailable={setControlApi}
             onEsQueryChange={setEsQuery}
             onFilterSelected={onFilterSelected}
           />
-          <AlertsTable
-            // Here we force a rerender when switching feature ids to prevent the data grid
-            // columns alignment from breaking after a change in the number of columns
-            key={ruleTypeIds.join()}
-            id="stack-alerts-page-table"
-            ruleTypeIds={ruleTypeIds}
-            consumers={consumers}
-            query={esQuery}
-            sort={defaultAlertsTableSort}
-            showAlertStatusWithFlapping
-            pageSize={20}
-            showInspectButton
-            renderActionsCell={RuleAlertActionsCell}
-            actionsColumnWidth={120}
-            getAlertFormatter={getAlertFormatter}
-            alertDetailsNavigation={alertDetailsNavigation}
-            services={{
-              data,
-              http,
-              notifications,
-              fieldFormats,
+          {hasInitialControlLoadingFinished && (
+            <AlertsTable
+              // Here we force a rerender when switching feature ids to prevent the data grid
+              // columns alignment from breaking after a change in the number of columns
+              key={ruleTypeIds.join()}
+              id="stack-alerts-page-table"
+              ruleTypeIds={ruleTypeIds}
+              consumers={consumers}
+              query={esQuery}
+              sort={defaultAlertsTableSort}
+              showAlertStatusWithFlapping
+              pageSize={20}
+              showInspectButton
+              renderActionsCell={RuleAlertActionsCell}
+              actionsColumnWidth={120}
+              getAlertFormatter={getAlertFormatter}
+              alertDetailsNavigation={alertDetailsNavigation}
+              services={{
+                data,
+                http,
+                notifications,
+                fieldFormats,
               application,
               licensing,
               settings,
             }}
-          />
+          />)}
         </EuiFlexGroup>
       )}
     </>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.tsx
@@ -317,11 +317,12 @@ const PageContentComponent: React.FC<PageContentProps> = ({
                 http,
                 notifications,
                 fieldFormats,
-              application,
-              licensing,
-              settings,
-            }}
-          />)}
+                application,
+                licensing,
+                settings,
+              }}
+            />
+          )}
         </EuiFlexGroup>
       )}
     </>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_search_bar/url_synced_alerts_search_bar.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_search_bar/url_synced_alerts_search_bar.test.tsx
@@ -48,8 +48,6 @@ const mockStateContainerDefaults = {
   onKueryChange: jest.fn(),
   filters: [],
   onFiltersChange: jest.fn(),
-  controlFilters: [],
-  onControlFiltersChange: jest.fn(),
   rangeFrom: 'now-15m',
   onRangeFromChange: jest.fn(),
   rangeTo: 'now',
@@ -64,6 +62,7 @@ const mockStateContainerDefaults = {
 const defaultProps = {
   appName: 'test',
   onEsQueryChange: jest.fn(),
+  onFilterControlsChange: jest.fn(),
 };
 
 const TestComponent = (propOverrides: Partial<UrlSyncedAlertsSearchBarProps>) => (
@@ -96,6 +95,60 @@ describe('UrlSyncedAlertsSearchBar', () => {
       expect.objectContaining({ storageKey: 'ruleDetailsAlerts.filterControls' }),
       expect.anything()
     );
+  });
+
+  it('forwards onFilterControlsChange and onControlApiAvailable to AlertFilterControls', () => {
+    jest.mocked(AlertFilterControls).mockImplementation(() => <div>AlertFilterControls</div>);
+    const onFilterControlsChange = jest.fn();
+    const onControlApiAvailable = jest.fn();
+    render(
+      <TestComponent
+        showFilterControls
+        onFilterControlsChange={onFilterControlsChange}
+        onControlApiAvailable={onControlApiAvailable}
+      />
+    );
+    expect(jest.mocked(AlertFilterControls)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onFiltersChange: onFilterControlsChange,
+        onInit: onControlApiAvailable,
+      }),
+      expect.anything()
+    );
+  });
+
+  it('wires setControlsUrlState to the URL state container so config edits round-trip', () => {
+    jest.mocked(AlertFilterControls).mockImplementation(() => <div>AlertFilterControls</div>);
+    const onFilterControlsConfigChange = jest.fn();
+    jest.mocked(useAlertSearchBarStateContainer).mockReturnValue({
+      ...mockStateContainerDefaults,
+      onFilterControlsChange: onFilterControlsConfigChange,
+    });
+    render(<TestComponent showFilterControls />);
+    expect(jest.mocked(AlertFilterControls)).toHaveBeenCalledWith(
+      expect.objectContaining({ setControlsUrlState: onFilterControlsConfigChange }),
+      expect.anything()
+    );
+  });
+
+  it('builds the ES query from page-supplied filterControls', () => {
+    jest.mocked(AlertFilterControls).mockImplementation(() => <div>AlertFilterControls</div>);
+    const onEsQueryChange = jest.fn();
+    const filterControls = [
+      {
+        meta: { key: ALERT_STATUS, params: { query: 'active' } },
+        query: { match_phrase: { [ALERT_STATUS]: 'active' } },
+      },
+    ];
+    render(
+      <TestComponent
+        showFilterControls
+        filterControls={filterControls}
+        onEsQueryChange={onEsQueryChange}
+      />
+    );
+    const lastCall = onEsQueryChange.mock.calls[onEsQueryChange.mock.calls.length - 1][0];
+    expect(JSON.stringify(lastCall)).toContain(ALERT_STATUS);
   });
 
   describe('defaultFilterControls', () => {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_search_bar/url_synced_alerts_search_bar.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_search_bar/url_synced_alerts_search_bar.tsx
@@ -6,12 +6,15 @@
  */
 
 import React, { useCallback, useEffect, useState, useMemo, memo } from 'react';
-import type { BoolQuery, Filter } from '@kbn/es-query';
+import type { BoolQuery, Filter, Query } from '@kbn/es-query';
 import { FILTERS } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { AlertFilterControls } from '@kbn/alerts-ui-shared/src/alert_filter_controls';
 import { SPACE_IDS } from '@kbn/rule-data-utils';
-import type { FilterControlConfig } from '@kbn/alerts-ui-shared/src/alert_filter_controls/types';
+import type {
+  FilterControlConfig,
+  FilterGroupHandler,
+} from '@kbn/alerts-ui-shared/src/alert_filter_controls/types';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { EuiButton, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { useKibana } from '../../..';
@@ -77,6 +80,19 @@ export interface UrlSyncedAlertsSearchBarProps
   showFilterControls?: boolean;
   urlStorageKey?: string;
   filterControlsStorageKey?: string;
+  /**
+   * Filters emitted by the filter controls. Owned by the parent page so that
+   * it can gate the alerts table on the controls being initialized.
+   */
+  filterControls?: Filter[];
+  /**
+   * Setter for the filter controls output filters.
+   */
+  onFilterControlsChange?: (filterControls: Filter[]) => void;
+  /**
+   * Fires with the control group handle once the controls have initialized.
+   */
+  onControlApiAvailable?: (controlGroupHandler: FilterGroupHandler | undefined) => void;
   onEsQueryChange: (esQuery: { bool: BoolQuery }) => void;
   onFilterSelected?: (filters: Filter[]) => void;
   defaultFilterControls?: FilterControlConfig[];
@@ -90,6 +106,9 @@ export const UrlSyncedAlertsSearchBar = ({
   showFilterControls = false,
   urlStorageKey = ALERTS_SEARCH_BAR_PARAMS_URL_STORAGE_KEY,
   filterControlsStorageKey: filterControlsStorageKeyProp = 'alertsSearchBar',
+  filterControls,
+  onFilterControlsChange = () => {},
+  onControlApiAvailable,
   onEsQueryChange,
   onFilterSelected,
   defaultFilterControls,
@@ -115,16 +134,14 @@ export const UrlSyncedAlertsSearchBar = ({
     // KQL bar filters
     filters,
     onFiltersChange,
-    // Controls bar filters
-    controlFilters,
-    onControlFiltersChange,
     // Time range
     rangeFrom,
     onRangeFromChange,
     rangeTo,
     onRangeToChange,
     // Controls bar configuration
-    filterControls,
+    filterControls: filterControlsConfig,
+    onFilterControlsChange: onFilterControlsConfigChange,
     // Saved KQL query
     savedQuery,
     setSavedQuery,
@@ -146,7 +163,7 @@ export const UrlSyncedAlertsSearchBar = ({
             from: rangeFrom,
           },
           kuery,
-          filters: [...filters, ...controlFilters],
+          filters: [...filters, ...(filterControls ?? [])],
         })
       );
 
@@ -158,7 +175,7 @@ export const UrlSyncedAlertsSearchBar = ({
       onKueryChange('');
     }
   }, [
-    controlFilters,
+    filterControls,
     filters,
     kuery,
     onEsQueryChange,
@@ -207,9 +224,16 @@ export const UrlSyncedAlertsSearchBar = ({
   }, [spaceId]);
 
   const controlFiltersWithSpace = useMemo(
-    () => [...controlFilters, ...spaceFilter],
-    [controlFilters, spaceFilter]
+    () => [...(filterControls ?? []), ...spaceFilter],
+    [filterControls, spaceFilter]
   );
+
+  const queryFilter = useMemo<Query | undefined>(
+    () => (kuery ? { query: kuery, language: 'kuery' } : undefined),
+    [kuery]
+  );
+
+  const timeRange = useMemo(() => ({ from: rangeFrom, to: rangeTo }), [rangeFrom, rangeTo]);
 
   return (
     <>
@@ -233,13 +257,18 @@ export const UrlSyncedAlertsSearchBar = ({
             dataViewSpec={{
               id: 'unified-alerts-dv',
               title: '.alerts-*',
+              timeFieldName: '@timestamp',
             }}
             spaceId={spaceId}
-            controlsUrlState={filterControls}
+            controlsUrlState={filterControlsConfig}
+            setControlsUrlState={onFilterControlsConfigChange}
             filters={controlFiltersWithSpace}
-            onFiltersChange={onControlFiltersChange}
+            onFiltersChange={onFilterControlsChange}
+            onInit={onControlApiAvailable}
             storageKey={filterControlsStorageKey}
             defaultControls={defaultFilterControls}
+            query={queryFilter}
+            timeRange={timeRange}
             services={{
               http,
               notifications,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_search_bar/use_alert_search_bar_state_container.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_search_bar/use_alert_search_bar_state_container.tsx
@@ -48,10 +48,6 @@ interface AlertSearchBarContainerState {
    */
   savedQueryId?: string;
   /**
-   * Filters applied from the controls bar
-   */
-  controlFilters: Filter[];
-  /**
    * Filter controls bar configuration
    */
   filterControls: FilterControlConfig[];
@@ -70,9 +66,6 @@ interface AlertSearchBarStateTransitions {
   setFilters: (
     state: AlertSearchBarContainerState
   ) => (filters: Filter[]) => AlertSearchBarContainerState;
-  setControlFilters: (
-    state: AlertSearchBarContainerState
-  ) => (controlFilters: Filter[]) => AlertSearchBarContainerState;
   setSavedQueryId: (
     state: AlertSearchBarContainerState
   ) => (savedQueryId?: string) => AlertSearchBarContainerState;
@@ -86,7 +79,6 @@ const defaultState: AlertSearchBarContainerState = {
   rangeTo: 'now',
   kuery: '',
   filters: [],
-  controlFilters: [],
   filterControls: [],
 };
 
@@ -95,7 +87,6 @@ const transitions: AlertSearchBarStateTransitions = {
   setRangeTo: (state) => (rangeTo) => ({ ...state, rangeTo }),
   setKuery: (state) => (kuery) => ({ ...state, kuery }),
   setFilters: (state) => (filters) => ({ ...state, filters }),
-  setControlFilters: (state) => (controlFilters) => ({ ...state, controlFilters }),
   setSavedQueryId: (state) => (savedQueryId) => ({ ...state, savedQueryId }),
   setFilterControls: (state) => (filterControls) => ({ ...state, filterControls }),
 };
@@ -116,17 +107,12 @@ export function useAlertSearchBarStateContainer(
 
   useUrlStateSyncEffect(stateContainer, urlStorageKey, replace);
 
-  const {
-    setRangeFrom,
-    setRangeTo,
-    setKuery,
-    setFilters,
-    setSavedQueryId,
-    setControlFilters,
-    setFilterControls,
-  } = stateContainer.transitions;
-  const { rangeFrom, rangeTo, kuery, filters, savedQueryId, controlFilters, filterControls } =
-    useContainerSelector(stateContainer, (state) => state);
+  const { setRangeFrom, setRangeTo, setKuery, setFilters, setSavedQueryId, setFilterControls } =
+    stateContainer.transitions;
+  const { rangeFrom, rangeTo, kuery, filters, savedQueryId, filterControls } = useContainerSelector(
+    stateContainer,
+    (state) => state
+  );
 
   useEffect(() => {
     if (!savedQuery) {
@@ -163,8 +149,6 @@ export function useAlertSearchBarStateContainer(
     onKueryChange: setKuery,
     filters,
     onFiltersChange: setFilters,
-    controlFilters,
-    onControlFiltersChange: setControlFilters,
     filterControls,
     onFilterControlsChange: setFilterControls,
     rangeFrom,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule.test.tsx
@@ -81,6 +81,28 @@ jest.mock('@kbn/response-ops-alerts-table/components/alerts_table', () => ({
   default: mockAlertsTable,
 }));
 
+// Mock the rule-details alert search bar to immediately signal control readiness so the
+// rule details alerts table renders during these tests (the real search bar's readiness
+// depends on the control group initializing asynchronously, which doesn't happen in jsdom).
+jest.mock('./rule_alert_search_bar', () => {
+  const ReactLib = jest.requireActual('react');
+  return {
+    RuleAlertSearchBar: ({
+      onFilterControlsChange,
+      onControlApiAvailable,
+    }: {
+      onFilterControlsChange?: (filters: unknown[]) => void;
+      onControlApiAvailable?: (api: unknown) => void;
+    }) => {
+      ReactLib.useEffect(() => {
+        onControlApiAvailable?.({});
+        onFilterControlsChange?.([]);
+      }, [onControlApiAvailable, onFilterControlsChange]);
+      return ReactLib.createElement('div', { 'data-test-subj': 'ruleAlertSearchBar' });
+    },
+  };
+});
+
 const { loadExecutionLogAggregations } = jest.requireMock(
   '../../../lib/rule_api/load_execution_log_aggregations'
 );

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule.tsx
@@ -7,7 +7,8 @@
 
 import React, { lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import type { BoolQuery } from '@kbn/es-query';
+import type { BoolQuery, Filter } from '@kbn/es-query';
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared/src/alert_filter_controls/types';
 import { useHistory, useLocation } from 'react-router-dom';
 import useObservable from 'react-use/lib/useObservable';
 import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiTabbedContent, useEuiTheme } from '@elastic/eui';
@@ -126,6 +127,12 @@ export function RuleComponent({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const lastReloadRequestTime = useMemo(() => new Date().getTime(), [refreshToken]);
   const [alertsSearchEsQuery, setAlertsSearchEsQuery] = useState<{ bool: BoolQuery }>();
+  const [filterControls, setFilterControls] = useState<Filter[]>();
+  const [controlApi, setControlApi] = useState<FilterGroupHandler | undefined>();
+  const hasInitialControlLoadingFinished = useMemo(
+    () => Boolean(controlApi) && Array.isArray(filterControls),
+    [controlApi, filterControls]
+  );
 
   const alertsTableQuery = useMemo(() => {
     const baseRuleFilter = {
@@ -184,7 +191,7 @@ export function RuleComponent({
   ].some(Boolean);
 
   const renderRuleAlertList = useCallback(() => {
-    if (ruleType.hasAlertsMappings) {
+    if (ruleType.hasAlertsMappings && hasInitialControlLoadingFinished) {
       const alertDetailsNavigation: AlertDetailsNavigation | undefined = hasObservabilityAccess
         ? {
             appId: 'observability',
@@ -227,6 +234,7 @@ export function RuleComponent({
     data,
     fieldFormats,
     getAlertFormatter,
+    hasInitialControlLoadingFinished,
     hasObservabilityAccess,
     http,
     alertsTableQuery,
@@ -242,14 +250,20 @@ export function RuleComponent({
     () => (
       <>
         <EuiSpacer size="m" />
-        <RuleAlertSearchBar ruleTypeId={ruleType.id} onEsQueryChange={setAlertsSearchEsQuery} />
+        <RuleAlertSearchBar
+          ruleTypeId={ruleType.id}
+          filterControls={filterControls}
+          onFilterControlsChange={setFilterControls}
+          onControlApiAvailable={setControlApi}
+          onEsQueryChange={setAlertsSearchEsQuery}
+        />
         <EuiSpacer size="s" />
         <EuiFlexGroup css={{ minHeight: 450 }} direction="column">
           <EuiFlexItem>{renderRuleAlertList()}</EuiFlexItem>
         </EuiFlexGroup>
       </>
     ),
-    [renderRuleAlertList, ruleType.id]
+    [filterControls, renderRuleAlertList, ruleType.id]
   );
 
   const scrollAlertsIntoView = useCallback(

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_search_bar.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_search_bar.test.tsx
@@ -26,8 +26,17 @@ describe('RuleAlertSearchBar', () => {
 
   it('wires rule-details alert search bar props correctly', () => {
     const onEsQueryChange = jest.fn();
+    const onFilterControlsChange = jest.fn();
+    const onControlApiAvailable = jest.fn();
 
-    render(<RuleAlertSearchBar ruleTypeId="my.rule.type" onEsQueryChange={onEsQueryChange} />);
+    render(
+      <RuleAlertSearchBar
+        ruleTypeId="my.rule.type"
+        onEsQueryChange={onEsQueryChange}
+        onFilterControlsChange={onFilterControlsChange}
+        onControlApiAvailable={onControlApiAvailable}
+      />
+    );
 
     expect(screen.getByTestId('ruleDetailsAlertsSearchBarRow')).toBeInTheDocument();
     expect(screen.getByTestId('urlSyncedAlertsSearchBar')).toBeInTheDocument();
@@ -43,13 +52,22 @@ describe('RuleAlertSearchBar', () => {
         urlStorageKey: RULE_DETAILS_ALERTS_SEARCH_BAR_PARAMS_URL_STORAGE_KEY,
         filterControlsStorageKey: RULE_DETAILS_FILTER_CONTROLS_STORAGE_KEY,
         onEsQueryChange,
+        onFilterControlsChange,
+        onControlApiAvailable,
       }),
       expect.anything()
     );
   });
 
   it('excludes the Rule filter control from defaultFilterControls', () => {
-    render(<RuleAlertSearchBar ruleTypeId="my.rule.type" onEsQueryChange={jest.fn()} />);
+    render(
+      <RuleAlertSearchBar
+        ruleTypeId="my.rule.type"
+        onEsQueryChange={jest.fn()}
+        onFilterControlsChange={jest.fn()}
+        onControlApiAvailable={jest.fn()}
+      />
+    );
 
     const [props] = jest.mocked(UrlSyncedAlertsSearchBar).mock.calls[0];
     const { defaultFilterControls } = props as unknown as {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_search_bar.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_search_bar.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import type { BoolQuery } from '@kbn/es-query';
+import type { BoolQuery, Filter } from '@kbn/es-query';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared/src/alert_filter_controls/types';
 import { UrlSyncedAlertsSearchBar } from '../../alerts_search_bar/url_synced_alerts_search_bar';
 import {
   RULE_DETAILS_ALERTS_SEARCH_BAR_PARAMS_URL_STORAGE_KEY,
@@ -21,10 +22,19 @@ import {
 
 interface RuleAlertSearchBarProps {
   ruleTypeId: string;
+  filterControls?: Filter[];
+  onFilterControlsChange: (filterControls: Filter[]) => void;
+  onControlApiAvailable: (controlGroupHandler: FilterGroupHandler | undefined) => void;
   onEsQueryChange: (esQuery: { bool: BoolQuery }) => void;
 }
 
-export const RuleAlertSearchBar = ({ ruleTypeId, onEsQueryChange }: RuleAlertSearchBarProps) => {
+export const RuleAlertSearchBar = ({
+  ruleTypeId,
+  filterControls,
+  onFilterControlsChange,
+  onControlApiAvailable,
+  onEsQueryChange,
+}: RuleAlertSearchBarProps) => {
   return (
     <Provider value={alertSearchBarStateContainer}>
       <EuiFlexGroup
@@ -42,6 +52,9 @@ export const RuleAlertSearchBar = ({ ruleTypeId, onEsQueryChange }: RuleAlertSea
             showSubmitButton
             urlStorageKey={RULE_DETAILS_ALERTS_SEARCH_BAR_PARAMS_URL_STORAGE_KEY}
             filterControlsStorageKey={RULE_DETAILS_FILTER_CONTROLS_STORAGE_KEY}
+            filterControls={filterControls}
+            onFilterControlsChange={onFilterControlsChange}
+            onControlApiAvailable={onControlApiAvailable}
             onEsQueryChange={onEsQueryChange}
             defaultFilterControls={RULE_DETAILS_FILTER_CONTROLS}
           />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps][Alerts] Fix stack alerts page double loading with filter controls (#271441)](https://github.com/elastic/kibana/pull/271441)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Umberto Pepato","email":"umbopepato@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-05T11:06:09Z","message":"[ResponseOps][Alerts] Fix stack alerts page double loading with filter controls (#271441)\n\n## 📄 Summary\n\nThe stack alerts table was firing two separate queries on initial load:\none before the filter controls were ready (with no control filters\napplied) and one after they emitted their initial state. This sometimes\ncaused a visible flash from all alerts to the filtered set.\n\nThe fix mirrors the approach already used on the Observability alerts\npage: the filter controls output is held in page-local state (initially\n`undefined`), and the table is not rendered until the controls have\nfinished initializing.\n\n- Changes the URL persistence approach: the filter controls\nconfiguration (what fields are shown and selected) is now stored in the\nURL instead of the derived ES filters. This is a better flow direction\nsince the configuration is the source of truth.\n- Forwards the KQL query and time range to the filter controls so their\noption lists are scoped to the current search context.\n\n> [!note]\n> The `controlFilters` URL param (which stored the filter controls\noutput) is no longer written or read after this change. Any existing\nbookmarked URLs containing it will simply ignore it on load, with the\ncontrols re-applying their filters as normal. This is not a breaking\nchange.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n### ⚙️ Environment Setup\n\nDo this **before** checking out the fix, on the base branch:\n\n1. Have some alerts available.\n2. Go to **Stack Management → Alerts**.\n3. Add a filter control without naming it (e.g. `client.ip`) and save\nit.\n4. Apply a filter selection in the new control so some filtering is\nactive.\n5. Now check out this branch and reload the page.\n\n### ✅ Happy Path\n\n1. After reloading with the fix applied, the filter customization should\nstill be in place, no \"Filter controls have changed\" banner should\nappear, and the previously applied filtering should still be active.\n2. Open DevTools Network and filter for\n`privateRuleRegistryAlertsSearchStrategy`. The table should trigger a\nsingle search cycle after the page loads (previously two).\n\n> ⚠️ Warning\n> Each search cycle produces two requests to that endpoint (one to start\nthe async search, one to poll for results). Before the fix expect two\nfull cycles, after the fix expect one.\n\n### ⚡️ Edge Cases\n\n1. Clear site data and reload. The page should load correctly with\ndefault settings and no errors.\n2. Change the time range to a window with no data. The filter control\noption lists should narrow accordingly.\n3. Type a KQL query. The filter control option lists should be scoped to\nmatching documents.\n\n### ❌ Failure Cases\n\n1. Reload with a corrupted or outdated URL state. The page should fall\nback to defaults gracefully.\n\n</details>\n\n## ⏪ Backport rationale\n\nFilter controls have been on the stack alerts page since 8.18, so this\nfix should be backported to all currently open 8.x and 9.x tracks.\n\n## 🔗 References\n\nFixes #183412\n\n## Release Notes\n\nFix Stack Alerts page fetching alerts twice on load\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c89b84e7a1efbcf698d7269dfac27d12d4e723e6","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Alerting","Team:ResponseOps","backport:version","reviewer:macroscope","v9.5.0","v9.4.3","v8.19.17","v9.3.6"],"title":"[ResponseOps][Alerts] Fix stack alerts page double loading with filter controls","number":271441,"url":"https://github.com/elastic/kibana/pull/271441","mergeCommit":{"message":"[ResponseOps][Alerts] Fix stack alerts page double loading with filter controls (#271441)\n\n## 📄 Summary\n\nThe stack alerts table was firing two separate queries on initial load:\none before the filter controls were ready (with no control filters\napplied) and one after they emitted their initial state. This sometimes\ncaused a visible flash from all alerts to the filtered set.\n\nThe fix mirrors the approach already used on the Observability alerts\npage: the filter controls output is held in page-local state (initially\n`undefined`), and the table is not rendered until the controls have\nfinished initializing.\n\n- Changes the URL persistence approach: the filter controls\nconfiguration (what fields are shown and selected) is now stored in the\nURL instead of the derived ES filters. This is a better flow direction\nsince the configuration is the source of truth.\n- Forwards the KQL query and time range to the filter controls so their\noption lists are scoped to the current search context.\n\n> [!note]\n> The `controlFilters` URL param (which stored the filter controls\noutput) is no longer written or read after this change. Any existing\nbookmarked URLs containing it will simply ignore it on load, with the\ncontrols re-applying their filters as normal. This is not a breaking\nchange.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n### ⚙️ Environment Setup\n\nDo this **before** checking out the fix, on the base branch:\n\n1. Have some alerts available.\n2. Go to **Stack Management → Alerts**.\n3. Add a filter control without naming it (e.g. `client.ip`) and save\nit.\n4. Apply a filter selection in the new control so some filtering is\nactive.\n5. Now check out this branch and reload the page.\n\n### ✅ Happy Path\n\n1. After reloading with the fix applied, the filter customization should\nstill be in place, no \"Filter controls have changed\" banner should\nappear, and the previously applied filtering should still be active.\n2. Open DevTools Network and filter for\n`privateRuleRegistryAlertsSearchStrategy`. The table should trigger a\nsingle search cycle after the page loads (previously two).\n\n> ⚠️ Warning\n> Each search cycle produces two requests to that endpoint (one to start\nthe async search, one to poll for results). Before the fix expect two\nfull cycles, after the fix expect one.\n\n### ⚡️ Edge Cases\n\n1. Clear site data and reload. The page should load correctly with\ndefault settings and no errors.\n2. Change the time range to a window with no data. The filter control\noption lists should narrow accordingly.\n3. Type a KQL query. The filter control option lists should be scoped to\nmatching documents.\n\n### ❌ Failure Cases\n\n1. Reload with a corrupted or outdated URL state. The page should fall\nback to defaults gracefully.\n\n</details>\n\n## ⏪ Backport rationale\n\nFilter controls have been on the stack alerts page since 8.18, so this\nfix should be backported to all currently open 8.x and 9.x tracks.\n\n## 🔗 References\n\nFixes #183412\n\n## Release Notes\n\nFix Stack Alerts page fetching alerts twice on load\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c89b84e7a1efbcf698d7269dfac27d12d4e723e6"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","8.19","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271441","number":271441,"mergeCommit":{"message":"[ResponseOps][Alerts] Fix stack alerts page double loading with filter controls (#271441)\n\n## 📄 Summary\n\nThe stack alerts table was firing two separate queries on initial load:\none before the filter controls were ready (with no control filters\napplied) and one after they emitted their initial state. This sometimes\ncaused a visible flash from all alerts to the filtered set.\n\nThe fix mirrors the approach already used on the Observability alerts\npage: the filter controls output is held in page-local state (initially\n`undefined`), and the table is not rendered until the controls have\nfinished initializing.\n\n- Changes the URL persistence approach: the filter controls\nconfiguration (what fields are shown and selected) is now stored in the\nURL instead of the derived ES filters. This is a better flow direction\nsince the configuration is the source of truth.\n- Forwards the KQL query and time range to the filter controls so their\noption lists are scoped to the current search context.\n\n> [!note]\n> The `controlFilters` URL param (which stored the filter controls\noutput) is no longer written or read after this change. Any existing\nbookmarked URLs containing it will simply ignore it on load, with the\ncontrols re-applying their filters as normal. This is not a breaking\nchange.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n### ⚙️ Environment Setup\n\nDo this **before** checking out the fix, on the base branch:\n\n1. Have some alerts available.\n2. Go to **Stack Management → Alerts**.\n3. Add a filter control without naming it (e.g. `client.ip`) and save\nit.\n4. Apply a filter selection in the new control so some filtering is\nactive.\n5. Now check out this branch and reload the page.\n\n### ✅ Happy Path\n\n1. After reloading with the fix applied, the filter customization should\nstill be in place, no \"Filter controls have changed\" banner should\nappear, and the previously applied filtering should still be active.\n2. Open DevTools Network and filter for\n`privateRuleRegistryAlertsSearchStrategy`. The table should trigger a\nsingle search cycle after the page loads (previously two).\n\n> ⚠️ Warning\n> Each search cycle produces two requests to that endpoint (one to start\nthe async search, one to poll for results). Before the fix expect two\nfull cycles, after the fix expect one.\n\n### ⚡️ Edge Cases\n\n1. Clear site data and reload. The page should load correctly with\ndefault settings and no errors.\n2. Change the time range to a window with no data. The filter control\noption lists should narrow accordingly.\n3. Type a KQL query. The filter control option lists should be scoped to\nmatching documents.\n\n### ❌ Failure Cases\n\n1. Reload with a corrupted or outdated URL state. The page should fall\nback to defaults gracefully.\n\n</details>\n\n## ⏪ Backport rationale\n\nFilter controls have been on the stack alerts page since 8.18, so this\nfix should be backported to all currently open 8.x and 9.x tracks.\n\n## 🔗 References\n\nFixes #183412\n\n## Release Notes\n\nFix Stack Alerts page fetching alerts twice on load\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c89b84e7a1efbcf698d7269dfac27d12d4e723e6"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.17","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->