### PR TITLE
[9.4] [Security Solution][Attacks Discovery] Fix possibly overflowing popover in attacks discovery page (#269352)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
@@ -395,7 +395,7 @@ const TakeActionComponent: React.FC<Props> = ({
     <>
       <EuiPopover
         aria-label={i18n.TAKE_ACTION}
-        anchorPosition="downCenter"
+        anchorPosition="upCenter"
         button={button}
         closePopover={closePopover}
         data-test-subj="takeAction"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution][Attacks Discovery] Fix possibly overflowing popover in attacks discovery page (#269352)](https://github.com/elastic/kibana/pull/269352)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-26T14:43:14Z","message":"[Security Solution][Attacks Discovery] Fix possibly overflowing popover in attacks discovery page (#269352)\n\n## Summary\n\n[See screenshot\nhere](https://elastic.slack.com/archives/C08U04SUN49/p1778687779903229)\n\n- move the default popover position to be `upCenter` so taller action\nitems can be seen\n\n<img width=\"1617\" height=\"713\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/edd4a77e-412b-43a0-9dd9-b93e4bdc2435\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f7d76b4d81b027abe9ce374696d8c860b9e09ca6","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","Team:Threat Hunting","Team: SecuritySolution","backport:version","v9.4.0","ci:use-selective-testing"],"title":"[Security Solution][Attacks Discovery] Fix possibly overflowing popover in attacks discovery page","number":269352,"url":"https://github.com/elastic/kibana/pull/269352","mergeCommit":{"message":"[Security Solution][Attacks Discovery] Fix possibly overflowing popover in attacks discovery page (#269352)\n\n## Summary\n\n[See screenshot\nhere](https://elastic.slack.com/archives/C08U04SUN49/p1778687779903229)\n\n- move the default popover position to be `upCenter` so taller action\nitems can be seen\n\n<img width=\"1617\" height=\"713\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/edd4a77e-412b-43a0-9dd9-b93e4bdc2435\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f7d76b4d81b027abe9ce374696d8c860b9e09ca6"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->