### PR TITLE
[content list] Make shared listing-table test helpers Content-List-aware

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/listing_table.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/listing_table.ts
@@ -10,35 +10,98 @@
 import type { Locator } from 'playwright/test';
 import type { ScoutPage } from '..';
 
+// Legacy `TableListView` (`@kbn/content-management-table-list-view`) subjects.
+const LEGACY_TABLE_LOADED = 'listingTable-isLoaded';
+const LEGACY_SEARCH_BOX = 'tableListSearchBox';
+const LEGACY_TAGS_FILTER_BUTTON = 'tagFilterPopoverButton';
+
+// `@kbn/content-list` subjects.
+const CONTENT_LIST_TABLE = 'content-list-table';
+const CONTENT_LIST_TABLE_SKELETON = 'content-list-table-skeleton';
+const CONTENT_LIST_ITEM_LINK = 'content-list-table-item-link';
+const CONTENT_LIST_SEARCH_BOX = 'contentListToolbar-searchBox';
+const CONTENT_LIST_TAGS_FILTER_BUTTON = 'contentListTagsRenderer';
+
+/**
+ * Page object for a listing page rendered by *either* the legacy
+ * `TableListView` or the `@kbn/content-list` framework.
+ *
+ * Cross-plugin suites (e.g. saved-objects tagging) drive listing pages they
+ * don't own at run time, so a `TableListView` -> Content List migration in one
+ * plugin used to silently break those suites — selective testing doesn't
+ * schedule them, and the subjects this object targeted only existed on the
+ * legacy table (see {@link https://github.com/elastic/kibana/pull/270044}).
+ * Resolving both subject families here keeps every consumer working across the
+ * migration regardless of which framework a given app has adopted.
+ */
 export class ListingTable {
+  /** Whichever framework's "loaded" table container is present. */
   private readonly table: Locator;
+  /** Whichever framework's per-row item links are present. */
+  private readonly itemLinks: Locator;
+  /** Whichever framework's toolbar search box is present. */
   private readonly searchBox: Locator;
 
   constructor(private readonly page: ScoutPage) {
-    this.table = this.page.testSubj.locator('listingTable-isLoaded');
-    this.searchBox = this.page.testSubj.locator('tableListSearchBox');
+    this.table = page.testSubj
+      .locator(LEGACY_TABLE_LOADED)
+      .or(page.testSubj.locator(CONTENT_LIST_TABLE));
+    this.itemLinks = page
+      .locator(`[data-test-subj="${LEGACY_TABLE_LOADED}"] .euiTableRow .euiLink`)
+      .or(page.testSubj.locator(CONTENT_LIST_ITEM_LINK));
+    this.searchBox = page.testSubj
+      .locator(LEGACY_SEARCH_BOX)
+      .or(page.testSubj.locator(CONTENT_LIST_SEARCH_BOX));
+  }
+
+  private async isContentList(): Promise<boolean> {
+    return (await this.page.testSubj.locator(CONTENT_LIST_TABLE).count()) > 0;
   }
 
   async waitUntilTableIsLoaded(options?: { timeout?: number }) {
-    await this.table.waitFor({ state: 'visible', timeout: options?.timeout });
+    const { timeout } = options ?? {};
+    await this.table.waitFor({ state: 'visible', timeout });
+    // Content List keeps the table container mounted behind a loading skeleton;
+    // wait for that skeleton to clear before interacting. Legacy has no skeleton.
+    const skeleton = this.page.testSubj.locator(CONTENT_LIST_TABLE_SKELETON);
+    if ((await skeleton.count()) > 0) {
+      await skeleton.waitFor({ state: 'hidden', timeout });
+    }
   }
 
+  /** Visible text of every row link on the current page. */
   async getAllItemsNames(): Promise<string[]> {
-    const links = this.table.locator('.euiTableRow .euiLink');
-    return links.allTextContents();
+    return this.itemLinks.allInnerTexts();
+  }
+
+  /** All rendered item links (one per row) on the current page. */
+  getItemLinks(): Locator {
+    return this.itemLinks;
+  }
+
+  /** Click the row whose item-link text exactly matches `name`. */
+  async clickItemByName(name: string) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    await this.itemLinks.filter({ hasText: new RegExp(`^${escaped}$`) }).click();
   }
 
   async searchFor(text: string) {
     await this.searchBox.fill(text);
-    await this.page.keyboard.press('Enter');
+    await this.searchBox.press('Enter');
     await this.waitUntilTableIsLoaded();
   }
 
   async selectFilterTags(...tagNames: string[]) {
-    await this.page.testSubj.click('tagFilterPopoverButton');
+    const contentList = await this.isContentList();
+    await this.page.testSubj.click(
+      contentList ? CONTENT_LIST_TAGS_FILTER_BUTTON : LEGACY_TAGS_FILTER_BUTTON
+    );
+    // Both frameworks emit `tag-searchbar-option-${key}` for tag options.
     for (const tagName of tagNames) {
       await this.page.testSubj.click(`tag-searchbar-option-${tagName.replace(' ', '_')}`);
     }
+    // Click the search box to dismiss the popover (click-outside) so the
+    // filtered results settle — works for both frameworks.
     await this.searchBox.click();
     await this.waitUntilTableIsLoaded();
   }

