### PR TITLE
[aw] Fix Claude reviewer Opus 4.8 params

### DIFF
--- a/.github/workflows/reviewer-claude.lock.yml
+++ b/.github/workflows/reviewer-claude.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e2ffa07c359258a80529656cef0f216a0dd14bce26a9fd3a19753ae91031d72f","compiler_version":"v0.76.1","strict":true,"agent_id":"claude","agent_model":"opus"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7c74ae0e564397b73a464cf1cfd20607bfcc0d78292810fad2e67a7e1ef46456","compiler_version":"v0.76.1","strict":true,"agent_id":"claude","agent_model":"opus"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"46d564922b082d0db93244972e8005ea6904ee5f","version":"v0.76.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.55"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.19"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -59,7 +59,7 @@ on:
   # bots: # Bots processed as bot check in pre-activation job
   # - github-actions[bot] # Bots processed as bot check in pre-activation job
   # - kibanamachine # Bots processed as bot check in pre-activation job
-  pull_request_target:
+  pull_request:
     types:
     - synchronize
     - reopened
@@ -107,12 +107,12 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (!github.event.repository.fork && (
+      needs.pre_activation.outputs.activated == 'true' && ((!github.event.repository.fork && (
       github.event_name == 'workflow_dispatch' ||
       (
       github.event.sender.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'reviewer:skip-ai') &&
-      github.event_name == 'pull_request_target' &&
+      github.event_name == 'pull_request' &&
       (
       (
       github.event.action == 'labeled' &&
@@ -124,7 +124,7 @@ jobs:
       )
       )
       )
-      ))
+      )) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -155,7 +155,7 @@ jobs:
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/reviewer-claude.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
           GH_AW_INFO_AWF_VERSION: "v0.25.55"
           GH_AW_INFO_ENGINE_ID: "claude"
       - name: Generate agentic run info
@@ -164,8 +164,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "claude"
           GH_AW_INFO_ENGINE_NAME: "Claude Code"
           GH_AW_INFO_MODEL: "opus"
-          GH_AW_INFO_VERSION: "2.1.111"
-          GH_AW_INFO_AGENT_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
+          GH_AW_INFO_AGENT_VERSION: "2.1.165"
           GH_AW_INFO_CLI_VERSION: "v0.76.1"
           GH_AW_INFO_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -261,20 +261,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_56940330101208c1_EOF'
+          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
           <system>
