### PR TITLE
[One Workflow] Add execution detail flyout with step inspection panel

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -415,6 +415,7 @@ export interface WorkflowDetailDto {
   definition: WorkflowYaml | null;
   yaml: string;
   valid: boolean;
+  tags?: string[];
 }
 
 export interface WorkflowPartialDetailDto extends Partial<WorkflowDetailDto> {

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
@@ -23,6 +23,10 @@ export const selectYamlString = createSelector(selectDetail, (detail) => detail.
 export const selectWorkflowId = createSelector(selectWorkflow, (workflow) => workflow?.id);
 export const selectIsEnabled = createSelector(selectWorkflow, (workflow) => !!workflow?.enabled);
 export const selectWorkflowName = createSelector(selectWorkflow, (workflow) => workflow?.name);
+export const selectWorkflowTags = createSelector(
+  selectWorkflow,
+  (workflow) => workflow?.tags ?? []
+);
 
 export const selectHasChanges = createSelector(
   selectDetail,

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { WorkflowExecutionDetail } from './ui/workflow_execution_detail';
+export { WorkflowExecutionFlyout } from './ui/workflow_execution_flyout';

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/build_step_executions_tree.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/build_step_executions_tree.ts
@@ -26,6 +26,7 @@ export interface StepExecutionTreeItem extends StepListTreeItem {
   stepExecutionId: string | null;
   isTriggerPseudoStep?: boolean;
   isChildWorkflowStep?: boolean;
+  attemptNumber?: number;
   children: StepExecutionTreeItem[];
 }
 
@@ -226,7 +227,31 @@ export function buildStepExecutionsTree(
     });
   }
 
-  return [...pseudoSteps, ...regularSteps];
+  return [...pseudoSteps, ...flattenRetryAttempts(regularSteps)];
+}
+
+const ATTEMPT_ID_REGEX = /^(\d+)-attempt$/;
+
+function flattenRetryAttempts(nodes: StepExecutionTreeItem[]): StepExecutionTreeItem[] {
+  return nodes.map((node) => {
+    const allChildrenAreAttempts =
+      node.children.length > 0 && node.children.every((c) => ATTEMPT_ID_REGEX.test(c.stepId));
+
+    if (allChildrenAreAttempts) {
+      const flattenedChildren = node.children.flatMap((attemptNode) => {
+        const match = attemptNode.stepId.match(ATTEMPT_ID_REGEX);
+        const attemptNumber = match ? parseInt(match[1], 10) : undefined;
+        return attemptNode.children.map((actualStep) => ({
+          ...actualStep,
+          attemptNumber,
+          children: flattenRetryAttempts(actualStep.children),
+        }));
+      });
+      return { ...node, children: flattenedChildren };
+    }
+
+    return { ...node, children: flattenRetryAttempts(node.children) };
+  });
 }
 
 /**

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/build_step_executions_tree.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/build_step_executions_tree.ts
@@ -50,6 +50,10 @@ function getStepTreeType(
     if (previousStepExecution.stepType === 'if') {
       return 'if-branch';
     }
+
+    if (previousStepExecution.stepType === 'switch') {
+      return 'enter-case-branch';
+    }
   }
 
   return 'unknown';

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/foreach_iteration_step_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/foreach_iteration_step_list.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiAccordion, EuiFlexGroup, EuiFlexItem, EuiLink, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { WorkflowStepExecutionDto } from '@kbn/workflows';
+import { formatDuration } from '../../../shared/lib/format_duration';
+
+interface ForeachIterationStepListProps {
+  stepExecution: WorkflowStepExecutionDto;
+  allStepExecutions: WorkflowStepExecutionDto[];
+  onSelectStep: (stepExecutionId: string) => void;
+}
+
+export const ForeachIterationStepList: React.FC<ForeachIterationStepListProps> = ({
+  stepExecution,
+  allStepExecutions,
+  onSelectStep,
+}) => {
+  const { euiTheme } = useEuiTheme();
+
+  const rows = useMemo(() => {
+    const { stepId } = stepExecution;
+    const result: Array<{ iterNum: number; step: WorkflowStepExecutionDto }> = [];
+
+    for (const s of allStepExecutions) {
+      const frame = s.scopeStack?.find((f) => f.stepId === stepId);
+      const iterScope = frame?.nestedScopes.find((sc) => sc.scopeId !== undefined);
+      if (!iterScope?.scopeId) continue;
+      const iterNum = parseInt(iterScope.scopeId, 10);
+      if (isNaN(iterNum)) continue;
+      result.push({ iterNum, step: s });
+    }
+
+    result.sort(
+      (a, b) =>
+        a.iterNum - b.iterNum ||
+        (a.step.globalExecutionIndex ?? 0) - (b.step.globalExecutionIndex ?? 0)
+    );
+    return result;
+  }, [stepExecution, allStepExecutions]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <EuiAccordion
+      id={`foreach-output-${stepExecution.id}`}
+      initialIsOpen={true}
+      arrowDisplay="left"
+      buttonContent={
+        <EuiText size="s">
+          <strong>
+            {i18n.translate('workflowsManagement.foreachIterationStepList.outputTitle', {
+              defaultMessage: 'Output',
+            })}
+          </strong>
+        </EuiText>
+      }
+    >
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="none"
+        css={css({ marginTop: euiTheme.size.s })}
+      >
+        {rows.map(({ iterNum, step }) => (
+          <EuiFlexItem key={step.id} grow={false}>
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              responsive={false}
+              css={css({ padding: `${euiTheme.size.xs} 0` })}
+            >
+              <EuiFlexItem
+                grow={false}
+                css={css({
+                  color: euiTheme.colors.textSubdued,
+                  fontVariantNumeric: 'tabular-nums',
+                  fontSize: euiTheme.font.scale.s * euiTheme.base,
+                  minWidth: '2.5em',
+                  textAlign: 'right',
+                })}
+              >
+                #{iterNum}
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiLink onClick={() => onSelectStep(step.id)}>{step.stepId}</EuiLink>
+              </EuiFlexItem>
+              {step.executionTimeMs != null && (
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {formatDuration(step.executionTimeMs)}
+                  </EuiText>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </EuiAccordion>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/foreach_iteration_step_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/foreach_iteration_step_list.tsx
@@ -7,52 +7,34 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiAccordion, EuiFlexGroup, EuiFlexItem, EuiLink, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiAccordion, EuiLink, EuiText, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import type { WorkflowStepExecutionDto } from '@kbn/workflows';
 import { formatDuration } from '../../../shared/lib/format_duration';
 
+export interface ForeachIterationRow {
+  iterNum: number;
+  step: WorkflowStepExecutionDto;
+}
+
 interface ForeachIterationStepListProps {
-  stepExecution: WorkflowStepExecutionDto;
-  allStepExecutions: WorkflowStepExecutionDto[];
+  executionId: string;
+  rows: ForeachIterationRow[];
   onSelectStep: (stepExecutionId: string) => void;
 }
 
 export const ForeachIterationStepList: React.FC<ForeachIterationStepListProps> = ({
-  stepExecution,
-  allStepExecutions,
+  executionId,
+  rows,
   onSelectStep,
 }) => {
   const { euiTheme } = useEuiTheme();
 
-  const rows = useMemo(() => {
-    const { stepId } = stepExecution;
-    const result: Array<{ iterNum: number; step: WorkflowStepExecutionDto }> = [];
-
-    for (const s of allStepExecutions) {
-      const frame = s.scopeStack?.find((f) => f.stepId === stepId);
-      const iterScope = frame?.nestedScopes.find((sc) => sc.scopeId !== undefined);
-      if (!iterScope?.scopeId) continue;
-      const iterNum = parseInt(iterScope.scopeId, 10);
-      if (isNaN(iterNum)) continue;
-      result.push({ iterNum, step: s });
-    }
-
-    result.sort(
-      (a, b) =>
-        a.iterNum - b.iterNum ||
-        (a.step.globalExecutionIndex ?? 0) - (b.step.globalExecutionIndex ?? 0)
-    );
-    return result;
-  }, [stepExecution, allStepExecutions]);
-
-  if (rows.length === 0) return null;
-
   return (
     <EuiAccordion
-      id={`foreach-output-${stepExecution.id}`}
+      id={`foreach-output-${executionId}`}
       initialIsOpen={true}
       arrowDisplay="left"
       buttonContent={
@@ -65,45 +47,70 @@ export const ForeachIterationStepList: React.FC<ForeachIterationStepListProps> =
         </EuiText>
       }
     >
-      <EuiFlexGroup
-        direction="column"
-        gutterSize="none"
-        css={css({ marginTop: euiTheme.size.s })}
+      <div css={css({ padding: `${euiTheme.size.s} 0 2px` })}>
+      <div
+        css={css({
+          border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+          borderRadius: '6px',
+        })}
       >
-        {rows.map(({ iterNum, step }) => (
-          <EuiFlexItem key={step.id} grow={false}>
-            <EuiFlexGroup
-              alignItems="center"
-              gutterSize="s"
-              responsive={false}
-              css={css({ padding: `${euiTheme.size.xs} 0` })}
+        <div css={css({ padding: '16px' })}>
+        <div
+          css={css({
+            display: 'flex',
+            borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+            padding: '7px 8px',
+          })}
+        >
+          <span css={css({ flex: '0 0 40px', fontSize: '12px', fontWeight: 600 })}>#</span>
+          <span css={css({ flex: 1, fontSize: '12px', fontWeight: 600 })}>
+            {i18n.translate('workflowsManagement.foreachIterationStepList.stepColumn', {
+              defaultMessage: 'Step',
+            })}
+          </span>
+          <span css={css({ fontSize: '12px', fontWeight: 600 })}>
+            {i18n.translate('workflowsManagement.foreachIterationStepList.durationColumn', {
+              defaultMessage: 'Duration',
+            })}
+          </span>
+        </div>
+        {rows.map(({ iterNum, step }, idx) => (
+          <div
+            key={step.id}
+            css={css({
+              display: 'flex',
+              borderBottom:
+                idx < rows.length - 1
+                  ? `1px solid ${euiTheme.colors.borderBaseSubdued}`
+                  : 'none',
+              padding: '4px 8px',
+              minHeight: '33px',
+              alignItems: 'center',
+            })}
+          >
+            <span
+              css={css({
+                flex: '0 0 40px',
+                fontSize: '12px',
+                color: euiTheme.colors.textSubdued,
+                fontVariantNumeric: 'tabular-nums',
+              })}
             >
-              <EuiFlexItem
-                grow={false}
-                css={css({
-                  color: euiTheme.colors.textSubdued,
-                  fontVariantNumeric: 'tabular-nums',
-                  fontSize: euiTheme.font.scale.s * euiTheme.base,
-                  minWidth: '2.5em',
-                  textAlign: 'right',
-                })}
-              >
-                #{iterNum}
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiLink onClick={() => onSelectStep(step.id)}>{step.stepId}</EuiLink>
-              </EuiFlexItem>
-              {step.executionTimeMs != null && (
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs" color="subdued">
-                    {formatDuration(step.executionTimeMs)}
-                  </EuiText>
-                </EuiFlexItem>
-              )}
-            </EuiFlexGroup>
-          </EuiFlexItem>
+              #{iterNum}
+            </span>
+            <span css={css({ flex: 1, fontSize: '12px' })}>
+              <EuiLink onClick={() => onSelectStep(step.id)}>{step.stepId}</EuiLink>
+            </span>
+            {step.executionTimeMs != null && (
+              <span css={css({ fontSize: '12px', color: euiTheme.colors.textSubdued })}>
+                {formatDuration(step.executionTimeMs)}
+              </span>
+            )}
+          </div>
         ))}
-      </EuiFlexGroup>
+        </div>
+      </div>
+      </div>
     </EuiAccordion>
   );
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_data_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_data_view.tsx
@@ -27,13 +27,38 @@ const Titles = {
   }),
 };
 
+export function buildForeachOutput(
+  stepExecution: WorkflowStepExecutionDto,
+  allStepExecutions: WorkflowStepExecutionDto[]
+): JsonValue {
+  const { stepId } = stepExecution;
+  const byIteration = new Map<number, Record<string, JsonValue>>();
+
+  for (const s of allStepExecutions) {
+    const frame = s.scopeStack?.find((f) => f.stepId === stepId);
+    const iterScope = frame?.nestedScopes.find((sc) => sc.scopeId !== undefined);
+    if (!iterScope?.scopeId) continue;
+    const iterNum = parseInt(iterScope.scopeId, 10);
+    if (isNaN(iterNum)) continue;
+    if (!byIteration.has(iterNum)) byIteration.set(iterNum, {});
+    if (s.output !== undefined && s.output !== null) {
+      byIteration.get(iterNum)![s.stepId] = s.output as JsonValue;
+    }
+  }
+
+  if (byIteration.size === 0) return null;
+  const maxIter = Math.max(...byIteration.keys());
+  return Array.from({ length: maxIter + 1 }, (_, i) => byIteration.get(i) ?? null);
+}
+
 interface StepExecutionDataViewProps {
   stepExecution: WorkflowStepExecutionDto;
   mode: 'input' | 'output';
+  allStepExecutions?: WorkflowStepExecutionDto[];
 }
 
 export const StepExecutionDataView = React.memo<StepExecutionDataViewProps>(
-  ({ stepExecution, mode }) => {
+  ({ stepExecution, mode, allStepExecutions }) => {
     const { data, title } = useMemo<{ data: JsonValue | undefined; title: string }>(() => {
       if (mode === 'input') {
         return { data: stepExecution.input, title: Titles.input };
@@ -44,9 +69,17 @@ export const StepExecutionDataView = React.memo<StepExecutionDataViewProps>(
             title: Titles.error,
           };
         }
+        const isForeachOrWhile =
+          stepExecution.stepType === 'foreach' || stepExecution.stepType === 'while';
+        if (isForeachOrWhile && stepExecution.output == null && allStepExecutions?.length) {
+          return {
+            data: buildForeachOutput(stepExecution, allStepExecutions),
+            title: Titles.output,
+          };
+        }
         return { data: stepExecution.output, title: Titles.output };
       }
-    }, [mode, stepExecution]);
+    }, [mode, stepExecution, allStepExecutions]);
 
     const fieldPathActionsPrefix: string | undefined = useMemo(() => {
       const isOverviewStep = stepExecution.stepType === '__overview';

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
@@ -68,8 +68,8 @@ export function StepExecutionTreeItemLabel({
             <span
               css={[
                 styles.attemptNumber,
-                isDangerous && styles.dangerousStepName,
                 selected && styles.selectedStepName,
+                isDangerous && styles.dangerousStepName,
               ]}
             >
               #{attemptNumber}{' '}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
@@ -65,7 +65,13 @@ export function StepExecutionTreeItemLabel({
       >
         <span data-test-subj="workflowStepName">
           {attemptNumber !== undefined && (
-            <span css={[styles.attemptNumber, isDangerous && styles.dangerousStepName]}>
+            <span
+              css={[
+                styles.attemptNumber,
+                isDangerous && styles.dangerousStepName,
+                selected && styles.selectedStepName,
+              ]}
+            >
               #{attemptNumber}{' '}
             </span>
           )}
@@ -85,7 +91,7 @@ export function StepExecutionTreeItemLabel({
           </EuiBadge>
         </EuiFlexItem>
       )}
-      {executionTimeMs && status !== ExecutionStatus.WAITING_FOR_INPUT && !isTriggerPseudoStep && (
+      {executionTimeMs !== null && status !== ExecutionStatus.WAITING_FOR_INPUT && !isTriggerPseudoStep && (
         <EuiFlexItem grow={false} css={[styles.duration, isDangerous && styles.durationDangerous]}>
           <EuiText size="xs" color="subdued">
             {formatDuration(executionTimeMs)}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
@@ -28,6 +28,7 @@ export interface StepExecutionTreeItemLabelProps {
   executionTimeMs: number | null;
   selected: boolean;
   onClick?: React.MouseEventHandler;
+  attemptNumber?: number;
 }
 
 export function StepExecutionTreeItemLabel({
@@ -36,6 +37,7 @@ export function StepExecutionTreeItemLabel({
   executionTimeMs,
   selected,
   onClick,
+  attemptNumber,
 }: StepExecutionTreeItemLabelProps) {
   const styles = useMemoCss(componentStyles);
   // Trigger pseudo-steps are not real steps, they are used to display the trigger context
@@ -61,7 +63,14 @@ export function StepExecutionTreeItemLabel({
           isInactiveStatus && styles.inactiveStepName,
         ]}
       >
-        <span data-test-subj="workflowStepName">{stepId}</span>
+        <span data-test-subj="workflowStepName">
+          {attemptNumber !== undefined && (
+            <span css={[styles.attemptNumber, isDangerous && styles.dangerousStepName]}>
+              #{attemptNumber}{' '}
+            </span>
+          )}
+          {stepId}
+        </span>
         {status === ExecutionStatus.SKIPPED && (
           <>
             {' '}
@@ -121,10 +130,9 @@ const componentStyles = {
     css({
       color: euiTheme.colors.textDanger,
     }),
-  executionIndex: ({ euiTheme }: UseEuiTheme) =>
+  attemptNumber: ({ euiTheme }: UseEuiTheme) =>
     css({
-      color: euiTheme.colors.textDisabled,
-      display: 'inline-block',
-      marginLeft: euiTheme.size.xs,
+      color: euiTheme.colors.textSubdued,
+      fontVariantNumeric: 'tabular-nums',
     }),
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
@@ -88,7 +88,7 @@ export const WorkflowExecutionDetail: React.FC<WorkflowExecutionDetailProps> = R
         executionId === workflowExecution?.id &&
         (workflowExecution?.stepExecutions?.length || isTerminalStatus(workflowExecution?.status))
       ) {
-        setSelectedStepExecution(PSEUDO_STEP_OVERVIEW);
+        setSelectedStepExecution(PSEUDO_STEP_TRIGGER);
       }
     }, [workflowExecution, selectedStepExecutionId, setSelectedStepExecution, executionId]);
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
@@ -281,6 +281,7 @@ export const WorkflowExecutionDetail: React.FC<WorkflowExecutionDetailProps> = R
             <WorkflowStepExecutionDetails
               workflowExecutionId={executionId}
               stepExecution={selectedStepExecution}
+              allStepExecutions={workflowExecution?.stepExecutions ?? []}
               workflowExecutionDuration={workflowExecution?.duration ?? undefined}
               isLoadingStepData={isLoadingStepData && !isPseudoStep}
               workflowExecutionStatus={workflowExecution?.status}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_detail.tsx
@@ -282,6 +282,7 @@ export const WorkflowExecutionDetail: React.FC<WorkflowExecutionDetailProps> = R
               workflowExecutionId={executionId}
               stepExecution={selectedStepExecution}
               allStepExecutions={workflowExecution?.stepExecutions ?? []}
+              onSelectStepExecution={setSelectedStepExecutionId}
               workflowExecutionDuration={workflowExecution?.duration ?? undefined}
               isLoadingStepData={isLoadingStepData && !isPseudoStep}
               workflowExecutionStatus={workflowExecution?.status}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
@@ -1,0 +1,700 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCodeBlock,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiTab,
+  EuiTabs,
+  EuiText,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useLayoutEffect, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { useChildWorkflowExecutions } from '../model/use_child_workflow_executions';
+import { useStepExecution } from '../model/use_step_execution';
+import { useWorkflowExecutionPolling } from '../../../entities/workflows/model/use_workflow_execution_polling';
+import { formatDuration } from '../../../shared/lib/format_duration';
+import { getStatusLabel } from '../../../shared/translations/status_translations';
+import { FormattedRelativeEnhanced } from '../../../shared/ui/formatted_relative_enhanced/formatted_relative_enhanced';
+import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
+import { WorkflowStepExecutionTree } from './workflow_step_execution_tree';
+
+export interface WorkflowExecutionFlyoutProps {
+  executionId: string;
+  workflowName: string;
+  workflowTags: string[];
+  onClose: () => void;
+}
+
+type FlyoutTabId = 'table' | 'json';
+
+const i18nTexts = {
+  back: i18n.translate('workflows.executionFlyout.back', { defaultMessage: 'Back' }),
+  result: i18n.translate('workflows.executionFlyout.result', { defaultMessage: 'Result' }),
+  executionTime: i18n.translate('workflows.executionFlyout.executionTime', {
+    defaultMessage: 'Execution time',
+  }),
+  executedBy: i18n.translate('workflows.executionFlyout.executedBy', {
+    defaultMessage: 'Executed by',
+  }),
+  tableTab: i18n.translate('workflows.executionFlyout.tableTab', { defaultMessage: 'Table' }),
+  jsonTab: i18n.translate('workflows.executionFlyout.jsonTab', { defaultMessage: 'JSON' }),
+  takeAction: i18n.translate('workflows.executionFlyout.takeAction', {
+    defaultMessage: 'Take action',
+  }),
+  share: i18n.translate('workflows.executionFlyout.share', { defaultMessage: 'Share' }),
+  close: i18n.translate('workflows.executionFlyout.close', { defaultMessage: 'Close' }),
+};
+
+const FLYOUT_CLASSNAME = 'workflowExecutionFlyout';
+const EXECUTION_PANEL_WIDTH = 480;
+const STEP_DETAIL_WIDTH = 480;
+
+const flattenToRows = (
+  value: unknown,
+  prefix = ''
+): Array<{ field: string; value: string }> => {
+  if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+    return [];
+  }
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, val]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      return flattenToRows(val, fullKey);
+    }
+    const display =
+      val === null
+        ? 'null'
+        : Array.isArray(val)
+        ? JSON.stringify(val)
+        : typeof val === 'string'
+        ? val
+        : String(val);
+    return [{ field: fullKey, value: display }];
+  });
+};
+
+const isTableable = (v: unknown): boolean =>
+  v !== null && v !== undefined && typeof v === 'object' && !Array.isArray(v) &&
+  Object.keys(v as object).length > 0;
+
+const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
+  const { euiTheme } = useEuiTheme();
+  const [view, setView] = useState<'table' | 'code'>(() => (isTableable(data) ? 'table' : 'code'));
+  const [filter, setFilter] = useState('');
+
+  const hasTable = isTableable(data);
+  const effectiveView = hasTable ? view : 'code';
+
+  const rows = useMemo(() => flattenToRows(data), [data]);
+  const filteredRows = useMemo(
+    () =>
+      filter
+        ? rows.filter(
+            (r) =>
+              r.field.toLowerCase().includes(filter.toLowerCase()) ||
+              r.value.toLowerCase().includes(filter.toLowerCase())
+          )
+        : rows,
+    [rows, filter]
+  );
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+        borderRadius: '10px',
+        overflow: 'hidden',
+        flexShrink: 0,
+      }}
+    >
+      {/* Section header bar */}
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '40px',
+          padding: '0 16px',
+          gap: '4px',
+          background: euiTheme.colors.lightestShade,
+          borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+        }}
+      >
+        <span css={{ flex: 1, fontSize: '12px', fontWeight: 600 }}>{label}</span>
+
+        {hasTable && (
+          <>
+            <EuiButtonIcon
+              iconType="list"
+              size="s"
+              color={effectiveView === 'table' ? 'primary' : 'text'}
+              aria-label={i18n.translate('workflows.executionFlyout.stepDetail.tableView', {
+                defaultMessage: 'Table view',
+              })}
+              onClick={() => setView('table')}
+            />
+            <EuiButtonIcon
+              iconType="editorCodeBlock"
+              size="s"
+              color={effectiveView === 'code' ? 'primary' : 'text'}
+              aria-label={i18n.translate('workflows.executionFlyout.stepDetail.codeView', {
+                defaultMessage: 'Code view',
+              })}
+              onClick={() => setView('code')}
+            />
+          </>
+        )}
+
+        {effectiveView === 'code' && (
+          <EuiButtonIcon
+            iconType="copyClipboard"
+            size="s"
+            color="text"
+            aria-label={i18n.translate('workflows.executionFlyout.stepDetail.copy', {
+              defaultMessage: 'Copy to clipboard',
+            })}
+            onClick={() => {
+              void navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+            }}
+          />
+        )}
+      </div>
+
+      {/* Section content */}
+      {effectiveView === 'code' ? (
+        <EuiCodeBlock
+          language="json"
+          fontSize="s"
+          transparentBackground
+          paddingSize="m"
+          overflowHeight={300}
+        >
+          {JSON.stringify(data ?? null, null, 2)}
+        </EuiCodeBlock>
+      ) : (
+        <>
+          <div css={{ padding: '12px 12px 0' }}>
+            <EuiFieldSearch
+              placeholder={i18n.translate(
+                'workflows.executionFlyout.stepDetail.filterPlaceholder',
+                { defaultMessage: 'Filter by field, value' }
+              )}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              compressed
+              fullWidth
+            />
+          </div>
+          <div css={{ padding: '0 12px 12px' }}>
+            <div
+              css={{
+                display: 'flex',
+                borderBottom: `1px solid ${euiTheme.colors.lightShade}`,
+                padding: '7px 8px',
+                marginTop: '10px',
+              }}
+            >
+              <span css={{ flex: '0 0 50%', fontSize: '12px', fontWeight: 600 }}>
+                {i18n.translate('workflows.executionFlyout.stepDetail.fieldColumn', {
+                  defaultMessage: 'Field',
+                })}
+              </span>
+              <span css={{ flex: '0 0 50%', fontSize: '12px', fontWeight: 600 }}>
+                {i18n.translate('workflows.executionFlyout.stepDetail.valueColumn', {
+                  defaultMessage: 'Value',
+                })}
+              </span>
+            </div>
+            {filteredRows.length === 0 ? (
+              <div
+                css={{ padding: '12px 8px', fontSize: '12px', color: euiTheme.colors.subduedText }}
+              >
+                {i18n.translate('workflows.executionFlyout.stepDetail.noData', {
+                  defaultMessage: 'No data',
+                })}
+              </div>
+            ) : (
+              filteredRows.map((row, idx) => (
+                <div
+                  key={idx}
+                  css={{
+                    display: 'flex',
+                    borderBottom: `1px solid ${euiTheme.colors.lightShade}`,
+                    padding: '4px 8px',
+                    minHeight: '25px',
+                    alignItems: 'center',
+                  }}
+                >
+                  <span
+                    css={{
+                      flex: '0 0 50%',
+                      fontSize: '12px',
+                      fontFamily: euiTheme.font.familyCode,
+                      color: euiTheme.colors.subduedText,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      paddingRight: '8px',
+                    }}
+                  >
+                    {row.field}
+                  </span>
+                  <span
+                    css={{
+                      flex: '0 0 50%',
+                      fontSize: '12px',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {row.value}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const formatExecutionDate = (isoString: string): string | null => {
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return null;
+  return date
+    .toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+    .replace(',', ' @');
+};
+
+export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
+  ({ executionId, workflowName, workflowTags, onClose }) => {
+    const { euiTheme } = useEuiTheme();
+    const [activeTab, setActiveTab] = useState<FlyoutTabId>('table');
+    const [selectedStepExecutionId, setSelectedStepExecutionId] = useState<string | null>(null);
+
+    const { workflowExecution, error } = useWorkflowExecutionPolling(executionId);
+
+    const selectedLightStep = useMemo(
+      () =>
+        workflowExecution?.stepExecutions.find((s) => s.id === selectedStepExecutionId) ?? null,
+      [workflowExecution?.stepExecutions, selectedStepExecutionId]
+    );
+
+    const { data: fullStepExecution, isLoading: isLoadingStepData } = useStepExecution(
+      executionId,
+      selectedStepExecutionId ?? undefined,
+      selectedLightStep?.status
+    );
+    const { childExecutions, isLoading: isLoadingChildExecutions } =
+      useChildWorkflowExecutions(workflowExecution);
+
+    const workflowDefinition = workflowExecution?.workflowDefinition ?? null;
+    const startedAt = useMemo(
+      () => (workflowExecution?.startedAt ? new Date(workflowExecution.startedAt) : null),
+      [workflowExecution?.startedAt]
+    );
+    const formattedDate = workflowExecution?.startedAt
+      ? formatExecutionDate(workflowExecution.startedAt)
+      : null;
+    const formattedDuration = useMemo(
+      () =>
+        workflowExecution?.duration != null ? formatDuration(workflowExecution.duration) : null,
+      [workflowExecution?.duration]
+    );
+
+    const stepName = selectedLightStep?.stepId ?? fullStepExecution?.stepId ?? '';
+
+    // Widen the flyout DOM element when the step detail panel is open (FlyoutPanels pattern).
+    useLayoutEffect(() => {
+      const el = document.querySelector<HTMLElement>(`.${FLYOUT_CLASSNAME}`);
+      if (!el) return;
+      const totalWidth = Math.min(
+        selectedStepExecutionId
+          ? EXECUTION_PANEL_WIDTH + STEP_DETAIL_WIDTH
+          : EXECUTION_PANEL_WIDTH,
+        window.innerWidth * 0.9
+      );
+      el.style.minWidth = `${totalWidth}px`;
+      el.style.maxWidth = `${totalWidth}px`;
+    }, [selectedStepExecutionId]);
+
+    return (
+      <EuiFlyout
+        onClose={onClose}
+        type="push"
+        paddingSize="none"
+        hideCloseButton
+        className={FLYOUT_CLASSNAME}
+        data-test-subj="workflowExecutionFlyout"
+      >
+        {/* Outer flex row — each column is a visually independent panel */}
+        <div css={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+
+          {/* ── Step detail panel (independent header + scrollable body) ── */}
+          {selectedStepExecutionId && (
+            <div
+              css={{
+                width: `${STEP_DETAIL_WIDTH}px`,
+                flexShrink: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                borderRight: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                css={{
+                  flex: 1,
+                  overflowY: 'auto',
+                  padding: '16px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '16px',
+                }}
+              >
+                {/* Header row — clean, no separator line */}
+                <div
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    flexShrink: 0,
+                  }}
+                >
+                  <span
+                    css={{
+                      flex: 1,
+                      fontSize: '16px',
+                      fontWeight: 600,
+                      color: euiTheme.colors.title,
+                      lineHeight: 1.25,
+                      wordBreak: 'break-all',
+                    }}
+                  >
+                    {stepName}
+                  </span>
+                  <EuiButtonIcon
+                    iconType="cross"
+                    aria-label={i18nTexts.close}
+                    color="text"
+                    size="s"
+                    onClick={() => setSelectedStepExecutionId(null)}
+                  />
+                </div>
+
+                {isLoadingStepData ? (
+                  <EuiFlexGroup justifyContent="center">
+                    <EuiFlexItem grow={false}>
+                      <EuiLoadingSpinner size="l" />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ) : (
+                  <>
+                    <StepDataSection
+                      key={`input-${selectedStepExecutionId}`}
+                      label={i18n.translate('workflows.executionFlyout.stepDetail.input', {
+                        defaultMessage: 'Input',
+                      })}
+                      data={fullStepExecution?.input}
+                    />
+                    <StepDataSection
+                      key={`output-${selectedStepExecutionId}`}
+                      label={i18n.translate('workflows.executionFlyout.stepDetail.output', {
+                        defaultMessage: 'Output',
+                      })}
+                      data={fullStepExecution?.error ?? fullStepExecution?.output}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* ── Execution panel (own EuiFlyoutHeader / Body / Footer) ── */}
+          <div css={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+            <EuiFlyoutHeader>
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
+                alignItems="center"
+                gutterSize="none"
+                responsive={false}
+                css={{
+                  height: '36px',
+                  padding: '0 8px',
+                  borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+                }}
+              >
+                <EuiButtonEmpty
+                  size="s"
+                  iconType="editorUndo"
+                  color="text"
+                  flush="left"
+                  onClick={onClose}
+                >
+                  {i18nTexts.back}
+                </EuiButtonEmpty>
+                <EuiFlexGroup
+                  gutterSize="none"
+                  alignItems="center"
+                  justifyContent="flexEnd"
+                  responsive={false}
+                >
+                  <EuiButtonIcon
+                    iconType="share"
+                    aria-label={i18nTexts.share}
+                    color="text"
+                    size="s"
+                  />
+                  <EuiButtonIcon
+                    iconType="cross"
+                    aria-label={i18nTexts.close}
+                    color="text"
+                    size="s"
+                    onClick={onClose}
+                  />
+                </EuiFlexGroup>
+              </EuiFlexGroup>
+
+              <div
+                css={{
+                  padding: '16px 16px 8px 16px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '16px',
+                }}
+              >
+                <div>
+                  <EuiTitle size="s">
+                    <h2 css={{ wordBreak: 'break-word' }}>{workflowName}</h2>
+                  </EuiTitle>
+                  {formattedDate && startedAt && (
+                    <EuiText size="xs" color="subdued" css={{ marginTop: '3px' }}>
+                      {formattedDate} (<FormattedRelativeEnhanced value={startedAt} />)
+                    </EuiText>
+                  )}
+                </div>
+
+                {workflowTags.length > 0 && (
+                  <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+                    {workflowTags.map((tag) => (
+                      <EuiFlexItem grow={false} key={tag}>
+                        <EuiBadge color="hollow">{tag}</EuiBadge>
+                      </EuiFlexItem>
+                    ))}
+                  </EuiFlexGroup>
+                )}
+
+                {workflowExecution ? (
+                  <div
+                    css={{
+                      border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+                      borderRadius: '10px',
+                      padding: '12px',
+                    }}
+                  >
+                    <div
+                      css={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: '16px',
+                      }}
+                    >
+                      <div css={{ display: 'flex', flexDirection: 'column', gap: '2px', flex: 1 }}>
+                        <EuiText
+                          size="s"
+                          color="subdued"
+                          css={{ fontWeight: 500, fontSize: '12px' }}
+                        >
+                          {i18nTexts.result}
+                        </EuiText>
+                        <EuiFlexGroup
+                          gutterSize="none"
+                          css={{ gap: '4px' }}
+                          alignItems="center"
+                          responsive={false}
+                        >
+                          <EuiFlexItem grow={false}>
+                            {getExecutionStatusIcon(euiTheme, workflowExecution.status)}
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiText size="s" css={{ fontWeight: 600, fontSize: '12px' }}>
+                              {getStatusLabel(workflowExecution.status)}
+                            </EuiText>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </div>
+
+                      <div
+                        aria-hidden="true"
+                        css={{
+                          width: '1px',
+                          alignSelf: 'stretch',
+                          background: euiTheme.colors.borderBaseSubdued,
+                          flexShrink: 0,
+                        }}
+                      />
+
+                      <div css={{ display: 'flex', flexDirection: 'column', gap: '2px', flex: 1 }}>
+                        <EuiText
+                          size="s"
+                          color="subdued"
+                          css={{ fontWeight: 500, fontSize: '12px' }}
+                        >
+                          {i18nTexts.executionTime}
+                        </EuiText>
+                        <EuiFlexGroup
+                          gutterSize="none"
+                          css={{ gap: '4px' }}
+                          alignItems="center"
+                          responsive={false}
+                        >
+                          <EuiFlexItem grow={false}>
+                            <EuiIcon type="clock" color="subdued" size="m" />
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiText size="s" css={{ fontWeight: 600, fontSize: '12px' }}>
+                              {formattedDuration ?? '-'}
+                            </EuiText>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </div>
+
+                      <div
+                        aria-hidden="true"
+                        css={{
+                          width: '1px',
+                          alignSelf: 'stretch',
+                          background: euiTheme.colors.borderBaseSubdued,
+                          flexShrink: 0,
+                        }}
+                      />
+
+                      <div css={{ display: 'flex', flexDirection: 'column', gap: '2px', flex: 1 }}>
+                        <EuiText
+                          size="s"
+                          color="subdued"
+                          css={{ fontWeight: 500, fontSize: '12px' }}
+                        >
+                          {i18nTexts.executedBy}
+                        </EuiText>
+                        <EuiText size="s" css={{ fontWeight: 600, fontSize: '12px' }}>
+                          {workflowExecution.executedBy ?? '-'}
+                        </EuiText>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <EuiLoadingSpinner size="m" />
+                )}
+              </div>
+            </EuiFlyoutHeader>
+
+            <EuiFlyoutBody
+              css={css`
+                .euiFlyoutBody__overflowContent {
+                  padding: 0;
+                }
+              `}
+            >
+              {!workflowExecution && !error ? (
+                <EuiFlexGroup
+                  justifyContent="center"
+                  css={{ padding: `${euiTheme.size.xl} ${euiTheme.size.base} 0` }}
+                >
+                  <EuiFlexItem grow={false}>
+                    <EuiLoadingSpinner size="l" />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              ) : (
+                <>
+                  <EuiTabs css={{ paddingInline: euiTheme.size.base }}>
+                    <EuiTab
+                      isSelected={activeTab === 'table'}
+                      onClick={() => setActiveTab('table')}
+                    >
+                      {i18nTexts.tableTab}
+                    </EuiTab>
+                    <EuiTab
+                      isSelected={activeTab === 'json'}
+                      onClick={() => setActiveTab('json')}
+                    >
+                      {i18nTexts.jsonTab}
+                    </EuiTab>
+                  </EuiTabs>
+                  <div
+                    css={{
+                      padding: `${euiTheme.size.s} ${euiTheme.size.base} ${euiTheme.size.base}`,
+                    }}
+                  >
+                    {activeTab === 'table' && (
+                      <WorkflowStepExecutionTree
+                        definition={workflowDefinition}
+                        execution={workflowExecution ?? null}
+                        error={error}
+                        onStepExecutionClick={setSelectedStepExecutionId}
+                        selectedId={selectedStepExecutionId}
+                        childExecutionsMap={childExecutions}
+                        isLoadingChildExecutions={isLoadingChildExecutions}
+                      />
+                    )}
+                    {activeTab === 'json' && workflowExecution && (
+                      <EuiCodeBlock language="json" fontSize="m" isCopyable overflowHeight="100%">
+                        {JSON.stringify(workflowExecution, null, 2)}
+                      </EuiCodeBlock>
+                    )}
+                  </div>
+                </>
+              )}
+            </EuiFlyoutBody>
+
+            <EuiFlyoutFooter>
+              <div css={{ padding: `${euiTheme.size.m} ${euiTheme.size.base}` }}>
+                <EuiFlexGroup justifyContent="flexEnd" gutterSize="none">
+                  <EuiFlexItem grow={false}>
+                    <EuiButton fill size="s" iconSide="right" iconType="arrowDown">
+                      {i18nTexts.takeAction}
+                    </EuiButton>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlyoutFooter>
+          </div>
+
+        </div>
+      </EuiFlyout>
+    );
+  }
+);
+WorkflowExecutionFlyout.displayName = 'WorkflowExecutionFlyout';

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
@@ -25,6 +25,7 @@ import {
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiLoadingSpinner,
+  EuiPagination,
   EuiPopover,
   EuiToken,
   EuiTab,
@@ -34,7 +35,7 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useLayoutEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { WorkflowStepExecutionDto } from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
@@ -51,6 +52,7 @@ import { FormattedRelativeEnhanced } from '../../../shared/ui/formatted_relative
 import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
 import { StepIcon } from '../../../shared/ui/step_icons/step_icon';
 import { buildForeachOutput } from './step_execution_data_view';
+import { ForeachIterationStepList, type ForeachIterationRow } from './foreach_iteration_step_list';
 import { WorkflowStepExecutionTree } from './workflow_step_execution_tree';
 
 export interface WorkflowExecutionFlyoutProps {
@@ -221,16 +223,38 @@ const AiStatsSection = ({ stats }: { stats: AiStepStats }) => {
   );
 };
 
+const SECTION_PAGE_SIZE = 10;
+
 const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
   const { euiTheme } = useEuiTheme();
   const [view, setView] = useState<'table' | 'code'>(() => (isTableable(data) ? 'table' : 'code'));
   const [isOpen, setIsOpen] = useState(true);
   const [isViewPopoverOpen, setIsViewPopoverOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [pageIndex, setPageIndex] = useState(0);
 
   const hasTable = isTableable(data);
   const effectiveView = hasTable ? view : 'code';
 
   const rows = useMemo(() => flattenToRows(data), [data]);
+
+  const filteredRows = useMemo(() => {
+    if (!searchTerm) return rows;
+    const term = searchTerm.toLowerCase();
+    return rows.filter(
+      (row) => row.field.toLowerCase().includes(term) || row.value.toLowerCase().includes(term)
+    );
+  }, [rows, searchTerm]);
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [searchTerm]);
+
+  const pageCount = Math.ceil(filteredRows.length / SECTION_PAGE_SIZE);
+  const paginatedRows = filteredRows.slice(
+    pageIndex * SECTION_PAGE_SIZE,
+    (pageIndex + 1) * SECTION_PAGE_SIZE
+  );
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: '8px', flexShrink: 0 }}>
@@ -340,6 +364,20 @@ const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
             </EuiCodeBlock>
           ) : (
             <div css={{ padding: '16px' }}>
+              {rows.length >= SECTION_PAGE_SIZE && (
+                <div css={{ marginBottom: '16px' }}>
+                  <EuiFieldSearch
+                    compressed
+                    fullWidth
+                    placeholder={i18n.translate(
+                      'workflows.executionFlyout.stepDetail.searchPlaceholder',
+                      { defaultMessage: 'Search fields and values' }
+                    )}
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                  />
+                </div>
+              )}
               <div
                 css={{
                   display: 'flex',
@@ -358,7 +396,7 @@ const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
                   })}
                 </span>
               </div>
-              {rows.length === 0 ? (
+              {filteredRows.length === 0 ? (
                 <div
                   css={{
                     padding: '12px 4px',
@@ -371,57 +409,72 @@ const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
                   })}
                 </div>
               ) : (
-                rows.map((row, idx) => (
-                  <div
-                    key={idx}
-                    css={{
-                      display: 'flex',
-                      borderBottom: idx < rows.length - 1 ? `1px solid ${euiTheme.colors.borderBaseSubdued}` : 'none',
-                      padding: '4px 4px',
-                      minHeight: '33px',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <span
+                <>
+                  {paginatedRows.map((row, idx) => (
+                    <div
+                      key={idx}
                       css={{
-                        flex: '0 0 50%',
                         display: 'flex',
+                        borderBottom:
+                          idx < paginatedRows.length - 1 || pageCount > 1
+                            ? `1px solid ${euiTheme.colors.borderBaseSubdued}`
+                            : 'none',
+                        padding: '4px 4px',
+                        minHeight: '33px',
                         alignItems: 'center',
-                        gap: '4px',
-                        overflow: 'hidden',
-                        paddingRight: '8px',
                       }}
                     >
-                      <EuiToken
-                        iconType={fieldTypeToToken[row.fieldType]}
-                        size="xs"
-                        css={{ flexShrink: 0, width: '12px', height: '12px', margin: 0 }}
-                      />
                       <span
                         css={{
+                          flex: '0 0 50%',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
+                          overflow: 'hidden',
+                          paddingRight: '8px',
+                        }}
+                      >
+                        <EuiToken
+                          iconType={fieldTypeToToken[row.fieldType]}
+                          size="xs"
+                          css={{ flexShrink: 0, width: '12px', height: '12px', margin: 0 }}
+                        />
+                        <span
+                          css={{
+                            fontSize: '12px',
+                            fontFamily: euiTheme.font.familyCode,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {row.field}
+                        </span>
+                      </span>
+                      <span
+                        css={{
+                          flex: '0 0 50%',
                           fontSize: '12px',
-                          fontFamily: euiTheme.font.familyCode,
                           overflow: 'hidden',
                           textOverflow: 'ellipsis',
                           whiteSpace: 'nowrap',
                         }}
                       >
-                        {row.field}
+                        {row.value}
                       </span>
-                    </span>
-                    <span
-                      css={{
-                        flex: '0 0 50%',
-                        fontSize: '12px',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {row.value}
-                    </span>
-                  </div>
-                ))
+                    </div>
+                  ))}
+                  {pageCount > 1 && (
+                    <div css={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 0' }}>
+                      <EuiPagination
+                        pageCount={pageCount}
+                        activePage={pageIndex}
+                        onPageClick={setPageIndex}
+                        compressed
+                      />
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}
@@ -465,7 +518,8 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
     const isPseudoStep =
       selectedStepExecutionId === '__overview' ||
       selectedStepExecutionId === 'trigger' ||
-      (selectedStepExecutionId?.startsWith('if-branch:') ?? false);
+      (selectedStepExecutionId?.startsWith('if-branch:') ?? false) ||
+      (selectedStepExecutionId?.startsWith('enter-case-branch:') ?? false);
 
     const pseudoStepExecution = useMemo<WorkflowStepExecutionDto | null>(() => {
       if (!workflowExecution) return null;
@@ -484,6 +538,26 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
           status: ExecutionStatus.COMPLETED,
           input: undefined,
           output: { result: branchName } as unknown as WorkflowStepExecutionDto['output'],
+          scopeStack: [],
+          workflowRunId: workflowExecution.id,
+          workflowId: workflowExecution.workflowId ?? '',
+          startedAt: '',
+          globalExecutionIndex: -1,
+          stepExecutionIndex: 0,
+          topologicalIndex: -1,
+        } as WorkflowStepExecutionDto;
+      }
+      if (selectedStepExecutionId?.startsWith('enter-case-branch:')) {
+        const parts = selectedStepExecutionId.split(':');
+        const caseName = parts[1];
+        const caseStatus = (parts[3] as ExecutionStatus) ?? ExecutionStatus.COMPLETED;
+        return {
+          id: selectedStepExecutionId,
+          stepId: caseName,
+          stepType: 'enter-case-branch',
+          status: caseStatus,
+          input: undefined,
+          output: undefined,
           scopeStack: [],
           workflowRunId: workflowExecution.id,
           workflowId: workflowExecution.workflowId ?? '',
@@ -533,6 +607,26 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
       (isForeachOrWhileStep && activeStepExecution != null && activeStepExecution.output == null
         ? buildForeachOutput(activeStepExecution, workflowExecution?.stepExecutions ?? [])
         : activeStepExecution?.output);
+
+    const foreachRows = useMemo((): ForeachIterationRow[] => {
+      const stepId = activeStepExecution?.stepId;
+      if (!stepId || !isForeachOrWhileStep || !workflowExecution?.stepExecutions?.length) return [];
+      const result: ForeachIterationRow[] = [];
+      for (const s of workflowExecution.stepExecutions) {
+        const frame = s.scopeStack.find((f) => f.stepId === stepId);
+        const iterScope = frame?.nestedScopes.find((sc) => sc.scopeId !== undefined);
+        if (!iterScope?.scopeId) continue;
+        const iterNum = parseInt(iterScope.scopeId, 10);
+        if (isNaN(iterNum)) continue;
+        result.push({ iterNum, step: s });
+      }
+      result.sort(
+        (a, b) =>
+          a.iterNum - b.iterNum ||
+          (a.step.globalExecutionIndex ?? 0) - (b.step.globalExecutionIndex ?? 0)
+      );
+      return result;
+    }, [activeStepExecution?.stepId, isForeachOrWhileStep, workflowExecution?.stepExecutions]);
 
     // Widen the flyout DOM element when the step detail panel is open (FlyoutPanels pattern).
     useLayoutEffect(() => {
@@ -628,6 +722,23 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                       <EuiLoadingSpinner size="l" />
                     </EuiFlexItem>
                   </EuiFlexGroup>
+                ) : activeStepExecution?.stepType === 'enter-case-branch' ? (
+                  <StepDataSection
+                    key={`status-${selectedStepExecutionId}`}
+                    label={i18n.translate('workflows.executionFlyout.caseBranch.statusLabel', {
+                      defaultMessage: 'Status',
+                    })}
+                    data={{
+                      result:
+                        activeStepExecution.status === ExecutionStatus.COMPLETED
+                          ? i18n.translate('workflows.executionFlyout.caseBranch.taken', {
+                              defaultMessage: 'Branch executed',
+                            })
+                          : i18n.translate('workflows.executionFlyout.caseBranch.skipped', {
+                              defaultMessage: 'Branch not taken',
+                            }),
+                    }}
+                  />
                 ) : (
                   <>
                     {executionMetadata && (
@@ -654,13 +765,21 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                       return aiStats ? <AiStatsSection stats={aiStats} /> : null;
                     })()}
                     {!isPseudoStep && (
-                      <StepDataSection
-                        key={`output-${selectedStepExecutionId}`}
-                        label={i18n.translate('workflows.executionFlyout.stepDetail.output', {
-                          defaultMessage: 'Output',
-                        })}
-                        data={stepOutputData}
-                      />
+                      isForeachOrWhileStep && foreachRows.length > 0 ? (
+                        <ForeachIterationStepList
+                          executionId={selectedStepExecutionId ?? ''}
+                          rows={foreachRows}
+                          onSelectStep={setSelectedStepExecutionId}
+                        />
+                      ) : (
+                        <StepDataSection
+                          key={`output-${selectedStepExecutionId}`}
+                          label={i18n.translate('workflows.executionFlyout.stepDetail.output', {
+                            defaultMessage: 'Output',
+                          })}
+                          data={stepOutputData}
+                        />
+                      )
                     )}
                   </>
                 )}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
@@ -50,6 +50,7 @@ import { getStatusLabel } from '../../../shared/translations/status_translations
 import { FormattedRelativeEnhanced } from '../../../shared/ui/formatted_relative_enhanced/formatted_relative_enhanced';
 import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
 import { StepIcon } from '../../../shared/ui/step_icons/step_icon';
+import { buildForeachOutput } from './step_execution_data_view';
 import { WorkflowStepExecutionTree } from './workflow_step_execution_tree';
 
 export interface WorkflowExecutionFlyoutProps {
@@ -525,6 +526,14 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
     const activeStepExecution = fullStepExecution ?? pseudoStepExecution;
     const stepName = selectedLightStep?.stepId ?? activeStepExecution?.stepId ?? '';
 
+    const activeStepType = selectedLightStep?.stepType ?? activeStepExecution?.stepType;
+    const isForeachOrWhileStep = activeStepType === 'foreach' || activeStepType === 'while';
+    const stepOutputData =
+      activeStepExecution?.error ??
+      (isForeachOrWhileStep && activeStepExecution != null && activeStepExecution.output == null
+        ? buildForeachOutput(activeStepExecution, workflowExecution?.stepExecutions ?? [])
+        : activeStepExecution?.output);
+
     // Widen the flyout DOM element when the step detail panel is open (FlyoutPanels pattern).
     useLayoutEffect(() => {
       const el = document.querySelector<HTMLElement>(`.${FLYOUT_CLASSNAME}`);
@@ -650,7 +659,7 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                         label={i18n.translate('workflows.executionFlyout.stepDetail.output', {
                           defaultMessage: 'Output',
                         })}
-                        data={activeStepExecution?.error ?? activeStepExecution?.output}
+                        data={stepOutputData}
                       />
                     )}
                   </>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
@@ -582,10 +582,10 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                     flexShrink: 0,
                   }}
                 >
-                  {selectedLightStep?.stepType && (
+                  {(selectedLightStep?.stepType ?? activeStepExecution?.stepType) && (
                     <StepIcon
-                      stepType={selectedLightStep.stepType}
-                      executionStatus={selectedLightStep.status}
+                      stepType={selectedLightStep?.stepType ?? activeStepExecution?.stepType ?? ''}
+                      executionStatus={selectedLightStep?.status ?? activeStepExecution?.status}
                       size="m"
                       css={{ flexShrink: 0 }}
                     />

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
@@ -38,6 +38,7 @@ import { formatDuration } from '../../../shared/lib/format_duration';
 import { getStatusLabel } from '../../../shared/translations/status_translations';
 import { FormattedRelativeEnhanced } from '../../../shared/ui/formatted_relative_enhanced/formatted_relative_enhanced';
 import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
+import { StepIcon } from '../../../shared/ui/step_icons/step_icon';
 import { WorkflowStepExecutionTree } from './workflow_step_execution_tree';
 
 export interface WorkflowExecutionFlyoutProps {
@@ -165,20 +166,6 @@ const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
             />
           </>
         )}
-
-        {effectiveView === 'code' && (
-          <EuiButtonIcon
-            iconType="copyClipboard"
-            size="s"
-            color="text"
-            aria-label={i18n.translate('workflows.executionFlyout.stepDetail.copy', {
-              defaultMessage: 'Copy to clipboard',
-            })}
-            onClick={() => {
-              void navigator.clipboard.writeText(JSON.stringify(data, null, 2));
-            }}
-          />
-        )}
       </div>
 
       {/* Section content */}
@@ -189,6 +176,7 @@ const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
           transparentBackground
           paddingSize="m"
           overflowHeight={300}
+          isCopyable
         >
           {JSON.stringify(data ?? null, null, 2)}
         </EuiCodeBlock>
@@ -392,6 +380,14 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                     flexShrink: 0,
                   }}
                 >
+                  {selectedLightStep?.stepType && (
+                    <StepIcon
+                      stepType={selectedLightStep.stepType}
+                      executionStatus={selectedLightStep.status}
+                      size="m"
+                      css={{ flexShrink: 0 }}
+                    />
+                  )}
                   <span
                     css={{
                       flex: 1,

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_flyout.tsx
@@ -17,11 +17,16 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
+  EuiHorizontalRule,
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiIcon,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
   EuiLoadingSpinner,
+  EuiPopover,
+  EuiToken,
   EuiTab,
   EuiTabs,
   EuiText,
@@ -31,8 +36,14 @@ import {
 import { css } from '@emotion/react';
 import React, { useLayoutEffect, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
+import type { WorkflowStepExecutionDto } from '@kbn/workflows';
+import { ExecutionStatus } from '@kbn/workflows';
 import { useChildWorkflowExecutions } from '../model/use_child_workflow_executions';
 import { useStepExecution } from '../model/use_step_execution';
+import {
+  buildOverviewStepExecutionFromContext,
+  buildTriggerStepExecutionFromContext,
+} from './workflow_pseudo_step_context';
 import { useWorkflowExecutionPolling } from '../../../entities/workflows/model/use_workflow_execution_polling';
 import { formatDuration } from '../../../shared/lib/format_duration';
 import { getStatusLabel } from '../../../shared/translations/status_translations';
@@ -72,10 +83,20 @@ const FLYOUT_CLASSNAME = 'workflowExecutionFlyout';
 const EXECUTION_PANEL_WIDTH = 480;
 const STEP_DETAIL_WIDTH = 480;
 
+type FieldType = 'string' | 'number' | 'boolean' | 'array' | 'null';
+
+const fieldTypeToToken: Record<FieldType, string> = {
+  string: 'tokenString',
+  number: 'tokenNumber',
+  boolean: 'tokenBoolean',
+  array: 'tokenArray',
+  null: 'tokenNull',
+};
+
 const flattenToRows = (
   value: unknown,
   prefix = ''
-): Array<{ field: string; value: string }> => {
+): Array<{ field: string; value: string; fieldType: FieldType }> => {
   if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
     return [];
   }
@@ -84,6 +105,11 @@ const flattenToRows = (
     if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
       return flattenToRows(val, fullKey);
     }
+    const fieldType: FieldType = val === null
+      ? 'null'
+      : Array.isArray(val)
+      ? 'array'
+      : (typeof val as FieldType);
     const display =
       val === null
         ? 'null'
@@ -92,7 +118,7 @@ const flattenToRows = (
         : typeof val === 'string'
         ? val
         : String(val);
-    return [{ field: fullKey, value: display }];
+    return [{ field: fullKey, value: display, fieldType }];
   });
 };
 
@@ -100,170 +126,305 @@ const isTableable = (v: unknown): boolean =>
   v !== null && v !== undefined && typeof v === 'object' && !Array.isArray(v) &&
   Object.keys(v as object).length > 0;
 
+interface AiStepStats {
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+const extractAiStats = (output: unknown): AiStepStats | null => {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) return null;
+  const o = output as Record<string, unknown>;
+  const usage = o.usage as Record<string, unknown> | undefined;
+  const model = typeof o.model === 'string' ? o.model : undefined;
+  // Cover both snake_case (Bedrock/Claude) and camelCase (OpenAI/agent) field names
+  const inputTokens = (
+    usage?.input_tokens ?? usage?.inputTokens ?? usage?.prompt_tokens
+  ) as number | undefined;
+  const outputTokens = (
+    usage?.output_tokens ?? usage?.outputTokens ?? usage?.completion_tokens
+  ) as number | undefined;
+  if (!model && inputTokens === undefined && outputTokens === undefined) return null;
+  return { model, inputTokens, outputTokens };
+};
+
+const isAiOrAgentStep = (stepType?: string): boolean =>
+  (stepType?.startsWith('ai.') ||
+    stepType?.startsWith('inference.') ||
+    stepType?.startsWith('bedrock.') ||
+    stepType?.startsWith('gen-ai.') ||
+    stepType?.startsWith('gemini.')) ??
+  false;
+
+const AiStatsSection = ({ stats }: { stats: AiStepStats }) => {
+  const { euiTheme } = useEuiTheme();
+  const [isOpen, setIsOpen] = useState(true);
+  const rows: Array<{ icon: string; label: string; value: string }> = [];
+  if (stats.model) {
+    rows.push({ icon: 'productAgent', label: i18n.translate('workflows.executionFlyout.aiStats.model', { defaultMessage: 'Model used' }), value: stats.model });
+  }
+  if (stats.inputTokens !== undefined) {
+    rows.push({ icon: 'inputOutput', label: i18n.translate('workflows.executionFlyout.aiStats.inputTokens', { defaultMessage: 'Input tokens' }), value: String(stats.inputTokens) });
+  }
+  if (stats.outputTokens !== undefined) {
+    rows.push({ icon: 'inputOutput', label: i18n.translate('workflows.executionFlyout.aiStats.outputTokens', { defaultMessage: 'Output tokens' }), value: String(stats.outputTokens) });
+  }
+  if (rows.length === 0) return null;
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: '8px', flexShrink: 0 }}>
+      <div css={{ display: 'flex', alignItems: 'center', height: '32px', gap: '4px' }}>
+        <EuiButtonIcon
+          iconType={isOpen ? 'arrowUp' : 'arrowDown'}
+          size="xs"
+          color="text"
+          aria-label={isOpen ? 'collapse' : 'expand'}
+          onClick={() => setIsOpen((v) => !v)}
+        />
+        <span css={{ fontSize: '14px', fontWeight: 600, color: euiTheme.colors.title }}>
+          {i18n.translate('workflows.executionFlyout.aiStats.label', { defaultMessage: 'Model' })}
+        </span>
+      </div>
+      {isOpen && (
+        <div
+          css={{
+            border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+            borderRadius: '6px',
+            overflow: 'hidden',
+            padding: '0 16px',
+          }}
+        >
+          {rows.map((row, idx) => (
+            <div
+              key={row.label}
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                borderBottom: idx < rows.length - 1 ? `1px solid ${euiTheme.colors.borderBaseSubdued}` : 'none',
+                padding: '8px 0',
+                minHeight: '33px',
+              }}
+            >
+              <EuiIcon type={row.icon} size="s" color="subdued" css={{ flexShrink: 0 }} />
+              <span css={{ flex: '0 0 50%', fontSize: '12px', color: euiTheme.colors.subduedText }}>
+                {row.label}
+              </span>
+              <span css={{ flex: 1, fontSize: '12px', fontFamily: euiTheme.font.familyCode, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {row.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const StepDataSection = ({ label, data }: { label: string; data: unknown }) => {
   const { euiTheme } = useEuiTheme();
   const [view, setView] = useState<'table' | 'code'>(() => (isTableable(data) ? 'table' : 'code'));
-  const [filter, setFilter] = useState('');
+  const [isOpen, setIsOpen] = useState(true);
+  const [isViewPopoverOpen, setIsViewPopoverOpen] = useState(false);
 
   const hasTable = isTableable(data);
   const effectiveView = hasTable ? view : 'code';
 
   const rows = useMemo(() => flattenToRows(data), [data]);
-  const filteredRows = useMemo(
-    () =>
-      filter
-        ? rows.filter(
-            (r) =>
-              r.field.toLowerCase().includes(filter.toLowerCase()) ||
-              r.value.toLowerCase().includes(filter.toLowerCase())
-          )
-        : rows,
-    [rows, filter]
-  );
 
   return (
-    <div
-      css={{
-        border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
-        borderRadius: '10px',
-        overflow: 'hidden',
-        flexShrink: 0,
-      }}
-    >
+    <div css={{ display: 'flex', flexDirection: 'column', gap: '8px', flexShrink: 0 }}>
       {/* Section header bar */}
       <div
         css={{
           display: 'flex',
           alignItems: 'center',
-          height: '40px',
-          padding: '0 16px',
+          height: '32px',
           gap: '4px',
-          background: euiTheme.colors.lightestShade,
-          borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
         }}
       >
-        <span css={{ flex: 1, fontSize: '12px', fontWeight: 600 }}>{label}</span>
-
+        <EuiButtonIcon
+          iconType={isOpen ? 'arrowUp' : 'arrowDown'}
+          size="xs"
+          color="text"
+          onClick={() => setIsOpen((v) => !v)}
+          aria-label={i18n.translate('workflows.executionFlyout.stepDetail.toggleSection', {
+            defaultMessage: '{label} section',
+            values: { label },
+          })}
+        />
+        <span css={{ flex: 1, fontSize: '14px', fontWeight: 600 }}>{label}</span>
         {hasTable && (
-          <>
-            <EuiButtonIcon
-              iconType="list"
-              size="s"
-              color={effectiveView === 'table' ? 'primary' : 'text'}
-              aria-label={i18n.translate('workflows.executionFlyout.stepDetail.tableView', {
-                defaultMessage: 'Table view',
-              })}
-              onClick={() => setView('table')}
+          <EuiPopover
+            isOpen={isViewPopoverOpen}
+            closePopover={() => setIsViewPopoverOpen(false)}
+            anchorPosition="downRight"
+            panelPaddingSize="none"
+            button={
+              <EuiButtonEmpty
+                size="xs"
+                iconType="arrowDown"
+                iconSide="right"
+                onClick={() => setIsViewPopoverOpen((v) => !v)}
+              >
+                {effectiveView === 'table'
+                  ? i18n.translate('workflows.executionFlyout.stepDetail.tableView', {
+                      defaultMessage: 'Table',
+                    })
+                  : i18n.translate('workflows.executionFlyout.stepDetail.codeView', {
+                      defaultMessage: 'JSON',
+                    })}
+              </EuiButtonEmpty>
+            }
+          >
+            <EuiContextMenuPanel
+              items={[
+                <EuiContextMenuItem
+                  key="table"
+                  icon={effectiveView === 'table' ? 'check' : 'empty'}
+                  onClick={() => {
+                    setView('table');
+                    setIsViewPopoverOpen(false);
+                  }}
+                >
+                  {i18n.translate('workflows.executionFlyout.stepDetail.tableView', {
+                    defaultMessage: 'Table',
+                  })}
+                </EuiContextMenuItem>,
+                <EuiContextMenuItem
+                  key="code"
+                  icon={effectiveView === 'code' ? 'check' : 'empty'}
+                  onClick={() => {
+                    setView('code');
+                    setIsViewPopoverOpen(false);
+                  }}
+                >
+                  {i18n.translate('workflows.executionFlyout.stepDetail.codeView', {
+                    defaultMessage: 'JSON',
+                  })}
+                </EuiContextMenuItem>,
+              ]}
             />
-            <EuiButtonIcon
-              iconType="editorCodeBlock"
-              size="s"
-              color={effectiveView === 'code' ? 'primary' : 'text'}
-              aria-label={i18n.translate('workflows.executionFlyout.stepDetail.codeView', {
-                defaultMessage: 'Code view',
-              })}
-              onClick={() => setView('code')}
-            />
-          </>
+          </EuiPopover>
         )}
       </div>
 
       {/* Section content */}
-      {effectiveView === 'code' ? (
-        <EuiCodeBlock
-          language="json"
-          fontSize="s"
-          transparentBackground
-          paddingSize="m"
-          overflowHeight={300}
-          isCopyable
+      {isOpen && (
+        <div
+          css={{
+            border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+            borderRadius: '6px',
+            overflow: 'hidden',
+          }}
         >
-          {JSON.stringify(data ?? null, null, 2)}
-        </EuiCodeBlock>
-      ) : (
-        <>
-          <div css={{ padding: '12px 12px 0' }}>
-            <EuiFieldSearch
-              placeholder={i18n.translate(
-                'workflows.executionFlyout.stepDetail.filterPlaceholder',
-                { defaultMessage: 'Filter by field, value' }
-              )}
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-              compressed
-              fullWidth
-            />
-          </div>
-          <div css={{ padding: '0 12px 12px' }}>
-            <div
-              css={{
-                display: 'flex',
-                borderBottom: `1px solid ${euiTheme.colors.lightShade}`,
-                padding: '7px 8px',
-                marginTop: '10px',
-              }}
+          {effectiveView === 'code' ? (
+            <EuiCodeBlock
+              language="json"
+              fontSize="s"
+              transparentBackground
+              paddingSize="m"
+              overflowHeight={300}
+              isCopyable
+              css={`
+                & .euiCodeBlock__controls {
+                  background: ${euiTheme.colors.emptyShade};
+                  top: 4px;
+                  right: 4px;
+                  padding: 2px;
+                  border-radius: 4px;
+                }
+              `}
             >
-              <span css={{ flex: '0 0 50%', fontSize: '12px', fontWeight: 600 }}>
-                {i18n.translate('workflows.executionFlyout.stepDetail.fieldColumn', {
-                  defaultMessage: 'Field',
-                })}
-              </span>
-              <span css={{ flex: '0 0 50%', fontSize: '12px', fontWeight: 600 }}>
-                {i18n.translate('workflows.executionFlyout.stepDetail.valueColumn', {
-                  defaultMessage: 'Value',
-                })}
-              </span>
-            </div>
-            {filteredRows.length === 0 ? (
+              {JSON.stringify(data ?? null, null, 2)}
+            </EuiCodeBlock>
+          ) : (
+            <div css={{ padding: '16px' }}>
               <div
-                css={{ padding: '12px 8px', fontSize: '12px', color: euiTheme.colors.subduedText }}
+                css={{
+                  display: 'flex',
+                  borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+                  padding: '7px 8px',
+                }}
               >
-                {i18n.translate('workflows.executionFlyout.stepDetail.noData', {
-                  defaultMessage: 'No data',
-                })}
+                <span css={{ flex: '0 0 50%', fontSize: '12px', fontWeight: 600 }}>
+                  {i18n.translate('workflows.executionFlyout.stepDetail.fieldColumn', {
+                    defaultMessage: 'Field',
+                  })}
+                </span>
+                <span css={{ flex: '0 0 50%', fontSize: '12px', fontWeight: 600 }}>
+                  {i18n.translate('workflows.executionFlyout.stepDetail.valueColumn', {
+                    defaultMessage: 'Value',
+                  })}
+                </span>
               </div>
-            ) : (
-              filteredRows.map((row, idx) => (
+              {rows.length === 0 ? (
                 <div
-                  key={idx}
                   css={{
-                    display: 'flex',
-                    borderBottom: `1px solid ${euiTheme.colors.lightShade}`,
-                    padding: '4px 8px',
-                    minHeight: '25px',
-                    alignItems: 'center',
+                    padding: '12px 4px',
+                    fontSize: '12px',
+                    color: euiTheme.colors.subduedText,
                   }}
                 >
-                  <span
-                    css={{
-                      flex: '0 0 50%',
-                      fontSize: '12px',
-                      fontFamily: euiTheme.font.familyCode,
-                      color: euiTheme.colors.subduedText,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      paddingRight: '8px',
-                    }}
-                  >
-                    {row.field}
-                  </span>
-                  <span
-                    css={{
-                      flex: '0 0 50%',
-                      fontSize: '12px',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {row.value}
-                  </span>
+                  {i18n.translate('workflows.executionFlyout.stepDetail.noData', {
+                    defaultMessage: 'No data',
+                  })}
                 </div>
-              ))
-            )}
-          </div>
-        </>
+              ) : (
+                rows.map((row, idx) => (
+                  <div
+                    key={idx}
+                    css={{
+                      display: 'flex',
+                      borderBottom: idx < rows.length - 1 ? `1px solid ${euiTheme.colors.borderBaseSubdued}` : 'none',
+                      padding: '4px 4px',
+                      minHeight: '33px',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <span
+                      css={{
+                        flex: '0 0 50%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '4px',
+                        overflow: 'hidden',
+                        paddingRight: '8px',
+                      }}
+                    >
+                      <EuiToken
+                        iconType={fieldTypeToToken[row.fieldType]}
+                        size="xs"
+                        css={{ flexShrink: 0, width: '12px', height: '12px', margin: 0 }}
+                      />
+                      <span
+                        css={{
+                          fontSize: '12px',
+                          fontFamily: euiTheme.font.familyCode,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {row.field}
+                      </span>
+                    </span>
+                    <span
+                      css={{
+                        flex: '0 0 50%',
+                        fontSize: '12px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {row.value}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
       )}
     </div>
   );
@@ -290,6 +451,7 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
     const { euiTheme } = useEuiTheme();
     const [activeTab, setActiveTab] = useState<FlyoutTabId>('table');
     const [selectedStepExecutionId, setSelectedStepExecutionId] = useState<string | null>(null);
+    const [stepSearchQuery, setStepSearchQuery] = useState('');
 
     const { workflowExecution, error } = useWorkflowExecutionPolling(executionId);
 
@@ -299,9 +461,48 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
       [workflowExecution?.stepExecutions, selectedStepExecutionId]
     );
 
+    const isPseudoStep =
+      selectedStepExecutionId === '__overview' ||
+      selectedStepExecutionId === 'trigger' ||
+      (selectedStepExecutionId?.startsWith('if-branch:') ?? false);
+
+    const pseudoStepExecution = useMemo<WorkflowStepExecutionDto | null>(() => {
+      if (!workflowExecution) return null;
+      if (selectedStepExecutionId === 'trigger') {
+        return buildTriggerStepExecutionFromContext(workflowExecution);
+      }
+      if (selectedStepExecutionId === '__overview') {
+        return buildOverviewStepExecutionFromContext(workflowExecution);
+      }
+      if (selectedStepExecutionId?.startsWith('if-branch:')) {
+        const branchName = selectedStepExecutionId.split(':')[1];
+        return {
+          id: selectedStepExecutionId,
+          stepId: branchName,
+          stepType: 'if-branch',
+          status: ExecutionStatus.COMPLETED,
+          input: undefined,
+          output: { result: branchName } as unknown as WorkflowStepExecutionDto['output'],
+          scopeStack: [],
+          workflowRunId: workflowExecution.id,
+          workflowId: workflowExecution.workflowId ?? '',
+          startedAt: '',
+          globalExecutionIndex: -1,
+          stepExecutionIndex: 0,
+          topologicalIndex: -1,
+        } as WorkflowStepExecutionDto;
+      }
+      return null;
+    }, [selectedStepExecutionId, workflowExecution]);
+
+    const executionMetadata = useMemo(() => {
+      if (!workflowExecution || selectedStepExecutionId !== 'trigger') return null;
+      return buildOverviewStepExecutionFromContext(workflowExecution).input;
+    }, [selectedStepExecutionId, workflowExecution]);
+
     const { data: fullStepExecution, isLoading: isLoadingStepData } = useStepExecution(
       executionId,
-      selectedStepExecutionId ?? undefined,
+      isPseudoStep ? undefined : (selectedStepExecutionId ?? undefined),
       selectedLightStep?.status
     );
     const { childExecutions, isLoading: isLoadingChildExecutions } =
@@ -321,7 +522,8 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
       [workflowExecution?.duration]
     );
 
-    const stepName = selectedLightStep?.stepId ?? fullStepExecution?.stepId ?? '';
+    const activeStepExecution = fullStepExecution ?? pseudoStepExecution;
+    const stepName = selectedLightStep?.stepId ?? activeStepExecution?.stepId ?? '';
 
     // Widen the flyout DOM element when the step detail panel is open (FlyoutPanels pattern).
     useLayoutEffect(() => {
@@ -409,7 +611,9 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                   />
                 </div>
 
-                {isLoadingStepData ? (
+                <EuiHorizontalRule margin="none" css={{ marginLeft: '-16px', marginRight: '-16px', width: 'calc(100% + 32px)' }} />
+
+                {isLoadingStepData && !isPseudoStep ? (
                   <EuiFlexGroup justifyContent="center">
                     <EuiFlexItem grow={false}>
                       <EuiLoadingSpinner size="l" />
@@ -417,20 +621,38 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                   </EuiFlexGroup>
                 ) : (
                   <>
+                    {executionMetadata && (
+                      <StepDataSection
+                        key={`metadata-${selectedStepExecutionId}`}
+                        label={i18n.translate('workflows.executionFlyout.stepDetail.metadata', {
+                          defaultMessage: 'Metadata',
+                        })}
+                        data={executionMetadata}
+                      />
+                    )}
                     <StepDataSection
                       key={`input-${selectedStepExecutionId}`}
                       label={i18n.translate('workflows.executionFlyout.stepDetail.input', {
                         defaultMessage: 'Input',
                       })}
-                      data={fullStepExecution?.input}
+                      data={activeStepExecution?.input}
                     />
-                    <StepDataSection
-                      key={`output-${selectedStepExecutionId}`}
-                      label={i18n.translate('workflows.executionFlyout.stepDetail.output', {
-                        defaultMessage: 'Output',
-                      })}
-                      data={fullStepExecution?.error ?? fullStepExecution?.output}
-                    />
+                    {!isPseudoStep && (() => {
+                      const stepType = selectedLightStep?.stepType ?? activeStepExecution?.stepType;
+                      const aiStats = isAiOrAgentStep(stepType)
+                        ? extractAiStats(activeStepExecution?.output)
+                        : null;
+                      return aiStats ? <AiStatsSection stats={aiStats} /> : null;
+                    })()}
+                    {!isPseudoStep && (
+                      <StepDataSection
+                        key={`output-${selectedStepExecutionId}`}
+                        label={i18n.translate('workflows.executionFlyout.stepDetail.output', {
+                          defaultMessage: 'Output',
+                        })}
+                        data={activeStepExecution?.error ?? activeStepExecution?.output}
+                      />
+                    )}
                   </>
                 )}
               </div>
@@ -649,6 +871,24 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                       {i18nTexts.jsonTab}
                     </EuiTab>
                   </EuiTabs>
+                  {activeTab === 'table' && (
+                    <div css={{ padding: `${euiTheme.size.base} ${euiTheme.size.base} 0` }}>
+                      <EuiFieldSearch
+                        fullWidth
+                        compressed
+                        placeholder={i18n.translate(
+                          'workflows.executionFlyout.stepSearch.placeholder',
+                          { defaultMessage: 'Type text' }
+                        )}
+                        value={stepSearchQuery}
+                        onChange={(e) => setStepSearchQuery(e.target.value)}
+                        aria-label={i18n.translate(
+                          'workflows.executionFlyout.stepSearch.ariaLabel',
+                          { defaultMessage: 'Search steps' }
+                        )}
+                      />
+                    </div>
+                  )}
                   <div
                     css={{
                       padding: `${euiTheme.size.s} ${euiTheme.size.base} ${euiTheme.size.base}`,
@@ -663,6 +903,7 @@ export const WorkflowExecutionFlyout = React.memo<WorkflowExecutionFlyoutProps>(
                         selectedId={selectedStepExecutionId}
                         childExecutionsMap={childExecutions}
                         isLoadingChildExecutions={isLoadingChildExecutions}
+                        searchQuery={stepSearchQuery}
                       />
                     )}
                     {activeTab === 'json' && workflowExecution && (

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_overview.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_overview.tsx
@@ -15,7 +15,6 @@ import { i18n } from '@kbn/i18n';
 import type { WorkflowStepExecutionDto } from '@kbn/workflows';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
 import { ResumeExecutionButton } from './resume_execution_button';
-import { StepExecutionDataView } from './step_execution_data_view';
 import { formatDuration } from '../../../shared/lib/format_duration';
 import { getStatusLabel } from '../../../shared/translations/status_translations';
 import { FormattedRelativeEnhanced } from '../../../shared/ui/formatted_relative_enhanced/formatted_relative_enhanced';
@@ -207,9 +206,6 @@ export const WorkflowExecutionOverview = React.memo<WorkflowExecutionOverviewPro
               />
             </EuiFlexItem>
           )}
-          <EuiFlexItem css={{ overflow: 'hidden', minHeight: 0 }}>
-            <StepExecutionDataView stepExecution={stepExecution} mode="input" />
-          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>
     );

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -133,8 +133,32 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
     const isForeachOrWhile =
       stepExecution?.stepType === 'foreach' || stepExecution?.stepType === 'while';
 
+    // Detect foreach/while steps by finding child steps in allStepExecutions whose scopeStack
+    // references this step. This works even when stepType is absent from the lightweight poll.
+    const foreachRows = useMemo(() => {
+      const stepId = stepExecution?.stepId;
+      if (!stepId || !allStepExecutions?.length || !onSelectStepExecution) {
+        return [];
+      }
+      const result: Array<{ iterNum: number; step: WorkflowStepExecutionDto }> = [];
+      for (const s of allStepExecutions) {
+        const frame = s.scopeStack.find((f) => f.stepId === stepId);
+        const iterScope = frame?.nestedScopes.find((sc) => sc.scopeId !== undefined);
+        if (!iterScope?.scopeId) continue;
+        const iterNum = parseInt(iterScope.scopeId, 10);
+        if (isNaN(iterNum)) continue;
+        result.push({ iterNum, step: s });
+      }
+      result.sort(
+        (a, b) =>
+          a.iterNum - b.iterNum ||
+          (a.step.globalExecutionIndex ?? 0) - (b.step.globalExecutionIndex ?? 0)
+      );
+      return result;
+    }, [stepExecution?.stepId, allStepExecutions, onSelectStepExecution]);
+
     const showInput = hasInput;
-    const showOutput = hasOutput || hasError || isForeachOrWhile;
+    const showOutput = hasOutput || hasError || isForeachOrWhile || foreachRows.length > 0;
 
     if (!stepExecution) {
       return (
@@ -273,10 +297,10 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
                   )}
                   {showOutput && (
                     <EuiFlexItem grow={false}>
-                      {isForeachOrWhile && allStepExecutions?.length && onSelectStepExecution ? (
+                      {foreachRows.length > 0 && onSelectStepExecution ? (
                         <ForeachIterationStepList
-                          stepExecution={stepExecution}
-                          allStepExecutions={allStepExecutions}
+                          executionId={stepExecution.id}
+                          rows={foreachRows}
                           onSelectStep={onSelectStepExecution}
                         />
                       ) : (

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -26,6 +26,7 @@ import { hasActiveModifierKey } from '@kbn/shared-ux-utility';
 import type { ChildWorkflowExecutionItem, WorkflowStepExecutionDto } from '@kbn/workflows';
 import { ExecutionStatus, isExecuteSyncStepType, isTerminalStatus } from '@kbn/workflows';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
+import { ForeachIterationStepList } from './foreach_iteration_step_list';
 import { ResumeExecutionButton } from './resume_execution_button';
 import { StepExecutionDataView } from './step_execution_data_view';
 import { WorkflowExecutionOverview } from './workflow_execution_overview';
@@ -48,6 +49,7 @@ interface WorkflowStepExecutionDetailsProps {
   childWorkflowExecution?: ChildWorkflowExecutionItem;
   /** When viewing a step that belongs to a nested execution, the parent workflow execution (to link to) */
   parentWorkflowExecution?: WorkflowExecutionLinkInfo;
+  onSelectStepExecution?: (stepExecutionId: string) => void;
 }
 
 export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDetailsProps>(
@@ -64,6 +66,7 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
     waitingStepExecutionId,
     childWorkflowExecution,
     parentWorkflowExecution,
+    onSelectStepExecution,
   }) => {
     const { euiTheme } = useEuiTheme();
     const workflowNav = useNavigateToExecution(
@@ -270,11 +273,19 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
                   )}
                   {showOutput && (
                     <EuiFlexItem grow={false}>
-                      <StepExecutionDataView
-                        stepExecution={stepExecution}
-                        mode="output"
-                        allStepExecutions={allStepExecutions}
-                      />
+                      {isForeachOrWhile && allStepExecutions?.length && onSelectStepExecution ? (
+                        <ForeachIterationStepList
+                          stepExecution={stepExecution}
+                          allStepExecutions={allStepExecutions}
+                          onSelectStep={onSelectStepExecution}
+                        />
+                      ) : (
+                        <StepExecutionDataView
+                          stepExecution={stepExecution}
+                          mode="output"
+                          allStepExecutions={allStepExecutions}
+                        />
+                      )}
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -36,6 +36,7 @@ import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
 interface WorkflowStepExecutionDetailsProps {
   workflowExecutionId: string;
   stepExecution?: WorkflowStepExecutionDto;
+  allStepExecutions?: WorkflowStepExecutionDto[];
   workflowExecutionDuration?: number;
   isLoadingStepData?: boolean;
   workflowExecutionStatus?: ExecutionStatus;
@@ -53,6 +54,7 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
   ({
     workflowExecutionId,
     stepExecution,
+    allStepExecutions,
     workflowExecutionDuration,
     isLoadingStepData,
     workflowExecutionStatus,
@@ -125,9 +127,11 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
     const hasInput = Boolean(stepExecution?.input);
     const hasOutput = Boolean(stepExecution?.output);
     const hasError = Boolean(stepExecution?.error);
+    const isForeachOrWhile =
+      stepExecution?.stepType === 'foreach' || stepExecution?.stepType === 'while';
 
     const showInput = hasInput;
-    const showOutput = hasOutput || hasError;
+    const showOutput = hasOutput || hasError || isForeachOrWhile;
 
     if (!stepExecution) {
       return (
@@ -266,7 +270,11 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
                   )}
                   {showOutput && (
                     <EuiFlexItem grow={false}>
-                      <StepExecutionDataView stepExecution={stepExecution} mode="output" />
+                      <StepExecutionDataView
+                        stepExecution={stepExecution}
+                        mode="output"
+                        allStepExecutions={allStepExecutions}
+                      />
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -16,12 +16,10 @@ import {
   EuiPanel,
   EuiSkeletonText,
   EuiSpacer,
-  EuiTab,
-  EuiTabs,
   EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { hasActiveModifierKey } from '@kbn/shared-ux-utility';
@@ -128,49 +126,8 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
     const hasOutput = Boolean(stepExecution?.output);
     const hasError = Boolean(stepExecution?.error);
 
-    const tabs = useMemo(() => {
-      if (isTriggerPseudoStep) {
-        const pseudoTabs: { id: string; name: string }[] = [];
-        if (hasError) {
-          pseudoTabs.push({
-            id: 'output',
-            name: 'Error',
-          });
-        }
-        if (hasInput) {
-          pseudoTabs.push({
-            id: 'input',
-            name: 'Input',
-          });
-        }
-        if (hasOutput) {
-          pseudoTabs.push({
-            id: 'output',
-            name: 'Output',
-          });
-        }
-        return pseudoTabs;
-      }
-      return [
-        {
-          id: 'output',
-          name: hasError ? 'Error' : 'Output',
-        },
-        {
-          id: 'input',
-          name: 'Input',
-        },
-      ];
-    }, [hasInput, hasOutput, hasError, isTriggerPseudoStep]);
-
-    const defaultTabId = isWaitingForInput ? 'input' : tabs[0]?.id ?? 'input';
-    const [selectedTabId, setSelectedTabId] = useState<string>(defaultTabId);
-
-    useEffect(() => {
-      // reset the tab to the default one on step change
-      setSelectedTabId(isWaitingForInput ? 'input' : tabs[0]?.id ?? 'input');
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [stepExecution?.stepId, stepExecution?.status, tabs[0].id]);
+    const showInput = hasInput;
+    const showOutput = hasOutput || hasError;
 
     if (!stepExecution) {
       return (
@@ -250,21 +207,6 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
               </EuiFlexGroup>
             </EuiFlexItem>
           )}
-          <EuiFlexItem grow={false}>
-            <EuiTabs expand>
-              {tabs.map((tab) => (
-                <EuiTab
-                  onClick={() => setSelectedTabId(tab.id)}
-                  isSelected={tab.id === selectedTabId}
-                  key={tab.id}
-                  css={{ lineHeight: 'normal' }}
-                  data-test-subj={`workflowStepTab_${tab.id}`}
-                >
-                  {tab.name}
-                </EuiTab>
-              ))}
-            </EuiTabs>
-          </EuiFlexItem>
           {isFinished ? (
             <EuiFlexItem css={{ overflowY: 'auto' }}>
               {isLoadingStepData ? (
@@ -272,12 +214,9 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
                   <EuiSkeletonText lines={4} />
                 </EuiPanel>
               ) : (
-                <>
-                  {selectedTabId === 'output' && (
-                    <StepExecutionDataView stepExecution={stepExecution} mode="output" />
-                  )}
-                  {selectedTabId === 'input' && (
-                    <>
+                <EuiFlexGroup direction="column" gutterSize="m">
+                  {showInput && (
+                    <EuiFlexItem grow={false}>
                       {isWaitingForInput && (
                         <>
                           <ResumeExecutionButton
@@ -323,9 +262,14 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
                         </>
                       )}
                       <StepExecutionDataView stepExecution={stepExecution} mode="input" />
-                    </>
+                    </EuiFlexItem>
                   )}
-                </>
+                  {showOutput && (
+                    <EuiFlexItem grow={false}>
+                      <StepExecutionDataView stepExecution={stepExecution} mode="output" />
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
               )}
             </EuiFlexItem>
           ) : (

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -145,8 +145,15 @@ function convertTreeToEuiTreeViewItems(
       item.stepType === 'if-branch' && !stepExecution
         ? `if-branch:${item.stepId}:${item.executionIndex}`
         : null;
+    // Enter-case-branch nodes (switch step cases) — same pattern, status encoded for the detail panel
+    const enterCaseBranchVirtualId =
+      item.stepType === 'enter-case-branch' && !stepExecution
+        ? `enter-case-branch:${item.stepId}:${item.executionIndex}:${item.status ?? ExecutionStatus.COMPLETED}`
+        : null;
     const selected = ifBranchVirtualId
       ? selectedId === ifBranchVirtualId
+      : enterCaseBranchVirtualId
+      ? selectedId === enterCaseBranchVirtualId
       : selectedId === stepExecution?.id;
 
     const stepId = stepExecution?.stepId ?? item.stepId;
@@ -165,6 +172,8 @@ function convertTreeToEuiTreeViewItems(
         onSelectStepExecution(stepExecution.id);
       } else if (ifBranchVirtualId) {
         onSelectStepExecution(ifBranchVirtualId);
+      } else if (enterCaseBranchVirtualId) {
+        onSelectStepExecution(enterCaseBranchVirtualId);
       }
     };
 
@@ -359,12 +368,12 @@ const filterStepTree = (
   }, []);
 };
 
-// Flatten virtual container nodes (if-branch, foreach-iteration, while-iteration):
-// - if-branch: promote branch label as a leaf, hoist its children to the same level
+// Flatten virtual container nodes (if-branch, foreach-iteration, while-iteration, enter-case-branch):
+// - if-branch / enter-case-branch: promote branch label as a leaf, hoist its children to the same level
 // - foreach/while-iteration: skip the container, hoist children with the iteration index as attemptNumber
 const flattenIfBranches = (items: StepExecutionTreeItem[]): StepExecutionTreeItem[] =>
   items.flatMap((item) => {
-    if (item.stepType === 'if-branch') {
+    if (item.stepType === 'if-branch' || item.stepType === 'enter-case-branch') {
       const branchTaken = item.children.some((c) => c.stepExecutionId != null);
       return [
         { ...item, status: branchTaken ? ExecutionStatus.COMPLETED : ExecutionStatus.SKIPPED, children: [] },

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -54,6 +54,79 @@ const TRIGGER_BOLT_ICON_SVG =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="%23535966" d="M7.04 13.274a.5.5 0 1 0 .892.453l3.014-5.931a.5.5 0 0 0-.445-.727H5.316L8.03 1.727a.5.5 0 1 0-.892-.453L4.055 7.343a.5.5 0 0 0 .446.726h5.185L7.04 13.274Z"/></svg>';
 
 
+function buildIterationExpandButton(
+  foreachParentId: string,
+  hiddenAttempts: number[],
+  hiddenChildren: StepExecutionTreeItem[],
+  stepExecutionMap: Map<string, WorkflowStepExecutionDto>,
+  euiTheme: EuiThemeComputed,
+  onToggleForeach: (id: string) => void
+): EuiTreeViewProps['items'][number] {
+  const minHidden = hiddenAttempts[0];
+  const maxHidden = hiddenAttempts[hiddenAttempts.length - 1];
+
+  const allHiddenFailed =
+    hiddenChildren.length > 0 &&
+    hiddenChildren.every((c) => {
+      const childExec = stepExecutionMap.get(c.stepExecutionId ?? '');
+      const childStatus = childExec?.status ?? c.status;
+      return childStatus != null && isDangerousStatus(childStatus);
+    });
+  const expandIconColor = allHiddenFailed
+    ? euiTheme.colors.danger
+    : euiTheme.colors.vis.euiColorVisSuccess0;
+
+  const handleExpand: React.MouseEventHandler = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onToggleForeach(foreachParentId);
+  };
+
+  return {
+    id: `foreach-expand-${foreachParentId}`,
+    label: (
+      <span
+        onClick={handleExpand}
+        css={css({
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          cursor: 'pointer',
+          fontSize: `${euiTheme.font.scale.s * euiTheme.base}px`,
+          lineHeight: euiTheme.font.lineHeightMultiplier,
+        })}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden={true}
+          css={css({ flexShrink: 0, color: expandIconColor })}
+        >
+          <path
+            d="M1 14L15 14V15L1 15L1 14ZM1 1L15 1V2L1 2L1 1ZM4 10L12 10V6L4 6L4 10ZM12 5C12.5523 5 13 5.44771 13 6V10C13 10.5523 12.5523 11 12 11L4 11C3.44772 11 3 10.5523 3 10L3 6C3 5.44772 3.44772 5 4 5L12 5Z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          css={css({
+            color: allHiddenFailed ? euiTheme.colors.danger : euiTheme.colors.textSubdued,
+            fontVariantNumeric: 'tabular-nums',
+          })}
+        >
+          #{minHidden}-{maxHidden}
+        </span>
+      </span>
+    ),
+    callback: () => {
+      onToggleForeach(foreachParentId);
+      return foreachParentId;
+    },
+  };
+}
+
 function convertTreeToEuiTreeViewItems(
   treeItems: StepExecutionTreeItem[],
   stepExecutionMap: Map<string, WorkflowStepExecutionDto>,
@@ -63,7 +136,7 @@ function convertTreeToEuiTreeViewItems(
   expandedForeachIds: Set<string>,
   onToggleForeach: (id: string) => void
 ): EuiTreeViewProps['items'] {
-  return treeItems.map((item) => {
+  return treeItems.flatMap((item) => {
     const stepExecution = stepExecutionMap.get(item.stepExecutionId ?? '');
     const status = (stepExecution?.status ?? item.status) ?? undefined;
 
@@ -98,7 +171,55 @@ function convertTreeToEuiTreeViewItems(
     // Check if this is a trigger pseudo-step
     const isTriggerPseudoStep = stepType.startsWith('trigger_');
 
-    return {
+    // Detect iteration children (have attemptNumber set by flattenIfBranches / flattenRetryAttempts)
+    const foreachChildAttempts = item.children
+      .map((c) => c.attemptNumber)
+      .filter((n): n is number => n !== undefined);
+
+    const isForeachOrWhileParent = stepType === 'foreach' || stepType === 'while';
+
+    // Retry parent: all children are retry attempts but the step is NOT a foreach/while loop.
+    // Remove the parent container and return children as siblings at this level.
+    if (foreachChildAttempts.length > 0 && !isForeachOrWhileParent) {
+      const foreachParentId = item.stepExecutionId ?? `${item.stepId}-${item.executionIndex}`;
+      const isExpanded = expandedForeachIds.has(foreachParentId);
+      const uniqueAttempts = [...new Set(foreachChildAttempts)];
+      const maxAttempt = Math.max(...uniqueAttempts);
+      const lastIterChildren = item.children.filter((c) => c.attemptNumber === maxAttempt);
+      const hiddenAttempts = uniqueAttempts.filter((n) => n !== maxAttempt).sort((a, b) => a - b);
+
+      const visibleChildren = isExpanded ? item.children : lastIterChildren;
+      const euiVisibleChildren = convertTreeToEuiTreeViewItems(
+        visibleChildren,
+        stepExecutionMap,
+        euiTheme,
+        selectedId,
+        onSelectStepExecution,
+        expandedForeachIds,
+        onToggleForeach
+      );
+
+      if (!isExpanded && hiddenAttempts.length > 0) {
+        const hiddenChildren = item.children.filter(
+          (c) => c.attemptNumber !== undefined && hiddenAttempts.includes(c.attemptNumber)
+        );
+        return [
+          buildIterationExpandButton(
+            foreachParentId,
+            hiddenAttempts,
+            hiddenChildren,
+            stepExecutionMap,
+            euiTheme,
+            onToggleForeach
+          ),
+          ...euiVisibleChildren,
+        ];
+      }
+
+      return euiVisibleChildren;
+    }
+
+    return [{
       id: item.stepExecutionId ?? ifBranchVirtualId ?? `${item.stepId}-${item.executionIndex}-no-step-execution`,
       css: [
         getStatusCss({ status, selected }, euiTheme),
@@ -142,12 +263,8 @@ function convertTreeToEuiTreeViewItems(
       children: (() => {
         if (item.children.length === 0) return undefined;
 
-        // Detect foreach/while iteration children (have attemptNumber set by flattenIfBranches)
-        const foreachChildAttempts = item.children
-          .map((c) => c.attemptNumber)
-          .filter((n): n is number => n !== undefined);
-
-        if (foreachChildAttempts.length > 0) {
+        // foreach/while parent: keep parent as container, show collapse button + last iteration
+        if (foreachChildAttempts.length > 0 && isForeachOrWhileParent) {
           const foreachParentId =
             item.stepExecutionId ?? `${item.stepId}-${item.executionIndex}`;
           const isExpanded = expandedForeachIds.has(foreachParentId);
@@ -156,10 +273,9 @@ function convertTreeToEuiTreeViewItems(
           const lastIterChildren = item.children.filter(
             (c) => c.attemptNumber === maxAttempt
           );
-          const hiddenAttempts = uniqueAttempts.filter((n) => n !== maxAttempt).sort((a, b) => a - b);
-          const hiddenIterationCount = hiddenAttempts.length;
-          const minHidden = hiddenAttempts[0];
-          const maxHidden = hiddenAttempts[hiddenAttempts.length - 1];
+          const hiddenAttempts = uniqueAttempts
+            .filter((n) => n !== maxAttempt)
+            .sort((a, b) => a - b);
 
           const visibleChildren = isExpanded ? item.children : lastIterChildren;
           const euiVisibleChildren = convertTreeToEuiTreeViewItems(
@@ -172,51 +288,21 @@ function convertTreeToEuiTreeViewItems(
             onToggleForeach
           );
 
-          if (!isExpanded && hiddenIterationCount > 0) {
-            const handleExpand: React.MouseEventHandler = (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onToggleForeach(foreachParentId);
-            };
-            const expandButtonItem: EuiTreeViewProps['items'][number] = {
-              id: `foreach-expand-${foreachParentId}`,
-              label: (
-                <span
-                  onClick={handleExpand}
-                  css={css({
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '6px',
-                    cursor: 'pointer',
-                    fontSize: `${euiTheme.font.scale.s * euiTheme.base}px`,
-                    lineHeight: euiTheme.font.lineHeightMultiplier,
-                  })}
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden={true}
-                    css={css({ flexShrink: 0, color: euiTheme.colors.vis.euiColorVisSuccess0 })}
-                  >
-                    <path
-                      d="M1 14L15 14V15L1 15L1 14ZM1 1L15 1V2L1 2L1 1ZM4 10L12 10V6L4 6L4 10ZM12 5C12.5523 5 13 5.44771 13 6V10C13 10.5523 12.5523 11 12 11L4 11C3.44772 11 3 10.5523 3 10L3 6C3 5.44772 3.44772 5 4 5L12 5Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <span css={css({ color: euiTheme.colors.textSubdued, fontVariantNumeric: 'tabular-nums' })}>
-                    #{minHidden}-{maxHidden}
-                  </span>
-                </span>
+          if (!isExpanded && hiddenAttempts.length > 0) {
+            const hiddenChildren = item.children.filter(
+              (c) => c.attemptNumber !== undefined && hiddenAttempts.includes(c.attemptNumber)
+            );
+            return [
+              buildIterationExpandButton(
+                foreachParentId,
+                hiddenAttempts,
+                hiddenChildren,
+                stepExecutionMap,
+                euiTheme,
+                onToggleForeach
               ),
-              callback: () => {
-                onToggleForeach(foreachParentId);
-                return foreachParentId;
-              },
-            };
-            return [expandButtonItem, ...euiVisibleChildren];
+              ...euiVisibleChildren,
+            ];
           }
 
           return euiVisibleChildren;
@@ -244,7 +330,7 @@ function convertTreeToEuiTreeViewItems(
           }
           return toOpen ?? '';
         },
-    };
+    }];
   });
 }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -15,7 +15,6 @@ import type {
 } from '@elastic/eui';
 import {
   EuiEmptyPrompt,
-  EuiHorizontalRule,
   EuiIcon,
   EuiLoadingSpinner,
   EuiText,
@@ -54,16 +53,19 @@ import type { ChildWorkflowExecutionsMap } from '../model/use_child_workflow_exe
 const TRIGGER_BOLT_ICON_SVG =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="%23535966" d="M7.04 13.274a.5.5 0 1 0 .892.453l3.014-5.931a.5.5 0 0 0-.445-.727H5.316L8.03 1.727a.5.5 0 1 0-.892-.453L4.055 7.343a.5.5 0 0 0 .446.726h5.185L7.04 13.274Z"/></svg>';
 
+
 function convertTreeToEuiTreeViewItems(
   treeItems: StepExecutionTreeItem[],
   stepExecutionMap: Map<string, WorkflowStepExecutionDto>,
   euiTheme: EuiThemeComputed,
   selectedId: string | null,
-  onSelectStepExecution: (stepExecutionId: string) => void
+  onSelectStepExecution: (stepExecutionId: string) => void,
+  expandedForeachIds: Set<string>,
+  onToggleForeach: (id: string) => void
 ): EuiTreeViewProps['items'] {
   return treeItems.map((item) => {
     const stepExecution = stepExecutionMap.get(item.stepExecutionId ?? '');
-    const status = stepExecution?.status ?? item.status;
+    const status = (stepExecution?.status ?? item.status) ?? undefined;
 
     // If-branch nodes have no real step execution; give them a stable virtual ID
     const ifBranchVirtualId =
@@ -137,16 +139,111 @@ function convertTreeToEuiTreeViewItems(
           attemptNumber={item.attemptNumber}
         />
       ),
-      children:
-        item.children.length > 0
-          ? convertTreeToEuiTreeViewItems(
-              item.children,
-              stepExecutionMap,
-              euiTheme,
-              selectedId,
-              onSelectStepExecution
-            )
-          : undefined,
+      children: (() => {
+        if (item.children.length === 0) return undefined;
+
+        // Detect foreach/while iteration children (have attemptNumber set by flattenIfBranches)
+        const foreachChildAttempts = item.children
+          .map((c) => c.attemptNumber)
+          .filter((n): n is number => n !== undefined);
+
+        if (foreachChildAttempts.length > 0) {
+          const foreachParentId =
+            item.stepExecutionId ?? `${item.stepId}-${item.executionIndex}`;
+          const isExpanded = expandedForeachIds.has(foreachParentId);
+          const uniqueAttempts = [...new Set(foreachChildAttempts)];
+          const maxAttempt = Math.max(...uniqueAttempts);
+          const lastIterChildren = item.children.filter(
+            (c) => c.attemptNumber === maxAttempt
+          );
+          const hiddenAttempts = uniqueAttempts.filter((n) => n !== maxAttempt).sort((a, b) => a - b);
+          const hiddenIterationCount = hiddenAttempts.length;
+          const minHidden = hiddenAttempts[0];
+          const maxHidden = hiddenAttempts[hiddenAttempts.length - 1];
+
+          const visibleChildren = isExpanded ? item.children : lastIterChildren;
+          const euiVisibleChildren = convertTreeToEuiTreeViewItems(
+            visibleChildren,
+            stepExecutionMap,
+            euiTheme,
+            selectedId,
+            onSelectStepExecution,
+            expandedForeachIds,
+            onToggleForeach
+          );
+
+          if (!isExpanded && hiddenIterationCount > 0) {
+            const handleExpand: React.MouseEventHandler = (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onToggleForeach(foreachParentId);
+            };
+            const expandButtonItem: EuiTreeViewProps['items'][number] = {
+              id: `foreach-expand-${foreachParentId}`,
+              icon: (
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  onClick={handleExpand}
+                  aria-hidden={true}
+                  css={css({ cursor: 'pointer', flexShrink: 0, color: euiTheme.colors.vis.euiColorVisSuccess0 })}
+                >
+                  <path
+                    d="M1 14L15 14V15L1 15L1 14ZM1 1L15 1V2L1 2L1 1ZM4 10L12 10V6L4 6L4 10ZM12 5C12.5523 5 13 5.44771 13 6V10C13 10.5523 12.5523 11 12 11L4 11C3.44772 11 3 10.5523 3 10L3 6C3 5.44772 3.44772 5 4 5L12 5Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              ),
+              label: (
+                <div
+                  onClick={handleExpand}
+                  css={css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: euiTheme.size.s,
+                    cursor: 'pointer',
+                    width: '100%',
+                    fontSize: `${euiTheme.font.scale.s * euiTheme.base}px`,
+                    lineHeight: euiTheme.font.lineHeightMultiplier,
+                  })}
+                >
+                  <span css={css({ flexShrink: 0, color: euiTheme.colors.textSubdued, fontVariantNumeric: 'tabular-nums' })}>
+                    #{minHidden}-{maxHidden}
+                  </span>
+                  <div
+                    css={css({
+                      flex: '1 1 auto',
+                      height: 0,
+                      borderTop: euiTheme.border.thin,
+                      alignSelf: 'center',
+                    })}
+                  />
+                </div>
+              ),
+              callback: () => {
+                onToggleForeach(foreachParentId);
+                return foreachParentId;
+              },
+            };
+            return [expandButtonItem, ...euiVisibleChildren];
+          }
+
+          return euiVisibleChildren;
+        }
+
+        return convertTreeToEuiTreeViewItems(
+          item.children,
+          stepExecutionMap,
+          euiTheme,
+          selectedId,
+          onSelectStepExecution,
+          expandedForeachIds,
+          onToggleForeach
+        );
+      })(),
       callback:
         // collapse/expand the tree view item when the button is clicked
         () => {
@@ -188,8 +285,9 @@ const filterStepTree = (
   }, []);
 };
 
-// Flatten if-branch container nodes: promote each branch to a leaf and hoist its
-// children to the same level. Status is derived from whether the branch was taken.
+// Flatten virtual container nodes (if-branch, foreach-iteration, while-iteration):
+// - if-branch: promote branch label as a leaf, hoist its children to the same level
+// - foreach/while-iteration: skip the container, hoist children with the iteration index as attemptNumber
 const flattenIfBranches = (items: StepExecutionTreeItem[]): StepExecutionTreeItem[] =>
   items.flatMap((item) => {
     if (item.stepType === 'if-branch') {
@@ -198,6 +296,14 @@ const flattenIfBranches = (items: StepExecutionTreeItem[]): StepExecutionTreeIte
         { ...item, status: branchTaken ? ExecutionStatus.COMPLETED : ExecutionStatus.SKIPPED, children: [] },
         ...flattenIfBranches(item.children),
       ];
+    }
+    if (item.stepType === 'foreach-iteration' || item.stepType === 'while-iteration') {
+      const iterationIndex = parseInt(item.stepId, 10);
+      const hoistedChildren = item.children.map((child) => ({
+        ...child,
+        attemptNumber: isNaN(iterationIndex) ? undefined : iterationIndex,
+      }));
+      return flattenIfBranches(hoistedChildren);
     }
     return [{ ...item, children: flattenIfBranches(item.children) }];
   });
@@ -216,6 +322,18 @@ export const WorkflowStepExecutionTree = ({
 }: WorkflowStepExecutionTreeProps) => {
   const styles = useMemoCss(componentStyles);
   const { euiTheme } = useEuiTheme();
+  const [expandedForeachIds, setExpandedForeachIds] = React.useState<Set<string>>(new Set());
+  const onToggleForeach = React.useCallback((id: string) => {
+    setExpandedForeachIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
 
   const failedBeforeSteps =
     execution != null && isFailedBeforeSteps(execution.status, execution.stepExecutions);
@@ -341,7 +459,9 @@ export const WorkflowStepExecutionTree = ({
       stepExecutionMap,
       euiTheme,
       selectedId,
-      onStepExecutionClick
+      onStepExecutionClick,
+      expandedForeachIds,
+      onToggleForeach
     );
 
     return (

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -180,48 +180,36 @@ function convertTreeToEuiTreeViewItems(
             };
             const expandButtonItem: EuiTreeViewProps['items'][number] = {
               id: `foreach-expand-${foreachParentId}`,
-              icon: (
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  onClick={handleExpand}
-                  aria-hidden={true}
-                  css={css({ cursor: 'pointer', flexShrink: 0, color: euiTheme.colors.vis.euiColorVisSuccess0 })}
-                >
-                  <path
-                    d="M1 14L15 14V15L1 15L1 14ZM1 1L15 1V2L1 2L1 1ZM4 10L12 10V6L4 6L4 10ZM12 5C12.5523 5 13 5.44771 13 6V10C13 10.5523 12.5523 11 12 11L4 11C3.44772 11 3 10.5523 3 10L3 6C3 5.44772 3.44772 5 4 5L12 5Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              ),
               label: (
-                <div
+                <span
                   onClick={handleExpand}
                   css={css({
                     display: 'flex',
                     alignItems: 'center',
-                    gap: euiTheme.size.s,
+                    gap: '6px',
                     cursor: 'pointer',
-                    width: '100%',
                     fontSize: `${euiTheme.font.scale.s * euiTheme.base}px`,
                     lineHeight: euiTheme.font.lineHeightMultiplier,
                   })}
                 >
-                  <span css={css({ flexShrink: 0, color: euiTheme.colors.textSubdued, fontVariantNumeric: 'tabular-nums' })}>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden={true}
+                    css={css({ flexShrink: 0, color: euiTheme.colors.vis.euiColorVisSuccess0 })}
+                  >
+                    <path
+                      d="M1 14L15 14V15L1 15L1 14ZM1 1L15 1V2L1 2L1 1ZM4 10L12 10V6L4 6L4 10ZM12 5C12.5523 5 13 5.44771 13 6V10C13 10.5523 12.5523 11 12 11L4 11C3.44772 11 3 10.5523 3 10L3 6C3 5.44772 3.44772 5 4 5L12 5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span css={css({ color: euiTheme.colors.textSubdued, fontVariantNumeric: 'tabular-nums' })}>
                     #{minHidden}-{maxHidden}
                   </span>
-                  <div
-                    css={css({
-                      flex: '1 1 auto',
-                      height: 0,
-                      borderTop: euiTheme.border.thin,
-                      alignSelf: 'center',
-                    })}
-                  />
-                </div>
+                </span>
               ),
               callback: () => {
                 onToggleForeach(foreachParentId);

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.tsx
@@ -31,12 +31,12 @@ import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type {
-  ExecutionStatus,
   WorkflowExecutionDto,
   WorkflowStepExecutionDto,
   WorkflowYaml,
 } from '@kbn/workflows';
 import {
+  ExecutionStatus,
   isDangerousStatus,
   isFailedBeforeSteps,
   isInProgressStatus,
@@ -46,7 +46,6 @@ import type { StepExecutionTreeItem } from './build_step_executions_tree';
 import { buildStepExecutionsTree, injectChildWorkflowSteps } from './build_step_executions_tree';
 import { StepExecutionTreeItemLabel } from './step_execution_tree_item_label';
 import {
-  buildOverviewStepExecutionFromContext,
   buildTriggerStepExecutionFromContext,
 } from './workflow_pseudo_step_context';
 import { StepIcon } from '../../../shared/ui/step_icons/step_icon';
@@ -64,8 +63,16 @@ function convertTreeToEuiTreeViewItems(
 ): EuiTreeViewProps['items'] {
   return treeItems.map((item) => {
     const stepExecution = stepExecutionMap.get(item.stepExecutionId ?? '');
-    const status = stepExecution?.status;
-    const selected = selectedId === stepExecution?.id;
+    const status = stepExecution?.status ?? item.status;
+
+    // If-branch nodes have no real step execution; give them a stable virtual ID
+    const ifBranchVirtualId =
+      item.stepType === 'if-branch' && !stepExecution
+        ? `if-branch:${item.stepId}:${item.executionIndex}`
+        : null;
+    const selected = ifBranchVirtualId
+      ? selectedId === ifBranchVirtualId
+      : selectedId === stepExecution?.id;
 
     const stepId = stepExecution?.stepId ?? item.stepId;
     const stepType = stepExecution?.stepType ?? item.stepType;
@@ -81,6 +88,8 @@ function convertTreeToEuiTreeViewItems(
       // Don't allow selecting skeleton steps
       if (stepExecution?.id) {
         onSelectStepExecution(stepExecution.id);
+      } else if (ifBranchVirtualId) {
+        onSelectStepExecution(ifBranchVirtualId);
       }
     };
 
@@ -88,7 +97,7 @@ function convertTreeToEuiTreeViewItems(
     const isTriggerPseudoStep = stepType.startsWith('trigger_');
 
     return {
-      id: item.stepExecutionId ?? `${item.stepId}-${item.executionIndex}-no-step-execution`,
+      id: item.stepExecutionId ?? ifBranchVirtualId ?? `${item.stepId}-${item.executionIndex}-no-step-execution`,
       css: [
         getStatusCss({ status, selected }, euiTheme),
         // Don't allow selecting skeleton steps using css, as we don't have a 'disabled' prop on the tree view item
@@ -125,6 +134,7 @@ function convertTreeToEuiTreeViewItems(
           status={status}
           executionTimeMs={stepExecution?.executionTimeMs ?? null}
           onClick={selectStepExecution}
+          attemptNumber={item.attemptNumber}
         />
       ),
       children:
@@ -140,7 +150,7 @@ function convertTreeToEuiTreeViewItems(
       callback:
         // collapse/expand the tree view item when the button is clicked
         () => {
-          let toOpen = item.stepExecutionId;
+          let toOpen = item.stepExecutionId ?? ifBranchVirtualId;
           if (!toOpen && item.children.length) {
             toOpen = item.children[0].stepExecutionId;
           }
@@ -161,7 +171,36 @@ export interface WorkflowStepExecutionTreeProps {
   selectedId: string | null;
   childExecutionsMap?: ChildWorkflowExecutionsMap;
   isLoadingChildExecutions?: boolean;
+  searchQuery?: string;
 }
+
+const filterStepTree = (
+  items: StepExecutionTreeItem[],
+  query: string
+): StepExecutionTreeItem[] => {
+  const lower = query.toLowerCase();
+  return items.reduce<StepExecutionTreeItem[]>((acc, item) => {
+    const filteredChildren = filterStepTree(item.children, query);
+    if (item.stepId.toLowerCase().includes(lower) || filteredChildren.length > 0) {
+      acc.push({ ...item, children: filteredChildren });
+    }
+    return acc;
+  }, []);
+};
+
+// Flatten if-branch container nodes: promote each branch to a leaf and hoist its
+// children to the same level. Status is derived from whether the branch was taken.
+const flattenIfBranches = (items: StepExecutionTreeItem[]): StepExecutionTreeItem[] =>
+  items.flatMap((item) => {
+    if (item.stepType === 'if-branch') {
+      const branchTaken = item.children.some((c) => c.stepExecutionId != null);
+      return [
+        { ...item, status: branchTaken ? ExecutionStatus.COMPLETED : ExecutionStatus.SKIPPED, children: [] },
+        ...flattenIfBranches(item.children),
+      ];
+    }
+    return [{ ...item, children: flattenIfBranches(item.children) }];
+  });
 
 const emptyPromptCommonProps: EuiEmptyPromptProps = { titleSize: 'xs', paddingSize: 's' };
 
@@ -173,6 +212,7 @@ export const WorkflowStepExecutionTree = ({
   selectedId,
   childExecutionsMap,
   isLoadingChildExecutions,
+  searchQuery,
 }: WorkflowStepExecutionTreeProps) => {
   const styles = useMemoCss(componentStyles);
   const { euiTheme } = useEuiTheme();
@@ -280,12 +320,6 @@ export const WorkflowStepExecutionTree = ({
       stepExecutionMap.set(childStep.id, childStep);
     }
 
-    const overviewPseudoStep = stepExecutionsTree.find((item) => item.stepType === '__overview');
-    if (overviewPseudoStep) {
-      const executionOverview = buildOverviewStepExecutionFromContext(execution);
-      stepExecutionMap.set('__overview', executionOverview);
-    }
-
     const triggerPseudoStep =
       stepExecutionsTree.find((item) => item.stepType === '__trigger') ??
       stepExecutionsTree.find((item) => item.stepType === '__inputs');
@@ -298,51 +332,27 @@ export const WorkflowStepExecutionTree = ({
         triggerPseudoStep.stepType = triggerExecution.stepType ?? '';
       }
     }
+    const visibleTree = stepExecutionsTree.filter((item) => item.stepType !== '__overview');
+    const filteredTree = searchQuery ? filterStepTree(visibleTree, searchQuery) : visibleTree;
+    const flatTree = flattenIfBranches(filteredTree);
+
     const items: EuiTreeViewProps['items'] = convertTreeToEuiTreeViewItems(
-      stepExecutionsTree,
+      flatTree,
       stepExecutionMap,
       euiTheme,
       selectedId,
       onStepExecutionClick
     );
 
-    const overviewItem = items.find(
-      (item) => stepExecutionMap.get(item.id)?.stepType === '__overview'
-    );
-    const regularItems = items.filter(
-      (item) => stepExecutionMap.get(item.id)?.stepType !== '__overview'
-    );
-
     return (
       <>
         <div css={styles.treeViewContainer}>
-          {overviewItem && (
-            <>
-              <EuiTreeView
-                showExpansionArrows
-                expandByDefault
-                items={[overviewItem]}
-                aria-label={i18n.translate(
-                  'workflows.WorkflowStepExecutionTree.overviewAriaLabel',
-                  {
-                    defaultMessage: 'Execution overview',
-                  }
-                )}
-              />
-              <EuiHorizontalRule
-                margin="none"
-                css={{ marginTop: euiTheme.size.xs, marginBottom: euiTheme.size.xs }}
-              />
-            </>
-          )}
-
-          {/* Regular steps */}
-          {regularItems.length > 0 && (
+          {items.length > 0 && (
             <EuiTreeView
               data-test-subj="workflowStepExecutionTree"
               showExpansionArrows
               expandByDefault
-              items={regularItems}
+              items={items}
               aria-label={i18n.translate(
                 'workflows.WorkflowStepExecutionTree.workflowStepExecutionTreeAriaLabel',
                 {

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_flyout.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { WorkflowExecutionList } from './workflow_execution_list_stateful';
+
+export interface WorkflowExecutionListFlyoutProps {
+  workflowId: string;
+  onClose: () => void;
+}
+
+export const WorkflowExecutionListFlyout = ({
+  workflowId,
+  onClose,
+}: WorkflowExecutionListFlyoutProps) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlyout
+      onClose={onClose}
+      type="push"
+      paddingSize="none"
+      hideCloseButton
+      style={{ minWidth: '480px', maxWidth: '480px' }}
+      data-test-subj="workflowExecutionListFlyout"
+    >
+      <EuiFlyoutHeader>
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
+          alignItems="center"
+          gutterSize="none"
+          responsive={false}
+          css={{
+            height: '36px',
+            padding: '0 8px',
+            borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+          }}
+        >
+          <EuiTitle size="xs">
+            <h2 css={{ paddingLeft: '8px' }}>
+              {i18n.translate('workflows.executionListFlyout.title', {
+                defaultMessage: 'Executions',
+              })}
+            </h2>
+          </EuiTitle>
+          <EuiButtonIcon
+            iconType="cross"
+            aria-label={i18n.translate('workflows.executionListFlyout.close', {
+              defaultMessage: 'Close',
+            })}
+            color="text"
+            size="s"
+            onClick={onClose}
+          />
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+
+      <EuiFlyoutBody
+        css={css`
+          .euiFlyoutBody__overflowContent {
+            padding: 0;
+          }
+        `}
+      >
+        <WorkflowExecutionList workflowId={workflowId} />
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_flyout.tsx
@@ -13,7 +13,6 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -43,7 +42,7 @@ export const WorkflowExecutionListFlyout = ({
     >
       <EuiFlyoutHeader>
         <EuiFlexGroup
-          justifyContent="spaceBetween"
+          justifyContent="flexEnd"
           alignItems="center"
           gutterSize="none"
           responsive={false}
@@ -53,13 +52,6 @@ export const WorkflowExecutionListFlyout = ({
             borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
           }}
         >
-          <EuiTitle size="xs">
-            <h2 css={{ paddingLeft: '8px' }}>
-              {i18n.translate('workflows.executionListFlyout.title', {
-                defaultMessage: 'Executions',
-              })}
-            </h2>
-          </EuiTitle>
           <EuiButtonIcon
             iconType="cross"
             aria-label={i18n.translate('workflows.executionListFlyout.close', {

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -7,11 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiButtonGroupOptionProps, UseEuiTheme } from '@elastic/eui';
+import type { UseEuiTheme } from '@elastic/eui';
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiButtonGroup,
   EuiButtonIcon,
   EuiCheckbox,
   EuiFlexGroup,
@@ -54,10 +53,6 @@ import {
 import { setIsTestModalOpen } from '../../../entities/workflows/store/workflow_detail/slice';
 import { useKibana } from '../../../hooks/use_kibana';
 import {
-  useWorkflowUrlState,
-  type WorkflowUrlStateTabType,
-} from '../../../hooks/use_workflow_url_state';
-import {
   getSaveWorkflowTooltipContent,
   getTestRunTooltipContent,
   ManagedWorkflowBadge,
@@ -93,28 +88,13 @@ const Translations = {
   }),
 };
 
-const ButtonGroupOptions: EuiButtonGroupOptionProps[] = [
-  {
-    id: 'workflow',
-    label: i18n.translate('workflows.workflowDetailHeader.workflow', {
-      defaultMessage: 'Workflow',
-    }),
-    iconType: 'grid',
-  },
-  {
-    id: 'executions',
-    label: i18n.translate('workflows.workflowDetailHeader.executions', {
-      defaultMessage: 'Executions',
-    }),
-    iconType: 'play',
-  },
-];
 
 export interface WorkflowDetailHeaderProps {
   isLoading: boolean;
   // TODO: manage it in a workflow state context
   highlightDiff: boolean;
   setHighlightDiff: React.Dispatch<React.SetStateAction<boolean>>;
+  onOpenExecutionList?: () => void;
 }
 
 interface GetSaveWorkflowButtonDisabledParams {
@@ -145,30 +125,13 @@ const getSaveWorkflowButtonDisabled = ({
   !hasUnsavedChanges;
 
 export const WorkflowDetailHeader = React.memo(
-  ({ isLoading, highlightDiff, setHighlightDiff }: WorkflowDetailHeaderProps) => {
+  ({ isLoading, highlightDiff, setHighlightDiff, onOpenExecutionList }: WorkflowDetailHeaderProps) => {
     const { id: workflowId } = useParams<{ id?: string }>();
     const { application } = useKibana().services;
     const styles = useMemoCss(componentStyles);
     const dispatch = useDispatch();
     const { canCreateWorkflow, canUpdateWorkflow, canExecuteWorkflow, canReadWorkflowExecution } =
       useWorkflowsCapabilities();
-
-    const workflowDetailTabButtonOptions = useMemo(
-      () =>
-        ButtonGroupOptions.map((option) =>
-          option.id === 'executions' && !canReadWorkflowExecution
-            ? {
-                ...option,
-                isDisabled: true,
-                title: '',
-                toolTipContent: executionsTabReadExecutionDisabledTooltip,
-              }
-            : option
-        ),
-      [canReadWorkflowExecution]
-    );
-
-    const { activeTab, setActiveTab } = useWorkflowUrlState();
 
     const workflow = useSelector(selectWorkflow);
     const isSyntaxValid = useSelector(selectIsYamlSyntaxValid);
@@ -335,28 +298,6 @@ export const WorkflowDetailHeader = React.memo(
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPageHeaderSection>
-            {workflowId && (
-              <EuiPageHeaderSection
-                css={{
-                  flexBasis: '15%',
-                }}
-              >
-                <EuiFlexGroup justifyContent="center">
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonGroup
-                      buttonSize="compressed"
-                      color="primary"
-                      options={workflowDetailTabButtonOptions}
-                      idSelected={activeTab}
-                      legend="Switch between workflow and executions"
-                      type="single"
-                      hasAriaDisabled={!canReadWorkflowExecution}
-                      onChange={(id) => setActiveTab(id as WorkflowUrlStateTabType)}
-                    />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiPageHeaderSection>
-            )}
             <EuiPageHeaderSection
               css={{
                 flexBasis: '40%',
@@ -391,6 +332,27 @@ export const WorkflowDetailHeader = React.memo(
                     })}
                   />
                 </EuiToolTip>
+                {workflowId && onOpenExecutionList && (
+                  <EuiToolTip
+                    content={
+                      !canReadWorkflowExecution
+                        ? executionsTabReadExecutionDisabledTooltip
+                        : undefined
+                    }
+                  >
+                    <EuiButtonEmpty
+                      size="s"
+                      iconType="play"
+                      onClick={onOpenExecutionList}
+                      disabled={!canReadWorkflowExecution}
+                      data-test-subj="openExecutionListButton"
+                    >
+                      {i18n.translate('workflows.workflowDetailHeader.executions', {
+                        defaultMessage: 'Executions',
+                      })}
+                    </EuiButtonEmpty>
+                  </EuiToolTip>
+                )}
                 <EuiFlexItem grow={false} css={styles.separator} />
                 <EuiToolTip content={runWorkflowTooltipContent}>
                   <EuiButtonIcon

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -36,7 +36,7 @@ import { loadConnectorsThunk } from '../../../entities/workflows/store/workflow_
 import { loadWorkflowThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_workflow_thunk';
 import { loadWorkflowsThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_workflows_thunk';
 import { WorkflowExecutionFlyout } from '../../../features/workflow_execution_detail';
-import { WorkflowExecutionList } from '../../../features/workflow_execution_list/ui/workflow_execution_list_stateful';
+import { WorkflowExecutionListFlyout } from '../../../features/workflow_execution_list/ui/workflow_execution_list_flyout';
 import { useAsyncThunkState } from '../../../hooks/use_async_thunk';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useTelemetry } from '../../../hooks/use_telemetry';
@@ -131,8 +131,29 @@ export function WorkflowDetailPage({ id }: { id?: string }) {
 
   // TODO: manage it in a workflow state context
   const [highlightDiff, setHighlightDiff] = useState(false);
+  const [isExecutionListOpen, setIsExecutionListOpen] = useState(false);
+
+  // If the page loads with an execution already selected (e.g. direct URL), open the list too
+  // so that closing the detail navigates back to the list rather than closing everything.
+  useEffect(() => {
+    if (selectedExecutionId) {
+      setIsExecutionListOpen(true);
+    }
+    // intentionally runs only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onOpenExecutionList = useCallback(() => {
+    setIsExecutionListOpen(true);
+  }, []);
+
+  const onCloseExecutionList = useCallback(() => {
+    setIsExecutionListOpen(false);
+    setSelectedExecution(null);
+  }, [setSelectedExecution]);
 
   const onCloseExecutionDetail = useCallback(() => {
+    // Clear the selected execution but keep the list open so the user goes back to the list.
     setSelectedExecution(null);
   }, [setSelectedExecution]);
 
@@ -177,6 +198,7 @@ export function WorkflowDetailPage({ id }: { id?: string }) {
           isLoading={isLoadingWorkflow}
           highlightDiff={highlightDiff}
           setHighlightDiff={setHighlightDiff}
+          onOpenExecutionList={id && canReadWorkflowExecution ? onOpenExecutionList : undefined}
         />
       </EuiFlexItem>
       <EuiFlexItem css={css({ overflow: 'hidden', minHeight: 0 })}>
@@ -186,13 +208,15 @@ export function WorkflowDetailPage({ id }: { id?: string }) {
           <>
             <WorkflowEditorLayout
               editor={<WorkflowDetailEditor highlightDiff={highlightDiff} />}
-              executionList={
-                id && activeTab === 'executions' && canReadWorkflowExecution ? (
-                  <WorkflowExecutionList workflowId={id} />
-                ) : null
-              }
+              executionList={null}
               executionDetail={null}
             />
+            {id && isExecutionListOpen && !selectedExecutionId && canReadWorkflowExecution && (
+              <WorkflowExecutionListFlyout
+                workflowId={id}
+                onClose={onCloseExecutionList}
+              />
+            )}
             {selectedExecutionId && canReadWorkflowExecution && (
               <WorkflowExecutionFlyout
                 executionId={selectedExecutionId}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -30,11 +30,12 @@ import {
   selectActiveTab,
   selectWorkflowId,
   selectWorkflowName,
+  selectWorkflowTags,
 } from '../../../entities/workflows/store/workflow_detail/selectors';
 import { loadConnectorsThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_connectors_thunk';
 import { loadWorkflowThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_workflow_thunk';
 import { loadWorkflowsThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_workflows_thunk';
-import { WorkflowExecutionDetail } from '../../../features/workflow_execution_detail';
+import { WorkflowExecutionFlyout } from '../../../features/workflow_execution_detail';
 import { WorkflowExecutionList } from '../../../features/workflow_execution_list/ui/workflow_execution_list_stateful';
 import { useAsyncThunkState } from '../../../hooks/use_async_thunk';
 import { useKibana } from '../../../hooks/use_kibana';
@@ -64,6 +65,7 @@ export function WorkflowDetailPage({ id }: { id?: string }) {
   const activeTabInStore = useSelector(selectActiveTab);
   const workflowId = useSelector(selectWorkflowId);
   const workflowName = useSelector(selectWorkflowName);
+  const workflowTags = useSelector(selectWorkflowTags);
 
   useWorkflowsBreadcrumbs(workflowName);
 
@@ -181,25 +183,25 @@ export function WorkflowDetailPage({ id }: { id?: string }) {
         {!isReady ? (
           <WorkflowDetailLoadingState />
         ) : (
-          <WorkflowEditorLayout
-            editor={<WorkflowDetailEditor highlightDiff={highlightDiff} />}
-            executionList={
-              id &&
-              activeTab === 'executions' &&
-              !selectedExecutionId &&
-              canReadWorkflowExecution ? (
-                <WorkflowExecutionList workflowId={id} />
-              ) : null
-            }
-            executionDetail={
-              selectedExecutionId && canReadWorkflowExecution ? (
-                <WorkflowExecutionDetail
-                  executionId={selectedExecutionId}
-                  onClose={onCloseExecutionDetail}
-                />
-              ) : null
-            }
-          />
+          <>
+            <WorkflowEditorLayout
+              editor={<WorkflowDetailEditor highlightDiff={highlightDiff} />}
+              executionList={
+                id && activeTab === 'executions' && canReadWorkflowExecution ? (
+                  <WorkflowExecutionList workflowId={id} />
+                ) : null
+              }
+              executionDetail={null}
+            />
+            {selectedExecutionId && canReadWorkflowExecution && (
+              <WorkflowExecutionFlyout
+                executionId={selectedExecutionId}
+                workflowName={workflowName ?? ''}
+                workflowTags={workflowTags}
+                onClose={onCloseExecutionDetail}
+              />
+            )}
+          </>
         )}
         <WorkflowDetailTestModal />
         <WorkflowDetailTestStepModal />

--- a/src/platform/plugins/shared/workflows_management/public/shared/lib/format_duration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/lib/format_duration.ts
@@ -13,6 +13,10 @@
  * @returns The formatted duration. e.g. "1m 30s", "1h 30m", "1d 3h", "1w 3d", etc.
  */
 export function formatDuration(durationMs: number): string {
+  if (durationMs < 1) {
+    return '<1ms';
+  }
+
   let weeks = 0;
   let days = 0;
   let hours = 0;

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { EuiSelectOption } from '@elastic/eui';
-import { EuiAccordion, EuiPanel, EuiSelect, EuiText } from '@elastic/eui';
+import { EuiAccordion, EuiFieldSearch, EuiPanel, EuiSelect, EuiSpacer, EuiText } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { JsonValue } from '@kbn/utility-types';
@@ -42,6 +42,7 @@ export interface ExecutionDataViewerProps {
 export const ExecutionDataViewer = React.memo<ExecutionDataViewerProps>(
   ({ data, title, fieldPathActionsPrefix }) => {
     const [selectedViewMode, setSelectedViewMode] = useState<'table' | 'json'>('table');
+    const [searchTerm, setSearchTerm] = useState('');
 
     const handleViewModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedViewMode(e.target.value as 'table' | 'json');
@@ -75,12 +76,25 @@ export const ExecutionDataViewer = React.memo<ExecutionDataViewerProps>(
       >
         <EuiPanel hasBorder paddingSize="none">
           {selectedViewMode === 'table' && data && (
-            <JSONDataTable
-              data={data}
-              title={title}
-              searchTerm=""
-              fieldPathActionsPrefix={fieldPathActionsPrefix}
-            />
+            <>
+              <EuiFieldSearch
+                compressed
+                fullWidth
+                placeholder={i18n.translate('workflows.executionDataViewer.searchPlaceholder', {
+                  defaultMessage: 'Search fields and values',
+                })}
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                css={{ borderRadius: 0, borderBottom: 'none', boxShadow: 'none' }}
+              />
+              <EuiSpacer size="xs" />
+              <JSONDataTable
+                data={data}
+                title={title}
+                searchTerm={searchTerm}
+                fieldPathActionsPrefix={fieldPathActionsPrefix}
+              />
+            </>
           )}
           {selectedViewMode === 'json' && <JsonDataCode json={data} />}
         </EuiPanel>

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.tsx
@@ -7,34 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiButtonGroupOptionProps } from '@elastic/eui';
-import { EuiButtonGroup, EuiFieldSearch, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { debounce } from 'lodash';
-import React, { useCallback, useMemo, useState } from 'react';
-import useLocalStorage from 'react-use/lib/useLocalStorage';
+import type { EuiSelectOption } from '@elastic/eui';
+import { EuiAccordion, EuiPanel, EuiSelect, EuiText } from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { JsonValue } from '@kbn/utility-types';
 import { JsonDataCode } from './json_data_code';
 import { JSONDataTable } from './json_data_table';
 
-const SearchTermStorageKey = 'workflows_management.step_execution.searchTerm';
-
-const ViewModeOptions: EuiButtonGroupOptionProps[] = [
+const viewModeOptions: EuiSelectOption[] = [
   {
-    id: 'table',
-    'data-test-subj': 'workflowViewMode_table',
-    label: i18n.translate('workflows.jsonDataTable.viewMode.table', {
-      defaultMessage: 'Table',
-    }),
-    iconType: 'table',
+    value: 'table',
+    text: i18n.translate('workflows.jsonDataTable.viewMode.table', { defaultMessage: 'Table' }),
   },
   {
-    id: 'json',
-    'data-test-subj': 'workflowViewMode_json',
-    label: i18n.translate('workflows.jsonDataTable.viewMode.json', {
-      defaultMessage: 'JSON',
-    }),
-    iconType: 'code',
+    value: 'json',
+    text: i18n.translate('workflows.jsonDataTable.viewMode.json', { defaultMessage: 'JSON' }),
   },
 ];
 
@@ -55,88 +43,48 @@ export const ExecutionDataViewer = React.memo<ExecutionDataViewerProps>(
   ({ data, title, fieldPathActionsPrefix }) => {
     const [selectedViewMode, setSelectedViewMode] = useState<'table' | 'json'>('table');
 
-    const [storedSearchTerm, setStoredSearchTerm] = useLocalStorage(SearchTermStorageKey, '');
-    const [searchTerm, setSearchTerm] = useState(storedSearchTerm ?? '');
-
-    const setStoredSearchTermDebounced = useMemo(
-      () => debounce(setStoredSearchTerm, 500),
-      [setStoredSearchTerm]
-    );
-
-    const handleViewModeChange = useCallback((id: string) => {
-      setSelectedViewMode(id as 'table' | 'json');
+    const handleViewModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedViewMode(e.target.value as 'table' | 'json');
     }, []);
 
-    const handleSearchTermChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { value } = e.target;
-        setSearchTerm(value);
-        setStoredSearchTermDebounced(value);
-      },
-      [setStoredSearchTermDebounced]
-    );
-
     return (
-      <EuiFlexGroup
+      <EuiAccordion
+        id={`execution-data-viewer-${title ?? 'data'}`}
         data-test-subj="workflowJsonDataViewer"
-        direction="column"
-        gutterSize="none"
-        responsive={false}
-        style={{ height: '100%' }}
+        initialIsOpen={true}
+        arrowDisplay="left"
+        buttonContent={
+          title ? (
+            <EuiText size="s">
+              <strong>{title}</strong>
+            </EuiText>
+          ) : undefined
+        }
+        extraAction={
+          <EuiSelect
+            compressed
+            options={viewModeOptions}
+            value={selectedViewMode}
+            onChange={handleViewModeChange}
+            aria-label={i18n.translate('workflows.jsonDataTable.viewMode', {
+              defaultMessage: 'View mode',
+            })}
+            data-test-subj="workflowViewModeSelect"
+          />
+        }
       >
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup responsive={false} gutterSize="s">
-            {selectedViewMode === 'table' && (
-              <EuiFlexItem>
-                <EuiFieldSearch
-                  compressed
-                  fullWidth
-                  placeholder="Filter by field, value"
-                  value={searchTerm}
-                  onChange={handleSearchTermChange}
-                  isClearable
-                  aria-label={i18n.translate('workflows.jsonDataTable.searchAriaLabel', {
-                    defaultMessage: 'Search fields and values',
-                  })}
-                />
-              </EuiFlexItem>
-            )}
-            <EuiFlexItem
-              grow={false}
-              css={{
-                justifySelf: 'flex-end',
-                marginLeft: 'auto',
-              }}
-            >
-              <EuiButtonGroup
-                isIconOnly
-                buttonSize="compressed"
-                color="primary"
-                type="single"
-                idSelected={selectedViewMode}
-                legend={i18n.translate('workflows.jsonDataTable.viewMode', {
-                  defaultMessage: 'View mode',
-                })}
-                onChange={handleViewModeChange}
-                options={ViewModeOptions}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={true} css={{ overflow: 'hidden', minHeight: 0 }}>
-          <EuiSpacer size="s" />
+        <EuiPanel hasBorder paddingSize="none">
           {selectedViewMode === 'table' && data && (
             <JSONDataTable
               data={data}
               title={title}
-              searchTerm={searchTerm}
+              searchTerm=""
               fieldPathActionsPrefix={fieldPathActionsPrefix}
             />
           )}
           {selectedViewMode === 'json' && <JsonDataCode json={data} />}
-        </EuiFlexItem>
-      </EuiFlexGroup>
+        </EuiPanel>
+      </EuiAccordion>
     );
   }
 );

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_data_table.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_data_table.tsx
@@ -15,7 +15,7 @@ import type {
 } from '@elastic/eui';
 import { copyToClipboard, EuiDataGrid, EuiEmptyPrompt, useResizeObserver } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { usePager } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
@@ -119,9 +119,14 @@ export const JSONDataTable = React.memo<JSONDataTableProps>(
 
     const { width: containerWidth } = useResizeObserver(containerRef.current);
     const { curPageIndex, pageSize, changePageIndex, changePageSize } = usePager({
-      initialPageSize: 20,
+      initialPageSize: 10,
       totalItems: filteredRecords.length,
     });
+
+    // Reset to first page whenever the search filter changes
+    useEffect(() => {
+      changePageIndex(0);
+    }, [searchTerm, changePageIndex]);
 
     const fieldCellActions = useMemo(() => {
       const cellActions: EuiDataGridColumnCellAction[] = [];
@@ -206,7 +211,7 @@ export const JSONDataTable = React.memo<JSONDataTableProps>(
 
     const pagination: EuiDataGridProps['pagination'] = useMemo(
       () => ({
-        pageSizeOptions: [20, 50, 100, 200],
+        pageSizeOptions: [10, 25, 50, 100],
         pageIndex: curPageIndex,
         pageSize,
         onChangeItemsPerPage: changePageSize,

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/step_icon.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/step_icon.tsx
@@ -79,9 +79,28 @@ export const StepIcon = React.memo(
         workflowsExtensions.getStepDefinition(stepType) ??
         findStepDefinitionByBaseType(stepType, workflowsExtensions);
       if (stepDefinition?.icon) {
+        const statusColor = shouldApplyColorToIcon
+          ? getExecutionStatusColors(euiTheme, executionStatus).color
+          : undefined;
         return withTooltip(
           <Suspense fallback={<EuiLoadingSpinner size="s" />}>
-            <EuiIcon type={stepDefinition.icon} size="m" {...rest} aria-hidden={true} />
+            <EuiIcon
+              type={stepDefinition.icon}
+              size="m"
+              color={statusColor}
+              css={
+                shouldApplyColorToIcon &&
+                executionStatus !== ExecutionStatus.COMPLETED &&
+                css`
+                  & * {
+                    fill: ${statusColor};
+                    color: ${statusColor};
+                  }
+                `
+              }
+              {...rest}
+              aria-hidden={true}
+            />
           </Suspense>,
           title
         );
@@ -89,9 +108,28 @@ export const StepIcon = React.memo(
 
       const connectorSpecIcon = getConnectorSpecIcon(stepType);
       if (connectorSpecIcon) {
+        const statusColor = shouldApplyColorToIcon
+          ? getExecutionStatusColors(euiTheme, executionStatus).color
+          : undefined;
         return withTooltip(
           <Suspense fallback={<EuiLoadingSpinner size="s" />}>
-            <EuiIcon type={connectorSpecIcon} size="m" {...rest} aria-hidden={true} />
+            <EuiIcon
+              type={connectorSpecIcon}
+              size="m"
+              color={statusColor}
+              css={
+                shouldApplyColorToIcon &&
+                executionStatus !== ExecutionStatus.COMPLETED &&
+                css`
+                  & * {
+                    fill: ${statusColor};
+                    color: ${statusColor};
+                  }
+                `
+              }
+              {...rest}
+              aria-hidden={true}
+            />
           </Suspense>,
           title
         );
@@ -99,9 +137,28 @@ export const StepIcon = React.memo(
 
       const actionTypeIcon = getActionTypeIcon(stepType, actionTypeRegistry);
       if (actionTypeIcon) {
+        const statusColor = shouldApplyColorToIcon
+          ? getExecutionStatusColors(euiTheme, executionStatus).color
+          : undefined;
         return withTooltip(
           <Suspense fallback={<EuiLoadingSpinner size="s" />}>
-            <EuiIcon type={actionTypeIcon} size="m" {...rest} aria-hidden={true} />
+            <EuiIcon
+              type={actionTypeIcon}
+              size="m"
+              color={statusColor}
+              css={
+                shouldApplyColorToIcon &&
+                executionStatus !== ExecutionStatus.COMPLETED &&
+                css`
+                  & * {
+                    fill: ${statusColor};
+                    color: ${statusColor};
+                  }
+                `
+              }
+              {...rest}
+              aria-hidden={true}
+            />
           </Suspense>,
           title
         );

--- a/src/platform/plugins/shared/workflows_management/server/api/lib/workflow_dto_transform.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/lib/workflow_dto_transform.ts
@@ -28,6 +28,7 @@ export const transformStorageDocumentToWorkflowDto = (
     name: source.name,
     description: source.description,
     enabled: source.enabled,
+    tags: source.tags,
     managed: source.managed,
     managedBy: source.managedBy,
     definitionHash: source.definitionHash,
@@ -68,6 +69,7 @@ export const transformStoragePartialToWorkflowDto = (
   if ('name' in source) dto.name = source.name;
   if ('description' in source) dto.description = source.description;
   if ('enabled' in source) dto.enabled = source.enabled;
+  if ('tags' in source) dto.tags = source.tags;
   if ('managed' in source) dto.managed = source.managed;
   if ('managedBy' in source) dto.managedBy = source.managedBy;
   if ('definitionHash' in source) dto.definitionHash = source.definitionHash;


### PR DESCRIPTION
## Summary

- **New `WorkflowExecutionFlyout`** (push flyout, replaces the old `WorkflowExecutionDetail`): header with workflow name, tags, status/duration/executed-by info blocks; tabbed step tree + raw JSON view; \"Take action\" footer
- **Step inspection panel**: slides in to the left of the execution panel when a step node is clicked; flyout expands to fit both panels via `useLayoutEffect` DOM width manipulation (same pattern as `data_view_field_editor` `FlyoutPanels`); has its own independent header so the two panels look visually separate
- **`StepDataSection` component**: auto-detects whether data is a plain object (table view) or primitive/array (code-only); table view flattens nested keys to dot-notation rows with a filter input; toggle icons in the section header switch between table ↔ code views; `key` prop resets state when a different step is selected
- **Tags fix**: server-side DTO transform now maps `tags` through to `WorkflowDetailDto`; added `tags?: string[]` to the type and a `selectWorkflowTags` Redux selector

## Test plan

- [ ] Open a workflow with tags — confirm tags appear in the flyout header
- [ ] Click an executed step in the tree — confirm the step panel slides in and the flyout widens
- [ ] Click a different step — confirm panel content updates and table/filter state resets
- [ ] Steps with object input/output — confirm table view is default with working filter
- [ ] Steps with primitive/array input/output — confirm code view only (no toggle)
- [ ] Toggle between table and code views
- [ ] Close step panel via × — confirm flyout returns to single-panel width
- [ ] Close flyout via back/× buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)