### PR TITLE
[Ona] Fix Kibana service binding and warm-up

### DIFF
--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -14,6 +14,10 @@ services:
   kibana:
     name: Kibana
     commands:
-      start: yarn start --no-base-path
+      start: yarn start --no-base-path --server.host=0.0.0.0
+      ready: |
+        until curl -sf -o /dev/null http://localhost:5601/api/status; do sleep 5; done
+        curl -sf -o /dev/null http://localhost:5601/login
+        ona environment port open 5601 --name Kibana --admission organization
     triggeredBy:
       - postDevcontainerStart


### PR DESCRIPTION
## Summary

Fixes two issues that prevent Kibana from being accessible via the Ona port URL on first environment start:

1. **Bind to `0.0.0.0`** — Kibana defaults to `127.0.0.1`, which the Ona reverse proxy cannot reach. Adds `--server.host=0.0.0.0` to the start command.
2. **Add `ready` command with warm-up** — The first page load in dev mode is slow enough to trigger a gateway timeout. The `ready` command polls `/api/status` until Kibana is up, then hits `/login` to pre-compile bundles so the port URL is usable immediately.

### Changes

- `.ona/automations.yaml`: Updated Kibana service start command and added ready command.