### PR TITLE
[Agent Builder] Report token usage in ai.agent workflow step

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -173,7 +173,7 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
       // context growth. Layer 1 (pre-emptive I/O enforcement) may have
       // already caught this at the transport level.
       let measuredOutputSize: number | undefined;
-      if (result.output != null && !result.error) {
+      if (result.output != null) {
         const maxBytes = this.getMaxResponseBytes();
         if (maxBytes > 0) {
           const outputSize = safeOutputSize(result.output);
@@ -206,7 +206,13 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
       }
 
       if (result.error) {
-        this.stepExecutionRuntime.failStep(new ExecutionError(result.error));
+        // Pass partial output (e.g. token-usage metadata accumulated before a
+        // stream error) so it is persisted and reachable via
+        // `steps.x.output.metadata.usage` even when the step fails.
+        this.stepExecutionRuntime.failStep(
+          new ExecutionError(result.error),
+          result.output ?? undefined
+        );
         if (stepSpan) {
           stepSpan.setOutcome('failure');
         }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
@@ -205,8 +205,15 @@ export class StepExecutionRuntime {
    * scopeStack / timing go through state, the FAILED-step `output: null`
    * sentinel goes through the IO service. Atomicity is preserved because
    * the two writes share a synchronous tick.
+   *
+   * @param error - The error that caused the step to fail.
+   * @param partialOutput - Optional partial output to persist alongside the
+   *   failure (e.g. token-usage metadata accumulated before the stream
+   *   errored). When provided, it is stored via the IO service instead of
+   *   the usual `null` sentinel so that downstream steps can still read
+   *   `steps.x.output.metadata.usage`.
    */
-  public failStep(error: Error): void {
+  public failStep(error: Error, partialOutput?: unknown): void {
     const executionError = ExecutionError.fromError(error);
     const serializedError = executionError.toSerializableObject();
 
@@ -235,9 +242,15 @@ export class StepExecutionRuntime {
       error: serializedError,
       ...(executionTimeMs !== undefined ? { executionTimeMs } : {}),
     });
-    // `null` is the FAILED-step sentinel — distinct from `undefined`
-    // (evicted) so the eviction predicate can keep them apart.
-    this.stepIoService.setStepOutput(this.stepExecutionId, null);
+    // When partial output is provided (e.g. token-usage metadata accumulated
+    // before a stream error), persist it so it remains reachable via
+    // `steps.x.output`. Otherwise write the `null` FAILED-step sentinel —
+    // distinct from `undefined` (evicted) so the eviction predicate can tell
+    // them apart.
+    this.stepIoService.setStepOutput(
+      this.stepExecutionId,
+      partialOutput !== undefined ? (partialOutput as JsonValue) : null
+    );
     this.logStepFail(executionError);
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -95,6 +95,16 @@ export const OutputSchema = z.object({
     .describe(
       'Conversation ID associated with this step execution. Present when create_conversation is enabled or conversation_id is provided.'
     ),
+  metadata: z
+    .object({
+      usage: z.object({
+        inputTokens: z.number().describe('Total input tokens consumed across all LLM rounds.'),
+        outputTokens: z.number().describe('Total output tokens produced across all LLM rounds.'),
+        totalTokens: z.number().describe('Sum of input and output tokens across all LLM rounds.'),
+      }),
+    })
+    .describe('Step execution metadata, including token usage across all LLM rounds.')
+    .optional(),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
@@ -483,7 +483,11 @@ describe('ai.agent workflow step (Agent Builder)', () => {
 
       const res = await step.handler(createContext({ input: { message: 'hi' } }));
 
-      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
+      expect(res.output?.metadata?.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      });
     });
 
     it('accumulates token usage across multiple rounds', async () => {
@@ -528,7 +532,11 @@ describe('ai.agent workflow step (Agent Builder)', () => {
       // Output should be from the last round
       expect(res.output?.message).toBe('final');
       // Usage should be the sum across all rounds
-      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 500, outputTokens: 200, totalTokens: 700 });
+      expect(res.output?.metadata?.usage).toEqual({
+        inputTokens: 500,
+        outputTokens: 200,
+        totalTokens: 700,
+      });
     });
 
     it('returns zero usage when round has no model_usage', async () => {
@@ -548,11 +556,16 @@ describe('ai.agent workflow step (Agent Builder)', () => {
 
       const res = await step.handler(createContext({ input: { message: 'hi' } }));
 
-      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+      expect(res.output?.metadata?.usage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      });
     });
 
     it('preserves partial token counts when the event stream errors mid-execution', async () => {
-      const { concat, throwError: rxThrowError } = jest.requireActual<typeof import('rxjs')>('rxjs');
+      const { concat, throwError: rxThrowError } =
+        jest.requireActual<typeof import('rxjs')>('rxjs');
 
       // Cold observable: emits one round with tokens, then errors
       const events$ = concat(
@@ -562,7 +575,12 @@ describe('ai.agent workflow step (Agent Builder)', () => {
             round: {
               id: 'r-1',
               response: { message: 'partial' },
-              model_usage: { connector_id: 'c', llm_calls: 1, input_tokens: 150, output_tokens: 60 },
+              model_usage: {
+                connector_id: 'c',
+                llm_calls: 1,
+                input_tokens: 150,
+                output_tokens: 60,
+              },
             },
           },
         }),
@@ -576,7 +594,11 @@ describe('ai.agent workflow step (Agent Builder)', () => {
 
       expect(res.error).toBeInstanceOf(Error);
       // Partial token counts are preserved in the output despite the error
-      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 150, outputTokens: 60, totalTokens: 210 });
+      expect(res.output?.metadata?.usage).toEqual({
+        inputTokens: 150,
+        outputTokens: 60,
+        totalTokens: 210,
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
@@ -28,7 +28,6 @@ describe('ai.agent workflow step (Agent Builder)', () => {
         getContext: jest.fn(),
         getScopedEsClient: jest.fn(),
         renderInputTemplate: jest.fn(),
-        callKibanaApi: jest.fn(),
       },
       logger: {
         debug: jest.fn(),
@@ -463,6 +462,121 @@ describe('ai.agent workflow step (Agent Builder)', () => {
 
       const callArg = execution.executeAgent.mock.calls[0][0];
       expect(callArg.params).not.toHaveProperty('telemetryMetadata');
+    });
+  });
+
+  describe('token usage', () => {
+    it('includes usage in output from a single round with model_usage', async () => {
+      const events$ = of({
+        type: ChatEventType.roundComplete,
+        data: {
+          round: {
+            id: 'r-1',
+            response: { message: 'hello' },
+            model_usage: { connector_id: 'c', llm_calls: 1, input_tokens: 100, output_tokens: 50 },
+          },
+        },
+      });
+
+      const execution = createExecutionMock(events$);
+      const step = getRunAgentStepDefinition({ internalStart: { execution } } as any);
+
+      const res = await step.handler(createContext({ input: { message: 'hi' } }));
+
+      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
+    });
+
+    it('accumulates token usage across multiple rounds', async () => {
+      const events$ = of(
+        {
+          type: ChatEventType.roundComplete,
+          data: {
+            round: {
+              id: 'r-1',
+              response: { message: 'intermediate' },
+              model_usage: {
+                connector_id: 'c',
+                llm_calls: 1,
+                input_tokens: 200,
+                output_tokens: 80,
+              },
+            },
+          },
+        },
+        {
+          type: ChatEventType.roundComplete,
+          data: {
+            round: {
+              id: 'r-2',
+              response: { message: 'final' },
+              model_usage: {
+                connector_id: 'c',
+                llm_calls: 1,
+                input_tokens: 300,
+                output_tokens: 120,
+              },
+            },
+          },
+        }
+      );
+
+      const execution = createExecutionMock(events$);
+      const step = getRunAgentStepDefinition({ internalStart: { execution } } as any);
+
+      const res = await step.handler(createContext({ input: { message: 'hi' } }));
+
+      // Output should be from the last round
+      expect(res.output?.message).toBe('final');
+      // Usage should be the sum across all rounds
+      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 500, outputTokens: 200, totalTokens: 700 });
+    });
+
+    it('returns zero usage when round has no model_usage', async () => {
+      const events$ = of({
+        type: ChatEventType.roundComplete,
+        data: {
+          round: {
+            id: 'r-1',
+            response: { message: 'ok' },
+            // no model_usage
+          },
+        },
+      });
+
+      const execution = createExecutionMock(events$);
+      const step = getRunAgentStepDefinition({ internalStart: { execution } } as any);
+
+      const res = await step.handler(createContext({ input: { message: 'hi' } }));
+
+      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+    });
+
+    it('preserves partial token counts when the event stream errors mid-execution', async () => {
+      const { concat, throwError: rxThrowError } = jest.requireActual<typeof import('rxjs')>('rxjs');
+
+      // Cold observable: emits one round with tokens, then errors
+      const events$ = concat(
+        of({
+          type: ChatEventType.roundComplete,
+          data: {
+            round: {
+              id: 'r-1',
+              response: { message: 'partial' },
+              model_usage: { connector_id: 'c', llm_calls: 1, input_tokens: 150, output_tokens: 60 },
+            },
+          },
+        }),
+        rxThrowError(() => new Error('stream interrupted'))
+      );
+
+      const execution = createExecutionMock(events$);
+      const step = getRunAgentStepDefinition({ internalStart: { execution } } as any);
+
+      const res = await step.handler(createContext({ input: { message: 'hi' } }));
+
+      expect(res.error).toBeInstanceOf(Error);
+      // Partial token counts are preserved in the output despite the error
+      expect(res.output?.metadata?.usage).toEqual({ inputTokens: 150, outputTokens: 60, totalTokens: 210 });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
@@ -28,6 +28,7 @@ describe('ai.agent workflow step (Agent Builder)', () => {
         getContext: jest.fn(),
         getScopedEsClient: jest.fn(),
         renderInputTemplate: jest.fn(),
+        callKibanaApi: jest.fn(),
       },
       logger: {
         debug: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.ts
@@ -13,7 +13,7 @@ import {
   AgentExecutionMode,
 } from '@kbn/agent-builder-common';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
-import { firstValueFrom, toArray } from 'rxjs';
+import { firstValueFrom, tap, toArray } from 'rxjs';
 import type { ServiceManager } from '../services';
 import {
   CONNECTOR_OR_INFERENCE_ID_CONFLICT_MESSAGE_WORKFLOW,
@@ -29,6 +29,10 @@ export const getRunAgentStepDefinition = (serviceManager: ServiceManager) => {
   return createServerStepDefinition({
     ...runAgentStepCommonDefinition,
     handler: async (context) => {
+      // Accumulate token usage outside the try/catch so partial counts are
+      // preserved even if the event stream errors mid-execution.
+      const usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
       try {
         const { schema, message, conversation_id: conversationId, attachments } = context.input;
 
@@ -86,16 +90,32 @@ export const getRunAgentStepDefinition = (serviceManager: ServiceManager) => {
           useTaskManager: false,
         });
 
-        const events = await firstValueFrom(events$.pipe(toArray()));
-        const roundEvent = events.find(isRoundCompleteEvent);
-        if (!roundEvent) {
+        const events = await firstValueFrom(
+          events$.pipe(
+            tap((event) => {
+              if (isRoundCompleteEvent(event)) {
+                const { model_usage: modelUsage } = event.data.round;
+                if (modelUsage) {
+                  usage.inputTokens += modelUsage.input_tokens;
+                  usage.outputTokens += modelUsage.output_tokens;
+                  usage.totalTokens += modelUsage.input_tokens + modelUsage.output_tokens;
+                }
+              }
+            }),
+            toArray()
+          )
+        );
+
+        const roundEvents = events.filter(isRoundCompleteEvent);
+        if (roundEvents.length === 0) {
           throw new Error('No round_complete event received from execution service');
         }
 
-        const round = roundEvent.data.round;
+        // Use the last round's response as the step output (final agent reply)
+        const lastRound = roundEvents[roundEvents.length - 1].data.round;
         const outputMessage = schema
-          ? JSON.stringify(round.response.structured_output)
-          : round.response.message;
+          ? JSON.stringify(lastRound.response.structured_output)
+          : lastRound.response.message;
 
         let outputConversationId: string | undefined;
         if (storeConversation) {
@@ -111,8 +131,9 @@ export const getRunAgentStepDefinition = (serviceManager: ServiceManager) => {
         return {
           output: {
             message: outputMessage,
-            structured_output: round.response.structured_output,
+            structured_output: lastRound.response.structured_output,
             ...(outputConversationId && { conversation_id: outputConversationId }),
+            metadata: { usage },
           },
         };
       } catch (error) {
@@ -121,6 +142,7 @@ export const getRunAgentStepDefinition = (serviceManager: ServiceManager) => {
           error instanceof Error ? error : new Error(String(error))
         );
         return {
+          output: { metadata: { usage } },
           error: error instanceof Error ? error : new Error(String(error)),
         };
       }

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.ts
@@ -142,7 +142,7 @@ export const getRunAgentStepDefinition = (serviceManager: ServiceManager) => {
           error instanceof Error ? error : new Error(String(error))
         );
         return {
-          output: { metadata: { usage } },
+          output: { message: '', metadata: { usage } },
           error: error instanceof Error ? error : new Error(String(error)),
         };
       }


### PR DESCRIPTION
Closes elastic/search-team#14860

## Summary

The `ai.agent` step was discarding token usage data from the agent execution event stream. This PR captures `input_tokens` and `output_tokens` from every `round_complete` event and returns them as `output.metadata.usage: { inputTokens, outputTokens, totalTokens }`.

## Changes

- **`run_agent_step.ts` (server)** — accumulate tokens via `tap` on the event stream (declared outside `try/catch` so partial counts survive stream errors); use `events.filter` across all `round_complete` events, taking the last as the final response; return `metadata: { usage }` in both success and error paths
- **`run_agent_step.ts` (common)** — add `metadata.usage` to `OutputSchema` so downstream steps can reference `steps.my_step.output.metadata.usage` with type safety
- **`run_agent_step.test.ts`** — 4 new tests: single round, multi-round accumulation, no model_usage, partial capture on stream error

## How to test

1. Create a workflow with an `ai.agent` step
2. Execute the workflow
3. Inspect the step execution result — `output.metadata.usage` should contain `inputTokens`, `outputTokens`, and `totalTokens`
4. For multi-round agents (agents that loop), verify the counts are summed across all rounds

### Checklist

- [x] Unit or functional tests were updated or added to cover the changes
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied
- [x] Review the backport guidelines and applied applicable `backport:*` labels