### PR TITLE
chore(deps): bump `@hapi/wreck` to `18.1.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "@hapi/hapi": "21.4.9",
     "@hapi/hoek": "11.0.7",
     "@hapi/inert": "7.1.0",
-    "@hapi/wreck": "18.1.1",
+    "@hapi/wreck": "18.1.2",
     "@hello-pangea/dnd": "18.0.1",
     "@kbn/aad-fixtures-plugin": "link:x-pack/platform/test/alerting_api_integration/common/plugins/aad",
     "@kbn/access-control-test-plugin": "link:x-pack/platform/test/spaces_api_integration/common/plugins/access_control_test_plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3556,16 +3556,7 @@
   dependencies:
     "@hapi/hoek" "^11.0.2"
 
-"@hapi/wreck@18.1.1":
-  version "18.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/wreck/-/wreck-18.1.1.tgz#06d5be6d706d6aa1ecf35e2bd39350f4632f0fbe"
-  integrity sha512-UwTeGBfAnB/1mkw4gD6IQGI/bgMu7iGmqgT8K+xxye3z4ZHhCZlmS2wuHBJmENhBJSKqvoYzJ71ds3Xfq4gofQ==
-  dependencies:
-    "@hapi/boom" "^10.0.1"
-    "@hapi/bourne" "^3.0.0"
-    "@hapi/hoek" "^11.0.2"
-
-"@hapi/wreck@^18.0.1", "@hapi/wreck@^18.1.1":
+"@hapi/wreck@18.1.2", "@hapi/wreck@^18.0.1", "@hapi/wreck@^18.1.1":
   version "18.1.2"
   resolved "https://registry.yarnpkg.com/@hapi/wreck/-/wreck-18.1.2.tgz#1c1c84427085d7018ff4157ef3eb1e2cf080b26b"
   integrity sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==


### PR DESCRIPTION
## Summary

Bump `@hapi/wreck` to `18.1.2`.

>[!IMPORTANT]
> 8.19 backport will be done via https://github.com/elastic/kibana/pull/273163



<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->