### PR TITLE
[8.19] [UII] Skip generating uninstall tokens for agentless policies (#272949)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/uninstall_token/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/uninstall_token/handlers.test.ts
@@ -126,6 +126,40 @@ describe('uninstall token handlers', () => {
       });
     });
 
+    it('should exclude managed and agentless policies from uninstall tokens', async () => {
+      const managedPolicy = createAgentPolicyMock({ id: 'managed-policy-id', is_managed: true });
+      const agentlessPolicy = createAgentPolicyMock({
+        id: 'agentless-policy-id',
+        supports_agentless: true,
+      });
+      mockAgentPolicyService.list.mockResolvedValue({
+        items: [managedPolicy, agentlessPolicy],
+        total: 2,
+        page: 1,
+        perPage: 2,
+      });
+      getTokenMetadataMock.mockResolvedValue(uninstallTokensResponseFixture);
+
+      await getUninstallTokensMetadataHandlerWithErrorHandler(context, request, response);
+
+      expect(mockAgentPolicyService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          kuery: expect.stringContaining('is_managed:true'),
+        })
+      );
+      expect(mockAgentPolicyService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          kuery: expect.stringContaining('supports_agentless:true'),
+        })
+      );
+      expect(getTokenMetadataMock).toHaveBeenCalledWith(undefined, undefined, 1, 20, [
+        'managed-policy-id',
+        'agentless-policy-id',
+      ]);
+    });
+
     it('should return internal error when uninstallTokenService throws error', async () => {
       getTokenMetadataMock.mockRejectedValue(Error('something happened'));
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/uninstall_token/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/uninstall_token/handlers.ts
@@ -43,7 +43,6 @@ export const getUninstallTokensMetadataHandler: FleetRequestHandler<
 
   const excludedPolicyIds = excludedPolicies.map((policy) => policy.id);
 
-
   let policyIdSearchTerm: string | undefined;
   let policyNameSearchTerm: string | undefined;
   if (search) {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/uninstall_token/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/uninstall_token/handlers.ts
@@ -35,13 +35,14 @@ export const getUninstallTokensMetadataHandler: FleetRequestHandler<
 
   const soClient = coreContext.savedObjects.client;
 
-  const { items: managedPolicies } = await agentPolicyService.list(soClient, {
+  const { items: excludedPolicies } = await agentPolicyService.list(soClient, {
     fields: ['id'],
     perPage: SO_SEARCH_LIMIT,
-    kuery: `${LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE}.is_managed:true`,
+    kuery: `${LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE}.is_managed:true OR ${LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE}.supports_agentless:true`,
   });
 
-  const managedPolicyIds = managedPolicies.map((policy) => policy.id);
+  const excludedPolicyIds = excludedPolicies.map((policy) => policy.id);
+
 
   let policyIdSearchTerm: string | undefined;
   let policyNameSearchTerm: string | undefined;
@@ -57,7 +58,7 @@ export const getUninstallTokensMetadataHandler: FleetRequestHandler<
     policyNameSearchTerm,
     page,
     perPage,
-    managedPolicyIds.length > 0 ? managedPolicyIds : undefined
+    excludedPolicyIds.length > 0 ? excludedPolicyIds : undefined
   );
 
   return response.ok({ body });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -494,6 +494,48 @@ describe('Agent policy', () => {
         )
       );
     });
+
+    it('should not generate uninstall token for agentless policies', async () => {
+      jest.spyOn(appContextService, 'getConfig').mockReturnValue({
+        agentless: { enabled: true },
+      } as any);
+      jest
+        .spyOn(appContextService, 'getCloud')
+        .mockReturnValue({ isServerlessEnabled: false, isCloudEnabled: true } as any);
+
+      const generateTokenForPolicyId = jest.fn().mockResolvedValue(undefined);
+      mockedAppContextService.getUninstallTokenService.mockReturnValueOnce({
+        scoped: jest.fn().mockReturnValue({ generateTokenForPolicyId }),
+      } as unknown as UninstallTokenServiceInterface);
+
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      await agentPolicyService.create(soClient, esClient, {
+        name: 'test agentless policy',
+        namespace: 'default',
+        supports_agentless: true,
+      });
+
+      expect(generateTokenForPolicyId).not.toHaveBeenCalled();
+    });
+
+    it('should generate uninstall token for non-agentless policies', async () => {
+      const generateTokenForPolicyId = jest.fn().mockResolvedValue(undefined);
+      mockedAppContextService.getUninstallTokenService.mockReturnValueOnce({
+        scoped: jest.fn().mockReturnValue({ generateTokenForPolicyId }),
+      } as unknown as UninstallTokenServiceInterface);
+
+      const soClient = getAgentPolicyCreateMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      await agentPolicyService.create(soClient, esClient, {
+        name: 'test regular policy',
+        namespace: 'default',
+      });
+
+      expect(generateTokenForPolicyId).toHaveBeenCalled();
+    });
   });
 
   // TODO: Add more test coverage to `get` service method

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -433,10 +433,14 @@ class AgentPolicyService {
       options
     );
 
