### PR TITLE
[Alerting v2] Add experimental badge to alerting v2 pages

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/experimental_badge.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/experimental_badge.tsx
@@ -20,6 +20,7 @@ const EXPERIMENTAL_TOOLTIP = i18n.translate('xpack.alertingV2.experimentalBadge.
 
 export const ExperimentalBadge = () => (
   <EuiBetaBadge
+    alignment="middle"
     label={EXPERIMENTAL_LABEL}
     tooltipContent={EXPERIMENTAL_TOOLTIP}
     tooltipPosition="bottom"

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/experimental_badge.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/experimental_badge.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBetaBadge } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const EXPERIMENTAL_LABEL = i18n.translate('xpack.alertingV2.experimentalBadge.label', {
+  defaultMessage: 'Experimental feature',
+});
+
+const EXPERIMENTAL_TOOLTIP = i18n.translate('xpack.alertingV2.experimentalBadge.tooltip', {
+  defaultMessage:
+    'This functionality is experimental and may be changed or removed completely in a future release. Elastic will work to fix any issues, but experimental features are not subject to the support SLA of official GA features.',
+});
+
+export const ExperimentalBadge = () => (
+  <EuiBetaBadge
+    label={EXPERIMENTAL_LABEL}
+    tooltipContent={EXPERIMENTAL_TOOLTIP}
+    tooltipPosition="bottom"
+    data-test-subj="alertingV2ExperimentalBadge"
+  />
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { AlertEpisodesListPage } from './alert_episodes_list_page';
@@ -172,6 +172,10 @@ describe('AlertEpisodesListPage', () => {
       const lastCall = mockUnifiedDataTable.mock.calls.at(-1)?.[0];
       expect(lastCall?.rows?.length).toBeGreaterThan(0);
     });
+  });
+
+  it('renders the experimental badge in the page header', () => {
+    expect(screen.getByTestId('alertingV2ExperimentalBadge')).toBeInTheDocument();
   });
 
   it('passes customBulkActions derived from episode actions to UnifiedDataTable', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
@@ -320,9 +320,11 @@ export const AlertEpisodesListPage = () => {
       <EuiPageHeader
         bottomBorder
         pageTitle={
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>{i18n.EPISODES_LIST_PAGE_TITLE}</EuiFlexItem>
-            <EuiFlexItem grow={false}>
+          <EuiFlexGroup component="span" alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false} component="span">
+              {i18n.EPISODES_LIST_PAGE_TITLE}
+            </EuiFlexItem>
+            <EuiFlexItem grow={false} component="span">
               <ExperimentalBadge />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
@@ -45,6 +45,7 @@ import {
   EpisodeRuleCell,
 } from '@kbn/alerting-v2-episodes-ui/components/episodes_table_cell_renderers';
 import { AlertEpisodeAssigneeCell } from '@kbn/alerting-v2-episodes-ui/components/assignee_cell';
+import { ExperimentalBadge } from '../../components/experimental_badge';
 import { paths } from '../../constants';
 import type { AlertEpisodesKibanaServices } from '../../episodes_kibana_services';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
@@ -318,7 +319,14 @@ export const AlertEpisodesListPage = () => {
     >
       <EuiPageHeader
         bottomBorder
-        pageTitle={i18n.EPISODES_LIST_PAGE_TITLE}
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>{i18n.EPISODES_LIST_PAGE_TITLE}</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ExperimentalBadge />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
         rightSideItems={[
           <EuiButton
             key="manage-rules"

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.test.tsx
@@ -144,6 +144,13 @@ describe('ExecutionHistoryPage', () => {
     expect(screen.getByRole('tab', { name: 'Policies' })).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('renders the experimental badge in the page header', () => {
+    mockFetchResult();
+    renderPage();
+
+    expect(screen.getByTestId('alertingV2ExperimentalBadge')).toBeInTheDocument();
+  });
+
   it('renders the denormalization info tooltip next to the title', () => {
     mockFetchResult();
     renderPage();

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.tsx
@@ -56,14 +56,14 @@ export const ExecutionHistoryPage = () => {
     <>
       <EuiPageHeader
         pageTitle={
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
+          <EuiFlexGroup component="span" alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false} component="span">
               <FormattedMessage
                 id="xpack.alertingV2.executionHistory.pageTitle"
                 defaultMessage="Execution history"
               />
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} component="span">
               <span data-test-subj="executionHistoryDenormalizationTip">
                 <EuiIconTip
                   type="info"
@@ -77,7 +77,7 @@ export const ExecutionHistoryPage = () => {
                 />
               </span>
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} component="span">
               <ExperimentalBadge />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { ExperimentalBadge } from '../../components/experimental_badge';
 import { ActionPolicyDetailsFlyoutContainer } from '../../components/action_policy/details_flyout/action_policy_details_flyout_container';
 import { RuleSummaryFlyoutContainer } from '../../components/rule/flyouts/rule_summary_flyout_container';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
@@ -75,6 +76,9 @@ export const ExecutionHistoryPage = () => {
                   )}
                 />
               </span>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ExperimentalBadge />
             </EuiFlexItem>
           </EuiFlexGroup>
         }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/list_action_policies_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/list_action_policies_page.test.tsx
@@ -220,6 +220,12 @@ describe('ListActionPoliciesPage', () => {
     });
   });
 
+  it('renders the experimental badge in the page header', () => {
+    renderPage();
+
+    expect(screen.getByTestId('alertingV2ExperimentalBadge')).toBeInTheDocument();
+  });
+
   it('formats updatedAt using the user date format setting', () => {
     renderPage();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/list_action_policies_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/list_action_policies_page.tsx
@@ -32,6 +32,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import moment from 'moment';
 import React, { useCallback, useMemo, useState } from 'react';
+import { ExperimentalBadge } from '../../components/experimental_badge';
 import { ActionPolicyDestinationsSummary } from '../../components/action_policy/action_policy_destinations_summary';
 import { ActionPolicySnoozePopover } from '../../components/action_policy/action_policy_snooze_popover';
 import { ActionPolicyStateBadge } from '../../components/action_policy/action_policy_state_badge';
@@ -409,10 +410,17 @@ export const ListActionPoliciesPage = () => {
     <>
       <EuiPageHeader
         pageTitle={
-          <FormattedMessage
-            id="xpack.alertingV2.actionPoliciesList.pageTitle"
-            defaultMessage="Action Policies"
-          />
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <FormattedMessage
+                id="xpack.alertingV2.actionPoliciesList.pageTitle"
+                defaultMessage="Action Policies"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ExperimentalBadge />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         }
         rightSideItems={[
           <EuiButton key="create-policy" onClick={navigateToCreate} fill>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/list_action_policies_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/list_action_policies_page.tsx
@@ -410,14 +410,14 @@ export const ListActionPoliciesPage = () => {
     <>
       <EuiPageHeader
         pageTitle={
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
+          <EuiFlexGroup component="span" alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false} component="span">
               <FormattedMessage
                 id="xpack.alertingV2.actionPoliciesList.pageTitle"
                 defaultMessage="Action Policies"
               />
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} component="span">
               <ExperimentalBadge />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
@@ -162,6 +162,19 @@ describe('RulesListPage', () => {
     jest.useRealTimers();
   });
 
+  it('renders the experimental badge in the page header', () => {
+    mockUseFetchRules.mockReturnValue({
+      data: { items: mockRules, total: 2, page: 1, perPage: 20 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('alertingV2ExperimentalBadge')).toBeInTheDocument();
+  });
+
   it('renders loading state', () => {
     mockUseFetchRules.mockReturnValue({
       data: undefined,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -148,14 +148,11 @@ export const RulesListPage = () => {
     <div>
       <EuiPageHeader
         pageTitle={
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <FormattedMessage
-                id="xpack.alertingV2.rulesList.pageTitle"
-                defaultMessage="Rules"
-              />
+          <EuiFlexGroup component="span" alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false} component="span">
+              <FormattedMessage id="xpack.alertingV2.rulesList.pageTitle" defaultMessage="Rules" />
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} component="span">
               <ExperimentalBadge />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -25,6 +25,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { useBoolean, useDebouncedValue } from '@kbn/react-hooks';
 import type { FindRulesSortField } from '@kbn/alerting-v2-schemas';
 import type { RuleApiResponse } from '../../services/rules_api';
+import { ExperimentalBadge } from '../../components/experimental_badge';
 import { useFetchRules } from '../../hooks/use_fetch_rules';
 import { useFetchRuleTags } from '../../hooks/use_fetch_rule_tags';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
@@ -147,7 +148,17 @@ export const RulesListPage = () => {
     <div>
       <EuiPageHeader
         pageTitle={
-          <FormattedMessage id="xpack.alertingV2.rulesList.pageTitle" defaultMessage="Rules" />
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <FormattedMessage
+                id="xpack.alertingV2.rulesList.pageTitle"
+                defaultMessage="Rules"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ExperimentalBadge />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         }
         rightSideItems={
           hasRules || hasActiveFilters


### PR DESCRIPTION
Closes #272871
Adds an "Experimental feature" badge (`EuiBetaBadge`) to each alerting v2 page header, so users who enable the `alerting:v2:experimentalFeatures` setting can see that the feature is pre-release.

Created a shared `ExperimentalBadge` component (`experimental_badge.tsx`) using `EuiBetaBadge` with `i18n` label "Experimental feature" and a tooltip disclaimer.

Added the badge to all four alerting v2 list pages:
- Rules list — badge next to "Rules" title
- Action policies — badge next to "Action Policies" title
- Episodes — badge next to "Alert episodes" title
- Execution history — badge next to "Execution history" title and existing info icon

## Test plan:
1.  Enable `alerting:v2:experimentalFeatures` in Advanced Settings
2.  Navigate to each alerting v2 page (`/app/management/alertingV2/rules`, `.../action_policies`, `.../episodes`, `.../execution_history`)
3.  Verify "EXPERIMENTAL FEATURE" badge is visible next to each page title
4.  Hover the badge to confirm the tooltip shows the disclaimer text
5.  Verify badge is properly aligned with the page title (no layout shifts)

<img width="1511" height="384" alt="image" src="https://github.com/user-attachments/assets/cc8e5621-4f42-4855-bd4c-308f21d165ef" />
