### PR TITLE
[9.3] Fix console tests (#255313)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/components/editor_content_spinner.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/editor_content_spinner.tsx
@@ -25,7 +25,12 @@ const useStyles = () => {
 export const EditorContentSpinner: FunctionComponent = () => {
   const styles = useStyles();
   return (
-    <EuiPageSection alignment="center" grow={true} css={styles.editorSpinner}>
+    <EuiPageSection
+      alignment="center"
+      grow={true}
+      css={styles.editorSpinner}
+      data-test-subj="consoleEditorContentSpinner"
+    >
       <EuiLoadingSpinner size="xxl" />
     </EuiPageSection>
   );

--- a/src/platform/plugins/shared/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
@@ -61,7 +61,7 @@ export const NetworkRequestStatusBar: FunctionComponent<Props> = ({
   if (requestInProgress) {
     content = (
       <EuiFlexItem grow={false}>
-        <EuiBadge color="hollow">
+        <EuiBadge color="hollow" data-test-subj="consoleRequestInProgressBadge">
           {i18n.translate('console.requestInProgressBadgeText', {
             defaultMessage: 'Request in progress',
           })}

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -302,6 +302,9 @@ export class MonacoEditorActionsProvider {
     } = context;
     const { toasts } = notifications;
     try {
+      // Update request state immediately so the UI can reflect progress
+      // even if parsing / sending the request is slow.
+      dispatch({ type: 'setRequestInFlight', payload: true });
       const allRequests = await this.getRequests();
       const selectedRequests = await this.getSelectedParsedRequests();
       if (selectedRequests.length) {
@@ -320,6 +323,7 @@ export class MonacoEditorActionsProvider {
               },
             })
           );
+          dispatch({ type: 'setRequestInFlight', payload: false });
           return;
         }
       }
@@ -341,14 +345,17 @@ export class MonacoEditorActionsProvider {
             defaultMessage: 'The selected request is not valid.',
           })
         );
+        dispatch({ type: 'setRequestInFlight', payload: false });
         return;
       } else if (!requests.length) {
-        toasts.add(
-          i18n.translate('console.notification.monaco.error.noRequestSelectedTitle', {
+        toasts.add({
+          title: i18n.translate('console.notification.monaco.error.noRequestSelectedTitle', {
             defaultMessage:
               'No request selected. Select a request by placing the cursor inside it.',
-          })
-        );
+          }),
+          color: 'primary',
+        });
+        dispatch({ type: 'setRequestInFlight', payload: false });
         return;
       }
 

--- a/src/platform/plugins/shared/console/public/application/stores/request.test.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/request.test.ts
@@ -31,6 +31,36 @@ describe('request store', () => {
     expect(initialValue.requestInFlight).toBe(false);
   });
 
+  it('should handle setRequestInFlight without clearing output', () => {
+    const stateWithData: Store = {
+      requestInFlight: false,
+      lastResult: {
+        data: [
+          {
+            response: {
+              value: 'test',
+              statusCode: 200,
+              statusText: 'OK',
+              timeMs: 50,
+              contentType: 'application/json' as BaseResponseType,
+            },
+            request: { data: '', method: 'GET', path: '/' },
+          },
+        ],
+      },
+    };
+
+    const action: Actions = { type: 'setRequestInFlight', payload: true };
+    const newState = reducer(stateWithData, action);
+
+    expect(newState).not.toBe(stateWithData);
+    expect(newState.requestInFlight).toBe(true);
+    expect(newState.lastResult.data).toStrictEqual(stateWithData.lastResult.data);
+
+    // Verify original state unchanged
+    expect(stateWithData.requestInFlight).toBe(false);
+  });
+
   it('should handle requestSuccess action with proper immutability', () => {
     const mockData: RequestResult[] = [
       {

--- a/src/platform/plugins/shared/console/public/application/stores/request.ts
+++ b/src/platform/plugins/shared/console/public/application/stores/request.ts
@@ -14,6 +14,7 @@ import type { RequestResult } from '../hooks/use_send_current_request/send_reque
 
 export type Actions =
   | { type: 'sendRequest'; payload: undefined }
+  | { type: 'setRequestInFlight'; payload: boolean }
   | { type: 'cleanRequest'; payload: undefined }
   | { type: 'requestSuccess'; payload: { data: RequestResult[] } }
   | { type: 'requestFail'; payload: RequestResult<string> | undefined };
@@ -42,6 +43,11 @@ export const reducer: Reducer<Store, Actions> = (state, action) => {
   if (action.type === 'sendRequest') {
     draft.requestInFlight = true;
     draft.lastResult = initialResultValue;
+    return draft;
+  }
+
+  if (action.type === 'setRequestInFlight') {
+    draft.requestInFlight = action.payload;
     return draft;
   }
 

--- a/src/platform/test/functional/apps/console/_console_ccs.ts
+++ b/src/platform/test/functional/apps/console/_console_ccs.ts
@@ -29,6 +29,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('navigateTo console');
       await PageObjects.common.navigateToApp('console');
       await PageObjects.console.skipTourIfExists();
+      await PageObjects.console.clearEditorText();
     });
 
     after(async () => {
@@ -38,15 +39,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     describe('Perform CCS Search in Console', () => {
-      before(async () => {
-        await PageObjects.console.clearEditorText();
-      });
       it('it should be able to access remote data', async () => {
         await PageObjects.console.enterText(
           '\nGET ftr-remote:logstash-*/_search\n {\n "query": {\n "bool": {\n "must": [\n {"match": {"extension" : "jpg"} \n}\n]\n}\n}\n}'
         );
-        await PageObjects.console.clickPlay();
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.console.clickPlayAndWaitForResults();
 
         await retry.try(async () => {
           const actualResponse = await PageObjects.console.getOutputText();

--- a/src/platform/test/functional/apps/console/_vector_tile.ts
+++ b/src/platform/test/functional/apps/console/_vector_tile.ts
@@ -31,7 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should validate response', async () => {
       await PageObjects.console.enterText(`GET kibana_sample_data_logs/_mvt/geo.coordinates/0/0/0`);
-      await PageObjects.console.clickPlay();
+      await PageObjects.console.clickPlayAndWaitForResults();
       await retry.try(async () => {
         const actualResponse = await PageObjects.console.getOutputText();
         expect(actualResponse).to.contain('"meta": [');

--- a/src/platform/test/functional/page_objects/console_page.ts
+++ b/src/platform/test/functional/page_objects/console_page.ts
@@ -247,6 +247,54 @@ export class ConsolePageObject extends FtrService {
     await this.testSubjects.click('sendRequestButton');
   }
 
+  public async clickPlayAndWaitForResults() {
+    const hadStatusBadge = await this.testSubjects.exists('consoleResponseStatusBadge');
+    const initialStatusText = hadStatusBadge
+      ? await this.testSubjects.getVisibleText('consoleResponseStatusBadge')
+      : '';
+    const hadOutput = await this.testSubjects.exists('consoleMonacoOutput');
+    const initialOutputText = hadOutput ? await this.getOutputText() : '';
+
+    await this.clickPlay();
+
+    // Wait for the UI to reflect request progress or completion.
+    // We capture state before clicking to correctly detect "already done" results.
+    await this.retry.try(async () => {
+      const loadingIndicatorsVisible =
+        (await this.testSubjects.exists('consoleEditorContentSpinner')) ||
+        (await this.testSubjects.exists('consoleRequestInProgressBadge'));
+      const hasStatusBadge = await this.testSubjects.exists('consoleResponseStatusBadge');
+      const currentStatusText = hasStatusBadge
+        ? await this.testSubjects.getVisibleText('consoleResponseStatusBadge')
+        : '';
+      const statusChanged = currentStatusText !== initialStatusText;
+      const hasOutput = await this.testSubjects.exists('consoleMonacoOutput');
+      const currentOutputText = hasOutput ? await this.getOutputText() : '';
+      const outputChanged = currentOutputText !== initialOutputText;
+
+      if (!loadingIndicatorsVisible && !statusChanged && !outputChanged) {
+        throw new Error('Expected console request to update the UI');
+      }
+    });
+
+    // Wait for the request to finish: loading indicators go away and output/status are present.
+    await this.waitForRequestToComplete();
+  }
+
+  public async waitForRequestToComplete() {
+    await this.retry.try(async () => {
+      const inProgress =
+        (await this.testSubjects.exists('consoleEditorContentSpinner')) ||
+        (await this.testSubjects.exists('consoleRequestInProgressBadge'));
+      const outputReady = await this.testSubjects.exists('consoleMonacoOutput');
+      const statusReady = await this.testSubjects.exists('consoleResponseStatusBadge');
+
+      if (inProgress || !outputReady || !statusReady) {
+        throw new Error('Expected console request to finish and render output');
+      }
+    });
+  }
+
   public async isPlayButtonVisible() {
     return await this.testSubjects.exists('sendRequestButton');
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix console tests (#255313)](https://github.com/elastic/kibana/pull/255313)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-05-28T10:03:34Z","message":"Fix console tests (#255313)\n\nCloses https://github.com/elastic/kibana/issues/240154\nCloses https://github.com/elastic/kibana/issues/240147\n\n## Summary\nI already attempted to fix this tests with\nhttps://github.com/elastic/kibana/pull/251276 but the failures\npersisted. The issue is that the console sendRequestButton click didn’t\ntrigger any immediate UI change because sendRequests() only dispatched\nsendRequest after some async work that can be slow like parsing and\nvalidation. To fix that, we dispatch sendRequest immediately at the\nstart of sendRequests() (and then cleanRequest), so we can use the\nspinner / “request in progress” badge for the tests.\n\nFlaky test runner\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12065\n\n\n\n\n\n## Summary by CodeRabbit\n\n* **New Features**\n* Added immediate UI feedback when requests are in progress, improving\nvisibility of request status during execution.\n\n* **Tests**\n* Enhanced test reliability with improved wait mechanisms for request\ncompletion verification.\n\n* **Chores**\n* Increased testability with improved test attributes and refactored\ntesting utilities.\n","sha":"3190c030de83525a394581e72d834541109abf71","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:version","v9.5.0","v9.4.3","v9.3.6"],"title":"Fix console tests","number":255313,"url":"https://github.com/elastic/kibana/pull/255313","mergeCommit":{"message":"Fix console tests (#255313)\n\nCloses https://github.com/elastic/kibana/issues/240154\nCloses https://github.com/elastic/kibana/issues/240147\n\n## Summary\nI already attempted to fix this tests with\nhttps://github.com/elastic/kibana/pull/251276 but the failures\npersisted. The issue is that the console sendRequestButton click didn’t\ntrigger any immediate UI change because sendRequests() only dispatched\nsendRequest after some async work that can be slow like parsing and\nvalidation. To fix that, we dispatch sendRequest immediately at the\nstart of sendRequests() (and then cleanRequest), so we can use the\nspinner / “request in progress” badge for the tests.\n\nFlaky test runner\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12065\n\n\n\n\n\n## Summary by CodeRabbit\n\n* **New Features**\n* Added immediate UI feedback when requests are in progress, improving\nvisibility of request status during execution.\n\n* **Tests**\n* Enhanced test reliability with improved wait mechanisms for request\ncompletion verification.\n\n* **Chores**\n* Increased testability with improved test attributes and refactored\ntesting utilities.\n","sha":"3190c030de83525a394581e72d834541109abf71"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255313","number":255313,"mergeCommit":{"message":"Fix console tests (#255313)\n\nCloses https://github.com/elastic/kibana/issues/240154\nCloses https://github.com/elastic/kibana/issues/240147\n\n## Summary\nI already attempted to fix this tests with\nhttps://github.com/elastic/kibana/pull/251276 but the failures\npersisted. The issue is that the console sendRequestButton click didn’t\ntrigger any immediate UI change because sendRequests() only dispatched\nsendRequest after some async work that can be slow like parsing and\nvalidation. To fix that, we dispatch sendRequest immediately at the\nstart of sendRequests() (and then cleanRequest), so we can use the\nspinner / “request in progress” badge for the tests.\n\nFlaky test runner\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12065\n\n\n\n\n\n## Summary by CodeRabbit\n\n* **New Features**\n* Added immediate UI feedback when requests are in progress, improving\nvisibility of request status during execution.\n\n* **Tests**\n* Enhanced test reliability with improved wait mechanisms for request\ncompletion verification.\n\n* **Chores**\n* Increased testability with improved test attributes and refactored\ntesting utilities.\n","sha":"3190c030de83525a394581e72d834541109abf71"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/272680","number":272680,"state":"MERGED","mergeCommit":{"sha":"70c666f0d26d0f495aad97398ead77a7ece3ad7b","message":"[9.4] Fix console tests (#255313) (#272680)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Fix console tests\n(#255313)](https://github.com/elastic/kibana/pull/255313)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>"}},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->