-    await appContextService
-      .getUninstallTokenService()
-      ?.scoped(soClient.getCurrentNamespace())
-      ?.generateTokenForPolicyId(newSo.id);
+    if (!agentPolicy.supports_agentless) {
+      await appContextService
+        .getUninstallTokenService()
+        ?.scoped(soClient.getCurrentNamespace())
+        ?.generateTokenForPolicyId(newSo.id);
+    } else {
+      logger.debug('Skipping uninstall token generation for agentless policy');
+    }
     await this.triggerAgentPolicyUpdatedEvent(esClient, 'created', newSo.id, {
       skipDeploy: options.skipDeploy,
       spaceId: soClient.getCurrentNamespace(),

--- a/x-pack/platform/plugins/shared/fleet/server/services/security/uninstall_token_service/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/security/uninstall_token_service/index.test.ts
@@ -768,6 +768,19 @@ describe('UninstallTokenService', () => {
             },
           ]);
         });
+
+        it('excludes agentless policies when calling generateTokensForAllPolicies', async () => {
+          mockAgentPolicyFetchAllAgentPolicyIds(canEncrypt);
+
+          await uninstallTokenService.generateTokensForAllPolicies();
+
+          expect(agentPolicyService.fetchAllAgentPolicyIds).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              kuery: expect.stringContaining('NOT ingest-agent-policies.supports_agentless:true'),
+            })
+          );
+        });
       });
 
       describe('agentTamperProtectionEnabled false', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/security/uninstall_token_service/index.ts
@@ -41,7 +41,11 @@ import type {
   UninstallTokenMetadata,
 } from '../../../../common/types/models/uninstall_token';
 
-import { UNINSTALL_TOKENS_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../../constants';
+import {
+  UNINSTALL_TOKENS_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
+  LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+} from '../../../constants';
 import { appContextService } from '../../app_context';
 import { agentPolicyService, getAgentPolicySavedObjectType } from '../../agent_policy';
 import { isSpaceAwarenessEnabled } from '../../spaces/helpers';
@@ -594,6 +598,7 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
   private async getAllPolicyIds(): Promise<string[]> {
     const agentPolicyIdsFetcher = await agentPolicyService.fetchAllAgentPolicyIds(this.soClient, {
       spaceId: '*',
+      kuery: `NOT ${LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE}.supports_agentless:true`,
     });
     const policyIds: string[] = [];
     for await (const agentPolicyId of agentPolicyIdsFetcher) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[UII] Skip generating uninstall tokens for agentless policies (#272949)](https://github.com/elastic/kibana/pull/272949)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-06-12T20:30:35Z","message":"[UII] Skip generating uninstall tokens for agentless policies (#272949)\n\n## Summary\n\nResolves #272815\n\nAgentless API/controller don't use uninstall tokens at all as part of\nthe agent pod teardown, so uninstall tokens are not needed for agentless\npolicies at all. This PR:\n\n- Skips generating uninstall tokens for agentless policies\n- Hides existing ones from the get uninstall tokens API response\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d939cb475e07ca8b7eb72131a97eacd0294d74f7","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:all-open","v9.5.0"],"title":"[UII] Skip generating uninstall tokens for agentless policies","number":272949,"url":"https://github.com/elastic/kibana/pull/272949","mergeCommit":{"message":"[UII] Skip generating uninstall tokens for agentless policies (#272949)\n\n## Summary\n\nResolves #272815\n\nAgentless API/controller don't use uninstall tokens at all as part of\nthe agent pod teardown, so uninstall tokens are not needed for agentless\npolicies at all. This PR:\n\n- Skips generating uninstall tokens for agentless policies\n- Hides existing ones from the get uninstall tokens API response\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d939cb475e07ca8b7eb72131a97eacd0294d74f7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272949","number":272949,"mergeCommit":{"message":"[UII] Skip generating uninstall tokens for agentless policies (#272949)\n\n## Summary\n\nResolves #272815\n\nAgentless API/controller don't use uninstall tokens at all as part of\nthe agent pod teardown, so uninstall tokens are not needed for agentless\npolicies at all. This PR:\n\n- Skips generating uninstall tokens for agentless policies\n- Hides existing ones from the get uninstall tokens API response\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d939cb475e07ca8b7eb72131a97eacd0294d74f7"}},{"url":"https://github.com/elastic/kibana/pull/273222","number":273222,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/273223","number":273223,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->