### PR TITLE
[Streams] Fix flaky Scout test: extend beforeEach timeout for draft stream simulation

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/draft_stream_simulation.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/draft_stream_simulation.spec.ts
@@ -67,6 +67,11 @@ test.describe(
     });
 
     test.beforeEach(async ({ browserAuth, apiServices, pageObjects }) => {
+      // Draft-stream samples are fetched via ES|QL from the parent and can take
+      // 30–60s on cloud targets. The default 60s Scout per-test budget (which
+      // includes hooks) is not enough for the full login → clear → goto →
+      // switchToColumnsView chain, so extend it for this suite.
+      test.setTimeout(120_000);
       await browserAuth.loginAsAdmin();
       await apiServices.streams.clearStreamProcessors(DRAFT_CHILD);
       await pageObjects.streams.gotoProcessingTab(DRAFT_CHILD);


### PR DESCRIPTION
Closes #269695. Completes the partial fix from #270189.

Sets a bigger timeout for the whole test to account for the increased assertion timeouts.