### PR TITLE
[core/rendering] Respect darkMode on anonymous pages

### DIFF
--- a/src/core/packages/rendering/server-internal/moon.yml
+++ b/src/core/packages/rendering/server-internal/moon.yml
@@ -28,6 +28,8 @@ dependsOn:
   - '@kbn/core-status-server-internal'
   - '@kbn/core-ui-settings-common'
   - '@kbn/core-ui-settings-server'
+  - '@kbn/core-saved-objects-server'
+  - '@kbn/core-saved-objects-server-mocks'
   - '@kbn/core-plugins-base-server-internal'
   - '@kbn/core-http-router-server-mocks'
   - '@kbn/core-http-server-mocks'

--- a/src/core/packages/rendering/server-internal/moon.yml
+++ b/src/core/packages/rendering/server-internal/moon.yml
@@ -57,6 +57,7 @@ dependsOn:
   - '@kbn/core-user-storage-server'
   - '@kbn/core-user-storage-server-mocks'
   - '@kbn/repo-info'
+  - '@kbn/logging'
 tags:
   - shared-server
   - package

--- a/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.test.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.test.ts
@@ -386,6 +386,48 @@ describe('bootstrapRenderer', () => {
         })
       );
     });
+
+    it('resolves darkMode from the default space when getDefaultSpaceDarkMode is provided', async () => {
+      const getDefaultSpaceDarkMode = jest.fn().mockResolvedValue(true);
+      const rendererWithDefaultSpace = bootstrapRendererFactory({
+        auth,
+        packageInfo,
+        uiPlugins,
+        baseHref: `/base-path/${packageInfo.buildShaShort}`,
+        themeName$,
+        getDefaultSpaceDarkMode,
+      });
+      const request = httpServerMock.createKibanaRequest();
+
+      await rendererWithDefaultSpace({ request, uiSettingsClient, isAnonymousPage: true });
+
+      expect(getDefaultSpaceDarkMode).toHaveBeenCalledTimes(1);
+      // The per-request client would 403 for unauthenticated users, so it must not be consulted.
+      expect(uiSettingsClient.get).not.toHaveBeenCalledWith('theme:darkMode');
+      expect(renderTemplateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ colorMode: 'dark' })
+      );
+    });
+
+    it('keeps the default light colorMode when getDefaultSpaceDarkMode resolves undefined', async () => {
+      const getDefaultSpaceDarkMode = jest.fn().mockResolvedValue(undefined);
+      const rendererWithDefaultSpace = bootstrapRendererFactory({
+        auth,
+        packageInfo,
+        uiPlugins,
+        baseHref: `/base-path/${packageInfo.buildShaShort}`,
+        themeName$,
+        getDefaultSpaceDarkMode,
+      });
+      const request = httpServerMock.createKibanaRequest();
+
+      await rendererWithDefaultSpace({ request, uiSettingsClient, isAnonymousPage: true });
+
+      expect(getDefaultSpaceDarkMode).toHaveBeenCalledTimes(1);
+      expect(renderTemplateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ colorMode: 'light' })
+      );
+    });
   });
 
   it('calls renderTemplate with the correct theme name', async () => {

--- a/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
@@ -38,6 +38,11 @@ interface FactoryOptions {
   auth: HttpAuth;
   userSettingsService?: InternalUserSettingsServiceSetup;
   themeName$: BehaviorSubject<ThemeName>;
+  /**
+   * Resolves the default space `theme:darkMode` for unauthenticated requests via an internal
+   * client. Returns `undefined` when unavailable, so the renderer keeps the default. See #127700.
+   */
+  getDefaultSpaceDarkMode?: () => Promise<DarkModeValue | undefined>;
 }
 
 interface RenderedOptions {
@@ -66,6 +71,7 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
   auth,
   userSettingsService,
   themeName$,
+  getDefaultSpaceDarkMode,
 }) => {
   const isAuthenticated = (request: KibanaRequest) => {
     const { status: authStatus } = auth.get(request);
@@ -133,6 +139,10 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
         } else {
           darkMode = parseDarkModeValue(await uiSettingsClient.get('theme:darkMode'));
         }
+      } else if (getDefaultSpaceDarkMode) {
+        // Unauthenticated requests have no user or space context, so fall back to the default
+        // space's `theme:darkMode`, resolved via an internal client. See #127700.
+        darkMode = (await getDefaultSpaceDarkMode()) ?? darkMode;
       }
     } catch (e) {
       // just use the default values in case of connectivity issues with ES

--- a/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
@@ -25,6 +25,7 @@ import { load } from 'cheerio';
 import { mockRouter } from '@kbn/core-http-router-server-mocks';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
+import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import {
   mockRenderingServiceParams,
   mockRenderingPrebootDeps,
@@ -38,7 +39,7 @@ import type {
 } from './types';
 import { RenderingService, DEFAULT_THEME_NAME_FEATURE_FLAG } from './rendering_service';
 import { AuthStatus } from '@kbn/core-http-server';
-import type { ThemeName } from '@kbn/core-ui-settings-common';
+import type { ThemeName, DarkModeValue } from '@kbn/core-ui-settings-common';
 import { DEFAULT_THEME_NAME } from '@kbn/core-ui-settings-common';
 import { BehaviorSubject } from 'rxjs';
 
@@ -867,6 +868,99 @@ describe('RenderingService', () => {
       service.start({ ...mockRenderingStartDeps, userStorage: { asScoped } });
 
       await expect(render(createKibanaRequest(), buildUiSettings())).rejects.toThrow('ES exploded');
+    });
+  });
+
+  describe('anonymous pages dark mode', () => {
+    const buildUiSettings = () => ({
+      client: uiSettingsServiceMock.createClient(),
+      globalClient: uiSettingsServiceMock.createClient(),
+    });
+
+    const renderAnonymousDarkMode = async (
+      render: InternalRenderingServiceSetup['render']
+    ): Promise<DarkModeValue> => {
+      const { body } = await render(
+        createKibanaRequest({ auth: { isAuthenticated: false } }),
+        buildUiSettings(),
+        { isAnonymousPage: true }
+      );
+      const dom = load(body);
+      const data = JSON.parse(dom('kbn-injected-metadata').attr('data') ?? '""');
+      return data.theme.darkMode;
+    };
+
+    beforeEach(() => {
+      // Distinct from the internal client value so tests can tell which source won.
+      getSettingValueMock.mockImplementation((settingName: string) =>
+        settingName === 'theme:darkMode' ? false : settingName
+      );
+    });
+
+    it('resolves theme:darkMode from the default space via an internal unscoped client', async () => {
+      const { render } = await service.setup(mockRenderingSetupDeps);
+
+      const savedObjects = savedObjectsServiceMock.createStartContract();
+      const uiSettings = uiSettingsServiceMock.createStartContract();
+      const internalUiSettingsClient = uiSettingsServiceMock.createClient();
+      internalUiSettingsClient.get.mockResolvedValue(true);
+      uiSettings.asScopedToClient.mockReturnValue(internalUiSettingsClient);
+
+      service.start({ ...mockRenderingStartDeps, savedObjects, uiSettings });
+
+      const darkMode = await renderAnonymousDarkMode(render);
+
+      expect(savedObjects.getUnsafeInternalClient).toHaveBeenCalledTimes(1);
+      expect(uiSettings.asScopedToClient).toHaveBeenCalledWith(
+        savedObjects.getUnsafeInternalClient.mock.results[0].value
+      );
+      expect(internalUiSettingsClient.get).toHaveBeenCalledWith('theme:darkMode');
+      // The default-space value wins over the registered default (`false`).
+      expect(darkMode).toBe(true);
+    });
+
+    it('falls back to the registered default when start deps are unavailable', async () => {
+      getSettingValueMock.mockImplementation((settingName: string) =>
+        settingName === 'theme:darkMode' ? true : settingName
+      );
+      const { render } = await service.setup(mockRenderingSetupDeps);
+
+      const darkMode = await renderAnonymousDarkMode(render);
+
+      expect(darkMode).toBe(true);
+    });
+
+    it('falls back to the registered default when the internal read throws', async () => {
+      getSettingValueMock.mockImplementation((settingName: string) =>
+        settingName === 'theme:darkMode' ? true : settingName
+      );
+      const { render } = await service.setup(mockRenderingSetupDeps);
+
+      const savedObjects = savedObjectsServiceMock.createStartContract();
+      const uiSettings = uiSettingsServiceMock.createStartContract();
+      const internalUiSettingsClient = uiSettingsServiceMock.createClient();
+      internalUiSettingsClient.get.mockRejectedValue(new Error('ES exploded'));
+      uiSettings.asScopedToClient.mockReturnValue(internalUiSettingsClient);
+
+      service.start({ ...mockRenderingStartDeps, savedObjects, uiSettings });
+
+      const darkMode = await renderAnonymousDarkMode(render);
+
+      expect(internalUiSettingsClient.get).toHaveBeenCalledWith('theme:darkMode');
+      expect(darkMode).toBe(true);
+    });
+
+    it('does not consult the internal client for authenticated pages', async () => {
+      const { render } = await service.setup(mockRenderingSetupDeps);
+
+      const savedObjects = savedObjectsServiceMock.createStartContract();
+      const uiSettings = uiSettingsServiceMock.createStartContract();
+      service.start({ ...mockRenderingStartDeps, savedObjects, uiSettings });
+
+      await render(createKibanaRequest(), buildUiSettings());
+
+      expect(savedObjects.getUnsafeInternalClient).not.toHaveBeenCalled();
+      expect(uiSettings.asScopedToClient).not.toHaveBeenCalled();
     });
   });
 

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -13,9 +13,11 @@ import { BehaviorSubject, firstValueFrom, of, map, catchError, take, timeout } f
 import { i18n as i18nLib } from '@kbn/i18n';
 import type { ThemeVersion } from '@kbn/ui-shared-deps-npm';
 
