### PR TITLE
[Entity Store] [POC] Add auto-discovery of log sources via Streams Knowledge Indicators

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/index.ts
@@ -7,11 +7,21 @@
 
 import type { PluginInitializerContext } from '@kbn/core-plugins-server';
 import type { StreamsConfig } from '../common/config';
-import type { StreamsPluginSetup, StreamsPluginStart } from './plugin';
+import type {
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginSetup,
+  StreamsPluginStart,
+} from './plugin';
 import type { StreamsRouteRepository } from './routes';
 import { config } from './config';
 
-export type { StreamsConfig, StreamsPluginSetup, StreamsPluginStart, StreamsRouteRepository };
+export type {
+  StreamsConfig,
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginSetup,
+  StreamsPluginStart,
+  StreamsRouteRepository,
+};
 export { config };
 
 export const plugin = async (context: PluginInitializerContext<StreamsConfig>) => {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FeatureClient } from '../feature/feature_client';
+import type { StreamsClient } from '../client';
+import { DefinitionNotFoundError } from '../errors/definition_not_found_error';
+import { createKnowledgeIndicatorsReader } from './knowledge_indicators_reader';
+
+const makeStreamsClient = (
+  streamNames: string[],
+  getStreamImpl?: (name: string) => Promise<unknown>
+): StreamsClient =>
+  ({
+    listStreams: jest.fn(async () => streamNames.map((name) => ({ name }))),
+    getStream: jest.fn(getStreamImpl ?? (async () => ({}))),
+  } as unknown as StreamsClient);
+
+const makeFeatureClient = (hits: unknown[] = []): FeatureClient =>
+  ({
+    getFeatures: jest.fn(async () => ({ hits, total: hits.length })),
+  } as unknown as FeatureClient);
+
+describe('createKnowledgeIndicatorsReader', () => {
+  it('pushes the schema type + minConfidence into the feature query', async () => {
+    const streamsClient = makeStreamsClient(['logs.a', 'logs.b']);
+    const featureClient = makeFeatureClient([{ uuid: 'x' }]);
+    const reader = createKnowledgeIndicatorsReader({ featureClient, streamsClient });
+
+    const result = await reader.listSchemaFeatures({ minConfidence: 60 });
+
+    expect(streamsClient.listStreams).toHaveBeenCalledTimes(1);
+    expect(featureClient.getFeatures).toHaveBeenCalledWith(['logs.a', 'logs.b'], {
+      type: ['schema'],
+      minConfidence: 60,
+    });
+    expect(result).toEqual([{ uuid: 'x' }]);
+  });
+
+  it('returns [] without querying features when there are no streams', async () => {
+    const streamsClient = makeStreamsClient([]);
+    const featureClient = makeFeatureClient();
+    const reader = createKnowledgeIndicatorsReader({ featureClient, streamsClient });
+
+    expect(await reader.listEntityFeatures()).toEqual([]);
+    expect(featureClient.getFeatures).not.toHaveBeenCalled();
+  });
+
+  it('resolves a present stream to a single-element pattern array', async () => {
+    const streamsClient = makeStreamsClient(['logs.a']);
+    const reader = createKnowledgeIndicatorsReader({
+      featureClient: makeFeatureClient(),
+      streamsClient,
+    });
+    expect(await reader.resolveIndexPatterns('logs.a')).toEqual(['logs.a']);
+  });
+
+  it('returns [] for a missing stream instead of throwing', async () => {
+    const streamsClient = makeStreamsClient(['logs.a'], async () => {
+      throw new DefinitionNotFoundError('nope');
+    });
+    const reader = createKnowledgeIndicatorsReader({
+      featureClient: makeFeatureClient(),
+      streamsClient,
+    });
+    expect(await reader.resolveIndexPatterns('logs.gone')).toEqual([]);
+  });
+
+  it('rethrows non-not-found errors from getStream', async () => {
+    const streamsClient = makeStreamsClient(['logs.a'], async () => {
+      throw new Error('boom');
+    });
+    const reader = createKnowledgeIndicatorsReader({
+      featureClient: makeFeatureClient(),
+      streamsClient,
+    });
+    await expect(reader.resolveIndexPatterns('logs.a')).rejects.toThrow('boom');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
@@ -25,17 +25,16 @@ const makeFeatureClient = (hits: unknown[] = []): FeatureClient =>
   } as unknown as FeatureClient);
 
 describe('createKnowledgeIndicatorsReader', () => {
-  it('pushes the schema type + minConfidence into the feature query', async () => {
+  it('pushes the dataset_analysis type into the feature query', async () => {
     const streamsClient = makeStreamsClient(['logs.a', 'logs.b']);
     const featureClient = makeFeatureClient([{ uuid: 'x' }]);
     const reader = createKnowledgeIndicatorsReader({ featureClient, streamsClient });
 
-    const result = await reader.listSchemaFeatures({ minConfidence: 60 });
+    const result = await reader.listDatasetAnalysisFeatures();
 
     expect(streamsClient.listStreams).toHaveBeenCalledTimes(1);
     expect(featureClient.getFeatures).toHaveBeenCalledWith(['logs.a', 'logs.b'], {
-      type: ['schema'],
-      minConfidence: 60,
+      type: ['dataset_analysis'],
     });
     expect(result).toEqual([{ uuid: 'x' }]);
   });
@@ -45,7 +44,7 @@ describe('createKnowledgeIndicatorsReader', () => {
     const featureClient = makeFeatureClient();
     const reader = createKnowledgeIndicatorsReader({ featureClient, streamsClient });
 
-    expect(await reader.listEntityFeatures()).toEqual([]);
+    expect(await reader.listDatasetAnalysisFeatures()).toEqual([]);
     expect(featureClient.getFeatures).not.toHaveBeenCalled();
   });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Feature } from '@kbn/streams-schema';
+import { isDefinitionNotFoundError } from '../errors/definition_not_found_error';
+import type { FeatureClient } from '../feature/feature_client';
+import type { StreamsClient } from '../client';
+
+/**
+ * Options shared by the per-class list methods on
+ * `StreamsKnowledgeIndicatorsReader`. Kept deliberately small: this surface
+ * only exposes knobs cross-plugin consumers should reach for. Pagination,
+ * excluded-feature inclusion, and arbitrary type selection are NOT exposed
+ * — those are properties of the internal `FeatureClient` that the integration
+ * has no business depending on.
+ */
+export interface StreamsKnowledgeIndicatorsListOptions {
+  /**
+   * Drops features below the given confidence (0–100). Entity store should
+   * pass its configured threshold here so changes are honored without code
+   * changes. Omit to receive every confidence level.
+   */
+  minConfidence?: number;
+}
+
+/**
+ * Read-only Knowledge Indicators surface intentionally narrowed for
+ * cross-plugin consumers (currently Entity Store v2's KI integration).
+ *
+ * Design constraints:
+ * - One method per feature class the integration consumes. No `type` filter
+ *   is exposed to callers; each method hardwires its single value so a
+ *   future consumer cannot accidentally read feature classes outside the
+ *   integration's scope through this surface.
+ * - No `limit` and no `includeExcluded`. Excluded features must never be
+ *   returned here, and pagination is an internal concern of the underlying
+ *   storage client.
+ * - Stale / expired features are filtered server-side by the underlying
+ *   `FeatureClient` defaults; this surface inherits that behavior.
+ *
+ * If a future use case genuinely needs broader access, extend this interface
+ * with another narrow, intent-named method rather than adding escape hatches
+ * to the existing methods.
+ */
+export interface StreamsKnowledgeIndicatorsReader {
+  /**
+   * Lists `type: 'entity'` Knowledge Indicators across all streams the
+   * caller is authorized to read. Filters are pushed into the underlying
+   * storage query — they are not applied client-side.
+   */
+  listEntityFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Lists `type: 'dependency'` Knowledge Indicators across all streams the
+   * caller is authorized to read. Each dependency feature carries
+   * `properties.source`, `properties.target`, and `properties.protocol`
+   * naming the two endpoints of a relationship. Filters are pushed into
+   * the underlying storage query — they are not applied client-side.
+   */
+  listDependencyFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Lists `type: 'schema'` Knowledge Indicators across all streams the caller
+   * is authorized to read. Schema features describe the log schema family
+   * evident in a stream (`properties.schema_family` ∈ `'ecs' | 'otel' |
+   * 'custom'`). Cross-plugin consumers (currently entity_store) read these
+   * to discover which streams carry entity-identity fields, and for their
+   * `properties.ecs_identity_aliases` table when present.
+   *
+   * Filters are pushed into the underlying storage query — they are not
+   * applied client-side.
+   */
+  listSchemaFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Resolves a stream name to the Elasticsearch index pattern(s) backing it.
+   *
+   * For wired streams the stream name equals the data-stream name, and
+   * Elasticsearch resolves the data-stream name in `FROM` clauses, so a
+   * single-element array `[streamName]` is sufficient. For classic
+   * (unmanaged) streams the same convention holds — the stream is itself
+   * the pre-existing data stream.
+   *
+   * Returns an empty array when the stream does not exist (rather than
+   * throwing) so callers can skip missing streams without try/catch.
+   */
+  resolveIndexPatterns(streamName: string): Promise<string[]>;
+}
+
+/**
+ * Builds a `StreamsKnowledgeIndicatorsReader` over already-scoped underlying
+ * clients. Pass the `FeatureClient` and `StreamsClient` you obtained from
+ * the streams plugin's `getScopedClients({ request })` (or, for tests, mocks
+ * matching the same interface).
+ */
+export const createKnowledgeIndicatorsReader = (deps: {
+  featureClient: FeatureClient;
+  streamsClient: StreamsClient;
+}): StreamsKnowledgeIndicatorsReader => {
+  const { featureClient, streamsClient } = deps;
+
+  const listFeaturesOfType = async (
+    type: 'entity' | 'dependency' | 'schema',
+    options?: StreamsKnowledgeIndicatorsListOptions
+  ): Promise<Feature[]> => {
+    const streams = await streamsClient.listStreams();
+    const streamNames = streams.map((stream) => stream.name);
+    if (streamNames.length === 0) {
+      return [];
+    }
+    const { hits } = await featureClient.getFeatures(streamNames, {
+      type: [type],
+      minConfidence: options?.minConfidence,
+    });
+    return hits;
+  };
+
+  return {
+    listEntityFeatures: (options) => listFeaturesOfType('entity', options),
+    listDependencyFeatures: (options) => listFeaturesOfType('dependency', options),
+    listSchemaFeatures: (options) => listFeaturesOfType('schema', options),
+
+    resolveIndexPatterns: async (streamName) => {
+      try {
+        await streamsClient.getStream(streamName);
+      } catch (error) {
+        if (isDefinitionNotFoundError(error)) {
+          return [];
+        }
+        throw error;
+      }
+      // Wired and classic streams alike: the stream name resolves directly to
+      // its backing data-stream pattern. Future variants (e.g. group streams
+      // composing multiple data streams) can extend this without breaking
+      // callers that only care about the array shape.
+      return [streamName];
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
@@ -5,27 +5,10 @@
  * 2.0.
  */
 
-import type { Feature } from '@kbn/streams-schema';
+import { DATASET_ANALYSIS_FEATURE_TYPE, type Feature } from '@kbn/streams-schema';
 import { isDefinitionNotFoundError } from '../errors/definition_not_found_error';
 import type { FeatureClient } from '../feature/feature_client';
 import type { StreamsClient } from '../client';
-
-/**
- * Options shared by the per-class list methods on
- * `StreamsKnowledgeIndicatorsReader`. Kept deliberately small: this surface
- * only exposes knobs cross-plugin consumers should reach for. Pagination,
- * excluded-feature inclusion, and arbitrary type selection are NOT exposed
- * — those are properties of the internal `FeatureClient` that the integration
- * has no business depending on.
- */
-export interface StreamsKnowledgeIndicatorsListOptions {
-  /**
-   * Drops features below the given confidence (0–100). Entity store should
-   * pass its configured threshold here so changes are honored without code
-   * changes. Omit to receive every confidence level.
-   */
-  minConfidence?: number;
-}
 
 /**
  * Read-only Knowledge Indicators surface intentionally narrowed for
@@ -48,33 +31,16 @@ export interface StreamsKnowledgeIndicatorsListOptions {
  */
 export interface StreamsKnowledgeIndicatorsReader {
   /**
-   * Lists `type: 'entity'` Knowledge Indicators across all streams the
-   * caller is authorized to read. Filters are pushed into the underlying
-   * storage query — they are not applied client-side.
+   * Lists `type: 'dataset_analysis'` Knowledge Indicators across all streams
+   * the caller is authorized to read. `dataset_analysis` is a deterministic,
+   * computed feature emitted once per analyzed stream; its
+   * `properties.analysis.fields` is an object keyed by
+   * `"<field.path> (<es_types>)"` (e.g. `"user.email (keyword)"`) with sampled
+   * value distributions. Cross-plugin consumers (currently entity_store) read
+   * these to discover which streams carry entity-identity fields and at which
+   * ES type. The `type` filter is pushed into the underlying storage query.
    */
-  listEntityFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
-
-  /**
-   * Lists `type: 'dependency'` Knowledge Indicators across all streams the
-   * caller is authorized to read. Each dependency feature carries
-   * `properties.source`, `properties.target`, and `properties.protocol`
-   * naming the two endpoints of a relationship. Filters are pushed into
-   * the underlying storage query — they are not applied client-side.
-   */
-  listDependencyFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
-
-  /**
-   * Lists `type: 'schema'` Knowledge Indicators across all streams the caller
-   * is authorized to read. Schema features describe the log schema family
-   * evident in a stream (`properties.schema_family` ∈ `'ecs' | 'otel' |
-   * 'custom'`). Cross-plugin consumers (currently entity_store) read these
-   * to discover which streams carry entity-identity fields, and for their
-   * `properties.ecs_identity_aliases` table when present.
-   *
-   * Filters are pushed into the underlying storage query — they are not
-   * applied client-side.
-   */
-  listSchemaFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+  listDatasetAnalysisFeatures(): Promise<Feature[]>;
 
   /**
    * Resolves a stream name to the Elasticsearch index pattern(s) backing it.
@@ -103,26 +69,18 @@ export const createKnowledgeIndicatorsReader = (deps: {
 }): StreamsKnowledgeIndicatorsReader => {
   const { featureClient, streamsClient } = deps;
 
-  const listFeaturesOfType = async (
-    type: 'entity' | 'dependency' | 'schema',
-    options?: StreamsKnowledgeIndicatorsListOptions
-  ): Promise<Feature[]> => {
-    const streams = await streamsClient.listStreams();
-    const streamNames = streams.map((stream) => stream.name);
-    if (streamNames.length === 0) {
-      return [];
-    }
-    const { hits } = await featureClient.getFeatures(streamNames, {
-      type: [type],
-      minConfidence: options?.minConfidence,
-    });
-    return hits;
-  };
-
   return {
-    listEntityFeatures: (options) => listFeaturesOfType('entity', options),
-    listDependencyFeatures: (options) => listFeaturesOfType('dependency', options),
-    listSchemaFeatures: (options) => listFeaturesOfType('schema', options),
+    listDatasetAnalysisFeatures: async () => {
+      const streams = await streamsClient.listStreams();
+      const streamNames = streams.map((stream) => stream.name);
+      if (streamNames.length === 0) {
+        return [];
+      }
+      const { hits } = await featureClient.getFeatures(streamNames, {
+        type: [DATASET_ANALYSIS_FEATURE_TYPE],
+      });
+      return hits;
+    },
 
     resolveIndexPatterns: async (streamName) => {
       try {

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -88,13 +88,30 @@ import {
 import { installMemoryWorkflows } from './lib/memory/install_managed_workflows';
 import { StreamsKIsOnboardingClient } from './lib/workflows/onboarding_workflow_client';
 import { STREAMS_SIGNIFICANT_EVENTS_MEMORY_ENABLED_FLAG } from '../common/feature_flags';
+import {
+  createKnowledgeIndicatorsReader,
+  type StreamsKnowledgeIndicatorsReader,
+} from './lib/streams/cross_plugin/knowledge_indicators_reader';
 
 const STREAMS_MANAGED_WORKFLOW_OWNER = 'streams';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface StreamsPluginStart {}
+
+export interface StreamsPluginStart {
+  /**
+   * Builds a request-scoped, read-only reader exposing the subset of stream
+   * Knowledge Indicators APIs intended for cross-plugin consumers. The
+   * reader is intentionally narrower than the internal `FeatureClient` /
+   * `StreamsClient` and never grants write access. See
+   * `StreamsKnowledgeIndicatorsReader` for the full surface.
+   */
+  getKnowledgeIndicatorsReader(args: {
+    request: KibanaRequest;
+  }): Promise<StreamsKnowledgeIndicatorsReader>;
+}
+
+export type { StreamsKnowledgeIndicatorsReader };
 
 export class StreamsPlugin
   implements
@@ -666,7 +683,24 @@ export class StreamsPlugin
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);
 
-    return {};
+    const streamsGetScopedClients = this.streamsGetScopedClients;
+    if (!streamsGetScopedClients) {
+      // Defensive: setup() always assigns this.streamsGetScopedClients before
+      // start() runs. Throwing surfaces a programming error rather than a
+      // silently broken cross-plugin reader.
+      throw new Error('Streams plugin: streamsGetScopedClients was not initialised in setup()');
+    }
+
+    return {
+      getKnowledgeIndicatorsReader: async ({ request }) => {
+        const scopedClients = await streamsGetScopedClients({ request });
+        const featureClient = await scopedClients.getFeatureClient();
+        return createKnowledgeIndicatorsReader({
+          featureClient,
+          streamsClient: scopedClients.streamsClient,
+        });
+      },
+    };
   }
 
   private async installMemoryWorkflowsIfEnabled(

--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -63,6 +63,7 @@ export const ENTITY_STORE_ROUTES = {
   },
   internal: {
     CHECK_PRIVILEGES: `${INTERNAL_BASE_ROUTE}/check_privileges`,
+    DISCOVERED_SOURCES: `${INTERNAL_BASE_ROUTE}/discovered_sources`,
     FORCE_LOG_EXTRACTION: `${INTERNAL_BASE_ROUTE}/{entityType}/force_log_extraction`,
     FORCE_CCS_EXTRACT_TO_UPDATES: `${INTERNAL_BASE_ROUTE}/{entityType}/force_ccs_extract_to_updates`,
     FORCE_HISTORY_SNAPSHOT: `${INTERNAL_BASE_ROUTE}/force_history_snapshot`,

--- a/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
@@ -17,7 +17,8 @@
       "licensing"
     ],
     "optionalPlugins": [
-      "encryptedSavedObjects"
+      "encryptedSavedObjects",
+      "streams"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -1835,7 +1835,6 @@ describe('LogsExtractionClient — KI-discovered index source', () => {
     reader?: StreamsKnowledgeIndicatorsReader,
     configOverrides?: Partial<{
       useDiscoveredIndexSource: boolean;
-      discoveredIndexSourceMinConfidence: number;
       additionalIndexPatterns: string[];
     }>
   ) => {
@@ -1872,20 +1871,30 @@ describe('LogsExtractionClient — KI-discovered index source', () => {
     return { client, dataViewsService };
   };
 
+  /**
+   * Builds the `properties.analysis.fields` shape a `dataset_analysis` feature
+   * carries, keyed by `formatDocumentAnalysis`'s `"<name> (<types>)"` format.
+   */
+  const analysisProps = (fieldKeys: string[]): Record<string, unknown> => ({
+    analysis: {
+      total: 100,
+      sampled: 100,
+      fields: Object.fromEntries(fieldKeys.map((key) => [key, ['sample (1%)']])),
+    },
+  });
+
   const readerWith = (
-    schemaFeatures: Array<{ stream_name: string; properties?: Record<string, unknown> }>
+    features: Array<{ stream_name: string; properties?: Record<string, unknown> }>
   ): StreamsKnowledgeIndicatorsReader => ({
-    listEntityFeatures: jest.fn(async () => []),
-    listDependencyFeatures: jest.fn(async () => []),
-    listSchemaFeatures: jest.fn(async () =>
-      schemaFeatures.map(
+    listDatasetAnalysisFeatures: jest.fn(async () =>
+      features.map(
         (f, i) =>
           ({
             id: `f${i}`,
             uuid: `u${i}`,
-            type: 'schema',
+            type: 'dataset_analysis',
             description: '',
-            confidence: 90,
+            confidence: 100,
             status: 'active',
             last_seen: '2026-06-01T00:00:00.000Z',
             stream_name: f.stream_name,
@@ -1898,7 +1907,7 @@ describe('LogsExtractionClient — KI-discovered index source', () => {
 
   it('keeps the security data view source when the flag is OFF (legacy behavior)', async () => {
     const reader = readerWith([
-      { stream_name: 'logs.okta', properties: { entity_field_presence: { user: ['user.name'] } } },
+      { stream_name: 'logs.okta', properties: analysisProps(['user.name (keyword)']) },
     ]);
     const { client, dataViewsService } = buildClient(reader, {
       useDiscoveredIndexSource: false,
@@ -1936,7 +1945,7 @@ describe('LogsExtractionClient — KI-discovered index source', () => {
     const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns(
       ['operator-extra-*'],
       [],
-      [] // zero qualifying schema features for this type
+      [] // zero qualifying dataset_analysis features for this type
     );
 
     expect(dataViewsService.get).not.toHaveBeenCalled();
@@ -1953,30 +1962,28 @@ describe('LogsExtractionClient — KI-discovered index source', () => {
       expect(result.provenance).toEqual([]);
     });
 
-    it('returns per-type sources + provenance derived from schema features', async () => {
+    it('returns per-type sources + provenance derived from dataset_analysis features', async () => {
       const reader = readerWith([
         {
           stream_name: 'logs.okta',
-          properties: { entity_field_presence: { user: ['user.name'], host: ['host.id'] } },
+          properties: analysisProps(['user.name (keyword)', 'host.id (keyword)']),
         },
         {
           stream_name: 'logs.apm',
-          properties: { entity_field_presence: { service: ['service.name'] } },
+          properties: analysisProps(['service.name (keyword)']),
         },
       ]);
       const { client } = buildClient(reader, {
         useDiscoveredIndexSource: true,
-        discoveredIndexSourceMinConfidence: 50,
       });
 
       const result = await client.getDiscoveredSources();
 
       expect(result.enabled).toBe(true);
-      expect(result.minConfidence).toBe(50);
       expect(result.sources.user).toEqual(['logs.okta']);
       expect(result.sources.host).toEqual(['logs.okta']);
       expect(result.sources.service).toEqual(['logs.apm']);
-      expect(reader.listSchemaFeatures).toHaveBeenCalledWith({ minConfidence: 50 });
+      expect(reader.listDatasetAnalysisFeatures).toHaveBeenCalledWith();
       expect(result.provenance.length).toBeGreaterThan(0);
     });
   });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -10,6 +10,8 @@ import type { CcsLogsExtractionClient } from '.';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { DataViewsService } from '@kbn/data-views-plugin/common';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import moment from 'moment';
 import { executeEsqlQuery } from '../../infra/elasticsearch/esql';
@@ -1824,6 +1826,158 @@ describe('LogsExtractionClient', () => {
       const result = await client.getRemainingLogsCount('user');
 
       expect(result).toBe(100);
+    });
+  });
+});
+
+describe('LogsExtractionClient — KI-discovered index source', () => {
+  const buildClient = (
+    reader?: StreamsKnowledgeIndicatorsReader,
+    configOverrides?: Partial<{
+      useDiscoveredIndexSource: boolean;
+      discoveredIndexSourceMinConfidence: number;
+      additionalIndexPatterns: string[];
+    }>
+  ) => {
+    const logsExtraction = LogExtractionConfig.parse({
+      docsLimit: 10000,
+      ...configOverrides,
+    });
+    const state = { logsExtraction } as EntityStoreGlobalState;
+    const globalStateClient = {
+      find: jest.fn().mockResolvedValue(state),
+      findOrThrow: jest.fn().mockResolvedValue(state),
+      update: jest.fn().mockResolvedValue({}),
+    };
+    const dataViewsService = {
+      get: jest.fn().mockResolvedValue({
+        getIndexPattern: jest.fn().mockReturnValue('logs-*,filebeat-*'),
+      }),
+    } as unknown as jest.Mocked<DataViewsService>;
+
+    const client = new LogsExtractionClient({
+      logger: loggerMock.create(),
+      namespace: 'default',
+      esClient: {} as ElasticsearchClient,
+      dataViewsService,
+      engineDescriptorClient: {
+        findOrThrow: jest.fn(),
+        update: jest.fn(),
+      } as unknown as EngineDescriptorClient,
+      globalStateClient: globalStateClient as unknown as EntityStoreGlobalStateClient,
+      ccsLogsExtractionClient:
+        createMockCcsLogsExtractionClient() as unknown as CcsLogsExtractionClient,
+      knowledgeIndicatorsReader: reader,
+    });
+    return { client, dataViewsService };
+  };
+
+  const readerWith = (
+    schemaFeatures: Array<{ stream_name: string; properties?: Record<string, unknown> }>
+  ): StreamsKnowledgeIndicatorsReader => ({
+    listEntityFeatures: jest.fn(async () => []),
+    listDependencyFeatures: jest.fn(async () => []),
+    listSchemaFeatures: jest.fn(async () =>
+      schemaFeatures.map(
+        (f, i) =>
+          ({
+            id: `f${i}`,
+            uuid: `u${i}`,
+            type: 'schema',
+            description: '',
+            confidence: 90,
+            status: 'active',
+            last_seen: '2026-06-01T00:00:00.000Z',
+            stream_name: f.stream_name,
+            properties: f.properties ?? {},
+          } as Feature)
+      )
+    ),
+    resolveIndexPatterns: jest.fn(async (streamName: string) => [streamName]),
+  });
+
+  it('keeps the security data view source when the flag is OFF (legacy behavior)', async () => {
+    const reader = readerWith([
+      { stream_name: 'logs.okta', properties: { entity_field_presence: { user: ['user.name'] } } },
+    ]);
+    const { client, dataViewsService } = buildClient(reader, {
+      useDiscoveredIndexSource: false,
+    });
+
+    const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns([], [], undefined);
+
+    expect(dataViewsService.get).toHaveBeenCalledTimes(1);
+    expect(localIndexPatterns).toContain('logs-*');
+    expect(localIndexPatterns).toContain('filebeat-*');
+  });
+
+  it('replaces the data view with discovered patterns when patterns are provided', async () => {
+    const { client, dataViewsService } = buildClient(undefined, {});
+
+    const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns(
+      ['operator-extra-*'],
+      [],
+      ['logs.okta', 'logs.apm']
+    );
+
+    // Data view is NOT queried, and its patterns are absent.
+    expect(dataViewsService.get).not.toHaveBeenCalled();
+    expect(localIndexPatterns).not.toContain('logs-*');
+    expect(localIndexPatterns).not.toContain('filebeat-*');
+    // Updates stream + operator additionalIndexPatterns + discovered are a union.
+    expect(localIndexPatterns).toContain('operator-extra-*');
+    expect(localIndexPatterns).toContain('logs.okta');
+    expect(localIndexPatterns).toContain('logs.apm');
+  });
+
+  it('extracts from updates + additional only (no data view) when discovered set is empty', async () => {
+    const { client, dataViewsService } = buildClient(undefined, {});
+
+    const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns(
+      ['operator-extra-*'],
+      [],
+      [] // zero qualifying schema features for this type
+    );
+
+    expect(dataViewsService.get).not.toHaveBeenCalled();
+    expect(localIndexPatterns).not.toContain('logs-*');
+    expect(localIndexPatterns).toContain('operator-extra-*');
+  });
+
+  describe('getDiscoveredSources', () => {
+    it('reports disabled + empty when streams reader is absent', async () => {
+      const { client } = buildClient(undefined, { useDiscoveredIndexSource: true });
+      const result = await client.getDiscoveredSources();
+      expect(result.enabled).toBe(true);
+      expect(result.sources).toEqual({ user: [], host: [], service: [], generic: [] });
+      expect(result.provenance).toEqual([]);
+    });
+
+    it('returns per-type sources + provenance derived from schema features', async () => {
+      const reader = readerWith([
+        {
+          stream_name: 'logs.okta',
+          properties: { entity_field_presence: { user: ['user.name'], host: ['host.id'] } },
+        },
+        {
+          stream_name: 'logs.apm',
+          properties: { entity_field_presence: { service: ['service.name'] } },
+        },
+      ]);
+      const { client } = buildClient(reader, {
+        useDiscoveredIndexSource: true,
+        discoveredIndexSourceMinConfidence: 50,
+      });
+
+      const result = await client.getDiscoveredSources();
+
+      expect(result.enabled).toBe(true);
+      expect(result.minConfidence).toBe(50);
+      expect(result.sources.user).toEqual(['logs.okta']);
+      expect(result.sources.host).toEqual(['logs.okta']);
+      expect(result.sources.service).toEqual(['logs.apm']);
+      expect(reader.listSchemaFeatures).toHaveBeenCalledWith({ minConfidence: 50 });
+      expect(result.provenance.length).toBeGreaterThan(0);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -161,11 +161,7 @@ export class LogsExtractionClient {
     if (!config.useDiscoveredIndexSource || !this.knowledgeIndicatorsReader) {
       return undefined;
     }
-    const { sources } = await loadPerTypeSourceIndices(
-      this.knowledgeIndicatorsReader,
-      { minConfidence: config.discoveredIndexSourceMinConfidence },
-      this.logger
-    );
+    const { sources } = await loadPerTypeSourceIndices(this.knowledgeIndicatorsReader, this.logger);
     const patterns = sources[type];
     this.logger.debug(
       `[entity_store] KI-discovered index source for type "${type}": ${patterns.length} pattern(s)${
@@ -176,27 +172,24 @@ export class LogsExtractionClient {
   }
 
   /**
-   * Read-only visibility into what the entity store auto-derives from KI schema
-   * features for each entity type, plus provenance (which stream/feature
-   * contributed and on which identity fields). Reflects the configured
-   * confidence floor. Returns empty sources when the streams plugin is absent.
-   * Reports `enabled` (the flag state) so operators can tell whether these
-   * sources are actually being used for extraction or are merely a preview.
+   * Read-only visibility into what the entity store auto-derives from KI
+   * dataset_analysis features for each entity type, plus provenance (which
+   * stream/feature contributed and on which identity fields). Returns empty
+   * sources when the streams plugin is absent. Reports `enabled` (the flag
+   * state) so operators can tell whether these sources are actually being used
+   * for extraction or are merely a preview.
    */
   public async getDiscoveredSources(): Promise<{
     enabled: boolean;
-    minConfidence: number;
     sources: PerTypeSourceIndices;
     provenance: PerTypeSourceProvenance[];
   }> {
     const globalState = await this.globalStateClient.findOrThrow();
-    const { useDiscoveredIndexSource, discoveredIndexSourceMinConfidence } =
-      globalState.logsExtraction;
+    const { useDiscoveredIndexSource } = globalState.logsExtraction;
 
     if (!this.knowledgeIndicatorsReader) {
       return {
         enabled: useDiscoveredIndexSource,
-        minConfidence: discoveredIndexSourceMinConfidence,
         sources: { user: [], host: [], service: [], generic: [] },
         provenance: [],
       };
@@ -204,12 +197,10 @@ export class LogsExtractionClient {
 
     const { sources, provenance } = await loadPerTypeSourceIndices(
       this.knowledgeIndicatorsReader,
-      { minConfidence: discoveredIndexSourceMinConfidence },
       this.logger
     );
     return {
       enabled: useDiscoveredIndexSource,
-      minConfidence: discoveredIndexSourceMinConfidence,
       sources,
       provenance,
     };
@@ -1015,8 +1006,8 @@ export class LogsExtractionClient {
    *   data view is NOT queried and there is no `logs-*` fallback. An empty
    *   discovered set means this engine sources only from `updates` + operator
    *   `additionalIndexPatterns` (typically nothing new) — deliberate, so a type
-   *   with no qualifying schema features does not silently fall back to the
-   *   coarse data view.
+   *   with no qualifying dataset_analysis features does not silently fall back
+   *   to the coarse data view.
    * - **Legacy (default).** When `discoveredSourcePatterns` is `undefined`, the
    *   Security Solution data view is appended as before (`logs-*` on failure).
    *

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -10,6 +10,12 @@ import moment from 'moment';
 import { SavedObjectsErrorHelpers, type ElasticsearchClient } from '@kbn/core/server';
 import type { DataViewsService } from '@kbn/data-views-plugin/common';
 import { isNonLocalIndexName } from '@kbn/es-query';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import {
+  loadPerTypeSourceIndices,
+  type PerTypeSourceIndices,
+  type PerTypeSourceProvenance,
+} from '../streams_features';
 import type {
   EntityType,
   ManagedEntityDefinition,
@@ -102,6 +108,13 @@ export interface LogsExtractionClientDependencies {
   engineDescriptorClient: EngineDescriptorClient;
   globalStateClient: EntityStoreGlobalStateClient;
   ccsLogsExtractionClient: CcsLogsExtractionClient;
+  /**
+   * Optional Knowledge Indicators reader used by the KI-discovered index source
+   * feature (`LogExtractionConfig.useDiscoveredIndexSource`). Absent / no-op
+   * when the streams plugin is not enabled, in which case the feature stays
+   * off regardless of the flag.
+   */
+  knowledgeIndicatorsReader?: StreamsKnowledgeIndicatorsReader;
 }
 
 export class LogsExtractionClient {
@@ -112,6 +125,7 @@ export class LogsExtractionClient {
   engineDescriptorClient: EngineDescriptorClient;
   globalStateClient: EntityStoreGlobalStateClient;
   ccsLogsExtractionClient: CcsLogsExtractionClient;
+  knowledgeIndicatorsReader?: StreamsKnowledgeIndicatorsReader;
 
   constructor({
     logger,
@@ -121,6 +135,7 @@ export class LogsExtractionClient {
     engineDescriptorClient,
     globalStateClient,
     ccsLogsExtractionClient,
+    knowledgeIndicatorsReader,
   }: LogsExtractionClientDependencies) {
     this.logger = logger;
     this.namespace = namespace;
@@ -129,6 +144,75 @@ export class LogsExtractionClient {
     this.engineDescriptorClient = engineDescriptorClient;
     this.globalStateClient = globalStateClient;
     this.ccsLogsExtractionClient = ccsLogsExtractionClient;
+    this.knowledgeIndicatorsReader = knowledgeIndicatorsReader;
+  }
+
+  /**
+   * Resolves the per-entity-type KI-discovered source index patterns for a run,
+   * or `undefined` when the feature is disabled (flag off or streams absent).
+   * `undefined` signals the index-pattern builders to keep the legacy
+   * Security-Solution-data-view source; a defined array (even empty) signals the
+   * data-view replacement path.
+   */
+  private async resolveDiscoveredSourcePatterns(
+    type: EntityType,
+    config: LogExtractionConfig
+  ): Promise<string[] | undefined> {
+    if (!config.useDiscoveredIndexSource || !this.knowledgeIndicatorsReader) {
+      return undefined;
+    }
+    const { sources } = await loadPerTypeSourceIndices(
+      this.knowledgeIndicatorsReader,
+      { minConfidence: config.discoveredIndexSourceMinConfidence },
+      this.logger
+    );
+    const patterns = sources[type];
+    this.logger.debug(
+      `[entity_store] KI-discovered index source for type "${type}": ${patterns.length} pattern(s)${
+        patterns.length ? ` (${patterns.join(', ')})` : ''
+      }`
+    );
+    return patterns;
+  }
+
+  /**
+   * Read-only visibility into what the entity store auto-derives from KI schema
+   * features for each entity type, plus provenance (which stream/feature
+   * contributed and on which identity fields). Reflects the configured
+   * confidence floor. Returns empty sources when the streams plugin is absent.
+   * Reports `enabled` (the flag state) so operators can tell whether these
+   * sources are actually being used for extraction or are merely a preview.
+   */
+  public async getDiscoveredSources(): Promise<{
+    enabled: boolean;
+    minConfidence: number;
+    sources: PerTypeSourceIndices;
+    provenance: PerTypeSourceProvenance[];
+  }> {
+    const globalState = await this.globalStateClient.findOrThrow();
+    const { useDiscoveredIndexSource, discoveredIndexSourceMinConfidence } =
+      globalState.logsExtraction;
+
+    if (!this.knowledgeIndicatorsReader) {
+      return {
+        enabled: useDiscoveredIndexSource,
+        minConfidence: discoveredIndexSourceMinConfidence,
+        sources: { user: [], host: [], service: [], generic: [] },
+        provenance: [],
+      };
+    }
+
+    const { sources, provenance } = await loadPerTypeSourceIndices(
+      this.knowledgeIndicatorsReader,
+      { minConfidence: discoveredIndexSourceMinConfidence },
+      this.logger
+    );
+    return {
+      enabled: useDiscoveredIndexSource,
+      minConfidence: discoveredIndexSourceMinConfidence,
+      sources,
+      provenance,
+    };
   }
 
   private async getLogExtractionConfigAndState(
@@ -218,9 +302,11 @@ export class LogsExtractionClient {
   public async getRemainingLogsCount(type: EntityType): Promise<number> {
     try {
       const { config, engineState } = await this.getLogExtractionConfigAndState(type);
+      const discoveredSourcePatterns = await this.resolveDiscoveredSourcePatterns(type, config);
       const indexPatterns = await this.getLocalIndexPatterns(
         config.additionalIndexPatterns,
-        config.excludedIndexPatterns
+        config.excludedIndexPatterns,
+        discoveredSourcePatterns
       );
       const { fromDateISO } = resolveMainExtractionWindow({ config, engineState });
       const toDateISO = moment().utc().toISOString();
@@ -272,9 +358,11 @@ export class LogsExtractionClient {
     logsCapApplied: boolean;
     logsProcessed: number;
   }> {
+    const discoveredSourcePatterns = await this.resolveDiscoveredSourcePatterns(type, config);
     const { localIndexPatterns, remoteIndexPatterns } = await this.getLocalAndRemoteIndexPatterns(
       config.additionalIndexPatterns,
-      config.excludedIndexPatterns
+      config.excludedIndexPatterns,
+      discoveredSourcePatterns
     );
     const latestIndex = getLatestEntitiesIndexName(this.namespace);
 
@@ -869,9 +957,13 @@ export class LogsExtractionClient {
    */
   public async getLocalAndRemoteIndexPatterns(
     additionalIndexPatterns: string[] = [],
-    excludedIndexPatterns: string[] = []
+    excludedIndexPatterns: string[] = [],
+    discoveredSourcePatterns?: string[]
   ): Promise<{ localIndexPatterns: string[]; remoteIndexPatterns: string[] }> {
-    const all = await this.getAllIndexPatternsIncludingRemote(additionalIndexPatterns);
+    const all = await this.getAllIndexPatternsIncludingRemote(
+      additionalIndexPatterns,
+      discoveredSourcePatterns
+    );
     const alertsIndex = getAlertsIndexName(this.namespace);
     const withoutAlerts = all.filter((index) => index !== alertsIndex);
 
@@ -901,24 +993,47 @@ export class LogsExtractionClient {
 
   public async getLocalIndexPatterns(
     additionalIndexPatterns: string[] = [],
-    excludedIndexPatterns: string[] = []
+    excludedIndexPatterns: string[] = [],
+    discoveredSourcePatterns?: string[]
   ): Promise<string[]> {
     const { localIndexPatterns } = await this.getLocalAndRemoteIndexPatterns(
       additionalIndexPatterns,
-      excludedIndexPatterns
+      excludedIndexPatterns,
+      discoveredSourcePatterns
     );
     return localIndexPatterns;
   }
 
   /**
-   * Builds the full list of index patterns (updates, additional, security data view)
-   * including CCS remote indices, without filtering by alerts or CCS.
+   * Builds the full list of source index patterns (including CCS remote indices,
+   * without filtering by alerts or CCS).
+   *
+   * Two mutually exclusive source models:
+   * - **KI-discovered (data-view replacement).** When `discoveredSourcePatterns`
+   *   is defined (the `useDiscoveredIndexSource` flag is on), the per-entity-type
+   *   KI-discovered patterns are the sole stream source. The Security Solution
+   *   data view is NOT queried and there is no `logs-*` fallback. An empty
+   *   discovered set means this engine sources only from `updates` + operator
+   *   `additionalIndexPatterns` (typically nothing new) — deliberate, so a type
+   *   with no qualifying schema features does not silently fall back to the
+   *   coarse data view.
+   * - **Legacy (default).** When `discoveredSourcePatterns` is `undefined`, the
+   *   Security Solution data view is appended as before (`logs-*` on failure).
+   *
+   * `updates` and operator `additionalIndexPatterns` are a hard union in both
+   * models.
    */
   private async getAllIndexPatternsIncludingRemote(
-    additionalIndexPatterns: string[] = []
+    additionalIndexPatterns: string[] = [],
+    discoveredSourcePatterns?: string[]
   ): Promise<string[]> {
     const updatesDataStream = getUpdatesEntitiesDataStreamName(this.namespace);
     const indexPatterns: string[] = [updatesDataStream, ...additionalIndexPatterns];
+
+    if (discoveredSourcePatterns !== undefined) {
+      indexPatterns.push(...discoveredSourcePatterns);
+      return indexPatterns;
+    }
 
     try {
       const secSolDataView = await this.dataViewsService.get(

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -22,10 +22,6 @@ export const LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT = '15m';
 export const LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT = 100_000;
 export const LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT = 'drop' as const;
 
-// Default confidence floor for KI-discovered source streams. 0 = include every
-// qualifying schema feature regardless of confidence; operators can raise it.
-export const LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT = 0;
-
 export type LogExtractionConfig = z.infer<typeof LogExtractionConfig>;
 export const LogExtractionConfig = z.object({
   additionalIndexPatterns: z.array(z.string()).default([]),
@@ -38,16 +34,6 @@ export const LogExtractionConfig = z.object({
    * byte-identical to a deployment without this feature.
    */
   useDiscoveredIndexSource: z.boolean().default(false),
-  /**
-   * Confidence floor (0–100) pushed into the schema-feature query when
-   * `useDiscoveredIndexSource` is enabled. Only effective while the flag is on.
-   */
-  discoveredIndexSourceMinConfidence: z
-    .number()
-    .int()
-    .min(0)
-    .max(100)
-    .default(LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT),
   fieldHistoryLength: z.number().int().default(10),
   lookbackPeriod: z
     .string()

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -22,10 +22,32 @@ export const LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT = '15m';
 export const LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT = 100_000;
 export const LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT = 'drop' as const;
 
+// Default confidence floor for KI-discovered source streams. 0 = include every
+// qualifying schema feature regardless of confidence; operators can raise it.
+export const LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT = 0;
+
 export type LogExtractionConfig = z.infer<typeof LogExtractionConfig>;
 export const LogExtractionConfig = z.object({
   additionalIndexPatterns: z.array(z.string()).default([]),
   excludedIndexPatterns: z.array(z.string()).default([]),
+  /**
+   * POC feature flag (idea 01 re-scope): when true, each engine sources its
+   * `FROM` from KI-discovered, per-entity-type index patterns instead of the
+   * Security Solution data view. The data view is NOT used as a source while
+   * this is enabled (no silent fallback). Default `false` keeps behavior
+   * byte-identical to a deployment without this feature.
+   */
+  useDiscoveredIndexSource: z.boolean().default(false),
+  /**
+   * Confidence floor (0–100) pushed into the schema-feature query when
+   * `useDiscoveredIndexSource` is enabled. Only effective while the flag is on.
+   */
+  discoveredIndexSourceMinConfidence: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .default(LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT),
   fieldHistoryLength: z.number().int().default(10),
   lookbackPeriod: z
     .string()

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
@@ -12,6 +12,7 @@ import {
   LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT,
   LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT,
   LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT,
+  LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT,
 } from './constants';
 
 export const EntityStoreGlobalStateTypeName = 'entity-store-global-state';
@@ -120,11 +121,41 @@ const version3: SavedObjectsFullModelVersion = {
   },
 };
 
+const logExtractionSchemaV4 = logExtractionSchemaV3.extends({
+  useDiscoveredIndexSource: schema.maybe(schema.boolean()),
+  discoveredIndexSourceMinConfidence: schema.maybe(schema.number()),
+});
+
+const globalStateSchemaV4 = globalStateSchemaV3.extends({
+  logsExtraction: logExtractionSchemaV4,
+});
+
+const version4: SavedObjectsFullModelVersion = {
+  changes: [
+    {
+      type: 'data_backfill',
+      backfillFn: () => ({
+        attributes: {
+          logsExtraction: {
+            useDiscoveredIndexSource: false,
+            discoveredIndexSourceMinConfidence:
+              LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT,
+          },
+        },
+      }),
+    },
+  ],
+  schemas: {
+    create: globalStateSchemaV4,
+    forwardCompatibility: globalStateSchemaV4.extends({}, { unknowns: 'ignore' }),
+  },
+};
+
 export const EntityStoreGlobalStateType: SavedObjectsType = {
   name: EntityStoreGlobalStateTypeName,
   hidden: false,
   namespaceType: 'multiple-isolated',
   mappings: EntityStoreGlobalStateTypeMappings,
-  modelVersions: { 1: version1, 2: version2, 3: version3 },
+  modelVersions: { 1: version1, 2: version2, 3: version3, 4: version4 },
   hiddenFromHttpApis: true,
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
@@ -12,7 +12,6 @@ import {
   LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT,
   LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT,
   LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT,
-  LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT,
 } from './constants';
 
 export const EntityStoreGlobalStateTypeName = 'entity-store-global-state';
@@ -123,7 +122,6 @@ const version3: SavedObjectsFullModelVersion = {
 
 const logExtractionSchemaV4 = logExtractionSchemaV3.extends({
   useDiscoveredIndexSource: schema.maybe(schema.boolean()),
-  discoveredIndexSourceMinConfidence: schema.maybe(schema.number()),
 });
 
 const globalStateSchemaV4 = globalStateSchemaV3.extends({
@@ -138,8 +136,6 @@ const version4: SavedObjectsFullModelVersion = {
         attributes: {
           logsExtraction: {
             useDiscoveredIndexSource: false,
-            discoveredIndexSourceMinConfidence:
-              LOG_EXTRACTION_DISCOVERED_SOURCE_MIN_CONFIDENCE_DEFAULT,
           },
         },
       }),

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  createKnowledgeIndicatorsReader,
+  createKnowledgeIndicatorsReaderFromStreamsStart,
+} from './knowledge_indicators_reader_factory';
+export {
+  ENTITY_TYPE_IDENTITY_FIELDS,
+  deriveEntityFieldPresence,
+  loadPerTypeSourceIndices,
+} from './load_per_type_source_indices';
+export type {
+  EntityFieldPresence,
+  LoadPerTypeSourceIndicesOptions,
+  PerTypeSourceIndices,
+  PerTypeSourceProvenance,
+} from './load_per_type_source_indices';

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
@@ -11,12 +11,11 @@ export {
 } from './knowledge_indicators_reader_factory';
 export {
   ENTITY_TYPE_IDENTITY_FIELDS,
-  deriveEntityFieldPresence,
+  deriveEntityFieldPresenceFromDatasetAnalysis,
   loadPerTypeSourceIndices,
 } from './load_per_type_source_indices';
 export type {
   EntityFieldPresence,
-  LoadPerTypeSourceIndicesOptions,
   PerTypeSourceIndices,
   PerTypeSourceProvenance,
 } from './load_per_type_source_indices';

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { StreamsPluginStart } from '@kbn/streams-plugin/server';
+import {
+  __NO_OP_KI_READER_FOR_TESTING,
+  createKnowledgeIndicatorsReaderFromStreamsStart,
+} from './knowledge_indicators_reader_factory';
+
+const logger = { debug: jest.fn(), warn: jest.fn() } as unknown as Logger;
+const request = {} as KibanaRequest;
+
+describe('createKnowledgeIndicatorsReaderFromStreamsStart', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns the shared no-op reader when streams is undefined', async () => {
+    const reader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+      streams: undefined,
+      request,
+      logger,
+    });
+    expect(reader).toBe(__NO_OP_KI_READER_FOR_TESTING);
+    expect(await reader.listSchemaFeatures()).toEqual([]);
+    expect(await reader.resolveIndexPatterns('any')).toEqual([]);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to streams.getKnowledgeIndicatorsReader when streams is present', async () => {
+    const delegateReader = { listSchemaFeatures: jest.fn() };
+    const streams = {
+      getKnowledgeIndicatorsReader: jest.fn(async () => delegateReader),
+    } as unknown as StreamsPluginStart;
+
+    const reader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+      streams,
+      request,
+      logger,
+    });
+
+    expect(streams.getKnowledgeIndicatorsReader).toHaveBeenCalledWith({ request });
+    expect(reader).toBe(delegateReader);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
@@ -26,13 +26,13 @@ describe('createKnowledgeIndicatorsReaderFromStreamsStart', () => {
       logger,
     });
     expect(reader).toBe(__NO_OP_KI_READER_FOR_TESTING);
-    expect(await reader.listSchemaFeatures()).toEqual([]);
+    expect(await reader.listDatasetAnalysisFeatures()).toEqual([]);
     expect(await reader.resolveIndexPatterns('any')).toEqual([]);
     expect(logger.debug).toHaveBeenCalledTimes(1);
   });
 
   it('delegates to streams.getKnowledgeIndicatorsReader when streams is present', async () => {
-    const delegateReader = { listSchemaFeatures: jest.fn() };
+    const delegateReader = { listDatasetAnalysisFeatures: jest.fn() };
     const streams = {
       getKnowledgeIndicatorsReader: jest.fn(async () => delegateReader),
     } as unknown as StreamsPluginStart;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type {
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginStart,
+} from '@kbn/streams-plugin/server';
+import type { EntityStoreCoreSetup } from '../../types';
+
+/**
+ * No-op reader returned when the streams plugin is not enabled in the
+ * deployment (it's an optional dependency in entity_store's `kibana.jsonc`).
+ *
+ * Returning empty arrays — rather than `null` or throwing — lets callers in
+ * the extract task drive a uniform "no Knowledge Indicators to process" branch
+ * without scattering `if (reader)` guards through the task flow. The semantics
+ * also align with `resolveIndexPatterns`'s documented behavior of returning
+ * `[]` for missing streams.
+ */
+const NO_OP_KI_READER: StreamsKnowledgeIndicatorsReader = {
+  listEntityFeatures: async () => [],
+  listDependencyFeatures: async () => [],
+  listSchemaFeatures: async () => [],
+  resolveIndexPatterns: async () => [],
+};
+
+/**
+ * Resolves a request-scoped `StreamsKnowledgeIndicatorsReader` for the given
+ * `fakeRequest`. Use this from any entity-store flow that needs to read
+ * Knowledge Indicators or resolve stream-backed index patterns.
+ *
+ * Behavior:
+ * - When streams is enabled, delegates to
+ *   `streamsStart.getKnowledgeIndicatorsReader({ request })`. The returned
+ *   reader inherits the request's auth / space scoping.
+ * - When streams is NOT enabled (optional dependency missing), returns
+ *   `NO_OP_KI_READER` and logs a single debug line. Entity store keeps
+ *   functioning without stream-derived sources.
+ */
+export const createKnowledgeIndicatorsReader = async ({
+  core,
+  fakeRequest,
+  logger,
+}: {
+  core: EntityStoreCoreSetup;
+  fakeRequest: KibanaRequest;
+  logger: Logger;
+}): Promise<StreamsKnowledgeIndicatorsReader> => {
+  const [, pluginsStart] = await core.getStartServices();
+  if (!pluginsStart.streams) {
+    logger.debug(
+      'Streams plugin not available; Knowledge Indicators reader will return empty results'
+    );
+    return NO_OP_KI_READER;
+  }
+  return pluginsStart.streams.getKnowledgeIndicatorsReader({ request: fakeRequest });
+};
+
+/**
+ * Request-scoped variant of {@link createKnowledgeIndicatorsReader} for callers
+ * that already hold a started `StreamsPluginStart` (typical in route handlers,
+ * which receive the start contract via the request context). Skips the
+ * `coreSetup.getStartServices()` round-trip that the background-task variant
+ * needs.
+ *
+ * Behavior matches the background-task factory: returns the no-op reader when
+ * `streams` is `undefined` (streams plugin not enabled in the deployment).
+ */
+export const createKnowledgeIndicatorsReaderFromStreamsStart = async ({
+  streams,
+  request,
+  logger,
+}: {
+  streams: StreamsPluginStart | undefined;
+  request: KibanaRequest;
+  logger: Logger;
+}): Promise<StreamsKnowledgeIndicatorsReader> => {
+  if (!streams) {
+    logger.debug(
+      'Streams plugin not available; Knowledge Indicators reader will return empty results'
+    );
+    return NO_OP_KI_READER;
+  }
+  return streams.getKnowledgeIndicatorsReader({ request });
+};
+
+/** Exported for tests so they can assert reference-equality against the fallback. */
+export const __NO_OP_KI_READER_FOR_TESTING = NO_OP_KI_READER;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
@@ -24,9 +24,7 @@ import type { EntityStoreCoreSetup } from '../../types';
  * `[]` for missing streams.
  */
 const NO_OP_KI_READER: StreamsKnowledgeIndicatorsReader = {
-  listEntityFeatures: async () => [],
-  listDependencyFeatures: async () => [],
-  listSchemaFeatures: async () => [],
+  listDatasetAnalysisFeatures: async () => [],
   resolveIndexPatterns: async () => [],
 };
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.test.ts
@@ -9,7 +9,7 @@ import type { Logger } from '@kbn/logging';
 import type { Feature } from '@kbn/streams-schema';
 import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
 import {
-  deriveEntityFieldPresence,
+  deriveEntityFieldPresenceFromDatasetAnalysis,
   loadPerTypeSourceIndices,
 } from './load_per_type_source_indices';
 
@@ -20,13 +20,27 @@ const logger = {
   info: jest.fn(),
 } as unknown as Logger;
 
+/**
+ * Builds the `properties.analysis.fields` shape a `dataset_analysis` feature
+ * carries. Keys mirror `formatDocumentAnalysis`'s `"<name> (<types>)"` format
+ * (e.g. `"user.email (keyword)"`); the sampled value lists are irrelevant to
+ * source discovery, so a single placeholder entry is used.
+ */
+const datasetAnalysisProps = (fieldKeys: string[]): Record<string, unknown> => ({
+  analysis: {
+    total: 100,
+    sampled: 100,
+    fields: Object.fromEntries(fieldKeys.map((key) => [key, ['sample (1%)']])),
+  },
+});
+
 const makeFeature = (overrides: Partial<Feature> & { stream_name: string }): Feature =>
   ({
     id: `feature-${overrides.stream_name}`,
     uuid: `uuid-${overrides.stream_name}`,
-    type: 'schema',
-    description: 'schema feature',
-    confidence: 90,
+    type: 'dataset_analysis',
+    description: 'dataset analysis feature',
+    confidence: 100,
     status: 'active',
     last_seen: '2026-06-01T00:00:00.000Z',
     properties: {},
@@ -37,91 +51,83 @@ const makeReader = (
   features: Feature[],
   resolve: (streamName: string) => string[] = (streamName) => [streamName]
 ): StreamsKnowledgeIndicatorsReader => ({
-  listEntityFeatures: jest.fn(async () => []),
-  listDependencyFeatures: jest.fn(async () => []),
-  listSchemaFeatures: jest.fn(async () => features),
+  listDatasetAnalysisFeatures: jest.fn(async () => features),
   resolveIndexPatterns: jest.fn(async (streamName: string) => resolve(streamName)),
 });
 
-describe('deriveEntityFieldPresence', () => {
-  it('reads explicit entity_field_presence values, intersected with the identity vocab', () => {
-    const present = deriveEntityFieldPresence(
+describe('deriveEntityFieldPresenceFromDatasetAnalysis', () => {
+  it('treats keyword-typed identity fields as present', () => {
+    const present = deriveEntityFieldPresenceFromDatasetAnalysis(
       makeFeature({
         stream_name: 'logs.app',
-        properties: {
-          entity_field_presence: {
-            user: ['user.name', 'user.email'],
-            host: ['host.name'],
-            // hallucinated field is dropped:
-            misc: ['not.an.identity.field'],
-          },
-        },
+        properties: datasetAnalysisProps([
+          'user.name (keyword)',
+          'user.email (keyword)',
+          'host.name (keyword)',
+        ]),
       })
     );
     expect(present).toEqual(new Set(['user.name', 'user.email', 'host.name']));
   });
 
-  it('reads ecs_identity_aliases keys as present identity fields', () => {
-    const present = deriveEntityFieldPresence(
+  it('ignores fields that are not in the identity vocabulary', () => {
+    const present = deriveEntityFieldPresenceFromDatasetAnalysis(
       makeFeature({
-        stream_name: 'logs.azure',
-        properties: {
-          ecs_identity_aliases: {
-            'user.email': ['azure.signin.userPrincipalName'],
-            'host.name': ['azure.resource.host'],
-          },
-        },
+        stream_name: 'logs.app',
+        properties: datasetAnalysisProps(['message (keyword)', 'not.an.identity.field (keyword)']),
       })
     );
-    expect(present).toEqual(new Set(['user.email', 'host.name']));
+    expect(present.size).toBe(0);
   });
 
-  it('falls back to scanning evidence strings for verbatim identity field names', () => {
-    const present = deriveEntityFieldPresence(
+  it('excludes identity fields mapped only as text or unmapped (unsafe types)', () => {
+    const present = deriveEntityFieldPresenceFromDatasetAnalysis(
       makeFeature({
-        stream_name: 'logs.custom',
-        evidence: ['field service.name observed in 92% of docs', 'no identity here'],
+        stream_name: 'logs.app',
+        properties: datasetAnalysisProps(['user.name (text)', 'user.email (unmapped - no type)']),
       })
     );
-    expect(present).toEqual(new Set(['service.name']));
+    expect(present.size).toBe(0);
   });
 
-  it('returns an empty set when nothing surfaces identity fields', () => {
-    const present = deriveEntityFieldPresence(
-      makeFeature({ stream_name: 'logs.noise', evidence: ['only message.text seen'] })
+  it('includes a multi-typed identity field when one of its types is keyword', () => {
+    const present = deriveEntityFieldPresenceFromDatasetAnalysis(
+      makeFeature({
+        stream_name: 'logs.app',
+        properties: datasetAnalysisProps(['user.name (text, keyword)']),
+      })
+    );
+    expect(present).toEqual(new Set(['user.name']));
+  });
+
+  it('returns an empty set when the feature has no analysis fields', () => {
+    const present = deriveEntityFieldPresenceFromDatasetAnalysis(
+      makeFeature({ stream_name: 'logs.noise', properties: {} })
     );
     expect(present.size).toBe(0);
   });
 });
 
 describe('loadPerTypeSourceIndices', () => {
-  it('short-circuits with empty sources and no I/O when minConfidence is null', async () => {
-    const reader = makeReader([makeFeature({ stream_name: 'logs.app' })]);
-    const { sources, provenance } = await loadPerTypeSourceIndices(
-      reader,
-      { minConfidence: null },
-      logger
-    );
-    expect(reader.listSchemaFeatures).not.toHaveBeenCalled();
-    expect(sources).toEqual({ user: [], host: [], service: [], generic: [] });
-    expect(provenance).toEqual([]);
+  it('lists dataset_analysis features without a confidence-floor argument', async () => {
+    const reader = makeReader([]);
+    await loadPerTypeSourceIndices(reader, logger);
+    expect(reader.listDatasetAnalysisFeatures).toHaveBeenCalledWith();
   });
 
-  it('qualifies a stream for every entity type whose identity fields it carries', async () => {
+  it('qualifies a stream for every entity type whose keyword identity fields it carries', async () => {
     const reader = makeReader([
       makeFeature({
         stream_name: 'logs.okta',
-        properties: {
-          entity_field_presence: { user: ['user.name'], host: ['host.id'] },
-        },
+        properties: datasetAnalysisProps(['user.name (keyword)', 'host.id (keyword)']),
       }),
       makeFeature({
         stream_name: 'logs.apm',
-        properties: { entity_field_presence: { service: ['service.name'] } },
+        properties: datasetAnalysisProps(['service.name (keyword)']),
       }),
     ]);
 
-    const { sources } = await loadPerTypeSourceIndices(reader, { minConfidence: 0 }, logger);
+    const { sources } = await loadPerTypeSourceIndices(reader, logger);
 
     expect(sources.user).toEqual(['logs.okta']);
     expect(sources.host).toEqual(['logs.okta']);
@@ -129,19 +135,23 @@ describe('loadPerTypeSourceIndices', () => {
     expect(sources.generic).toEqual([]);
   });
 
-  it('passes the configured confidence floor to the reader', async () => {
-    const reader = makeReader([]);
-    await loadPerTypeSourceIndices(reader, { minConfidence: 75 }, logger);
-    expect(reader.listSchemaFeatures).toHaveBeenCalledWith({ minConfidence: 75 });
+  it('does not qualify a stream whose identity fields are all unsafe types', async () => {
+    const reader = makeReader([
+      makeFeature({
+        stream_name: 'logs.text',
+        properties: datasetAnalysisProps(['user.name (text)', 'host.name (unmapped - no type)']),
+      }),
+    ]);
+
+    const { sources, provenance } = await loadPerTypeSourceIndices(reader, logger);
+
+    expect(sources).toEqual({ user: [], host: [], service: [], generic: [] });
+    expect(provenance).toEqual([]);
   });
 
-  it('returns empty sources when there are zero schema features', async () => {
+  it('returns empty sources when there are zero dataset_analysis features', async () => {
     const reader = makeReader([]);
-    const { sources, provenance } = await loadPerTypeSourceIndices(
-      reader,
-      { minConfidence: 0 },
-      logger
-    );
+    const { sources, provenance } = await loadPerTypeSourceIndices(reader, logger);
     expect(sources).toEqual({ user: [], host: [], service: [], generic: [] });
     expect(provenance).toEqual([]);
   });
@@ -151,46 +161,39 @@ describe('loadPerTypeSourceIndices', () => {
       [
         makeFeature({
           stream_name: 'logs.gone',
-          properties: { entity_field_presence: { user: ['user.name'] } },
+          properties: datasetAnalysisProps(['user.name (keyword)']),
         }),
       ],
       () => [] // resolveIndexPatterns returns nothing
     );
-    const { sources, provenance } = await loadPerTypeSourceIndices(
-      reader,
-      { minConfidence: 0 },
-      logger
-    );
+    const { sources, provenance } = await loadPerTypeSourceIndices(reader, logger);
     expect(sources.user).toEqual([]);
     expect(provenance).toEqual([]);
   });
 
-  it('dedupes patterns and records provenance with matched fields', async () => {
-    const reader = makeReader([
-      makeFeature({
-        stream_name: 'logs.dup',
-        confidence: 80,
-        properties: { entity_field_presence: { user: ['user.name', 'user.email'] } },
-      }),
-      makeFeature({
-        stream_name: 'logs.dup',
-        confidence: 70,
-        properties: { entity_field_presence: { user: ['user.id'] } },
-      }),
-    ]);
-
-    const { sources, provenance } = await loadPerTypeSourceIndices(
-      reader,
-      { minConfidence: 0 },
-      logger
+  it('dedupes patterns across streams and records provenance with matched fields', async () => {
+    const reader = makeReader(
+      [
+        makeFeature({
+          stream_name: 'logs.dup-a',
+          properties: datasetAnalysisProps(['user.name (keyword)', 'user.email (keyword)']),
+        }),
+        makeFeature({
+          stream_name: 'logs.dup-b',
+          properties: datasetAnalysisProps(['user.id (keyword)']),
+        }),
+      ],
+      () => ['shared-user-index-*'] // both streams resolve to the same pattern
     );
 
-    expect(sources.user).toEqual(['logs.dup']);
+    const { sources, provenance } = await loadPerTypeSourceIndices(reader, logger);
+
+    expect(sources.user).toEqual(['shared-user-index-*']);
     expect(provenance).toHaveLength(2);
     expect(provenance[0]).toMatchObject({
       entityType: 'user',
-      streamName: 'logs.dup',
-      matchedFields: ['user.email', 'user.name'].sort(),
+      streamName: 'logs.dup-a',
+      matchedFields: ['user.email', 'user.name'],
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import {
+  deriveEntityFieldPresence,
+  loadPerTypeSourceIndices,
+} from './load_per_type_source_indices';
+
+const logger = {
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+} as unknown as Logger;
+
+const makeFeature = (overrides: Partial<Feature> & { stream_name: string }): Feature =>
+  ({
+    id: `feature-${overrides.stream_name}`,
+    uuid: `uuid-${overrides.stream_name}`,
+    type: 'schema',
+    description: 'schema feature',
+    confidence: 90,
+    status: 'active',
+    last_seen: '2026-06-01T00:00:00.000Z',
+    properties: {},
+    ...overrides,
+  } as Feature);
+
+const makeReader = (
+  features: Feature[],
+  resolve: (streamName: string) => string[] = (streamName) => [streamName]
+): StreamsKnowledgeIndicatorsReader => ({
+  listEntityFeatures: jest.fn(async () => []),
+  listDependencyFeatures: jest.fn(async () => []),
+  listSchemaFeatures: jest.fn(async () => features),
+  resolveIndexPatterns: jest.fn(async (streamName: string) => resolve(streamName)),
+});
+
+describe('deriveEntityFieldPresence', () => {
+  it('reads explicit entity_field_presence values, intersected with the identity vocab', () => {
+    const present = deriveEntityFieldPresence(
+      makeFeature({
+        stream_name: 'logs.app',
+        properties: {
+          entity_field_presence: {
+            user: ['user.name', 'user.email'],
+            host: ['host.name'],
+            // hallucinated field is dropped:
+            misc: ['not.an.identity.field'],
+          },
+        },
+      })
+    );
+    expect(present).toEqual(new Set(['user.name', 'user.email', 'host.name']));
+  });
+
+  it('reads ecs_identity_aliases keys as present identity fields', () => {
+    const present = deriveEntityFieldPresence(
+      makeFeature({
+        stream_name: 'logs.azure',
+        properties: {
+          ecs_identity_aliases: {
+            'user.email': ['azure.signin.userPrincipalName'],
+            'host.name': ['azure.resource.host'],
+          },
+        },
+      })
+    );
+    expect(present).toEqual(new Set(['user.email', 'host.name']));
+  });
+
+  it('falls back to scanning evidence strings for verbatim identity field names', () => {
+    const present = deriveEntityFieldPresence(
+      makeFeature({
+        stream_name: 'logs.custom',
+        evidence: ['field service.name observed in 92% of docs', 'no identity here'],
+      })
+    );
+    expect(present).toEqual(new Set(['service.name']));
+  });
+
+  it('returns an empty set when nothing surfaces identity fields', () => {
+    const present = deriveEntityFieldPresence(
+      makeFeature({ stream_name: 'logs.noise', evidence: ['only message.text seen'] })
+    );
+    expect(present.size).toBe(0);
+  });
+});
+
+describe('loadPerTypeSourceIndices', () => {
+  it('short-circuits with empty sources and no I/O when minConfidence is null', async () => {
+    const reader = makeReader([makeFeature({ stream_name: 'logs.app' })]);
+    const { sources, provenance } = await loadPerTypeSourceIndices(
+      reader,
+      { minConfidence: null },
+      logger
+    );
+    expect(reader.listSchemaFeatures).not.toHaveBeenCalled();
+    expect(sources).toEqual({ user: [], host: [], service: [], generic: [] });
+    expect(provenance).toEqual([]);
+  });
+
+  it('qualifies a stream for every entity type whose identity fields it carries', async () => {
+    const reader = makeReader([
+      makeFeature({
+        stream_name: 'logs.okta',
+        properties: {
+          entity_field_presence: { user: ['user.name'], host: ['host.id'] },
+        },
+      }),
+      makeFeature({
+        stream_name: 'logs.apm',
+        properties: { entity_field_presence: { service: ['service.name'] } },
+      }),
+    ]);
+
+    const { sources } = await loadPerTypeSourceIndices(reader, { minConfidence: 0 }, logger);
+
+    expect(sources.user).toEqual(['logs.okta']);
+    expect(sources.host).toEqual(['logs.okta']);
+    expect(sources.service).toEqual(['logs.apm']);
+    expect(sources.generic).toEqual([]);
+  });
+
+  it('passes the configured confidence floor to the reader', async () => {
+    const reader = makeReader([]);
+    await loadPerTypeSourceIndices(reader, { minConfidence: 75 }, logger);
+    expect(reader.listSchemaFeatures).toHaveBeenCalledWith({ minConfidence: 75 });
+  });
+
+  it('returns empty sources when there are zero schema features', async () => {
+    const reader = makeReader([]);
+    const { sources, provenance } = await loadPerTypeSourceIndices(
+      reader,
+      { minConfidence: 0 },
+      logger
+    );
+    expect(sources).toEqual({ user: [], host: [], service: [], generic: [] });
+    expect(provenance).toEqual([]);
+  });
+
+  it('skips streams that resolve to no index patterns (deleted / inaccessible)', async () => {
+    const reader = makeReader(
+      [
+        makeFeature({
+          stream_name: 'logs.gone',
+          properties: { entity_field_presence: { user: ['user.name'] } },
+        }),
+      ],
+      () => [] // resolveIndexPatterns returns nothing
+    );
+    const { sources, provenance } = await loadPerTypeSourceIndices(
+      reader,
+      { minConfidence: 0 },
+      logger
+    );
+    expect(sources.user).toEqual([]);
+    expect(provenance).toEqual([]);
+  });
+
+  it('dedupes patterns and records provenance with matched fields', async () => {
+    const reader = makeReader([
+      makeFeature({
+        stream_name: 'logs.dup',
+        confidence: 80,
+        properties: { entity_field_presence: { user: ['user.name', 'user.email'] } },
+      }),
+      makeFeature({
+        stream_name: 'logs.dup',
+        confidence: 70,
+        properties: { entity_field_presence: { user: ['user.id'] } },
+      }),
+    ]);
+
+    const { sources, provenance } = await loadPerTypeSourceIndices(
+      reader,
+      { minConfidence: 0 },
+      logger
+    );
+
+    expect(sources.user).toEqual(['logs.dup']);
+    expect(provenance).toHaveLength(2);
+    expect(provenance[0]).toMatchObject({
+      entityType: 'user',
+      streamName: 'logs.dup',
+      matchedFields: ['user.email', 'user.name'].sort(),
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import type { EntityType } from '../../../common/domain/definitions/entity_schema';
+
+/**
+ * Identity source fields per entity type — the fields whose presence in a
+ * stream qualifies that stream as a source for the corresponding engine.
+ *
+ * These mirror each static engine's identity contract as expressed in the
+ * entity definitions under `common/domain/definitions/`:
+ * - `user`   → `euidRanking` / `documentsFilter` key off `user.{email,id,name,domain}`.
+ * - `host`   → `host.{id,name,hostname}`.
+ * - `service`→ `service.name`.
+ * - `generic`→ `entity.id` (rarely surfaced by schema features; kept for completeness).
+ *
+ * Keeping this list here (rather than deriving it from the `euidRanking`
+ * branches at runtime) is deliberate: the ranking branches encode precedence
+ * and composition rules that are irrelevant to "does this stream carry any of
+ * this engine's identity fields?". Expanding an engine's identity contract is
+ * an audited change that should update this constant in lockstep.
+ */
+export const ENTITY_TYPE_IDENTITY_FIELDS = {
+  user: ['user.email', 'user.id', 'user.name', 'user.domain'],
+  host: ['host.id', 'host.name', 'host.hostname'],
+  service: ['service.name'],
+  generic: ['entity.id'],
+} as const satisfies Record<EntityType, readonly string[]>;
+
+const ENTITY_TYPES = Object.keys(ENTITY_TYPE_IDENTITY_FIELDS) as EntityType[];
+
+/** Union of every identity field across all entity types, used to scan evidence strings. */
+const ALL_IDENTITY_FIELDS: readonly string[] = Array.from(
+  new Set(Object.values(ENTITY_TYPE_IDENTITY_FIELDS).flat())
+);
+
+/**
+ * The set of ECS identity fields a schema feature surfaces for a stream.
+ * Derived from the feature, never persisted — recomputed each run.
+ */
+export type EntityFieldPresence = ReadonlySet<string>;
+
+/**
+ * Derives which ECS identity fields a `schema`-class feature surfaces for its
+ * stream. Three signals are combined (most authoritative first); any field
+ * found by any signal counts as present:
+ *
+ * 1. `properties.entity_field_presence` — an explicit object the LLM may emit,
+ *    keyed by entity type with arrays of identity field names. Values are
+ *    intersected with the known identity vocabulary so a hallucinated field
+ *    cannot qualify a stream.
+ * 2. `properties.ecs_identity_aliases` — POC 3's alias table. Its KEYS are ECS
+ *    identity destinations the stream can populate, so a present key means the
+ *    stream carries that identity (via alias).
+ * 3. `evidence` strings — deterministic fallback: any identity field name that
+ *    appears verbatim as a token in an evidence string is treated as present.
+ *    This is the floor that works even when the LLM emits neither structured
+ *    property above.
+ */
+export const deriveEntityFieldPresence = (feature: Feature): EntityFieldPresence => {
+  const present = new Set<string>();
+  const properties =
+    feature.properties && typeof feature.properties === 'object'
+      ? (feature.properties as Record<string, unknown>)
+      : undefined;
+
+  // Signal 1 — explicit entity_field_presence object.
+  const rawPresence = properties?.entity_field_presence;
+  if (rawPresence && typeof rawPresence === 'object' && !Array.isArray(rawPresence)) {
+    for (const value of Object.values(rawPresence as Record<string, unknown>)) {
+      if (!Array.isArray(value)) continue;
+      for (const field of value) {
+        if (typeof field === 'string' && ALL_IDENTITY_FIELDS.includes(field)) {
+          present.add(field);
+        }
+      }
+    }
+  }
+
+  // Signal 2 — ecs_identity_aliases keys (alias destinations the stream populates).
+  const rawAliases = properties?.ecs_identity_aliases;
+  if (rawAliases && typeof rawAliases === 'object' && !Array.isArray(rawAliases)) {
+    for (const key of Object.keys(rawAliases as Record<string, unknown>)) {
+      if (ALL_IDENTITY_FIELDS.includes(key)) {
+        present.add(key);
+      }
+    }
+  }
+
+  // Signal 3 — evidence-string scan (deterministic fallback).
+  if (Array.isArray(feature.evidence)) {
+    for (const line of feature.evidence) {
+      if (typeof line !== 'string') continue;
+      for (const field of ALL_IDENTITY_FIELDS) {
+        if (line.includes(field)) {
+          present.add(field);
+        }
+      }
+    }
+  }
+
+  return present;
+};
+
+/** Per-type resolved index patterns. One array per entity type; deduped, order-stable. */
+export type PerTypeSourceIndices = Record<EntityType, string[]>;
+
+/** Provenance for the visibility surface: which stream/feature qualified for which type, and why. */
+export interface PerTypeSourceProvenance {
+  entityType: EntityType;
+  streamName: string;
+  indexPatterns: string[];
+  featureUuid: string;
+  confidence: number;
+  /** The identity fields that caused this stream to qualify for `entityType`. */
+  matchedFields: string[];
+}
+
+export interface LoadPerTypeSourceIndicesOptions {
+  /**
+   * Confidence floor pushed into the schema-feature query. When `null` the
+   * loader short-circuits and returns empty sources WITHOUT any I/O — the
+   * "auto-discovery disabled" branch the config flag defaults to.
+   */
+  minConfidence: number | null;
+}
+
+const emptySources = (): PerTypeSourceIndices => ({
+  user: [],
+  host: [],
+  service: [],
+  generic: [],
+});
+
+/**
+ * Loads the per-entity-type extraction source index patterns for the current
+ * run, derived automatically from whatever `schema`-class Knowledge Indicators
+ * exist. There is no operator registry/toggle: every qualifying stream is
+ * included for every type its identity fields satisfy.
+ *
+ * Behavior:
+ * - `minConfidence === null` → returns empty sources, no I/O (disabled branch).
+ * - Otherwise lists schema features above threshold, resolves index patterns
+ *   once per distinct stream, derives identity-field presence per feature, and
+ *   assigns the stream's patterns to each entity type whose identity fields
+ *   intersect that presence.
+ * - Patterns are deduped per type. Streams that resolve to no index patterns
+ *   (deleted / inaccessible) are skipped.
+ *
+ * Caching is the caller's responsibility — `LogsExtractionClient` calls this
+ * once per extraction run and reuses the result across engine passes.
+ */
+export const loadPerTypeSourceIndices = async (
+  reader: StreamsKnowledgeIndicatorsReader,
+  options: LoadPerTypeSourceIndicesOptions,
+  logger: Logger
+): Promise<{ sources: PerTypeSourceIndices; provenance: PerTypeSourceProvenance[] }> => {
+  if (options.minConfidence === null) {
+    return { sources: emptySources(), provenance: [] };
+  }
+
+  const features = await reader.listSchemaFeatures({ minConfidence: options.minConfidence });
+  if (features.length === 0) {
+    return { sources: emptySources(), provenance: [] };
+  }
+
+  // Resolve once per distinct stream — a stream may carry multiple schema features.
+  const indexPatternsByStream = new Map<string, string[]>();
+  const distinctStreamNames = Array.from(new Set(features.map((feature) => feature.stream_name)));
+  await Promise.all(
+    distinctStreamNames.map(async (streamName) => {
+      try {
+        indexPatternsByStream.set(streamName, await reader.resolveIndexPatterns(streamName));
+      } catch (error) {
+        logger.warn(
+          `[entity_store] Failed to resolve index patterns for stream ${streamName}: ${
+            error instanceof Error ? error.message : String(error)
+          }; this stream will be skipped for source discovery`
+        );
+        indexPatternsByStream.set(streamName, []);
+      }
+    })
+  );
+
+  const sourceSets: Record<EntityType, Set<string>> = {
+    user: new Set(),
+    host: new Set(),
+    service: new Set(),
+    generic: new Set(),
+  };
+  const provenance: PerTypeSourceProvenance[] = [];
+
+  for (const feature of features) {
+    const indexPatterns = indexPatternsByStream.get(feature.stream_name) ?? [];
+    if (indexPatterns.length === 0) {
+      continue;
+    }
+    const presence = deriveEntityFieldPresence(feature);
+    if (presence.size === 0) {
+      continue;
+    }
+
+    for (const entityType of ENTITY_TYPES) {
+      const matchedFields = ENTITY_TYPE_IDENTITY_FIELDS[entityType].filter((field) =>
+        presence.has(field)
+      );
+      if (matchedFields.length === 0) {
+        continue;
+      }
+      for (const pattern of indexPatterns) {
+        sourceSets[entityType].add(pattern);
+      }
+      provenance.push({
+        entityType,
+        streamName: feature.stream_name,
+        indexPatterns,
+        featureUuid: feature.uuid,
+        confidence: feature.confidence,
+        matchedFields,
+      });
+    }
+  }
+
+  return {
+    sources: {
+      user: Array.from(sourceSets.user),
+      host: Array.from(sourceSets.host),
+      service: Array.from(sourceSets.service),
+      generic: Array.from(sourceSets.generic),
+    },
+    provenance,
+  };
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_per_type_source_indices.ts
@@ -19,7 +19,7 @@ import type { EntityType } from '../../../common/domain/definitions/entity_schem
  * - `user`   → `euidRanking` / `documentsFilter` key off `user.{email,id,name,domain}`.
  * - `host`   → `host.{id,name,hostname}`.
  * - `service`→ `service.name`.
- * - `generic`→ `entity.id` (rarely surfaced by schema features; kept for completeness).
+ * - `generic`→ `entity.id` (rarely surfaced by dataset_analysis; kept for completeness).
  *
  * Keeping this list here (rather than deriving it from the `euidRanking`
  * branches at runtime) is deliberate: the ranking branches encode precedence
@@ -36,76 +36,78 @@ export const ENTITY_TYPE_IDENTITY_FIELDS = {
 
 const ENTITY_TYPES = Object.keys(ENTITY_TYPE_IDENTITY_FIELDS) as EntityType[];
 
-/** Union of every identity field across all entity types, used to scan evidence strings. */
+/** Union of every identity field across all entity types. */
 const ALL_IDENTITY_FIELDS: readonly string[] = Array.from(
   new Set(Object.values(ENTITY_TYPE_IDENTITY_FIELDS).flat())
 );
 
 /**
- * The set of ECS identity fields a schema feature surfaces for a stream.
- * Derived from the feature, never persisted — recomputed each run.
+ * The set of ECS identity fields a `dataset_analysis` feature surfaces for a
+ * stream at a safe ES type. Derived from the feature, never persisted —
+ * recomputed each run.
  */
 export type EntityFieldPresence = ReadonlySet<string>;
 
 /**
- * Derives which ECS identity fields a `schema`-class feature surfaces for its
- * stream. Three signals are combined (most authoritative first); any field
- * found by any signal counts as present:
- *
- * 1. `properties.entity_field_presence` — an explicit object the LLM may emit,
- *    keyed by entity type with arrays of identity field names. Values are
- *    intersected with the known identity vocabulary so a hallucinated field
- *    cannot qualify a stream.
- * 2. `properties.ecs_identity_aliases` — POC 3's alias table. Its KEYS are ECS
- *    identity destinations the stream can populate, so a present key means the
- *    stream carries that identity (via alias).
- * 3. `evidence` strings — deterministic fallback: any identity field name that
- *    appears verbatim as a token in an evidence string is treated as present.
- *    This is the floor that works even when the LLM emits neither structured
- *    property above.
+ * ES field types accepted as identity sources. `keyword` is exact-match and
+ * aggregatable, so it is safe to extract/group on; `text` / `match_only_text`
+ * and unmapped fields are intentionally excluded. Centralized so the safe set
+ * can be widened later (e.g. `ip`, `boolean`) without touching call sites.
  */
-export const deriveEntityFieldPresence = (feature: Feature): EntityFieldPresence => {
+const SAFE_IDENTITY_FIELD_TYPES = new Set<string>(['keyword']);
+
+/**
+ * Parses a `dataset_analysis` field key into its field name and ES type list.
+ *
+ * Keys are produced by `formatDocumentAnalysis`'s `getFieldKey`:
+ * - `"user.email (keyword)"`   → `{ name: 'user.email', types: ['keyword'] }`
+ * - `"x (text, keyword)"`      → `{ name: 'x', types: ['text', 'keyword'] }`
+ * - `"y (unmapped - no type)"` → `{ name: 'y', types: [] }`
+ *
+ * A key that does not match the `"<name> (<inner>)"` shape is treated as a
+ * bare field name with no known type (and therefore cannot qualify).
+ */
+const parseDatasetAnalysisFieldKey = (key: string): { name: string; types: string[] } => {
+  const match = key.match(/^(.*)\s\(([^)]*)\)$/);
+  if (!match) {
+    return { name: key, types: [] };
+  }
+  const [, name, inner] = match;
+  if (inner === 'unmapped - no type') {
+    return { name, types: [] };
+  }
+  return { name, types: inner.split(',').map((type) => type.trim()) };
+};
+
+/**
+ * Derives which ECS identity fields a `dataset_analysis` feature surfaces for
+ * its stream. The computed feature exposes `properties.analysis.fields`, an
+ * object keyed by `"<field.path> (<es_types>)"`. A field qualifies only when
+ * its name is a known identity field AND it is mapped at a safe type
+ * (`SAFE_IDENTITY_FIELD_TYPES`), so unsafe `text` / unmapped fields never
+ * promote a stream to a source.
+ */
+export const deriveEntityFieldPresenceFromDatasetAnalysis = (
+  feature: Feature
+): EntityFieldPresence => {
   const present = new Set<string>();
-  const properties =
-    feature.properties && typeof feature.properties === 'object'
-      ? (feature.properties as Record<string, unknown>)
+  const analysis = (feature.properties as Record<string, unknown> | undefined)?.analysis;
+  const fields =
+    analysis && typeof analysis === 'object'
+      ? (analysis as Record<string, unknown>).fields
       : undefined;
-
-  // Signal 1 — explicit entity_field_presence object.
-  const rawPresence = properties?.entity_field_presence;
-  if (rawPresence && typeof rawPresence === 'object' && !Array.isArray(rawPresence)) {
-    for (const value of Object.values(rawPresence as Record<string, unknown>)) {
-      if (!Array.isArray(value)) continue;
-      for (const field of value) {
-        if (typeof field === 'string' && ALL_IDENTITY_FIELDS.includes(field)) {
-          present.add(field);
-        }
-      }
+  if (!fields || typeof fields !== 'object') {
+    return present;
+  }
+  for (const key of Object.keys(fields as Record<string, unknown>)) {
+    const { name, types } = parseDatasetAnalysisFieldKey(key);
+    if (
+      ALL_IDENTITY_FIELDS.includes(name) &&
+      types.some((type) => SAFE_IDENTITY_FIELD_TYPES.has(type))
+    ) {
+      present.add(name);
     }
   }
-
-  // Signal 2 — ecs_identity_aliases keys (alias destinations the stream populates).
-  const rawAliases = properties?.ecs_identity_aliases;
-  if (rawAliases && typeof rawAliases === 'object' && !Array.isArray(rawAliases)) {
-    for (const key of Object.keys(rawAliases as Record<string, unknown>)) {
-      if (ALL_IDENTITY_FIELDS.includes(key)) {
-        present.add(key);
-      }
-    }
-  }
-
-  // Signal 3 — evidence-string scan (deterministic fallback).
-  if (Array.isArray(feature.evidence)) {
-    for (const line of feature.evidence) {
-      if (typeof line !== 'string') continue;
-      for (const field of ALL_IDENTITY_FIELDS) {
-        if (line.includes(field)) {
-          present.add(field);
-        }
-      }
-    }
-  }
-
   return present;
 };
 
@@ -123,15 +125,6 @@ export interface PerTypeSourceProvenance {
   matchedFields: string[];
 }
 
-export interface LoadPerTypeSourceIndicesOptions {
-  /**
-   * Confidence floor pushed into the schema-feature query. When `null` the
-   * loader short-circuits and returns empty sources WITHOUT any I/O — the
-   * "auto-discovery disabled" branch the config flag defaults to.
-   */
-  minConfidence: number | null;
-}
-
 const emptySources = (): PerTypeSourceIndices => ({
   user: [],
   host: [],
@@ -141,37 +134,34 @@ const emptySources = (): PerTypeSourceIndices => ({
 
 /**
  * Loads the per-entity-type extraction source index patterns for the current
- * run, derived automatically from whatever `schema`-class Knowledge Indicators
- * exist. There is no operator registry/toggle: every qualifying stream is
- * included for every type its identity fields satisfy.
+ * run, derived automatically from the deterministic `dataset_analysis`
+ * Knowledge Indicators that exist. There is no operator registry/toggle: every
+ * qualifying stream is included for every type its identity fields satisfy.
  *
  * Behavior:
- * - `minConfidence === null` → returns empty sources, no I/O (disabled branch).
- * - Otherwise lists schema features above threshold, resolves index patterns
- *   once per distinct stream, derives identity-field presence per feature, and
- *   assigns the stream's patterns to each entity type whose identity fields
- *   intersect that presence.
+ * - Lists `dataset_analysis` features, resolves index patterns once per
+ *   distinct stream, derives identity-field presence per feature (keyword-typed
+ *   identity fields only), and assigns the stream's patterns to each entity
+ *   type whose identity fields intersect that presence.
  * - Patterns are deduped per type. Streams that resolve to no index patterns
  *   (deleted / inaccessible) are skipped.
  *
- * Caching is the caller's responsibility — `LogsExtractionClient` calls this
- * once per extraction run and reuses the result across engine passes.
+ * Enable/disable gating lives in the callers (they skip this entirely when
+ * `useDiscoveredIndexSource` is off), so there is no disabled short-circuit
+ * here. Caching is the caller's responsibility — `LogsExtractionClient` calls
+ * this once per extraction run and reuses the result across engine passes.
  */
 export const loadPerTypeSourceIndices = async (
   reader: StreamsKnowledgeIndicatorsReader,
-  options: LoadPerTypeSourceIndicesOptions,
   logger: Logger
 ): Promise<{ sources: PerTypeSourceIndices; provenance: PerTypeSourceProvenance[] }> => {
-  if (options.minConfidence === null) {
-    return { sources: emptySources(), provenance: [] };
-  }
-
-  const features = await reader.listSchemaFeatures({ minConfidence: options.minConfidence });
+  const features = await reader.listDatasetAnalysisFeatures();
   if (features.length === 0) {
     return { sources: emptySources(), provenance: [] };
   }
 
-  // Resolve once per distinct stream — a stream may carry multiple schema features.
+  // Resolve once per distinct stream — dataset_analysis emits one feature per
+  // stream, but dedupe defensively in case of overlap.
   const indexPatternsByStream = new Map<string, string[]>();
   const distinctStreamNames = Array.from(new Set(features.map((feature) => feature.stream_name)));
   await Promise.all(
@@ -202,7 +192,7 @@ export const loadPerTypeSourceIndices = async (
     if (indexPatterns.length === 0) {
       continue;
     }
-    const presence = deriveEntityFieldPresence(feature);
+    const presence = deriveEntityFieldPresenceFromDatasetAnalysis(feature);
     if (presence.size === 0) {
       continue;
     }

--- a/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
@@ -24,6 +24,7 @@ import { CcsLogsExtractionClient, LogsExtractionClient } from './domain/logs_ext
 import { HistorySnapshotClient } from './domain/history_snapshot';
 import { CRUDClient } from './domain/crud';
 import { ResolutionClient } from './domain/resolution';
+import { createKnowledgeIndicatorsReaderFromStreamsStart } from './domain/streams_features';
 import type { TelemetryReporter } from './telemetry/events';
 
 interface EntityStoreApiRequestHandlerContextDeps {
@@ -83,6 +84,11 @@ export async function createRequestHandlerContext({
     namespace,
     ccsLogExtractionStateClient
   );
+  const knowledgeIndicatorsReader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+    streams: startPlugins.streams,
+    request,
+    logger,
+  });
   const logsExtractionClient = new LogsExtractionClient({
     logger,
     namespace,
@@ -91,6 +97,7 @@ export async function createRequestHandlerContext({
     engineDescriptorClient,
     globalStateClient,
     ccsLogsExtractionClient,
+    knowledgeIndicatorsReader,
   });
 
   const historySnapshotClient = new HistorySnapshotClient({
@@ -136,6 +143,7 @@ export async function createRequestHandlerContext({
     logsExtractionClient,
     historySnapshotClient,
     security: startPlugins.security,
+    streams: startPlugins.streams,
     namespace,
   };
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/discovered_sources.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/discovered_sources.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IKibanaResponse } from '@kbn/core-http-server';
+import { API_VERSIONS, ENTITY_STORE_ROUTES } from '../../../common';
+import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
+import type { EntityStorePluginRouter } from '../../types';
+import { wrapMiddlewares } from '../middleware';
+import type { PerTypeSourceIndices, PerTypeSourceProvenance } from '../../domain/streams_features';
+
+export interface DiscoveredSourcesResponseBody {
+  /** Whether KI-discovered sources are actually used for extraction (the flag). */
+  enabled: boolean;
+  /** Confidence floor applied when listing schema features. */
+  minConfidence: number;
+  /** Per-entity-type resolved source index patterns the store would extract from. */
+  sources: PerTypeSourceIndices;
+  /** Which stream/feature contributed each pattern, and on which identity fields. */
+  provenance: PerTypeSourceProvenance[];
+}
+
+/**
+ * Read-only operator visibility into the KI-discovered, per-entity-type
+ * extraction sources. Deliberately has NO mutation surface: the entity store
+ * derives sources automatically from available schema features, so there is
+ * nothing to select or deselect here. The only operator lever is upstream —
+ * which streams Knowledge Indicators are run on.
+ */
+export function registerDiscoveredSources(router: EntityStorePluginRouter) {
+  router.versioned
+    .get({
+      path: ENTITY_STORE_ROUTES.internal.DISCOVERED_SOURCES,
+      access: 'internal',
+      summary: 'Get KI-discovered extraction sources',
+      description:
+        'Returns the per-entity-type index patterns the entity store auto-derives from Knowledge Indicators schema features, with provenance. Read-only.',
+      security: {
+        authz: DEFAULT_ENTITY_STORE_PERMISSIONS,
+      },
+      enableQueryVersion: true,
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v2,
+        validate: false,
+      },
+      wrapMiddlewares(
+        async (ctx, req, res): Promise<IKibanaResponse<DiscoveredSourcesResponseBody>> => {
+          const entityStoreCtx = await ctx.entityStore;
+          const { logger, logsExtractionClient } = entityStoreCtx;
+          logger.debug('Discovered sources API invoked');
+
+          const result = await logsExtractionClient.getDiscoveredSources();
+
+          return res.ok({ body: result });
+        }
+      )
+    );
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/discovered_sources.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/discovered_sources.ts
@@ -15,8 +15,6 @@ import type { PerTypeSourceIndices, PerTypeSourceProvenance } from '../../domain
 export interface DiscoveredSourcesResponseBody {
   /** Whether KI-discovered sources are actually used for extraction (the flag). */
   enabled: boolean;
-  /** Confidence floor applied when listing schema features. */
-  minConfidence: number;
   /** Per-entity-type resolved source index patterns the store would extract from. */
   sources: PerTypeSourceIndices;
   /** Which stream/feature contributed each pattern, and on which identity fields. */
@@ -26,9 +24,9 @@ export interface DiscoveredSourcesResponseBody {
 /**
  * Read-only operator visibility into the KI-discovered, per-entity-type
  * extraction sources. Deliberately has NO mutation surface: the entity store
- * derives sources automatically from available schema features, so there is
- * nothing to select or deselect here. The only operator lever is upstream —
- * which streams Knowledge Indicators are run on.
+ * derives sources automatically from available dataset_analysis features, so
+ * there is nothing to select or deselect here. The only operator lever is
+ * upstream — which streams Knowledge Indicators are run on.
  */
 export function registerDiscoveredSources(router: EntityStorePluginRouter) {
   router.versioned
@@ -37,7 +35,7 @@ export function registerDiscoveredSources(router: EntityStorePluginRouter) {
       access: 'internal',
       summary: 'Get KI-discovered extraction sources',
       description:
-        'Returns the per-entity-type index patterns the entity store auto-derives from Knowledge Indicators schema features, with provenance. Read-only.',
+        'Returns the per-entity-type index patterns the entity store auto-derives from Knowledge Indicators dataset_analysis features, with provenance. Read-only.',
       security: {
         authz: DEFAULT_ENTITY_STORE_PERMISSIONS,
       },

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
@@ -28,3 +28,4 @@ export { registerGetMaintainers } from './entity_maintainers/get_maintainers';
 export { registerInitMaintainers } from './entity_maintainers/init';
 export { registerRunMaintainer } from './entity_maintainers/run';
 export { registerCheckPrivileges } from './check_privileges';
+export { registerDiscoveredSources } from './discovered_sources';

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
@@ -25,7 +25,6 @@ export const LogExtractionInstallParams = LogExtractionConfig.pick({
   additionalIndexPatterns: true,
   excludedIndexPatterns: true,
   useDiscoveredIndexSource: true,
-  discoveredIndexSourceMinConfidence: true,
   lookbackPeriod: true,
   frequency: true,
   delay: true,
@@ -43,7 +42,6 @@ export const LogExtractionUpdateParams = z.object({
   additionalIndexPatterns: z.array(z.string()).optional(),
   excludedIndexPatterns: z.array(z.string()).optional(),
   useDiscoveredIndexSource: z.boolean().optional(),
-  discoveredIndexSourceMinConfidence: z.number().int().min(0).max(100).optional(),
   lookbackPeriod: z
     .string()
     .regex(/[smdh]$/)

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
@@ -24,6 +24,8 @@ export const LogExtractionInstallParams = LogExtractionConfig.pick({
   fieldHistoryLength: true,
   additionalIndexPatterns: true,
   excludedIndexPatterns: true,
+  useDiscoveredIndexSource: true,
+  discoveredIndexSourceMinConfidence: true,
   lookbackPeriod: true,
   frequency: true,
   delay: true,
@@ -40,6 +42,8 @@ export const LogExtractionUpdateParams = z.object({
   fieldHistoryLength: z.number().int().optional(),
   additionalIndexPatterns: z.array(z.string()).optional(),
   excludedIndexPatterns: z.array(z.string()).optional(),
+  useDiscoveredIndexSource: z.boolean().optional(),
+  discoveredIndexSourceMinConfidence: z.number().int().min(0).max(100).optional(),
   lookbackPeriod: z
     .string()
     .regex(/[smdh]$/)

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
@@ -29,6 +29,7 @@ import {
   registerResolutionGroup,
   registerUpdate,
   registerCheckPrivileges,
+  registerDiscoveredSources,
 } from './apis';
 import type { EntityStorePluginRouter } from '../types';
 
@@ -41,6 +42,7 @@ export function registerRoutes(router: EntityStorePluginRouter) {
   registerForceCcsExtractToUpdates(router);
   registerForceHistorySnapshot(router);
   registerCheckPrivileges(router);
+  registerDiscoveredSources(router);
   registerCRUDCreate(router);
   registerCRUDUpdate(router);
   registerCRUDBulkUpdate(router);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/factories.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/factories.ts
@@ -16,6 +16,7 @@ import {
   EngineDescriptorClient,
   EntityStoreGlobalStateClient,
 } from '../domain/saved_objects';
+import { createKnowledgeIndicatorsReaderFromStreamsStart } from '../domain/streams_features';
 import type { TelemetryReporter } from '../telemetry/events';
 
 export interface LogsExtractionClientFactoryResult {
@@ -58,6 +59,15 @@ export async function createLogsExtractionClient({
     new CcsLogExtractionStateClient(soClient, namespace, logger)
   );
 
+  // Request-scoped Knowledge Indicators reader. Returns a no-op reader when the
+  // (optional) streams plugin is not enabled, so the extraction client works
+  // unchanged in deployments without streams.
+  const knowledgeIndicatorsReader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+    streams: pluginsStart.streams,
+    request: fakeRequest,
+    logger,
+  });
+
   const logsExtractionClient = new LogsExtractionClient({
     logger,
     namespace,
@@ -66,6 +76,7 @@ export async function createLogsExtractionClient({
     engineDescriptorClient: new EngineDescriptorClient(soClient, namespace, logger),
     globalStateClient: new EntityStoreGlobalStateClient(soClient, namespace, logger),
     ccsLogsExtractionClient,
+    knowledgeIndicatorsReader,
   });
 
   return {

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -28,6 +28,7 @@ import type {
 import type { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { CoreSetup } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { StreamsPluginStart } from '@kbn/streams-plugin/server';
 import type { AssetManagerClient } from './domain/asset_manager';
 import type { EntityMaintainersClient } from './domain/entity_maintainers';
 import type { FeatureFlags } from './infra/feature_flags';
@@ -50,6 +51,13 @@ export interface EntityStoreStartPlugins {
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   licensing: LicensingPluginStart;
+  /**
+   * Optional, declared in `kibana.jsonc` as `optionalPlugins.streams` so the
+   * entity store keeps working in deployments that don't have streams
+   * enabled. Consumers must guard against `undefined` at the call site (the
+   * no-op reader in `createKnowledgeIndicatorsReader` is the canonical fallback).
+   */
+  streams?: StreamsPluginStart;
 }
 
 export interface EntityStoreApiRequestHandlerContext {
@@ -64,6 +72,14 @@ export interface EntityStoreApiRequestHandlerContext {
   logsExtractionClient: LogsExtractionClient;
   historySnapshotClient: HistorySnapshotClient;
   security: SecurityPluginStart;
+  /**
+   * Optional streams plugin start, mirroring `EntityStoreStartPlugins.streams`.
+   * Exposed on the request context so route handlers that need a
+   * `StreamsKnowledgeIndicatorsReader` (e.g. the discovered-sources visibility
+   * route) can build one from a real `KibanaRequest`. `undefined` when streams
+   * is not enabled — consumers must guard at the call site.
+   */
+  streams?: StreamsPluginStart;
   namespace: string;
 }
 

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -57,6 +57,7 @@ export const ENTITY_STORE_ROUTES = {
   },
   internal: {
     CHECK_PRIVILEGES: `${INTERNAL_BASE}/check_privileges`,
+    DISCOVERED_SOURCES: `${INTERNAL_BASE}/discovered_sources`,
     FORCE_LOG_EXTRACTION: (entityType: string) =>
       `${INTERNAL_BASE}/${entityType}/force_log_extraction`,
     FORCE_CCS_EXTRACT_TO_UPDATES: (entityType: string) =>

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/discovered_sources.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/discovered_sources.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import {
+  clearEntityStoreIndices,
+  forceLogExtraction,
+  ingestDoc,
+  searchDocById,
+} from '../fixtures/helpers';
+
+/**
+ * Exercises the KI-discovered index source feature (idea 01 re-scope):
+ * - the read-only `discovered_sources` visibility route, and
+ * - the `useDiscoveredIndexSource` flag plumbing + data-view-replacement path.
+ *
+ * NOTE: asserting that a specific KI-discovered index pattern becomes the
+ * extraction `FROM` requires seeding `schema`-class Knowledge Indicators on a
+ * real Streams stream (KI is manually triggered upstream and depends on the
+ * Streams inference pipeline). That end-to-end seeding is a follow-up; here we
+ * verify the contract deterministically: the visibility route shape, the flag
+ * toggling through config, and that the updates stream remains a hard-union
+ * source under the replacement path.
+ */
+apiTest.describe('Entity Store KI-discovered index source', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+  let internalHeaders: Record<string, string>;
+
+  const setFlag = async (
+    apiClient: Parameters<Parameters<typeof apiTest>[2]>[0]['apiClient'],
+    enabled: boolean
+  ) => {
+    const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {
+        logExtraction: {
+          useDiscoveredIndexSource: enabled,
+          discoveredIndexSourceMinConfidence: 0,
+        },
+      },
+    });
+    expect(response.statusCode).toBe(200);
+  };
+
+  apiTest.beforeAll(async ({ samlAuth, apiClient, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader, ...PUBLIC_HEADERS };
+    internalHeaders = { ...credentials.cookieHeader, ...INTERNAL_HEADERS };
+
+    await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
+
+    // Data view backing the legacy source path (only used when the flag is off).
+    const dataViewResponse = await apiClient.post('/api/data_views/data_view', {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {
+        override: true,
+        data_view: {
+          id: 'security-solution-default',
+          name: 'security-solution-default',
+          title: 'logs-*',
+          timeFieldName: '@timestamp',
+        },
+      },
+    });
+    expect(dataViewResponse.statusCode).toBe(200);
+
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(response.statusCode).toBe(201);
+  });
+
+  apiTest.afterAll(async ({ apiClient, esClient }) => {
+    await setFlag(apiClient, false);
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(response.statusCode).toBe(200);
+    await clearEntityStoreIndices(esClient);
+  });
+
+  apiTest(
+    'discovered_sources route returns the per-type shape and reflects the flag',
+    async ({ apiClient }) => {
+      await setFlag(apiClient, false);
+      const off = await apiClient.get(ENTITY_STORE_ROUTES.internal.DISCOVERED_SOURCES, {
+        headers: internalHeaders,
+        responseType: 'json',
+      });
+      expect(off.statusCode).toBe(200);
+      expect(off.body.enabled).toBe(false);
+      // All four engine keys are always present, even with no schema features.
+      expect(Object.keys(off.body.sources).sort()).toStrictEqual([
+        'generic',
+        'host',
+        'service',
+        'user',
+      ]);
+      expect(Array.isArray(off.body.provenance)).toBe(true);
+
+      await setFlag(apiClient, true);
+      const on = await apiClient.get(ENTITY_STORE_ROUTES.internal.DISCOVERED_SOURCES, {
+        headers: internalHeaders,
+        responseType: 'json',
+      });
+      expect(on.statusCode).toBe(200);
+      expect(on.body.enabled).toBe(true);
+      expect(on.body.minConfidence).toBe(0);
+    }
+  );
+
+  apiTest(
+    'with the flag enabled, extraction still sources the updates stream (hard union preserved)',
+    async ({ apiClient, esClient }) => {
+      await setFlag(apiClient, true);
+
+      await ingestDoc(esClient, {
+        '@timestamp': '2026-05-10T10:00:00Z',
+        event: { module: 'okta' },
+        host: { id: 'ki-src-host-1', name: 'ki-src-server-01' },
+      });
+
+      const extraction = await forceLogExtraction(
+        apiClient,
+        internalHeaders,
+        'host',
+        '2026-05-10T09:00:00Z',
+        '2026-05-10T11:00:00Z'
+      );
+        expect(extraction.statusCode).toBe(200);
+        expect(extraction.body).toMatchObject({ success: true });
+        expect((extraction.body as { count: number }).count).toBeGreaterThanOrEqual(1);
+
+      const hit = await searchDocById(esClient, 'host:ki-src-host-1');
+      expect(hit.hits.hits).toHaveLength(1);
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/discovered_sources.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/discovered_sources.spec.ts
@@ -27,8 +27,8 @@ import {
  * - the `useDiscoveredIndexSource` flag plumbing + data-view-replacement path.
  *
  * NOTE: asserting that a specific KI-discovered index pattern becomes the
- * extraction `FROM` requires seeding `schema`-class Knowledge Indicators on a
- * real Streams stream (KI is manually triggered upstream and depends on the
+ * extraction `FROM` requires seeding `dataset_analysis` Knowledge Indicators on
+ * a real Streams stream (KI is manually triggered upstream and depends on the
  * Streams inference pipeline). That end-to-end seeding is a follow-up; here we
  * verify the contract deterministically: the visibility route shape, the flag
  * toggling through config, and that the updates stream remains a hard-union
@@ -48,7 +48,6 @@ apiTest.describe('Entity Store KI-discovered index source', { tag: ENTITY_STORE_
       body: {
         logExtraction: {
           useDiscoveredIndexSource: enabled,
-          discoveredIndexSourceMinConfidence: 0,
         },
       },
     });
@@ -107,7 +106,7 @@ apiTest.describe('Entity Store KI-discovered index source', { tag: ENTITY_STORE_
       });
       expect(off.statusCode).toBe(200);
       expect(off.body.enabled).toBe(false);
-      // All four engine keys are always present, even with no schema features.
+      // All four engine keys are always present, even with no dataset_analysis features.
       expect(Object.keys(off.body.sources).sort()).toStrictEqual([
         'generic',
         'host',
@@ -123,7 +122,6 @@ apiTest.describe('Entity Store KI-discovered index source', { tag: ENTITY_STORE_
       });
       expect(on.statusCode).toBe(200);
       expect(on.body.enabled).toBe(true);
-      expect(on.body.minConfidence).toBe(0);
     }
   );
 
@@ -145,9 +143,9 @@ apiTest.describe('Entity Store KI-discovered index source', { tag: ENTITY_STORE_
         '2026-05-10T09:00:00Z',
         '2026-05-10T11:00:00Z'
       );
-        expect(extraction.statusCode).toBe(200);
-        expect(extraction.body).toMatchObject({ success: true });
-        expect((extraction.body as { count: number }).count).toBeGreaterThanOrEqual(1);
+      expect(extraction.statusCode).toBe(200);
+      expect(extraction.body).toMatchObject({ success: true });
+      expect((extraction.body as { count: number }).count).toBeGreaterThanOrEqual(1);
 
       const hit = await searchDocById(esClient, 'host:ki-src-host-1');
       expect(hit.hits.hits).toHaveLength(1);

--- a/x-pack/solutions/security/plugins/entity_store/tsconfig.json
+++ b/x-pack/solutions/security/plugins/entity_store/tsconfig.json
@@ -39,6 +39,8 @@
     "@kbn/es-query",
     "@kbn/security-plugin",
     "@kbn/streamlang",
+    "@kbn/streams-plugin",
+    "@kbn/streams-schema",
     "@kbn/safer-lodash-set",
     "@kbn/tracing-utils",
     "@kbn/esql-language",


### PR DESCRIPTION
## Summary

This change introduces a new mode for Entity Store's logs extraction, allowing it to automatically discover source index patterns from the Streams plugin's computed `dataset_analysis` Knowledge Indicators (KIs).

Key features:
- **KI-driven source resolution:** The `LogsExtractionClient` uses `dataset_analysis` features to identify data streams that carry entity identity fields (e.g., `user.name`, `host.id`) and resolves them to their backing Elasticsearch index patterns. `dataset_analysis` is a deterministic, computed feature emitted once per analyzed stream; its `properties.analysis.fields` encodes each field's Elasticsearch type, so only safe `keyword`-typed identity fields qualify a stream (`text` / `match_only_text` / unmapped fields are rejected).
- **`StreamsKnowledgeIndicatorsReader`:** A new, deliberately narrowed API surface in the Streams plugin (`StreamsPluginStart.getKnowledgeIndicatorsReader`) provides a read-only interface for cross-plugin consumers like Entity Store. It exposes `listDatasetAnalysisFeatures` + `resolveIndexPatterns`.
- **Optional Streams dependency:** Entity Store declares Streams as an optional plugin. If Streams is not enabled, the KI reader gracefully defaults to a no-op, and log extraction continues using the legacy Security Solution data view.
- **Feature flag control:** The `useDiscoveredIndexSource` setting (off by default) toggles this behavior, replacing the Security Solution data view as the source when enabled. With the flag off, behavior is byte-identical to `main`.
- **Visibility API:** A new internal API route `/api/entity_store/internal/discovered_sources` provides read-only insight into the per-entity-type resolved patterns, provenance (which stream/feature/fields contributed), and current enablement status of KI-discovered sources.
- **Backwards compatibility:** The global-state saved object is upgraded (model version 4 + backfill) to add the `useDiscoveredIndexSource` flag.

When the flag is on, each engine (`user` / `host` / `service` / `generic`) sources its `FROM` from `updates ∪ additionalIndexPatterns ∪ per-type discovered patterns`. The data view is not used as a source while enabled (no silent fallback): a type with zero qualifying features extracts from `updates ∪ additionalIndexPatterns` only.

> **Note on the `dataset_analysis` choice:** An earlier revision of this POC derived identity-field presence from LLM-generated `schema` features (`entity_field_presence` / `ecs_identity_aliases` / `evidence` strings). That signal proved model-dependent — the same stream qualified under one LLM but not another, because qualification leaned on free-text evidence. It was repointed to the deterministic, computed `dataset_analysis` feature, which also carries each field's ES type (enabling the `keyword` safety gate). The `discoveredIndexSourceMinConfidence` knob was removed accordingly, since `dataset_analysis` features are always `confidence: 100`.

This enhancement aims to make entity extraction dynamic, adapting to evolving data sources without requiring manual configuration updates.


## Recording 

https://github.com/user-attachments/assets/d6d7e40c-abaa-4b1c-a4fe-a2e47df890d4

