### PR TITLE
[9.4] [Fleet] Fix support for per-integration overrides for OTel integrations (#270487)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/output.ts
@@ -173,6 +173,10 @@ export const OUTPUT_TYPES_WITH_PRESET_SUPPORT: Array<ValueOf<OutputType>> = [
   outputType.RemoteElasticsearch,
 ];
 
+export const OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT: Array<ValueOf<OutputType>> = [
+  outputType.Elasticsearch,
+];
+
 export const OUTPUT_HEALTH_DATA_STREAM = 'logs-fleet_server.output_health-default';
 
 export const LOGSTASH_API_KEY_CLUSTER_PERMISSIONS = ['monitor', 'manage_own_api_key'];

--- a/x-pack/platform/plugins/shared/fleet/common/services/otelcol_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/otelcol_helpers.ts
@@ -20,7 +20,9 @@ export const packageInfoHasOtelInputs = (packageInfo: PackageInfo | undefined) =
     getNormalizedInputs(template).some((input) => input.type === OTEL_COLLECTOR_INPUT_TYPE)
   );
 
-export const packagePolicyHasOtelInputs = (packagePolicyInputs: PackagePolicyInput[] | undefined) =>
+export const packagePolicyHasOtelInputs = (
+  packagePolicyInputs: Array<Pick<PackagePolicyInput, 'type' | 'enabled'>> | undefined
+) =>
   (packagePolicyInputs || []).some(
     (input) => input.type === OTEL_COLLECTOR_INPUT_TYPE && input.enabled
   );

--- a/x-pack/platform/plugins/shared/fleet/common/services/output_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/output_helpers.test.ts
@@ -7,8 +7,12 @@
 
 import { load } from 'js-yaml';
 
+import { OTEL_COLLECTOR_INPUT_TYPE } from '../constants';
+import { outputType, OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT } from '../constants/output';
+
 import {
   getAllowedOutputTypesForAgentPolicy,
+  getAllowedOutputTypesForPackagePolicy,
   outputYmlIncludesReservedPerformanceKey,
 } from './output_helpers';
 
@@ -23,10 +27,10 @@ describe('getAllowedOutputTypesForAgentPolicy', () => {
     } as any);
 
     expect(res).toHaveLength(4);
-    expect(res).toContain('elasticsearch');
-    expect(res).toContain('logstash');
-    expect(res).toContain('kafka');
-    expect(res).toContain('remote_elasticsearch');
+    expect(res).toContain(outputType.Elasticsearch);
+    expect(res).toContain(outputType.Logstash);
+    expect(res).toContain(outputType.Kafka);
+    expect(res).toContain(outputType.RemoteElasticsearch);
   });
 
   it('should return only elasticsearch for an agent policy with APM', () => {
@@ -38,7 +42,7 @@ describe('getAllowedOutputTypesForAgentPolicy', () => {
       ],
     } as any);
 
-    expect(res).toEqual(['elasticsearch']);
+    expect(res).toEqual([outputType.Elasticsearch]);
   });
 
   it('should return only elasticsearch for an agent policy with Fleet Server', () => {
@@ -50,7 +54,7 @@ describe('getAllowedOutputTypesForAgentPolicy', () => {
       ],
     } as any);
 
-    expect(res).toEqual(['elasticsearch']);
+    expect(res).toEqual([outputType.Elasticsearch]);
   });
 
   it('should return only elasticsearch for an agent policy with Fleet Server not yet installed', () => {
@@ -58,33 +62,128 @@ describe('getAllowedOutputTypesForAgentPolicy', () => {
       has_fleet_server: true,
     } as any);
 
-    expect(res).toEqual(['elasticsearch']);
+    expect(res).toEqual([outputType.Elasticsearch]);
   });
 
   it('should return only elasticsearch for an agentless agent policy', () => {
     const res = getAllowedOutputTypesForAgentPolicy({ supports_agentless: true } as any);
 
-    expect(res).toEqual(['elasticsearch']);
+    expect(res).toEqual([outputType.Elasticsearch]);
   });
-});
 