+import type { Logger } from '@kbn/logging';
 import type { CoreContext } from '@kbn/core-base-server-internal';
 import type { KibanaRequest, HttpAuth } from '@kbn/core-http-server';
-import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
+import type { IUiSettingsClient, UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
+import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { UiPlugins } from '@kbn/core-plugins-base-server-internal';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import type { UserStorageServiceStart } from '@kbn/core-user-storage-server';
@@ -74,7 +76,13 @@ export class RenderingService {
   private airgapped: boolean = false;
   private isCoreRenderingInReactConcurrentMode: boolean = true;
   private userStorageStart?: UserStorageServiceStart;
-  constructor(private readonly coreContext: CoreContext) {}
+  private savedObjectsStart?: SavedObjectsServiceStart;
+  private uiSettingsStart?: UiSettingsServiceStart;
+  private defaultSpaceUiSettingsClient?: IUiSettingsClient;
+  private readonly logger: Logger;
+  constructor(private readonly coreContext: CoreContext) {
+    this.logger = coreContext.logger.get('rendering');
+  }
 
   public async preboot({
     http,
@@ -90,6 +98,7 @@ export class RenderingService {
           packageInfo: this.coreContext.env.packageInfo,
           auth: http.auth,
           themeName$: this.themeName$,
+          getDefaultSpaceDarkMode: () => this.getDefaultSpaceDarkMode(),
         }),
       });
     });
