### PR TITLE
[fleet][otel_collector]: Rewrite storage references to suffixed extensions

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -756,6 +756,198 @@ describe('generateOtelcolConfig', () => {
     expect(result.service?.extensions).not.toContain(`beatsauth/default/${expectedSuffix}`);
   });
 
+  it('should suffix a receiver storage reference to match a stream-declared file_storage extension', () => {
+    const inputId = 'otelcol-akamai-1';
+    const streamId = 'otelcol-akamai-siem_otel-1';
+    const expectedSuffix = `${inputId}-${streamId}`;
+
+    const otelInputWithStorage: FullAgentPolicyInput = {
+      type: OTEL_COLLECTOR_INPUT_TYPE,
+      id: inputId,
+      name: inputId,
+      revision: 0,
+      data_stream: { namespace: 'default' },
+      use_output: 'default',
+      package_policy_id: 'akamai-policy',
+      streams: [
+        {
+          id: streamId,
+          data_stream: { dataset: 'akamai.siem', type: 'logs' },
+          extensions: {
+            file_storage: { directory: '/usr/share/elastic-agent/state' },
+          },
+          receivers: {
+            akamai_siem: {
+              storage: 'file_storage',
+              config_id: 'abc',
+            },
+          },
+          service: {
+            extensions: ['file_storage'],
+            pipelines: {
+              logs: { receivers: ['akamai_siem'] },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = generateOtelcolConfig({
+      inputs: [otelInputWithStorage],
+      dataOutput: defaultOutput,
+    });
+
+    // The extension key must be suffixed
+    expect(result.extensions?.[`file_storage/${expectedSuffix}`]).toEqual({
+      directory: '/usr/share/elastic-agent/state',
+    });
+    expect(result.extensions?.file_storage).toBeUndefined();
+
+    // The service.extensions reference must also be suffixed
+    expect(result.service?.extensions).toContain(`file_storage/${expectedSuffix}`);
+    expect(result.service?.extensions).not.toContain('file_storage');
+
+    // The receiver storage reference must be suffixed to match the renamed extension key
+    const suffixedReceiver = result.receivers?.[`akamai_siem/${expectedSuffix}`];
+    expect(suffixedReceiver?.storage).toBe(`file_storage/${expectedSuffix}`);
+    expect(suffixedReceiver?.config_id).toBe('abc');
+  });
+
+  it('should leave a receiver storage reference untouched when it points at a globally-injected extension', () => {
+    const inputId = 'otelcol-akamai-2';
+    const streamId = 'otelcol-akamai-siem_otel-1';
+    const expectedSuffix = `${inputId}-${streamId}`;
+
+    // elasticsearch_storage is injected externally by elastic-agent with a stable,
+    // un-suffixed ID; it is never declared in the stream's component map.
+    const otelInputExternalStorage: FullAgentPolicyInput = {
+      type: OTEL_COLLECTOR_INPUT_TYPE,
+      id: inputId,
+      name: inputId,
+      revision: 0,
+      data_stream: { namespace: 'default' },
+      use_output: 'default',
+      package_policy_id: 'akamai-policy-2',
+      streams: [
+        {
+          id: streamId,
+          data_stream: { dataset: 'akamai.siem', type: 'logs' },
+          receivers: {
+            akamai_siem: {
+              storage: 'elasticsearch_storage',
+            },
+          },
+          service: {
+            pipelines: {
+              logs: { receivers: ['akamai_siem'] },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = generateOtelcolConfig({
+      inputs: [otelInputExternalStorage],
+      dataOutput: defaultOutput,
+    });
+
+    const suffixedReceiver = result.receivers?.[`akamai_siem/${expectedSuffix}`];
+    expect(suffixedReceiver?.storage).toBe('elasticsearch_storage');
+  });
+
+  it('should leave a receiver storage reference untouched when the extension is not declared at all', () => {
+    const inputId = 'otelcol-akamai-3';
+    const streamId = 'otelcol-akamai-siem_otel-1';
+    const expectedSuffix = `${inputId}-${streamId}`;
+
+    const otelInputUnknownStorage: FullAgentPolicyInput = {
+      type: OTEL_COLLECTOR_INPUT_TYPE,
+      id: inputId,
+      name: inputId,
+      revision: 0,
+      data_stream: { namespace: 'default' },
+      use_output: 'default',
+      package_policy_id: 'akamai-policy-3',
+      streams: [
+        {
+          id: streamId,
+          data_stream: { dataset: 'akamai.siem', type: 'logs' },
+          receivers: {
+            akamai_siem: {
+              storage: 'nonexistent_extension',
+            },
+          },
+          service: {
+            pipelines: {
+              logs: { receivers: ['akamai_siem'] },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = generateOtelcolConfig({
+      inputs: [otelInputUnknownStorage],
+      dataOutput: defaultOutput,
+    });
+
+    // Validating extension existence is the collector's job at startup, not the renderer's.
+    const suffixedReceiver = result.receivers?.[`akamai_siem/${expectedSuffix}`];
+    expect(suffixedReceiver?.storage).toBe('nonexistent_extension');
+  });
+
+  it('should suffix both storage and auth.authenticator references independently in the same receiver', () => {
+    const inputId = 'otelcol-akamai-4';
+    const streamId = 'otelcol-akamai-siem_otel-1';
+    const expectedSuffix = `${inputId}-${streamId}`;
+
+    const otelInputBoth: FullAgentPolicyInput = {
+      type: OTEL_COLLECTOR_INPUT_TYPE,
+      id: inputId,
+      name: inputId,
+      revision: 0,
+      data_stream: { namespace: 'default' },
+      use_output: 'default',
+      package_policy_id: 'akamai-policy-4',
+      streams: [
+        {
+          id: streamId,
+          data_stream: { dataset: 'akamai.siem', type: 'logs' },
+          extensions: {
+            file_storage: { directory: '/usr/share/elastic-agent/state' },
+            bearertokenauth: { token: 'secret' },
+          },
+          receivers: {
+            akamai_siem: {
+              storage: 'file_storage',
+              auth: { authenticator: 'bearertokenauth' },
+            },
+          },
+          service: {
+            extensions: ['file_storage', 'bearertokenauth'],
+            pipelines: {
+              logs: { receivers: ['akamai_siem'] },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = generateOtelcolConfig({
+      inputs: [otelInputBoth],
+      dataOutput: defaultOutput,
+    });
+
+    const suffixedReceiver = result.receivers?.[`akamai_siem/${expectedSuffix}`];
+    expect(suffixedReceiver?.storage).toBe(`file_storage/${expectedSuffix}`);
+    expect(suffixedReceiver?.auth?.authenticator).toBe(`bearertokenauth/${expectedSuffix}`);
+
+    expect(result.extensions?.[`file_storage/${expectedSuffix}`]).toEqual({
+      directory: '/usr/share/elastic-agent/state',
+    });
+    expect(result.extensions?.[`bearertokenauth/${expectedSuffix}`]).toEqual({ token: 'secret' });
+  });
+
   it('should add elasticapm connector and processor for traces input with use_apm enabled', () => {
     const inputs: FullAgentPolicyInput[] = [otelTracesInputWithAPM];
     expect(generateOtelcolConfig({ inputs, dataOutput: defaultOutput })).toEqual({

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -499,10 +499,15 @@ function alignPipelineSignalType(
   return { [newKey]: pipeline };
 }
 
-// Recursively walks a component config body and rewrites auth.authenticator
-// references whose bare ID appears in originalToSuffixedExtensionIds.
-// This covers the OTel configauth convention where receivers/exporters/etc.
-// reference extensions via `auth: { authenticator: <extension-id> }`.
+// Recursively walks a component config body and rewrites extension references
+// whose bare ID appears in originalToSuffixedExtensionIds. This covers two OTel
+// conventions for referencing an in-stream extension:
+//   - configauth: `auth: { authenticator: <extension-id> }` on receivers/exporters/etc.
+//   - storage: `storage: <extension-id>` on receivers (e.g. akamai_siem).
+// Both rewrites share the same guard: only references whose bare name was declared
+// as an extension in this stream are suffixed. Globally-injected extensions (e.g.
+// `elasticsearch_storage`, `beatsauth/default`) are not in the map, so the `?? val`
+// fallback leaves them untouched — no special-casing by extension type.
 function rewriteOtelcolExtensionReferences(
   value: unknown,
   originalToSuffixedExtensionIds: Record<string, string>
@@ -526,6 +531,8 @@ function rewriteOtelcolExtensionReferences(
         ...authObj,
         authenticator: originalToSuffixedExtensionIds[authenticator] ?? authenticator,
       };
+    } else if (key === 'storage' && typeof val === 'string') {
+      result[key] = originalToSuffixedExtensionIds[val] ?? val;
     } else {
       result[key] = rewriteOtelcolExtensionReferences(val, originalToSuffixedExtensionIds);
     }


### PR DESCRIPTION
## Release note

Fixed OpenTelemetry integrations that declare a storage extension within a
data stream (such as the Akamai SIEM integration) failing to start. Fleet now
rewrites a receiver's `storage` reference to the per-stream extension ID it
generates, matching the behavior already in place for `auth.authenticator`
references.

## Summary
```
The OTel collector policy renderer renames every component declared in a
data-stream stream with a per-stream suffix and rewrites auth.authenticator
references to match the renamed extension keys. A receiver's storage:
reference to a stream-declared extension was not rewritten, so the collector
looked up the bare extension ID (e.g. file_storage), found only the suffixed
key, and failed to start. The akamai SIEM integration is the first to hit
this; any future otelcol integration declaring an in-stream storage
extension would too.

Fold a storage: rewrite into the same pass that handles auth.authenticator,
sharing its guard: a reference is suffixed only when its bare name was
declared as an extension in the same stream. Globally-injected extensions
such as elasticsearch_storage are not in that map, so the fallback leaves
them untouched without any extension-type special-casing.
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Issues
 - Closes: https://github.com/elastic/kibana/issues/273281
 
### Identify risks
None

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



