### PR TITLE
[Kibana Security + Alerts] Add rule.mute_alerts operation group to alerting feature privilege schema

### DIFF
--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
@@ -314,6 +314,43 @@ describe(`feature_privilege_builder`, () => {
         `);
       });
 
+      test('grants `manage_alerts` privileges to rules under feature consumer', () => {
+        const actions = new Actions();
+        const alertingFeaturePrivileges = new FeaturePrivilegeAlertingBuilder(actions);
+
+        const privilege: FeatureKibanaPrivileges = {
+          alerting: {
+            rule: {
+              all: [],
+              manage_alerts: [{ ruleTypeId: 'alert-type', consumers: ['my-consumer'] }],
+            },
+          },
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: [],
+        };
+
+        const feature = new KibanaFeature({
+          id: 'my-feature',
+          name: 'my-feature',
+          app: [],
+          category: { id: 'foo', label: 'foo' },
+          privileges: {
+            all: privilege,
+            read: privilege,
+          },
+        });
+
+        expect(alertingFeaturePrivileges.getActions(privilege, feature)).toMatchInlineSnapshot(`
+          Array [
+            "alerting:alert-type/my-consumer/rule/muteAlert",
+            "alerting:alert-type/my-consumer/rule/unmuteAlert",
+          ]
+        `);
+      });
+
       test('grants `all` privileges to rules under feature consumer', () => {
         const actions = new Actions();
         const alertingFeaturePrivileges = new FeaturePrivilegeAlertingBuilder(actions);

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
@@ -314,7 +314,7 @@ describe(`feature_privilege_builder`, () => {
         `);
       });
 