@@ -126,6 +135,7 @@ export class RenderingService {
         auth: http.auth,
         themeName$: this.themeName$,
         userSettingsService: userSettings,
+        getDefaultSpaceDarkMode: () => this.getDefaultSpaceDarkMode(),
       }),
     });
 
@@ -143,8 +153,10 @@ export class RenderingService {
     };
   }
 
-  public start({ featureFlags, userStorage }: RenderingStartDeps) {
+  public start({ featureFlags, userStorage, savedObjects, uiSettings }: RenderingStartDeps) {
     this.userStorageStart = userStorage;
+    this.savedObjectsStart = savedObjects;
+    this.uiSettingsStart = uiSettings;
     featureFlags
       .getStringValue$<ThemeName>(DEFAULT_THEME_NAME_FEATURE_FLAG, DEFAULT_THEME_NAME)
       // Parse the input feature flag value to ensure it's of type ThemeName
@@ -258,7 +270,14 @@ export class RenderingService {
     const isThemeOverridden = settings.user['theme:darkMode']?.isOverridden ?? false;
 
     let darkMode: DarkModeValue;
-    if (userSettingDarkMode !== undefined && !isThemeOverridden) {
+    if (isAnonymousPage) {
+      // Anonymous pages have no user or space context, so fall back to the default space's
+      // `theme:darkMode`, resolved via an internal (unscoped) client to avoid a 403.
+      // See https://github.com/elastic/kibana/issues/127700.
+      darkMode =
+        (await this.getDefaultSpaceDarkMode()) ??
+        getSettingValue<DarkModeValue>('theme:darkMode', settings, parseDarkModeValue);
+    } else if (userSettingDarkMode !== undefined && !isThemeOverridden) {
       darkMode = userSettingDarkMode;
     } else {
       darkMode = getSettingValue<DarkModeValue>('theme:darkMode', settings, parseDarkModeValue);
@@ -416,12 +435,44 @@ export class RenderingService {
 
   public async stop() {}
 
+  /**
+   * Resolves the default space `theme:darkMode` for anonymous pages using an internal, unscoped
+   * client (the per-request client would 403 for unauthenticated users). Returns `undefined` when
+   * the start deps are unavailable (e.g. preboot) or the read fails, so callers fall back to the
+   * registered default. Only the theme value is read; no user settings are exposed to the page.
+   */
+  private async getDefaultSpaceDarkMode(): Promise<DarkModeValue | undefined> {
+    const { savedObjectsStart, uiSettingsStart } = this;
+    if (!savedObjectsStart || !uiSettingsStart) {
+      return undefined;
+    }
+
+    try {
+      this.defaultSpaceUiSettingsClient ??= uiSettingsStart.asScopedToClient(
+        savedObjectsStart.getUnsafeInternalClient()
+      );
+      const rawValue = await this.defaultSpaceUiSettingsClient.get<unknown>('theme:darkMode');
+      return parseDarkModeValue(rawValue);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to resolve the default space "theme:darkMode" setting for an anonymous page: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return undefined;
+    }
+  }
+
   private async fetchUserStorageValues(request: KibanaRequest): Promise<Record<string, unknown>> {
     const userStorage = this.userStorageStart;
-    if (!userStorage) return {};
+    if (!userStorage) {
+      return {};
+    }
 
     const client = userStorage.asScoped(request);
-    if (!client) return {};
+    if (!client) {
+      return {};
+    }
 
     return client.getForInjection();
   }

--- a/src/core/packages/rendering/server-internal/src/test_helpers/params.ts
+++ b/src/core/packages/rendering/server-internal/src/test_helpers/params.ts
@@ -17,6 +17,8 @@ import { userSettingsServiceMock } from '@kbn/core-user-settings-server-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-server-mocks';
 import { coreFeatureFlagsMock } from '@kbn/core-feature-flags-server-mocks';
 import { userStorageServiceMock } from '@kbn/core-user-storage-server-mocks';
+import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 
 const context = mockCoreContext.create();
 // Mock the airgapped config to return a boolean value
@@ -55,4 +57,6 @@ export const mockRenderingSetupDeps = {
 export const mockRenderingStartDeps = {
   featureFlags: coreFeatureFlagsMock.createStart(),
   userStorage: userStorageServiceMock.createStartContract(),
+  savedObjects: savedObjectsServiceMock.createStartContract(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
 };

--- a/src/core/packages/rendering/server-internal/src/types.ts
+++ b/src/core/packages/rendering/server-internal/src/types.ts
@@ -17,7 +17,8 @@ import type {
 import type { InternalElasticsearchServiceSetup } from '@kbn/core-elasticsearch-server-internal';
 import type { InternalStatusServiceSetup } from '@kbn/core-status-server-internal';
 import type { DarkModeValue } from '@kbn/core-ui-settings-common';
-import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
+import type { IUiSettingsClient, UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
+import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { UiPlugins } from '@kbn/core-plugins-base-server-internal';
 import type { InternalCustomBrandingSetup } from '@kbn/core-custom-branding-server-internal';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
@@ -71,6 +72,12 @@ export interface RenderingStartDeps {
   featureFlags: FeatureFlagsStart;
   /** Optional so `render()` is safe to call before `start()` runs. */
   userStorage?: UserStorageServiceStart;
+  /**
+   * Used to resolve the default space `theme:darkMode` for anonymous pages via an internal,
+   * unscoped client. Optional so `render()` stays safe before `start()` runs (e.g. preboot).
+   */
+  savedObjects?: SavedObjectsServiceStart;
+  uiSettings?: UiSettingsServiceStart;
 }
 
 /** @internal */

--- a/src/core/packages/rendering/server-internal/tsconfig.json
+++ b/src/core/packages/rendering/server-internal/tsconfig.json
@@ -53,6 +53,7 @@
     "@kbn/core-user-storage-server",
     "@kbn/core-user-storage-server-mocks",
     "@kbn/repo-info",
+    "@kbn/logging",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/rendering/server-internal/tsconfig.json
+++ b/src/core/packages/rendering/server-internal/tsconfig.json
@@ -24,6 +24,8 @@
     "@kbn/core-status-server-internal",
     "@kbn/core-ui-settings-common",
     "@kbn/core-ui-settings-server",
+    "@kbn/core-saved-objects-server",
+    "@kbn/core-saved-objects-server-mocks",
     "@kbn/core-plugins-base-server-internal",
     "@kbn/core-http-router-server-mocks",
     "@kbn/core-http-server-mocks",

--- a/src/core/packages/root/server-internal/src/server.ts
+++ b/src/core/packages/root/server-internal/src/server.ts
@@ -620,6 +620,8 @@ export class Server {
     this.rendering.start({
       featureFlags: featureFlagsStart,
       userStorage: userStorageStart,
+      savedObjects: savedObjectsStart,
+      uiSettings: uiSettingsStart,
     });
 
     this.coreStart = {


### PR DESCRIPTION
## Summary

Closes #127700.

Anonymous pages (the login page, and any page served via `httpResources.renderAnonymousCoreApp`) ignored the `theme:darkMode` UI setting. The rendering service skips `getUserProvided()` for anonymous requests because the request-scoped uiSettings client would `403` for unauthenticated users, so dark mode always fell back to the registered default. The bootstrap loader (`bootstrap-anonymous.js`) likewise hardcoded light mode for unauthenticated requests, so even the initial paint and theme tag were light.

Per the discussion on the issue, unauthenticated pages now follow the **default space**'s `theme:darkMode`, resolved internally:

- `RenderingService` lazily builds an internal, unscoped client — `uiSettings.asScopedToClient(savedObjects.getUnsafeInternalClient())` (default namespace, internal Kibana user) — and reads `theme:darkMode` for anonymous render paths.
- The same resolver is threaded into the bootstrap renderer so the loading splash + theme tag also respect it for unauthenticated requests.
- On any error, or before `start()` has run (e.g. preboot), it falls back to the registered default.

Only the theme value is read — no user settings are injected into anonymous pages, preserving the existing security scoping (the `banner:textContent` concern raised on the issue still holds).

### Notes
- The Reset Session and Unauthenticated pages mentioned on the issue have since moved to `public/` (client-side React) and render inside the app shell, so they pick up the corrected injected theme metadata automatically.

## Test plan

- [ ] Unit tests added for the rendering service (resolves from default space; falls back when deps are absent; falls back when the read throws; not consulted for authenticated pages) and the bootstrap renderer.
- [ ] Manual: set `theme:darkMode` in the default space, enable security, log out, and confirm the login page renders in dark mode.

### Release note
Unauthenticated pages such as the login page now respect the default space's dark mode setting.