### PR TITLE
[Saved Objects] Don't treat WIP types as removed types in CI check

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/check_removed_types.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/check_removed_types.ts
@@ -22,13 +22,18 @@ export const checkRemovedTypes: Task = async (ctx, task) => {
       title: 'Detecting conflicts with removed types',
       task: async () => {
         ctx.currentRemovedTypes = await getRemovedTypes();
-        await detectConflictsWithRemovedTypes(ctx.to!, ctx.currentRemovedTypes);
+        await detectConflictsWithRemovedTypes(ctx.to!, ctx.currentRemovedTypes, ctx.wipTypes);
       },
     },
     {
       title: `Detecting new removed types`,
       task: () => {
-        ctx.newRemovedTypes = detectNewRemovedTypes(ctx.from!, ctx.to!, ctx.currentRemovedTypes);
+        ctx.newRemovedTypes = detectNewRemovedTypes(
+          ctx.from!,
+          ctx.to!,
+          ctx.currentRemovedTypes,
+          ctx.wipTypes
+        );
       },
     },
     {

--- a/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_conflicts_removed_types.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_conflicts_removed_types.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { MigrationSnapshot } from '../../types';
+import { isSavedObjectsCheckError, RULE_IDS } from '../../findings';
+import { detectConflictsWithRemovedTypes } from './detect_conflicts_removed_types';
+
+const snapshotWithTypes = (...typeNames: string[]): MigrationSnapshot => ({
+  meta: {
+    date: '2026-01-01',
+    kibanaCommitHash: 'abc',
+    buildUrl: null,
+    pullRequestUrl: null,
+    timestamp: 0,
+  },
+  typeDefinitions: Object.fromEntries(
+    typeNames.map((name) => [
+      name,
+      {
+        name,
+        migrationVersions: [],
+        schemaVersions: [],
+        modelVersions: [],
+        mappings: {},
+        hash: '',
+      },
+    ])
+  ),
+});
+
+describe('detectConflictsWithRemovedTypes', () => {
+  it('does not throw when no registered type reuses a removed name', async () => {
+    const to = snapshotWithTypes('dashboard', 'visualization');
+
+    await expect(detectConflictsWithRemovedTypes(to, ['legacy_type'])).resolves.toBeUndefined();
+  });
+
+  it('throws when a registered type reuses a previously removed name', async () => {
+    const to = snapshotWithTypes('dashboard', 'legacy_type');
+
+    await expect(detectConflictsWithRemovedTypes(to, ['legacy_type'])).rejects.toThrow(
+      /Cannot re-register previously removed type 'legacy_type'/
+    );
+  });
+
+  it('surfaces the conflict as a REMOVED_TYPE_NAME_REUSED finding', async () => {
+    const to = snapshotWithTypes('legacy_type');
+
+    expect.assertions(3);
+    try {
+      await detectConflictsWithRemovedTypes(to, ['legacy_type']);
+    } catch (err) {
+      expect(isSavedObjectsCheckError(err)).toBe(true);
+      if (isSavedObjectsCheckError(err)) {
+        expect(err.findings).toHaveLength(1);
+        expect(err.findings[0].ruleId).toBe(RULE_IDS.REMOVED_TYPE_NAME_REUSED);
+      }
+    }
+  });
+
+  it('does not throw when the reused name belongs to a WIP type', async () => {
+    const to = snapshotWithTypes('dashboard', 'alerting_rule');
+
+    await expect(
+      detectConflictsWithRemovedTypes(to, ['alerting_rule'], ['alerting_rule'])
+    ).resolves.toBeUndefined();
+  });
+
+  it('still throws for non-WIP conflicts when WIP types are present', async () => {
+    const to = snapshotWithTypes('alerting_rule', 'legacy_type');
+
+    await expect(
+      detectConflictsWithRemovedTypes(to, ['alerting_rule', 'legacy_type'], ['alerting_rule'])
+    ).rejects.toThrow(/'legacy_type'/);
+  });
+});

--- a/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_conflicts_removed_types.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_conflicts_removed_types.ts
@@ -11,21 +11,25 @@ import type { MigrationSnapshot } from '../../types';
 import { RULE_IDS, SavedObjectsCheckError } from '../../findings';
 
 /**
- * Detects new types in 'to' that conflict with previously removed types
+ * Detects new types in 'to' that conflict with previously removed types.
+ *
+ * WIP types are exempt from this check: a type that was registered, removed,
+ * and is now being re-introduced as a WIP type is a legitimate use case (e.g.
+ * an existing type converted into a WIP type), so it must not be treated as an
+ * illegal reuse of a removed type name.
  */
 export async function detectConflictsWithRemovedTypes(
   to: MigrationSnapshot,
-  currentRemovedTypes: string[]
+  currentRemovedTypes: string[],
+  wipTypes: string[] = []
 ) {
   const toTypes = Object.keys(to.typeDefinitions);
+  const removedTypes = new Set(currentRemovedTypes);
+  const wipTypeSet = new Set(wipTypes);
 
-  const conflictingTypes: string[] = [];
-
-  for (const type of toTypes) {
-    if (currentRemovedTypes.includes(type)) {
-      conflictingTypes.push(type);
-    }
-  }
+  const conflictingTypes = toTypes.filter(
+    (type) => removedTypes.has(type) && !wipTypeSet.has(type)
+  );
 
   if (conflictingTypes.length === 0) {
     return;

--- a/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_new_removed_types.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_new_removed_types.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { MigrationSnapshot } from '../../types';
+import { detectNewRemovedTypes } from './detect_new_removed_types';
+
+const snapshotWithTypes = (...typeNames: string[]): MigrationSnapshot => ({
+  meta: {
+    date: '2026-01-01',
+    kibanaCommitHash: 'abc',
+    buildUrl: null,
+    pullRequestUrl: null,
+    timestamp: 0,
+  },
+  typeDefinitions: Object.fromEntries(
+    typeNames.map((name) => [
+      name,
+      {
+        name,
+        migrationVersions: [],
+        schemaVersions: [],
+        modelVersions: [],
+        mappings: {},
+        hash: '',
+      },
+    ])
+  ),
+});
+
+describe('detectNewRemovedTypes', () => {
+  it('flags a type that exists in the baseline but is no longer registered', () => {
+    const from = snapshotWithTypes('dashboard', 'legacy_type');
+    const to = snapshotWithTypes('dashboard');
+
+    expect(detectNewRemovedTypes(from, to, [])).toEqual(['legacy_type']);
+  });
+
+  it('does not flag a type that is already tracked in removed_types.json', () => {
+    const from = snapshotWithTypes('dashboard', 'legacy_type');
+    const to = snapshotWithTypes('dashboard');
+
+    expect(detectNewRemovedTypes(from, to, ['legacy_type'])).toEqual([]);
+  });
+
+  it('does not flag an existing type that was converted into a WIP type', () => {
+    const from = snapshotWithTypes('dashboard', 'alerting_rule');
+    const to = snapshotWithTypes('dashboard');
+
+    expect(detectNewRemovedTypes(from, to, [], ['alerting_rule'])).toEqual([]);
+  });
+
+  it('still flags genuinely removed types alongside WIP types', () => {
+    const from = snapshotWithTypes('dashboard', 'alerting_rule', 'legacy_type');
+    const to = snapshotWithTypes('dashboard');
+
+    expect(detectNewRemovedTypes(from, to, [], ['alerting_rule'])).toEqual(['legacy_type']);
+  });
+
+  it('returns the removed types sorted alphabetically', () => {
+    const from = snapshotWithTypes('zeta', 'alpha', 'kept');
+    const to = snapshotWithTypes('kept');
+
+    expect(detectNewRemovedTypes(from, to, [])).toEqual(['alpha', 'zeta']);
+  });
+
+  it('returns an empty array when nothing was removed', () => {
+    const from = snapshotWithTypes('dashboard');
+    const to = snapshotWithTypes('dashboard', 'new_type');
+
+    expect(detectNewRemovedTypes(from, to, [])).toEqual([]);
+  });
+});

--- a/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_new_removed_types.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/removed_types/detect_new_removed_types.ts
@@ -10,24 +10,26 @@
 import type { MigrationSnapshot } from '../../types';
 
 /**
- * Detects for new removed types by comparing two snapshots and identifying
- * types that exist in 'from' but not in 'to' and not already in removed_types.json
+ * Detects new removed types by comparing two snapshots and identifying
+ * types that exist in 'from' but not in 'to', and are neither already in
+ * removed_types.json nor part of the WIP types allowlist.
+ *
+ * WIP types are excluded because a type that is converted into a WIP type
+ * disappears from the current ('to') snapshot. Without this guard, such a
+ * type would be wrongly classified as removed and added to removed_types.json,
+ * which would then permanently prevent it from being registered again.
  */
 export function detectNewRemovedTypes(
   from: MigrationSnapshot,
   to: MigrationSnapshot,
-  currentRemovedTypes: string[]
+  currentRemovedTypes: string[],
+  wipTypes: string[] = []
 ): string[] {
   const fromTypes = Object.keys(from.typeDefinitions);
-  const toTypes = Object.keys(to.typeDefinitions);
+  const toTypes = new Set(Object.keys(to.typeDefinitions));
+  const ignoredTypes = new Set([...currentRemovedTypes, ...wipTypes]);
 
-  const removedTypes: string[] = [];
-
-  for (const type of fromTypes) {
-    if (!toTypes.includes(type) && !currentRemovedTypes.includes(type)) {
-      removedTypes.push(type);
-    }
-  }
+  const removedTypes = fromTypes.filter((type) => !toTypes.has(type) && !ignoredTypes.has(type));
 
   return removedTypes.sort();
 }


### PR DESCRIPTION
## Summary

The `Check changes in Saved Objects` CI check was wrongly flagging **WIP Saved Object types** as removed.

When an existing SO type is converted into a [WIP type](https://github.com/elastic/kibana/pull/269108) (added to `wip_types.json`), it is filtered out of the current type-registry snapshot. The removed-type detection then saw the type present in the baseline (`from`) but absent from the current snapshot (`to`) and:

1. `detectNewRemovedTypes` added it to `removed_types.json`, and
2. `detectConflictsWithRemovedTypes` subsequently rejected it with:

   > Error: Type 'alerting_rule' can't be used because it's been added to the legacy types

This blocked early adopters of WIP types (e.g. alerting v2) from registering their own types.

### Fix

Both removed-type detectors are now **WIP-aware** (the WIP allowlist is already loaded into `ctx.wipTypes` before `checkRemovedTypes` runs):

- `detectNewRemovedTypes` excludes WIP types, so converting an existing type into a WIP type no longer adds it to `removed_types.json`.
- `detectConflictsWithRemovedTypes` exempts WIP types, so a type that is being (re)introduced as WIP is not treated as an illegal reuse of a removed type name.

Previously, detection relied implicitly on a side-effecting `delete ctx.from.typeDefinitions[wipType]` mutation in `validate_so_changes.ts`, which did not protect the conflict check (it runs against the unfiltered `to` snapshot). The detectors now take `wipTypes` explicitly.

No change to `removed_types.json` is included: on `main` no currently-WIP type is present there. Branches that already have a stale WIP entry should drop it; with this fix it will not be re-added.

## Test plan

- [x] Added unit tests for `detectNewRemovedTypes` (WIP types not flagged; genuinely removed types still flagged).
- [x] Added unit tests for `detectConflictsWithRemovedTypes` (WIP names exempt; non-WIP reuse still throws).
- [x] `node scripts/jest packages/kbn-check-saved-objects-cli/src/migrations/removed_types/` — 11 passing.

Made with [Cursor](https://cursor.com)