### PR TITLE
[8.19] chore(deps): bump `react-use` to `17.6.1` (#273212)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1292,7 +1292,7 @@
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.30.4",
     "react-shortcuts": "2.1.0",
-    "react-use": "17.6.0",
+    "react-use": "17.6.1",
     "react-virtualized": "9.22.5",
     "react-window": "1.8.10",
     "react-window-infinite-loader": "1.0.9",

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
@@ -11,7 +11,7 @@
 @types/eslint@8.44.2
 @types/estree@0.0.50
 @types/estree@1.0.8
-@types/js-cookie@2.2.6
+@types/js-cookie@3.0.6
 @types/json-schema@7.0.11
 @types/node@22.19.1
 @types/trusted-types@2.0.7
@@ -79,7 +79,7 @@ hyphenate-style-name@1.0.3
 icss-utils@5.1.0
 inline-style-prefixer@7.0.1
 jest-worker@27.5.1
-js-cookie@2.2.1
+js-cookie@3.0.8
 json-parse-even-better-errors@2.3.1
 json-schema-traverse@0.4.1
 json-schema-traverse@1.0.0
@@ -117,7 +117,7 @@ postcss@8.5.14
 prettier@2.8.8
 punycode@2.3.1
 react-universal-interface@0.6.2
-react-use@17.6.0
+react-use@17.6.1
 require-from-string@2.0.2
 resize-observer-polyfill@1.5.1
 rtl-css-js@1.16.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -13312,10 +13312,10 @@
   dependencies:
     "@types/sizzle" "*"
 
-"@types/js-cookie@^2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
-  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+"@types/js-cookie@^3.0.0":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
 
 "@types/js-search@1.4.0":
   version "1.4.0"
@@ -23948,10 +23948,10 @@ jquery@3.7.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
 
-js-cookie@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@^3.0.0:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.8.tgz#444e6f4b27a5d844594fef61c9d6bca5f0787688"
+  integrity sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==
 
 js-levenshtein@^1.1.6:
   version "1.1.6"
@@ -28994,17 +28994,17 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use@17.6.0:
-  version "17.6.0"
-  resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.6.0.tgz#2101a3a79dc965a25866b21f5d6de4b128488a14"
-  integrity sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==
+react-use@17.6.1:
+  version "17.6.1"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.6.1.tgz#c9692540f2230b763e42076fbf350e7e33ec2e21"
+  integrity sha512-uibb3pgzV4LFsYPHyXYGu7dD2+pyk/ZJlPH+AizBR3zolqPWyCleKcWWbUQaKSKfydwgnQ3ymGm1Ab3/saGHCA==
   dependencies:
-    "@types/js-cookie" "^2.2.6"
+    "@types/js-cookie" "^3.0.0"
     "@xobotyi/scrollbar-width" "^1.9.5"
     copy-to-clipboard "^3.3.1"
     fast-deep-equal "^3.1.3"
     fast-shallow-equal "^1.0.0"
-    js-cookie "^2.2.1"
+    js-cookie "^3.0.0"
     nano-css "^5.6.2"
     react-universal-interface "^0.6.2"
     resize-observer-polyfill "^1.5.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): bump `react-use` to `17.6.1` (#273212)](https://github.com/elastic/kibana/pull/273212)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-06-12T18:32:39Z","message":"chore(deps): bump `react-use` to `17.6.1` (#273212)\n\n## Summary\n\nBump `react-use` to `17.6.1`.","sha":"24a86585bcd8fb6a45f9e1b5c2fb9aac4033be84","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"chore(deps): bump `react-use` to `17.6.1`","number":273212,"url":"https://github.com/elastic/kibana/pull/273212","mergeCommit":{"message":"chore(deps): bump `react-use` to `17.6.1` (#273212)\n\n## Summary\n\nBump `react-use` to `17.6.1`.","sha":"24a86585bcd8fb6a45f9e1b5c2fb9aac4033be84"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273212","number":273212,"mergeCommit":{"message":"chore(deps): bump `react-use` to `17.6.1` (#273212)\n\n## Summary\n\nBump `react-use` to `17.6.1`.","sha":"24a86585bcd8fb6a45f9e1b5c2fb9aac4033be84"}},{"url":"https://github.com/elastic/kibana/pull/273216","number":273216,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/273217","number":273217,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->