### PR TITLE
[Cloud Connect] Fix small issue with service registration

### DIFF
--- a/x-pack/platform/plugins/shared/cloud_connect/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/plugin.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { featuresPluginMock } from '@kbn/features-plugin/server/mocks';
+import { CloudConnectedPlugin } from './plugin';
+import {
+  CloudConnectApiKeyType,
+  CloudConnectApiKeyEncryptionParams,
+} from './saved_objects/cloud_connect_api_key';
+
+function createPlugin() {
+  const context = coreMock.createPluginInitializerContext({
+    cloudUrl: 'https://cloud.test',
+  });
+  return new CloudConnectedPlugin(context);
+}
+
+function buildSetupDeps(cloudOverrides?: Record<string, unknown>) {
+  return {
+    features: featuresPluginMock.createSetup(),
+    encryptedSavedObjects: encryptedSavedObjectsMock.createSetup(),
+    cloud: cloudOverrides
+      ? ({ isCloudEnabled: false, isEce: false, ...cloudOverrides } as any)
+      : undefined,
+  };
+}
+
+describe('CloudConnectedPlugin.setup()', () => {
+  describe('saved object type registration', () => {
+    it('registers the SO type on ESS (isCloudEnabled=true, isEce=false)', () => {
+      const plugin = createPlugin();
+      const core = coreMock.createSetup();
+      const plugins = buildSetupDeps({ isCloudEnabled: true, isEce: false });
+
+      plugin.setup(core, plugins);
+
+      expect(core.savedObjects.registerType).toHaveBeenCalledWith(CloudConnectApiKeyType);
+      expect(plugins.encryptedSavedObjects.registerType).toHaveBeenCalledWith(
+        CloudConnectApiKeyEncryptionParams
+      );
+    });
+
+    it('registers the SO type on ECE (isCloudEnabled=true, isEce=true)', () => {
+      const plugin = createPlugin();
+      const core = coreMock.createSetup();
+      const plugins = buildSetupDeps({ isCloudEnabled: true, isEce: true });
+
+      plugin.setup(core, plugins);
+
+      expect(core.savedObjects.registerType).toHaveBeenCalledWith(CloudConnectApiKeyType);
+      expect(plugins.encryptedSavedObjects.registerType).toHaveBeenCalledWith(
+        CloudConnectApiKeyEncryptionParams
+      );
+    });
+
+    it('registers the SO type when cloud plugin is absent (self-managed)', () => {
+      const plugin = createPlugin();
+      const core = coreMock.createSetup();
+      const plugins = buildSetupDeps();
+
+      plugin.setup(core, plugins);
+
+      expect(core.savedObjects.registerType).toHaveBeenCalledWith(CloudConnectApiKeyType);
+      expect(plugins.encryptedSavedObjects.registerType).toHaveBeenCalledWith(
+        CloudConnectApiKeyEncryptionParams
+      );
+    });
+  });
+
+  describe('ESS gate', () => {
+    it('does NOT register features or routes on ESS', () => {
+      const plugin = createPlugin();
+      const core = coreMock.createSetup();
+      const plugins = buildSetupDeps({ isCloudEnabled: true, isEce: false });
+
+      plugin.setup(core, plugins);
+
+      expect(plugins.features.registerKibanaFeature).not.toHaveBeenCalled();
+      expect(core.http.createRouter).not.toHaveBeenCalled();
+    });
+
+    it('DOES register features and routes on ECE', () => {
+      const plugin = createPlugin();
+      const core = coreMock.createSetup();
+      const plugins = buildSetupDeps({ isCloudEnabled: true, isEce: true });
+
+      plugin.setup(core, plugins);
+
+      expect(plugins.features.registerKibanaFeature).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cloud_connect/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/plugin.ts
@@ -73,7 +73,13 @@ export class CloudConnectedPlugin
   ): CloudConnectedPluginSetup {
     this.logger.debug('cloudConnected: Setup');
 
-    // Skip plugin registration if running on ESS.
+    // Always register the SO type and its encryption params so that migrations never fail
+    // on clusters that accumulated cloud-connect-api-key documents (e.g. ESS 9.3.x clusters
+    // upgrading to 9.4.0+ where the type would otherwise not be registered). See INC-3152.
+    core.savedObjects.registerType(CloudConnectApiKeyType);
+    plugins.encryptedSavedObjects.registerType(CloudConnectApiKeyEncryptionParams);
+
+    // Skip the rest of plugin registration if running on ESS.
     // CCM is enabled for ECE deployments and self-managed clusters.
     if (plugins.cloud?.isCloudEnabled && !plugins.cloud?.isEce) {
       this.logger.debug('cloudConnected: Skipping setup - running on ESS');
@@ -83,12 +89,6 @@ export class CloudConnectedPlugin
 
     // Register the feature with privileges
     plugins.features.registerKibanaFeature(cloudConnectedFeature);
-
-    // Register the saved object type for API key storage
-    core.savedObjects.registerType(CloudConnectApiKeyType);
-
-    // Register encryption for the API key saved object
-    plugins.encryptedSavedObjects.registerType(CloudConnectApiKeyEncryptionParams);
 
     // Register HTTP routes
     const router = core.http.createRouter();

--- a/x-pack/platform/plugins/shared/cloud_connect/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/plugin.ts
@@ -75,7 +75,7 @@ export class CloudConnectedPlugin
 
     // Always register the SO type and its encryption params so that migrations never fail
     // on clusters that accumulated cloud-connect-api-key documents (e.g. ESS 9.3.x clusters
-    // upgrading to 9.4.0+ where the type would otherwise not be registered). See INC-3152.
+    // upgrading to 9.4.0+ where the type would otherwise not be registered).
     core.savedObjects.registerType(CloudConnectApiKeyType);
     plugins.encryptedSavedObjects.registerType(CloudConnectApiKeyEncryptionParams);
 


### PR DESCRIPTION
## Summary

On 9.4.0+, the `cloud-connect-api-key` SO type was no longer registered, causing migration failures for clusters that accumulated these objects on 9.3.x. The SO type and its encryption registration should register unconditionally on all environments.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->