-      test('grants `manage_alerts` privileges to rules under feature consumer', () => {
+      test('grants `mute_alerts` privileges to rules under feature consumer', () => {
         const actions = new Actions();
         const alertingFeaturePrivileges = new FeaturePrivilegeAlertingBuilder(actions);
 
@@ -322,7 +322,7 @@ describe(`feature_privilege_builder`, () => {
           alerting: {
             rule: {
               all: [],
-              manage_alerts: [{ ruleTypeId: 'alert-type', consumers: ['my-consumer'] }],
+              mute_alerts: [{ ruleTypeId: 'alert-type', consumers: ['my-consumer'] }],
             },
           },
           savedObject: {

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
@@ -61,8 +61,8 @@ const manageRuleSettingsOperations: Record<AlertingEntity, string[]> = {
   alert: [],
 };
 
-// Per-alert snooze/unsnooze reuses these same operations, so this group covers all four actions.
-const manageAlertsOperations: Record<AlertingEntity, string[]> = {
+// Per-alert snooze/unsnooze reuses muteAlert/unmuteAlert internally, so this group covers both.
+const muteAlertsOperations: Record<AlertingEntity, string[]> = {
   rule: ['muteAlert', 'unmuteAlert'],
   alert: [],
 };
@@ -114,7 +114,7 @@ export class FeaturePrivilegeAlertingBuilder extends BaseFeaturePrivilegeBuilder
       const manualRun = get(privilegeDefinition.alerting, `${entity}.manual_run`) ?? [];
       const manageRuleSettings =
         get(privilegeDefinition.alerting, `${entity}.manage_rule_settings`) ?? [];
-      const manageAlerts = get(privilegeDefinition.alerting, `${entity}.manage_alerts`) ?? [];
+      const muteAlerts = get(privilegeDefinition.alerting, `${entity}.mute_alerts`) ?? [];
       const read = get(privilegeDefinition.alerting, `${entity}.read`) ?? [];
 
       return uniq([
@@ -123,7 +123,7 @@ export class FeaturePrivilegeAlertingBuilder extends BaseFeaturePrivilegeBuilder
         ...getAlertingPrivilege(enableOperations[entity], enable, entity),
         ...getAlertingPrivilege(manualRunOperations[entity], manualRun, entity),
         ...getAlertingPrivilege(manageRuleSettingsOperations[entity], manageRuleSettings, entity),
-        ...getAlertingPrivilege(manageAlertsOperations[entity], manageAlerts, entity),
+        ...getAlertingPrivilege(muteAlertsOperations[entity], muteAlerts, entity),
       ]);
     };
 

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
@@ -61,6 +61,7 @@ const manageRuleSettingsOperations: Record<AlertingEntity, string[]> = {
   alert: [],
 };
 
+// Per-alert snooze/unsnooze reuses these same operations, so this group covers all four actions.
 const manageAlertsOperations: Record<AlertingEntity, string[]> = {
   rule: ['muteAlert', 'unmuteAlert'],
   alert: [],

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
@@ -61,6 +61,11 @@ const manageRuleSettingsOperations: Record<AlertingEntity, string[]> = {
   alert: [],
 };
 
+const manageAlertsOperations: Record<AlertingEntity, string[]> = {
+  rule: ['muteAlert', 'unmuteAlert'],
+  alert: [],
+};
+
 const writeOperations: Record<AlertingEntity, string[]> = {
   rule: [
     'create',
@@ -108,6 +113,7 @@ export class FeaturePrivilegeAlertingBuilder extends BaseFeaturePrivilegeBuilder
       const manualRun = get(privilegeDefinition.alerting, `${entity}.manual_run`) ?? [];
       const manageRuleSettings =
         get(privilegeDefinition.alerting, `${entity}.manage_rule_settings`) ?? [];
+      const manageAlerts = get(privilegeDefinition.alerting, `${entity}.manage_alerts`) ?? [];
       const read = get(privilegeDefinition.alerting, `${entity}.read`) ?? [];
 
       return uniq([
@@ -116,6 +122,7 @@ export class FeaturePrivilegeAlertingBuilder extends BaseFeaturePrivilegeBuilder
         ...getAlertingPrivilege(enableOperations[entity], enable, entity),
         ...getAlertingPrivilege(manualRunOperations[entity], manualRun, entity),
         ...getAlertingPrivilege(manageRuleSettingsOperations[entity], manageRuleSettings, entity),
+        ...getAlertingPrivilege(manageAlertsOperations[entity], manageAlerts, entity),
       ]);
     };
 

--- a/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
+++ b/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
@@ -150,11 +150,11 @@ export interface FeatureKibanaPrivileges {
        */
       manage_rule_settings?: AlertingKibanaPrivilege;
       /**
-       * List of rule types and consumers for which users should have the ability to mute, unmute,
-       * snooze, and unsnooze per-alert instances when granted this privilege. Per-alert snooze
-       * reuses the muteAlert/unmuteAlert operations internally, so both are covered by this group.
+       * List of rule types and consumers for which users should have the ability to mute and unmute
+       * per-alert instances when granted this privilege. Per-alert snooze/unsnooze reuses the
+       * muteAlert/unmuteAlert operations internally and is therefore also covered.
        */
-      manage_alerts?: AlertingKibanaPrivilege;
+      mute_alerts?: AlertingKibanaPrivilege;
     };
     alert?: {
       /**

--- a/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
+++ b/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
@@ -149,6 +149,11 @@ export interface FeatureKibanaPrivileges {
        * ```
        */
       manage_rule_settings?: AlertingKibanaPrivilege;
+      /**
+       * List of rule types and consumers for which users should have the ability to mute and unmute
+       * per-alert instances when granted this privilege.
+       */
+      manage_alerts?: AlertingKibanaPrivilege;
     };
     alert?: {
       /**

--- a/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
+++ b/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
@@ -150,8 +150,9 @@ export interface FeatureKibanaPrivileges {
        */
       manage_rule_settings?: AlertingKibanaPrivilege;
       /**
-       * List of rule types and consumers for which users should have the ability to mute and unmute
-       * per-alert instances when granted this privilege.
+       * List of rule types and consumers for which users should have the ability to mute, unmute,
+       * snooze, and unsnooze per-alert instances when granted this privilege. Per-alert snooze
+       * reuses the muteAlert/unmuteAlert operations internally, so both are covered by this group.
        */
       manage_alerts?: AlertingKibanaPrivilege;
     };


### PR DESCRIPTION
Closes #273245

Adds a new `mute_alerts` operation group to the alerting privilege builder. Granting `alerting.rule.mute_alerts` on a feature emits `rule/muteAlert` and `rule/unmuteAlert` action strings without also granting `rule.all`.

This covers per-alert mute, unmute, snooze, and unsnooze. Per-alert snooze (shipped in elastic/response-ops-team#606) reuses the `muteAlert`/`unmuteAlert` operations internally — there is no separate snooze op.

Framework prerequisite for elastic/response-ops-team#585.