--- a/src/platform/test/functional/services/listing_table.ts
+++ b/src/platform/test/functional/services/listing_table.ts
@@ -17,6 +17,32 @@ const PREFIX_MAP = {
   map: 'map',
 };
 
+// `@kbn/content-list` subjects, mirrored from the Scout `ListingTable` page
+// object and the `contentList` FTR service. Kept here so this service resolves
+// either framework — see the class JSDoc.
+const CONTENT_LIST_TABLE = 'content-list-table';
+const CONTENT_LIST_TABLE_SKELETON = 'content-list-table-skeleton';
+const CONTENT_LIST_ITEM_LINK = 'content-list-table-item-link';
+const CONTENT_LIST_SEARCH_BOX = 'contentListToolbar-searchBox';
+const CONTENT_LIST_TAGS_FILTER_BUTTON = 'contentListTagsRenderer';
+const CONTENT_LIST_SELECTION_BAR_DELETE = 'contentListToolbar-selectionBar-deleteButton';
+
+const itemLinkSelector = (appName: AppName) =>
+  `[data-test-subj^="${PREFIX_MAP[appName]}ListingTitleLink-"], [data-test-subj="${CONTENT_LIST_ITEM_LINK}"]`;
+
+/**
+ * Drives a listing page rendered by *either* the legacy `TableListView` or the
+ * `@kbn/content-list` framework.
+ *
+ * A `TableListView` -> Content List migration in one plugin can break suites in
+ * other plugins that navigate to the migrated listing at run time (selective
+ * testing won't schedule them — see
+ * {@link https://github.com/elastic/kibana/pull/270044}). The listing-load,
+ * search, tag-filter, item-link and bulk-delete affordances below resolve both
+ * subject families so those consumers survive the migration. Helpers tied to
+ * legacy `TableListView` DOM (inspect flyout, per-row checkbox selection,
+ * pagination) remain legacy-only; migrate them when their listing moves.
+ */
 export class ListingTableService extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly find = this.ctx.getService('find');
