### PR TITLE
[Streams] Require a commit message when saving a memory entry

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/sig_events_memory.skill.md.text
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/sig_events_memory.skill.md.text
@@ -46,7 +46,7 @@ One of the most important aspects of a wiki is cross-referencing:
 - Search before writing — avoid creating duplicates
 - Use memory_patch for small edits, memory_write for new pages or full rewrites
 - Keep pages focused — one topic per page, split large documents
-- Include context in change summaries so the version history is useful
+- **Always provide a meaningful `change_summary`** for every memory_write and memory_patch call — this is required, not optional. The summary must explain *why* you are making the change (e.g. "Recorded nginx restart pattern observed during incident-42"), not just *what* changed. A vague summary like "Updated page" makes the history useless. This is even more important for agent-generated changes than for human edits, because there is no interactive context: the summary is the only record of the agent's intent.
 - When updating pages, preserve existing content and add to it rather than replacing
 - Never delete pages without explicit user confirmation
 - Page names should be descriptive and unique (e.g. "nginx-prod-overview" not just "nginx")

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_write.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_write.ts
@@ -33,7 +33,13 @@ const memoryWriteSchema = z.object({
     .optional()
     .describe('IDs of other memory pages referenced from this content.'),
   tags: z.array(z.string()).optional().describe('Optional classification tags.'),
-  change_summary: z.string().optional().describe('Human-readable description of what was changed.'),
+  change_summary: z
+    .string()
+    .describe(
+      'Required: explain why you are creating or overwriting this page — what prompted this write, what was learned, or what changed. ' +
+        'This is stored in the version history and is the primary way for humans to understand the intent behind every agent write. ' +
+        'Without a meaningful summary the history is useless. Be specific (e.g. "Recorded nginx restart pattern observed during incident-42" not "Updated page").'
+    ),
 });
 
 export const createMemoryWriteTool = ({
@@ -75,7 +81,7 @@ export const createMemoryWriteTool = ({
           references,
           tags,
           user,
-          changeSummary: changeSummary ?? `Overwrote page "${name}"`,
+          changeSummary,
         });
         return {
           results: [

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_write.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_write.ts
@@ -108,6 +108,7 @@ export const createMemoryWriteTool = ({
         references,
         tags,
         user,
+        changeSummary,
       });
 
       return {

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -234,7 +234,16 @@ export class MemoryServiceImpl implements MemoryService {
   // ── Public API ──
 
   async create(params: CreateMemoryParams): Promise<MemoryEntry> {
-    const { name, title, content, categories = [], references = [], tags = [], user } = params;
+    const {
+      name,
+      title,
+      content,
+      categories = [],
+      references = [],
+      tags = [],
+      user,
+      changeSummary,
+    } = params;
 
     const existing = await this._getByName(name);
     if (existing) {
@@ -259,7 +268,12 @@ export class MemoryServiceImpl implements MemoryService {
         updated_by: user,
       };
       await this._indexPage(restored);
-      await this._writeHistory(restored, 'create', `Restored entry "${name}"`, user);
+      await this._writeHistory(
+        restored,
+        'create',
+        changeSummary ?? `Restored entry "${name}"`,
+        user
+      );
       return restored;
     }
 
@@ -279,7 +293,7 @@ export class MemoryServiceImpl implements MemoryService {
     };
 
     await this._indexPage(entry);
-    await this._writeHistory(entry, 'create', `Created entry "${name}"`, user);
+    await this._writeHistory(entry, 'create', changeSummary ?? `Created entry "${name}"`, user);
     return entry;
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/types.ts
@@ -95,6 +95,7 @@ export interface CreateMemoryParams {
   references?: string[];
   tags?: string[];
   user: string;
+  changeSummary?: string;
 }
 
 /** Parameters for updating a memory entry */

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/tab.tsx
@@ -13,6 +13,8 @@ import {
   EuiButtonEmpty,
   EuiConfirmModal,
   EuiFieldSearch,
+  EuiFieldText,
+  EuiFormRow,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -324,12 +326,14 @@ function EntryFlyout({
   const { updateEntry, deleteEntry } = useMemoryMutations();
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState('');
+  const [changeSummary, setChangeSummary] = useState('');
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDiscardModal, setShowDiscardModal] = useState(false);
 
   const handleEdit = useCallback(() => {
     if (entry) {
       setEditContent(entry.content);
+      setChangeSummary('');
       setIsEditing(true);
     }
   }, [entry]);
@@ -337,13 +341,13 @@ function EntryFlyout({
   const handleSave = useCallback(() => {
     if (entry && editContent !== entry.content) {
       updateEntry.mutate(
-        { id: entry.id, content: editContent, change_summary: 'Manual edit via UI' },
+        { id: entry.id, content: editContent, change_summary: changeSummary || undefined },
         { onSuccess: () => setIsEditing(false) }
       );
     } else {
       setIsEditing(false);
     }
-  }, [entry, editContent, updateEntry]);
+  }, [entry, editContent, changeSummary, updateEntry]);
 
   const handleDelete = useCallback(() => {
     if (entry) {
@@ -426,6 +430,23 @@ function EntryFlyout({
                   data-test-subj="streamsMemoryEditArea"
                 />
                 <EuiSpacer size="m" />
+                <EuiFormRow
+                  label={i18n.translate('xpack.streams.memory.changeSummaryLabel', {
+                    defaultMessage: 'Describe your change',
+                  })}
+                  fullWidth
+                >
+                  <EuiFieldText
+                    value={changeSummary}
+                    onChange={(e) => setChangeSummary(e.target.value)}
+                    placeholder={i18n.translate('xpack.streams.memory.changeSummaryPlaceholder', {
+                      defaultMessage: 'e.g. "Corrected outdated deployment steps"',
+                    })}
+                    fullWidth
+                    data-test-subj="streamsMemoryChangeSummary"
+                  />
+                </EuiFormRow>
+                <EuiSpacer size="s" />
                 <EuiFlexGroup gutterSize="s">
                   <EuiFlexItem grow={false}>
                     <EuiButton


### PR DESCRIPTION
## Summary

Adds a required \"Describe your change\" text field to the memory entry edit flow in the UI, and makes \`change_summary\` required in the \`memory_write\` agent tool (it was already required in \`memory_patch\`).

**UI (human editors):**
- A \"Describe your change\" field appears below the content textarea when editing a memory entry
- The value is forwarded as \`change_summary\` to the update API so version history shows a meaningful description for every manual edit

**Agent tool (\`memory_write\`):**
- \`change_summary\` is now required — agents must explain *why* they are creating or overwriting a page (what was learned, what prompted the write)
- The generic \"Overwrote page\" fallback is removed; agents must provide a specific message
- This is even more important for agent writes than human edits: the summary is the only persistent record of the agent's intent once the conversation ends

**Skill (\`sig_events_memory.skill.md.text\`):**
- Updated best-practices section with a prominent rule explaining that \`change_summary\` is required for all write and patch calls, and that vague summaries like \"Updated page\" are not acceptable

## Test plan

- [ ] Open a memory entry, click Edit — verify a \"Describe your change\" text field appears below the content textarea
- [ ] Save with a description — verify the version history table shows that text in the Summary column
- [ ] Save without filling in the description — verify the save still succeeds (field is not enforced as required in the UI)
- [ ] Verify agent-generated changes (Scrape / Consolidate / Synthesize) still record their own summaries correctly
- [ ] Verify that the \`memory_write\` tool schema now requires \`change_summary\` (inspect tool definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Implements elastic/nightshift-program#228 — memory administration pages (change summary on manual edits).