### PR TITLE
[docs] Add 9.4.0 breaking change: Entity Analytics V2 custom-role index privileges

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -38,6 +38,36 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 
 ## 9.4.0 [kibana-9.4.0-breaking-changes]
 
+$$$kibana-PR_NUMBER$$$
+::::{dropdown} Entity Analytics V2 requires additional index privileges for custom roles
+**Details**<br> In 9.4.0, Entity Store V2 is enabled by default on Stateful deployments and reads entity data from a new set of indices. Roles that grant access to the **Security → Entity Analytics** experience must now include `read` on the following index patterns:
+
+- `.entities.v2.latest.security_*`
+- `.entities.v2.updates.security_*`
+- `entities-latest-*`
+- `risk-score.risk-score-*`
+
+The built-in Serverless and Stack Security roles (`viewer`, `editor`, `t1_analyst`, `t2_analyst`, `t3_analyst`, `threat_intelligence_analyst`, `rule_author`, `soc_manager`, `detections_admin`, `platform_engineer`, `endpoint_operations_analyst`, `endpoint_policy_manager`) have been updated to grant these privileges. Custom roles authored against the V1 index patterns (`.entities.v1.latest.security_*`) are not updated automatically.
+
+**Impact**<br> Users assigned a custom role that does not include the index patterns above will see the **Advanced Entity Analytics** page load in a degraded state — without entity data and without the standard "insufficient privileges" message. Users assigned built-in Security roles are not affected.
+
+**Action**<br> If you use custom roles to control access to Entity Analytics, add `read` on the V2 entity and risk-score index patterns to each affected role:
+
+```yaml
+- names:
+    - ".entities.v2.latest.security_*"
+    - ".entities.v2.updates.security_*"
+    - "entities-latest-*"
+    - "risk-score.risk-score-*"
+  privileges:
+    - read
+```
+
+On Serverless, custom roles also require the `read_project_routing` cluster privilege as a temporary workaround tracked in [#264219]({{kib-pull}}264219).
+
+View [#PR_NUMBER]({{kib-pull}}PR_NUMBER).
+::::
+
 $$$kibana-255122-9.4.0$$$
 ::::{dropdown} The `_source` field mode is now saved to the template index settings
 **Details**<br> The index and component template forms in **Index Management** previously saved the `_source` field mode (`stored` and `synthetic`) in the `mappings._source.mode` setting. This path is deprecated and has no effect in {{es}}. The form now uses the correct `settings.index.mapping.source.mode` setting. Other `_source` options (`enabled`, `includes`, and `excludes`) remain in mappings.

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -39,7 +39,7 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 ## 9.4.0 [kibana-9.4.0-breaking-changes]
 
 $$$kibana-PR_NUMBER$$$
-::::{dropdown} Entity Analytics V2 requires additional index privileges for custom roles
+::::{dropdown} As of 9.4.x Entity Analytics requires additional index privileges for custom roles
 **Details**<br> In 9.4.0, Entity Store V2 is enabled by default on Stateful deployments and reads entity data from a new set of indices. Roles that grant access to the **Security → Entity Analytics** experience must now include `read` on the following index patterns:
 
 - `.entities.v2.latest.security_*`
@@ -51,21 +51,16 @@ The built-in Serverless and Stack Security roles (`viewer`, `editor`, `t1_analys
 
 **Impact**<br> Users assigned a custom role that does not include the index patterns above will see the **Advanced Entity Analytics** page load in a degraded state — without entity data and without the standard "insufficient privileges" message. Users assigned built-in Security roles are not affected.
 
-**Action**<br> If you use custom roles to control access to Entity Analytics, add `read` on the V2 entity and risk-score index patterns to each affected role:
+**Action**<br> If you use custom roles to control access to Entity Analytics, add `read` on the V2 entity-store and risk-score index patterns to each affected role:
 
 ```yaml
 - names:
     - ".entities.v2.latest.security_*"
-    - ".entities.v2.updates.security_*"
     - "entities-latest-*"
     - "risk-score.risk-score-*"
   privileges:
     - read
 ```
-
-On Serverless, custom roles also require the `read_project_routing` cluster privilege as a temporary workaround tracked in [#264219]({{kib-pull}}264219).
-
-View [#PR_NUMBER]({{kib-pull}}PR_NUMBER).
 ::::
 
 $$$kibana-255122-9.4.0$$$


### PR DESCRIPTION
## Summary

Adds a **retroactive 9.4.0 breaking-change entry** to `docs/release-notes/breaking-changes.md` for the custom-role permission change introduced when Entity Store V2 was enabled by default on Stateful.

Entity Store V2 reads entity data from new index patterns (`.entities.v2.latest.security_*`, `entities-latest-*`) and surfaces risk data from `risk-score.risk-score-*`. Built-in Serverless and Stack Security roles were updated for V2 during the rollout; **custom roles authored against the V1 patterns were not** (and cannot be) updated automatically — leading to a degraded \"Advanced Entity Analytics\" page load for affected customers.

### Why retroactive

The privilege change shipped in 9.4.0 without a breaking-change entry. Filing it now so customers on or upgrading to 9.4.0 (and operators auditing custom roles) have a stable reference.

## Release notes

Documentation-only.
