### PR TITLE
[ingest_hub] Skip onboarding Scout suites on Cloud when core settings route is unavailable

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_connect_step.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_connect_step.spec.ts
@@ -10,7 +10,20 @@ import { expect } from '@kbn/scout/ui';
 import { test } from '../fixtures';
 
 test.describe('Onboarding connect step', { tag: tags.stateful.classic }, () => {
-  test.beforeAll(async ({ apiServices }) => {
+  test.beforeAll(async ({ apiServices, config }) => {
+    // The /internal/core/_settings route is only registered when
+    // coreApp.allowDynamicConfigOverrides=true (Scout's local stateful base config).
+    // ECH deployments don't carry that override, so the PUT 404s. Skip on Cloud.
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      config.isCloud === true,
+      `Core API returns 404 for 'ingestHub.onboardingEnabled' on ECH`
+    );
+    // skip() in beforeAll only skips the tests, not the hook body itself.
+    if (config.isCloud) {
+      return;
+    }
+
     await apiServices.core.settings({
       'feature_flags.overrides': {
         'ingestHub.onboardingEnabled': 'true',
@@ -18,7 +31,10 @@ test.describe('Onboarding connect step', { tag: tags.stateful.classic }, () => {
     });
   });
 
-  test.afterAll(async ({ apiServices }) => {
+  test.afterAll(async ({ apiServices, config }) => {
+    if (config.isCloud) {
+      return;
+    }
     await apiServices.core.settings({
       'feature_flags.overrides': {
         'ingestHub.onboardingEnabled': 'false',

--- a/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_ff_enabled.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_ff_enabled.spec.ts
@@ -10,7 +10,20 @@ import { expect } from '@kbn/scout/ui';
 import { test } from '../fixtures';
 
 test.describe('Onboarding app — FF enabled', { tag: tags.stateful.classic }, () => {
-  test.beforeAll(async ({ apiServices }) => {
+  test.beforeAll(async ({ apiServices, config }) => {
+    // The /internal/core/_settings route is only registered when
+    // coreApp.allowDynamicConfigOverrides=true (Scout's local stateful base config).
+    // ECH deployments don't carry that override, so the PUT 404s. Skip on Cloud.
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      config.isCloud === true,
+      `Core API returns 404 for 'ingestHub.onboardingEnabled' on ECH`
+    );
+    // skip() in beforeAll only skips the tests, not the hook body itself.
+    if (config.isCloud) {
+      return;
+    }
+
     await apiServices.core.settings({
       'feature_flags.overrides': {
         'ingestHub.onboardingEnabled': 'true',
@@ -18,7 +31,10 @@ test.describe('Onboarding app — FF enabled', { tag: tags.stateful.classic }, (
     });
   });
 
-  test.afterAll(async ({ apiServices }) => {
+  test.afterAll(async ({ apiServices, config }) => {
+    if (config.isCloud) {
+      return;
+    }
     await apiServices.core.settings({
       'feature_flags.overrides': {
         'ingestHub.onboardingEnabled': 'false',

--- a/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_permissions_viewer.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_permissions_viewer.spec.ts
@@ -33,7 +33,20 @@ test.describe(
   'Onboarding connect step IAM permissions viewer',
   { tag: tags.stateful.classic },
   () => {
-    test.beforeAll(async ({ apiServices }) => {
+    test.beforeAll(async ({ apiServices, config }) => {
+      // The /internal/core/_settings route is only registered when
+      // coreApp.allowDynamicConfigOverrides=true (Scout's local stateful base config).
+      // ECH deployments don't carry that override, so the PUT 404s. Skip on Cloud.
+      // eslint-disable-next-line playwright/no-skipped-test
+      test.skip(
+        config.isCloud === true,
+        `Core API returns 404 for 'ingestHub.onboardingEnabled' on ECH`
+      );
+      // skip() in beforeAll only skips the tests, not the hook body itself.
+      if (config.isCloud) {
+        return;
+      }
+
       await apiServices.core.settings({
         'feature_flags.overrides': {
           'ingestHub.onboardingEnabled': 'true',
@@ -41,7 +54,10 @@ test.describe(
       });
     });
 
-    test.afterAll(async ({ apiServices }) => {
+    test.afterAll(async ({ apiServices, config }) => {
+      if (config.isCloud) {
+        return;
+      }
       await apiServices.core.settings({
         'feature_flags.overrides': {
           'ingestHub.onboardingEnabled': 'false',

--- a/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_services_step.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_hub/test/scout/ui/tests/onboarding_services_step.spec.ts
@@ -15,7 +15,20 @@ import { test } from '../fixtures';
 // Default active category: Security, Identity and Compliance (first in CATEGORY_ORDER).
 
 test.describe('Onboarding services step', { tag: tags.stateful.classic }, () => {
-  test.beforeAll(async ({ apiServices }) => {
+  test.beforeAll(async ({ apiServices, config }) => {
+    // The /internal/core/_settings route is only registered when
+    // coreApp.allowDynamicConfigOverrides=true (Scout's local stateful base config).
+    // ECH deployments don't carry that override, so the PUT 404s. Skip on Cloud.
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      config.isCloud === true,
+      `Core API returns 404 for 'ingestHub.onboardingEnabled' on ECH`
+    );
+    // skip() in beforeAll only skips the tests, not the hook body itself.
+    if (config.isCloud) {
+      return;
+    }
+
     await apiServices.core.settings({
       'feature_flags.overrides': {
         'ingestHub.onboardingEnabled': 'true',
@@ -23,7 +36,10 @@ test.describe('Onboarding services step', { tag: tags.stateful.classic }, () => 
     });
   });
 
-  test.afterAll(async ({ apiServices }) => {
+  test.afterAll(async ({ apiServices, config }) => {
+    if (config.isCloud) {
+      return;
+    }
     await apiServices.core.settings({
       'feature_flags.overrides': {
         'ingestHub.onboardingEnabled': 'false',


### PR DESCRIPTION
Fixes: #272990
Fixes: #272969
Fixes: #270987
Fixes: #272028

Applies a workaround to skip failing tests for cloud deployment because of unavailable `/internal/core/_settings` route, the same way [it's done in Fleet](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts#L13-L42).