### PR TITLE
[failed-test-reporter] Broaden `ECONNREFUSED` matching in Scout failure filter

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_scout_failures.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_scout_failures.ts
@@ -77,7 +77,7 @@ const LIKELY_IRRELEVANT_FAILURE_SUBSTRINGS: readonly string[] = [
   // Cloud session creation failures are environmental (cloud login endpoint unavailable, MFA, etc.).
   'Failed to create the new cloud session',
   // Network connection refused errors are environmental (target host/service unreachable).
-  'connect ECONNREFUSED',
+  'ECONNREFUSED',
 ];
 
 const isLikelyIrrelevant = (name: string, failure: string) => {


### PR DESCRIPTION
I have noticed the failed test reporter is opening `failed-test` Github issues for `ECONNREFUSED: Connection refused` test failures (see [matching GitHub issues](https://github.com/elastic/kibana/issues?q=is%3Aissue%20state%3Aopen%20label%3Afailed-test%20%22ECONNREFUSED%3A%20Connection%20refused%22)). This PR broadens the existing Scout filters so that we don't open issues for error messages that contain `ECONNREFUSED` (creates less noise for the teams + saves millions of failed test investigation tokens).