### PR TITLE
[9.4] feat(obs-exploration-team, obs-presentation-team): replace title props and wrap EuiButtonIcon with EuiToolTip (#271495)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/help_popover/help_popover.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/help_popover/help_popover.tsx
@@ -15,6 +15,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiText,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import styled from '@emotion/styled';
@@ -50,13 +51,15 @@ export function HelpPopoverButton({
   }
 
   return (
-    <EuiButtonIcon
-      data-test-subj="apmHelpPopoverButtonButton"
-      className="apmHelpPopover__buttonIcon"
-      iconType="question"
-      aria-label={buttonText}
-      onClick={onClick}
-    />
+    <EuiToolTip content={buttonText} disableScreenReaderOutput>
+      <EuiButtonIcon
+        data-test-subj="apmHelpPopoverButtonButton"
+        className="apmHelpPopover__buttonIcon"
+        iconType="question"
+        aria-label={buttonText}
+        onClick={onClick}
+      />
+    </EuiToolTip>
   );
 }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/agent_config_table.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/agent_config_table.tsx
@@ -11,11 +11,12 @@ import { get } from 'lodash';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import {
   EuiBasicTable,
-  EuiText,
   EuiButton,
   EuiButtonIcon,
-  copyToClipboard,
   EuiFieldPassword,
+  EuiText,
+  EuiToolTip,
+  copyToClipboard,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { secretTokenKeys } from '../../../tutorial/config_agent/commands/get_apm_agent_commands';
@@ -57,15 +58,22 @@ function ConfigurationValueColumn({
         </EuiText>
       )}
       {value && (
-        <EuiButtonIcon
-          data-test-subj="apmConfigurationValueColumnButton"
-          aria-label={i18n.translate('xpack.apm.onboarding.column.value.copyIconText', {
+        <EuiToolTip
+          content={i18n.translate('xpack.apm.onboarding.column.value.copyIconText', {
             defaultMessage: 'Copy to clipboard',
           })}
-          color="text"
-          iconType="copy"
-          onClick={() => copyToClipboard(value)}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="apmConfigurationValueColumnButton"
+            aria-label={i18n.translate('xpack.apm.onboarding.column.value.copyIconText', {
+              defaultMessage: 'Copy to clipboard',
+            })}
+            color="text"
+            iconType="copy"
+            onClick={() => copyToClipboard(value)}
+          />
+        </EuiToolTip>
       )}
     </>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_dashboards/context_menu.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_dashboards/context_menu.tsx
@@ -6,7 +6,13 @@
  */
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
-import { EuiButtonIcon, EuiContextMenuPanel, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
 
 interface Props {
   items: React.ReactNode[];
@@ -29,16 +35,23 @@ export function ContextMenu({ items }: Props) {
         defaultMessage: 'More actions',
       })}
       button={
-        <EuiButtonIcon
-          data-test-subj="apmContextMenuButton"
-          display="base"
-          size="s"
-          iconType="boxesVertical"
-          aria-label={i18n.translate('xpack.apm.serviceDashboards.contextMenu.moreLabel', {
+        <EuiToolTip
+          content={i18n.translate('xpack.apm.serviceDashboards.contextMenu.moreLabel', {
             defaultMessage: 'More',
           })}
-          onClick={onButtonClick}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="apmContextMenuButton"
+            display="base"
+            size="s"
+            iconType="boxesVertical"
+            aria-label={i18n.translate('xpack.apm.serviceDashboards.contextMenu.moreLabel', {
+              defaultMessage: 'More',
+            })}
+            onClick={onButtonClick}
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiButtonIcon, RIGHT_ALIGNMENT, EuiScreenReaderOnly } from '@elastic/eui';
+import { EuiButtonIcon, EuiScreenReaderOnly, EuiToolTip, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ReactNode } from 'react';
 import React from 'react';
@@ -273,14 +273,21 @@ export function getColumns({
             isOpen={itemIdToOpenActionMenuRowMap[instanceItem.serviceNodeName]}
             anchorPosition="leftCenter"
             button={
-              <EuiButtonIcon
-                aria-label={i18n.translate('xpack.apm.getColumns.euiButtonIcon.editLabel', {
+              <EuiToolTip
+                content={i18n.translate('xpack.apm.getColumns.euiButtonIcon.editLabel', {
                   defaultMessage: 'Edit',
                 })}
-                data-test-subj={`instanceActionsButton_${instanceItem.serviceNodeName}`}
-                iconType="boxesVertical"
-                onClick={() => toggleRowActionMenu(instanceItem.serviceNodeName)}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  aria-label={i18n.translate('xpack.apm.getColumns.euiButtonIcon.editLabel', {
+                    defaultMessage: 'Edit',
+                  })}
+                  data-test-subj={`instanceActionsButton_${instanceItem.serviceNodeName}`}
+                  iconType="boxesVertical"
+                  onClick={() => toggleRowActionMenu(instanceItem.serviceNodeName)}
+                />
+              </EuiToolTip>
             }
           >
             <InstanceActionsMenu
@@ -307,19 +314,24 @@ export function getColumns({
       width: '40px',
       isExpander: true,
       render: (instanceItem: MainStatsServiceInstanceItem) => {
+        const isExpanded = Boolean(itemIdToExpandedRowMap[instanceItem.serviceNodeName]);
+        const toggleLabel = isExpanded
+          ? i18n.translate('xpack.apm.serviceOverview.instancesTable.collapse', {
+              defaultMessage: 'Collapse',
+            })
+          : i18n.translate('xpack.apm.serviceOverview.instancesTable.expand', {
+              defaultMessage: 'Expand',
+            });
+
         return (
-          <EuiButtonIcon
-            data-test-subj={`instanceDetailsButton_${instanceItem.serviceNodeName}`}
-            onClick={() => toggleRowDetails(instanceItem.serviceNodeName)}
-            aria-label={
-              itemIdToExpandedRowMap[instanceItem.serviceNodeName] ? 'Collapse' : 'Expand'
-            }
-            iconType={
-              itemIdToExpandedRowMap[instanceItem.serviceNodeName]
-                ? 'chevronSingleUp'
-                : 'chevronSingleDown'
-            }
-          />
+          <EuiToolTip content={toggleLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              data-test-subj={`instanceDetailsButton_${instanceItem.serviceNodeName}`}
+              onClick={() => toggleRowDetails(instanceItem.serviceNodeName)}
+              aria-label={toggleLabel}
+              iconType={isExpanded ? 'chevronSingleUp' : 'chevronSingleDown'}
+            />
+          </EuiToolTip>
         );
       },
     },

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_value_input.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/advanced_config_value_input.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { EuiButtonIcon, EuiFieldText, EuiFormRow, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useMemo } from 'react';
 import { useState } from 'react';
@@ -81,15 +81,25 @@ export function AdvancedConfigValueInput({
         value={configValue}
         onChange={(e) => handleValueChange(e.target.value)}
         append={
-          <EuiButtonIcon
-            data-test-subj="apmSettingsRemoveAdvancedConfigurationButton"
-            aria-label={i18n.translate('xpack.apm.agentConfig.settingsPage.removeButtonAriaLabel', {
+          <EuiToolTip
+            content={i18n.translate('xpack.apm.agentConfig.settingsPage.removeButtonAriaLabel', {
               defaultMessage: 'Remove advanced configuration',
             })}
-            iconType="trash"
-            color={'danger'}
-            onClick={() => onDelete(configKey, id)}
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              data-test-subj="apmSettingsRemoveAdvancedConfigurationButton"
+              aria-label={i18n.translate(
+                'xpack.apm.agentConfig.settingsPage.removeButtonAriaLabel',
+                {
+                  defaultMessage: 'Remove advanced configuration',
+                }
+              )}
+              iconType="trash"
+              color="danger"
+              onClick={() => onDelete(configKey, id)}
+            />
+          </EuiToolTip>
         }
       />
     </EuiFormRow>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_configurations/list/index.tsx
@@ -194,33 +194,47 @@ export function AgentConfigurationList({ status, configurations, refetch }: Prop
             width: euiTheme.size.xl,
             name: '',
             render: (config: Config) => (
-              <EuiButtonIcon
-                data-test-subj="apmColumnsButton"
-                aria-label={i18n.translate('xpack.apm.columns.euiButtonIcon.editLabel', {
+              <EuiToolTip
+                content={i18n.translate('xpack.apm.columns.euiButtonIcon.editLabel', {
                   defaultMessage: 'Edit',
                 })}
-                iconType="pencil"
-                href={apmRouter.link('/settings/agent-configuration/edit', {
-                  query: {
-                    name: config.service.name,
-                    environment: config.service.environment,
-                  },
-                })}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  data-test-subj="apmColumnsButton"
+                  aria-label={i18n.translate('xpack.apm.columns.euiButtonIcon.editLabel', {
+                    defaultMessage: 'Edit',
+                  })}
+                  iconType="pencil"
+                  href={apmRouter.link('/settings/agent-configuration/edit', {
+                    query: {
+                      name: config.service.name,
+                      environment: config.service.environment,
+                    },
+                  })}
+                />
+              </EuiToolTip>
             ),
           },
           {
             width: euiTheme.size.xl,
             name: '',
             render: (config: Config) => (
-              <EuiButtonIcon
-                data-test-subj="apmColumnsButton"
-                aria-label={i18n.translate('xpack.apm.columns.euiButtonIcon.deleteLabel', {
+              <EuiToolTip
+                content={i18n.translate('xpack.apm.columns.euiButtonIcon.deleteLabel', {
                   defaultMessage: 'Delete',
                 })}
-                iconType="trash"
-                onClick={() => setConfigToBeDeleted(config)}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  data-test-subj="apmColumnsButton"
+                  aria-label={i18n.translate('xpack.apm.columns.euiButtonIcon.deleteLabel', {
+                    defaultMessage: 'Delete',
+                  })}
+                  iconType="trash"
+                  onClick={() => setConfigToBeDeleted(config)}
+                />
+              </EuiToolTip>
             ),
           },
         ]

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_keys/create_agent_key/agent_key_callout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_keys/create_agent_key/agent_key_callout.tsx
@@ -7,7 +7,14 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiSpacer, EuiCallOut, EuiButtonIcon, EuiCopy, EuiFieldPassword } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiCopy,
+  EuiFieldPassword,
+  EuiSpacer,
+  EuiToolTip,
+} from '@elastic/eui';
 
 interface Props {
   name: string;
@@ -45,17 +52,27 @@ export function AgentKeyCallOut({ name, token }: Props) {
           append={
             <EuiCopy textToCopy={token}>
               {(copy) => (
-                <EuiButtonIcon
-                  data-test-subj="apmAgentKeyCallOutButton"
-                  iconType="copy"
-                  onClick={copy}
-                  aria-label={i18n.translate(
+                <EuiToolTip
+                  content={i18n.translate(
                     'xpack.apm.settings.agentKeys.copyAgentKeyField.copyButton',
                     {
                       defaultMessage: 'Copy to clipboard',
                     }
                   )}
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    data-test-subj="apmAgentKeyCallOutButton"
+                    iconType="copy"
+                    onClick={copy}
+                    aria-label={i18n.translate(
+                      'xpack.apm.settings.agentKeys.copyAgentKeyField.copyButton',
+                      {
+                        defaultMessage: 'Copy to clipboard',
+                      }
+                    )}
+                  />
+                </EuiToolTip>
               )}
             </EuiCopy>
           }

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/storage_explorer/services_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/storage_explorer/services_table/index.tsx
@@ -235,21 +235,24 @@ export function ServicesTable({ summaryStatsData, loadingSummaryStats }: Props) 
         </EuiScreenReaderOnly>
       ),
       render: ({ serviceName }: { serviceName: string }) => {
+        const isExpanded = Boolean(itemIdToExpandedRowMap[serviceName]);
+        const toggleLabel = isExpanded
+          ? i18n.translate('xpack.apm.storageExplorer.table.collapse', {
+              defaultMessage: 'Collapse',
+            })
+          : i18n.translate('xpack.apm.storageExplorer.table.expand', {
+              defaultMessage: 'Expand',
+            });
+
         return (
-          <EuiButtonIcon
-            data-test-subj={`storageDetailsButton_${serviceName}`}
-            onClick={() => toggleRowDetails(serviceName)}
-            aria-label={
-              itemIdToExpandedRowMap[serviceName]
-                ? i18n.translate('xpack.apm.storageExplorer.table.collapse', {
-                    defaultMessage: 'Collapse',
-                  })
-                : i18n.translate('xpack.apm.storageExplorer.table.expand', {
-                    defaultMessage: 'Expand',
-                  })
-            }
-            iconType={itemIdToExpandedRowMap[serviceName] ? 'chevronSingleUp' : 'chevronSingleDown'}
-          />
+          <EuiToolTip content={toggleLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              data-test-subj={`storageDetailsButton_${serviceName}`}
+              onClick={() => toggleRowDetails(serviceName)}
+              aria-label={toggleLabel}
+              iconType={isExpanded ? 'chevronSingleUp' : 'chevronSingleDown'}
+            />
+          </EuiToolTip>
         );
       },
     },

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/duration_distribution_chart_with_scrubber/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/duration_distribution_chart_with_scrubber/index.tsx
@@ -133,7 +133,7 @@ export function DurationDistributionChartWithScrubber({
             ) : (
               <>
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="info" title={emptySelectionText} size="s" />
+                  <EuiIcon type="info" size="s" aria-hidden={true} />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText size="xs">{emptySelectionText}</EuiText>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -8,9 +8,9 @@
 import { i18n } from '@kbn/i18n';
 import {
   EuiBasicTable,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonIcon,
   RIGHT_ALIGNMENT,
   type EuiBasicTableColumn,
 } from '@elastic/eui';
@@ -133,6 +133,7 @@ function ActionsCell<T extends object>({
       actions={resolvedActions}
       dataTestSubjPrefix="apmManagedTableActionsMenu"
       button={
+        // eslint-disable-next-line @elastic/eui/tooltip-button-icon-wrap -- ActionsContextMenu uses React.cloneElement to inject onClick on the button; wrapping with EuiToolTip would put onClick on the tooltip wrapper and break the popover trigger
         <EuiButtonIcon
           data-test-subj="apmManagedTableActionsCellButton"
           aria-label={i18n.translate('xpack.apm.managedTable.actionsAriaLabel', {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -133,7 +133,6 @@ function ActionsCell<T extends object>({
       actions={resolvedActions}
       dataTestSubjPrefix="apmManagedTableActionsMenu"
       button={
-        // eslint-disable-next-line @elastic/eui/tooltip-button-icon-wrap -- ActionsContextMenu uses React.cloneElement to inject onClick on the button; wrapping with EuiToolTip would put onClick on the tooltip wrapper and break the popover trigger
         <EuiButtonIcon
           data-test-subj="apmManagedTableActionsCellButton"
           aria-label={i18n.translate('xpack.apm.managedTable.actionsAriaLabel', {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/popover_tooltip/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/popover_tooltip/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
@@ -34,18 +34,20 @@ export function PopoverTooltip({
         })
       }
       button={
-        <EuiButtonIcon
-          data-test-subj="apmPopoverTooltipButton"
-          aria-label={ariaLabel}
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            setIsPopoverOpen(!isPopoverOpen);
-            event.stopPropagation();
-          }}
-          size="xs"
-          color="primary"
-          iconType={iconType}
-          style={{ height: 'auto' }}
-        />
+        <EuiToolTip content={ariaLabel} disableScreenReaderOutput>
+          <EuiButtonIcon
+            data-test-subj="apmPopoverTooltipButton"
+            aria-label={ariaLabel}
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              setIsPopoverOpen(!isPopoverOpen);
+              event.stopPropagation();
+            }}
+            size="xs"
+            color="primary"
+            iconType={iconType}
+            style={{ height: 'auto' }}
+          />
+        </EuiToolTip>
       }
     >
       {children}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
@@ -7,9 +7,10 @@
 
 import {
   EuiButtonIcon,
-  EuiSkeletonText,
   EuiPopover,
   EuiPopoverTitle,
+  EuiSkeletonText,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import React from 'react';
@@ -47,17 +48,19 @@ export function IconPopover({
       anchorPosition="downCenter"
       ownFocus={false}
       button={
-        <EuiButtonIcon
-          display="base"
-          color="text"
-          onClick={onClick}
-          iconType={icon.type}
-          aria-label={title}
-          iconSize={icon.size ?? 'l'}
-          className="serviceIcon_button"
-          data-test-subj={`popover_${title}`}
-          size="m"
-        />
+        <EuiToolTip content={title} disableScreenReaderOutput>
+          <EuiButtonIcon
+            display="base"
+            color="text"
+            onClick={onClick}
+            iconType={icon.type}
+            aria-label={title}
+            iconSize={icon.size ?? 'l'}
+            className="serviceIcon_button"
+            data-test-subj={`popover_${title}`}
+            size="m"
+          />
+        </EuiToolTip>
       }
       isOpen={isOpen}
       closePopover={onClose}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/span_links/span_links_table.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/span_links/span_links_table.tsx
@@ -17,6 +17,7 @@ import {
   EuiLink,
   EuiPopover,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
@@ -178,16 +179,23 @@ export function SpanLinksTable({ items }: Props) {
               defaultMessage: 'Actions',
             })}
             button={
-              <EuiButtonIcon
-                data-test-subj="apmColumnsButton"
-                aria-label={i18n.translate('xpack.apm.spanLinks.table.actions.edit.ariaLabel', {
+              <EuiToolTip
+                content={i18n.translate('xpack.apm.spanLinks.table.actions.edit.ariaLabel', {
                   defaultMessage: 'Edit',
                 })}
-                iconType="boxesVertical"
-                onClick={() => {
-                  setIdActionMenuOpen(id);
-                }}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  data-test-subj="apmColumnsButton"
+                  aria-label={i18n.translate('xpack.apm.spanLinks.table.actions.edit.ariaLabel', {
+                    defaultMessage: 'Edit',
+                  })}
+                  iconType="boxesVertical"
+                  onClick={() => {
+                    setIdActionMenuOpen(id);
+                  }}
+                />
+              </EuiToolTip>
             }
             isOpen={idActionMenuOpen === id}
             closePopover={() => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/waterfall_accordion_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/waterfall_accordion_button.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiButtonIcon, useEuiTheme } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 
@@ -19,18 +19,8 @@ export function WaterfallAccordionButton({ isOpen, onClick }: WaterfallAccordion
   const { euiTheme } = useEuiTheme();
 
   return (
-    <EuiButtonIcon
-      size="m"
-      onClick={onClick}
-      iconType={isOpen ? 'fold' : 'unfold'}
-      data-test-subj="traceWaterfallAccordionButton"
-      css={css`
-        position: absolute;
-        z-index: ${euiTheme.levels.menu};
-        padding: ${euiTheme.size.m};
-        width: auto;
-      `}
-      aria-label={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
+    <EuiToolTip
+      content={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
         defaultMessage: 'Click to {isAccordionOpen} the waterfall',
         values: {
           isAccordionOpen: isOpen
@@ -42,6 +32,32 @@ export function WaterfallAccordionButton({ isOpen, onClick }: WaterfallAccordion
               }),
         },
       })}
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        size="m"
+        onClick={onClick}
+        iconType={isOpen ? 'fold' : 'unfold'}
+        data-test-subj="traceWaterfallAccordionButton"
+        css={css`
+          position: absolute;
+          z-index: ${euiTheme.levels.menu};
+          padding: ${euiTheme.size.m};
+          width: auto;
+        `}
+        aria-label={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
+          defaultMessage: 'Click to {isAccordionOpen} the waterfall',
+          values: {
+            isAccordionOpen: isOpen
+              ? i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.fold', {
+                  defaultMessage: 'fold',
+                })
+              : i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.unfold', {
+                  defaultMessage: 'unfold',
+                }),
+          },
+        })}
+      />
+    </EuiToolTip>
   );
 }

--- a/x-pack/solutions/observability/plugins/apm/public/tutorial/config_agent/opentelemetry_instructions.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/tutorial/config_agent/opentelemetry_instructions.tsx
@@ -10,10 +10,11 @@ import { i18n } from '@kbn/i18n';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import {
   EuiBasicTable,
+  EuiButtonIcon,
   EuiLink,
   EuiSpacer,
   EuiText,
-  EuiButtonIcon,
+  EuiToolTip,
   copyToClipboard,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -71,18 +72,25 @@ export function OpenTelemetryInstructions({ apmServerUrl, secretToken }: Props) 
             {value}
           </EuiText>
           {value && (
-            <EuiButtonIcon
-              data-test-subj="apmColumnsButton"
-              aria-label={i18n.translate(
-                'xpack.apm.tutorial.config_otel.column.value.copyIconText',
-                {
-                  defaultMessage: 'Copy to clipboard',
-                }
-              )}
-              color="text"
-              iconType="copy"
-              onClick={() => copyToClipboard(value)}
-            />
+            <EuiToolTip
+              content={i18n.translate('xpack.apm.tutorial.config_otel.column.value.copyIconText', {
+                defaultMessage: 'Copy to clipboard',
+              })}
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                data-test-subj="apmColumnsButton"
+                aria-label={i18n.translate(
+                  'xpack.apm.tutorial.config_otel.column.value.copyIconText',
+                  {
+                    defaultMessage: 'Copy to clipboard',
+                  }
+                )}
+                color="text"
+                iconType="copy"
+                onClick={() => copyToClipboard(value)}
+              />
+            </EuiToolTip>
           )}
         </>
       ),


### PR DESCRIPTION
Backport of https://github.com/elastic/kibana/pull/271495 to 9.4. Excludes service_map_legend.tsx since it doesn't exist on 9.4 (was added on main in #270184, not backported).