### PR TITLE
[Streams] Add confidence score to memory pages

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/sig_events_memory.skill.md.text
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/sig_events_memory.skill.md.text
@@ -50,4 +50,16 @@ One of the most important aspects of a wiki is cross-referencing:
 - When updating pages, preserve existing content and add to it rather than replacing
 - Never delete pages without explicit user confirmation
 - Page names should be descriptive and unique (e.g. "nginx-prod-overview" not just "nginx")
+- **Always set `confidence` on every write (required).** Use 0–100 to honestly represent how certain you are about the page's content: 90+ for directly observed facts, 60–80 for strong inferences, 30–50 for reasonable hypotheses, <30 for speculation. Accuracy matters more than appearing confident — a low confidence score prompts humans to verify the information rather than act on incorrect data.
 </best_practices>
+
+<confidence>
+The `confidence` field (0–100) is set by the agent on every memory_write and memory_patch call and is visible to humans in the UI:
+- **90–100**: Verified fact — directly observed, confirmed by the user, or cross-validated from multiple sources
+- **70–89**: High confidence — strongly inferred from clear evidence, likely correct
+- **50–69**: Moderate confidence — plausible hypothesis, consistent with observations but not verified
+- **20–49**: Low confidence — educated guess or extrapolation with notable uncertainty
+- **0–19**: Speculation — very uncertain, written to capture an idea for future investigation
+
+When reading pages, treat `confidence` as a signal: high-confidence pages are authoritative; low-confidence pages are starting points for investigation. When patching a page, re-evaluate the confidence based on the updated content — increasing it when new evidence strengthens a claim, decreasing it when corrections reveal earlier information was unreliable.
+</confidence>

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_patch.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_patch.ts
@@ -55,6 +55,16 @@ const memoryPatchSchema = z.object({
     .max(20)
     .describe('List of patch operations to apply in order.'),
   change_summary: z.string().describe('Human-readable description of what was changed (required).'),
+  confidence: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .describe(
+      'Required: your confidence in the accuracy of this page content after applying these patches, 0–100. ' +
+        '100 = verified fact; 50 = plausible but unconfirmed; 0 = pure speculation. ' +
+        'Update this when the patch changes how certain you are about the content.'
+    ),
 });
 
 const applySearchReplace = (
@@ -167,7 +177,7 @@ export const createMemoryPatchTool = ({
   schema: memoryPatchSchema,
   tags: ['memory'],
   confirmation: { askUser: 'never' },
-  handler: async ({ id, name, operations, change_summary: changeSummary }, context) => {
+  handler: async ({ id, name, operations, change_summary: changeSummary, confidence }, context) => {
     const memoryService = getMemoryService(context.esClient.asCurrentUser);
     const { request, esClient } = context;
     const { username: user } = await getUserFromRequest({
@@ -247,6 +257,7 @@ export const createMemoryPatchTool = ({
         content: currentContent,
         user,
         changeSummary,
+        confidence,
       });
 
       return {

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_read.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_read.ts
@@ -149,6 +149,7 @@ export const createMemoryReadTool = ({
               references: entry.references,
               updated_at: entry.updated_at,
               updated_by: entry.updated_by,
+              confidence: entry.confidence,
               content,
               total_lines: totalLines,
               returned_range: { start, end: start + slicedLines.length },

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
@@ -99,6 +99,7 @@ export const createMemorySearchTool = ({
                 categories: r.categories,
                 updated_at: r.updated_at,
                 updated_by: r.updated_by,
+                confidence: r.confidence,
               })),
             },
           },

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_write.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_write.ts
@@ -34,6 +34,17 @@ const memoryWriteSchema = z.object({
     .describe('IDs of other memory pages referenced from this content.'),
   tags: z.array(z.string()).optional().describe('Optional classification tags.'),
   change_summary: z.string().optional().describe('Human-readable description of what was changed.'),
+  confidence: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .describe(
+      'Required: your confidence in the accuracy of this page content, 0–100. ' +
+        '100 = verified fact you are certain of; 50 = plausible but unconfirmed; 0 = pure speculation or hypothesis. ' +
+        'Be honest — this helps readers calibrate how much to trust the page. ' +
+        'Examples: 90 for something you directly observed, 60 for something inferred, 20 for an educated guess.'
+    ),
 });
 
 export const createMemoryWriteTool = ({
@@ -50,7 +61,7 @@ export const createMemoryWriteTool = ({
   tags: ['memory'],
   confirmation: { askUser: 'never' },
   handler: async (
-    { name, title, content, categories, references, tags, change_summary: changeSummary },
+    { name, title, content, categories, references, tags, change_summary: changeSummary, confidence },
     context
   ) => {
     const memoryService = getMemoryService(context.esClient.asCurrentUser);
@@ -76,6 +87,7 @@ export const createMemoryWriteTool = ({
           tags,
           user,
           changeSummary: changeSummary ?? `Overwrote page "${name}"`,
+          confidence,
         });
         return {
           results: [
@@ -102,6 +114,7 @@ export const createMemoryWriteTool = ({
         references,
         tags,
         user,
+        confidence,
       });
 
       return {

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
@@ -31,6 +31,8 @@ export const memoriesMappings = {
     updated_by: mappings.keyword(),
     // Soft-delete flag: true on tombstone documents written by MemoryServiceImpl.delete()
     is_deleted: mappings.boolean(),
+    // Agent-assessed confidence in the accuracy of this page's content (0–100)
+    confidence: mappings.integer(),
   },
 } satisfies MappingsDefinition;
 
@@ -38,7 +40,7 @@ export type StoredMemoryPage = GetFieldsOf<typeof memoriesMappings>;
 
 export const memoriesDataStream: DataStreamDefinition<typeof memoriesMappings, StoredMemoryPage> = {
   name: MEMORIES_DATA_STREAM,
-  version: 1,
+  version: 2,
   hidden: true,
   template: {
     priority: 500,

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
@@ -472,4 +472,42 @@ describe('MemoryServiceImpl', () => {
 
     await expect(service.getBacklinks({ id: target.id })).resolves.toEqual([]);
   });
+
+  it('persists confidence on create, preserves it when update omits it, overwrites when supplied, and projects it in search', async () => {
+    mockedUuidV4
+      .mockReturnValueOnce('entry-conf-1')
+      .mockReturnValueOnce('history-conf-1')
+      .mockReturnValueOnce('history-conf-2')
+      .mockReturnValueOnce('history-conf-3');
+    const { service } = createService();
+
+    // Create with confidence=80 — should be persisted
+    const created = await service.create({
+      name: 'conf-page',
+      title: 'Conf page',
+      content: 'body',
+      user,
+      confidence: 80,
+    });
+    expect(created.confidence).toBe(80);
+    await expect(service.get({ id: created.id })).resolves.toMatchObject({ confidence: 80 });
+
+    // Update without supplying confidence — should be preserved from current
+    const updatedNoConf = await service.update({ id: created.id, content: 'body v2', user });
+    expect(updatedNoConf.confidence).toBe(80);
+
+    // Update with a new confidence value — should be overwritten
+    const updatedWithConf = await service.update({
+      id: created.id,
+      content: 'body v3',
+      user,
+      confidence: 95,
+    });
+    expect(updatedWithConf.confidence).toBe(95);
+
+    // Search — confidence should appear in results
+    const results = await service.search({ query: 'body', size: 5 });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: created.id, confidence: 95 });
+  });
 });

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -94,6 +94,7 @@ export class MemoryServiceImpl implements MemoryService {
       created_by: entry.created_by,
       updated_by: entry.updated_by,
       is_deleted: entry.is_deleted ?? false,
+      ...(entry.confidence !== undefined && { confidence: entry.confidence }),
     };
 
     const response = await this.dataStreamClient.create({
@@ -234,7 +235,16 @@ export class MemoryServiceImpl implements MemoryService {
   // ── Public API ──
 
   async create(params: CreateMemoryParams): Promise<MemoryEntry> {
-    const { name, title, content, categories = [], references = [], tags = [], user } = params;
+    const {
+      name,
+      title,
+      content,
+      categories = [],
+      references = [],
+      tags = [],
+      user,
+      confidence,
+    } = params;
 
     const existing = await this._getByName(name);
     if (existing) {
@@ -257,6 +267,7 @@ export class MemoryServiceImpl implements MemoryService {
         updated_at: now,
         created_by: tombstone.created_by,
         updated_by: user,
+        ...(confidence !== undefined && { confidence }),
       };
       await this._indexPage(restored);
       await this._writeHistory(restored, 'create', `Restored entry "${name}"`, user);
@@ -276,6 +287,7 @@ export class MemoryServiceImpl implements MemoryService {
       updated_at: now,
       created_by: user,
       updated_by: user,
+      ...(confidence !== undefined && { confidence }),
     };
 
     await this._indexPage(entry);
@@ -324,6 +336,7 @@ export class MemoryServiceImpl implements MemoryService {
       ...(params.categories !== undefined && { categories: params.categories }),
       ...(params.references !== undefined && { references: params.references }),
       ...(params.tags !== undefined && { tags: params.tags }),
+      ...(params.confidence !== undefined && { confidence: params.confidence }),
       version: nextVersion,
       updated_at: now,
       updated_by: user,
@@ -565,6 +578,7 @@ export class MemoryServiceImpl implements MemoryService {
           updated_by: source.updated_by,
           tags: source.tags ?? [],
           categories: source.categories ?? [],
+          ...(source.confidence !== undefined && { confidence: source.confidence }),
         },
       ];
     });

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/types.ts
@@ -37,6 +37,12 @@ export interface MemoryEntry {
   updated_by: string;
   /** Present and true for soft-deleted tombstone documents */
   is_deleted?: boolean;
+  /**
+   * Agent-assessed confidence in the accuracy of this page's content, 0–100.
+   * 100 = verified fact; 0 = pure speculation. Agents must set this on every write.
+   * May be undefined for pages written before this field was introduced.
+   */
+  confidence?: number;
 }
 
 /**
@@ -84,6 +90,7 @@ export interface MemorySearchResult {
   updated_by: string;
   tags: string[];
   categories: string[];
+  confidence?: number;
 }
 
 /** Parameters for creating a memory entry */
@@ -95,6 +102,7 @@ export interface CreateMemoryParams {
   references?: string[];
   tags?: string[];
   user: string;
+  confidence?: number;
 }
 
 /** Parameters for updating a memory entry */
@@ -108,6 +116,7 @@ export interface UpdateMemoryParams {
   tags?: string[];
   user: string;
   changeSummary?: string;
+  confidence?: number;
 }
 
 /** Parameters for searching memory */

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/memory/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/memory/route.ts
@@ -70,6 +70,7 @@ const createEntryRoute = createServerRoute({
       categories: z.array(z.string()).optional(),
       references: z.array(z.string()).optional(),
       tags: z.array(z.string()).optional(),
+      confidence: z.number().int().min(0).max(100).optional(),
     }),
   }),
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
@@ -167,6 +168,7 @@ const updateEntryRoute = createServerRoute({
       references: z.array(z.string()).optional(),
       tags: z.array(z.string()).optional(),
       change_summary: z.string().optional(),
+      confidence: z.number().int().min(0).max(100).optional(),
     }),
   }),
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
@@ -183,6 +185,7 @@ const updateEntryRoute = createServerRoute({
       id: params.path.id,
       ...params.body,
       changeSummary: params.body.change_summary,
+      confidence: params.body.confidence,
       user,
     });
   },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/tab.tsx
@@ -50,6 +50,12 @@ import {
 } from './use_memory';
 import type { MemoryCategoryNode, MemoryVersionRecord } from './types';
 
+const getConfidenceColor = (confidence: number): 'success' | 'warning' | 'danger' => {
+  if (confidence >= 70) return 'success';
+  if (confidence >= 40) return 'warning';
+  return 'danger';
+};
+
 export function MemoryTab() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
@@ -193,6 +199,16 @@ export function MemoryTab() {
                       <EuiFlexItem>
                         <EuiText size="s">{result.snippet}</EuiText>
                       </EuiFlexItem>
+                      {result.confidence !== undefined && (
+                        <EuiFlexItem grow={false}>
+                          <EuiBadge color={getConfidenceColor(result.confidence)}>
+                            {i18n.translate('xpack.streams.memory.searchResultConfidence', {
+                              defaultMessage: '{score}% confidence',
+                              values: { score: result.confidence },
+                            })}
+                          </EuiBadge>
+                        </EuiFlexItem>
+                      )}
                     </EuiFlexGroup>
                   </EuiFlexItem>
                 ))}
@@ -395,16 +411,30 @@ function EntryFlyout({
                 ))}
               </EuiFlexGroup>
               <EuiSpacer size="xs" />
-              <EuiText size="xs" color="subdued">
-                {i18n.translate('xpack.streams.memory.entryMeta', {
-                  defaultMessage: 'Version {version} · Updated {updatedAt} by {updatedBy}',
-                  values: {
-                    version: entry.version,
-                    updatedAt: new Date(entry.updated_at).toLocaleString(),
-                    updatedBy: entry.updated_by,
-                  },
-                })}
-              </EuiText>
+              <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {i18n.translate('xpack.streams.memory.entryMeta', {
+                      defaultMessage: 'Version {version} · Updated {updatedAt} by {updatedBy}',
+                      values: {
+                        version: entry.version,
+                        updatedAt: new Date(entry.updated_at).toLocaleString(),
+                        updatedBy: entry.updated_by,
+                      },
+                    })}
+                  </EuiText>
+                </EuiFlexItem>
+                {entry.confidence !== undefined && (
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color={getConfidenceColor(entry.confidence)}>
+                      {i18n.translate('xpack.streams.memory.confidenceBadge', {
+                        defaultMessage: 'Confidence: {score}%',
+                        values: { score: entry.confidence },
+                      })}
+                    </EuiBadge>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
             </>
           ) : (
             <EuiText>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/types.ts
@@ -18,6 +18,7 @@ export interface MemoryEntry {
   updated_at: string;
   created_by: string;
   updated_by: string;
+  confidence?: number;
 }
 
 export interface MemoryCategoryNode {
@@ -37,6 +38,7 @@ export interface MemorySearchResult {
   updated_by: string;
   tags: string[];
   categories: string[];
+  confidence?: number;
 }
 
 export interface MemoryVersionRecord {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/use_memory.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/memory/use_memory.ts
@@ -113,6 +113,7 @@ export const useMemoryMutations = () => {
       content?: string;
       tags?: string[];
       change_summary?: string;
+      confidence?: number;
     }) =>
       core.http.put<MemoryEntry>(`${MEMORY_BASE}/entries/${id}`, {
         body: JSON.stringify(params),


### PR DESCRIPTION
## Summary

Adds a `confidence` field (integer 0–100) to every memory page. Agents must set this on every `memory_write` and `memory_patch` call. The score reflects how certain the agent is about the accuracy of the page content — human editors can see it in the UI to calibrate how much to trust the information.

**Scale:**
- 90–100: Verified fact — directly observed or cross-validated
- 70–89: High confidence — strongly inferred from clear evidence
- 50–69: Moderate confidence — plausible hypothesis, not verified
- 20–49: Low confidence — educated guess with notable uncertainty
- 0–19: Speculation — written to capture an idea for investigation

**Server:**
- `data_stream.ts`: adds `confidence: integer` mapping (version bump 1→2)
- `types.ts`: adds `confidence` to `MemoryEntry`, `CreateMemoryParams`, `UpdateMemoryParams`, `MemorySearchResult`
- `memory_service.ts`: threads confidence through `_indexPage`, `create`, `update`, and `search`
- `route.ts`: accepts `confidence` in create and update request body schemas

**Agent tools:**
- `memory_write.ts`: adds required `confidence` parameter with scale guidance
- `memory_patch.ts`: adds required `confidence` parameter
- `memory_read.ts` / `memory_search.ts`: include confidence in tool output so agents see it when reading

**UI:**
- Entry flyout header: shows a colored confidence badge (green ≥70%, orange ≥40%, red <40%) alongside version/author metadata
- Search results: shows confidence badge on each result card

**Skill:**
- `sig_events_memory.skill.md.text`: adds a `<confidence>` section with full scale, interpretation guidance, and instructions to re-evaluate confidence when patching

## Test plan

- [ ] Create a new memory page via agent tool — verify `confidence` is required and stored
- [ ] Open a memory entry in the UI — verify the confidence badge appears with correct color
- [ ] Search memory — verify confidence badge appears on each result
- [ ] Patch an existing page via agent — verify confidence can be updated independently of content
- [ ] Read a page via agent tool — verify confidence is included in the returned data
- [ ] Verify pages without confidence (written before this change) show no badge rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Part of elastic/nightshift-program#236 — memory quality and drift controls.