### PR TITLE
[Obs][Scout] Migrate exploratory_view FTR test to Scout

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/test/scout/ui/fixtures/page_objects/exploratory_view.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/test/scout/ui/fixtures/page_objects/exploratory_view.ts
@@ -35,6 +35,25 @@ export class ExploratoryViewPage {
     await this.page.click(`button[role="option"]:has-text("${value}")`);
   }
 
+  /**
+   * Expands the inline editor for a series so its breakdown / metric controls
+   * become available. Series rendered from a prefilled URL (e.g. opened from the
+   * UX app's "Explore data" link) start collapsed.
+   */
+  async editSeries(seriesId: number = 0): Promise<void> {
+    await this.page.testSubj.click(`editSeries${seriesId}`);
+  }
+
+  /**
+   * Selects a breakdown by its underlying field name (the EuiSuperSelect option's
+   * `id` is the field, while the visible label is a human-readable name), e.g.
+   * `user_agent.name`. Mirrors the FTR's `[id="user_agent.name"]` selector.
+   */
+  async selectSeriesBreakdownByField(fieldId: string): Promise<void> {
+    await this.page.testSubj.locator('seriesBreakdown').click();
+    await this.page.locator(`[id="${fieldId}"]`).click();
+  }
+
   async applySeriesChanges(): Promise<void> {
     await this.page.testSubj.click('seriesChangesApplyButton');
   }

--- a/x-pack/solutions/observability/plugins/exploratory_view/test/scout/ui/tests/ux_prefill_exploratory_view.spec.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/test/scout/ui/tests/ux_prefill_exploratory_view.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../fixtures';
+
+/**
+ * Ported from the FTR `observability_functional` suite
+ * (`apps/observability/exploratory_view.ts`).
+ *
+ * The original drove the integration end to end across four sequential `it`s
+ * sharing one browser session: open the UX (RUM) app, click its "Explore data"
+ * link, land on a prefilled Exploratory View, and break the series down by
+ * `user_agent.name`. It runs here against the same RUM archives the suite's
+ * global setup already ingests (`rum_8.0.0` + `rum_test_data`).
+ *
+ * Notes vs the FTR:
+ *  - One Scout `test` with a `test.step` per stage instead of four shared `it`s,
+ *    so a failure points at the offending stage without leaking browser state.
+ *  - The FTR's `expect((await find.byCssSelector('dd')).getVisibleText()).to.eql(true)`
+ *    assertion is dropped: it compared an un-awaited `Promise` to a boolean, so it
+ *    asserted nothing meaningful. The lens-render + breakdown assertions cover the
+ *    intent (the prefilled visualization renders and responds to a breakdown).
+ */
+test.describe(
+  'Exploratory View - prefilled from the UX app',
+  { tag: tags.stateful.classic },
+  () => {
+    // Matches the RUM archive's data window (Jan 2021); the range propagates from
+    // the UX app into the prefilled Exploratory View URL.
+    const rangeFrom = '2021-01-17T16:46:15.338Z';
+    const rangeTo = '2021-01-19T17:01:32.309Z';
+
+    test('opens a prefilled Exploratory View and breaks down by user agent', async ({
+      page,
+      pageObjects,
+      browserAuth,
+    }) => {
+      const { exploratoryView } = pageObjects;
+
+      await test.step('go to the UX app', async () => {
+        await browserAuth.loginAsAdmin();
+        await page.gotoApp('ux', { params: { rangeFrom, rangeTo } });
+        await expect(page.testSubj.locator('uxAnalyzeBtn')).toBeVisible();
+      });
+
+      await test.step('open Exploratory View via "Explore data"', async () => {
+        await page.testSubj.click('uxAnalyzeBtn');
+        await exploratoryView.waitForLoadingToFinish();
+      });
+
+      await test.step('renders a prefilled lens visualization', async () => {
+        await expect(page.testSubj.locator('xyVisChart')).toBeVisible();
+        await expect(
+          page.locator('div[data-title="Prefilled from exploratory view app"]')
+        ).toBeVisible();
+      });
+
+      await test.step('breaks the series down by user_agent.name', async () => {
+        await exploratoryView.editSeries(0);
+        await exploratoryView.selectSeriesBreakdownByField('user_agent.name');
+        await exploratoryView.applySeriesChanges();
+        await exploratoryView.waitForLoadingToFinish();
+
+        // A per-browser breakdown yields one legend item per distinct user agent.
+        await expect(exploratoryView.echLegendItemLocator).toHaveCount(11);
+      });
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Part of the `observability_functional` FTR → Scout migration (Addresses #263519).

Migrates the FTR `apps/observability/exploratory_view.ts` suite into the existing
**exploratory_view** Scout UI suite. The test exercises the UX (RUM) → Exploratory
View integration:

- opens the **UX app** (`/app/ux`) over the RUM data window,
- follows its **"Explore data"** (`uxAnalyzeBtn`) link to a **prefilled Exploratory View**,
- asserts the lens visualization renders (`xyVisChart` + the `Prefilled from exploratory view app` title),
- breaks the series down by **`user_agent.name`** and asserts the resulting legend item count.

### Why here

Both the `ux` and `exploratory_view` plugins are owned by `@elastic/actionable-obs-team`.
The exploratory_view Scout suite already ingests the same RUM archives
(`rum_8.0.0` + `rum_test_data`) via global setup and ships the `ExploratoryViewPage`
page object with the breakdown helpers, so this reuses that infrastructure.

### Notes vs the FTR

- The four sequential `it`s (shared browser session) become one `test` with a
  `test.step` per stage, so a failure pinpoints the offending stage.
- The FTR's `expect((await find.byCssSelector('dd')).getVisibleText()).to.eql(true)`
  assertion is **dropped** — it compared an un-awaited `Promise` to a boolean and
  asserted nothing meaningful. The lens-render + breakdown assertions cover the intent.
- `ExploratoryViewPage` gains `editSeries` and `selectSeriesBreakdownByField`
  (id-based, mirroring the FTR's `[id="user_agent.name"]`).

## Test plan

- [ ] `node scripts/check.js --scope branch` (local) — lint ✓, jest ✓ (175 tests), tsc ✓.
- [ ] Scout CI run of the exploratory_view UI suite (stateful/classic).

Made with [Cursor](https://cursor.com)