### PR TITLE
[AGENTS.md] Add Node version, Scout server, and commit hygiene guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Kibana
 
 ## Setup
+- Use the Node version pinned in `.nvmrc` (matches `engines.node` in `package.json`); a mismatched version fails fast with `Kibana does not support the current Node.js version`. Select it with your version manager (e.g. `nvm use`) before running any `node`/`yarn` command.
 - Run `yarn kbn bootstrap` for initial setup, after switching branches, or when encountering dependency errors
 
 ## Overview
@@ -34,6 +35,7 @@ Run `node scripts/check.js --scope=local|staged|branch` to validate changes (Jes
 
 ### Scout (UI/API with Playwright)
 `node scripts/scout run-tests --arch stateful --domain classic --config <scoutConfigPath>` (or `--testFiles <specPath1,specPath2>`)
+- When iterating, start the stack once with `node scripts/scout start-server --stateful` and run `run-tests` against it, instead of rebooting ES+Kibana on every run.
 
 ## Code Style Guidelines
 Follow existing patterns in the target area first; below are common defaults.
@@ -93,5 +95,6 @@ Follow existing patterns in the target area first; below are common defaults.
 - Unsure: read more code; if still stuck, ask w/ short options. Never guess.
 - Fix root cause (not band-aid).
 - Make focused changes; avoid unrelated refactors.
+- Before committing, review `git status`/diff and stage only intended files. Never commit generated artifacts (`*.d.ts`, build output), scratch/planning notes, or debug scripts. Keep PRs minimal — unrelated changes trigger extra reviewer churn.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Run `node scripts/check.js --scope=local|staged|branch` to validate changes (Jes
 - For new tests, prefer using Scout
 
 ### Scout (UI/API with Playwright)
+`node scripts/scout run-tests --arch stateful --domain classic --config <scoutConfigPath>` (or `--testFiles <specPath1,specPath2>`)
 - When iterating, start the stack once with `node scripts/scout start-server --arch stateful --domain classic` and run `run-tests` against it, instead of rebooting ES+Kibana on every run.
 
 ## Code Style Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Run `node scripts/check.js --scope=local|staged|branch` to validate changes (Jes
 - For new tests, prefer using Scout
 
 ### Scout (UI/API with Playwright)
-`node scripts/scout run-tests --arch stateful --domain classic --config <scoutConfigPath>` (or `--testFiles <specPath1,specPath2>`)
+- When iterating, start the stack once with `node scripts/scout start-server --arch stateful --domain classic` and run `run-tests` against it, instead of rebooting ES+Kibana on every run.
 - When iterating, start the stack once with `node scripts/scout start-server --stateful` and run `run-tests` against it, instead of rebooting ES+Kibana on every run.
 
 ## Code Style Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Kibana
 
 ## Setup
-- Use the Node version pinned in `.nvmrc` (matches `engines.node` in `package.json`); a mismatched version fails fast with `Kibana does not support the current Node.js version`. Select it with your version manager (e.g. `nvm use`) before running any `node`/`yarn` command.
+- Use the Node version pinned in `.nvmrc` (matches `engines.node` in `package.json`).
 - Run `yarn kbn bootstrap` for initial setup, after switching branches, or when encountering dependency errors
 
 ## Overview
@@ -95,6 +95,5 @@ Follow existing patterns in the target area first; below are common defaults.
 - Unsure: read more code; if still stuck, ask w/ short options. Never guess.
 - Fix root cause (not band-aid).
 - Make focused changes; avoid unrelated refactors.
-- Before committing, review `git status`/diff and stage only intended files. Never commit generated artifacts (`*.d.ts`, build output), scratch/planning notes, or debug scripts. Keep PRs minimal — unrelated changes trigger extra reviewer churn.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,9 @@ Follow existing patterns in the target area first; below are common defaults.
 - Avoid inline styles unless consistent with the file’s conventions.
 - Use `@elastic/eui` components with Emotion (`@emotion/react`) for styling.
 
+### Schema validation
+- When adding `schema.string()` / `schema.arrayOf()` (`@kbn/config-schema`) or `z.string()` / `z.array()` (`zod`) for HTTP request input, always bound them (`maxLength` / `maxSize` / `.max()`) to avoid the CodeQL DoS findings `js/kibana/unbounded-string-in-schema` and `js/kibana/unbounded-array-in-schema`.
+
 ## Internationalization (i18n)
 - Guidelines are found in src/platform/packages/shared/kbn-i18n/GUIDELINE.md
 - Run `node scripts/i18n_check --fix` to check for and fix errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,6 @@ Run `node scripts/check.js --scope=local|staged|branch` to validate changes (Jes
 
 ### Scout (UI/API with Playwright)
 - When iterating, start the stack once with `node scripts/scout start-server --arch stateful --domain classic` and run `run-tests` against it, instead of rebooting ES+Kibana on every run.
-- When iterating, start the stack once with `node scripts/scout start-server --stateful` and run `run-tests` against it, instead of rebooting ES+Kibana on every run.
 
 ## Code Style Guidelines
 Follow existing patterns in the target area first; below are common defaults.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Follow existing patterns in the target area first; below are common defaults.
 - Use `@elastic/eui` components with Emotion (`@emotion/react`) for styling.
 
 ### Schema validation
-- When adding `schema.string()` / `schema.arrayOf()` (`@kbn/config-schema`) or `z.string()` / `z.array()` (`zod`) for HTTP request input, always bound them (`maxLength` / `maxSize` / `.max()`). The CodeQL DoS queries enforce this for `js/kibana/unbounded-string-in-schema` (covers `schema.string()` and `z.string()`) and `js/kibana/unbounded-array-in-schema` (covers `schema.arrayOf()` only); `z.array()` is not flagged today but should still be bounded with `.max()`.
+- When adding `schema.string()` / `schema.arrayOf()` (`@kbn/config-schema`) or `z.string()` / `z.array()` (`zod`) for HTTP request input, always bound them (`maxLength` / `maxSize` / `.max()`) to prevent unbounded-input DoS.
 
 ## Internationalization (i18n)
 - Guidelines are found in src/platform/packages/shared/kbn-i18n/GUIDELINE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Follow existing patterns in the target area first; below are common defaults.
 - Use `@elastic/eui` components with Emotion (`@emotion/react`) for styling.
 
 ### Schema validation
-- When adding `schema.string()` / `schema.arrayOf()` (`@kbn/config-schema`) or `z.string()` / `z.array()` (`zod`) for HTTP request input, always bound them (`maxLength` / `maxSize` / `.max()`) to avoid the CodeQL DoS findings `js/kibana/unbounded-string-in-schema` and `js/kibana/unbounded-array-in-schema`.
+- When adding `schema.string()` / `schema.arrayOf()` (`@kbn/config-schema`) or `z.string()` / `z.array()` (`zod`) for HTTP request input, always bound them (`maxLength` / `maxSize` / `.max()`). The CodeQL DoS queries enforce this for `js/kibana/unbounded-string-in-schema` (covers `schema.string()` and `z.string()`) and `js/kibana/unbounded-array-in-schema` (covers `schema.arrayOf()` only); `z.array()` is not flagged today but should still be bounded with `.max()`.
 
 ## Internationalization (i18n)
 - Guidelines are found in src/platform/packages/shared/kbn-i18n/GUIDELINE.md


### PR DESCRIPTION
## Summary

Adds repo-level guidance to the root `AGENTS.md` that were recurring
sources of avoidable friction for AI agents working in the repo:

- **Setup — Node version**: call out that Kibana pins Node via `.nvmrc`
  (matching `engines.node` in `package.json`). Agents repeatedly ran
  `node`/`yarn` commands with the wrong default Node and had to recover.
- **Scout — iteration workflow**: document starting the stack once with
  `node scripts/scout start-server --arch stateful --domain classic` and
  running `run-tests` against it, instead of rebooting ES+Kibana on every
  test run.
- **Schema validation**: bound `schema.string()` / `schema.arrayOf()`
  (`@kbn/config-schema`) and `z.string()` / `z.array()` (`zod`) for HTTP
  request input to avoid the `js/kibana/unbounded-string-in-schema` and
  `js/kibana/unbounded-array-in-schema` CodeQL DoS findings. Folds in the
  suggestion from #275145 instead of a dedicated always-in-context skill.

These are documentation-only changes to `AGENTS.md` — no runtime code is
affected.

## Test plan

- N/A — documentation only.