-          GH_AW_PROMPT_56940330101208c1_EOF
+          GH_AW_PROMPT_3f7542937b09f3bb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_56940330101208c1_EOF'
+          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:10), submit_pull_request_review, reply_to_pull_request_review_comment(max:10), resolve_pull_request_review_thread(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_56940330101208c1_EOF
+          GH_AW_PROMPT_3f7542937b09f3bb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_56940330101208c1_EOF'
+          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -303,13 +303,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_56940330101208c1_EOF
+          GH_AW_PROMPT_3f7542937b09f3bb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_56940330101208c1_EOF'
+          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
           </system>
           {{#runtime-import .github/agents/code-reviewer.md}}
           {{#runtime-import .github/workflows/reviewer-claude.md}}
-          GH_AW_PROMPT_56940330101208c1_EOF
+          GH_AW_PROMPT_3f7542937b09f3bb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -426,7 +426,7 @@ jobs:
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/reviewer-claude.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
           GH_AW_INFO_AWF_VERSION: "v0.25.55"
           GH_AW_INFO_ENGINE_ID: "claude"
       - name: Set runtime paths
@@ -499,7 +499,7 @@ jobs:
       - name: Install AWF binary
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.55
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.111
+        run: npm install -g @anthropic-ai/claude-code@2.1.165
       - name: Parse integrity filter lists
         id: parse-guard-vars
         env:
@@ -534,9 +534,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_75acb54df5653a11_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0efb609e31fd4057_EOF'
           {"add_comment":{"footer":true,"max":1,"target":"${{ env.PR_NUMBER }}"},"create_pull_request_review_comment":{"max":10,"side":"RIGHT","target":"${{ env.PR_NUMBER }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"reply_to_pull_request_review_comment":{"footer":true,"max":10,"target":"${{ env.PR_NUMBER }}"},"report_incomplete":{},"resolve_pull_request_review_thread":{"max":10},"submit_pull_request_review":{"allowed_events":["COMMENT"],"footer":"if-body","max":1,"target":"${{ env.PR_NUMBER }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_75acb54df5653a11_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0efb609e31fd4057_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -817,7 +817,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.19'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c22701e413f4ee9d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_81d03fb71049f01f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -860,7 +860,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c22701e413f4ee9d_EOF
+          GH_AW_MCP_CONFIG_81d03fb71049f01f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -986,6 +986,7 @@ jobs:
           BASH_DEFAULT_TIMEOUT_MS: 60000
           BASH_MAX_TIMEOUT_MS: 60000
           CLAUDE_CODE_DISABLE_FAST_MODE: 1
+          CLAUDE_CODE_EFFORT_LEVEL: high
           CLAUDE_CODE_SUBAGENT_MODEL: opus[1m]
           DISABLE_BUG_COMMAND: 1
           DISABLE_ERROR_REPORTING: 1
@@ -1192,7 +1193,7 @@ jobs:
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/reviewer-claude.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
           GH_AW_INFO_AWF_VERSION: "v0.25.55"
           GH_AW_INFO_ENGINE_ID: "claude"
       - name: Download agent output artifact
@@ -1333,7 +1334,7 @@ jobs:
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/reviewer-claude.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
           GH_AW_INFO_AWF_VERSION: "v0.25.55"
           GH_AW_INFO_ENGINE_ID: "claude"
       - name: Download agent output artifact
@@ -1422,7 +1423,7 @@ jobs:
       - name: Install AWF binary
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.55
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.111
+        run: npm install -g @anthropic-ai/claude-code@2.1.165
       - name: Execute Claude Code CLI
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true
@@ -1468,6 +1469,7 @@ jobs:
           BASH_DEFAULT_TIMEOUT_MS: 60000
           BASH_MAX_TIMEOUT_MS: 60000
           CLAUDE_CODE_DISABLE_FAST_MODE: 1
+          CLAUDE_CODE_EFFORT_LEVEL: high
           CLAUDE_CODE_SUBAGENT_MODEL: opus[1m]
           DISABLE_BUG_COMMAND: 1
           DISABLE_ERROR_REPORTING: 1
@@ -1527,12 +1529,12 @@ jobs:
 
   pre_activation:
     if: >
-      !github.event.repository.fork && (
+      (!github.event.repository.fork && (
       github.event_name == 'workflow_dispatch' ||
       (
       github.event.sender.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'reviewer:skip-ai') &&
-      github.event_name == 'pull_request_target' &&
+      github.event_name == 'pull_request' &&
       (
       (
       github.event.action == 'labeled' &&
@@ -1544,7 +1546,7 @@ jobs:
       )
       )
       )
-      )
+      )) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -1562,7 +1564,7 @@ jobs:
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/reviewer-claude.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
           GH_AW_INFO_AWF_VERSION: "v0.25.55"
           GH_AW_INFO_ENGINE_ID: "claude"
       - name: Check team membership for workflow
@@ -1611,7 +1613,7 @@ jobs:
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "claude"
       GH_AW_ENGINE_MODEL: "opus"
-      GH_AW_ENGINE_VERSION: "2.1.111"
+      GH_AW_ENGINE_VERSION: "2.1.165"
       GH_AW_WORKFLOW_ID: "reviewer-claude"
       GH_AW_WORKFLOW_NAME: "Claude Reviewer"
       GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/reviewer-claude.md"
@@ -1636,7 +1638,7 @@ jobs:
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Claude Reviewer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/reviewer-claude.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.111"
+          GH_AW_INFO_VERSION: "2.1.165"
           GH_AW_INFO_AWF_VERSION: "v0.25.55"
           GH_AW_INFO_ENGINE_ID: "claude"
       - name: Download agent output artifact

--- a/.github/workflows/reviewer-claude.lock.yml
+++ b/.github/workflows/reviewer-claude.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7c74ae0e564397b73a464cf1cfd20607bfcc0d78292810fad2e67a7e1ef46456","compiler_version":"v0.76.1","strict":true,"agent_id":"claude","agent_model":"opus"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"25ec44da0da5c01e2168bf301791e6082f1b169031cce7832a0bc50489dc5502","compiler_version":"v0.76.1","strict":true,"agent_id":"claude","agent_model":"opus"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"46d564922b082d0db93244972e8005ea6904ee5f","version":"v0.76.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.55"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.19"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -59,7 +59,7 @@ on:
   # bots: # Bots processed as bot check in pre-activation job
   # - github-actions[bot] # Bots processed as bot check in pre-activation job
   # - kibanamachine # Bots processed as bot check in pre-activation job
-  pull_request:
+  pull_request_target:
     types:
     - synchronize
     - reopened
@@ -107,12 +107,12 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && ((!github.event.repository.fork && (
+      needs.pre_activation.outputs.activated == 'true' && (!github.event.repository.fork && (
       github.event_name == 'workflow_dispatch' ||
       (
       github.event.sender.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'reviewer:skip-ai') &&
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       (
       (
       github.event.action == 'labeled' &&
@@ -124,7 +124,7 @@ jobs:
       )
       )
       )
-      )) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id))
+      ))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -261,20 +261,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
+          cat << 'GH_AW_PROMPT_50c89de8f1edf7a7_EOF'
           <system>
-          GH_AW_PROMPT_3f7542937b09f3bb_EOF
+          GH_AW_PROMPT_50c89de8f1edf7a7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
+          cat << 'GH_AW_PROMPT_50c89de8f1edf7a7_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:10), submit_pull_request_review, reply_to_pull_request_review_comment(max:10), resolve_pull_request_review_thread(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_3f7542937b09f3bb_EOF
+          GH_AW_PROMPT_50c89de8f1edf7a7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
+          cat << 'GH_AW_PROMPT_50c89de8f1edf7a7_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -303,13 +303,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_3f7542937b09f3bb_EOF
+          GH_AW_PROMPT_50c89de8f1edf7a7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3f7542937b09f3bb_EOF'
+          cat << 'GH_AW_PROMPT_50c89de8f1edf7a7_EOF'
           </system>
           {{#runtime-import .github/agents/code-reviewer.md}}
           {{#runtime-import .github/workflows/reviewer-claude.md}}
-          GH_AW_PROMPT_3f7542937b09f3bb_EOF
+          GH_AW_PROMPT_50c89de8f1edf7a7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -534,9 +534,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0efb609e31fd4057_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ba76cdc0bc4e0054_EOF'
           {"add_comment":{"footer":true,"max":1,"target":"${{ env.PR_NUMBER }}"},"create_pull_request_review_comment":{"max":10,"side":"RIGHT","target":"${{ env.PR_NUMBER }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"reply_to_pull_request_review_comment":{"footer":true,"max":10,"target":"${{ env.PR_NUMBER }}"},"report_incomplete":{},"resolve_pull_request_review_thread":{"max":10},"submit_pull_request_review":{"allowed_events":["COMMENT"],"footer":"if-body","max":1,"target":"${{ env.PR_NUMBER }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0efb609e31fd4057_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ba76cdc0bc4e0054_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -817,7 +817,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.19'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_81d03fb71049f01f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_9c1c92d9f506ce4b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -860,7 +860,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_81d03fb71049f01f_EOF
+          GH_AW_MCP_CONFIG_9c1c92d9f506ce4b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1529,12 +1529,12 @@ jobs:
 
   pre_activation:
     if: >
-      (!github.event.repository.fork && (
+      !github.event.repository.fork && (
       github.event_name == 'workflow_dispatch' ||
       (
       github.event.sender.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'reviewer:skip-ai') &&
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       (
       (
       github.event.action == 'labeled' &&
@@ -1546,7 +1546,7 @@ jobs:
       )
       )
       )
-      )) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
+      )
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/reviewer-claude.md
+++ b/.github/workflows/reviewer-claude.md
@@ -1,7 +1,7 @@
 ---
 name: Claude Reviewer
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
@@ -47,7 +47,7 @@ if: >-
     (
       github.event.sender.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'reviewer:skip-ai') &&
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       (
         (
           github.event.action == 'labeled' &&
@@ -136,6 +136,6 @@ safe-outputs:
 # Claude PR Reviewer
 
 Using the imported reviewer instructions:
-- Run in review mode for `pull_request` and manual `workflow_dispatch` events without a comment id.
+- Run in review mode for `pull_request_target` and manual `workflow_dispatch` events without a comment id.
 - Run in follow-up response mode when `workflow_dispatch` includes a comment id from the Reviewer Comment Dispatcher.
 - This reviewer's own gh-aw workflow id is `reviewer-claude`. Use it as "this reviewer's own workflow id" when matching review threads to resolve.

--- a/.github/workflows/reviewer-claude.md
+++ b/.github/workflows/reviewer-claude.md
@@ -1,7 +1,7 @@
 ---
 name: Claude Reviewer
 on:
-  pull_request_target:
+  pull_request:
     types: [synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
@@ -22,7 +22,7 @@ imports:
   - .github/agents/code-reviewer.md
 engine:
   id: claude
-  version: "2.1.111"
+  version: "2.1.165"
   model: opus
   max-turns: 120
   env:
@@ -33,6 +33,7 @@ engine:
     ANTHROPIC_DEFAULT_OPUS_MODEL: llm-gateway/claude-opus-4-8[1m]
     ANTHROPIC_DEFAULT_HAIKU_MODEL: llm-gateway/claude-haiku-4-5
     ANTHROPIC_DEFAULT_SONNET_MODEL: llm-gateway/claude-sonnet-4-6
+    CLAUDE_CODE_EFFORT_LEVEL: high
     CLAUDE_CODE_SUBAGENT_MODEL: opus[1m]
 # Activation rules:
 # - Manual runs always activate.
@@ -46,7 +47,7 @@ if: >-
     (
       github.event.sender.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'reviewer:skip-ai') &&
-      github.event_name == 'pull_request_target' &&
+      github.event_name == 'pull_request' &&
       (
         (
           github.event.action == 'labeled' &&
@@ -135,6 +136,6 @@ safe-outputs:
 # Claude PR Reviewer
 
 Using the imported reviewer instructions:
-- Run in review mode for `pull_request_target` and manual `workflow_dispatch` events without a comment id.
+- Run in review mode for `pull_request` and manual `workflow_dispatch` events without a comment id.
 - Run in follow-up response mode when `workflow_dispatch` includes a comment id from the Reviewer Comment Dispatcher.
 - This reviewer's own gh-aw workflow id is `reviewer-claude`. Use it as "this reviewer's own workflow id" when matching review threads to resolve.


### PR DESCRIPTION
## Summary

The Claude reviewer is failing after the bump to `Opus 4.8` due to incompatibility with the CLI version. Example:
https://github.com/elastic/kibana/actions/runs/27033997321/job/79794420739#step:28:317

- Bumps the Claude CLI to `2.1.165`.
- Sets `CLAUDE_CODE_EFFORT_LEVEL=high` so Opus 4.8 uses the expected adaptive-thinking effort control.

### Testing
Workflow dispatch with this branch as ref:
https://github.com/elastic/kibana/actions/runs/27034793333