### PR TITLE
fix: (tests, spaces): fix flaky copy-to-space ambiguous-conflict assertion

### DIFF
--- a/x-pack/platform/test/spaces_api_integration/common/suites/copy_to_space.agnostic.ts
+++ b/x-pack/platform/test/spaces_api_integration/common/suites/copy_to_space.agnostic.ts
@@ -764,20 +764,38 @@ export function copyToSpaceTestSuiteFactory(context: DeploymentAgnosticFtrProvid
                 // for certain objects in the test setup.
                 const importAmbiguousConflictError = (errors as SavedObjectsImportFailure[])?.[0]
                   .error as SavedObjectsImportAmbiguousConflictError;
-                // It doesn't matter if overwrite is enabled or not, the object will not be copied because there are two matches in the destination space
+                // It doesn't matter if overwrite is enabled or not, the object will not be copied because there are two matches in the destination space.
+                // The `updatedAt` values cannot be known upfront (test setup updates the
+                // spaces list for some objects), so look each one up by id from the response
+                // rather than by position.
+                const actualDestinations = importAmbiguousConflictError?.destinations ?? [];
+                const updatedAtById = (destinationId: string) =>
+                  actualDestinations.find((destination) => destination.id === destinationId)
+                    ?.updatedAt;
+                // The server sorts ambiguous-conflict destinations by `updatedAt` descending,
+                // then by `id` ascending as a tiebreak (see check_origin_conflicts.ts). Mirror
+                // that exact order here so the assertion stays deterministic even when the two
+                // objects end up with different `updatedAt` values during setup (sorting only
+                // by id was flaky: it held only while both shared an identical `updatedAt`).
                 const destinations = [
-                  // response destinations should be sorted by ID in ascending order
                   {
                     id: 'conflict_2_all',
                     title: 'A shared saved-object in all spaces',
-                    updatedAt: importAmbiguousConflictError?.destinations[0].updatedAt,
+                    updatedAt: updatedAtById('conflict_2_all'),
                   },
                   {
                     id: 'conflict_2_space_2',
                     title: 'A shared saved-object in one space',
-                    updatedAt: importAmbiguousConflictError?.destinations[1].updatedAt,
+                    updatedAt: updatedAtById('conflict_2_space_2'),
                   },
-                ];
+                ].sort((a, b) => {
+                  const aUpdatedAt = a.updatedAt ?? '';
+                  const bUpdatedAt = b.updatedAt ?? '';
+                  if (aUpdatedAt !== bUpdatedAt) {
+                    return aUpdatedAt < bUpdatedAt ? 1 : -1; // descending
+                  }
+                  return a.id < b.id ? -1 : 1; // ascending
+                });
                 expect(success).to.eql(false);
                 expect(successCount).to.eql(0);
                 expect(successResults).to.be(undefined);


### PR DESCRIPTION
## Summary

The `copying with an ambiguous conflict` assertion in copy_to_space.agnostic.ts hard-coded the response destinations in id-ascending order and read each `updatedAt` by array position. The server (check_origin_conflicts.ts) sorts ambiguous-conflict destinations by `updatedAt` descending with `id` ascending only as a tiebreak, so the test's assumption held only while both conflicting objects shared an identical `updatedAt`. When test setup left them with `updatedAt` values a moment apart, the server returned them in `updatedAt`-desc order and the assertion failed (e.g. appex-qa serverless FTR build 9631).

Mirror the server's comparator in the test and resolve each expected `updatedAt` by id rather than by position, so the assertion is deterministic regardless of setup timing.




<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->