### PR TITLE
[Alerting] Remove actionsAuthorization execute gate from per-alert mute/unmute

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.test.ts
@@ -89,7 +89,7 @@ describe('mute alert instance', () => {
 
     expect(auditLoggerMock.log).toHaveBeenCalledTimes(1);
     expect(authorizationMock.ensureAuthorized).toHaveBeenCalledTimes(1);
-    expect(actionsAuthorizationMock.ensureAuthorized).toHaveBeenCalledTimes(1);
+    expect(actionsAuthorizationMock.ensureAuthorized).not.toHaveBeenCalled();
     expect(ruleTypeRegistryMock.ensureRuleTypeEnabled).toHaveBeenCalledTimes(1);
     expect(getAlertIndicesAliasMock).toHaveBeenCalledTimes(1);
     expect(alertsServiceMock.isExistingAlert).not.toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe('mute alert instance', () => {
 
     expect(auditLoggerMock.log).toHaveBeenCalledTimes(1);
     expect(authorizationMock.ensureAuthorized).toHaveBeenCalledTimes(1);
-    expect(actionsAuthorizationMock.ensureAuthorized).toHaveBeenCalledTimes(1);
+    expect(actionsAuthorizationMock.ensureAuthorized).not.toHaveBeenCalled();
     expect(ruleTypeRegistryMock.ensureRuleTypeEnabled).toHaveBeenCalledTimes(1);
     expect(getAlertIndicesAliasMock).toHaveBeenCalledTimes(2);
     expect(alertsServiceMock.isExistingAlert).toHaveBeenCalledTimes(1);

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.ts
@@ -58,7 +58,6 @@ async function muteInstanceWithOCC(
       operation: WriteOperations.MuteAlert,
       entity: AlertingAuthorizationEntity.Rule,
     });
-
   } catch (error) {
     context.auditLogger?.log(
       ruleAuditEvent({

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.ts
@@ -59,9 +59,6 @@ async function muteInstanceWithOCC(
       entity: AlertingAuthorizationEntity.Rule,
     });
 
-    if (attributes.actions.length) {
-      await context.actionsAuthorization.ensureAuthorized({ operation: 'execute' });
-    }
   } catch (error) {
     context.auditLogger?.log(
       ruleAuditEvent({

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unmute_alert/unmute_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unmute_alert/unmute_instance.test.ts
@@ -198,7 +198,6 @@ describe('unmuteInstance()', () => {
       const rulesClient = new RulesClient(rulesClientParams);
       await rulesClient.unmuteInstance({ alertId: '1', alertInstanceId: '2' });
 
-      expect(actionsAuthorization.ensureAuthorized).toHaveBeenCalledWith({ operation: 'execute' });
       expect(authorization.ensureAuthorized).toHaveBeenCalledWith({
         entity: 'rule',
         consumer: 'myApp',

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unmute_alert/unmute_instance.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unmute_alert/unmute_instance.ts
@@ -51,9 +51,6 @@ async function unmuteInstanceWithOCC(
       operation: WriteOperations.UnmuteAlert,
       entity: AlertingAuthorizationEntity.Rule,
     });
-    if (attributes.actions.length) {
-      await context.actionsAuthorization.ensureAuthorized({ operation: 'execute' });
-    }
   } catch (error) {
     context.auditLogger?.log(
       ruleAuditEvent({

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/mute_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/mute_instance.test.ts
@@ -221,7 +221,7 @@ describe('muteInstance()', () => {
         query: { validateAlertsExistence: false },
       });
 
-      expect(actionsAuthorization.ensureAuthorized).toHaveBeenCalledWith({ operation: 'execute' });
+      expect(actionsAuthorization.ensureAuthorized).not.toHaveBeenCalled();
       expect(authorization.ensureAuthorized).toHaveBeenCalledWith({
         entity: 'rule',
         consumer: 'myApp',

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/mute_instance.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/mute_instance.ts
@@ -75,16 +75,9 @@ export default function createMuteAlertInstanceTests({ getService }: FtrProvider
                 statusCode: 403,
               });
               break;
-            case 'space_1_all_alerts_none_actions at space1':
-              expect(response.statusCode).to.eql(403);
-              expect(response.body).to.eql({
-                error: 'Forbidden',
-                message: `Unauthorized to execute actions`,
-                statusCode: 403,
-              });
-              break;
             case 'superuser at space1':
             case 'space_1_all at space1':
+            case 'space_1_all_alerts_none_actions at space1':
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.statusCode).to.eql(204);
               expect(response.body).to.eql('');

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unmute_instance.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unmute_instance.ts
@@ -84,16 +84,9 @@ export default function createMuteAlertInstanceTests({ getService }: FtrProvider
                 statusCode: 403,
               });
               break;
-            case 'space_1_all_alerts_none_actions at space1':
-              expect(response.statusCode).to.eql(403);
-              expect(response.body).to.eql({
-                error: 'Forbidden',
-                message: `Unauthorized to execute actions`,
-                statusCode: 403,
-              });
-              break;
             case 'superuser at space1':
             case 'space_1_all at space1':
+            case 'space_1_all_alerts_none_actions at space1':
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.statusCode).to.eql(204);
               expect(response.body).to.eql('');


### PR DESCRIPTION
Closes #273246

Removes the `actionsAuthorization.execute` gate from `mute_instance.ts` and `unmute_instance.ts`. Muting/snoozing suppresses connector firing and never causes one, so gating it on the ability to execute connectors isn't necessary. Today the gate is invisibly satisfied because snoozers are always also rule authors. With the upcoming `manage_alerts` privilege (elastic/response-ops-team#585) creating a snooze-without-rule.all persona, the gate would 403 on every connector-backed rule.

## Note about safety of this change, re: API keys

I was initially concerned this would cause a problem with the API key regeneration on update, and that we were requiring the "connector execute" privilege on all of these update flows because every one of them replaced the API key used to execute the rule. Having looked into it, I found the following:

[update_rule.ts](https://github.com/elastic/kibana/blob/439bebddc878c454f731d81c94522346256d0758/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts#L326-L363)

Update rule path triggers a full API key replacement flow.

[mute_instance.ts](https://github.com/elastic/kibana/blob/439bebddc878c454f731d81c94522346256d0758/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/mute_alert/mute_instance.ts#L107-L116)

No change to the API key on the mute path.