### PR TITLE
[Agent Builder] Fix SML API scout test fixtures missing ingestion_method field

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/sml_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/sml_api.spec.ts
@@ -69,6 +69,7 @@ apiTest.describe('Agent Builder — SML internal API', { tag: [...tags.stateful.
         updated_at: now,
         spaces: ['default'],
         permissions: [],
+        ingestion_method: 'crawled',
       },
     });
   });
@@ -195,6 +196,7 @@ apiTest.describe('Agent Builder — SML internal API', { tag: [...tags.stateful.
           updated_at: now,
           spaces: ['default'],
           permissions: [],
+          ingestion_method: 'crawled',
         },
       });
 


### PR DESCRIPTION
## Summary

- PR #270921 added `ingestion_method` as a required field to the SML Elasticsearch index schema (`sml_storage.ts`) with `dynamic: strict` mapping
- The two scout test fixtures that directly call `sysEsClient.index()` were not updated to include this field
- Elasticsearch rejects these documents with `mapper_parsing_exception`, causing `resolveSmlAttachItems` to return `success: false`
- This has been failing consistently since 2026-06-01 with 65 accumulated failures (tracked in #261565)

**Fix:** Add `ingestion_method: 'crawled'` to both test fixtures in `sml_api.spec.ts` — identical to the fix already on branch `apmats/sml-search-api` (commit `1b343aa2e56e`).

## Test plan

- [ ] CI should pass X-Pack Agent Builder Stateful API Integration Tests (#261565)
- [ ] No logic changes — test fixtures only

Closes #261565

🤖 Generated with [Claude Code](https://claude.com/claude-code)