### PR TITLE
[Security Solution][Entity Analytics] Add RiskScoreStatusPanel for em…

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
@@ -33,6 +33,7 @@ import { useRiskScorePreview } from '../../api/hooks/use_preview_risk_scores';
 import { EntityIconByType } from '../entity_store/helpers';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { useEntityAnalyticsTypes } from '../../hooks/use_enabled_entity_types';
+import { RiskScoreStatusPanel, useRiskScoreStatus } from '../risk_score_status_panel';
 import type { AlertFilter } from './common';
 
 interface IRiskScorePreviewPanel {
@@ -182,6 +183,23 @@ const RiskEnginePreview: React.FC<{
     filters: alertFilters && alertFilters.length > 0 ? alertFilters : undefined,
   });
 
+  // The preview returns one bucket per entity type. We treat the result as
+  // empty only once the request has resolved and every bucket is empty, so we
+  // don't flash the status callout during the initial fetch.
+  const isPreviewEmpty =
+    !isLoading &&
+    !!data &&
+    entityTypes.every(
+      (entityType) =>
+        getRiskiestScores(data.scores[entityType], EntityTypeToIdentifierField[entityType])
+          .length === 0
+    );
+
+  const status = useRiskScoreStatus({
+    isResultEmpty: isPreviewEmpty,
+    facts: { scoringWindow: { start: from, end: to } },
+  });
+
   if (isError) {
     return (
       <EuiCallOut
@@ -209,6 +227,27 @@ const RiskEnginePreview: React.FC<{
 
       <EuiSpacer />
       <EuiSpacer />
+
+      {/*
+       * When the preview yields zero scores across every entity type, surface
+       * a status callout explaining *why* before the (empty) accordions below.
+       * The status hook returns `unknown` whenever there is real data, so this
+       * block is naturally suppressed in the happy path.
+       */}
+      {!isLoading && status.reason !== 'unknown' && (
+        <>
+          <RiskScoreStatusPanel
+            reason={status.reason}
+            facts={status.facts}
+            variant="callout"
+            // We're already on the management page; the destination of the
+            // default action is the page the user is viewing.
+            primaryAction={null}
+            data-test-subj="risk-score-preview-status"
+          />
+          <EuiSpacer />
+        </>
+      )}
 
       {entityTypes.map((entityType) => (
         <Fragment key={entityType}>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/facts_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/facts_list.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiTextColor } from '@elastic/eui';
+import moment from 'moment';
+import type { RiskScoreStatusFacts } from './types';
+import {
+  FACT_ENTITIES_TRACKED,
+  FACT_LAST_RUN,
+  FACT_MATCHING_ALERTS,
+  FACT_SCORING_WINDOW,
+} from './translations';
+
+interface FactsListProps {
+  facts: RiskScoreStatusFacts;
+  'data-test-subj'?: string;
+}
+
+type FactItem = { icon: string; text: string; 'data-test-subj': string };
+
+export const FactsList: React.FC<FactsListProps> = ({
+  facts,
+  'data-test-subj': dataTestSubj = 'risk-score-status-facts',
+}) => {
+  const items = useMemo<FactItem[]>(() => {
+    const list: FactItem[] = [];
+
+    if (facts.lastSuccessTimestamp) {
+      list.push({
+        icon: 'checkInCircleFilled',
+        text: FACT_LAST_RUN(moment(facts.lastSuccessTimestamp).fromNow()),
+        'data-test-subj': `${dataTestSubj}-lastRun`,
+      });
+    }
+    if (facts.entitiesTracked != null) {
+      list.push({
+        icon: 'users',
+        text: FACT_ENTITIES_TRACKED(facts.entitiesTracked),
+        'data-test-subj': `${dataTestSubj}-entitiesTracked`,
+      });
+    }
+    if (facts.scoringWindow) {
+      list.push({
+        icon: 'search',
+        text: FACT_SCORING_WINDOW(facts.scoringWindow.start, facts.scoringWindow.end),
+        'data-test-subj': `${dataTestSubj}-scoringWindow`,
+      });
+    }
+    if (facts.matchingAlertsCount != null) {
+      list.push({
+        icon: 'bell',
+        text: FACT_MATCHING_ALERTS(facts.matchingAlertsCount),
+        'data-test-subj': `${dataTestSubj}-matchingAlerts`,
+      });
+    }
+
+    return list;
+  }, [facts, dataTestSubj]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs" data-test-subj={dataTestSubj}>
+      {items.map((item) => (
+        <EuiFlexItem key={item['data-test-subj']} grow={false}>
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
+            responsive={false}
+            data-test-subj={item['data-test-subj']}
+          >
+            <EuiFlexItem grow={false}>
+              <EuiIcon type={item.icon} size="s" color="subdued" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs">
+                <EuiTextColor color="subdued">{item.text}</EuiTextColor>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { RiskScoreStatusPanel } from './risk_score_status_panel';
+export { useRiskScoreStatus, type UseRiskScoreStatusResult } from './use_risk_score_status';
+export type {
+  RiskScoreStatusReason,
+  RiskScoreStatusFacts,
+  RiskScoreStatusAction,
+  RiskScoreStatusPanelProps,
+} from './types';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/risk_score_status_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/risk_score_status_panel.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RiskScoreStatusPanel } from './risk_score_status_panel';
+import type { RiskScoreStatusReason } from './types';
+
+describe('RiskScoreStatusPanel', () => {
+  describe('reason copy', () => {
+    const reasons: RiskScoreStatusReason[] = [
+      'no_matching_alerts',
+      'engine_never_run',
+      'engine_disabled',
+      'engine_not_installed',
+      'unknown',
+    ];
+
+    it.each(reasons)('renders a title and description for reason "%s"', (reason) => {
+      render(<RiskScoreStatusPanel reason={reason} />);
+
+      const panel = screen.getByTestId('risk-score-status-panel');
+      expect(panel).toBeInTheDocument();
+      // Both title and description should have non-empty text content.
+      expect(panel.textContent ?? '').not.toBe('');
+    });
+
+    it('uses an override title and description when provided', () => {
+      render(
+        <RiskScoreStatusPanel
+          reason="no_matching_alerts"
+          title="Custom title"
+          description="Custom description"
+        />
+      );
+
+      expect(screen.getByText('Custom title')).toBeInTheDocument();
+      expect(screen.getByText('Custom description')).toBeInTheDocument();
+    });
+  });
+
+  describe('variants', () => {
+    it('renders an EuiEmptyPrompt by default (variant="panel")', () => {
+      render(<RiskScoreStatusPanel reason="no_matching_alerts" />);
+      // EuiEmptyPrompt has a `euiEmptyPrompt` class on its container.
+      expect(screen.getByTestId('risk-score-status-panel')).toHaveClass('euiEmptyPrompt', {
+        exact: false,
+      });
+    });
+
+    it('renders an EuiCallOut for variant="callout"', () => {
+      render(<RiskScoreStatusPanel reason="no_matching_alerts" variant="callout" />);
+      expect(screen.getByTestId('risk-score-status-panel')).toHaveClass('euiCallOut', {
+        exact: false,
+      });
+    });
+
+    it('renders only the description for variant="inline"', () => {
+      render(
+        <RiskScoreStatusPanel
+          reason="no_matching_alerts"
+          variant="inline"
+          description="Inline copy"
+          // primaryAction should be ignored for inline variant.
+          primaryAction={{ label: 'Action', onClick: jest.fn() }}
+          facts={{ entitiesTracked: 5 }}
+        />
+      );
+
+      expect(screen.getByText('Inline copy')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('risk-score-status-panel-facts')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('facts list', () => {
+    it('renders supplied facts and omits absent ones', () => {
+      render(
+        <RiskScoreStatusPanel
+          reason="no_matching_alerts"
+          facts={{
+            entitiesTracked: 1247,
+            matchingAlertsCount: 0,
+            // scoringWindow and lastSuccessTimestamp deliberately omitted
+          }}
+        />
+      );
+
+      expect(
+        screen.getByTestId('risk-score-status-panel-facts-entitiesTracked')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('risk-score-status-panel-facts-matchingAlerts')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('risk-score-status-panel-facts-scoringWindow')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('risk-score-status-panel-facts-lastRun')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render the facts list when no facts are supplied', () => {
+      render(<RiskScoreStatusPanel reason="no_matching_alerts" />);
+      expect(screen.queryByTestId('risk-score-status-panel-facts')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('primaryAction', () => {
+    it('renders the action button when an action is supplied', async () => {
+      const onClick = jest.fn();
+      render(
+        <RiskScoreStatusPanel
+          reason="no_matching_alerts"
+          primaryAction={{ label: 'Review settings', onClick }}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: 'Review settings' });
+      await userEvent.click(button);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits the action button when no primaryAction is supplied', () => {
+      render(<RiskScoreStatusPanel reason="no_matching_alerts" />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('omits the action button when primaryAction is explicitly null', () => {
+      render(<RiskScoreStatusPanel reason="no_matching_alerts" primaryAction={null} />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('data-test-subj', () => {
+    it('honours a custom data-test-subj prefix', () => {
+      render(
+        <RiskScoreStatusPanel
+          reason="no_matching_alerts"
+          data-test-subj="my-panel"
+          facts={{ entitiesTracked: 1 }}
+          primaryAction={{ label: 'Go', onClick: jest.fn() }}
+        />
+      );
+
+      expect(screen.getByTestId('my-panel')).toBeInTheDocument();
+      expect(screen.getByTestId('my-panel-facts')).toBeInTheDocument();
+      expect(screen.getByTestId('my-panel-primaryAction')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/risk_score_status_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/risk_score_status_panel.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiEmptyPrompt,
+  EuiSpacer,
+  EuiText,
+  EuiTextColor,
+  type IconType,
+} from '@elastic/eui';
+import { FactsList } from './facts_list';
+import { copyForReason } from './translations';
+import type {
+  RiskScoreStatusAction,
+  RiskScoreStatusPanelProps,
+  RiskScoreStatusReason,
+} from './types';
+
+const ICON_BY_REASON: Record<RiskScoreStatusReason, IconType> = {
+  no_matching_alerts: 'clock',
+  engine_never_run: 'play',
+  engine_disabled: 'eyeClosed',
+  engine_not_installed: 'package',
+  unknown: 'questionInCircle',
+};
+
+const COLOR_BY_REASON: Record<RiskScoreStatusReason, 'primary' | 'warning'> = {
+  no_matching_alerts: 'primary',
+  engine_never_run: 'primary',
+  engine_disabled: 'warning',
+  engine_not_installed: 'warning',
+  unknown: 'primary',
+};
+
+/**
+ * Empty / degraded-state panel for risk-score surfaces.
+ *
+ * One reusable component that explains *why* a risk-score chart, table or
+ * preview is empty, and gives the user a clear next step. Designed to be
+ * dropped into multiple surfaces (home page donut, management page preview,
+ * combined donut, entity flyout) so the vocabulary stays consistent.
+ *
+ * The component does not query anything itself — pair it with
+ * {@link useRiskScoreStatus} (or another caller-side computation) to derive
+ * the `reason` and `facts`.
+ */
+export const RiskScoreStatusPanel: React.FC<RiskScoreStatusPanelProps> = ({
+  reason,
+  facts,
+  primaryAction,
+  variant = 'panel',
+  title,
+  description,
+  'data-test-subj': dataTestSubj = 'risk-score-status-panel',
+}) => {
+  const copy = copyForReason(reason);
+  const icon = ICON_BY_REASON[reason];
+  const resolvedTitle = title ?? copy.title;
+  const resolvedDescription = description ?? copy.description;
+  const resolvedAction = resolveAction(primaryAction);
+
+  if (variant === 'inline') {
+    return (
+      <EuiText size="s" data-test-subj={dataTestSubj}>
+        <EuiTextColor color="subdued">{resolvedDescription}</EuiTextColor>
+      </EuiText>
+    );
+  }
+
+  const body = (
+    <>
+      <EuiText size="s">
+        <EuiTextColor color="subdued">{resolvedDescription}</EuiTextColor>
+      </EuiText>
+      {facts ? (
+        <>
+          <EuiSpacer size="m" />
+          <FactsList facts={facts} data-test-subj={`${dataTestSubj}-facts`} />
+        </>
+      ) : null}
+      {resolvedAction ? (
+        <>
+          <EuiSpacer size="m" />
+          <EuiButton
+            iconType="arrowRight"
+            iconSide="right"
+            onClick={resolvedAction.onClick}
+            data-test-subj={resolvedAction['data-test-subj'] ?? `${dataTestSubj}-primaryAction`}
+          >
+            {resolvedAction.label}
+          </EuiButton>
+        </>
+      ) : null}
+    </>
+  );
+
+  if (variant === 'callout') {
+    return (
+      <EuiCallOut
+        title={resolvedTitle}
+        color={COLOR_BY_REASON[reason]}
+        iconType={icon}
+        data-test-subj={dataTestSubj}
+      >
+        {body}
+      </EuiCallOut>
+    );
+  }
+
+  return (
+    <EuiEmptyPrompt
+      iconType={icon}
+      iconColor="subdued"
+      titleSize="s"
+      title={<h3>{resolvedTitle}</h3>}
+      body={body}
+      paddingSize="m"
+      data-test-subj={dataTestSubj}
+    />
+  );
+};
+
+/**
+ * `primaryAction` semantics:
+ * - `undefined` → use the default action (left for the caller to wire up via
+ *   props in a follow-up; today the component shows nothing).
+ * - `null` → explicitly suppress the action (e.g. already on the destination).
+ * - object → render with the supplied label and `onClick`.
+ *
+ * The component intentionally has no built-in navigation default to keep it
+ * decoupled from the router; that wiring belongs at the call site.
+ */
+const resolveAction = (
+  primaryAction: RiskScoreStatusPanelProps['primaryAction']
+): RiskScoreStatusAction | undefined => {
+  if (primaryAction === null) {
+    return undefined;
+  }
+  return primaryAction ?? undefined;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/translations.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { RiskScoreStatusReason } from './types';
+
+const NS = 'xpack.securitySolution.entityAnalytics.riskScoreStatus';
+
+interface ReasonCopy {
+  title: string;
+  description: string;
+  defaultActionLabel: string;
+}
+
+const COPY_BY_REASON: Record<RiskScoreStatusReason, ReasonCopy> = {
+  no_matching_alerts: {
+    title: i18n.translate(`${NS}.noMatchingAlerts.title`, {
+      defaultMessage: 'No risk scores to display yet',
+    }),
+    description: i18n.translate(`${NS}.noMatchingAlerts.description`, {
+      defaultMessage:
+        'The risk engine ran successfully but found no alerts matching your entities in the current scoring window.',
+    }),
+    defaultActionLabel: i18n.translate(`${NS}.noMatchingAlerts.actionLabel`, {
+      defaultMessage: 'Review engine settings',
+    }),
+  },
+  engine_never_run: {
+    title: i18n.translate(`${NS}.engineNeverRun.title`, {
+      defaultMessage: "Risk engine hasn't run yet",
+    }),
+    description: i18n.translate(`${NS}.engineNeverRun.description`, {
+      defaultMessage:
+        "The engine is installed but hasn't completed a scoring run in this space yet. The first run may take a few minutes.",
+    }),
+    defaultActionLabel: i18n.translate(`${NS}.engineNeverRun.actionLabel`, {
+      defaultMessage: 'Check engine status',
+    }),
+  },
+  engine_disabled: {
+    title: i18n.translate(`${NS}.engineDisabled.title`, {
+      defaultMessage: 'Risk scoring is disabled',
+    }),
+    description: i18n.translate(`${NS}.engineDisabled.description`, {
+      defaultMessage:
+        'The risk engine is installed but currently disabled, so new scores are not being produced.',
+    }),
+    defaultActionLabel: i18n.translate(`${NS}.engineDisabled.actionLabel`, {
+      defaultMessage: 'Enable risk engine',
+    }),
+  },
+  engine_not_installed: {
+    title: i18n.translate(`${NS}.engineNotInstalled.title`, {
+      defaultMessage: 'Get started with risk scoring',
+    }),
+    description: i18n.translate(`${NS}.engineNotInstalled.description`, {
+      defaultMessage:
+        'Set up the risk engine to begin scoring users, hosts, and services based on alert activity.',
+    }),
+    defaultActionLabel: i18n.translate(`${NS}.engineNotInstalled.actionLabel`, {
+      defaultMessage: 'Set up risk engine',
+    }),
+  },
+  unknown: {
+    title: i18n.translate(`${NS}.unknown.title`, {
+      defaultMessage: 'No risk scores available',
+    }),
+    description: i18n.translate(`${NS}.unknown.description`, {
+      defaultMessage: 'The risk engine has not produced scores for the entities in this view.',
+    }),
+    defaultActionLabel: i18n.translate(`${NS}.unknown.actionLabel`, {
+      defaultMessage: 'Review engine settings',
+    }),
+  },
+};
+
+export const copyForReason = (reason: RiskScoreStatusReason): ReasonCopy => COPY_BY_REASON[reason];
+
+export const FACT_LAST_RUN = (relativeTime: string) =>
+  i18n.translate(`${NS}.facts.lastRun`, {
+    defaultMessage: 'Engine healthy — last run {relativeTime}',
+    values: { relativeTime },
+  });
+
+export const FACT_ENTITIES_TRACKED = (count: number) =>
+  i18n.translate(`${NS}.facts.entitiesTracked`, {
+    defaultMessage: '{count, plural, one {# entity} other {# entities}} tracked',
+    values: { count },
+  });
+
+export const FACT_SCORING_WINDOW = (start: string, end: string) =>
+  i18n.translate(`${NS}.facts.scoringWindow`, {
+    defaultMessage: 'Scoring window — {start} to {end}',
+    values: { start, end },
+  });
+
+export const FACT_MATCHING_ALERTS = (count: number) =>
+  i18n.translate(`${NS}.facts.matchingAlerts`, {
+    defaultMessage: '{count, plural, one {# matching alert} other {# matching alerts}} in window',
+    values: { count },
+  });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/types.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactNode } from 'react';
+
+/**
+ * Discriminant for the empty / degraded state being rendered.
+ *
+ * Each reason maps to a specific icon, title, description and default action
+ * inside the panel. Adding a new reason here is a deliberate widening of the
+ * vocabulary the UI uses to talk to the user about engine state — prefer
+ * extending this enum rather than passing free-form copy through `title` /
+ * `description`, so the wording stays consistent across surfaces.
+ */
+export type RiskScoreStatusReason =
+  /** Engine ran successfully but produced no scores in the current window. */
+  | 'no_matching_alerts'
+  /** Engine is installed but has not completed a scoring run yet. */
+  | 'engine_never_run'
+  /** Engine is installed but currently disabled by the user. */
+  | 'engine_disabled'
+  /** Engine has not been installed in this space. */
+  | 'engine_not_installed'
+  /** Catch-all when no other reason can be confidently inferred. */
+  | 'unknown';
+
+/**
+ * Optional diagnostic facts displayed below the description.
+ *
+ * Every field is independently optional — the {@link FactsList} subcomponent
+ * renders only the rows it has data for. Callers should pass whatever they can
+ * cheaply produce and omit the rest rather than synthesising placeholder
+ * values.
+ */
+export interface RiskScoreStatusFacts {
+  /**
+   * ISO timestamp of the maintainer task's last successful run.
+   *
+   * Not exposed by `GET /api/risk_score/engine/status` today; left in the type
+   * surface so callers can populate it once a backend route is available.
+   */
+  lastSuccessTimestamp?: string;
+  /** Total entities present in the entity store for this surface's scope. */
+  entitiesTracked?: number;
+  /** The engine's configured scoring window. */
+  scoringWindow?: {
+    start: string;
+    end: string;
+  };
+  /**
+   * Count of alerts that matched the engine's configured filters in the
+   * scoring window. May be `undefined` if the surface has not (or cannot)
+   * compute it.
+   */
+  matchingAlertsCount?: number;
+}
+
+export interface RiskScoreStatusAction {
+  label: ReactNode;
+  onClick: () => void;
+  'data-test-subj'?: string;
+}
+
+export interface RiskScoreStatusPanelProps {
+  /** Reason for the empty / degraded state. */
+  reason: RiskScoreStatusReason;
+  /** Optional diagnostic facts; omitted facts are not rendered. */
+  facts?: RiskScoreStatusFacts;
+  /**
+   * Primary action button. Defaults are wired by `reason`; pass `null` to
+   * suppress the default (e.g. when the panel is already on the destination
+   * page), or pass an object to override.
+   */
+  primaryAction?: RiskScoreStatusAction | null;
+  /**
+   * Visual density.
+   * - `panel`: full {@link EuiEmptyPrompt}, for empty surfaces (home page).
+   * - `callout`: {@link EuiCallOut}, for situated explanations above tables
+   *   (management preview).
+   * - `inline`: bare text only, for single-entity surfaces (flyout).
+   */
+  variant?: 'panel' | 'callout' | 'inline';
+  /** Override the default title for the given reason. */
+  title?: ReactNode;
+  /** Override the default description for the given reason. */
+  description?: ReactNode;
+  'data-test-subj'?: string;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/use_risk_score_status.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/use_risk_score_status.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useRiskScoreStatus } from './use_risk_score_status';
+import { useRiskEngineStatus } from '../../api/hooks/use_risk_engine_status';
+import { RiskEngineStatusEnum } from '../../../../common/api/entity_analytics/risk_engine/engine_status_route.gen';
+
+jest.mock('../../api/hooks/use_risk_engine_status');
+
+const mockUseRiskEngineStatus = useRiskEngineStatus as jest.Mock;
+
+const setEngineStatus = (status: keyof typeof RiskEngineStatusEnum | undefined, isLoading = false) =>
+  mockUseRiskEngineStatus.mockReturnValue({
+    data: status ? { risk_engine_status: RiskEngineStatusEnum[status] } : undefined,
+    isLoading,
+  });
+
+describe('useRiskScoreStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns isLoading: true while the engine status query is loading', () => {
+    setEngineStatus(undefined, true);
+
+    const { result } = renderHook(() => useRiskScoreStatus());
+
+    expect(result.current).toEqual({
+      reason: 'unknown',
+      facts: {},
+      isLoading: true,
+    });
+  });
+
+  it('returns isLoading: true and reason: unknown when skip is set', () => {
+    setEngineStatus('ENABLED');
+
+    const { result } = renderHook(() => useRiskScoreStatus({ skip: true }));
+
+    expect(result.current).toEqual({
+      reason: 'unknown',
+      facts: {},
+      isLoading: true,
+    });
+  });
+
+  it('maps NOT_INSTALLED to engine_not_installed', () => {
+    setEngineStatus('NOT_INSTALLED');
+
+    const { result } = renderHook(() => useRiskScoreStatus());
+
+    expect(result.current.reason).toBe('engine_not_installed');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('maps DISABLED to engine_disabled', () => {
+    setEngineStatus('DISABLED');
+
+    const { result } = renderHook(() => useRiskScoreStatus());
+
+    expect(result.current.reason).toBe('engine_disabled');
+  });
+
+  it('returns no_matching_alerts when engine is ENABLED and the caller reports an empty result', () => {
+    setEngineStatus('ENABLED');
+
+    const { result } = renderHook(() => useRiskScoreStatus({ isResultEmpty: true }));
+
+    expect(result.current.reason).toBe('no_matching_alerts');
+  });
+
+  it('returns unknown when engine is ENABLED and the caller has data', () => {
+    setEngineStatus('ENABLED');
+
+    const { result } = renderHook(() => useRiskScoreStatus({ isResultEmpty: false }));
+
+    expect(result.current.reason).toBe('unknown');
+  });
+
+  it('forwards caller-supplied facts into the result', () => {
+    setEngineStatus('ENABLED');
+
+    const { result } = renderHook(() =>
+      useRiskScoreStatus({
+        isResultEmpty: true,
+        facts: { entitiesTracked: 42, scoringWindow: { start: 'now-30d', end: 'now' } },
+      })
+    );
+
+    expect(result.current.facts).toEqual({
+      entitiesTracked: 42,
+      scoringWindow: { start: 'now-30d', end: 'now' },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/use_risk_score_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_status_panel/use_risk_score_status.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import {
+  RiskEngineStatusEnum,
+  type RiskEngineStatus,
+} from '../../../../common/api/entity_analytics/risk_engine/engine_status_route.gen';
+import { useRiskEngineStatus } from '../../api/hooks/use_risk_engine_status';
+import type { RiskScoreStatusFacts, RiskScoreStatusReason } from './types';
+
+interface UseRiskScoreStatusOptions {
+  /**
+   * Whether the caller's data fetch returned an empty result (zero scored
+   * entities). The hook cannot determine this on its own — only the caller
+   * knows whether its specific query yielded rows.
+   */
+  isResultEmpty?: boolean;
+  /**
+   * Skip the engine-status fetch (e.g. while a parent feature-flag is still
+   * resolving). When `true` the hook returns `unknown` and `isLoading: true`.
+   */
+  skip?: boolean;
+  /**
+   * Optional facts to merge into the returned `facts` object. Useful when the
+   * caller already has values like `entitiesTracked` from its own query and
+   * wants them displayed in the panel.
+   */
+  facts?: RiskScoreStatusFacts;
+}
+
+export interface UseRiskScoreStatusResult {
+  reason: RiskScoreStatusReason;
+  facts: RiskScoreStatusFacts;
+  isLoading: boolean;
+}
+
+/**
+ * Computes which {@link RiskScoreStatusReason} applies for a risk-score
+ * surface, based on engine status plus a caller-supplied "is the data empty?"
+ * signal.
+ *
+ * Intentionally narrow: this hook only distinguishes the reasons we can
+ * reliably infer from public API surfaces today
+ * (`engine_not_installed`, `engine_disabled`, `no_matching_alerts`,
+ * `unknown`). License / privilege / feature-flag gating already has dedicated
+ * callout components elsewhere and is out of scope here.
+ *
+ * The `engine_never_run` reason is reserved for a follow-up when the status
+ * endpoint exposes a `lastSuccessTimestamp` field — right now there's no way
+ * to distinguish "enabled but never produced output" from "enabled and the
+ * current configuration just doesn't match any alerts" without that data.
+ */
+export const useRiskScoreStatus = (
+  options: UseRiskScoreStatusOptions = {}
+): UseRiskScoreStatusResult => {
+  const { isResultEmpty, skip, facts: callerFacts } = options;
+  const { data: engineStatus, isLoading: isEngineStatusLoading } = useRiskEngineStatus(
+    skip ? { refetchInterval: false } : {}
+  );
+
+  return useMemo<UseRiskScoreStatusResult>(() => {
+    const facts: RiskScoreStatusFacts = { ...callerFacts };
+
+    if (skip || isEngineStatusLoading) {
+      return { reason: 'unknown', facts, isLoading: true };
+    }
+
+    const status: RiskEngineStatus | undefined = engineStatus?.risk_engine_status;
+
+    if (status === RiskEngineStatusEnum.NOT_INSTALLED) {
+      return { reason: 'engine_not_installed', facts, isLoading: false };
+    }
+
+    if (status === RiskEngineStatusEnum.DISABLED) {
+      return { reason: 'engine_disabled', facts, isLoading: false };
+    }
+
+    if (status === RiskEngineStatusEnum.ENABLED && isResultEmpty === true) {
+      return { reason: 'no_matching_alerts', facts, isLoading: false };
+    }
+
+    return { reason: 'unknown', facts, isLoading: false };
+  }, [skip, isEngineStatusLoading, engineStatus, isResultEmpty, callerFacts]);
+};


### PR DESCRIPTION
### Summary

Today every risk-score surface (donut chart, KPI tiles, management preview) quietly conflates two very different cases: an entity that scored zero alerts (genuine `Unknown` per the engine's score range) and an entity that the engine never produced a score for at all (`null` calculated_level). The UI shows the same empty / Unknown ring in both cases, so users hit a chart that looks broken with no way to tell whether the engine ran, whether it's disabled, or whether their filters just don't match anything.

This is POC code only - fully claude created, please treat more like a suggestion so far 🙇

This change introduces a reusable status panel that explicitly names the reason a surface has no scores:

  - `engine_not_installed`     engine has not been set up in this space
  - `engine_disabled`          installed but currently off
  - `no_matching_alerts`       engine ran successfully, found no alerts
  - `engine_never_run`         reserved for a follow-up (needs lastSuccessTimestamp)
  - `unknown`                  fallback when no other reason can be inferred

The component is intentionally a drop-in: `<RiskScoreStatusPanel>` plus `useRiskScoreStatus({ isResultEmpty })`. Variants (`panel`, `callout`, `inline`) cover the different visual contexts where empty scoring shows up.

First integration point is the entity analytics management page's risk score preview section — when the preview comes back empty across every entity type we render a callout above the (still rendered) accordion list explaining why, so the user is no longer left guessing.

Follow-ups (intentionally out of scope here):
  - Drop into the home page donut chart and combined donut
  - Add a real `lastSuccessTimestamp` to the engine status endpoint so the `engine_never_run` reason becomes inferable
  - Fix `esqlRecordsToSeverityCount` so `null` levels stop being conflated with the `Unknown` severity bucket

### Demo Video
https://github.com/user-attachments/assets/aa3f6d44-8aff-40a6-ab2c-8d2a2a726a41

**This video shows a couple of states to render:**

1. **Entity Store not installed, so risk engine has not installed / run yet:**  panel prompts you to set it up. 
2. **Engine Enabled, no risk scores:** panel explains the engine ran but nothing matched, e.g. no alerts. 
3. **Entities Exist, but none have matching alerts:** same as above. 
4. **Entities with alerts in store:** Happy path, no panel, just the preview
