### PR TITLE
[One workflow] Improve empty workflows screen for viewer role

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/components/workflows_empty_state/workflows_empty_state.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflows_empty_state/workflows_empty_state.test.tsx
@@ -9,11 +9,10 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { I18nProvider } from '@kbn/i18n-react';
-import { WorkflowsEmptyState } from './workflows_empty_state';
+import { WorkflowsEmptyState, WorkflowsEmptyStateReadOnly } from './workflows_empty_state';
+import { TestProvider } from '../../shared/mocks/test_providers';
 
-// Mock useKibana hook
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
+jest.mock('../../hooks/use_kibana', () => ({
   useKibana: () => ({
     services: {
       http: {
@@ -25,23 +24,20 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
   }),
 }));
 
-const renderWithIntl = (component: React.ReactElement) => {
-  return render(<I18nProvider>{component}</I18nProvider>);
-};
+const renderWithProviders = (component: React.ReactElement) =>
+  render(<TestProvider>{component}</TestProvider>);
 
 describe('WorkflowsEmptyState', () => {
   it('renders the empty state with title and description', () => {
-    renderWithIntl(<WorkflowsEmptyState />);
+    renderWithProviders(<WorkflowsEmptyState />);
 
     expect(screen.getByText('Get Started with Workflows')).toBeInTheDocument();
     expect(screen.getByText(/Workflows let you automate repetitive tasks/)).toBeInTheDocument();
   });
 
-  it('renders the create button when user can create workflows', () => {
+  it('renders the create button when onCreateWorkflow is provided', () => {
     const onCreateWorkflow = jest.fn();
-    renderWithIntl(
-      <WorkflowsEmptyState canCreateWorkflow={true} onCreateWorkflow={onCreateWorkflow} />
-    );
+    renderWithProviders(<WorkflowsEmptyState onCreateWorkflow={onCreateWorkflow} />);
 
     const createButton = screen.getByText('Create workflow');
     expect(createButton).toBeInTheDocument();
@@ -50,27 +46,21 @@ describe('WorkflowsEmptyState', () => {
     expect(onCreateWorkflow).toHaveBeenCalledTimes(1);
   });
 
-  it('does not render the create button when user cannot create workflows', () => {
-    renderWithIntl(<WorkflowsEmptyState canCreateWorkflow={false} />);
-
-    expect(screen.queryByText('Create workflow')).not.toBeInTheDocument();
-  });
-
   it('does not render the create button when onCreateWorkflow is not provided', () => {
-    renderWithIntl(<WorkflowsEmptyState canCreateWorkflow={true} />);
+    renderWithProviders(<WorkflowsEmptyState />);
 
     expect(screen.queryByText('Create workflow')).not.toBeInTheDocument();
   });
 
   it('renders the footer with documentation link', () => {
-    renderWithIntl(<WorkflowsEmptyState />);
+    renderWithProviders(<WorkflowsEmptyState />);
 
     expect(screen.getByText('Need help?')).toBeInTheDocument();
     expect(screen.getByText('Read documentation')).toBeInTheDocument();
   });
 
   it('renders the illustration image', () => {
-    renderWithIntl(<WorkflowsEmptyState />);
+    renderWithProviders(<WorkflowsEmptyState />);
 
     const images = screen.getAllByRole('presentation');
     const mainImage = images.find((img) => img.tagName === 'IMG');
@@ -79,5 +69,29 @@ describe('WorkflowsEmptyState', () => {
       'src',
       '/mock-base-path/plugins/workflowsManagement/assets/empty_state.svg'
     );
+  });
+});
+
+describe('WorkflowsEmptyStateReadOnly', () => {
+  it('renders the read-only empty state with title and description', () => {
+    renderWithProviders(<WorkflowsEmptyStateReadOnly />);
+
+    expect(screen.getByText('Workflows list will be here')).toBeInTheDocument();
+    expect(screen.getByText(/Workflows let you automate repetitive tasks/)).toBeInTheDocument();
+  });
+
+  it('does not render create workflow actions', () => {
+    renderWithProviders(<WorkflowsEmptyStateReadOnly />);
+
+    expect(screen.queryByText('Create workflow')).not.toBeInTheDocument();
+    expect(screen.queryByText('Example workflows')).not.toBeInTheDocument();
+    expect(screen.queryByText('Need help?')).not.toBeInTheDocument();
+  });
+
+  it('shows the required write privilege in the footer', () => {
+    renderWithProviders(<WorkflowsEmptyStateReadOnly />);
+
+    expect(screen.getByText('Minimum privileges required:')).toBeInTheDocument();
+    expect(screen.getByText('Workflows: Write')).toBeInTheDocument();
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/components/workflows_empty_state/workflows_empty_state.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflows_empty_state/workflows_empty_state.tsx
@@ -21,15 +21,12 @@ import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { WORKFLOWS_DOCUMENTATION_URL } from '../../../common';
 import { useKibana } from '../../hooks/use_kibana';
+import { PrivilegesFooter } from '../workflows_required_priveleges_footer';
 interface WorkflowsEmptyStateProps {
   onCreateWorkflow?: () => void;
-  canCreateWorkflow?: boolean;
 }
 
-export function WorkflowsEmptyState({
-  onCreateWorkflow,
-  canCreateWorkflow = false,
-}: WorkflowsEmptyStateProps) {
+export function WorkflowsEmptyState({ onCreateWorkflow }: WorkflowsEmptyStateProps) {
   const { http } = useKibana().services;
   return (
     <EuiEmptyPrompt
@@ -61,7 +58,7 @@ export function WorkflowsEmptyState({
         </>
       }
       actions={
-        canCreateWorkflow && onCreateWorkflow ? (
+        onCreateWorkflow ? (
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiButton color="primary" fill onClick={onCreateWorkflow} iconType="plusCircle">
@@ -105,6 +102,51 @@ export function WorkflowsEmptyState({
             />
           </EuiLink>
         </>
+      }
+    />
+  );
+}
+
+export function WorkflowsEmptyStateReadOnly() {
+  const { http } = useKibana().services;
+  return (
+    <EuiEmptyPrompt
+      icon={
+        <EuiImage
+          size="fullWidth"
+          src={http?.basePath.prepend('/plugins/workflowsManagement/assets/empty_state.svg')}
+          alt=""
+        />
+      }
+      title={
+        <h2 style={{ whiteSpace: 'nowrap' }}>
+          <FormattedMessage
+            id="workflows.emptyStateReadOnly.title"
+            defaultMessage="Workflows list will be here"
+          />
+        </h2>
+      }
+      layout="horizontal"
+      color="plain"
+      body={
+        <>
+          <p>
+            <FormattedMessage
+              id="workflows.emptyStateReadOnly.body.firstParagraph"
+              defaultMessage="Workflows let you automate repetitive tasks and streamline processes across your environment."
+            />
+          </p>
+        </>
+      }
+      footer={
+        <PrivilegesFooter
+          permissions={[
+            {
+              id: 'platform.plugins.shared.workflows_management.writeWorkflowPermissionText',
+              default: 'Workflows: Write',
+            },
+          ]}
+        />
       }
     />
   );

--- a/src/platform/plugins/shared/workflows_management/public/components/workflows_privileges/workflows_privileges_wrapper.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflows_privileges/workflows_privileges_wrapper.tsx
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import React, { useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -14,6 +13,7 @@ import { useWorkflowsCapabilities } from '@kbn/workflows-ui';
 import { useTelemetry } from '../../hooks/use_telemetry';
 import { useWorkflowsBreadcrumbs } from '../../hooks/use_workflow_breadcrumbs/use_workflow_breadcrumbs';
 import { AccessDenied } from '../access_denied/access_denied';
+import { PrivilegesFooter } from '../workflows_required_priveleges_footer';
 
 export const WorkflowsPrivilegesWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { canReadWorkflow } = useWorkflowsCapabilities();
@@ -43,37 +43,16 @@ const PrivilegesAccessDenied = () => {
           defaultMessage="To view workflows in this space, you need additional privileges."
         />
       }
-      footer={<PrivilegesFooter />}
+      footer={
+        <PrivilegesFooter
+          permissions={[
+            {
+              id: 'platform.plugins.shared.workflows_management.readWorkflowPermissionText',
+              default: 'Workflows: Read',
+            },
+          ]}
+        />
+      }
     />
   );
 };
-
-const PrivilegesFooter = () => (
-  <EuiFlexGroup
-    gutterSize="s"
-    wrap
-    direction="column"
-    justifyContent="center"
-    responsive={false}
-    alignItems="center"
-  >
-    <EuiFlexItem>
-      <EuiText color="subdued" textAlign="center" size="xs">
-        <p css={{ marginBlock: 0 }}>
-          <FormattedMessage
-            id="platform.plugins.shared.workflows_management.ui.noReadAccess.requiredPrivileges"
-            defaultMessage="Minimum privileges required:"
-          />
-        </p>
-      </EuiText>
-    </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <EuiBadge color="hollow">
-        <FormattedMessage
-          id="platform.plugins.shared.workflows_management.readWorkflowPermissionText"
-          defaultMessage="Workflows: Read"
-        />
-      </EuiBadge>
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);

--- a/src/platform/plugins/shared/workflows_management/public/components/workflows_required_priveleges_footer.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflows_required_priveleges_footer.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+interface PermissionBadge {
+  id: string;
+  default: string;
+}
+
+export const PrivilegesFooter = ({ permissions }: { permissions: PermissionBadge[] }) => (
+  <EuiFlexGroup
+    gutterSize="s"
+    wrap
+    direction="column"
+    justifyContent="center"
+    responsive={false}
+    alignItems="center"
+  >
+    <EuiFlexItem>
+      <EuiText color="subdued" textAlign="center" size="xs">
+        <p css={{ marginBlock: 0 }}>
+          <FormattedMessage
+            id="platform.plugins.shared.workflows_management.ui.noReadAccess.requiredPrivileges"
+            defaultMessage="Minimum privileges required:"
+          />
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+    {permissions.map((perm) => (
+      <EuiFlexItem grow={false} key={perm.id}>
+        <EuiBadge color="hollow">
+          <FormattedMessage id={perm.id} defaultMessage={perm.default} />
+        </EuiBadge>
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGroup>
+);

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.test.tsx
@@ -101,6 +101,10 @@ jest.mock('../../../components', () => ({
   ),
 }));
 
+jest.mock('../../../components/workflows_empty_state/workflows_empty_state', () => ({
+  WorkflowsEmptyStateReadOnly: () => <div data-test-subj="workflows-empty-state-readonly" />,
+}));
+
 jest.mock('../../run_workflow/ui/workflow_execute_modal', () => ({
   WorkflowExecuteModal: () => <div data-test-subj="workflow-execute-modal" />,
 }));
@@ -227,7 +231,7 @@ describe('WorkflowList', () => {
   });
 
   describe('empty state', () => {
-    it('shows empty state when there are no workflows and no filters', () => {
+    it('shows the create empty state when there are no workflows and the user can create', () => {
       mockUseWorkflows.mockReturnValue({
         data: { results: [], total: 0, ...defaultSearch },
         isLoading: false,
@@ -236,6 +240,26 @@ describe('WorkflowList', () => {
       });
       renderComponent({ search: { ...defaultSearch } });
       expect(screen.getByTestId('workflows-empty-state')).toBeInTheDocument();
+    });
+
+    it('shows the read-only empty state when there are no workflows and the user cannot create', () => {
+      const { useWorkflowsCapabilities } = jest.requireMock('@kbn/workflows-ui') as {
+        useWorkflowsCapabilities: jest.Mock;
+      };
+      useWorkflowsCapabilities.mockReturnValue({
+        ...mockCreateMockWorkflowsCapabilities(),
+        canCreateWorkflow: false,
+      });
+
+      mockUseWorkflows.mockReturnValue({
+        data: { results: [], total: 0, ...defaultSearch },
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      renderComponent({ search: { ...defaultSearch } });
+
+      expect(screen.getByTestId('workflows-empty-state-readonly')).toBeInTheDocument();
     });
 
     it('does not show empty state when filters are applied even with no results', () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
@@ -29,6 +29,7 @@ import { useExportWithReferences } from './use_export_with_references';
 import { WorkflowListTable } from './workflow_list_table';
 import { WorkflowsUtilityBar } from './workflows_utility_bar';
 import { WorkflowsEmptyState } from '../../../components';
+import { WorkflowsEmptyStateReadOnly } from '../../../components/workflows_empty_state/workflows_empty_state';
 import { useWorkflowActions } from '../../../entities/workflows/model/use_workflow_actions';
 import { useKibana } from '../../../hooks/use_kibana';
 import { useTelemetry } from '../../../hooks/use_telemetry';
@@ -307,10 +308,11 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
     return (
       <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: '60vh' }}>
         <EuiFlexItem grow={false}>
-          <WorkflowsEmptyState
-            onCreateWorkflow={onCreateWorkflow}
-            canCreateWorkflow={canCreateWorkflow}
-          />
+          {canCreateWorkflow ? (
+            <WorkflowsEmptyState onCreateWorkflow={onCreateWorkflow} />
+          ) : (
+            <WorkflowsEmptyStateReadOnly />
+          )}
         </EuiFlexItem>
       </EuiFlexGroup>
     );


### PR DESCRIPTION
closes: https://github.com/elastic/security-team/issues/17255

## Summary

<img width="884" height="490" alt="image" src="https://github.com/user-attachments/assets/78c51382-d7bd-43cf-b0cd-63081a62fdee" />

Fixes the workflows list empty state for users who can read workflows but cannot create them. Instead of showing the "Get Started" prompt with a broken create action, those users now see a read-only empty state that explains workflows are not available yet and lists the **Workflows: Write** privilege required to create them.

- Add `WorkflowsEmptyStateReadOnly` for viewer users on an empty workflow list
- Extract shared `PrivilegesFooter` for required-privilege badges (also used by the access-denied screen)
- Simplify `WorkflowsEmptyState` so the create button depends on `onCreateWorkflow` only