### PR TITLE
[Alertingv2] [RuleBuilder-Threshold alert rule] Index field doesn't list existing indices

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -361,8 +361,14 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
           selectedOptions={
             thresholdValues.indexPattern ? [{ label: thresholdValues.indexPattern }] : []
           }
-          onCreateOption={(val) => update('indexPattern', val)}
+          onCreateOption={(val) => {
+            update('indexPattern', val);
+            return true;
+          }}
           onChange={(opts) => update('indexPattern', opts[0]?.label ?? '')}
+          customOptionText={i18n.translate('xpack.alertingV2.ruleBuilder.indexCustomOption', {
+            defaultMessage: 'Use {searchValue} as an index pattern',
+          })}
           placeholder={i18n.translate('xpack.alertingV2.ruleBuilder.indexPlaceholder', {
             defaultMessage: 'Enter index pattern (e.g. logs-*)',
           })}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -28,6 +28,7 @@ import {
 } from '@elastic/eui';
 import type { ComposeFormValues } from '../../compose_form_types';
 import { useDataFields } from '../../../../form/hooks/use_data_fields';
+import { useIndexSources } from '../../../../form/hooks/use_index_sources';
 import { ScheduleField } from '../../../../form/fields/schedule_field';
 import { LookbackWindowField } from '../../../../form/fields/lookback_window_field';
 import { ModeSelect } from '../../../../form/fields/mode_select';
@@ -66,6 +67,11 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
     useBuilderState<ThresholdFormValues>();
   const { setValue, watch } = useFormContext<ComposeFormValues>();
   const isAlert = watch('kind') === 'alert';
+
+  const { data: indexOptions, isLoading: isLoadingIndices } = useIndexSources({
+    http: services.http,
+    application: services.application,
+  });
 
   const fromQuery = thresholdValues.indexPattern ? `FROM ${thresholdValues.indexPattern}` : '';
 
@@ -350,6 +356,8 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
           fullWidth
           compressed
           singleSelection={{ asPlainText: true }}
+          isLoading={isLoadingIndices}
+          options={indexOptions}
           selectedOptions={
             thresholdValues.indexPattern ? [{ label: thresholdValues.indexPattern }] : []
           }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/query_key_factory.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/query_key_factory.ts
@@ -20,6 +20,7 @@
  */
 export const ruleFormKeys = {
   all: ['ruleForm'] as const,
+  indexSources: () => [...ruleFormKeys.all, 'indexSources'] as const,
   preview: (query: string, timeField: string, lookback: string) =>
     [...ruleFormKeys.all, 'preview', query, timeField, lookback] as const,
   queryColumns: (query: string) => [...ruleFormKeys.all, 'queryColumns', query] as const,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_index_sources.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_index_sources.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { applicationServiceMock } from '@kbn/core-application-browser-mocks';
+import { getESQLSources } from '@kbn/esql-utils';
+import { SOURCES_TYPES } from '@kbn/esql-types';
+import { createQueryClientWrapper } from '../../test_utils';
+import { useIndexSources } from './use_index_sources';
+
+jest.mock('@kbn/esql-utils');
+
+const mockGetESQLSources = jest.mocked(getESQLSources);
+
+describe('useIndexSources', () => {
+  let http: ReturnType<typeof httpServiceMock.createStartContract>;
+  let application: ReturnType<typeof applicationServiceMock.createStartContract>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    http = httpServiceMock.createStartContract();
+    application = applicationServiceMock.createStartContract();
+  });
+
+  it('fetches and maps sources to combo box options', async () => {
+    mockGetESQLSources.mockResolvedValue([
+      { name: 'logs-*', hidden: false },
+      { name: 'metrics-*', hidden: false },
+    ]);
+
+    const { result } = renderHook(() => useIndexSources({ http, application }), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([{ label: 'logs-*' }, { label: 'metrics-*' }]);
+    expect(mockGetESQLSources).toHaveBeenCalledWith({ application, http }, undefined);
+  });
+
+  it('filters out hidden sources', async () => {
+    mockGetESQLSources.mockResolvedValue([
+      { name: 'logs-*', hidden: false },
+      { name: '.internal-index', hidden: true },
+      { name: 'metrics-*', hidden: false },
+    ]);
+
+    const { result } = renderHook(() => useIndexSources({ http, application }), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([{ label: 'logs-*' }, { label: 'metrics-*' }]);
+  });
+
+  it('filters out integration sources', async () => {
+    mockGetESQLSources.mockResolvedValue([
+      { name: 'logs-*', hidden: false, type: SOURCES_TYPES.INDEX },
+      { name: 'nginx', hidden: false, type: SOURCES_TYPES.INTEGRATION },
+      { name: 'apache', hidden: false, type: SOURCES_TYPES.INTEGRATION },
+      { name: 'metrics-apm.*', hidden: false, type: SOURCES_TYPES.DATA_STREAM },
+    ]);
+
+    const { result } = renderHook(() => useIndexSources({ http, application }), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([{ label: 'logs-*' }, { label: 'metrics-apm.*' }]);
+  });
+
+  it('returns empty array when fetch fails', async () => {
+    mockGetESQLSources.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useIndexSources({ http, application }), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns empty array while loading', () => {
+    mockGetESQLSources.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useIndexSources({ http, application }), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_index_sources.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_index_sources.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
+import { useQuery } from '@kbn/react-query';
+import { getESQLSources } from '@kbn/esql-utils';
+import { SOURCES_TYPES } from '@kbn/esql-types';
+import { ruleFormKeys } from './query_key_factory';
+
+interface UseIndexSourcesParams {
+  http: HttpSetup;
+  application: ApplicationStart;
+}
+
+const STALE_TIME = 30_000;
+
+export const useIndexSources = ({ http, application }: UseIndexSourcesParams) => {
+  const query = useQuery({
+    queryKey: ruleFormKeys.indexSources(),
+    queryFn: async () => {
+      const sources = await getESQLSources({ application, http }, undefined);
+      return sources
+        .filter((s) => !s.hidden && s.type !== SOURCES_TYPES.INTEGRATION)
+        .map((s) => ({ label: s.name }));
+    },
+    refetchOnWindowFocus: false,
+    staleTime: STALE_TIME,
+    retry: 1,
+  });
+
+  return {
+    data: query.data ?? [],
+    isLoading: query.isFetching,
+  };
+};


### PR DESCRIPTION
Closes [#556](https://github.com/elastic/rna-program/issues/556)

This PR adds a `useIndexSources` hook that fetches available ES|QL sources (indices, aliases, data streams) via `getESQLSources` from `@kbn/esql-utils` and populates the combo box. Fleet integration packages are filtered out since they aren't valid ES index patterns.

## Changes
New: `use_index_sources.ts `- React Query hook that calls `getESQLSources`, filters hidden sources and integrations, maps results to `{ label }` options
New: `use_index_sources.test.ts `- 5 unit tests covering fetch/map, hidden filtering, integration filtering, error fallback, and loading state
Modified: `query_key_factory.ts` - added `indexSources` cache key
Modified: `alert_condition_step.tsx` - wired options and isLoading into the Index `EuiComboBox`

## Test plan

- [x]  `useIndexSources` unit tests pass (5/5)
- [x]  tests passed

**Manual testing:**
1.  Open threshold rule builder flyout - index combo box shows available indices in dropdown
2.  Type a partial name - client-side filtering narrows the list
3.  Select an index from dropdown - downstream fields (time field, group by) populate correctly
4.  Type a custom pattern that's not in the list (e.g. my-custom-*) - `onCreateOption` still works