### PR TITLE
[Alerting v2] Rule Builder: Fix stat labels with spaces breaking STATS ES|QL generation

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/build_esql.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/build_esql.test.ts
@@ -133,6 +133,24 @@ describe('buildThresholdEsql', () => {
       expect(result).toContain('errors = COUNT(*) WHERE status >= 500');
     });
 
+    it('escapes stat labels containing spaces', () => {
+      const result = buildThresholdEsql(
+        makeValues({
+          stats: [{ id: '1', label: 'error count', aggregation: Aggregation.COUNT }],
+          alertConditions: [
+            { id: '1', metric: 'error count', comparator: Comparator.GT, threshold: [100] },
+          ],
+        })
+      );
+      expect(result).toContain('`error count` = COUNT(*)');
+    });
+
+    it('does not escape simple stat labels', () => {
+      const result = buildThresholdEsql(makeValues());
+      expect(result).toContain('count = COUNT(*)');
+      expect(result).not.toContain('`count`');
+    });
+
     it('includes multiple stats', () => {
       const result = buildThresholdEsql(
         makeValues({

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/build_esql.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/build_esql.ts
@@ -75,7 +75,7 @@ const parseStatsCommand = (
   stats: StatDefinition[],
   groupByFields: string[]
 ): ESQLSingleAstItem[] => {
-  const assignments = stats.map((s) => `${s.label} = ${buildAggFragment(s)}`);
+  const assignments = stats.map((s) => `${escapeField(s.label)} = ${buildAggFragment(s)}`);
   const groupBy =
     groupByFields.length > 0 ? ` BY ${groupByFields.map(escapeField).join(', ')}` : '';
   const src = `ROW x = 1 | STATS ${assignments.join(', ')}${groupBy}`;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/parse_esql.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/parse_esql.test.ts
@@ -767,6 +767,20 @@ describe('parseThresholdEsql', () => {
       expect(parsed!.groupByFields).toEqual(['region']);
     });
 
+    it('round-trips stat labels containing spaces', () => {
+      const original = makeValues({
+        stats: [{ id: '1', label: 'error count', aggregation: Aggregation.COUNT }],
+        alertConditions: [
+          { id: '1', metric: 'error count', comparator: Comparator.GT, threshold: [100] },
+        ],
+      });
+      const { esql, parsed } = roundTrip(original);
+      expect(esql).toContain('`error count` = COUNT(*)');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.stats[0].label).toBe('error count');
+      expect(parsed!.alertConditions[0].metric).toBe('error count');
+    });
+
     it('round-trips with no alert conditions (STATS only)', () => {
       const original = makeValues({
         alertConditions: [],


### PR DESCRIPTION
Closes https://github.com/elastic/rna-program/issues/558

## Summary

Fixes a bug where stat labels containing spaces (e.g. `error count`) in the threshold rule builder produced invalid ES|QL. The label was interpolated directly into the `STATS` command string without escaping, causing a parse error.

**Root cause:** `parseStatsCommand` in `build_esql.ts` used `s.label` directly in the string template, but the `escapeField()` helper (which backtick-wraps non-identifier names) was not applied to labels — only to field names and group-by fields.

**Fix:** Apply `escapeField()` to stat labels so `error count` becomes `` `error count` `` in the generated ES|QL. The parser already strips backticks when reconstructing builder state, so the round-trip works correctly.

- EVAL labels and alert condition metrics were already safe — they use `Builder.expression.column()` which auto-escapes.

## Test plan

- [x] New test: stat label with spaces produces backtick-escaped STATS assignment
- [x] New test: simple labels are not unnecessarily escaped
- [x] New test: round-trip (build → parse) preserves labels with spaces
- [x] All 129 existing build/parse tests still pass


Made with [Cursor](https://cursor.com)