### PR TITLE
[Alerting v2] Move kind field to the top of the form

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
@@ -131,6 +131,14 @@ export function AlertConditionStep({
 
   return (
     <>
+      <ModeSelect
+        value={isAlert ? 'alert' : 'signal'}
+        onChange={onKindChange}
+        disabled={!state.queryCommitted || isEditing}
+        compressed
+        data-test-subj="composeDiscoverModeSelect"
+      />
+      <EuiSpacer size="m" />
       <EuiTitle size="xs">
         <h3>
           <FormattedMessage
@@ -298,15 +306,6 @@ export function AlertConditionStep({
           data-test-subj="composeDiscoverGroupFields"
         />
       </EuiFormRow>
-
-      <EuiSpacer size="m" />
-      <ModeSelect
-        value={isAlert ? 'alert' : 'signal'}
-        onChange={onKindChange}
-        disabled={!state.queryCommitted || isEditing}
-        compressed
-        data-test-subj="composeDiscoverModeSelect"
-      />
 
       {isAlert && (
         <>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -318,6 +318,13 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
 
   return (
     <>
+      <ModeSelect
+        value={isAlert ? 'alert' : 'signal'}
+        onChange={handleModeChange}
+        compressed
+        data-test-subj="ruleBuilderModeSelect"
+      />
+      <EuiSpacer size="m" />
       {/* ── Header with preview icon ── */}
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
@@ -834,15 +841,6 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
           defaultMessage="Add condition"
         />
       </EuiButtonEmpty>
-
-      {/* ── Mode select ── */}
-      <EuiSpacer size="m" />
-      <ModeSelect
-        value={isAlert ? 'alert' : 'signal'}
-        onChange={handleModeChange}
-        compressed
-        data-test-subj="ruleBuilderModeSelect"
-      />
 
       {/* ── Schedule and lookback ── */}
       <EuiSpacer size="m" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -318,6 +318,7 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
 
   return (
     <>
+      {/* ── Mode select ── */}
       <ModeSelect
         value={isAlert ? 'alert' : 'signal'}
         onChange={handleModeChange}


### PR DESCRIPTION
## Summary

Closes #273151

Moves the rule kind selector (Alert vs Signal) to the top of both the Discover flyout form and the rule builder form, so users choose the rule's intent before configuring conditions.

- **Discover flyout** (`compose_discover_form/alert_condition_step.tsx`): `ModeSelect` moved above the "ES|QL query" section.
- **Rule builder** (`rule_builder/threshold/alert_condition_step.tsx`): `ModeSelect` moved above the "Data source" section.

## Test plan

- [ ] Open the Discover flyout and confirm the kind dropdown appears at the top, before the ES|QL query section.
- [ ] Open the rule builder and confirm the kind dropdown appears at the top, before the data source fields.
- [ ] Verify switching kind still correctly affects what fields/options are shown below it in both forms.
