### PR TITLE
[kbn-ui] Add internal developer docs, published to codex.elastic.dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3723,10 +3723,11 @@ docs/release-notes                            @elastic/ski-docs
 docs/docset.yml                               @elastic/ski-docs
 docs/redirects.yml                            @elastic/ski-docs
 
-# Internal developer docs, published to codex.elastic.dev only. Teams adding a subject own its
-# directory; add that entry below rather than in the generated block, which is rewritten by
-# `node scripts/generate codeowners`.
-docs-dev/                                     @elastic/appex-sharedux
+# Internal developer docs, published to codex.elastic.dev only. Only the shared scaffolding is
+# owned here; teams adding a subject own its directory and add that entry below, rather than in
+# the generated block, which is rewritten by `node scripts/generate codeowners`.
+docs-dev/docset.yml                           @elastic/appex-sharedux
+docs-dev/index.md                             @elastic/appex-sharedux
 docs-dev/kbn-ui/                              @elastic/appex-sharedux
 
 # Side navigation title glossary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3723,6 +3723,12 @@ docs/release-notes                            @elastic/ski-docs
 docs/docset.yml                               @elastic/ski-docs
 docs/redirects.yml                            @elastic/ski-docs
 
+# Internal developer docs, published to codex.elastic.dev only. Teams adding a subject own its
+# directory; add that entry below rather than in the generated block, which is rewritten by
+# `node scripts/generate codeowners`.
+docs-dev/                                     @elastic/appex-sharedux
+docs-dev/kbn-ui/                              @elastic/appex-sharedux
+
 # Side navigation title glossary
 src/platform/packages/shared/shared-ux/label_formatter/src/to_sentence_case.ts @elastic/ski-docs
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1615,7 +1615,7 @@ x-pack/platform/test/serverless/api_integration/test_suites/platform_security @e
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_document_profile @elastic/obs-signals-traces-team @elastic/obs-signals-logs-team @elastic/obs-signals-metrics-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile @elastic/obs-signals-traces-team @elastic/obs-signals-logs-team @elastic/obs-signals-metrics-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile @elastic/obs-signals-traces-team
-/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-signals-traces-team 
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-signals-traces-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting
 /src/platform/plugins/shared/discover/test/scout/security_experience/ @elastic/security-threat-hunting
 
@@ -3726,8 +3726,8 @@ docs/redirects.yml                            @elastic/ski-docs
 # Internal developer docs, published to codex.elastic.dev only. Only the shared scaffolding is
 # owned here; teams adding a subject own its directory and add that entry below, rather than in
 # the generated block, which is rewritten by `node scripts/generate codeowners`.
-docs-dev/docset.yml                           @elastic/appex-sharedux
-docs-dev/index.md                             @elastic/appex-sharedux
+docs-dev/docset.yml                           @elastic/kibana-tech-leads
+docs-dev/index.md                             @elastic/kibana-tech-leads
 docs-dev/kbn-ui/                              @elastic/appex-sharedux
 
 # Side navigation title glossary

--- a/.github/workflows/codex-preview-cleanup.yml
+++ b/.github/workflows/codex-preview-cleanup.yml
@@ -1,0 +1,14 @@
+name: elastic-internal-docs-cleanup
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  preview:
+    uses: elastic/docs-actions/.github/workflows/codex-preview-cleanup.yml@v1
+    permissions:
+      contents: none
+      id-token: write
+      deployments: write

