### PR TITLE
[Agent Builder] Add proactive RAG for automatic memory context injection

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/actions.ts
@@ -19,6 +19,7 @@ export enum AgentActionType {
   HandOver = 'hand_over',
   StructuredAnswer = 'structured_answer',
   BackgroundExecutionComplete = 'background_execution_complete',
+  ProactiveContext = 'proactive_context',
 }
 
 export interface ToolCallResult {
@@ -71,13 +72,20 @@ export interface BackgroundExecutionCompleteAction {
   execution: BackgroundExecutionState;
 }
 
+export interface ProactiveContextAction {
+  type: AgentActionType.ProactiveContext;
+  contextId: string;
+  content: string;
+}
+
 export type ResearchAgentAction =
   | ToolCallAction
   | ExecuteToolAction
   | ToolPromptAction
   | HandoverAction
   | AgentErrorAction
-  | BackgroundExecutionCompleteAction;
+  | BackgroundExecutionCompleteAction
+  | ProactiveContextAction;
 
 // answer phase actions
 
@@ -122,6 +130,12 @@ export function isBackgroundExecutionCompleteAction(
   action: AgentAction
 ): action is BackgroundExecutionCompleteAction {
   return action.type === AgentActionType.BackgroundExecutionComplete;
+}
+
+export function isProactiveContextAction(
+  action: AgentAction
+): action is ProactiveContextAction {
+  return action.type === AgentActionType.ProactiveContext;
 }
 
 // creation helpers
@@ -193,5 +207,16 @@ export function backgroundExecutionCompleteAction(
   return {
     type: AgentActionType.BackgroundExecutionComplete,
     execution,
+  };
+}
+
+export function proactiveContextAction(
+  contextId: string,
+  content: string
+): ProactiveContextAction {
+  return {
+    type: AgentActionType.ProactiveContext,
+    contextId,
+    content,
   };
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/constants.ts
@@ -11,6 +11,7 @@ export const BACKGROUND_CHECK_CYCLE_INTERVAL = 3;
 export const steps = {
   init: 'init',
   checkBackgroundWork: 'checkBackgroundWork',
+  injectProactiveContext: 'injectProactiveContext',
   researchAgent: 'researchAgent',
   executeTool: 'executeTool',
   handleToolInterrupt: 'handleToolInterrupt',

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
@@ -33,6 +33,7 @@ import {
   errorAction,
   handoverAction,
   backgroundExecutionCompleteAction,
+  proactiveContextAction,
   isAgentErrorAction,
   isHandoverAction,
   isStructuredAnswerAction,
@@ -40,6 +41,8 @@ import {
   isToolPromptAction,
 } from './actions';
 import type { ProcessedConversation } from './utils/prepare_conversation';
+import type { ProactiveRagSession } from './proactive_rag';
+import { formatProactiveContext } from './proactive_rag';
 
 // number of successive recoverable errors we try to recover from before throwing
 const MAX_ERROR_COUNT = 2;
@@ -57,6 +60,7 @@ export const createAgentGraph = ({
   promptFactory,
   backgroundExecutionService,
   roundId,
+  proactiveRagSession,
 }: {
   chatModel: InferenceChatModel;
   toolManager: ToolManager;
@@ -70,6 +74,7 @@ export const createAgentGraph = ({
   promptFactory: PromptFactory;
   backgroundExecutionService?: BackgroundExecutionService;
   roundId: string;
+  proactiveRagSession?: ProactiveRagSession;
 }) => {
   const init = async () => {
     return {};
@@ -105,6 +110,49 @@ export const createAgentGraph = ({
     };
   };
 
+  const injectProactiveContext = async (state: StateType) => {
+    logger.info(`[ProactiveRAG:Graph] injectProactiveContext step called`);
+    logger.info(`[ProactiveRAG:Graph]   hasSession=${!!proactiveRagSession}`);
+
+    if (!proactiveRagSession) {
+      logger.info(`[ProactiveRAG:Graph]   No session, returning empty`);
+      return {};
+    }
+
+    // Only inject proactive context once per conversation
+    if (state.injectedProactiveContextIds && state.injectedProactiveContextIds.length > 0) {
+      logger.info(
+        `[ProactiveRAG:Graph]   Already injected ${state.injectedProactiveContextIds.length} context(s), skipping`
+      );
+      return {};
+    }
+
+    const readyContext = proactiveRagSession.getReadyContext();
+    logger.info(`[ProactiveRAG:Graph]   readyContext=${!!readyContext}`);
+
+    if (!readyContext) {
+      logger.info(`[ProactiveRAG:Graph]   No ready context, returning empty`);
+      return {};
+    }
+
+    logger.info(
+      `[ProactiveRAG:Graph]   Context id=${readyContext.id}, findings=${readyContext.findings.length}`
+    );
+
+    proactiveRagSession.markInjected(readyContext.id);
+
+    const formattedContent = formatProactiveContext(readyContext);
+
+    logger.info(
+      `[ProactiveRAG:Graph]   INJECTING context ${readyContext.id} with ${readyContext.findings.length} findings as action!`
+    );
+
+    return {
+      mainActions: [proactiveContextAction(readyContext.id, formattedContent)],
+      injectedProactiveContextIds: [readyContext.id],
+    };
+  };
+
   const researchAgent = async (state: StateType) => {
     const researcherModel = chatModel.bindTools(toolManager.list()).withConfig({
       tags: [tags.agent, tags.researchAgent],
@@ -114,12 +162,12 @@ export const createAgentGraph = ({
       events.emit(createReasoningEvent(getRandomThinkingMessage(), { transient: true }));
     }
     try {
-      const response = await researcherModel.invoke(
-        await promptFactory.getMainPrompt({
-          cycleLimit: state.cycleLimit,
-          actions: state.mainActions,
-        })
-      );
+      const mainPrompt = await promptFactory.getMainPrompt({
+        cycleLimit: state.cycleLimit,
+        actions: state.mainActions,
+      });
+
+      const response = await researcherModel.invoke(mainPrompt);
 
       const currentCycle = state.currentCycle + 1;
       const action = processResearchResponse(response, { cycle: currentCycle });
@@ -185,9 +233,57 @@ export const createAgentGraph = ({
 
     lastAction.tool_calls.forEach((toolCall) => toolManager.recordToolUse(toolCall.toolName));
 
+    if (proactiveRagSession) {
+      const delayMs = proactiveRagSession.getConfig().toolCallDelayMs;
+      if (delayMs > 0) {
+        logger.info(
+          `[ProactiveRAG:Graph] executeTool - waiting ${delayMs}ms for proactive RAG to search`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        logger.info(`[ProactiveRAG:Graph] executeTool - delay complete, proceeding with tool call`);
+      }
+    }
+
     const toolCallMessage = createToolCallMessage(lastAction.tool_calls, lastAction.message);
     const toolNodeResult = await toolNode.invoke([toolCallMessage], {});
     const actions = processToolNodeResponse(toolNodeResult, { cycle: state.currentCycle });
+
+    if (proactiveRagSession) {
+      logger.info(`[ProactiveRAG:Graph] executeTool - updating session with tool results`);
+
+      const toolResultTexts = toolNodeResult
+        .filter((msg): msg is BaseMessage & { content: string } => typeof msg.content === 'string')
+        .map((msg) => msg.content)
+        .filter((content) => content.length > 0);
+
+      logger.info(
+        `[ProactiveRAG:Graph] executeTool - found ${toolResultTexts.length} text results`
+      );
+
+      if (toolResultTexts.length > 0) {
+        logger.info(
+          `[ProactiveRAG:Graph] executeTool - result preview: ${toolResultTexts[0]?.substring(
+            0,
+            300
+          )}...`
+        );
+
+        const emptyConversation = {
+          id: '',
+          agent_id: '',
+          user: { username: '' },
+          title: '',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          rounds: [],
+        };
+        proactiveRagSession.updateWithActions(emptyConversation, toolResultTexts);
+      } else {
+        logger.info(`[ProactiveRAG:Graph] executeTool - no text results to update with`);
+      }
+    } else {
+      logger.info(`[ProactiveRAG:Graph] executeTool - no proactiveRagSession available`);
+    }
 
     return {
       mainActions: actions,
@@ -276,13 +372,15 @@ export const createAgentGraph = ({
   const graphBuilder = new StateGraph(StateAnnotation)
     .addNode(steps.init, init)
     .addNode(steps.checkBackgroundWork, checkBackgroundWork)
+    .addNode(steps.injectProactiveContext, injectProactiveContext)
     .addNode(steps.researchAgent, researchAgent)
     .addNode(steps.executeTool, executeTool)
     .addNode(steps.handleToolInterrupt, handleToolInterrupt)
     .addNode(steps.finalize, finalize)
     .addEdge(_START_, steps.init)
     .addEdge(steps.init, steps.checkBackgroundWork)
-    .addEdge(steps.checkBackgroundWork, steps.researchAgent)
+    .addEdge(steps.checkBackgroundWork, steps.injectProactiveContext)
+    .addEdge(steps.injectProactiveContext, steps.researchAgent)
     .addConditionalEdges(steps.executeTool, executeToolEdge, {
       [steps.checkBackgroundWork]: steps.checkBackgroundWork,
       [steps.handleToolInterrupt]: steps.handleToolInterrupt,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
@@ -119,14 +119,6 @@ export const createAgentGraph = ({
       return {};
     }
 
-    // Only inject proactive context once per conversation
-    if (state.injectedProactiveContextIds && state.injectedProactiveContextIds.length > 0) {
-      logger.info(
-        `[ProactiveRAG:Graph]   Already injected ${state.injectedProactiveContextIds.length} context(s), skipping`
-      );
-      return {};
-    }
-
     const readyContext = proactiveRagSession.getReadyContext();
     logger.info(`[ProactiveRAG:Graph]   readyContext=${!!readyContext}`);
 
@@ -138,6 +130,17 @@ export const createAgentGraph = ({
     logger.info(
       `[ProactiveRAG:Graph]   Context id=${readyContext.id}, findings=${readyContext.findings.length}`
     );
+    logger.info(
+      `[ProactiveRAG:Graph]   Already injected IDs: [${
+        state.injectedProactiveContextIds?.join(', ') ?? 'none'
+      }]`
+    );
+
+    // Only inject each unique context once (dedupe by ID)
+    if (state.injectedProactiveContextIds?.includes(readyContext.id)) {
+      logger.info(`[ProactiveRAG:Graph]   Context ${readyContext.id} already injected, skipping`);
+      return {};
+    }
 
     proactiveRagSession.markInjected(readyContext.id);
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/context_extractor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/context_extractor.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createHash } from 'crypto';
+import type { Conversation, ConversationRound } from '@kbn/agent-builder-common';
+import { isToolCallStep } from '@kbn/agent-builder-common';
+import type { ExtractedContext } from './types';
+
+/**
+ * Extracts searchable context from a conversation.
+ * Uses heuristics to identify topics, entities, and user intent.
+ */
+export const extractContext = (conversation: Conversation): ExtractedContext => {
+  const rounds = conversation.rounds ?? [];
+
+  const topics = extractTopics(rounds);
+  const entities = extractEntities(rounds);
+  const recentQuestions = extractRecentQuestions(rounds);
+  const userIntent = inferUserIntent(rounds);
+  const toolResultTopics = extractFromToolResults(rounds);
+
+  const allTopics = [...new Set([...topics, ...toolResultTopics])].slice(0, 15);
+
+  const contextString = [...allTopics, ...entities, ...recentQuestions, userIntent].join('|');
+
+  const hash = createHash('sha256').update(contextString).digest('hex').substring(0, 16);
+
+  return {
+    topics: allTopics,
+    entities,
+    recentQuestions,
+    userIntent,
+    hash,
+  };
+};
+
+/**
+ * Extract context from in-progress tool results (actions array from graph state).
+ * This allows discovering relevant context from tool outputs mid-execution.
+ */
+export const extractContextFromActions = (
+  conversation: Conversation,
+  actionResults: string[]
+): ExtractedContext => {
+  const baseContext = extractContext(conversation);
+
+  const actionTopics = extractTopicsFromText(actionResults.join(' '));
+  const actionEntities = extractEntitiesFromText(actionResults.join(' '));
+
+  const allTopics = [...new Set([...baseContext.topics, ...actionTopics])].slice(0, 15);
+  const allEntities = [...new Set([...baseContext.entities, ...actionEntities])].slice(0, 15);
+
+  const contextString = [
+    ...allTopics,
+    ...allEntities,
+    ...baseContext.recentQuestions,
+    baseContext.userIntent,
+  ].join('|');
+
+  const hash = createHash('sha256').update(contextString).digest('hex').substring(0, 16);
+
+  return {
+    topics: allTopics,
+    entities: allEntities,
+    recentQuestions: baseContext.recentQuestions,
+    userIntent: baseContext.userIntent,
+    hash,
+  };
+};
+
+/**
+ * Build a search query from extracted context.
+ */
+export const buildSearchQuery = (context: ExtractedContext): string => {
+  const parts: string[] = [];
+
+  if (context.userIntent) {
+    parts.push(context.userIntent);
+  }
+
+  if (context.topics.length > 0) {
+    parts.push(context.topics.slice(0, 3).join(' '));
+  }
+
+  if (context.entities.length > 0) {
+    parts.push(context.entities.slice(0, 3).join(' '));
+  }
+
+  if (context.recentQuestions.length > 0) {
+    parts.push(context.recentQuestions[0]);
+  }
+
+  return parts.join(' ').trim().substring(0, 500);
+};
+
+const extractTopics = (rounds: ConversationRound[]): string[] => {
+  const topics = new Set<string>();
+  const recentRounds = rounds.slice(-5);
+
+  for (const round of recentRounds) {
+    const message = round.input?.message ?? '';
+    const extracted = extractTopicsFromText(message);
+    extracted.forEach((t) => topics.add(t));
+  }
+
+  return Array.from(topics).slice(0, 10);
+};
+
+const extractTopicsFromText = (text: string): string[] => {
+  const topicPatterns = [
+    /(?:about|regarding|concerning|related to)\s+([^,.?!]+)/gi,
+    /(?:how to|what is|explain)\s+([^,.?!]+)/gi,
+    /(?:issue with|problem with|error in)\s+([^,.?!]+)/gi,
+  ];
+
+  const topics = new Set<string>();
+
+  for (const pattern of topicPatterns) {
+    const matches = text.matchAll(pattern);
+    for (const match of matches) {
+      const topic = match[1]?.trim().toLowerCase();
+      if (topic && topic.length > 2 && topic.length < 50) {
+        topics.add(topic);
+      }
+    }
+  }
+
+  const words = text.toLowerCase().split(/\s+/);
+  const technicalTerms = words.filter(
+    (word) => /^[a-z][-a-z0-9_.]*[a-z0-9]$/.test(word) && word.length > 3
+  );
+  for (const term of technicalTerms.slice(0, 10)) {
+    topics.add(term);
+  }
+
+  const errorCodePatterns = [/\b(PSE-\d+)\b/gi, /\b(ERR[_-]?\d+)\b/gi, /\b([A-Z]{2,5}-\d{3,})\b/g];
+  for (const pattern of errorCodePatterns) {
+    const matches = text.matchAll(pattern);
+    for (const match of matches) {
+      topics.add(match[1].toUpperCase());
+    }
+  }
+
+  return Array.from(topics);
+};
+
+const extractEntities = (rounds: ConversationRound[]): string[] => {
+  const entities = new Set<string>();
+  const recentRounds = rounds.slice(-5);
+
+  for (const round of recentRounds) {
+    const message = round.input?.message ?? '';
+    const response = round.response?.message ?? '';
+    const combined = `${message} ${response}`;
+    const extracted = extractEntitiesFromText(combined);
+    extracted.forEach((e) => entities.add(e));
+  }
+
+  return Array.from(entities).slice(0, 10);
+};
+
+const extractEntitiesFromText = (text: string): string[] => {
+  const entityPatterns = [
+    /\b([a-z][-a-z0-9]*(?:[-_][a-z0-9]+)+)\b/gi,
+    /\b(service|host|pod|container|namespace|index|stream)[-_:]?([a-z0-9][-a-z0-9]*)/gi,
+    /\b([a-z]+(?:Service|Manager|Client|Handler|Controller))\b/g,
+    /\b(redis|postgres|mysql|mongodb|kafka|rabbitmq|elasticsearch)\b/gi,
+    /\b(checkout|payment|cart|inventory|shipping|order)\b/gi,
+  ];
+
+  const entities = new Set<string>();
+
+  for (const pattern of entityPatterns) {
+    const matches = text.matchAll(pattern);
+    for (const match of matches) {
+      const entity = (match[2] ? `${match[1]}-${match[2]}` : match[1])?.toLowerCase();
+      if (entity && entity.length > 2 && entity.length < 50) {
+        entities.add(entity);
+      }
+    }
+  }
+
+  return Array.from(entities);
+};
+
+const extractFromToolResults = (rounds: ConversationRound[]): string[] => {
+  const topics = new Set<string>();
+  const recentRounds = rounds.slice(-3);
+
+  for (const round of recentRounds) {
+    const steps = round.steps ?? [];
+    for (const step of steps) {
+      if (isToolCallStep(step)) {
+        for (const result of step.results ?? []) {
+          const resultText = extractTextFromToolResult(result);
+
+          const extracted = extractTopicsFromText(resultText);
+          extracted.forEach((t) => topics.add(t));
+
+          const entities = extractEntitiesFromText(resultText);
+          entities.forEach((e) => topics.add(e));
+        }
+      }
+    }
+  }
+
+  return Array.from(topics);
+};
+
+const extractTextFromToolResult = (result: { type: string; data?: unknown }): string => {
+  if (!result.data) {
+    return '';
+  }
+
+  if (typeof result.data === 'string') {
+    return result.data;
+  }
+
+  if (typeof result.data === 'object') {
+    return JSON.stringify(result.data);
+  }
+
+  return String(result.data);
+};
+
+const extractRecentQuestions = (rounds: ConversationRound[]): string[] => {
+  const questions: string[] = [];
+  const recentRounds = rounds.slice(-3);
+
+  for (const round of recentRounds) {
+    const message = round.input?.message ?? '';
+
+    if (
+      message.includes('?') ||
+      /^(what|how|why|when|where|who|can|could|would|should|is|are|do|does)/i.test(message)
+    ) {
+      const cleanQuestion = message
+        .replace(/[^\w\s?]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .substring(0, 200);
+
+      if (cleanQuestion.length > 10) {
+        questions.push(cleanQuestion);
+      }
+    }
+  }
+
+  return questions;
+};
+
+const inferUserIntent = (rounds: ConversationRound[]): string => {
+  if (rounds.length === 0) {
+    return '';
+  }
+
+  const lastRound = rounds[rounds.length - 1];
+  const message = lastRound.input?.message ?? '';
+
+  const intentPatterns: Array<{ pattern: RegExp; intent: string }> = [
+    { pattern: /debug|troubleshoot|investigate|diagnose/i, intent: 'troubleshooting' },
+    { pattern: /why|cause|reason|explain/i, intent: 'understanding root cause' },
+    { pattern: /fix|resolve|solve|repair/i, intent: 'finding a solution' },
+    { pattern: /monitor|alert|watch|track/i, intent: 'monitoring and alerting' },
+    { pattern: /performance|slow|latency|throughput/i, intent: 'performance analysis' },
+    { pattern: /error|exception|failure|crash/i, intent: 'error investigation' },
+    { pattern: /log|metric|trace|span/i, intent: 'observability data analysis' },
+    { pattern: /deploy|release|rollout|upgrade/i, intent: 'deployment analysis' },
+  ];
+
+  for (const { pattern, intent } of intentPatterns) {
+    if (pattern.test(message)) {
+      return intent;
+    }
+  }
+
+  if (message.includes('?')) {
+    return 'answering a question';
+  }
+
+  return 'general assistance';
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  ProactiveContext,
+  ProactiveRagConfig,
+  ProactiveRagSession,
+  ExtractedContext,
+  MemoryFinding,
+  OnContextReadyFn,
+  ProactiveRagSessionParams,
+} from './types';
+
+export type { ProactiveRagService } from './proactive_rag_service';
+
+export { createProactiveRagService, formatProactiveContext } from './proactive_rag_service';
+export { createProactiveRagSession } from './proactive_rag_session';
+export { extractContext, extractContextFromActions, buildSearchQuery } from './context_extractor';
+export { searchMemory } from './memory_search_agent';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/memory_search_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/memory_search_agent.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import type { InferenceChatModel } from '@kbn/inference-langchain';
+import type { ExtractedContext, MemoryFinding, ProactiveRagConfig } from './types';
+import { buildSearchQuery } from './context_extractor';
+
+const MEMORIES_DATA_STREAM = '.significant_events-memories';
+
+interface MemoryPage {
+  id: string;
+  name: string;
+  title: string;
+  content: string;
+  categories: string[];
+  tags: string[];
+  is_deleted?: boolean;
+}
+
+interface SearchMemoryParams {
+  context: ExtractedContext;
+  esClient: ElasticsearchClient;
+  chatModel: InferenceChatModel;
+  config: ProactiveRagConfig;
+  logger: Logger;
+}
+
+interface SearchMemoryResult {
+  findings: MemoryFinding[];
+  searchQuery: string;
+}
+
+/**
+ * Search memory wiki pages for relevant information.
+ * Uses ES search followed by LLM-based relevance assessment.
+ */
+export const searchMemory = async ({
+  context,
+  esClient,
+  chatModel,
+  config,
+  logger,
+}: SearchMemoryParams): Promise<SearchMemoryResult> => {
+  logger.info(`[ProactiveRAG:searchMemory] Starting search...`);
+
+  const searchQuery = buildSearchQuery(context);
+  logger.info(`[ProactiveRAG:searchMemory] Built search query: "${searchQuery}"`);
+
+  if (!searchQuery || searchQuery.length < 3) {
+    logger.info(
+      `[ProactiveRAG:searchMemory] Query too short (${searchQuery?.length ?? 0} chars), skipping`
+    );
+    return { findings: [], searchQuery };
+  }
+
+  try {
+    logger.info(`[ProactiveRAG:searchMemory] Searching ES index ${MEMORIES_DATA_STREAM}...`);
+
+    const searchResults = await searchMemoryPages({
+      esClient,
+      query: searchQuery,
+      size: config.maxFindings * 2,
+      logger,
+    });
+
+    logger.info(`[ProactiveRAG:searchMemory] ES returned ${searchResults.length} results`);
+
+    if (searchResults.length === 0) {
+      logger.info(`[ProactiveRAG:searchMemory] No ES results, returning empty`);
+      return { findings: [], searchQuery };
+    }
+
+    searchResults.forEach((r, i) => {
+      logger.info(
+        `[ProactiveRAG:searchMemory]   Result ${i + 1}: "${r.page.title}" (score=${r.score})`
+      );
+    });
+
+    logger.info(`[ProactiveRAG:searchMemory] Assessing relevance with LLM...`);
+
+    const findings = await assessRelevance({
+      context,
+      searchResults,
+      chatModel,
+      config,
+      logger,
+    });
+
+    logger.info(`[ProactiveRAG:searchMemory] LLM assessed ${findings.length} as relevant`);
+
+    return { findings, searchQuery };
+  } catch (error) {
+    logger.error(`[ProactiveRAG:searchMemory] Search failed: ${error}`);
+    return { findings: [], searchQuery };
+  }
+};
+
+interface SearchMemoryPagesParams {
+  esClient: ElasticsearchClient;
+  query: string;
+  size: number;
+  logger: Logger;
+}
+
+interface MemorySearchHit {
+  page: MemoryPage;
+  score: number;
+  snippet: string;
+}
+
+const searchMemoryPages = async ({
+  esClient,
+  query,
+  size,
+  logger,
+}: SearchMemoryPagesParams): Promise<MemorySearchHit[]> => {
+  try {
+    const response = await esClient.search<MemoryPage>({
+      index: MEMORIES_DATA_STREAM,
+      track_total_hits: false,
+      size,
+      query: {
+        bool: {
+          must: [
+            {
+              multi_match: {
+                query,
+                fields: ['title^3', 'content', 'name^2', 'tags^2', 'categories^2'],
+                type: 'best_fields',
+                fuzziness: 'AUTO',
+              },
+            },
+          ],
+          must_not: [{ term: { is_deleted: true } }],
+        },
+      },
+      collapse: { field: 'id' },
+      sort: [{ _score: { order: 'desc' } }],
+      highlight: {
+        fields: {
+          content: { fragment_size: 300, number_of_fragments: 1 },
+          title: {},
+        },
+      },
+    });
+
+    return response.hits.hits.flatMap((hit) => {
+      const source = hit._source;
+      if (!source || source.is_deleted) return [];
+
+      return [
+        {
+          page: source,
+          score: hit._score ?? 0,
+          snippet: hit.highlight?.content?.[0] ?? source.content.substring(0, 300),
+        },
+      ];
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('index_not_found_exception')) {
+      logger.debug('Memory index not found, skipping proactive RAG search');
+      return [];
+    }
+    throw error;
+  }
+};
+
+interface AssessRelevanceParams {
+  context: ExtractedContext;
+  searchResults: MemorySearchHit[];
+  chatModel: InferenceChatModel;
+  config: ProactiveRagConfig;
+  logger: Logger;
+}
+
+const assessRelevance = async ({
+  context,
+  searchResults,
+  chatModel,
+  config,
+  logger,
+}: AssessRelevanceParams): Promise<MemoryFinding[]> => {
+  if (searchResults.length === 0) {
+    return [];
+  }
+
+  const contextSummary = [
+    context.userIntent && `User intent: ${context.userIntent}`,
+    context.topics.length > 0 && `Topics: ${context.topics.join(', ')}`,
+    context.entities.length > 0 && `Entities: ${context.entities.join(', ')}`,
+    context.recentQuestions.length > 0 && `Recent question: ${context.recentQuestions[0]}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const pagesInfo = searchResults
+    .map(
+      (result, idx) =>
+        `[${idx + 1}] "${result.page.title}" (${result.page.name})\nSnippet: ${result.snippet}`
+    )
+    .join('\n\n');
+
+  const prompt = `You are assessing which knowledge base pages are relevant to the current conversation context.
+
+## Conversation Context
+${contextSummary}
+
+## Candidate Pages
+${pagesInfo}
+
+## Task
+For each page that is HIGHLY relevant to the conversation context, provide:
+1. The page number (1-${searchResults.length})
+2. A brief reason why it's relevant (1 sentence)
+
+Only include pages that would genuinely help answer the user's question or provide important background context.
+Respond in JSON format:
+{
+  "relevant_pages": [
+    { "page_number": 1, "reason": "Explains the service architecture being discussed" },
+    { "page_number": 3, "reason": "Contains troubleshooting steps for this error type" }
+  ]
+}
+
+If no pages are relevant, respond with: { "relevant_pages": [] }`;
+
+  try {
+    const response = await chatModel.invoke(prompt);
+    const content = typeof response.content === 'string' ? response.content : '';
+
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      logger.debug('Proactive RAG: Could not parse LLM relevance response');
+      return searchResults.slice(0, config.maxFindings).map((result) => ({
+        pageId: result.page.id,
+        pageName: result.page.name,
+        pageTitle: result.page.title,
+        relevantExcerpt: result.snippet,
+        relevanceReason: 'Potentially relevant based on search score',
+        score: result.score,
+      }));
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]) as {
+      relevant_pages?: Array<{ page_number: number; reason: string }>;
+    };
+
+    const relevantPages = parsed.relevant_pages ?? [];
+
+    return relevantPages
+      .filter((p) => p.page_number >= 1 && p.page_number <= searchResults.length)
+      .slice(0, config.maxFindings)
+      .map((p) => {
+        const result = searchResults[p.page_number - 1];
+        return {
+          pageId: result.page.id,
+          pageName: result.page.name,
+          pageTitle: result.page.title,
+          relevantExcerpt: result.snippet,
+          relevanceReason: p.reason,
+          score: result.score,
+        };
+      });
+  } catch (error) {
+    logger.warn(`Proactive RAG relevance assessment failed: ${error}`);
+    return searchResults
+      .filter((r) => r.score >= config.minScore)
+      .slice(0, config.maxFindings)
+      .map((result) => ({
+        pageId: result.page.id,
+        pageName: result.page.name,
+        pageTitle: result.page.title,
+        relevantExcerpt: result.snippet,
+        relevanceReason: 'Relevant based on search score',
+        score: result.score,
+      }));
+  }
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/proactive_rag_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/proactive_rag_service.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import type { InferenceChatModel } from '@kbn/inference-langchain';
+import type { Conversation } from '@kbn/agent-builder-common';
+import type { ProactiveRagSession, ProactiveRagConfig, ProactiveContext } from './types';
+import { createProactiveRagSession } from './proactive_rag_session';
+
+const DEFAULT_CONFIG: ProactiveRagConfig = {
+  debounceMs: 500,
+  maxFindings: 3,
+  minScore: 0.5,
+  toolCallDelayMs: 1500,
+};
+
+interface ProactiveRagServiceDeps {
+  logger: Logger;
+}
+
+interface StartSessionParams {
+  conversation: Conversation;
+  esClient: ElasticsearchClient;
+  chatModel: InferenceChatModel;
+  config?: Partial<ProactiveRagConfig>;
+  onContextReady?: (context: ProactiveContext) => void;
+}
+
+/**
+ * Service for managing proactive RAG sessions.
+ */
+export interface ProactiveRagService {
+  /**
+   * Start a new proactive RAG session for a conversation.
+   */
+  startSession(params: StartSessionParams): ProactiveRagSession;
+}
+
+/**
+ * Creates the proactive RAG service.
+ */
+export const createProactiveRagService = ({
+  logger,
+}: ProactiveRagServiceDeps): ProactiveRagService => {
+  logger.info(`[ProactiveRAG:Service] Creating ProactiveRagService`);
+
+  const startSession = ({
+    conversation,
+    esClient,
+    chatModel,
+    config: configOverrides,
+    onContextReady,
+  }: StartSessionParams): ProactiveRagSession => {
+    const config: ProactiveRagConfig = {
+      ...DEFAULT_CONFIG,
+      ...configOverrides,
+    };
+
+    logger.info(`[ProactiveRAG:Service] Starting session with config: ${JSON.stringify(config)}`);
+    logger.info(
+      `[ProactiveRAG:Service] Initial conversation has ${conversation.rounds?.length ?? 0} rounds`
+    );
+
+    const sessionLogger = logger.get('proactive-rag');
+
+    const session = createProactiveRagSession({
+      esClient,
+      chatModel,
+      config,
+      logger: sessionLogger,
+      onContextReady:
+        onContextReady ??
+        (() => {
+          logger.info(`[ProactiveRAG:Service] onContextReady callback fired (no handler provided)`);
+        }),
+    });
+
+    logger.info(`[ProactiveRAG:Service] Session created, calling initial update()`);
+    session.update(conversation);
+
+    return session;
+  };
+
+  return {
+    startSession,
+  };
+};
+
+/**
+ * Format proactive context for injection into the conversation.
+ */
+export const formatProactiveContext = (context: ProactiveContext): string => {
+  const findingsText = context.findings
+    .map(
+      (f) => `### ${f.pageTitle}
+${f.relevantExcerpt}
+
+_Relevance: ${f.relevanceReason}_`
+    )
+    .join('\n\n');
+
+  return `<proactive_context>
+Based on the current conversation, here is relevant background information from the knowledge base:
+
+${findingsText}
+
+Consider this context when responding. Reference specific details if they help answer the user's question.
+</proactive_context>`;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/proactive_rag_session.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/proactive_rag_session.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import type { InferenceChatModel } from '@kbn/inference-langchain';
+import type { Conversation } from '@kbn/agent-builder-common';
+import type {
+  ProactiveRagSession,
+  ProactiveContext,
+  ProactiveRagConfig,
+  OnContextReadyFn,
+} from './types';
+import { extractContext, extractContextFromActions } from './context_extractor';
+import { searchMemory } from './memory_search_agent';
+import type { ExtractedContext } from './types';
+
+interface CreateSessionParams {
+  esClient: ElasticsearchClient;
+  chatModel: InferenceChatModel;
+  config: ProactiveRagConfig;
+  logger: Logger;
+  onContextReady: OnContextReadyFn;
+}
+
+/**
+ * Creates a proactive RAG session that monitors conversation updates
+ * and searches memory in the background with debouncing.
+ */
+export const createProactiveRagSession = ({
+  esClient,
+  chatModel,
+  config,
+  logger,
+  onContextReady,
+}: CreateSessionParams): ProactiveRagSession => {
+  let debounceTimer: NodeJS.Timeout | null = null;
+  let lastContextHash: string | null = null;
+  let readyContext: ProactiveContext | undefined;
+  let isSearching = false;
+  let isStopped = false;
+  const injectedIds = new Set<string>();
+
+  logger.info(
+    `[ProactiveRAG] Session created with config: debounceMs=${config.debounceMs}, maxFindings=${config.maxFindings}`
+  );
+
+  const performSearch = async (context: ExtractedContext) => {
+    logger.info(
+      `[ProactiveRAG] performSearch called - isStopped=${isStopped}, isSearching=${isSearching}`
+    );
+
+    if (isStopped || isSearching) {
+      logger.info(
+        `[ProactiveRAG] performSearch skipped - isStopped=${isStopped}, isSearching=${isSearching}`
+      );
+      return;
+    }
+
+    if (context.hash === lastContextHash) {
+      logger.info(
+        `[ProactiveRAG] performSearch skipped - context unchanged (hash=${context.hash})`
+      );
+      return;
+    }
+
+    logger.info(`[ProactiveRAG] performSearch starting search - hash=${context.hash}`);
+    logger.info(`[ProactiveRAG] Context topics: [${context.topics.join(', ')}]`);
+    logger.info(`[ProactiveRAG] Context entities: [${context.entities.join(', ')}]`);
+    logger.info(`[ProactiveRAG] Context intent: ${context.userIntent}`);
+
+    lastContextHash = context.hash;
+    isSearching = true;
+
+    try {
+      logger.info(`[ProactiveRAG] Calling searchMemory...`);
+
+      const result = await searchMemory({
+        context,
+        esClient,
+        chatModel,
+        config,
+        logger,
+      });
+
+      logger.info(
+        `[ProactiveRAG] searchMemory returned - findings=${result.findings.length}, query="${result.searchQuery}"`
+      );
+
+      if (isStopped) {
+        logger.info(`[ProactiveRAG] Session stopped during search, discarding results`);
+        return;
+      }
+
+      if (result.findings.length > 0) {
+        readyContext = {
+          id: uuidV4(),
+          searchQuery: result.searchQuery,
+          findings: result.findings,
+          generatedAt: new Date().toISOString(),
+        };
+
+        logger.info(
+          `[ProactiveRAG] Context READY - id=${readyContext.id}, findings=${result.findings.length}`
+        );
+        result.findings.forEach((f, i) => {
+          logger.info(`[ProactiveRAG]   Finding ${i + 1}: "${f.pageTitle}" (score=${f.score})`);
+        });
+
+        onContextReady(readyContext);
+      } else {
+        logger.info(`[ProactiveRAG] No relevant pages found for query "${result.searchQuery}"`);
+      }
+    } catch (error) {
+      logger.error(`[ProactiveRAG] Search error: ${error}`);
+    } finally {
+      isSearching = false;
+    }
+  };
+
+  const scheduleSearch = (context: ExtractedContext) => {
+    logger.info(
+      `[ProactiveRAG] scheduleSearch called - isStopped=${isStopped}, debounceMs=${config.debounceMs}`
+    );
+
+    if (isStopped) {
+      logger.info(`[ProactiveRAG] scheduleSearch skipped - session stopped`);
+      return;
+    }
+
+    if (debounceTimer) {
+      logger.info(`[ProactiveRAG] Clearing previous debounce timer`);
+      clearTimeout(debounceTimer);
+    }
+
+    logger.info(`[ProactiveRAG] Scheduling search in ${config.debounceMs}ms...`);
+
+    debounceTimer = setTimeout(() => {
+      logger.info(`[ProactiveRAG] Debounce timer fired - executing search`);
+      performSearch(context).catch((error) => {
+        logger.error(`[ProactiveRAG] Async search error: ${error}`);
+      });
+    }, config.debounceMs);
+  };
+
+  const update = (conversation: Conversation) => {
+    logger.info(`[ProactiveRAG] update() called - rounds=${conversation.rounds?.length ?? 0}`);
+
+    const context = extractContext(conversation);
+    logger.info(
+      `[ProactiveRAG] Extracted context from conversation - hash=${context.hash}, topics=${context.topics.length}`
+    );
+
+    scheduleSearch(context);
+  };
+
+  const updateWithActions = (conversation: Conversation, actionResults: string[]) => {
+    logger.info(
+      `[ProactiveRAG] updateWithActions() called - actionResults=${actionResults.length}`
+    );
+
+    if (actionResults.length === 0) {
+      logger.info(`[ProactiveRAG] No action results, falling back to update()`);
+      return update(conversation);
+    }
+
+    const previewLength = Math.min(500, actionResults[0]?.length ?? 0);
+    logger.info(
+      `[ProactiveRAG] Action result[0] preview: ${actionResults[0]?.substring(0, previewLength)}...`
+    );
+
+    const context = extractContextFromActions(conversation, actionResults);
+    logger.info(
+      `[ProactiveRAG] Extracted context from actions - hash=${
+        context.hash
+      }, topics=[${context.topics.join(', ')}]`
+    );
+
+    scheduleSearch(context);
+  };
+
+  const getReadyContext = (): ProactiveContext | undefined => {
+    logger.info(`[ProactiveRAG] getReadyContext() called - hasContext=${!!readyContext}`);
+    return readyContext;
+  };
+
+  const wasInjected = (contextId: string): boolean => {
+    const result = injectedIds.has(contextId);
+    logger.info(`[ProactiveRAG] wasInjected(${contextId}) = ${result}`);
+    return result;
+  };
+
+  const markInjected = (contextId: string): void => {
+    logger.info(`[ProactiveRAG] markInjected(${contextId})`);
+    injectedIds.add(contextId);
+  };
+
+  const stop = () => {
+    logger.info(`[ProactiveRAG] stop() called`);
+    isStopped = true;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  };
+
+  const getConfig = (): ProactiveRagConfig => {
+    return config;
+  };
+
+  return {
+    update,
+    updateWithActions,
+    getReadyContext,
+    wasInjected,
+    markInjected,
+    getConfig,
+    stop,
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/proactive_rag/types.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Conversation } from '@kbn/agent-builder-common';
+
+/**
+ * Context extracted from the conversation for memory search.
+ */
+export interface ExtractedContext {
+  /** Key topics discussed in the conversation */
+  topics: string[];
+  /** Named entities mentioned (services, hosts, etc.) */
+  entities: string[];
+  /** Recent questions from the user */
+  recentQuestions: string[];
+  /** Inferred user intent */
+  userIntent: string;
+  /** Hash for change detection (to avoid redundant searches) */
+  hash: string;
+}
+
+/**
+ * A finding from the memory search.
+ */
+export interface MemoryFinding {
+  /** Page ID */
+  pageId: string;
+  /** Page name */
+  pageName: string;
+  /** Page title */
+  pageTitle: string;
+  /** Relevant excerpt from the page content */
+  relevantExcerpt: string;
+  /** Why this finding is relevant to the conversation */
+  relevanceReason: string;
+  /** Relevance score from search */
+  score: number;
+}
+
+/**
+ * Ready-to-inject proactive context.
+ */
+export interface ProactiveContext {
+  /** Unique ID for this context injection */
+  id: string;
+  /** The search query that was used */
+  searchQuery: string;
+  /** Findings from memory */
+  findings: MemoryFinding[];
+  /** When this context was generated */
+  generatedAt: string;
+}
+
+/**
+ * Configuration for the proactive RAG service.
+ */
+export interface ProactiveRagConfig {
+  /** Debounce interval in milliseconds */
+  debounceMs: number;
+  /** Maximum number of findings to include */
+  maxFindings: number;
+  /** Minimum score threshold for findings */
+  minScore: number;
+  /** Delay before tool execution to give proactive RAG time to search (ms) */
+  toolCallDelayMs: number;
+}
+
+/**
+ * Callback when proactive context is ready.
+ */
+export type OnContextReadyFn = (context: ProactiveContext) => void;
+
+/**
+ * Parameters for starting a proactive RAG session.
+ */
+export interface ProactiveRagSessionParams {
+  /** Initial conversation state */
+  conversation: Conversation;
+  /** Callback when context is ready for injection */
+  onContextReady: OnContextReadyFn;
+}
+
+/**
+ * A proactive RAG session that monitors conversation and searches memory.
+ */
+export interface ProactiveRagSession {
+  /** Update the session with new conversation state */
+  update(conversation: Conversation): void;
+  /** Update the session with action results from tool calls (for mid-execution discovery) */
+  updateWithActions(conversation: Conversation, actionResults: string[]): void;
+  /** Get ready context if available (non-blocking) */
+  getReadyContext(): ProactiveContext | undefined;
+  /** Check if context with given ID was already injected */
+  wasInjected(contextId: string): boolean;
+  /** Mark context as injected */
+  markInjected(contextId: string): void;
+  /** Get the session configuration */
+  getConfig(): ProactiveRagConfig;
+  /** Stop the session and cleanup */
+  stop(): void;
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/actions.ts
@@ -30,6 +30,7 @@ import {
   isHandoverAction,
   isToolCallAction,
   isExecuteToolAction,
+  isProactiveContextAction,
 } from '../../actions';
 
 export const formatResearcherActionHistory = ({
@@ -75,6 +76,9 @@ export const formatResearcherActionHistory = ({
     }
     if (isBackgroundExecutionCompleteAction(action)) {
       formatted.push(createUserMessage(formatSystemNotice(action.execution)));
+    }
+    if (isProactiveContextAction(action)) {
+      formatted.push(createUserMessage(action.content));
     }
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -46,6 +46,7 @@ import { steps } from './constants';
 import { createPromptFactory } from './prompts';
 import { BackgroundExecutionService } from './background_execution_service';
 import type { StateType } from './state';
+import { createProactiveRagService } from './proactive_rag';
 
 const chatAgentGraphName = 'default-agent-builder-agent';
 
@@ -253,6 +254,28 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
     experimentalFeatures,
   });
 
+  logger.info(`[ProactiveRAG] Creating proactive RAG service and session...`);
+  const proactiveRagService = createProactiveRagService({ logger });
+  const proactiveRagSession = proactiveRagService.startSession({
+    conversation: conversation ?? {
+      id: '',
+      agent_id: agentId ?? '',
+      user: { username: '' },
+      title: '',
+      created_at: conversationTimestamp,
+      updated_at: conversationTimestamp,
+      rounds: [],
+    },
+    esClient: context.esClient.asCurrentUser,
+    chatModel: model.chatModel,
+    onContextReady: (ctx) => {
+      logger.info(
+        `[ProactiveRAG] Context ready callback: ${ctx.id} with ${ctx.findings.length} findings`
+      );
+    },
+  });
+  logger.info(`[ProactiveRAG] Session created and started`);
+
   const agentGraph = createAgentGraph({
     logger,
     events: { emit: eventEmitter },
@@ -266,6 +289,7 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
     promptFactory,
     backgroundExecutionService,
     roundId,
+    proactiveRagSession,
   });
 
   logger.debug(`Running chat agent with graph: ${chatAgentGraphName}, runId: ${runId}`);
@@ -349,6 +373,9 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   });
 
   const round = await extractRound(events$);
+
+  proactiveRagSession.stop();
+
   return {
     round,
   };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/state.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/state.ts
@@ -43,6 +43,11 @@ export const StateAnnotation = Annotation.Root({
     default: () => [],
   }),
   finalAnswer: Annotation<string>(),
+  // IDs of proactive contexts that have been injected
+  injectedProactiveContextIds: Annotation<string[]>({
+    reducer: (a, b) => [...new Set([...(a ?? []), ...(b ?? [])])],
+    default: () => [],
+  }),
 });
 
 export type StateType = typeof StateAnnotation.State;


### PR DESCRIPTION
## Summary

Adds a background system that continuously searches the SigEvent memory for relevant wiki pages and injects them into the agent conversation when applicable. This enables the agent to leverage organizational knowledge without explicit user requests and without explicit tool calls or reasearch sub agents after every log search etc.

<img width="846" height="801" alt="Screenshot 2026-06-08 at 15 19 47" src="https://github.com/user-attachments/assets/c36bc982-66a7-49fb-aa9d-45749ddf39e7" />


## Architecture

```mermaid
flowchart TB
    subgraph "Agent Execution Graph"
        Start([Start]) --> Init[init]
        Init --> CheckBg[checkBackgroundWork]
        CheckBg --> InjectCtx[injectProactiveContext]
        InjectCtx --> Research[researchAgent]
        Research -->|tool_call| ExecTool[executeTool]
        ExecTool -->|update context| Session
        ExecTool --> CheckBg
        Research -->|handover| Finalize[finalize]
        Finalize --> End([End])
    end

    subgraph "Proactive RAG Session"
        Session[ProactiveRagSession]
        Session -->|debounced| Extract[extractContext]
        Extract --> Search[searchMemory]
        Search -->|ES query| ES[(Elasticsearch<br/>.significant_events-memories)]
        Search -->|relevance check| LLM[LLM Assessment]
        LLM -->|findings| Ready[readyContext]
    end

    subgraph "Context Flow"
        Ready -->|getReadyContext| InjectCtx
        InjectCtx -->|proactiveContextAction| Actions[mainActions]
        Actions -->|formatResearcherActionHistory| Prompt[LLM Prompt]
    end

    style Session fill:#e1f5fe
    style Ready fill:#c8e6c9
    style Actions fill:#fff3e0
```

## Parallel Execution

```mermaid
sequenceDiagram
    participant User
    participant Agent as Main Agent
    participant Tools
    participant RAG as Proactive RAG Session
    participant ES as Elasticsearch
    participant LLM as LLM (relevance)

    User->>Agent: "Why is checkout broken?"
    
    activate Agent
    activate RAG
    
    par Main Agent Flow
        Agent->>Tools: get_logs()
        Tools-->>Agent: [log entries with PSE-001]
        Agent->>RAG: updateWithActions(logs)
    and Background RAG Search
        RAG->>RAG: extractContext(conversation)
        RAG->>ES: search memories
        ES-->>RAG: [Payment Errors, Checkout Arch]
        RAG->>LLM: assess relevance
        LLM-->>RAG: [relevant pages + reasons]
        RAG->>RAG: readyContext = findings
    end
    
    Note over Agent,RAG: Next cycle - check for ready context
    
    Agent->>RAG: getReadyContext()
    RAG-->>Agent: ProactiveContext
    Agent->>Agent: add ProactiveContextAction
    
    Agent->>Tools: search(PSE-001)
    Note right of Agent: LLM prompt now includes<br/>proactive context about<br/>Payment Service Error Codes
    
    Tools-->>Agent: [error details]
    Agent-->>User: "PSE-001 is a Payment Gateway Timeout..."
    
    deactivate Agent
    deactivate RAG
```

## How it works

1. **Session Creation**: When a chat agent runs, a `ProactiveRagSession` is created
2. **Context Extraction**: After each tool execution, the session extracts topics/entities from tool results
3. **Background Search**: A debounced search queries the SigEvent memory data stream
4. **Relevance Assessment**: An LLM evaluates which pages are relevant to the conversation
5. **Injection**: Ready context is injected as a `ProactiveContextAction` in mainActions
6. **Prompt Building**: The action is rendered as a user message in the prompt (cache-friendly)

## Key design decisions

- **Action-based injection**: Context is stored as an action, preserving KV cache for prefix messages
- **Single injection**: Only one proactive context is injected per conversation to avoid redundancy
- **Debounced search**: Prevents excessive searches during rapid tool executions
- **Tool-triggered updates**: Context is re-extracted after tool calls to discover new relevant information

## Test plan

- [ ] Verify proactive context appears in traces when relevant memory pages exist
- [ ] Confirm only one `<proactive_context>` block appears in prompts
- [ ] Check that system prompt remains stable (no cache busting)