@@ -38,7 +64,10 @@ export class ListingTableService extends FtrService {
   });
 
   private async getSearchFilter() {
-    return await this.testSubjects.find('tableListSearchBox');
+    if (await this.testSubjects.exists('tableListSearchBox', { timeout: 1000 })) {
+      return this.testSubjects.find('tableListSearchBox');
+    }
+    return this.testSubjects.find(CONTENT_LIST_SEARCH_BOX);
   }
 
   /**
@@ -87,13 +116,16 @@ export class ListingTableService extends FtrService {
 
   public async waitUntilTableIsLoaded() {
     await this.retry.try(async () => {
-      const isLoaded = await this.testSubjects.exists('listingTable-isLoaded');
-
-      if (isLoaded) {
+      if (await this.testSubjects.exists('listingTable-isLoaded', { timeout: 1000 })) {
         return true;
-      } else {
-        throw new Error('Waiting');
       }
+      // Content List keeps its table mounted behind a loading skeleton.
+      if (await this.testSubjects.exists(CONTENT_LIST_TABLE, { timeout: 1000 })) {
+        if (!(await this.testSubjects.exists(CONTENT_LIST_TABLE_SKELETON, { timeout: 1000 }))) {
+          return true;
+        }
+      }
+      throw new Error('Waiting');
     });
   }
 
@@ -141,12 +173,21 @@ export class ListingTableService extends FtrService {
 
   public async openTagPopover(): Promise<void> {
     this.log.debug('ListingTable.openTagPopover');
-    await this.tagPopoverToggle.open();
+    if (await this.testSubjects.exists('tagFilterPopoverButton', { timeout: 1000 })) {
+      await this.tagPopoverToggle.open();
+      return;
+    }
+    await this.testSubjects.click(CONTENT_LIST_TAGS_FILTER_BUTTON);
   }
 
   public async closeTagPopover(): Promise<void> {
     this.log.debug('ListingTable.closeTagPopover');
-    await this.tagPopoverToggle.close();
+    if (await this.testSubjects.exists('tagFilterPopoverButton', { timeout: 1000 })) {
+      await this.tagPopoverToggle.close();
+      return;
+    }
+    // Content List's filter is a toggle button; clicking it again dismisses it.
+    await this.testSubjects.click(CONTENT_LIST_TAGS_FILTER_BUTTON);
   }
 
   /**
@@ -238,7 +279,7 @@ export class ListingTableService extends FtrService {
   public async expectItemsCount(appName: AppName, count: number, findTimeout?: number) {
     await this.retry.try(async () => {
       const elements = await this.find.allByCssSelector(
-        `[data-test-subj^="${PREFIX_MAP[appName]}ListingTitleLink"]`,
+        itemLinkSelector(appName),
         findTimeout ?? 10000
       );
       expect(elements.length).to.equal(count);
@@ -282,15 +323,17 @@ export class ListingTableService extends FtrService {
   public async searchAndExpectItemsCount(appName: AppName, name: string, count: number) {
     await this.searchForItemWithName(name);
     await this.retry.try(async () => {
-      const links = await this.testSubjects.findAll(
-        `${PREFIX_MAP[appName]}ListingTitleLink-${name.replace(/ /g, '-')}`
-      );
+      const links = await this.find.allByCssSelector(itemLinkSelector(appName));
       expect(links.length).to.equal(count);
     });
   }
 
   public async clickDeleteSelected() {
-    await this.testSubjects.click('deleteSelectedItems');
+    if (await this.testSubjects.exists('deleteSelectedItems', { timeout: 1000 })) {
+      await this.testSubjects.click('deleteSelectedItems');
+      return;
+    }
+    await this.testSubjects.click(CONTENT_LIST_SELECTION_BAR_DELETE);
   }
 
   public async selectFirstItemInList() {
@@ -321,9 +364,20 @@ export class ListingTableService extends FtrService {
    * Clicks item on Landing page by link name if it is present
    */
   public async clickItemLink(appName: AppName, name: string) {
-    await this.testSubjects.click(
-      `${PREFIX_MAP[appName]}ListingTitleLink-${name.split(' ').join('-')}`
-    );
+    const legacySubj = `${PREFIX_MAP[appName]}ListingTitleLink-${name.split(' ').join('-')}`;
+    if (await this.testSubjects.exists(legacySubj, { timeout: 1000 })) {
+      await this.testSubjects.click(legacySubj);
+      return;
+    }
+    // Content List item links carry no per-item subject; match on exact text.
+    const links = await this.testSubjects.findAll(CONTENT_LIST_ITEM_LINK);
+    for (const link of links) {
+      if ((await link.getVisibleText()).trim() === name) {
+        await link.click();
+        return;
+      }
+    }
+    throw new Error(`No listing row found with name "${name}".`);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/saved_objects_listing_page.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/saved_objects_listing_page.ts
@@ -44,7 +44,12 @@ export class SavedObjectsListingPage {
 
   getItemLinks(appName: AppName): Locator {
     const testSubjPrefix = APP_TEST_SUBJECT_PREFIX[appName];
-    return this.page.locator(`[data-test-subj^="${testSubjPrefix}ListingTitleLink-"]`);
+    // Match the legacy `TableListView` per-app link or the framework-agnostic
+    // Content List item link, so this keeps working whether or not `appName`'s
+    // listing has migrated to `@kbn/content-list`.
+    return this.page.locator(
+      `[data-test-subj^="${testSubjPrefix}ListingTitleLink-"], [data-test-subj="content-list-table-item-link"]`
+    );
   }
 
   async getAllItemNames(appName: AppName): Promise<string[]> {
@@ -52,9 +57,11 @@ export class SavedObjectsListingPage {
   }
 
   async clickItemLink(appName: AppName, name: string) {
-    const testSubjPrefix = APP_TEST_SUBJECT_PREFIX[appName];
-    await this.page.testSubj.click(
-      `${testSubjPrefix}ListingTitleLink-${name.split(' ').join('-')}`
-    );
+    // Content List item links carry no per-item subject, so match on exact link
+    // text — which equals the title in both frameworks.
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    await this.getItemLinks(appName)
+      .filter({ hasText: new RegExp(`^${escaped}$`) })
+      .click();
   }
 }


### PR DESCRIPTION
## Summary

Makes the **shared** listing-table test abstractions resolve *either* the legacy `TableListView` subjects **or** the `@kbn/content-list` subjects, so a listing migrating to Content List in one plugin no longer breaks cross-plugin suites that drive that listing at run time.

- `@kbn/scout` `ListingTable` page object (consumed by the saved-objects tagging Scout suite).
- FTR `listingTable` service (consumed by ~35 dashboard / lens / visualize / maps / spaces / cases suites).
- Tagging `SavedObjectsListingPage` item-link helpers (combined selector).

### Background

In #270044 the Maps listing was migrated from `TableListView` to Content List. It passed PR CI and was merged, then immediately reverted: the saved-objects tagging Scout suite (`tags_maps_integration.spec.ts`, owned by a different team) navigates to the Maps listing at run time and waits for `listingTable-isLoaded`, which the migrated page no longer renders. PR-time Scout **selective testing** never scheduled that suite because there is no static `@kbn/` dependency edge from `saved_objects_tagging` to `maps` — the coupling is purely a runtime `page.goto(app('maps'))`. The full suite only runs on merge (`kibana-on-merge`), so the break surfaced on `main`.

This PR removes the root cause for the whole class of migration: the shared helpers now understand both frameworks, so any consumer survives a downstream `TableListView` -> Content List migration.

### What's covered

The listing-load contract that breaks on migration: table-loaded wait (incl. Content List loading skeleton), toolbar search box, item links (count / names / click-by-name), tag filter popover, and bulk-delete. Tag *options* already share the `tag-searchbar-option-${key}` subject across both frameworks — only the popover-open button differs.

Helpers tied to legacy `TableListView` DOM (inspect flyout, per-row checkbox selection, pagination) intentionally stay legacy-only; they can migrate alongside their listing when needed.

## Stacking

This is PR 1 of 2. The Maps migration will be re-landed stacked on top of this branch; with these helpers in place the tagging Scout suite passes against the migrated Maps listing.

## Validation

- `node scripts/type_check --project src/platform/packages/shared/kbn-scout/tsconfig.json`
- `node scripts/type_check --project src/platform/test/tsconfig.json`
- `node scripts/type_check --project x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json`
- `node scripts/eslint` on changed files.

The Content List code paths are exercised once a consumed listing is migrated (the stacked Maps PR); on `main` today these helpers continue to resolve the legacy subjects, so existing suites are unaffected.

## Test plan

- [ ] Existing tagging Scout suite still green on `main` (legacy path).
- [ ] Stacked Maps PR's tagging Scout suite green against the migrated listing (Content List path).

> [!NOTE]
> Follow-up (not in this PR): generalize Scout selective testing to treat cross-app `page.goto(app('X'))` navigation as an implicit consumer of `X`'s plugin, so suites like this are scheduled on the migration PR itself.