### PR TITLE
[kbn-evals] Make `example_count` optional for backward compatibility with older API responses

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/common_attributes.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/common_attributes.gen.ts
@@ -109,7 +109,7 @@ export const EvaluatorStats = lazySchema(() =>
     dataset_id: z.string().max(1024),
     dataset_name: z.string().max(256),
     evaluator_name: z.string().max(256),
-    example_count: z.number().int().nonnegative(),
+    example_count: z.number().int().nonnegative().optional().default(0),
     stats: z.object({
       mean: z.number(),
       median: z.number(),

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/common_attributes.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/common_attributes.schema.yaml
@@ -224,7 +224,6 @@ components:
         - dataset_id
         - dataset_name
         - evaluator_name
-        - example_count
         - stats
 
     TraceSpan:


### PR DESCRIPTION
## Summary

Follow-up to #272881. The `example_count` field on `EvaluatorStats` was added as required, which breaks the CLI terminal reporter and experiment retrieval when fetching from servers that haven't been updated yet (e.g. serverless). `GetEvaluationExperimentResponse.parse()` throws because the response doesn't include `example_count`.

This makes `example_count` optional with a default of `0` so older responses parse correctly. New servers still include it from the cardinality aggregation.

### Before the fix - terminal report crashes
<img width="858" height="192" alt="image" src="https://github.com/user-attachments/assets/64e00c69-43d0-430b-aff9-051ff567e717" />

### After the fix
<img width="766" height="595" alt="image" src="https://github.com/user-attachments/assets/09ce511f-e269-4393-8ca0-6b050d88171a" />

## Test plan

- `node scripts/jest x-pack/platform/packages/shared/kbn-evals-common/impl/query_builders.test.ts` passes
- CLI `node scripts/evals start` no longer fails when fetching experiment stats from a server without the `example_count` field

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


