### PR TITLE
[APM] Improve visibility of anomalies in service overview

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/anomaly_detection/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/anomaly_detection/index.ts
@@ -7,8 +7,10 @@
 
 import { i18n } from '@kbn/i18n';
 import { getSeverityType } from '@kbn/ml-anomaly-utils/get_severity_type';
-import { getSeverityColor as mlGetSeverityColor } from '@kbn/ml-anomaly-utils/get_severity_color';
 import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
+import { getThemeResolvedSeverityColor, ML_ANOMALY_THRESHOLD } from '@kbn/ml-anomaly-utils';
+import type { EuiThemeComputed, RecursivePartial } from '@elastic/eui';
+import type { PointStyle } from '@elastic/charts';
 export type { ServiceAnomalyStats } from '@kbn/apm-types';
 
 export function getSeverity(score: number | undefined) {
@@ -19,8 +21,24 @@ export function getSeverity(score: number | undefined) {
   return getSeverityType(score);
 }
 
-export function getSeverityColor(score: number) {
-  return mlGetSeverityColor(score);
+export function getSeverityColor(score: number, uiTheme: EuiThemeComputed) {
+  return getThemeResolvedSeverityColor(score, uiTheme);
+}
+
+export function getSeverityPointStyle(
+  score: number,
+  uiTheme: EuiThemeComputed
+): RecursivePartial<PointStyle> {
+  const color = getSeverityColor(score, uiTheme);
+  const radius = score >= ML_ANOMALY_THRESHOLD.MINOR ? 4 : 3;
+
+  return {
+    visible: 'always',
+    opacity: 1,
+    radius,
+    fill: color,
+    shape: 'triangle',
+  };
 }
 
 export const ML_ERRORS = {

--- a/x-pack/solutions/observability/plugins/apm/public/components/alerting/rule_types/anomaly_rule_type/select_anomaly_severity.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/alerting/rule_types/anomaly_rule_type/select_anomaly_severity.tsx
@@ -8,15 +8,19 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { EuiHealth, EuiSpacer, EuiSuperSelect, EuiText } from '@elastic/eui';
+import { EuiHealth, EuiSpacer, EuiSuperSelect, EuiText, useEuiTheme } from '@elastic/eui';
 import { getSeverityColor } from '../../../../../common/anomaly_detection';
 import type { AnomalyAlertSeverityType } from '../../../../../common/rules/apm_rule_types';
 import { ANOMALY_ALERT_SEVERITY_TYPES } from '../../../../../common/rules/apm_rule_types';
 
 export function AnomalySeverity({ type }: { type: AnomalyAlertSeverityType }) {
+  const { euiTheme } = useEuiTheme();
   const selectedOption = ANOMALY_ALERT_SEVERITY_TYPES.find((option) => option.type === type)!;
   return (
-    <EuiHealth color={getSeverityColor(selectedOption.threshold)} style={{ lineHeight: 'inherit' }}>
+    <EuiHealth
+      color={getSeverityColor(selectedOption.threshold, euiTheme)}
+      style={{ lineHeight: 'inherit' }}
+    >
       {selectedOption.label}
     </EuiHealth>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { EuiBadge, EuiHealth, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiHealth, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import { getSeverity, getSeverityColor } from '../../../../../common/anomaly_detection';
@@ -57,6 +57,7 @@ const anomaliesBadgeHealthCss = css`
 `;
 
 export function AnomaliesBadge({ score }: { score?: number }) {
+  const { euiTheme } = useEuiTheme();
   const severity = getSeverity(score);
   const text = formatLabelWithScore(getI18nLabel(severity), score);
 
@@ -75,7 +76,7 @@ export function AnomaliesBadge({ score }: { score?: number }) {
       <EuiBadge tabIndex={0} color="hollow" css={anomaliesBadgeCss}>
         <EuiHealth
           textSize="inherit"
-          color={score === undefined ? 'subdued' : getSeverityColor(score)}
+          color={score === undefined ? 'subdued' : getSeverityColor(score, euiTheme)}
           css={anomaliesBadgeHealthCss}
         >
           {text}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx
@@ -12,6 +12,7 @@ import { ServiceMapGraph } from './graph';
 import { getSeverityColor } from '../../../../common/anomaly_detection';
 import type { ServiceMapNode } from '../../../../common/service_map';
 import { MOCK_EUI_THEME, MOCK_EUI_THEME_FOR_USE_THEME } from './constants';
+import type { EuiThemeComputed } from '@elastic/eui';
 
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
@@ -353,7 +354,9 @@ describe('ServiceMapGraph - MiniMap', () => {
         type: 'service',
       };
 
-      expect(nodeColorFn(scoredNode)).toBe(getSeverityColor(90));
+      expect(nodeColorFn(scoredNode)).toBe(
+        getSeverityColor(90, MOCK_EUI_THEME_FOR_USE_THEME as unknown as EuiThemeComputed)
+      );
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/anomaly_detection.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/anomaly_detection.tsx
@@ -68,7 +68,7 @@ export function AnomalyDetection({ serviceName, serviceAnomalyStats }: Props) {
       {hasAnomalyDetectionScore && (
         <section css={contentLineStyles}>
           <div css={verticallyCenteredStyles}>
-            <EuiHealth color={getSeverityColor(anomalyScore as number)}>
+            <EuiHealth color={getSeverityColor(anomalyScore as number, euiTheme)}>
               <span>
                 {i18n.translate('xpack.apm.serviceMap.anomalyDetectionPopoverScoreWithValue', {
                   defaultMessage: '{metric}: {score}',

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_legend.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_legend.tsx
@@ -319,7 +319,11 @@ export function ServiceMapLegend({ controlIconCss }: ServiceMapLegendProps) {
           {ANOMALY_SCORE_LEVELS.map(({ score, label }) => (
             <EuiFlexItem key={label}>
               <EuiHealth
-                color={score === undefined ? euiTheme.colors.textSubdued : getSeverityColor(score)}
+                color={
+                  score === undefined
+                    ? euiTheme.colors.textSubdued
+                    : getSeverityColor(score, euiTheme)
+                }
               >
                 <EuiText size="xs">{label}</EuiText>
               </EuiHealth>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_minimap.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_minimap.tsx
@@ -22,7 +22,7 @@ export function ServiceMapMinimap() {
       if (isServiceNodeData(node.data)) {
         const { anomalyScore } = node.data.serviceAnomalyStats ?? {};
         if (anomalyScore !== undefined) {
-          return getSeverityColor(anomalyScore);
+          return getSeverityColor(anomalyScore, euiTheme);
         }
         return euiTheme.colors.primary;
       }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/helper/get_chart_anomaly_timeseries.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/helper/get_chart_anomaly_timeseries.tsx
@@ -12,7 +12,7 @@ import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import { ML_ANOMALY_THRESHOLD } from '@kbn/ml-anomaly-utils/anomaly_threshold';
 import type { AreaSeriesStyle, RecursivePartial } from '@elastic/charts';
 import type { EuiThemeComputed } from '@elastic/eui';
-import { getSeverityColor } from '../../../../../common/anomaly_detection';
+import { getSeverityColor, getSeverityPointStyle } from '../../../../../common/anomaly_detection';
 import type { ServiceAnomalyTimeseries } from '../../../../../common/anomaly_detection/service_anomaly_timeseries';
 import type { APMChartSpec } from '../../../../../typings/timeseries';
 
@@ -58,17 +58,29 @@ export function getChartAnomalyTimeseries({
 
   const severities = [
     {
+      severity: ML_ANOMALY_SEVERITY.CRITICAL,
+      threshold: ML_ANOMALY_THRESHOLD.CRITICAL,
+    },
+    {
       severity: ML_ANOMALY_SEVERITY.MAJOR,
       threshold: ML_ANOMALY_THRESHOLD.MAJOR,
     },
     {
-      severity: ML_ANOMALY_SEVERITY.CRITICAL,
-      threshold: ML_ANOMALY_THRESHOLD.CRITICAL,
+      severity: ML_ANOMALY_SEVERITY.MINOR,
+      threshold: ML_ANOMALY_THRESHOLD.MINOR,
+    },
+    {
+      severity: ML_ANOMALY_SEVERITY.WARNING,
+      threshold: ML_ANOMALY_THRESHOLD.WARNING,
+    },
+    {
+      severity: ML_ANOMALY_SEVERITY.LOW,
+      threshold: ML_ANOMALY_THRESHOLD.LOW,
     },
   ];
 
   const scores: APMChartSpec[] = severities.map(({ severity, threshold }) => {
-    const color = getSeverityColor(threshold);
+    const color = getSeverityColor(threshold, euiTheme);
 
     const style: RecursivePartial<AreaSeriesStyle> = {
       line: {
@@ -77,14 +89,7 @@ export function getChartAnomalyTimeseries({
       area: {
         fill: color,
       },
-      point: {
-        visible: 'always',
-        opacity: 0.75,
-        radius: 3,
-        strokeWidth: 1,
-        fill: color,
-        stroke: rgba(0, 0, 0, 0.1),
-      },
+      point: getSeverityPointStyle(threshold, euiTheme),
     };
 
     const data = anomalyTimeseries.anomalies.map((anomaly) => ({
@@ -100,16 +105,16 @@ export function getChartAnomalyTimeseries({
     return {
       title: i18n.translate('xpack.apm.anomalyScore', {
         defaultMessage:
-          '{severity, select, minor {Minor} major {Major} critical {Critical} other {unknown severity}} anomaly',
+          '{severity, select, low {Low} warning {Warning} minor {Minor} major {Major} critical {Critical} other {Unknown severity}} anomaly',
         values: {
           severity,
         },
       }),
       type: 'line',
-      hideLegend: !hasAnomalies,
       lineSeriesStyle: style,
       data,
       color,
+      hideLegend: !hasAnomalies,
     };
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_map/service_node.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_map/service_node.tsx
@@ -99,7 +99,7 @@ export const ServiceNode = memo(
 
       return {
         borderColor: hasScore
-          ? getSeverityColor(score)
+          ? getSeverityColor(score, euiTheme)
           : selected
           ? euiTheme.colors.primary
           : euiTheme.colors.mediumShade,


### PR DESCRIPTION
## Summary (Draft)

Changes included:

- Anomalies are rendered as triangles instead of dots to distinguish them from chart data
- Transparency is removed, all anomaly indicators have opacity 1
- Radius increased to 4 for minor anomalies or higher
- Anomalies series now display their legend (`hideLegend: false`)
- All severities are displayed (minor, warning and low used to be excluded)
- Empty severity series are excluded and won't render a legend since they don't have visible content

<img width="688" height="399" alt="Screenshot 2026-06-05 at 16 51 45" src="https://github.com/user-attachments/assets/037fa6dd-2d47-41c0-9ea8-1520aee2205a" />





