### PR TITLE
[8.19] Remove query params from external calls (#273057)

### DIFF
--- a/src/core/packages/application/browser-internal/src/register_analytics_context_provider.ts
+++ b/src/core/packages/application/browser-internal/src/register_analytics_context_provider.ts
@@ -19,9 +19,9 @@ export function registerAnalyticsContextProvider({
 }) {
   analytics.registerContextProvider({
     name: 'page url',
-    context$: location$.pipe(map((location) => ({ page_url: location }))),
+    context$: location$.pipe(map((location) => ({ page_url: location.split('?')[0] }))),
     schema: {
-      page_url: { type: 'text', _meta: { description: 'The page url' } },
+      page_url: { type: 'text', _meta: { description: 'The page url without the query params' } },
     },
   });
 }

--- a/src/core/packages/root/browser-internal/src/apm_system.ts
+++ b/src/core/packages/root/browser-internal/src/apm_system.ts
@@ -60,6 +60,22 @@ export class ApmSystem {
       user_agent: navigator.userAgent,
     });
 
+    // Remove the query params from the URLs (page's URL and refererer)
+    apm.addFilter((payload) => {
+      payload.transactions.forEach((transaction) => {
+        if (transaction.context && transaction.context.page) {
+          const { url, referer } = transaction.context.page;
+          if (url) {
+            transaction.context.page.url = url.split('?')[0];
+          }
+          if (referer) {
+            transaction.context.page.referer = referer.split('?')[0];
+          }
+        }
+      });
+      return payload;
+    });
+
     this.addHttpRequestNormalization(apm);
     this.addRouteChangeNormalization(apm);
 

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/public/plugin.ts
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_experiments/public/plugin.ts
@@ -124,6 +124,8 @@ export class CloudExperimentsPlugin
             : this.initializerContext.env.packageInfo.version,
       },
       bootstrap,
+      // Remove the query params from the URL
+      eventUrlTransformer: (url) => url.split('?')[0],
     });
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remove query params from external calls (#273057)](https://github.com/elastic/kibana/pull/273057)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alejandro Fernández Haro","email":"alejandro.haro@elastic.co"},"sourceCommit":{"committedDate":"2026-06-10T12:29:50Z","message":"Remove query params from external calls (#273057)\n\n## Summary\n\nThis PR removes data from our telemetry services that we don't care\nabout. This way, our collected data is cleaner, and we can have better\ninsights.\n\n### Checklist\n\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"64e38357f2f1bac8bcbcbaafdd4007966c96d12f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.5.0","v9.4.3","v9.3.6"],"title":"Remove query params from external calls","number":273057,"url":"https://github.com/elastic/kibana/pull/273057","mergeCommit":{"message":"Remove query params from external calls (#273057)\n\n## Summary\n\nThis PR removes data from our telemetry services that we don't care\nabout. This way, our collected data is cleaner, and we can have better\ninsights.\n\n### Checklist\n\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"64e38357f2f1bac8bcbcbaafdd4007966c96d12f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273057","number":273057,"mergeCommit":{"message":"Remove query params from external calls (#273057)\n\n## Summary\n\nThis PR removes data from our telemetry services that we don't care\nabout. This way, our collected data is cleaner, and we can have better\ninsights.\n\n### Checklist\n\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"64e38357f2f1bac8bcbcbaafdd4007966c96d12f"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/273110","number":273110,"state":"MERGED","mergeCommit":{"sha":"73cd216b01b416421c599cc94d2d47320d3673c9","message":"[9.4] Remove query params from external calls (#273057) (#273110)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Remove query params from external calls\n(#273057)](https://github.com/elastic/kibana/pull/273057)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alejandro Fernández Haro <alejandro.haro@elastic.co>"}},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/273109","number":273109,"state":"MERGED","mergeCommit":{"sha":"6a831b825c205e8c9a77875a434886a3221f10b0","message":"[9.3] Remove query params from external calls (#273057) (#273109)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Remove query params from external calls\n(#273057)](https://github.com/elastic/kibana/pull/273057)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alejandro Fernández Haro <alejandro.haro@elastic.co>"}}]}] BACKPORT-->