### PR TITLE
Replace Elastic logo with elasticheart on boot splash

### DIFF
--- a/src/core/packages/apps/server-internal/assets/legacy_styles.css
+++ b/src/core/packages/apps/server-internal/assets/legacy_styles.css
@@ -109,13 +109,13 @@ body, html {
   100% { transform: scale3d(.98, .98, 2); }
 }
 
-.kbnLoaderWrap .kbnLoader path {
+.kbnLoaderWrap .kbnLoader > g {
   transform-style: preserve-3d;
   transform-origin: 50% 50%;
 }
 
 @media not (prefers-reduced-motion: reduce) {
-  .kbnLoaderWrap .kbnLoader path {
+  .kbnLoaderWrap .kbnLoader > g {
     animation-name: kbnLoadingElastic;
     animation-fill-mode: forwards;
     animation-direction: alternate;
@@ -124,12 +124,12 @@ body, html {
     animation-iteration-count: infinite;
   }
 
-  .kbnLoaderWrap .kbnLoader path:nth-of-type(1) { animation-delay: 0s; }
-  .kbnLoaderWrap .kbnLoader path:nth-of-type(2) { animation-delay: 0.035s; }
-  .kbnLoaderWrap .kbnLoader path:nth-of-type(3) { animation-delay: 0.125s; }
-  .kbnLoaderWrap .kbnLoader path:nth-of-type(4) { animation-delay: 0.155s; }
-  .kbnLoaderWrap .kbnLoader path:nth-of-type(5) { animation-delay: 0.075s; }
-  .kbnLoaderWrap .kbnLoader path:nth-of-type(6) { animation-delay: 0.06s; }
+  .kbnLoaderWrap .kbnLoader > g:nth-of-type(1) { animation-delay: 0s; }
+  .kbnLoaderWrap .kbnLoader > g:nth-of-type(2) { animation-delay: 0.035s; }
+  .kbnLoaderWrap .kbnLoader > g:nth-of-type(3) { animation-delay: 0.125s; }
+  .kbnLoaderWrap .kbnLoader > g:nth-of-type(4) { animation-delay: 0.155s; }
+  .kbnLoaderWrap .kbnLoader > g:nth-of-type(5) { animation-delay: 0.075s; }
+  .kbnLoaderWrap .kbnLoader > g:nth-of-type(6) { animation-delay: 0.06s; }
 }
 
 .kbnProgress {

--- a/src/core/packages/rendering/server-internal/src/views/logo.test.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/logo.test.tsx
@@ -9,9 +9,7 @@
 
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { load, type CheerioAPI } from 'cheerio';
-
-import { icon as EuiLogoElasticIcon } from '@elastic/eui/lib/components/icon/assets/logo_elastic';
+import { load } from 'cheerio';
 
 import { Logo } from './logo';
 
@@ -19,16 +17,16 @@ const render = () => load(renderToStaticMarkup(<Logo />));
 
 describe('Logo (boot splash)', () => {
   it('carries the .kbnLoader hook so legacy_styles.css can animate it', () => {
-    // legacy_styles.css selects `.kbnLoaderWrap .kbnLoader path` to apply
-    // the EuiLoadingElastic keyframes; this class must stay in sync.
+    // legacy_styles.css selects `.kbnLoaderWrap .kbnLoader > g` to apply
+    // the kbnLoadingElastic keyframes; this class must stay in sync.
     expect(render()('svg.kbnLoader')).toHaveLength(1);
   });
 
-  it('renders the six logoElastic paths the keyframes target via nth-of-type', () => {
+  it('renders six top-level <g> groups the keyframes target via nth-of-type', () => {
     // legacy_styles.css applies a staggered `animation-delay` to
-    // `nth-of-type(1)`..`nth-of-type(6)`. Adding/removing a path here
-    // would silently break the animation cadence.
-    expect(render()('svg.kbnLoader > path')).toHaveLength(6);
+    // `> g:nth-of-type(1)`..`> g:nth-of-type(6)`. Adding/removing a
+    // group here would silently break the animation cadence.
+    expect(render()('svg.kbnLoader > g')).toHaveLength(6);
   });
 
   it('is decorative; the loading announcement belongs to the wrapper', () => {
@@ -37,26 +35,12 @@ describe('Logo (boot splash)', () => {
     expect(render()('svg').attr('aria-hidden')).toBe('true');
   });
 
-  // Drift guard: rather than hard-coding the palette, compare our inlined
-  // SSR copy of the logo against the actual `logoElastic` asset shipped
-  // by `@elastic/eui` (the same one `<EuiLoadingElastic />` uses under
-  // the hood, see node_modules/@elastic/eui/lib/components/icon/assets/
-  // logo_elastic.js). If EUI rebrands the logo, this test fails and the
-  // next person knows to re-copy the SVG paths into logo.tsx.
-  it('stays byte-for-byte in sync with @elastic/eui logoElastic', () => {
-    const collect = ($: CheerioAPI) =>
-      $('path')
-        .map((_, el) => ({
-          fill: $(el).attr('fill'),
-          stroke: $(el).attr('stroke'),
-          'stroke-width': $(el).attr('stroke-width'),
-          d: $(el).attr('d'),
-        }))
-        .get();
-
-    const ours = render();
-    const eui = load(renderToStaticMarkup(<EuiLogoElasticIcon />));
-
-    expect(collect(ours)).toEqual(collect(eui));
+  it('contains clip-path defs for the heart shape', () => {
+    const $ = render();
+    // Cheerio in default (HTML) mode lowercases tag names, so we check
+    // the raw defs innerHTML for the SVG clipPath elements instead.
+    const defsHtml = $('defs').html() ?? '';
+    const clipPathCount = (defsHtml.match(/<clipPath/g) || []).length;
+    expect(clipPathCount).toBeGreaterThanOrEqual(6);
   });
 });

--- a/src/core/packages/rendering/server-internal/src/views/logo.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/logo.tsx
@@ -11,27 +11,16 @@ import type { FC } from 'react';
 import React from 'react';
 
 /**
- * Server-rendered Elastic logo used by the boot splash and the legacy
- * browser error screen (see `template.tsx`).
+ * Server-rendered Elastic heart logo used by the boot splash and the
+ * legacy browser error screen (see `template.tsx`).
  *
- * The SVG below is an inlined copy of the `logoElastic` asset shipped by
- * `@elastic/eui` (the same one `<EuiLoadingElastic />` renders under the
- * hood):
- *
- *   - source asset:   @elastic/eui/src/components/icon/assets/logo_elastic.tsx
- *   - compiled copy:  @elastic/eui/lib/components/icon/assets/logo_elastic.js
- *   - loader styles:  @elastic/eui/src/components/loading/loading_elastic.styles.ts
+ * The SVG is the "elasticheart" — the Elastic logo pieces arranged
+ * inside a heart shape, clipped by nested clip-path groups.
  *
  * Combined with the staggered keyframes in `legacy_styles.css`
- * (`@keyframes kbnLoadingElastic`), the splash animates identically to
- * `<EuiLoadingElastic size="xxl" />`.
- *
- * If you ever need to refresh the markup, the unit test
- * `logo.test.tsx` ("stays byte-for-byte in sync with @elastic/eui
- * logoElastic") compares this copy against the live EUI asset and will
- * fail if EUI rebrands — re-copy the `<path>` elements from the source
- * above (preserving their order: the keyframes target each path via
- * `:nth-of-type`).
+ * (`@keyframes kbnLoadingElastic`), the splash animates each of the
+ * six colored sections. The animation targets the top-level `<g>`
+ * groups via `g:nth-of-type`.
  *
  * We can't render the EUI component itself here: this template is sent
  * to the browser before any JS / Emotion has executed, so the splash
@@ -45,49 +34,146 @@ import React from 'react';
 export const Logo: FC = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="32"
-    height="32"
-    viewBox="0 0 32 32"
-    fill="none"
-    data-type="logoElastic"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    width="144"
+    height="144"
+    viewBox="0 0 144 144"
     className="kbnLoader"
     aria-hidden="true"
   >
-    <path
-      fill="#0B64DD"
-      stroke="#fff"
-      strokeWidth="1.2"
-      d="M27.565 11.242c5.1 1.94 4.872 9.396-.245 11.127l-.162.055-.167-.039-5.28-1.238-.268-.063-.127-.244-1.4-2.69-.217-.417.352-.31 6.904-6.07.272-.24.338.13Z"
-    />
-    <path
-      fill="#9ADC30"
-      stroke="#fff"
-      strokeWidth="1.2"
-      d="m22.047 21.239 4.8 1.125.316.074.11.304.066.19c.623 1.964-.26 3.78-1.652 4.797-1.434 1.048-3.51 1.32-5.182.022l-.29-.225.069-.361 1.037-5.454.117-.615.61.143Z"
-    />
-    <path
-      fill="#1BA9F5"
-      stroke="#fff"
-      strokeWidth="1.2"
-      d="m5.01 9.63 5.267 1.255.283.067.122.264 1.235 2.65.187.4-.328.298-6.733 6.1-.272.248-.345-.132C1.939 19.83.72 17.456.752 15.153c.032-2.308 1.321-4.644 3.932-5.508l.162-.054.165.039Z"
-    />
-    <path
-      fill="#F04E98"
-      stroke="#fff"
-      strokeWidth="1.2"
-      d="M6.281 4.32c1.416-1.08 3.48-1.387 5.222-.069l.297.226-.07.366-1.053 5.474-.118.615-.609-.144-4.8-1.137-.316-.075-.11-.306c-.709-1.967.149-3.876 1.557-4.95Z"
-    />
-    <path
-      fill="#02BCB7"
-      stroke="#fff"
-      strokeWidth="1.2"
-      d="m12.466 14.433 7.03 3.211.188.086.095.183 1.555 2.985.096.184-.04.206-1.165 6.101-.024.122-.068.103c-2.68 3.958-6.902 4.71-10.268 3.26-3.356-1.447-5.834-5.07-5.126-9.736l.033-.21.158-.144 6.884-6.25.293-.265.36.164Z"
-    />
-    <path
-      fill="#FEC514"
-      stroke="#fff"
-      strokeWidth="1.2"
-      d="M11.892 4.41C14.438.676 18.741.105 22.134 1.54c3.392 1.433 5.99 4.92 5.102 9.362l-.039.2-.153.133-7.066 6.213-.293.258-.353-.163-7.002-3.21-.201-.093-.094-.2-1.38-2.988-.081-.177.037-.19L11.8 4.633l.023-.121.07-.102Z"
-    />
+    <defs>
+      <clipPath id="clip-0">
+        <path
+          clipRule="nonzero"
+          d="M 44 15 L 135 15 L 135 65 L 44 65 Z M 44 15"
+        />
+      </clipPath>
+      <clipPath id="clip-1">
+        <path
+          clipRule="nonzero"
+          d="M 72 33.199219 C 44 5.101562 6 12.5 6 49 C 6 85.5 72 128.101562 72 128.101562 C 72 128.101562 138.101562 85.5 138.101562 49 C 138.101562 27.503906 124.988281 15.914062 108.382812 15.914062 C 96.867188 15.914062 83.671875 21.488281 72 33.199219"
+        />
+      </clipPath>
+      <clipPath id="clip-2">
+        <path
+          clipRule="nonzero"
+          d="M 10 44 L 102 44 L 102 129 L 10 129 Z M 10 44"
+        />
+      </clipPath>
+      <clipPath id="clip-3">
+        <path
+          clipRule="nonzero"
+          d="M 72 33.199219 C 44 5.101562 6 12.5 6 49 C 6 85.5 72 128.101562 72 128.101562 C 72 128.101562 138.101562 85.5 138.101562 49 C 138.101562 27.503906 124.988281 15.914062 108.382812 15.914062 C 96.867188 15.914062 83.671875 21.488281 72 33.199219"
+        />
+      </clipPath>
+      <clipPath id="clip-4">
+        <path
+          clipRule="nonzero"
+          d="M 15 15 L 51 15 L 51 29 L 15 29 Z M 15 15"
+        />
+      </clipPath>
+      <clipPath id="clip-5">
+        <path
+          clipRule="nonzero"
+          d="M 72 33.199219 C 44 5.101562 6 12.5 6 49 C 6 85.5 72 128.101562 72 128.101562 C 72 128.101562 138.101562 85.5 138.101562 49 C 138.101562 27.503906 124.988281 15.914062 108.382812 15.914062 C 96.867188 15.914062 83.671875 21.488281 72 33.199219"
+        />
+      </clipPath>
+      <clipPath id="clip-6">
+        <path
+          clipRule="nonzero"
+          d="M 6 21 L 52 21 L 52 80 L 6 80 Z M 6 21"
+        />
+      </clipPath>
+      <clipPath id="clip-7">
+        <path
+          clipRule="nonzero"
+          d="M 72 33.199219 C 44 5.101562 6 12.5 6 49 C 6 85.5 72 128.101562 72 128.101562 C 72 128.101562 138.101562 85.5 138.101562 49 C 138.101562 27.503906 124.988281 15.914062 108.382812 15.914062 C 96.867188 15.914062 83.671875 21.488281 72 33.199219"
+        />
+      </clipPath>
+      <clipPath id="clip-8">
+        <path
+          clipRule="nonzero"
+          d="M 94 78 L 130 78 L 130 115 L 94 115 Z M 94 78"
+        />
+      </clipPath>
+      <clipPath id="clip-9">
+        <path
+          clipRule="nonzero"
+          d="M 72 33.199219 C 44 5.101562 6 12.5 6 49 C 6 85.5 72 128.101562 72 128.101562 C 72 128.101562 138.101562 85.5 138.101562 49 C 138.101562 27.503906 124.988281 15.914062 108.382812 15.914062 C 96.867188 15.914062 83.671875 21.488281 72 33.199219"
+        />
+      </clipPath>
+      <clipPath id="clip-10">
+        <path
+          clipRule="nonzero"
+          d="M 92 27 L 139 27 L 139 86 L 92 86 Z M 92 27"
+        />
+      </clipPath>
+      <clipPath id="clip-11">
+        <path
+          clipRule="nonzero"
+          d="M 72 33.199219 C 44 5.101562 6 12.5 6 49 C 6 85.5 72 128.101562 72 128.101562 C 72 128.101562 138.101562 85.5 138.101562 49 C 138.101562 27.503906 124.988281 15.914062 108.382812 15.914062 C 96.867188 15.914062 83.671875 21.488281 72 33.199219"
+        />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#clip-0)">
+      <g clipPath="url(#clip-1)">
+        <path
+          fillRule="nonzero"
+          fill="rgb(100%, 78.039551%, 18.431091%)"
+          fillOpacity="1"
+          d="M 51.800781 45.601562 L 92.5 64.101562 L 133.5 28.101562 C 138.398438 3.199219 122.199219 -20.898438 97.398438 -25.800781 C 79.5 -29.300781 61.101562 -21.898438 50.800781 -6.800781 L 44 28.601562 Z M 51.800781 45.601562"
+        />
+      </g>
+    </g>
+    <g clipPath="url(#clip-2)">
+      <g clipPath="url(#clip-3)">
+        <path
+          fillRule="nonzero"
+          fill="rgb(0%, 69.020081%, 68.235779%)"
+          fillOpacity="1"
+          d="M 11.601562 80.5 C 11 83.5 10.699219 86.601562 10.699219 89.699219 C 10.699219 115.101562 31.398438 135.699219 56.800781 135.601562 C 72 135.601562 86.199219 128.101562 94.699219 115.5 L 101.5 80.199219 L 92.5 62.898438 L 51.601562 44.300781 Z M 11.601562 80.5"
+        />
+      </g>
+    </g>
+    <g clipPath="url(#clip-4)">
+      <g clipPath="url(#clip-5)">
+        <path
+          fillRule="nonzero"
+          fill="rgb(94.117737%, 38.038635%, 62.745667%)"
+          fillOpacity="1"
+          d="M 16.601562 22.199219 L 44.5 28.800781 L 50.601562 -2.898438 C 41 -10.300781 27.101562 -8.398438 19.800781 1.199219 C 15.199219 7.199219 14 15.199219 16.601562 22.199219"
+        />
+      </g>
+    </g>
+    <g clipPath="url(#clip-6)">
+      <g clipPath="url(#clip-7)">
+        <path
+          fillRule="nonzero"
+          fill="rgb(0%, 62.745667%, 86.274719%)"
+          fillOpacity="1"
+          d="M 13.898438 21.601562 C 1.398438 25.800781 -7.101562 37.601562 -7.199219 50.800781 C -7.199219 63.5 0.699219 75 12.601562 79.5 L 51.699219 44.199219 L 44.5 28.898438 Z M 13.898438 21.601562"
+        />
+      </g>
+    </g>
+    <g clipPath="url(#clip-8)">
+      <g clipPath="url(#clip-9)">
+        <path
+          fillRule="nonzero"
+          fill="rgb(56.863403%, 77.6474%, 25.489807%)"
+          fillOpacity="1"
+          d="M 94.398438 110.199219 C 104.101562 117.5 117.898438 115.5 125.199219 105.800781 C 129.699219 99.898438 130.800781 92.101562 128.300781 85.101562 L 100.5 78.601562 Z M 94.398438 110.199219"
+        />
+      </g>
+    </g>
+    <g clipPath="url(#clip-10)">
+      <g clipPath="url(#clip-11)">
+        <path
+          fillRule="nonzero"
+          fill="rgb(0%, 45.881653%, 74.118042%)"
+          fillOpacity="1"
+          d="M 100.5 78.601562 L 131.199219 85.800781 C 143.800781 81.601562 152.199219 69.800781 152.300781 56.601562 C 152.300781 43.898438 144.398438 32.398438 132.5 27.898438 L 92.398438 63 Z M 100.5 78.601562"
+        />
+      </g>
+    </g>
   </svg>
 );

--- a/src/core/packages/rendering/server-internal/src/views/template.test.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/template.test.tsx
@@ -65,8 +65,8 @@ describe('Template (boot splash)', () => {
     const defaultSvg = $default('#kbn_loading_message .kbnLoaderWrap > svg');
     const customImg = $custom('#kbn_loading_message .kbnLoaderWrap > img');
 
-    expect(defaultSvg.attr('width')).toBe('32'); // SVG viewBox is 32; CSS scales it.
-    expect(defaultSvg.attr('viewBox')).toBe('0 0 32 32');
+    expect(defaultSvg.attr('width')).toBe('144'); // SVG viewBox is 144; CSS scales it.
+    expect(defaultSvg.attr('viewBox')).toBe('0 0 144 144');
     expect(customImg.attr('width')).toBe('40');
     expect(customImg.attr('height')).toBe('40');
   });


### PR DESCRIPTION
## Summary

Replaces the standard Elastic logo shown during "Loading Elastic" with the [elasticheart](https://gist.githubusercontent.com/tylersmalley/3b9844fbbd0878d200a50b2232c1c67d/raw/d42fa5a54f03bbea1b1c877508a2b61faa241157/elasticheart.svg) — the Elastic logo pieces arranged inside a heart shape, clipped by nested clip-path groups.

### Changes

- **`logo.tsx`** — Replaced the `logoElastic` SVG with the elasticheart SVG (same 6 colored sections, now wrapped in `<g>` elements with heart-shaped clip paths).
- **`legacy_styles.css`** — Updated animation selectors from `.kbnLoader path:nth-of-type` to `.kbnLoader > g:nth-of-type` to target the top-level `<g>` groups in the new SVG structure. The staggered `animation-delay` values are unchanged.
- **`logo.test.tsx`** — Removed the EUI `logoElastic` byte-for-byte sync guard (no longer applicable). Tests now validate the `.kbnLoader` class, 6 top-level `<g>` groups, `aria-hidden`, and clip-path defs.
- **`template.test.tsx`** — Updated expected SVG intrinsic dimensions from 32×32 to 144×144 (CSS still scales to 40×40).