### PR TITLE
[One Workflow] Fix waitForInput documentation popover layout

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.test.ts
@@ -366,14 +366,18 @@ describe('BaseMonacoConnectorHandler', () => {
     });
 
     it('should separate additional info with blank lines for markdown rendering', () => {
-      const result = handler.exposedCreateConnectorOverview('ai.agent', 'Run an AI agent', [
-        '**Type**: AI/ML connector for inference and analysis',
-        '**Usage**: Configure parameters in the `with` block to customize the connector behavior.',
-        '**Documentation**: Configure model parameters and input data',
-      ]);
+      const result = handler.exposedCreateConnectorOverview(
+        'waitForInput',
+        'Wait For Input connector for workflow automation',
+        [
+          '**Type**: Pause execution until external input is provided (human-in-the-loop)',
+          '**Usage**: Configure parameters in the `with` block to customize the connector behavior.',
+          '**Documentation**: Configure the message displayed to the user when waiting for input',
+        ]
+      );
 
       expect(result).toContain(
-        '**Type**: AI/ML connector for inference and analysis\n\n**Usage**: Configure parameters in the `with` block to customize the connector behavior.\n\n**Documentation**: Configure model parameters and input data'
+        '**Type**: Pause execution until external input is provided (human-in-the-loop)\n\n**Usage**: Configure parameters in the `with` block to customize the connector behavior.\n\n**Documentation**: Configure the message displayed to the user when waiting for input'
       );
     });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.test.ts
@@ -365,6 +365,18 @@ describe('BaseMonacoConnectorHandler', () => {
       expect(result).toContain('Returns up to 10,000 hits');
     });
 
+    it('should separate additional info with blank lines for markdown rendering', () => {
+      const result = handler.exposedCreateConnectorOverview('ai.agent', 'Run an AI agent', [
+        '**Type**: AI/ML connector for inference and analysis',
+        '**Usage**: Configure parameters in the `with` block to customize the connector behavior.',
+        '**Documentation**: Configure model parameters and input data',
+      ]);
+
+      expect(result).toContain(
+        '**Type**: AI/ML connector for inference and analysis\n\n**Usage**: Configure parameters in the `with` block to customize the connector behavior.\n\n**Documentation**: Configure model parameters and input data'
+      );
+    });
+
     it('should handle no additional info', () => {
       const result = handler.exposedCreateConnectorOverview(
         'elasticsearch.search',

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/base_monaco_connector_handler.ts
@@ -178,7 +178,10 @@ export abstract class BaseMonacoConnectorHandler implements MonacoConnectorHandl
     const lines = [`**Connector**: \`${connectorType}\``, '', description];
 
     if (additionalInfo && additionalInfo.length > 0) {
-      lines.push('', ...additionalInfo);
+      // Markdown renderers (including Monaco hover/docs) treat single newlines as spaces;
+      // separate overview fields with blank lines so labels like Type/Usage/Documentation
+      // each appear on their own line.
+      lines.push('', additionalInfo.join('\n\n'));
     }
 
     return lines.join('\n');


### PR DESCRIPTION
## Summary

- Fix workflow YAML editor connector hover documentation so **Type**, **Usage**, and **Documentation** render on separate lines instead of a single run-on line.
- Monaco markdown treats single newlines as spaces; `createConnectorOverview` now joins additional info sections with blank lines.

## Before

<img width="2182" height="726" alt="image" src="https://github.com/user-attachments/assets/7f778294-d948-486f-93a7-9bd573ae9200" />

## After

<img width="418" height="175" alt="image" src="https://github.com/user-attachments/assets/d515b485-48ed-4d93-a951-a3917ad874cd" />

## References

Closes elastic/security-team#17736