### PR TITLE
[Agent Builder][CL] Add new SML index type + let the step populate permissions.elasticsea…

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -26,7 +26,7 @@
 export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; handlerHash: string }> = [
   {
     id: 'contextEngine.addEntry',
-    handlerHash: '27344216178a96568fc8bcaf53701928a274b598b297a9b39bfbae6eb8b5b8ff',
+    handlerHash: 'a646e235b593db9e6bb0c7a87117252689fd26171ea34c05e8c308cf7632d365',
   },
   {
     id: 'ai.agent',

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
@@ -39,6 +39,7 @@ const MAX_SML_DESCRIPTION_LENGTH = 8192;
 const MAX_SML_CONTENT_LENGTH = 50_000;
 const MAX_SML_REFERENCES = 100;
 const MAX_SML_PERMISSIONS = 100;
+const MAX_SML_ES_INDICES = 100;
 
 const ChunkSchema = z.object({
   type: z
@@ -72,6 +73,13 @@ const ChunkSchema = z.object({
     .max(MAX_SML_PERMISSIONS)
     .optional()
     .describe('Optional Kibana privilege strings required to view the chunk later.'),
+  elasticsearchIndices: z
+    .array(z.string().max(MAX_SML_IDENTIFIER_LENGTH))
+    .max(MAX_SML_ES_INDICES)
+    .optional()
+    .describe(
+      'Optional Elasticsearch index / alias / data-stream names whose data this chunk depends on. Viewers must hold the ES `read` privilege on every listed name to see the chunk at search time.'
+    ),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
@@ -29,6 +29,7 @@ import {
 import { resolveSmlAttachItems } from './services/sml/execute_sml_attach_items';
 import type { SmlService } from './services/sml/types';
 import { registerAgentContextLayerWorkflowSteps } from './workflow_steps';
+import { corpusEntrySmlType } from './sml_types/corpus_entry';
 
 export class AgentContextLayerPlugin
   implements
@@ -59,6 +60,11 @@ export class AgentContextLayerPlugin
     registerFeatures({ features: setupDeps.features });
 
     const smlSetup = this.smlServiceInstance.setup({ logger: this.logger.get('sml') });
+
+    // Register the neutral 'corpus_entry' SML type so workflow authors can sink
+    // ad-hoc / eval documents (e.g. the BrowseComp-Plus corpus) via the
+    // contextEngine.addEntry step without reusing a solution-owned type.
+    smlSetup.registerType(corpusEntrySmlType);
 
     registerSmlCrawlerTaskDefinition({
       taskManager: setupDeps.taskManager,

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/corpus_entry.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/corpus_entry.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SmlTypeDefinition } from '../services/sml/types';
+
+export const CORPUS_ENTRY_SML_TYPE = 'corpus_entry';
+
+/**
+ * Neutral SML type for ad-hoc / eval corpus documents written directly via the
+ * `contextEngine.addEntry` workflow step (content-mode, `ingestion_method:
+ * 'manual'`).
+ *
+ * It is intentionally registered by the Agent Context Layer host plugin rather
+ * than a solution plugin: corpus entries (e.g. the BrowseComp-Plus eval corpus)
+ * do not belong to any product surface, so this gives workflow authors a
+ * non-solution-specific namespace to sink documents into for end-to-end tests.
+ *
+ * There is no crawler integration: `list` yields nothing and `getSmlData`
+ * returns `undefined`, so the crawler never produces entries for this type
+ * (writes only ever arrive through the workflow step's content-mode path, which
+ * skips `getSmlData`). `toAttachment` returns `undefined` because a corpus entry
+ * is searchable but does not resolve to a typed conversation attachment.
+ */
+export const corpusEntrySmlType: SmlTypeDefinition = {
+  id: CORPUS_ENTRY_SML_TYPE,
+
+  // No crawling: entries are written explicitly via contextEngine.addEntry.
+  list: (_context) => ({
+    [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true as const, value: [] }) }),
+  }),
+
+  // Content-mode writes supply chunks directly; getSmlData is never invoked.
+  getSmlData: async () => undefined,
+
+  // Corpus entries are searchable but not resolvable to a conversation attachment.
+  toAttachment: async () => undefined,
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/corpus_entry.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/corpus_entry.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { AttachmentType } from '@kbn/agent-builder-common/attachments';
 import type { SmlTypeDefinition } from '../services/sml/types';
 
 export const CORPUS_ENTRY_SML_TYPE = 'corpus_entry';
@@ -22,8 +23,11 @@ export const CORPUS_ENTRY_SML_TYPE = 'corpus_entry';
  * There is no crawler integration: `list` yields nothing and `getSmlData`
  * returns `undefined`, so the crawler never produces entries for this type
  * (writes only ever arrive through the workflow step's content-mode path, which
- * skips `getSmlData`). `toAttachment` returns `undefined` because a corpus entry
- * is searchable but does not resolve to a typed conversation attachment.
+ * skips `getSmlData`). Unlike solution-owned types (dashboard, significant
+ * event) whose `toAttachment` re-fetches the live source object, a corpus entry
+ * has no external origin to resolve — its content is self-contained in the
+ * stored SML document. So `toAttachment` builds the attachment directly from
+ * the indexed `title` / `content` / `description`.
  */
 export const corpusEntrySmlType: SmlTypeDefinition = {
   id: CORPUS_ENTRY_SML_TYPE,
@@ -36,6 +40,33 @@ export const corpusEntrySmlType: SmlTypeDefinition = {
   // Content-mode writes supply chunks directly; getSmlData is never invoked.
   getSmlData: async () => undefined,
 
-  // Corpus entries are searchable but not resolvable to a conversation attachment.
-  toAttachment: async () => undefined,
+  /**
+   * Surface the stored document as a built-in `text` attachment so Agent
+   * Builder can attach it to a conversation.
+   *
+   * We return `data` inline (rather than a by-reference `origin`) on purpose:
+   * the attachment state manager only re-resolves content from `origin` when
+   * `data` is absent, and a corpus entry has no live source to resolve against
+   * — the indexed document is the source of truth. Title and description are
+   * folded into the content so the agent sees the full KI, not just the body.
+   */
+  toAttachment: async (item) => {
+    const sections = [
+      item.title ? `# ${item.title}` : undefined,
+      item.description,
+      item.content,
+    ].filter((section): section is string => Boolean(section && section.trim()));
+
+    if (sections.length === 0) {
+      return undefined;
+    }
+
+    return {
+      id: item.id,
+      type: AttachmentType.text,
+      data: { content: sections.join('\n\n') },
+      ...(item.description ? { description: item.description } : {}),
+      readonly: true,
+    };
+  },
 };

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.test.ts
@@ -220,6 +220,7 @@ describe('createContextEngineAddEntryStepDefinition', () => {
           user_id: 'u',
           references: ['r1'],
           permissions: ['p1'],
+          elasticsearchIndices: ['idx1'],
         },
       ],
     });
@@ -235,7 +236,7 @@ describe('createContextEngineAddEntryStepDefinition', () => {
       references: [{ uri: 'r1' }],
       permissions: {
         kibana: { privileges: [{ name: 'p1' }] },
-        elasticsearch: { indices: [] },
+        elasticsearch: { indices: [{ name: 'idx1' }] },
       },
     });
   });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
@@ -149,12 +149,15 @@ export const createContextEngineAddEntryStepDefinition = ({
             ...(chunk.references !== undefined
               ? { references: chunk.references.map((uri) => ({ uri })) }
               : {}),
-            // The workflow input carries flat Kibana privilege strings; map
-            // them into the nested permissions shape (no ES index gating is
-            // expressible via this step yet).
+            // Map the workflow input's flat permission lists into the nested
+            // SML permissions shape: `permissions` -> Kibana privilege names,
+            // `elasticsearchIndices` -> ES index / alias / data-stream names
+            // that gate the chunk behind the viewer's ES `read` privilege.
             permissions: {
               kibana: { privileges: (chunk.permissions ?? []).map((name) => ({ name })) },
-              elasticsearch: { indices: [] },
+              elasticsearch: {
+                indices: (chunk.elasticsearchIndices ?? []).map((name) => ({ name })),
+              },
             },
           }));
 


### PR DESCRIPTION
Add corpus_entry type + ES index permissions to contextEngine.addEntry

Register a neutral `corpus_entry` SML type in the agent_context_layer host
plugin so workflow authors can sink ad-hoc documents without reusing a solution-owned type.

Add an optional `elasticsearchIndices` field to the contextEngine.addEntry
chunk schema and map it into permissions.elasticsearch.indices so KIs can be
gated behind the viewer's ES `read` privilege on their source index.

Regenerate the Scout handler hash for contextEngine.addEntry (needs
workflows-eng re-approval).
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