--- a/.github/workflows/codex-preview.yml
+++ b/.github/workflows/codex-preview.yml
@@ -1,0 +1,33 @@
+# Elastic Internal Docs (codex.elastic.dev) — builds the docs-dev/ docset only. Kibana's public
+# elastic.co docs live in docs/ and are built by docs-build.yml, so `path` keeps the two apart.
+#
+# The push trigger drives the reusable workflow's `update-link-index` job, which registers this
+# docset in elastic/codex-link-index and is what makes the nightly codex.elastic.dev build pick
+# it up. That job's token fetch is not `continue-on-error`, so it fails the build unless this
+# repo has a Backstage token policy:
+# https://backstage.elastic.dev/create/templates/default/register-elastic-internal-docs-token-policies
+name: elastic-internal-docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
+
+jobs:
+  preview:
+    permissions:
+      id-token: write
+      deployments: write
+      contents: read
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/codex-preview.yml@v1
+    with:
+      path: docs-dev
+      # Resolve `:::{storybook}` embeds against this PR's Storybook artifacts, the only place
+      # unmerged stories exist. Requires this PR's Buildkite storybook-docs step to have finished
+      # uploading. Empty outside a PR, leaving docset.yml's committed `main` default.
+      build-env: >-
+        ${{ github.event.pull_request.number
+        && format('KIBANA_STORYBOOK_REGISTRY=https://ci-artifacts.kibana.dev/storybooks/pr-{0}/storybook-docs/docs_registry.json', github.event.pull_request.number)
+        || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .artifacts
 docs/**/.artifacts
+docs-dev/**/.artifacts
 /.superset
 .aws-config.json
 .bk.yaml

--- a/docs-dev/docset.yml
+++ b/docs-dev/docset.yml
@@ -1,0 +1,23 @@
+project: 'Kibana'
+
+icon: kibana
+
+registry: internal
+
+storybook:
+  # Registry of embeddable Storybook stories that resolves `:::{storybook}` directives
+  # (e.g. `:id: kibana:<alias>:<story>`). The committed default is the registry published
+  # from `main` by the storybook-docs CI step (see
+  # .buildkite/scripts/steps/storybooks/build_and_upload.ts). Local serve and per-PR
+  # previews override it via the allow-listed `KIBANA_STORYBOOK_REGISTRY` env var without
+  # editing this file (docs-builder env interpolation, elastic/docs-builder#3486).
+  registry: ${KIBANA_STORYBOOK_REGISTRY:-https://ci-artifacts.kibana.dev/storybooks/main/storybook-docs/docs_registry.json}
+
+subs:
+  kib: 'Kibana'
+
+# Subject-matter TOCs live in each folder's `toc.yml`. Add a new `- toc: <subject>` entry
+# when introducing another documentation area under `docs-dev/`.
+toc:
+  - file: index.md
+  - toc: kbn-ui

--- a/docs-dev/index.md
+++ b/docs-dev/index.md
@@ -1,0 +1,12 @@
+---
+navigation_title: Kibana
+description: Internal developer documentation for Kibana — component libraries, platform packages, and engineering guides published only to Elastic Internal Docs.
+---
+
+# Kibana
+
+Internal developer documentation for the Kibana repository. Content here is published to [Elastic Internal Docs](https://codex.elastic.dev) only — it is not part of the public [Elastic documentation](https://www.elastic.co/docs).
+
+## Subjects
+
+- [Kibana UI (`@kbn/ui`)](kbn-ui/index.md) — reusable, opinionated UI components built on EUI.

--- a/docs-dev/kbn-ui/feedback.md
+++ b/docs-dev/kbn-ui/feedback.md
@@ -1,0 +1,84 @@
+---
+navigation_title: Feedback
+---
+
+# @kbn/ui-feedback [kbn-ui-feedback]
+
+The UI for One Feedback — a universal way for users to rate their experience and submit feedback from anywhere in {{kib}}. The package is self-contained so it can be distributed to external consumers (for example, Cloud UI) alongside {{kib}} itself.
+
+It exposes two components:
+
+* `FeedbackTriggerButton` — a header button that opens the feedback form in a modal.
+* `FeedbackContainer` — the feedback form itself, for hosts that manage their own container.
+
+## Trigger button [kbn-ui-feedback-trigger-button]
+
+The button lives in the global header and opens the form on click. It is disabled until usage collection is opted in.
+
+:::{storybook}
+:id: kibana:kbn_ui:feedback--trigger-button
+:::
+
+## Feedback form [kbn-ui-feedback-form]
+
+`FeedbackContainer` renders the CSAT buttons, the context-aware questions, and the optional email-contact section.
+
+:::{storybook}
+:id: kibana:kbn_ui:feedback--form
+:::
+
+## Usage [kbn-ui-feedback-usage]
+
+Both components are driven entirely by callbacks, so the host owns data fetching, telemetry, and toasts.
+
+```tsx
+import { FeedbackTriggerButton } from '@kbn/ui-feedback';
+
+<FeedbackTriggerButton
+  getQuestions={getQuestions}
+  getAppDetails={getAppDetails}
+  getCurrentUserEmail={getCurrentUserEmail}
+  sendFeedback={sendFeedback}
+  showToast={showToast}
+  checkTelemetryOptIn={checkTelemetryOptIn}
+/>;
+```
+
+| Prop | Description |
+| --- | --- |
+| `getQuestions` | Resolves the context-aware questions for an app id. |
+| `getAppDetails` | Returns the current app's `title`, `id`, and `url`. |
+| `getCurrentUserEmail` | Resolves the current user's email, used to prefill the email field. |
+| `sendFeedback` | Persists the submitted feedback. |
+| `showToast` | Surfaces success and error toasts to the user. |
+| `checkTelemetryOptIn` | Resolves whether usage collection is opted in (`FeedbackTriggerButton` only). |
+
+Questions are defined per application in the `@kbn/feedback-registry` package. See the One Feedback plugin docs for how to register them.
+
+## Development [kbn-ui-feedback-development]
+
+Run the stories in the shared `kbn-ui` Storybook:
+
+```bash
+yarn storybook kbn_ui
+```
+
+## Testing [kbn-ui-feedback-testing]
+
+```bash
+yarn test:jest src/platform/kbn-ui/feedback
+```
+
+## Previewing docs [kbn-ui-feedback-previewing-docs]
+
+From the repository root:
+
+```bash
+yarn storybook_docs kbn_ui --dev --docs-path docs-dev
+```
+
+Or serve the docset directly:
+
+```bash
+docs-builder serve --path docs-dev
+```

--- a/docs-dev/kbn-ui/feedback.md
+++ b/docs-dev/kbn-ui/feedback.md
@@ -6,12 +6,14 @@ navigation_title: Feedback
 
 The UI for One Feedback — a universal way for users to rate their experience and submit feedback from anywhere in {{kib}}. The package is self-contained so it can be distributed to external consumers (for example, Cloud UI) alongside {{kib}} itself.
 
+## Components
+
 It exposes two components:
 
 * `FeedbackTriggerButton` — a header button that opens the feedback form in a modal.
 * `FeedbackContainer` — the feedback form itself, for hosts that manage their own container.
 
-## Trigger button [kbn-ui-feedback-trigger-button]
+### Trigger button [kbn-ui-feedback-trigger-button]
 
 The button lives in the global header and opens the form on click. It is disabled until usage collection is opted in.
 
@@ -19,7 +21,7 @@ The button lives in the global header and opens the form on click. It is disable
 :id: kibana:kbn_ui:feedback--trigger-button
 :::
 
-## Feedback form [kbn-ui-feedback-form]
+### Feedback form [kbn-ui-feedback-form]
 
 `FeedbackContainer` renders the CSAT buttons, the context-aware questions, and the optional email-contact section.
 
@@ -57,28 +59,8 @@ Questions are defined per application in the `@kbn/feedback-registry` package. S
 
 ## Development [kbn-ui-feedback-development]
 
-Run the stories in the shared `kbn-ui` Storybook:
-
-```bash
-yarn storybook kbn_ui
-```
-
-## Testing [kbn-ui-feedback-testing]
+See [Development](index.md#kbn-ui-development) for how to run the shared Storybook and preview these docs. Run this package's tests with:
 
 ```bash
 yarn test:jest src/platform/kbn-ui/feedback
-```
-
-## Previewing docs [kbn-ui-feedback-previewing-docs]
-
-From the repository root:
-
-```bash
-yarn storybook_docs kbn_ui --dev --docs-path docs-dev
-```
-
-Or serve the docset directly:
-
-```bash
-docs-builder serve --path docs-dev
 ```

--- a/docs-dev/kbn-ui/index.md
+++ b/docs-dev/kbn-ui/index.md
@@ -4,13 +4,23 @@ navigation_title: Kibana UI
 
 # Kibana UI (`@kbn/ui`)
 
-Reusable, opinionated UI components for Kibana, built on top of [EUI](https://elastic.github.io/eui/) and `@elastic/eui`.
+Reusable, opinionated UI for Kibana — components that compose [EUI](https://elastic.github.io/eui/), plus the layout and chrome primitives EUI intentionally leaves to the application.
 
 ## What is Kibana UI?
 
-EUI is Elastic's design language and component library — flexible, product-agnostic primitives shared across Kibana, Cloud UI, AutoOps, and internal apps. That agnosticism is the right choice for a shared library, but it means EUI intentionally stays out of Kibana-specific concerns like persistence, state management, and data fetching.
+EUI is Elastic's design language and component library — flexible, product-agnostic primitives shared across Kibana, Cloud UI, AutoOps, and internal apps. That agnosticism is the right choice for a shared library, but it means EUI intentionally stays out of Kibana-specific concerns like persistence, state management, data fetching, and how a Kibana page is put together.
 
 `@kbn/ui` is the layer above EUI where those concerns live. Think of EUI as atoms and molecules; `@kbn/ui` composes them into the molecules and organisms that define how Kibana's UI actually works: page templates, data tables with built-in persistence, search + filter patterns, empty states, and more. EUI remains the foundation — `@kbn/ui` extends it, it does not replace it.
+
+Not everything here is an EUI composition, though. Kibana also needs structure EUI deliberately doesn't provide: the application shell's CSS grid, the side navigation, and the constants and hooks that go with them. These consume EUI's theme tokens and breakpoints rather than its components, and they belong here for the same reason the compositions do — each one encodes a Kibana-wide decision that every plugin would otherwise re-litigate.
+
+In practice, packages fall into a few shapes:
+
+- **EUI compositions** — `@kbn/ui-callout`, `@kbn/ui-feedback`. Opinionated defaults layered over EUI components.
+- **Structure and chrome** — `@kbn/ui-chrome-layout`, `@kbn/ui-side-navigation`. The shell Kibana renders everything else inside; closer to layout primitives than to EUI wrappers.
+- **Supporting utilities** — `@kbn/ui-chrome-layout-utils`, `@kbn/ui-chrome-layout-constants`. Shared tokens, hooks, and helpers the above depend on.
+
+A package doesn't need to be a candidate for promotion to EUI to belong here. Some patterns will graduate upward; others, like the application grid, are Kibana's by nature and simply need one canonical home.
 
 ## Why do we need it?
 
@@ -75,6 +85,6 @@ Packages use the `@kbn/ui-<component>` naming convention and are owned by `@elas
 
 ### Guidelines
 
-- **Compose EUI, don't fork it.** Wrap and configure `@elastic/eui` components; avoid reimplementing what EUI already provides.
+- **Compose EUI, don't fork it.** Where EUI provides a primitive, wrap and configure it instead of reimplementing it. Structural components EUI doesn't cover should still build on its theme tokens and breakpoints.
 - **Opinionated defaults, escape hatches.** Encode "the Kibana way" by default, but allow overrides where necessary.
 - **Mark portability intent.** If a component is a candidate for extraction to Cloud UI or promotion to EUI, note it in the package README.

--- a/docs-dev/kbn-ui/index.md
+++ b/docs-dev/kbn-ui/index.md
@@ -1,26 +1,25 @@
 ---
-navigation_title: Kibana UI
+navigation_title: kbn/ui - Kibana UI
 ---
 
-# Kibana UI (`@kbn/ui`)
+# `@kbn/ui` - Kibana UI
 
-Reusable, opinionated UI for Kibana — components that compose [EUI](https://elastic.github.io/eui/), plus the layout and chrome primitives EUI intentionally leaves to the application.
+Reusable, opinionated UI patterns and components built specifically for Kibana.
 
 ## What is Kibana UI?
 
-EUI is Elastic's design language and component library — flexible, product-agnostic primitives shared across Kibana, Cloud UI, AutoOps, and internal apps. That agnosticism is the right choice for a shared library, but it means EUI intentionally stays out of Kibana-specific concerns like persistence, state management, data fetching, and how a Kibana page is put together.
+`@kbn/ui` is Kibana's canonical presentation layer. While [`@elastic/eui`](https://elastic.github.io/eui/) provides Elastic's product-agnostic design language and foundational components, `@kbn/ui` builds on those primitives to solve Kibana-specific UI concerns.
 
-`@kbn/ui` is the layer above EUI where those concerns live. Think of EUI as atoms and molecules; `@kbn/ui` composes them into the molecules and organisms that define how Kibana's UI actually works: page templates, data tables with built-in persistence, search + filter patterns, empty states, and more. EUI remains the foundation — `@kbn/ui` extends it, it does not replace it.
+Where EUI gives you flexible building blocks, `@kbn/ui` provides the opinionated glue. It can encapsulate the things EUI intentionally leaves out: state management, URL persistence, data fetching context, application-level layout, etc. By standardizing these patterns, `@kbn/ui` prevents every plugin from re-litigating how to build a standard Kibana user experience.
 
-Not everything here is an EUI composition, though. Kibana also needs structure EUI deliberately doesn't provide: the application shell's CSS grid, the side navigation, and the constants and hooks that go with them. These consume EUI's theme tokens and breakpoints rather than its components, and they belong here for the same reason the compositions do — each one encodes a Kibana-wide decision that every plugin would otherwise re-litigate.
+The packages within `@kbn/ui` generally provide:
 
-In practice, packages fall into a few shapes:
+- **Opinionated Wrappers:** Thin layers over EUI components that enforce Kibana's visual guidelines by providing standard defaults and restricting props.
+- **Composed Patterns:** Higher-order components that wire EUI primitives to Kibana's logic or combine multiple primitives (e.g., standard data tables, search/filter bars).
+- **Structure and Layout:** The scaffolding that plugins render inside, such as page templates, application shell grids, and global navigation.
+- **Supporting Utilities:** The shared hooks, constants, and tokens that power Kibana's UI layer.
 
-- **EUI compositions** — `@kbn/ui-callout`, `@kbn/ui-feedback`. Opinionated defaults layered over EUI components.
-- **Structure and chrome** — `@kbn/ui-chrome-layout`, `@kbn/ui-side-navigation`. The shell Kibana renders everything else inside; closer to layout primitives than to EUI wrappers.
-- **Supporting utilities** — `@kbn/ui-chrome-layout-utils`, `@kbn/ui-chrome-layout-constants`. Shared tokens, hooks, and helpers the above depend on.
-
-A package doesn't need to be a candidate for promotion to EUI to belong here. Some patterns will graduate upward; others, like the application grid, are Kibana's by nature and simply need one canonical home.
+Not every component in `@kbn/ui` is meant for eventual promotion to EUI. Some patterns may graduate upward, but many—- like the application shell or Kibana-specific data contexts—- belong permanently in `@kbn/ui` as the definitive way to build Kibana interfaces.
 
 ## Why do we need it?
 
@@ -49,14 +48,14 @@ onSave: (data: Record<string, unknown>) => Promise<void>
 savedObjectsClient: SavedObjectsClientContract
 ```
 
-### Allowed dependencies
+### Expected dependencies
 
 - `@elastic/eui`
 - `@emotion/react`, `@emotion/css`
 - `react`, `react-dom`
 - `@kbn/i18n`
 
-Additional exceptions _will_ exist, require review, and should be kept to an absolute minimum.
+Additional dependencies _may_ exist, will require review, and should be kept to an absolute minimum.
 
 ## Package structure
 
@@ -74,6 +73,34 @@ src/platform/kbn-ui/
 ```
 
 Packages use the `@kbn/ui-<component>` naming convention and are owned by `@elastic/appex-sharedux`.
+
+## Development [kbn-ui-development]
+
+All `@kbn/ui-*` packages share a single Storybook and docset.
+
+Run the stories in the shared `kbn-ui` Storybook:
+
+```bash
+yarn storybook kbn_ui
+```
+
+Run a package's tests:
+
+```bash
+yarn test:jest src/platform/kbn-ui/<component>
+```
+
+Preview these docs from the repository root:
+
+```bash
+yarn storybook_docs kbn_ui --dev --docs-path docs-dev
+```
+
+Or serve the docset directly:
+
+```bash
+docs-builder serve --path docs-dev
+```
 
 ## Contributing
 

--- a/docs-dev/kbn-ui/index.md
+++ b/docs-dev/kbn-ui/index.md
@@ -1,0 +1,80 @@
+---
+navigation_title: Kibana UI
+---
+
+# Kibana UI (`@kbn/ui`)
+
+Reusable, opinionated UI components for Kibana, built on top of [EUI](https://elastic.github.io/eui/) and `@elastic/eui`.
+
+## What is Kibana UI?
+
+EUI is Elastic's design language and component library — flexible, product-agnostic primitives shared across Kibana, Cloud UI, AutoOps, and internal apps. That agnosticism is the right choice for a shared library, but it means EUI intentionally stays out of Kibana-specific concerns like persistence, state management, and data fetching.
+
+`@kbn/ui` is the layer above EUI where those concerns live. Think of EUI as atoms and molecules; `@kbn/ui` composes them into the molecules and organisms that define how Kibana's UI actually works: page templates, data tables with built-in persistence, search + filter patterns, empty states, and more. EUI remains the foundation — `@kbn/ui` extends it, it does not replace it.
+
+## Why do we need it?
+
+Kibana has no shared, canonical patterns for common UI flows. The same compositions — search + table, filter bars, empty states, persistent table settings, and more — are often rebuilt independently across plugins, with varying approaches and trade-offs. A recent UI audit surfaced 600+ UX issues stemming from this fragmentation.
+
+EUI major upgrades compound the problem. Every plugin bound directly to EUI primitives absorbs its own share of breaking changes and visual regressions.
+
+`@kbn/ui` is the missing default — a single set of building blocks that encode "the Kibana way."
+
+- **Less code for the same outcome.** Common flows take fewer lines, freeing effort for feature-specific UX.
+- **Accessibility baked in.** Focus management, keyboard navigation, and screen reader support are handled at the component level.
+- **EUI upgrade insulation.** `@kbn/ui` absorbs EUI breaking changes and exposes a stable contract.
+- **One place to evolve.** Global UX tweaks and visual refreshes roll out by updating the layer, not every plugin.
+
+## Portability
+
+Components here are designed to be **portable**. They work in Kibana today, but they can be extracted for use in Cloud UI or promoted up to EUI when a pattern proves valuable across all Elastic products.
+
+To keep that door open, components are fully independent of Kibana. They don't import Kibana core, plugins, or packages that depend on them. Instead, they expose simple, generic interfaces — callbacks, event handlers, context providers — that consumers wire to whatever backing services they need. A component should work in Storybook or Cloud UI with zero Kibana knowledge; the Kibana-specific bridging happens in consuming code, not here.
+
+```tsx
+// Good: generic callback the consumer can wire to anything.
+onSave: (data: Record<string, unknown>) => Promise<void>
+
+// Bad: leaking a Kibana service type into the component.
+savedObjectsClient: SavedObjectsClientContract
+```
+
+### Allowed dependencies
+
+- `@elastic/eui`
+- `@emotion/react`, `@emotion/css`
+- `react`, `react-dom`
+- `@kbn/i18n`
+
+Additional exceptions _will_ exist, require review, and should be kept to an absolute minimum.
+
+## Package structure
+
+Each component lives in its own package under `src/platform/kbn-ui/`:
+
+```
+src/platform/kbn-ui/
+├── <component_name>/
+│   ├── kibana.jsonc
+│   ├── tsconfig.json
+│   ├── package.json
+│   ├── index.ts
+│   └── src/
+└── README.md
+```
+
+Packages use the `@kbn/ui-<component>` naming convention and are owned by `@elastic/appex-sharedux`.
+
+## Contributing
+
+1. Create a new package directory under `src/platform/kbn-ui/`.
+2. Add a `kibana.jsonc` with `"group": "platform"`, `"visibility": "shared"`, and the `@kbn/ui-<name>` id.
+3. Export a single public API from `index.ts` — no subpath imports.
+4. Include unit tests alongside source files.
+5. Respect the dependency and portability rules above.
+
+### Guidelines
+
+- **Compose EUI, don't fork it.** Wrap and configure `@elastic/eui` components; avoid reimplementing what EUI already provides.
+- **Opinionated defaults, escape hatches.** Encode "the Kibana way" by default, but allow overrides where necessary.
+- **Mark portability intent.** If a component is a candidate for extraction to Cloud UI or promotion to EUI, note it in the package README.

--- a/docs-dev/kbn-ui/toc.yml
+++ b/docs-dev/kbn-ui/toc.yml
@@ -1,0 +1,3 @@
+toc:
+  - file: index.md
+  - file: feedback.md

--- a/src/dev/precommit_hook/casing_check_config.js
+++ b/src/dev/precommit_hook/casing_check_config.js
@@ -75,7 +75,9 @@ export const IGNORE_PATTERNS = [
   'x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/product_docs/**/*',
 ];
 
-export const KEBAB_CASE_PATTERNS = ['docs/**/*'];
+// Docset paths become URL slugs, so both documentation trees follow the docs convention rather
+// than Kibana's. `docs-dev` holds the internal-only docset published to codex.elastic.dev.
+export const KEBAB_CASE_PATTERNS = ['docs/**/*', 'docs-dev', 'docs-dev/**/*'];
 
 /**
  * Contains the logic that decides what is the expected casing for each Kibana resource (folders, files)

--- a/src/platform/kbn-ui/feedback/README.md
+++ b/src/platform/kbn-ui/feedback/README.md
@@ -1,3 +1,5 @@
 # @kbn/ui-feedback
 
 Feedback form components.
+
+See [`docs-dev/kbn-ui/feedback.md`](../../../../docs-dev/kbn-ui/feedback.md) for usage and embedded Storybook examples (published to Elastic Internal Docs).

--- a/src/platform/kbn-ui/feedback/moon.yml
+++ b/src/platform/kbn-ui/feedback/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/i18n-react'
   - '@kbn/test-jest-helpers'
   - '@kbn/i18n'
+  - '@kbn/storybook'
 tags:
   - shared-browser
   - package

--- a/src/platform/kbn-ui/feedback/src/__stories__/feedback.stories.tsx
+++ b/src/platform/kbn-ui/feedback/src/__stories__/feedback.stories.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { Meta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import type { EmbeddableStoryObj } from '@kbn/storybook';
+
+import { FeedbackTriggerButton, FeedbackContainer } from '../components';
+import type { FeedbackFormData, FeedbackRegistryEntry } from '../types';
+
+const questions: FeedbackRegistryEntry[] = [
+  {
+    id: 'overall_experience',
+    order: 1,
+    question: 'How would you rate your overall experience?',
+    placeholder: {
+      i18nId: 'kbnUI.feedback.stories.overallExperiencePlaceholder',
+      defaultMessage: 'Tell us about your experience',
+    },
+  },
+  {
+    id: 'missing_features',
+    order: 2,
+    question: 'What features are you missing?',
+    placeholder: {
+      i18nId: 'kbnUI.feedback.stories.missingFeaturesPlaceholder',
+      defaultMessage: 'Let us know what would make this better',
+    },
+  },
+];
+
+const services = {
+  getQuestions: async () => questions,
+  getAppDetails: () => ({ title: 'Storybook', id: 'storybook', url: 'https://example.com' }),
+  getCurrentUserEmail: async () => undefined,
+  sendFeedback: async (data: FeedbackFormData) => action('sendFeedback')(data),
+  showToast: (title: string, type: 'success' | 'error') => action('showToast')({ title, type }),
+};
+
+const meta: Meta = {
+  title: 'Feedback',
+};
+
+export default meta;
+
+export const TriggerButton: EmbeddableStoryObj = {
+  tags: ['embeddable'],
+  parameters: { embeddable: { height: 48 } },
+  render: () => <FeedbackTriggerButton {...services} checkTelemetryOptIn={async () => true} />,
+};
+
+export const Form: EmbeddableStoryObj = {
+  tags: ['embeddable'],
+  parameters: { embeddable: { height: 640 } },
+  render: () => (
+    <FeedbackContainer {...services} hideFeedbackContainer={action('hideFeedbackContainer')} />
+  ),
+};

--- a/src/platform/kbn-ui/feedback/tsconfig.json
+++ b/src/platform/kbn-ui/feedback/tsconfig.json
@@ -11,6 +11,7 @@
     "@kbn/i18n-react",
     "@kbn/test-jest-helpers",
     "@kbn/i18n",
+    "@kbn/storybook",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/kbn-ui/storybook-config/preview.ts
+++ b/src/platform/kbn-ui/storybook-config/preview.ts
@@ -7,19 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/* eslint-disable @typescript-eslint/no-namespace,@typescript-eslint/no-empty-interface */
-declare global {
-  namespace NodeJS {
-    interface Global {}
-    interface InspectOptions {}
-    type ConsoleConstructor = console.ConsoleConstructor;
-  }
-}
-/* eslint-enable */
-
-import jest from 'jest-mock';
-/* @ts-expect-error TS doesn't see jest as a property of window, and I don't want to edit our global config. */
-window.jest = jest;
 import type { Preview } from '@storybook/react';
 
 const preview: Preview = {

--- a/src/platform/packages/shared/kbn-storybook/README.md
+++ b/src/platform/packages/shared/kbn-storybook/README.md
@@ -116,10 +116,16 @@ To keep the loop fast, `--dev` reuses an existing static Storybook build (`built
 
 ### Docs-Builder Integration
 
-When `--dev` finds a `docset.yml` colocated with the alias (e.g. `src/platform/kbn-ui/docset.yml` for `kbn_ui`) and `docs-builder` is on your `PATH`, it automatically launches `docs-builder serve` for that docset. It points `KIBANA_STORYBOOK_REGISTRY` at your local registry so embeds render live against your local assets.
+When `--dev` finds a `docset.yml` colocated with the alias and `docs-builder` is on your `PATH`, it automatically launches `docs-builder serve` for that docset. It points `KIBANA_STORYBOOK_REGISTRY` at your local registry so embeds render live against your local assets.
+
+Kibana's internal developer docs live in `docs-dev/` rather than beside the packages they document, so auto-detection finds nothing for aliases such as `kbn_ui`. Pass the docset explicitly:
+
+```bash
+yarn storybook_docs kbn_ui --dev --docs-path docs-dev
+```
 
 Options for docs-builder integration:
-- `--docs-path <dir>`: Point at a different docset.
+- `--docs-path <dir>`: Point at a docset auto-detection won't find, or a different one.
 - `--docs-port <port>`: Override docs-builder's default port.
 - `--no-docs`: Skip launching docs-builder entirely.
 

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.test.ts
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { readdirSync } from 'fs';
 import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import {
   buildDocsAssets,
   buildDocsArchive,
@@ -380,6 +381,39 @@ describe('createInlineRegistryWebpackConfig', () => {
     expect(config.experiments).toMatchObject({
       outputModule: true,
     });
+  });
+
+  it('shakes the docs entry and test runtime out of the @storybook/react chunks', () => {
+    const config = createInlineRegistryWebpackConfig({
+      entryPath: '/storybook-docs/shared_ux/registry_entry.js',
+      docsDir: '/storybook-docs/shared_ux',
+    });
+
+    const rule = config.module?.rules?.find(
+      (candidate) =>
+        typeof candidate === 'object' && candidate !== null && candidate.sideEffects === false
+    );
+
+    expect(rule).toEqual(
+      expect.objectContaining({
+        test: expect.any(RegExp),
+        sideEffects: false,
+        // Scoped to the rule, not the whole config, so stories keep their own `@storybook/test`.
+        resolve: { alias: { '@storybook/test': false } },
+      })
+    );
+
+    const { test: pattern } = rule as { test: RegExp };
+    const distDir = dirname(require.resolve('@storybook/react/package.json'));
+    const chunks = readdirSync(join(distDir, 'dist')).filter(
+      (file) => file.startsWith('chunk-') && file.endsWith('.mjs')
+    );
+
+    // Asserted against the installed copy so a Storybook upgrade that renames the hashed chunks
+    // fails here rather than silently regrowing the bundle by ~360KB.
+    expect(chunks).not.toHaveLength(0);
+    expect(chunks.filter((file) => pattern.test(join(distDir, 'dist', file)))).toEqual(chunks);
+    expect(pattern.test(join(distDir, 'dist', 'index.mjs'))).toBe(false);
   });
 });
 

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_assets.ts
@@ -263,6 +263,24 @@ export const createInlineRegistryWebpackConfig = ({
       module: {
         rules: [
           {
+            // `@storybook/react`'s barrel has a bare import of its `entry-preview-docs` chunk
+            // (docgen argTypes, source snippets, `jsdoc-type-pratt-parser`) to support
+            // `__definePreview`, which the embed runtime never uses. The package declares no
+            // `sideEffects`, so webpack cannot drop that ~360KB on its own. These chunks only
+            // declare bindings, making unused ones safe to elide. The name carries a build hash,
+            // so `docs_assets.test.ts` asserts the pattern still matches what is installed.
+            test: /[\\/]node_modules[\\/]@storybook[\\/]react[\\/]dist[\\/]chunk-[A-Za-z0-9]+\.mjs$/,
+            sideEffects: false,
+            resolve: {
+              // Those same chunks lazily import `@storybook/test` (~635KB) from `beforeAll`, only
+              // to install testing-library `act()` wrappers. The embed runtime never invokes
+              // `beforeAll`, and Storybook wraps the import in a bare `try`/`catch`, so stubbing it
+              // is inert. Scoped to this rule so a story's own `@storybook/test` import still
+              // resolves to the real package.
+              alias: { '@storybook/test': false },
+            },
+          },
+          {
             test: /\.(js|jsx|ts|tsx|mjs)$/,
             exclude: /node_modules/,
             use: {

--- a/src/platform/packages/shared/kbn-storybook/src/lib/docs_test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/docs_test.ts
@@ -120,8 +120,9 @@ const hasDocset = (dir: string): boolean =>
   DOCSET_FILES.some((file) => existsSync(join(dir, file)));
 
 // Walk up from an alias's Storybook config toward the repo root, returning the nearest
-// directory that holds a docset.yml (the docs-builder docset colocated with the package,
-// e.g. src/platform/kbn-ui). Returns undefined when no docset lives on that path.
+// directory that holds a docset.yml. Returns undefined when no docset lives on that path,
+// which is the case for docsets kept outside the package tree, such as `docs-dev`; those
+// need `--docs-path`.
 const findDocsetDir = (startDir: string): string | undefined => {
   let dir = resolve(startDir);
   for (;;) {
@@ -168,9 +169,10 @@ const startDocsBuilder = ({
   port?: number;
   log: StorybookDocsTestLog;
 }): ChildProcess => {
-  // Run from inside the docset directory with no --path: a docset nested more than one
-  // level below the git root otherwise trips docs-builder's disjoint-scope-roots check.
-  const args = ['serve', ...(port ? ['--port', String(port)] : [])];
+  // Run from inside the docset directory: a docset nested more than one level below the git
+  // root otherwise trips docs-builder's disjoint-scope-roots check. `--path .` is still
+  // required because discovery starting at the git root prefers the public `docs/docset.yml`.
+  const args = ['serve', '--path', '.', ...(port ? ['--port', String(port)] : [])];
   log.info(`Starting docs-builder in ${docsetDir} with KIBANA_STORYBOOK_REGISTRY=${registryUrl}`);
   const child = spawn('docs-builder', args, {
     cwd: docsetDir,

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime/registry.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime/registry.ts
@@ -18,6 +18,7 @@ import type {
 } from './types';
 import { createShadowMount, createStoryElement } from './render';
 import { createResizeController } from './resize';
+import { preventHostScrollLock } from './scroll_lock';
 
 const getEmbeddableParameters = (story: ComposedStory): EmbeddableStoryParameters =>
   story.parameters?.embeddable ?? {};
@@ -36,6 +37,8 @@ export const createDocsRegistry = ({
   const roots = new WeakMap<HTMLElement, ReturnType<typeof createRoot>>();
   const resize = createResizeController();
   const annotations = setProjectAnnotations(projectAnnotations);
+
+  preventHostScrollLock();
 
   const getComposedStory = async (storybookId: string): Promise<ComposedStory> => {
     const loadStoryModule = storyModules[storybookId];

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime/scroll_lock.test.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime/scroll_lock.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isHostScrollLock, preventHostScrollLock } from './scroll_lock';
+
+// Verbatim from `react-remove-scroll-bar`, which `EuiFocusTrap` mounts for `scrollLock`. A rename
+// of its classes is harmless, but dropping the `body` rule would make this guard dead code.
+const REMOVE_SCROLL_BAR_CSS = `
+  .with-scroll-bars-hidden {
+   overflow: hidden !important;
+   padding-right: 11px !important;
+  }
+  body {
+    overflow: hidden !important;
+    overscroll-behavior: contain;
+    position: relative !important;padding-right: 11px !important;
+  }
+  .right-scroll-bar-position { right: 11px !important; }
+`;
+
+// `EuiOverlayMask`'s `<Global>` styles, which reach the head only when a story renders without a
+// shadow root and Emotion therefore falls back to the document cache.
+const OVERLAY_MASK_CSS = 'body{overflow:hidden;};label:euiOverlayMaskBodyStyles;';
+
+const makeStyle = (textContent: string) => ({ tagName: 'STYLE', textContent, disabled: false });
+
+describe('isHostScrollLock', () => {
+  it('matches the stylesheets that freeze the host page', () => {
+    expect(isHostScrollLock(REMOVE_SCROLL_BAR_CSS)).toBe(true);
+    expect(isHostScrollLock(OVERLAY_MASK_CSS)).toBe(true);
+    expect(isHostScrollLock('html body { overflow: hidden }')).toBe(true);
+    expect(isHostScrollLock('main, body { overflow : HIDDEN }')).toBe(true);
+  });
+
+  it('leaves unrelated stylesheets alone', () => {
+    // Only `body` itself propagates overflow to the viewport, so narrower rules are not the leak.
+    expect(isHostScrollLock('.somebody { overflow: hidden }')).toBe(false);
+    expect(isHostScrollLock('.euiModal { overflow: hidden }')).toBe(false);
+    expect(isHostScrollLock('body { overflow: auto }')).toBe(false);
+    expect(isHostScrollLock('body { margin: 0 }')).toBe(false);
+    expect(isHostScrollLock('')).toBe(false);
+  });
+});
+
+describe('preventHostScrollLock', () => {
+  const observe = jest.fn();
+  let notify: MutationCallback | undefined;
+
+  beforeEach(() => {
+    observe.mockClear();
+    notify = undefined;
+
+    class FakeMutationObserver {
+      constructor(callback: MutationCallback) {
+        notify = callback;
+      }
+      public observe = observe;
+    }
+
+    Object.assign(global, {
+      document: { head: { tagName: 'HEAD' } },
+      MutationObserver: FakeMutationObserver,
+    });
+  });
+
+  afterEach(() => {
+    delete (global as { document?: unknown }).document;
+    delete (global as { MutationObserver?: unknown }).MutationObserver;
+  });
+
+  const addToHead = (...nodes: unknown[]) =>
+    notify?.([{ addedNodes: nodes } as unknown as MutationRecord], {} as MutationObserver);
+
+  it('watches the head for stylesheets added after boot', () => {
+    preventHostScrollLock();
+
+    expect(observe).toHaveBeenCalledWith({ tagName: 'HEAD' }, { childList: true });
+  });
+
+  it('disables a scroll-locking stylesheet without touching the rest', () => {
+    preventHostScrollLock();
+
+    const scrollLock = makeStyle(REMOVE_SCROLL_BAR_CSS);
+    const docsSiteStyle = makeStyle('body { font-family: sans-serif }');
+    addToHead(scrollLock, docsSiteStyle);
+
+    expect(scrollLock.disabled).toBe(true);
+    expect(docsSiteStyle.disabled).toBe(false);
+  });
+
+  it('ignores non-stylesheet nodes', () => {
+    preventHostScrollLock();
+
+    const script = { tagName: 'SCRIPT', textContent: 'body { overflow: hidden }', disabled: false };
+    addToHead(script);
+
+    expect(script.disabled).toBe(false);
+  });
+
+  it('no-ops where MutationObserver is unavailable', () => {
+    delete (global as { MutationObserver?: unknown }).MutationObserver;
+
+    expect(() => preventHostScrollLock()).not.toThrow();
+    expect(observe).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime/scroll_lock.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/embed_runtime/scroll_lock.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Anchored on the selector so rules for classes that merely end in `body` (`.somebody`) do not
+// qualify, and `html body` still does.
+const HOST_SCROLL_LOCK = /(?:^|[\s,>+~])body\s*\{[^}]*overflow\s*:\s*hidden/i;
+
+/** True when `css` would freeze scrolling on the page hosting the embeds. */
+export const isHostScrollLock = (css: string): boolean => HOST_SCROLL_LOCK.test(css);
+
+const disableHostScrollLock = (node: Node): void => {
+  const style = node as HTMLStyleElement;
+
+  if (style.tagName !== 'STYLE' || !isHostScrollLock(style.textContent ?? '')) {
+    return;
+  }
+
+  style.disabled = true;
+};
+
+/**
+ * Focus-trapping EUI overlays lock scrolling through `EuiFocusTrap`, which has
+ * `react-remove-scroll-bar` append a stylesheet to `document.head` setting
+ * `body { overflow: hidden !important }`. The shadow root cannot contain it, and `EuiModal`
+ * hardcodes `scrollLock` after spreading `focusTrapProps`, so a story opening a modal would
+ * otherwise freeze the docs page around it.
+ *
+ * Disabling the whole sheet is safe: every rule in it compensates for a scrollbar that stays
+ * visible here. Matching the declaration rather than the library's class name avoids depending on
+ * a transitive package, and only sheets added after boot are inspected, so the docs site's own
+ * styles are never touched.
+ */
+export const preventHostScrollLock = (): void => {
+  if (
+    typeof MutationObserver === 'undefined' ||
+    typeof document === 'undefined' ||
+    !document.head
+  ) {
+    return;
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach(({ addedNodes }) => addedNodes.forEach(disableHostScrollLock));
+  });
+
+  observer.observe(document.head, { childList: true });
+};


### PR DESCRIPTION
## Summary

Adds `docs-dev/`, a Kibana docset marked `registry: internal`, so developer documentation publishes to [Elastic Internal Docs](https://codex.elastic.dev) and never appears on elastic.co. The `@kbn/ui-feedback` docs are its first subject, and they embed live Storybook stories through `:::{storybook}` directives.

Kibana's public docset stays in `docs/`. Holding the two in separate trees is what lets one repo publish to both registries: an earlier revision of this PR colocated the internal docset at `src/platform/kbn-ui/docset.yml`, and that collided with `docs/docset.yml` during discovery.

### Changes

**Embeddable stories.** `feedback.stories.tsx` covers `FeedbackTriggerButton` and `FeedbackContainer`, tagged `embeddable` so docs-builder can render them inline. The feedback `tsconfig.json` picks up `@kbn/storybook` for the `EmbeddableStoryObj` type.

**The docset.** `docs-dev/docset.yml` plus a landing page, and a `kbn-ui/` subject holding the package overview and the feedback page. Subject TOCs live in each folder's `toc.yml`, so adding an area is one `- toc: <subject>` entry. `@kbn/ui-feedback`'s `README.md` points at the published page, `.gitignore` covers docs-builder's `.artifacts` output, and ownership sits in the manual section of `CODEOWNERS` because `node scripts/generate codeowners` rebuilds the generated block from `kibana.jsonc` files and would drop an entry for a directory that isn't a package.

**Local serving.** `--dev` discovers a docset by walking up from the alias's Storybook config, which finds nothing when the docset lives in `docs-dev/`. `yarn storybook_docs kbn_ui --dev --docs-path docs-dev` now covers that case.

**Registry bundle size.** The inline registry docs pages load was 908KB (260KB gzipped) while containing almost no Kibana code. `kbn_ui`'s `preview.ts` set `window.jest` via `jest-mock`, which pulled in `jest-util` and, through `graceful-fs`, browser polyfills for `fs`, `stream`, `buffer`, `assert`, and `url`; `@kbn/storybook/preset` already sets `window.jest` for every Storybook instance, so the alias-level shim was a duplicate. Separately, `@storybook/react`'s barrel unconditionally evaluates its `entry-preview-docs` chunk for `__definePreview`, which the embed runtime never calls, so those chunks are marked side-effect free to let webpack shake out the docgen machinery. A `resolve.alias` scoped to that same rule also drops the `@storybook/test` chunk Storybook lazily imports from `beforeAll`, without affecting stories that import it directly. `registry.js` is now 341KB (106KB gzipped), and total emitted JS drops from 1.55MB to 380KB.

**CI.** `codex-preview.yml` builds `docs-dev/` on pull requests and posts preview links; `codex-preview-cleanup.yml` tears the preview down when the PR closes. Both call the shared `elastic/docs-actions` workflows.

### Registry and previews

`:::{storybook}` embeds resolve against the registry configured in `docs-dev/docset.yml`. The committed default is the registry published from `main`; local serve and per-PR previews override it through the allow-listed `KIBANA_STORYBOOK_REGISTRY` variable, so neither a temporary commit nor a pre-merge revert is needed. Previews resolve against this PR's own artifacts, the only place unmerged stories exist.

Preview: [index](https://codex.elastic.dev/_preview/elastic/kibana/pull/272934/index) · [kbn-ui](https://codex.elastic.dev/_preview/elastic/kibana/pull/272934/kbn-ui) · [feedback](https://codex.elastic.dev/_preview/elastic/kibana/pull/272934/kbn-ui/feedback)

### Live publishing

Enabled. On push to main the shared workflow's `update-link-index` job registers the docset in `elastic/codex-link-index`, which the nightly codex build reads to discover it. [elastic/catalog-info#4411](https://github.com/elastic/catalog-info/pull/4411) registered the Backstage token policy that job requires and granted the codex build read access to this repo.

The `main` Storybook registry holds no stories until this merges, and docs-builder treats an empty registry as an error rather than a warning, so the first successful live build is necessarily the one after merge.

### Upstream work this depended on

- [docs-builder#3772](https://github.com/elastic/docs-builder/pull/3772) — codex discovery now prefers the docset whose `registry` matches the environment instead of always taking `docs/docset.yml` (closes [#3767](https://github.com/elastic/docs-builder/issues/3767))
- [docs-actions#267](https://github.com/elastic/docs-actions/pull/267) — `path` input, so the build can target a non-`docs` root
- [docs-actions#270](https://github.com/elastic/docs-actions/pull/270) — `build-env` input, so previews can pass `KIBANA_STORYBOOK_REGISTRY`
- [docs-infra#379](https://github.com/elastic/docs-infra/pull/379) — adds `elastic/kibana` to the Codex internal OIDC allowlist

Because of these, Kibana calls the shared workflow like every other repo rather than maintaining a fork of it.

> Scope is intentionally limited to `@kbn/ui-feedback`. The legacy One Feedback plugin doc (`x-pack/.../feedback/feedback.mdx`, docsmobile) is left untouched.

## Stack

- #272933 — Shared Storybook config for `kbn-ui` (merged)
- #272926 — Move feedback to `@kbn/ui-feedback` (merged)
- #272927 — Build and publish Storybook docs assets for docs-builder (merged)
- **#272934 — Internal developer docs with embeddable Storybook stories ← this PR**

## Test plan

- [ ] `yarn storybook kbn_ui` shows the `Feedback` stories (trigger button + form) and they render.
- [ ] `yarn storybook_docs kbn_ui --dev --docs-path docs-dev` serves the docset and both `feedback--*` embeds resolve.
- [ ] The PR preview renders `docs-dev/kbn-ui/feedback.md` with both embeds resolved.
- [ ] Both `feedback--*` embeds still render and stay interactive with the slimmed registry bundle.

