### PR TITLE
[Background search tests] Fix stale elements flakyness

### DIFF
--- a/src/platform/test/functional/services/search_sessions.ts
+++ b/src/platform/test/functional/services/search_sessions.ts
@@ -18,7 +18,6 @@ const APP_MENU_OVERFLOW_BUTTON = 'app-menu-overflow-button';
 const BACKGROUND_SEARCH_FLYOUT_ENTRYPOINT = 'openBackgroundSearchFlyoutButton';
 const BACKGROUND_SEARCH_SUBMIT_BUTTON = 'querySubmitButton-secondary-button';
 const BACKGROUND_SEARCH_CANCEL_BUTTON = 'queryCancelButton-secondary-button';
-const BACKGROUND_SEARCH_COMPLETED_MESSAGE = 'Background search completed';
 
 export class SearchSessionsService extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');

--- a/src/platform/test/functional/services/search_sessions.ts
+++ b/src/platform/test/functional/services/search_sessions.ts
@@ -18,11 +18,13 @@ const APP_MENU_OVERFLOW_BUTTON = 'app-menu-overflow-button';
 const BACKGROUND_SEARCH_FLYOUT_ENTRYPOINT = 'openBackgroundSearchFlyoutButton';
 const BACKGROUND_SEARCH_SUBMIT_BUTTON = 'querySubmitButton-secondary-button';
 const BACKGROUND_SEARCH_CANCEL_BUTTON = 'queryCancelButton-secondary-button';
+const BACKGROUND_SEARCH_COMPLETED_MESSAGE = 'Background search completed';
 
 export class SearchSessionsService extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly log = this.ctx.getService('log');
   private readonly retry = this.ctx.getService('retry');
+  private readonly retryOnStale = this.ctx.getService('retryOnStale');
   private readonly security = this.ctx.getService('security');
   private readonly toasts = this.ctx.getService('toasts');
   private readonly es = this.ctx.getService('es');
@@ -100,26 +102,30 @@ export class SearchSessionsService extends FtrService {
   }
 
   private async dismissSuccessToast() {
-    const successToast = await this.getSuccessToast();
-    if (!successToast) return;
-    const closeBtn = await successToast.findByTestSubject('toastCloseButton');
-    await closeBtn.click();
+    await this.retryOnStale(async () => {
+      const successToast = await this.getSuccessToast();
+      if (!successToast) return;
+      const closeBtn = await successToast.findByTestSubject('toastCloseButton');
+      await closeBtn.click();
 
-    await this.retry.waitFor('success toast to be dismissed', async () => {
-      const _successToast = await this.getSuccessToast();
-      return !_successToast;
+      await this.retry.waitFor('success toast to be dismissed', async () => {
+        const _successToast = await this.getSuccessToast();
+        return !_successToast;
+      });
     });
   }
 
   private async getSuccessToast() {
-    const toasts = await this.toasts.getAll();
-    for (const toast of toasts) {
-      const text = await toast.getVisibleText();
-      if (text.includes('Background search completed')) {
-        return toast;
+    return await this.retryOnStale(async () => {
+      const toasts = await this.toasts.getAll();
+      for (const toast of toasts) {
+        const text = await toast.getVisibleText();
+        if (text.includes('Background search completed')) {
+          return toast;
+        }
       }
-    }
-    return null;
+      return null;
+    });
   }
 
   public async openFlyoutFromToast() {
@@ -171,14 +177,17 @@ export class SearchSessionsService extends FtrService {
       'Failed to fetch background search info',
     ];
 
-    const toasts = await this.toasts.getAll();
-    for (const toast of toasts) {
-      const text = await toast.getVisibleText();
-      if (messages.some((message) => text.includes(message))) {
-        return true;
+    return await this.retryOnStale(async () => {
+      const toasts = await this.toasts.getAll();
+      for (const toast of toasts) {
+        const text = await toast.getVisibleText();
+        if (messages.some((message) => text.includes(message))) {
+          return true;
+        }
       }
-    }
-    return false;
+
+      return false;
+    });
   }
 
   /*


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/264781

This test is now failing some times because it's using stale elements and the test driver doesn't like that. I'm not sure if we want to fix it because there Scout migration is in progress, but just in case, this seems to fix the problem.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->