### PR TITLE
[SLO] Make composite SLO tables responsive

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/composite_slo/composite_slo_members_table.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/composite_slo/composite_slo_members_table.tsx
@@ -47,7 +47,6 @@ const getMemberColumns = (
       defaultMessage: 'Member SLO',
     }),
     truncateText: true,
-    width: '220px',
   },
   {
     field: 'status',
@@ -62,7 +61,6 @@ const getMemberColumns = (
     name: i18n.translate('xpack.slo.compositeSloList.members.instanceId', {
       defaultMessage: 'Instance',
     }),
-    width: '220px',
     render: (instanceId?: string) => instanceId ?? NOT_AVAILABLE_LABEL,
   },
   {
@@ -161,6 +159,7 @@ export function CompositeSloMembersTable({
   return (
     <div css={{ padding: '16px' }}>
       <EuiBasicTable
+        css={{ overflowX: 'auto' }}
         tableCaption={i18n.translate('xpack.slo.compositeSloList.members.tableCaption', {
           defaultMessage: 'Member SLOs',
         })}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/composite_slo/composite_slo_table.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/composite_slo/composite_slo_table.tsx
@@ -212,7 +212,6 @@ export function CompositeSloTable({
       name: i18n.translate('xpack.slo.compositeSloList.columns.name', {
         defaultMessage: 'Name',
       }),
-      width: '200px',
       truncateText: true,
       sortable: true,
     },
@@ -221,7 +220,6 @@ export function CompositeSloTable({
       name: i18n.translate('xpack.slo.compositeSloList.columns.tags', {
         defaultMessage: 'Tags',
       }),
-      width: '130px',
       render: (tags: string[]) => (
         <EuiFlexGroup gutterSize="xs" responsive={false} css={{ overflow: 'hidden' }}>
           {tags.map((tag) => (


### PR DESCRIPTION
## Summary

Composite SLO tables defined a fixed pixel `width` on nearly every column, so they did not scale with the viewport. This switches to a hybrid flex layout: utility/numeric columns keep small fixed widths while the primary text columns flex to fill available space.

- `composite_slo_table.tsx`: drop fixed `width` from the `name` and `tags` columns so they expand.
- `composite_slo_members_table.tsx`: drop fixed `width` from `name` and `instanceId`, and add `overflowX: 'auto'` so the nested table degrades gracefully on narrow screens.

No prop, i18n, or `data-test-subj` changes.

## Test plan

- [ ] Composite SLO list renders correctly at narrow and wide window widths
- [ ] Expanded member row table is responsive

Made with [Cursor](https://cursor.com)