### PR TITLE
[ResponseOps][Alerting v2] Switch to lastValueFrom in async esql queries

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/utils/run_esql_async_search.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/utils/run_esql_async_search.test.ts
@@ -35,6 +35,24 @@ describe('runEsqlAsyncSearch', () => {
     );
   });
 
+  it('returns rawResponse from the last emission when search requires multiple requests', async () => {
+    const intermediateResponse: ESQLSearchResponse = { columns: [], values: [] };
+    const finalResponse: ESQLSearchResponse = {
+      columns: [{ name: 'count', type: 'long' }],
+      values: [[99]],
+    };
+    const search = jest
+      .fn()
+      .mockReturnValue(
+        of({ rawResponse: intermediateResponse, isRunning: true }, { rawResponse: finalResponse })
+      );
+    const data = { search: { search } } as unknown as DataPublicPluginStart;
+
+    const result = await runEsqlAsyncSearch({ data, params: { query: 'FROM foo' } });
+
+    expect(result).toEqual(finalResponse);
+  });
+
   it('forwards abortSignal to search', async () => {
     const rawResponse: ESQLSearchResponse = { columns: [], values: [] };
     const search = jest.fn().mockReturnValue(of({ rawResponse }));

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/utils/run_esql_async_search.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/utils/run_esql_async_search.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { firstValueFrom } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
 import { ESQL_ASYNC_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
@@ -25,7 +25,7 @@ export const runEsqlAsyncSearch = async ({
   params,
   abortSignal,
 }: RunEsqlAsyncSearchOptions): Promise<ESQLSearchResponse> => {
-  const response = await firstValueFrom(
+  const response = await lastValueFrom(
     data.search.search<
       IKibanaSearchRequest<ESQLSearchParams>,
       IKibanaSearchResponse<ESQLSearchResponse>


### PR DESCRIPTION
## 📄 Summary

Switches to `lastValueFrom` in the `runEsqlAsyncSearch` utility in order to correctly await ES|QL async searches that take two separate requests to return the final value.

## ⏪ Backport rationale

Pre-GA alerting v2 work, not backporting

## 🔗 References

Fixes https://github.com/elastic/rna-program/issues/570

## Release Notes

## ☑️ Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.