-describe('getAllowedOutputTypesForPackagePolicy', () => {
-  it('should return all available output type for a package policy without agentless support', () => {
+  it('should return only OTel-supported output types when any package policy has an enabled OTel input', () => {
     const res = getAllowedOutputTypesForAgentPolicy({
       package_policies: [
         {
           package: { name: 'nginx' },
+          inputs: [{ type: 'log', enabled: true }],
+        },
+        {
+          package: { name: 'otel' },
+          inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, enabled: true }],
+        },
+      ],
+    } as any);
+
+    expect(res).toEqual(OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT);
+  });
+
+  it('should not restrict outputs when OTel input is disabled', () => {
+    const res = getAllowedOutputTypesForAgentPolicy({
+      package_policies: [
+        {
+          package: { name: 'otel' },
+          inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, enabled: false }],
         },
       ],
     } as any);
 
     expect(res).toHaveLength(4);
+    expect(res).toContain(outputType.Logstash);
+    expect(res).toContain(outputType.Kafka);
+  });
+
+  it('should still return only elasticsearch for fleet server even when an OTel input is also present', () => {
+    const res = getAllowedOutputTypesForAgentPolicy({
+      package_policies: [
+        {
+          package: { name: 'fleet_server' },
+          inputs: [],
+        },
+        {
+          package: { name: 'otel' },
+          inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, enabled: true }],
+        },
+      ],
+    } as any);
+
+    expect(res).toEqual([outputType.Elasticsearch]);
+  });
+});
+
+describe('getAllowedOutputTypesForPackagePolicy', () => {
+  it('should return all available output types for a non-agentless policy without OTel inputs', () => {
+    const res = getAllowedOutputTypesForPackagePolicy({
+      supports_agentless: false,
+      inputs: [{ type: 'log', streams: [], enabled: true }],
+    } as any);
+
+    expect(res).toHaveLength(4);
+    expect(res).toContain(outputType.Elasticsearch);
+    expect(res).toContain(outputType.Logstash);
+    expect(res).toContain(outputType.Kafka);
+    expect(res).toContain(outputType.RemoteElasticsearch);
   });
 
   it('should return only elasticsearch for a package policy with agentless support', () => {
-    const res = getAllowedOutputTypesForAgentPolicy({ supports_agentless: true } as any);
+    const res = getAllowedOutputTypesForPackagePolicy({
+      supports_agentless: true,
+      inputs: [],
+    } as any);
 
-    expect(res).toEqual(['elasticsearch']);
+    expect(res).toEqual([outputType.Elasticsearch]);
+  });
+
+  it('should return only OTel-supported output types when any input is an OTel input', () => {
+    const res = getAllowedOutputTypesForPackagePolicy({
+      supports_agentless: false,
+      inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, streams: [], enabled: true }],
+    } as any);
+
+    expect(res).toEqual(OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT);
+  });
+
+  it('should return only OTel-supported output types when mixed inputs contain an OTel input', () => {
+    const res = getAllowedOutputTypesForPackagePolicy({
+      supports_agentless: false,
+      inputs: [
+        { type: 'log', streams: [], enabled: true },
+        { type: OTEL_COLLECTOR_INPUT_TYPE, streams: [], enabled: true },
+      ],
+    } as any);
+
+    expect(res).toEqual(OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT);
+  });
+
+  it('should return AGENTLESS_ALLOWED_OUTPUT_TYPES (not OTel list) when agentless even with OTel input', () => {
+    const res = getAllowedOutputTypesForPackagePolicy({
+      supports_agentless: true,
+      inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, streams: [], enabled: true }],
+    } as any);
+
+    expect(res).toEqual([outputType.Elasticsearch]);
+  });
+
+  it('should return all available output types when inputs field is missing (safe default)', () => {
+    const res = getAllowedOutputTypesForPackagePolicy({
+      supports_agentless: false,
+    } as any);
+
+    expect(res).toHaveLength(4);
+    expect(res).toContain(outputType.Elasticsearch);
+    expect(res).toContain(outputType.Logstash);
+    expect(res).toContain(outputType.Kafka);
+    expect(res).toContain(outputType.RemoteElasticsearch);
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/output_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/output_helpers.ts
@@ -16,10 +16,16 @@ import {
   FLEET_SYNTHETICS_PACKAGE,
   outputType,
   OUTPUT_TYPES_WITH_PRESET_SUPPORT,
+  OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT,
   RESERVED_CONFIG_YML_KEYS,
   AGENTLESS_ALLOWED_OUTPUT_TYPES,
   DEFAULT_OUTPUT,
 } from '../constants';
+
+import { packagePolicyHasOtelInputs } from './otelcol_helpers';
+
+const agentPolicyHasOtelInputs = (agentPolicy: Partial<AgentPolicy>): boolean =>
+  (agentPolicy.package_policies ?? []).some((pp) => packagePolicyHasOtelInputs(pp.inputs));
 
 const sameClusterRestrictedPackages = [
   FLEET_SERVER_PACKAGE,
@@ -47,17 +53,27 @@ export function getAllowedOutputTypesForAgentPolicy(agentPolicy: Partial<AgentPo
     return AGENTLESS_ALLOWED_OUTPUT_TYPES;
   }
 
+  if (agentPolicyHasOtelInputs(agentPolicy)) {
+    return OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT;
+  }
+
   return Object.values(outputType);
 }
 
 /**
- * Return allowed output type for a given package policy
+ * Return allowed output types for a given package policy.
  */
 export function getAllowedOutputTypesForPackagePolicy(
-  packagePolicy: Pick<PackagePolicy, 'supports_agentless'>
+  packagePolicy: Pick<PackagePolicy, 'supports_agentless'> & {
+    inputs?: Array<{ type: string; enabled: boolean }>;
+  }
 ): string[] {
   if (packagePolicy.supports_agentless) {
     return AGENTLESS_ALLOWED_OUTPUT_TYPES;
+  }
+
+  if (packagePolicyHasOtelInputs(packagePolicy.inputs)) {
+    return OUTPUT_TYPES_WITH_OTEL_EXPORTER_SUPPORT;
   }
 
   return Object.values(outputType);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/hooks.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/hooks.tsx
@@ -9,7 +9,7 @@ import { useMemo, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { LICENCE_FOR_OUTPUT_PER_INTEGRATION } from '../../../../../../../../../common/constants';
-import type { NewPackagePolicy, PackagePolicy } from '../../../../../../../../../common/types';
+import type { NewPackagePolicy } from '../../../../../../../../../common/types';
 import type { RegistryVarGroup } from '../../../../../../types';
 import { getAllowedOutputTypesForPackagePolicy } from '../../../../../../../../../common/services/output_helpers';
 import { useGetOutputs, useLicense } from '../../../../../../hooks';
@@ -30,7 +30,9 @@ export function useDataStreamId() {
 }
 
 export function useOutputs(
-  packagePolicy: Pick<PackagePolicy, 'supports_agentless'>,
+  packagePolicy: Pick<NewPackagePolicy, 'supports_agentless'> & {
+    inputs?: Array<{ type: string; enabled: boolean }>;
+  },
   packageName: string
 ) {
   const licenseService = useLicense();

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -2094,6 +2094,208 @@ describe('getFullAgentPolicy', () => {
       // proxy should be undefined when proxy_id doesn't match
       expect(callArgs.proxy).toBeUndefined();
     });
+
+    it('should pass remote_elasticsearch dataOutput to generateOtelcolConfig', async () => {
+      mockedFetchRelatedSavedObjects.mockResolvedValue({
+        outputs: [
+          {
+            id: 'remote-output-id',
+            is_default: true,
+            is_default_monitoring: true,
+            name: 'remote-output',
+            type: 'remote_elasticsearch',
+            hosts: ['https://remote-es.example.com:9200'],
+          },
+        ],
+        proxies: [],
+        dataOutput: {
+          id: 'remote-output-id',
+          is_default: true,
+          is_default_monitoring: true,
+          name: 'remote-output',
+          type: 'remote_elasticsearch',
+          hosts: ['https://remote-es.example.com:9200'],
+        },
+        monitoringOutput: {
+          id: 'remote-output-id',
+          is_default: true,
+          is_default_monitoring: true,
+          name: 'remote-output',
+          type: 'remote_elasticsearch',
+          hosts: ['https://remote-es.example.com:9200'],
+        },
+        downloadSource: {
+          id: 'default-download-source-id',
+          is_default: true,
+          name: 'Default host',
+          host: 'http://default-registry.co',
+        },
+        downloadSourceProxy: undefined,
+        fleetServerHost: {
+          name: 'default Fleet Server',
+          id: '93f74c0-e876-11ea-b7d3-8b2acec6f75c',
+          is_default: true,
+          host_urls: ['http://fleetserver:8220'],
+          is_preconfigured: false,
+        },
+      });
+
+      mockAgentPolicy({ package_policies: [] });
+
+      await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
+
+      expect(mockedGenerateOtelcolConfig).toHaveBeenCalled();
+      const callArgs = mockedGenerateOtelcolConfig.mock.calls[0][0];
+      expect(callArgs.dataOutput).toMatchObject({
+        type: 'remote_elasticsearch',
+        hosts: ['https://remote-es.example.com:9200'],
+      });
+    });
+
+    it('should pass packageOutputs with override entry when package policy has output_id', async () => {
+      const overrideOutputId = 'override-output-id';
+      mockedFetchRelatedSavedObjects.mockResolvedValue({
+        outputs: [
+          {
+            id: 'test-id',
+            is_default: true,
+            is_default_monitoring: true,
+            name: 'default',
+            type: 'elasticsearch',
+            hosts: ['http://127.0.0.1:9201'],
+          },
+          {
+            id: overrideOutputId,
+            is_default: false,
+            is_default_monitoring: false,
+            name: 'override',
+            type: 'elasticsearch',
+            hosts: ['http://override-es:9201'],
+          },
+        ],
+        proxies: [],
+        dataOutput: {
+          id: 'test-id',
+          is_default: true,
+          is_default_monitoring: true,
+          name: 'default',
+          type: 'elasticsearch',
+          hosts: ['http://127.0.0.1:9201'],
+        },
+        monitoringOutput: {
+          id: 'test-id',
+          is_default: true,
+          is_default_monitoring: true,
+          name: 'default',
+          type: 'elasticsearch',
+          hosts: ['http://127.0.0.1:9201'],
+        },
+        downloadSource: {
+          id: 'default-download-source-id',
+          is_default: true,
+          name: 'Default host',
+          host: 'http://default-registry.co',
+        },
+        downloadSourceProxy: undefined,
+        fleetServerHost: {
+          name: 'default Fleet Server',
+          id: '93f74c0-e876-11ea-b7d3-8b2acec6f75c',
+          is_default: true,
+          host_urls: ['http://fleetserver:8220'],
+          is_preconfigured: false,
+        },
+      });
+
+      mockAgentPolicy({
+        package_policies: [
+          {
+            id: 'pkg-policy-1',
+            name: 'otel-policy',
+            namespace: 'default',
+            enabled: true,
+            output_id: overrideOutputId,
+            package: { name: 'otelpackage', version: '1.0.0', title: 'OTel Package' },
+            inputs: [{ type: 'otelcol', enabled: true, streams: [] }],
+            created_at: '',
+            updated_at: '',
+            created_by: '',
+            updated_by: '',
+            revision: 1,
+            policy_id: '',
+            policy_ids: [''],
+          },
+        ],
+      });
+
+      await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
+
+      expect(mockedGenerateOtelcolConfig).toHaveBeenCalled();
+      const callArgs = mockedGenerateOtelcolConfig.mock.calls[0][0];
+      expect(callArgs.packageOutputs).toBeInstanceOf(Map);
+      const packageOutputs = callArgs.packageOutputs as Map<string, Output>;
+      expect(packageOutputs.size).toBe(1);
+      expect(packageOutputs.get('pkg-policy-1')).toBeDefined();
+      expect(packageOutputs.get('pkg-policy-1')!.id).toBe(overrideOutputId);
+    });
+
+    it('should pass empty packageOutputs when no package policies have output_id', async () => {
+      mockAgentPolicy({
+        package_policies: [
+          {
+            id: 'pkg-policy-1',
+            name: 'otel-policy',
+            namespace: 'default',
+            enabled: true,
+            package: { name: 'otelpackage', version: '1.0.0', title: 'OTel Package' },
+            inputs: [{ type: 'otelcol', enabled: true, streams: [] }],
+            created_at: '',
+            updated_at: '',
+            created_by: '',
+            updated_by: '',
+            revision: 1,
+            policy_id: '',
+            policy_ids: [''],
+          },
+        ],
+      });
+
+      await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
+
+      expect(mockedGenerateOtelcolConfig).toHaveBeenCalled();
+      const callArgs = mockedGenerateOtelcolConfig.mock.calls[0][0];
+      expect(callArgs.packageOutputs).toBeInstanceOf(Map);
+      expect((callArgs.packageOutputs as Map<string, Output>).size).toBe(0);
+    });
+
+    it('should omit a packageOutputs entry when the output_id references a non-existent output', async () => {
+      mockAgentPolicy({
+        package_policies: [
+          {
+            id: 'pkg-policy-1',
+            name: 'otel-policy',
+            namespace: 'default',
+            enabled: true,
+            output_id: 'nonexistent-output-id',
+            package: { name: 'otelpackage', version: '1.0.0', title: 'OTel Package' },
+            inputs: [{ type: 'otelcol', enabled: true, streams: [] }],
+            created_at: '',
+            updated_at: '',
+            created_by: '',
+            updated_by: '',
+            revision: 1,
+            policy_id: '',
+            policy_ids: [''],
+          },
+        ],
+      });
+
+      await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
+
+      expect(mockedGenerateOtelcolConfig).toHaveBeenCalled();
+      const callArgs = mockedGenerateOtelcolConfig.mock.calls[0][0];
+      expect(callArgs.packageOutputs).toBeInstanceOf(Map);
+      expect((callArgs.packageOutputs as Map<string, Output>).size).toBe(0);
+    });
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -166,9 +166,24 @@ export async function getFullAgentPolicy(
     const dataOutputProxy = dataOutput?.proxy_id
       ? proxies.find((p) => p.id === dataOutput.proxy_id)
       : undefined;
+
+    const packageOutputs = new Map<string, Output>();
+    for (const pkgPolicy of (agentPolicy.package_policies ?? []) as PackagePolicy[]) {
+      if (!pkgPolicy.output_id) continue;
+      const override = outputs.find((o) => o.id === pkgPolicy.output_id);
+      if (override) {
+        packageOutputs.set(pkgPolicy.id, override);
+      } else {
+        logger.warn(
+          `Output override [${pkgPolicy.output_id}] for package policy [${pkgPolicy.id}] not found, falling back to data output`
+        );
+      }
+    }
+
     otelcolConfig = generateOtelcolConfig({
       inputs: agentInputs,
       dataOutput,
+      packageOutputs,
       packageInfoCache,
       proxy: dataOutputProxy,
       logger,
@@ -273,6 +288,11 @@ export async function getFullAgentPolicy(
         packagePolicy
       );
     } else {
+      if (packagePolicy.output_id) {
+        logger.warn(
+          `Output override [${packagePolicy.output_id}] for package policy [${packagePolicy.id}] not found, falling back to data output`
+        );
+      }
       packagePoliciesByOutputId[getOutputIdForAgentPolicy(dataOutput)].push(packagePolicy);
     }
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -7,7 +7,7 @@
 
 import type { Output, FullAgentPolicyInput, TemplateAgentPolicyInput } from '../../types';
 
-import { OTEL_COLLECTOR_INPUT_TYPE } from '../../../common/constants';
+import { OTEL_COLLECTOR_INPUT_TYPE, outputType } from '../../../common/constants';
 
 import { generateOtelcolConfig } from './otel_collector';
 
@@ -282,7 +282,7 @@ describe('generateOtelcolConfig', () => {
         },
       },
       connectors: {
-        forward: {},
+        'forward/default': {},
       },
       exporters: {
         'elasticsearch/default': {
@@ -294,10 +294,10 @@ describe('generateOtelcolConfig', () => {
           'metrics/test-1-stream-id-1': {
             receivers: ['httpcheck/test-1-stream-id-1'],
             processors: ['transform/test-1-stream-id-1', 'transform/test-1-stream-id-1-routing'],
-            exporters: ['forward'],
+            exporters: ['forward/default'],
           },
-          metrics: {
-            receivers: ['forward'],
+          'metrics/default': {
+            receivers: ['forward/default'],
             exporters: ['elasticsearch/default'],
           },
         },
@@ -337,7 +337,7 @@ describe('generateOtelcolConfig', () => {
         },
       },
       connectors: {
-        forward: {},
+        'forward/fleet-default-output': {},
       },
       exporters: {
         'elasticsearch/fleet-default-output': {
@@ -349,10 +349,10 @@ describe('generateOtelcolConfig', () => {
           'metrics/test-1-stream-id-1': {
             receivers: ['httpcheck/test-1-stream-id-1'],
             processors: ['transform/test-1-stream-id-1', 'transform/test-1-stream-id-1-routing'],
-            exporters: ['forward'],
+            exporters: ['forward/fleet-default-output'],
           },
-          metrics: {
-            receivers: ['forward'],
+          'metrics/fleet-default-output': {
+            receivers: ['forward/fleet-default-output'],
             exporters: ['elasticsearch/fleet-default-output'],
           },
         },
@@ -390,7 +390,7 @@ describe('generateOtelcolConfig', () => {
         },
       },
       connectors: {
-        forward: {},
+        'forward/default': {},
       },
       exporters: {
         'elasticsearch/default': {
@@ -402,10 +402,10 @@ describe('generateOtelcolConfig', () => {
           'metrics/test-1-stream-id-1': {
             receivers: ['httpcheck/test-1-stream-id-1'],
             processors: ['transform/test-1-stream-id-1', 'transform/test-1-stream-id-1-routing'],
-            exporters: ['forward'],
+            exporters: ['forward/default'],
           },
-          metrics: {
-            receivers: ['forward'],
+          'metrics/default': {
+            receivers: ['forward/default'],
             exporters: ['elasticsearch/default'],
           },
         },
@@ -505,7 +505,7 @@ describe('generateOtelcolConfig', () => {
         },
       },
       connectors: {
-        forward: {},
+        'forward/default': {},
       },
       exporters: {
         'elasticsearch/default': {
@@ -517,15 +517,15 @@ describe('generateOtelcolConfig', () => {
           'metrics/test-1-stream-id-1': {
             receivers: ['httpcheck/test-1-stream-id-1'],
             processors: ['transform/test-1-stream-id-1', 'transform/test-1-stream-id-1-routing'],
-            exporters: ['forward'],
+            exporters: ['forward/default'],
           },
           'metrics/test-2-stream-id-1': {
             receivers: ['httpcheck/test-2-stream-id-1'],
             processors: ['transform/test-2-stream-id-1', 'transform/test-2-stream-id-1-routing'],
-            exporters: ['forward'],
+            exporters: ['forward/default'],
           },
-          metrics: {
-            receivers: ['forward'],
+          'metrics/default': {
+            receivers: ['forward/default'],
             exporters: ['elasticsearch/default'],
           },
         },
@@ -573,7 +573,7 @@ describe('generateOtelcolConfig', () => {
         },
       },
       connectors: {
-        forward: {},
+        'forward/default': {},
       },
       exporters: {
         'elasticsearch/default': {
@@ -589,10 +589,10 @@ describe('generateOtelcolConfig', () => {
               'transform/2/test-3-stream-id-1',
               'transform/test-3-stream-id-1-routing',
             ],
-            exporters: ['forward'],
+            exporters: ['forward/default'],
           },
-          metrics: {
-            receivers: ['forward'],
+          'metrics/default': {
+            receivers: ['forward/default'],
             exporters: ['elasticsearch/default'],
           },
         },
@@ -797,7 +797,7 @@ describe('generateOtelcolConfig', () => {
       },
       connectors: {
         'elasticapm/apmtest': {},
-        forward: {},
+        'forward/default': {},
       },
       exporters: {
         'elasticsearch/default': {
@@ -808,20 +808,20 @@ describe('generateOtelcolConfig', () => {
         pipelines: {
           'traces/test-traces-stream-id-1': {
             receivers: ['zipkin/test-traces-stream-id-1'],
-            exporters: ['elasticapm/apmtest', 'forward'],
+            exporters: ['elasticapm/apmtest', 'forward/default'],
             processors: ['elasticapm/apmtest', 'transform/test-traces-stream-id-1-routing'],
           },
           'metrics/apmtest-aggregated-apm-metrics': {
             receivers: ['elasticapm/apmtest'],
             processors: ['transform/apmtest-apm-namespace-routing'],
-            exporters: ['forward'],
+            exporters: ['forward/default'],
           },
-          traces: {
-            receivers: ['forward'],
+          'traces/default': {
+            receivers: ['forward/default'],
             exporters: ['elasticsearch/default'],
           },
-          metrics: {
-            receivers: ['forward'],
+          'metrics/default': {
+            receivers: ['forward/default'],
             exporters: ['elasticsearch/default'],
           },
         },
@@ -906,12 +906,12 @@ describe('generateOtelcolConfig', () => {
     expect(result.service?.pipelines?.['metrics/ns-a-aggregated-apm-metrics']).toEqual({
       receivers: ['elasticapm/ns-a'],
       processors: ['transform/ns-a-apm-namespace-routing'],
-      exporters: ['forward'],
+      exporters: ['forward/default'],
     });
     expect(result.service?.pipelines?.['metrics/ns-b-aggregated-apm-metrics']).toEqual({
       receivers: ['elasticapm/ns-b'],
       processors: ['transform/ns-b-apm-namespace-routing'],
-      exporters: ['forward'],
+      exporters: ['forward/default'],
     });
     expect(
       result.service?.pipelines?.['metrics/policy-a-stream-id-1-aggregated-apm-metrics']
@@ -986,7 +986,7 @@ describe('generateOtelcolConfig', () => {
     expect(result.service?.pipelines?.['metrics/ns-shared-aggregated-apm-metrics']).toEqual({
       receivers: ['elasticapm/ns-shared'],
       processors: ['transform/ns-shared-apm-namespace-routing'],
-      exporters: ['forward'],
+      exporters: ['forward/default'],
     });
 
     expect(result.service?.pipelines?.['traces/policy-a-stream-id-1']?.exporters).toContain(
@@ -1140,7 +1140,7 @@ describe('generateOtelcolConfig', () => {
       expect(result.service?.pipelines?.['metrics/default-aggregated-apm-metrics']).toEqual({
         receivers: ['elasticapm/default'],
         processors: ['transform/default-apm-namespace-routing'],
-        exporters: ['forward'],
+        exporters: ['forward/default'],
       });
       const tracesPipelineKey = 'traces/otlp/test-multi-signal-stream-id-1';
       const tracesPipeline = result.service?.pipelines?.[tracesPipelineKey];
@@ -1470,7 +1470,7 @@ describe('generateOtelcolConfig', () => {
 
       expect(result.receivers).toHaveProperty('otlp/integration-otel-stream-id-1');
       expect(result.exporters).toHaveProperty('elasticsearch/default');
-      expect(result.service?.pipelines).toHaveProperty('metrics');
+      expect(result.service?.pipelines).toHaveProperty('metrics/default');
     });
 
     it('uses defaultPackageInfo for dynamic signal types when packageInfoCache has no meta match', () => {
@@ -2471,6 +2471,466 @@ describe('generateOtelcolConfig', () => {
 
       expect(result.extensions?.['beatsauth/default']).toBeDefined();
       expect(result.exporters?.['elasticsearch/default']).toHaveProperty('auth');
+    });
+  });
+
+  it('should fall back to default output when packageOutputs is empty', () => {
+    const inputA: FullAgentPolicyInput = {
+      ...otelInput1,
+      id: 'input-a',
+      name: 'input-a',
+      package_policy_id: 'pkg-policy-a',
+    };
+    expect(
+      generateOtelcolConfig({
+        inputs: [inputA],
+        dataOutput: defaultOutput,
+        packageOutputs: new Map(),
+      })
+    ).toEqual({
+      receivers: {
+        'httpcheck/input-a-stream-id-1': {
+          targets: [{ endpoints: ['https://epr.elastic.co'] }],
+        },
+      },
+      processors: {
+        'transform/input-a-stream-id-1': {
+          metric_statements: ['set(metric.description, "Sum") where metric.type == "Sum"'],
+        },
+        'transform/input-a-stream-id-1-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: [
+                'set(attributes["data_stream.type"], "metrics")',
+                'set(attributes["data_stream.dataset"], "somedataset")',
+                'set(attributes["data_stream.namespace"], "testing")',
+              ],
+            },
+          ],
+        },
+      },
+      connectors: {
+        'forward/default': {},
+      },
+      exporters: {
+        'elasticsearch/default': {
+          endpoints: ['http://localhost:9200'],
+        },
+      },
+      service: {
+        pipelines: {
+          'metrics/input-a-stream-id-1': {
+            receivers: ['httpcheck/input-a-stream-id-1'],
+            processors: ['transform/input-a-stream-id-1', 'transform/input-a-stream-id-1-routing'],
+            exporters: ['forward/default'],
+          },
+          'metrics/default': {
+            receivers: ['forward/default'],
+            exporters: ['elasticsearch/default'],
+          },
+        },
+      },
+    });
+  });
+
+  it('should route streams to the override output when packageOutputs contains an entry', () => {
+    const overrideOutput: Output = {
+      id: 'override-output-id',
+      name: 'override-output',
+      type: outputType.Elasticsearch,
+      is_default: false,
+      is_default_monitoring: false,
+      hosts: ['http://override-es:9200'],
+    };
+    const inputA: FullAgentPolicyInput = {
+      ...otelInput1,
+      id: 'input-a',
+      name: 'input-a',
+      package_policy_id: 'pkg-policy-a',
+    };
+    expect(
+      generateOtelcolConfig({
+        inputs: [inputA],
+        dataOutput: defaultOutput,
+        packageOutputs: new Map([['pkg-policy-a', overrideOutput]]),
+      })
+    ).toEqual({
+      receivers: {
+        'httpcheck/input-a-stream-id-1': {
+          targets: [{ endpoints: ['https://epr.elastic.co'] }],
+        },
+      },
+      processors: {
+        'transform/input-a-stream-id-1': {
+          metric_statements: ['set(metric.description, "Sum") where metric.type == "Sum"'],
+        },
+        'transform/input-a-stream-id-1-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: [
+                'set(attributes["data_stream.type"], "metrics")',
+                'set(attributes["data_stream.dataset"], "somedataset")',
+                'set(attributes["data_stream.namespace"], "testing")',
+              ],
+            },
+          ],
+        },
+      },
+      connectors: {
+        'forward/override-output-id': {},
+      },
+      exporters: {
+        'elasticsearch/override-output-id': {
+          endpoints: ['http://override-es:9200'],
+        },
+      },
+      service: {
+        pipelines: {
+          'metrics/input-a-stream-id-1': {
+            receivers: ['httpcheck/input-a-stream-id-1'],
+            processors: ['transform/input-a-stream-id-1', 'transform/input-a-stream-id-1-routing'],
+            exporters: ['forward/override-output-id'],
+          },
+          'metrics/override-output-id': {
+            receivers: ['forward/override-output-id'],
+            exporters: ['elasticsearch/override-output-id'],
+          },
+        },
+      },
+    });
+  });
+
+  it('should route to different outputs for two inputs with different overrides', () => {
+    const overrideOutput: Output = {
+      id: 'override-output-id',
+      name: 'override-output',
+      type: outputType.Elasticsearch,
+      is_default: false,
+      is_default_monitoring: false,
+      hosts: ['http://override-es:9200'],
+    };
+    const inputA: FullAgentPolicyInput = {
+      ...otelInput1,
+      id: 'input-a',
+      name: 'input-a',
+      package_policy_id: 'pkg-policy-a',
+    };
+    const inputB: FullAgentPolicyInput = {
+      ...otelInput2,
+      id: 'input-b',
+      name: 'input-b',
+      package_policy_id: 'pkg-policy-b',
+    };
+    expect(
+      generateOtelcolConfig({
+        inputs: [inputA, inputB],
+        dataOutput: defaultOutput,
+        packageOutputs: new Map([
+          ['pkg-policy-a', overrideOutput],
+          ['pkg-policy-b', { ...defaultOutput, is_default: false }],
+        ]),
+      })
+    ).toEqual({
+      receivers: {
+        'httpcheck/input-a-stream-id-1': {
+          targets: [{ endpoints: ['https://epr.elastic.co'] }],
+        },
+        'httpcheck/input-b-stream-id-1': {
+          targets: [{ endpoints: ['https://www.elastic.co'] }],
+        },
+      },
+      processors: {
+        'transform/input-a-stream-id-1': {
+          metric_statements: ['set(metric.description, "Sum") where metric.type == "Sum"'],
+        },
+        'transform/input-a-stream-id-1-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: [
+                'set(attributes["data_stream.type"], "metrics")',
+                'set(attributes["data_stream.dataset"], "somedataset")',
+                'set(attributes["data_stream.namespace"], "testing")',
+              ],
+            },
+          ],
+        },
+        'transform/input-b-stream-id-1': {
+          metric_statements: ['set(metric.description, "Sum") where metric.type == "Sum"'],
+        },
+        'transform/input-b-stream-id-1-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: [
+                'set(attributes["data_stream.type"], "metrics")',
+                'set(attributes["data_stream.dataset"], "otherdataset")',
+                'set(attributes["data_stream.namespace"], "default")',
+              ],
+            },
+          ],
+        },
+      },
+      connectors: {
+        'forward/override-output-id': {},
+        'forward/fleet-default-output': {},
+      },
+      exporters: {
+        'elasticsearch/override-output-id': {
+          endpoints: ['http://override-es:9200'],
+        },
+        'elasticsearch/fleet-default-output': {
+          endpoints: ['http://localhost:9200'],
+        },
+      },
+      service: {
+        pipelines: {
+          'metrics/input-a-stream-id-1': {
+            receivers: ['httpcheck/input-a-stream-id-1'],
+            processors: ['transform/input-a-stream-id-1', 'transform/input-a-stream-id-1-routing'],
+            exporters: ['forward/override-output-id'],
+          },
+          'metrics/input-b-stream-id-1': {
+            receivers: ['httpcheck/input-b-stream-id-1'],
+            processors: ['transform/input-b-stream-id-1', 'transform/input-b-stream-id-1-routing'],
+            exporters: ['forward/fleet-default-output'],
+          },
+          'metrics/override-output-id': {
+            receivers: ['forward/override-output-id'],
+            exporters: ['elasticsearch/override-output-id'],
+          },
+          'metrics/fleet-default-output': {
+            receivers: ['forward/fleet-default-output'],
+            exporters: ['elasticsearch/fleet-default-output'],
+          },
+        },
+      },
+    });
+  });
+
+  it('should route one input to override and one to default when only one has an override', () => {
+    const overrideOutput: Output = {
+      id: 'override-output-id',
+      name: 'override-output',
+      type: outputType.Elasticsearch,
+      is_default: false,
+      is_default_monitoring: false,
+      hosts: ['http://override-es:9200'],
+    };
+    const inputA: FullAgentPolicyInput = {
+      ...otelInput1,
+      id: 'input-a',
+      name: 'input-a',
+      package_policy_id: 'pkg-policy-a',
+    };
+    const inputB: FullAgentPolicyInput = {
+      ...otelInput2,
+      id: 'input-b',
+      name: 'input-b',
+      package_policy_id: 'pkg-policy-b',
+    };
+    expect(
+      generateOtelcolConfig({
+        inputs: [inputA, inputB],
+        dataOutput: defaultOutput,
+        packageOutputs: new Map([['pkg-policy-a', overrideOutput]]),
+      })
+    ).toEqual({
+      receivers: {
+        'httpcheck/input-a-stream-id-1': {
+          targets: [{ endpoints: ['https://epr.elastic.co'] }],
+        },
+        'httpcheck/input-b-stream-id-1': {
+          targets: [{ endpoints: ['https://www.elastic.co'] }],
+        },
+      },
+      processors: {
+        'transform/input-a-stream-id-1': {
+          metric_statements: ['set(metric.description, "Sum") where metric.type == "Sum"'],
+        },
+        'transform/input-a-stream-id-1-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: [
+                'set(attributes["data_stream.type"], "metrics")',
+                'set(attributes["data_stream.dataset"], "somedataset")',
+                'set(attributes["data_stream.namespace"], "testing")',
+              ],
+            },
+          ],
+        },
+        'transform/input-b-stream-id-1': {
+          metric_statements: ['set(metric.description, "Sum") where metric.type == "Sum"'],
+        },
+        'transform/input-b-stream-id-1-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: [
+                'set(attributes["data_stream.type"], "metrics")',
+                'set(attributes["data_stream.dataset"], "otherdataset")',
+                'set(attributes["data_stream.namespace"], "default")',
+              ],
+            },
+          ],
+        },
+      },
+      connectors: {
+        'forward/override-output-id': {},
+        'forward/default': {},
+      },
+      exporters: {
+        'elasticsearch/override-output-id': {
+          endpoints: ['http://override-es:9200'],
+        },
+        'elasticsearch/default': {
+          endpoints: ['http://localhost:9200'],
+        },
+      },
+      service: {
+        pipelines: {
+          'metrics/input-a-stream-id-1': {
+            receivers: ['httpcheck/input-a-stream-id-1'],
+            processors: ['transform/input-a-stream-id-1', 'transform/input-a-stream-id-1-routing'],
+            exporters: ['forward/override-output-id'],
+          },
+          'metrics/input-b-stream-id-1': {
+            receivers: ['httpcheck/input-b-stream-id-1'],
+            processors: ['transform/input-b-stream-id-1', 'transform/input-b-stream-id-1-routing'],
+            exporters: ['forward/default'],
+          },
+          'metrics/override-output-id': {
+            receivers: ['forward/override-output-id'],
+            exporters: ['elasticsearch/override-output-id'],
+          },
+          'metrics/default': {
+            receivers: ['forward/default'],
+            exporters: ['elasticsearch/default'],
+          },
+        },
+      },
+    });
+  });
+
+  it('should throw when packageOutputs contains an unsupported output type', () => {
+    const logstashOutput: Output = {
+      id: 'logstash-output-id',
+      name: 'logstash',
+      type: 'logstash' as any,
+      is_default: false,
+      is_default_monitoring: false,
+      hosts: ['localhost:5044'],
+    };
+    const inputA: FullAgentPolicyInput = {
+      ...otelInput1,
+      id: 'input-a',
+      name: 'input-a',
+      package_policy_id: 'pkg-policy-a',
+    };
+    expect(() =>
+      generateOtelcolConfig({
+        inputs: [inputA],
+        dataOutput: defaultOutput,
+        packageOutputs: new Map([['pkg-policy-a', logstashOutput]]),
+      })
+    ).toThrow();
+  });
+
+  it('should route APM aggregated pipeline to the default output even when the input has an override', () => {
+    const overrideOutput: Output = {
+      id: 'override-output-id',
+      name: 'override-output',
+      type: outputType.Elasticsearch,
+      is_default: false,
+      is_default_monitoring: false,
+      hosts: ['http://override-es:9200'],
+    };
+    const apmInput: FullAgentPolicyInput = {
+      ...otelTracesInputWithAPM,
+      id: 'apm-input',
+      name: 'apm-input',
+      package_policy_id: 'pkg-policy-a',
+      data_stream: { namespace: 'apmtest' },
+    };
+    expect(
+      generateOtelcolConfig({
+        inputs: [apmInput],
+        dataOutput: defaultOutput,
+        packageOutputs: new Map([['pkg-policy-a', overrideOutput]]),
+      })
+    ).toEqual({
+      receivers: {
+        'zipkin/apm-input-stream-id-1': { endpoint: 'localhost:9411' },
+      },
+      processors: {
+        'transform/apm-input-stream-id-1-routing': {
+          trace_statements: [
+            {
+              context: 'span',
+              statements: [
+                'set(attributes["data_stream.type"], "traces")',
+                'set(attributes["data_stream.dataset"], "zipkinreceiver")',
+                'set(attributes["data_stream.namespace"], "apmtest")',
+              ],
+            },
+            {
+              context: 'spanevent',
+              statements: [
+                'set(attributes["data_stream.type"], "logs")',
+                'set(attributes["data_stream.dataset"], "zipkinreceiver")',
+                'set(attributes["data_stream.namespace"], "apmtest")',
+              ],
+            },
+          ],
+        },
+        'elasticapm/apmtest': {},
+        'transform/apmtest-apm-namespace-routing': {
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: ['set(attributes["data_stream.namespace"], "apmtest")'],
+            },
+          ],
+        },
+      },
+      connectors: {
+        'elasticapm/apmtest': {},
+        'forward/override-output-id': {},
+        'forward/default': {},
+      },
+      exporters: {
+        'elasticsearch/override-output-id': {
+          endpoints: ['http://override-es:9200'],
+        },
+        'elasticsearch/default': {
+          endpoints: ['http://localhost:9200'],
+        },
+      },
+      service: {
+        pipelines: {
+          'traces/apm-input-stream-id-1': {
+            receivers: ['zipkin/apm-input-stream-id-1'],
+            exporters: ['elasticapm/apmtest', 'forward/override-output-id'],
+            processors: ['elasticapm/apmtest', 'transform/apm-input-stream-id-1-routing'],
+          },
+          'metrics/apmtest-aggregated-apm-metrics': {
+            receivers: ['elasticapm/apmtest'],
+            processors: ['transform/apmtest-apm-namespace-routing'],
+            exporters: ['forward/default'],
+          },
+          'traces/override-output-id': {
+            receivers: ['forward/override-output-id'],
+            exporters: ['elasticsearch/override-output-id'],
+          },
+          'metrics/default': {
+            receivers: ['forward/default'],
+            exporters: ['elasticsearch/default'],
+          },
+        },
+      },
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -51,6 +51,7 @@ import { hasDynamicSignalTypes } from '../../../common/services';
 export function generateOtelcolConfig({
   inputs,
   dataOutput,
+  packageOutputs,
   packageInfoCache,
   proxy,
   logger,
@@ -58,11 +59,27 @@ export function generateOtelcolConfig({
 }: {
   inputs: FullAgentPolicyInput[] | TemplateAgentPolicyInput[];
   dataOutput?: Output;
+  /** Per-package-policy output overrides: maps package policy ID to its assigned Output. */
+  packageOutputs?: Map<string, Output>;
   packageInfoCache?: Map<string, PackageInfo>;
   proxy?: FleetProxy;
   logger?: Logger;
   defaultPackageInfo?: PackageInfo;
 }): OTelCollectorConfig {
+  // Pipeline IDs grouped by the output ID they route to. Built during the per-stream pass
+  // and consumed by attachOtelcolExporter to emit per-output fan-in pipelines. Sets dedupe
+  // namespace-keyed APM aggregated pipelines that are recorded once per package policy.
+  const pipelineIdsByOutputId = new Map<string, Set<OTelCollectorPipelineID>>();
+  const recordPipeline = (outputId: string, pipelineId: OTelCollectorPipelineID) => {
+    const set = pipelineIdsByOutputId.get(outputId);
+    if (set) {
+      set.add(pipelineId);
+    } else {
+      pipelineIdsByOutputId.set(outputId, new Set([pipelineId]));
+    }
+  };
+  const defaultOutputId = dataOutput ? getOutputIdForAgentPolicy(dataOutput) : undefined;
+
   const otelConfigs: OTelCollectorConfig[] = inputs
     .filter((input) => input.type === OTEL_COLLECTOR_INPUT_TYPE)
     .flatMap((input) => {
@@ -90,6 +107,11 @@ export function generateOtelcolConfig({
             inputType: input.type,
           })
         : false;
+
+      // Resolve which output this input's package policy routes to (override or policy default).
+      const packagePolicyId = (input as FullAgentPolicyInput).package_policy_id;
+      const override = packagePolicyId ? packageOutputs?.get(packagePolicyId) : undefined;
+      const resolvedOutputId = override ? getOutputIdForAgentPolicy(override) : defaultOutputId;
 
       const otelInputs: OTelCollectorConfig[] = (input?.streams ?? []).map((stream) => {
         // Avoid dots in keys, as they can create subobjects in agent config.
@@ -190,6 +212,12 @@ export function generateOtelcolConfig({
         // does not receive the per-stream routing transform.
         otelConfig = appendOtelComponents(otelConfig, 'processors', [attributesTransform]);
 
+        if (resolvedOutputId) {
+          for (const pipelineId of Object.keys(otelConfig.service?.pipelines ?? {})) {
+            recordPipeline(resolvedOutputId, pipelineId);
+          }
+        }
+
         if (shouldAddAPMConfig) {
           otelConfig.connectors ??= {};
           otelConfig.processors ??= {};
@@ -204,10 +232,17 @@ export function generateOtelcolConfig({
               },
             ],
           };
-          otelConfig.service.pipelines![`metrics/${namespace}-aggregated-apm-metrics`] = {
+          const apmPipelineId: OTelCollectorPipelineID = `metrics/${namespace}-aggregated-apm-metrics`;
+          otelConfig.service.pipelines![apmPipelineId] = {
             receivers: [`elasticapm/${namespace}`],
             processors: [`transform/${namespace}-apm-namespace-routing`],
           };
+          // APM aggregated pipelines are keyed by namespace (not by package policy), so they
+          // always route to the policy default output even if per-stream pipelines override it.
+          // Per-override aggregation would change APM semantics and is deferred.
+          if (defaultOutputId) {
+            recordPipeline(defaultOutputId, apmPipelineId);
+          }
         }
 
         return otelConfig;
@@ -221,7 +256,55 @@ export function generateOtelcolConfig({
   }
 
   const config = mergeOtelcolConfigs(otelConfigs);
-  return attachOtelcolExporter(config, dataOutput, proxy, logger);
+
+  // Templates (and other inputless paths) skip exporter attachment.
+  if (!dataOutput) {
+    return config;
+  }
+
+  const outputsById = resolveOutputsById({
+    referencedOutputIds: pipelineIdsByOutputId.keys(),
+    dataOutput,
+    defaultOutputId,
+    packageOutputs,
+  });
+
+  return attachOtelcolExporter(config, outputsById, pipelineIdsByOutputId, proxy, logger);
+}
+
+/**
+ * Resolve the set of Outputs referenced by the per-stream routing pass, keyed by the
+ * pipeline-suffix output ID used in the OTel config. The returned IDs are either the
+ * agent-policy default output alias (e.g. "default") or a raw `output.id`. Overrides
+ * on non-OTel package policies never appear in `referencedOutputIds`, so this does
+ * not need to prune.
+ */
+function resolveOutputsById({
+  referencedOutputIds,
+  dataOutput,
+  defaultOutputId,
+  packageOutputs,
+}: {
+  referencedOutputIds: Iterable<string>;
+  dataOutput: Output;
+  defaultOutputId: string | undefined;
+  packageOutputs?: Map<string, Output>;
+}): Map<string, Output> {
+  const outputsByRawId = new Map<string, Output>([[dataOutput.id, dataOutput]]);
+  if (packageOutputs) {
+    for (const output of packageOutputs.values()) {
+      outputsByRawId.set(output.id, output);
+    }
+  }
+
+  const outputsById = new Map<string, Output>();
+  for (const outputId of referencedOutputIds) {
+    const output = outputId === defaultOutputId ? dataOutput : outputsByRawId.get(outputId);
+    if (output) {
+      outputsById.set(outputId, output);
+    }
+  }
+  return outputsById;
 }
 
 function buildDataStreamStatements(type: string, dataset: string, namespace: string): string[] {
@@ -590,54 +673,57 @@ function parseOutputConfigYaml(yaml: string | null | undefined): Record<string, 
 
 function attachOtelcolExporter(
   config: OTelCollectorConfig,
-  dataOutput?: Output,
+  outputsById: Map<string, Output>,
+  pipelineIdsByOutputId: Map<string, Set<OTelCollectorPipelineID>>,
   proxy?: FleetProxy,
   logger?: Logger
 ): OTelCollectorConfig {
-  if (!dataOutput) {
-    return config;
-  }
+  for (const [outputId, output] of outputsById) {
+    const { extensions, exporters } = generateOtelcolExporter(output, proxy, logger);
 
-  const { extensions, exporters } = generateOtelcolExporter(dataOutput, proxy, logger);
-  config.connectors = {
-    ...config.connectors,
-    forward: {},
-  };
-  if (Object.keys(extensions).length > 0) {
-    config.extensions = {
-      ...config.extensions,
-      ...extensions,
+    config.connectors = {
+      ...config.connectors,
+      [`forward/${outputId}`]: {},
     };
-  }
-  config.exporters = {
-    ...config.exporters,
-    ...exporters,
-  };
 
-  const extensionIDs = Object.keys(extensions);
-  if (extensionIDs.length > 0) {
-    config.service = {
-      ...config.service,
-      extensions: [...(config.service?.extensions ?? []), ...extensionIDs],
-    };
-  }
-
-  if (config.service?.pipelines) {
-    const signalTypes = new Set<string>();
-    Object.entries(config.service.pipelines).forEach(([id, pipeline]) => {
-      config.service!.pipelines![id] = {
-        ...pipeline,
-        exporters: [...(pipeline.exporters || []), 'forward'],
+    if (Object.keys(extensions).length > 0) {
+      config.extensions = {
+        ...config.extensions,
+        ...extensions,
       };
-      signalTypes.add(getSignalType(id));
-    });
+      config.service = {
+        ...config.service,
+        extensions: [...(config.service?.extensions ?? []), ...Object.keys(extensions)],
+      };
+    }
 
-    signalTypes.forEach((id) => {
-      config.service!.pipelines![id] = {
-        receivers: ['forward'],
+    config.exporters = {
+      ...config.exporters,
+      ...exporters,
+    };
+
+    const pipelineIds = pipelineIdsByOutputId.get(outputId);
+    if (!pipelineIds) continue;
+
+    // Route per-stream pipelines to this output's forward connector, then emit one fan-in
+    // pipeline per (signalType, outputId) pair.
+    const signalTypes = new Set<string>();
+    for (const pipelineId of pipelineIds) {
+      const pipeline = config.service?.pipelines?.[pipelineId];
+      if (pipeline) {
+        pipeline.exporters = [...(pipeline.exporters ?? []), `forward/${outputId}`];
+        signalTypes.add(getSignalType(pipelineId));
+      }
+    }
+
+    config.service ??= { pipelines: {} };
+    config.service.pipelines ??= {};
+    for (const signalType of signalTypes) {
+      config.service.pipelines[`${signalType}/${outputId}`] = {
+        receivers: [`forward/${outputId}`],
         exporters: Object.keys(exporters),
       };
-    });
+    }
   }
 
   return config;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/outputs_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/outputs_helpers.ts
@@ -110,7 +110,9 @@ export async function validateOutputForPolicy(
 export async function validateAgentPolicyOutputForIntegration(
   soClient: SavedObjectsClientContract,
   agentPolicy: AgentPolicy,
-  packagePolicy: Pick<PackagePolicy, 'supports_agentless'>,
+  packagePolicy: Pick<PackagePolicy, 'supports_agentless'> & {
+    inputs?: Array<{ type: string; enabled: boolean }>;
+  },
   packageName: string,
   isNewPackagePolicy: boolean = true
 ) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.test.ts
@@ -13,8 +13,11 @@ import { appContextService } from '../app_context';
 import { licenseService } from '../license';
 import { outputService } from '../output';
 
+import { OTEL_COLLECTOR_INPUT_TYPE } from '../../../common/constants';
+
 import {
   canDeployCustomPackageAsAgentlessOrThrow,
+  canUseOutputForIntegration,
   mapPackagePolicySavedObjectToPackagePolicy,
   preflightCheckPackagePolicy,
 } from './utils';
@@ -327,6 +330,82 @@ describe('Package Policy Utils', () => {
         '[data_stream.type]: required for stream in package "composable-integration"'
       );
     });
+  });
+});
+
+describe('canUseOutputForIntegration', () => {
+  const soClient = savedObjectsClientMock.create();
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should reject a Logstash output_id on a package policy with an OTel input', async () => {
+    jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+    jest
+      .spyOn(outputService, 'get')
+      .mockResolvedValue({ id: 'logstash-output', type: 'logstash' } as any);
+
+    const result = await canUseOutputForIntegration(soClient, {
+      output_id: 'logstash-output',
+      package: { name: 'host_metrics_otel', version: '1.0.0', title: 'Host Metrics OTel' },
+      supports_agentless: false,
+      inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, enabled: true, streams: [] }],
+    } as any);
+
+    expect(result.canUseOutputForIntegrationResult).toBe(false);
+    expect(result.errorMessage).toMatch(/not usable with package/);
+  });
+
+  it('should reject a Kafka output_id on a package policy with an OTel input', async () => {
+    jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+    jest
+      .spyOn(outputService, 'get')
+      .mockResolvedValue({ id: 'kafka-output', type: 'kafka' } as any);
+
+    const result = await canUseOutputForIntegration(soClient, {
+      output_id: 'kafka-output',
+      package: { name: 'host_metrics_otel', version: '1.0.0', title: 'Host Metrics OTel' },
+      supports_agentless: false,
+      inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, enabled: true, streams: [] }],
+    } as any);
+
+    expect(result.canUseOutputForIntegrationResult).toBe(false);
+    expect(result.errorMessage).toMatch(/not usable with package/);
+  });
+
+  it('should accept an Elasticsearch output_id on a package policy with an OTel input', async () => {
+    jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+    jest
+      .spyOn(outputService, 'get')
+      .mockResolvedValue({ id: 'es-output', type: 'elasticsearch' } as any);
+
+    const result = await canUseOutputForIntegration(soClient, {
+      output_id: 'es-output',
+      package: { name: 'host_metrics_otel', version: '1.0.0', title: 'Host Metrics OTel' },
+      supports_agentless: false,
+      inputs: [{ type: OTEL_COLLECTOR_INPUT_TYPE, enabled: true, streams: [] }],
+    } as any);
+
+    expect(result.canUseOutputForIntegrationResult).toBe(true);
+    expect(result.errorMessage).toBeNull();
+  });
+
+  it('should still permit Logstash output_id on a non-OTel package policy (regression guard)', async () => {
+    jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+    jest
+      .spyOn(outputService, 'get')
+      .mockResolvedValue({ id: 'logstash-output', type: 'logstash' } as any);
+
+    const result = await canUseOutputForIntegration(soClient, {
+      output_id: 'logstash-output',
+      package: { name: 'nginx', version: '1.0.0', title: 'Nginx' },
+      supports_agentless: false,
+      inputs: [{ type: 'log', enabled: true, streams: [] }],
+    } as any);
+
+    expect(result.canUseOutputForIntegrationResult).toBe(true);
+    expect(result.errorMessage).toBeNull();
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/utils.ts
@@ -116,7 +116,9 @@ export function canUseMultipleAgentPolicies() {
 
 export async function canUseOutputForIntegration(
   soClient: SavedObjectsClientContract,
-  packagePolicy: Pick<PackagePolicy, 'output_id' | 'package' | 'supports_agentless'>
+  packagePolicy: Pick<PackagePolicy, 'output_id' | 'package' | 'supports_agentless'> & {
+    inputs?: Array<{ type: string; enabled: boolean }>;
+  }
 ) {
   const outputId = packagePolicy.output_id;
   const packageName = packagePolicy.package?.name;

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy_otel_output.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy_otel_output.ts
@@ -149,9 +149,6 @@ export default function (providerContext: FtrProviderContext) {
       return fullPolicy.exporters?.[`elasticsearch/${outputId}`];
     }
 
-    // -----------------------------------------------------------------------
-    // Test 1: ssl params from config_yaml appear in beatsauth extension
-    // -----------------------------------------------------------------------
     it('includes ssl parameters from config_yaml in the beatsauth extension', async () => {
       const outputId = await createOutput({
         config_yaml:
@@ -176,9 +173,6 @@ export default function (providerContext: FtrProviderContext) {
       }
     });
 
-    // -----------------------------------------------------------------------
-    // Test 2: timeout / idle_connection_timeout from config_yaml appear in beatsauth
-    // -----------------------------------------------------------------------
     it('includes timeout and idle_connection_timeout from config_yaml in the beatsauth extension', async () => {
       const outputId = await createOutput({
         config_yaml: 'timeout: 30s\nidle_connection_timeout: 5s',
@@ -200,9 +194,6 @@ export default function (providerContext: FtrProviderContext) {
       }
     });
 
-    // -----------------------------------------------------------------------
-    // Test 3: structured ssl fields take precedence over config_yaml
-    // -----------------------------------------------------------------------
     it('structured ssl fields take precedence over config_yaml values in beatsauth', async () => {
       const outputId = await createOutput({
         // config_yaml sets verification_mode to none — structured field should override to full
@@ -232,9 +223,6 @@ export default function (providerContext: FtrProviderContext) {
       }
     });
 
-    // -----------------------------------------------------------------------
-    // Test 4: otel_disable_beatsauth=true — no beatsauth extension, no auth in exporter
-    // -----------------------------------------------------------------------
     it('omits beatsauth extension and exporter auth when otel_disable_beatsauth is true', async () => {
       const outputId = await createOutput({
         otel_disable_beatsauth: true,
@@ -261,9 +249,6 @@ export default function (providerContext: FtrProviderContext) {
       }
     });
 
-    // -----------------------------------------------------------------------
-    // Test 5: otel_disable_beatsauth=true — otel_exporter_config_yaml still merged
-    // -----------------------------------------------------------------------
     it('still merges otel_exporter_config_yaml into the exporter when otel_disable_beatsauth is true', async () => {
       const outputId = await createOutput({
         otel_disable_beatsauth: true,
@@ -287,9 +272,6 @@ export default function (providerContext: FtrProviderContext) {
       }
     });
 
-    // -----------------------------------------------------------------------
-    // Test 6: otel_disable_beatsauth=false (explicit) — beatsauth is still generated
-    // -----------------------------------------------------------------------
     it('generates beatsauth normally when otel_disable_beatsauth is false', async () => {
       const outputId = await createOutput({
         otel_disable_beatsauth: false,
@@ -311,6 +293,48 @@ export default function (providerContext: FtrProviderContext) {
       } finally {
         await deleteAgentPolicy(agentPolicyId);
         await deleteOutput(outputId);
+      }
+    });
+
+    it('rejects updating a policy data output to Logstash when the policy has an OTel integration', async () => {
+      const { body: logstashBody } = await supertest
+        .post('/api/fleet/outputs')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: `logstash-output-${uuidv4()}`,
+          type: 'logstash',
+          hosts: ['logstash.example.com:5044'],
+          is_default: false,
+          is_default_monitoring: false,
+        })
+        .expect(200);
+      const logstashOutputId = logstashBody.item.id;
+
+      const {
+        body: {
+          item: { id: agentPolicyId },
+        },
+      } = await supertest
+        .post('/api/fleet/agent_policies')
+        .set('kbn-xsrf', 'xxxx')
+        .send({ name: `otel-logstash-test-${uuidv4()}`, namespace: 'default' })
+        .expect(200);
+
+      try {
+        await addOtelPackagePolicy(agentPolicyId);
+
+        await supertest
+          .put(`/api/fleet/agent_policies/${agentPolicyId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `otel-logstash-test-${uuidv4()}`,
+            namespace: 'default',
+            data_output_id: logstashOutputId,
+          })
+          .expect(400);
+      } finally {
+        await deleteAgentPolicy(agentPolicyId);
+        await deleteOutput(logstashOutputId);
       }
     });
   });

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy_otel_overrides.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy_otel_overrides.ts
@@ -1,0 +1,227 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Integration tests for per-integration OTel output overrides in Fleet agent policies.
+ *
+ * - When an OTel package policy has output_id set, the generated OTel config must route
+ *   that integration's streams through the override output (separate elasticsearch/<id>
+ *   exporter, forward/<id> connector, and <signal>/<id> fan-in pipeline).
+ * - Attempting to set a non-ES (e.g. Logstash) output_id on an OTel package policy must
+ *   be rejected with a 400.
+ * - A policy mixing OTel integrations with and without overrides must contain routing paths
+ *   for both the default output and the override output.
+ */
+
+import expect from '@kbn/expect';
+import { v4 as uuidv4 } from 'uuid';
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { skipIfNoDockerRegistry } from '../../helpers';
+
+const DYNAMIC_PKG = 'test_otel_dynamic';
+const DYNAMIC_PKG_VERSION = '1.0.0';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const esArchiver = getService('esArchiver');
+  const fleetAndAgents = getService('fleetAndAgents');
+
+  describe('OTel per-integration output overrides in full agent policy', () => {
+    skipIfNoDockerRegistry(providerContext);
+
+    before(async () => {
+      await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+      await fleetAndAgents.setup();
+
+      await supertest
+        .post(`/api/fleet/epm/packages/${DYNAMIC_PKG}/${DYNAMIC_PKG_VERSION}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+    });
+
+    after(async () => {
+      await supertest
+        .delete(`/api/fleet/epm/packages/${DYNAMIC_PKG}/${DYNAMIC_PKG_VERSION}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true });
+
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+    });
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    async function createEsOutput(name?: string): Promise<string> {
+      const { body } = await supertest
+        .post('/api/fleet/outputs')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: name ?? `otel-override-output-${uuidv4()}`,
+          type: 'elasticsearch',
+          hosts: ['https://override-es.example.com:9200'],
+          is_default: false,
+          is_default_monitoring: false,
+        })
+        .expect(200);
+      return body.item.id;
+    }
+
+    async function createLogstashOutput(): Promise<string> {
+      const { body } = await supertest
+        .post('/api/fleet/outputs')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: `logstash-output-${uuidv4()}`,
+          type: 'logstash',
+          hosts: ['logstash.example.com:5044'],
+          is_default: false,
+          is_default_monitoring: false,
+        })
+        .expect(200);
+      return body.item.id;
+    }
+
+    async function deleteOutput(outputId: string) {
+      await supertest
+        .delete(`/api/fleet/outputs/${outputId}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true });
+    }
+
+    async function createAgentPolicy(): Promise<string> {
+      const {
+        body: {
+          item: { id },
+        },
+      } = await supertest
+        .post('/api/fleet/agent_policies')
+        .set('kbn-xsrf', 'xxxx')
+        .send({ name: `otel-overrides-test-${uuidv4()}`, namespace: 'default' })
+        .expect(200);
+      return id;
+    }
+
+    async function deleteAgentPolicy(agentPolicyId: string) {
+      await supertest
+        .post('/api/fleet/agent_policies/delete')
+        .set('kbn-xsrf', 'xxxx')
+        .send({ agentPolicyId });
+    }
+
+    async function postOtelPackagePolicy(
+      agentPolicyId: string,
+      outputId: string | undefined,
+      expectStatus: 200 | 400
+    ) {
+      const payload: Record<string, unknown> = {
+        name: `otel-pkg-policy-${uuidv4()}`,
+        namespace: 'default',
+        policy_id: agentPolicyId,
+        package: { name: DYNAMIC_PKG, version: DYNAMIC_PKG_VERSION },
+        inputs: {
+          'otlpreceiver-otelcol': {
+            enabled: true,
+            streams: {
+              'test_otel_dynamic.otlpreceiver': { enabled: true, vars: {} },
+            },
+          },
+        },
+      };
+      if (outputId !== undefined) {
+        payload.output_id = outputId;
+      }
+      await supertest
+        .post('/api/fleet/package_policies')
+        .set('kbn-xsrf', 'xxxx')
+        .send(payload)
+        .expect(expectStatus);
+    }
+
+    async function getFullAgentPolicy(agentPolicyId: string): Promise<Record<string, any>> {
+      const { body } = await supertest
+        .get(`/api/fleet/agent_policies/${agentPolicyId}/full`)
+        .set('kbn-xsrf', 'xxxx')
+        .expect(200);
+      return body.item;
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1: override ES output → routed through override exporter/connector/fan-in
+    // -------------------------------------------------------------------------
+    it('routes streams through the override ES output when package policy has output_id', async () => {
+      const overrideOutputId = await createEsOutput();
+      const agentPolicyId = await createAgentPolicy();
+
+      try {
+        await postOtelPackagePolicy(agentPolicyId, overrideOutputId, 200);
+        const fullPolicy = await getFullAgentPolicy(agentPolicyId);
+
+        // OTel config is spread at the root of the full agent policy.
+        expect(fullPolicy.connectors?.[`forward/${overrideOutputId}`]).to.eql({});
+        expect(fullPolicy.exporters?.[`elasticsearch/${overrideOutputId}`]).to.be.ok();
+
+        // A fan-in pipeline must exist for the override; at least one per-stream pipeline must
+        // export to forward/<overrideOutputId>.
+        const pipelines = fullPolicy.service?.pipelines ?? {};
+        const overrideFanInKeys = Object.keys(pipelines).filter((k) =>
+          k.endsWith(`/${overrideOutputId}`)
+        );
+        expect(overrideFanInKeys.length).to.be.greaterThan(0);
+
+        const streamPipelinesRoutingToOverride = Object.values(pipelines).filter((pipeline: any) =>
+          (pipeline.exporters ?? []).includes(`forward/${overrideOutputId}`)
+        );
+        expect(streamPipelinesRoutingToOverride.length).to.be.greaterThan(0);
+      } finally {
+        await deleteAgentPolicy(agentPolicyId);
+        await deleteOutput(overrideOutputId);
+      }
+    });
+
+    // -------------------------------------------------------------------------
+    // Test 2: Logstash output_id on an OTel package policy → rejected with 400
+    // -------------------------------------------------------------------------
+    it('rejects a Logstash output_id on an OTel package policy with a 400 error', async () => {
+      const logstashOutputId = await createLogstashOutput();
+      const agentPolicyId = await createAgentPolicy();
+
+      try {
+        await postOtelPackagePolicy(agentPolicyId, logstashOutputId, 400);
+      } finally {
+        await deleteAgentPolicy(agentPolicyId);
+        await deleteOutput(logstashOutputId);
+      }
+    });
+
+    // -------------------------------------------------------------------------
+    // Test 3: mixed policy — one OTel pkg with override, one without → two routing paths
+    // -------------------------------------------------------------------------
+    it('generates routing paths for both override and default output in a mixed policy', async () => {
+      const overrideOutputId = await createEsOutput();
+      const agentPolicyId = await createAgentPolicy();
+
+      try {
+        await postOtelPackagePolicy(agentPolicyId, overrideOutputId, 200);
+        await postOtelPackagePolicy(agentPolicyId, undefined, 200);
+
+        const fullPolicy = await getFullAgentPolicy(agentPolicyId);
+
+        // Both an override forward connector and a default forward connector must be present.
+        expect(fullPolicy.connectors?.[`forward/${overrideOutputId}`]).to.eql({});
+        expect(fullPolicy.connectors?.['forward/default']).to.eql({});
+        expect(fullPolicy.exporters?.[`elasticsearch/${overrideOutputId}`]).to.be.ok();
+        expect(fullPolicy.exporters?.['elasticsearch/default']).to.be.ok();
+      } finally {
+        await deleteAgentPolicy(agentPolicyId);
+        await deleteOutput(overrideOutputId);
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
@@ -18,6 +18,7 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./version_specific_policies'));
     loadTestFile(require.resolve('./agent_policy_otel_routing'));
     loadTestFile(require.resolve('./agent_policy_otel_output'));
+    loadTestFile(require.resolve('./agent_policy_otel_overrides'));
     loadTestFile(require.resolve('./agent_policy_input_logfile_dataset'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Fleet] Fix support for per-integration overrides for OTel integrations (#270487)](https://github.com/elastic/kibana/pull/270487)

<!--BACKPORT [{"sourcePullRequest":{"number":270487,"url":"https://github.com/elastic/kibana/pull/270487","title":"[Fleet] Fix support for per-integration overrides for OTel integrations"}}] BACKPORT-->
