### PR TITLE
[Alerting] Add rule.mute_alerts operation group to alerting feature privilege schema

### DIFF
--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
@@ -314,6 +314,43 @@ describe(`feature_privilege_builder`, () => {
         `);
       });
 
+      test('grants `mute_alerts` privileges to rules under feature consumer', () => {
+        const actions = new Actions();
+        const alertingFeaturePrivileges = new FeaturePrivilegeAlertingBuilder(actions);
+
+        const privilege: FeatureKibanaPrivileges = {
+          alerting: {
+            rule: {
+              all: [],
+              mute_alerts: [{ ruleTypeId: 'alert-type', consumers: ['my-consumer'] }],
+            },
+          },
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: [],
+        };
+
+        const feature = new KibanaFeature({
+          id: 'my-feature',
+          name: 'my-feature',
+          app: [],
+          category: { id: 'foo', label: 'foo' },
+          privileges: {
+            all: privilege,
+            read: privilege,
+          },
+        });
+
+        expect(alertingFeaturePrivileges.getActions(privilege, feature)).toMatchInlineSnapshot(`
+          Array [
+            "alerting:alert-type/my-consumer/rule/muteAlert",
+            "alerting:alert-type/my-consumer/rule/unmuteAlert",
+          ]
+        `);
+      });
+
       test('grants `all` privileges to rules under feature consumer', () => {
         const actions = new Actions();
         const alertingFeaturePrivileges = new FeaturePrivilegeAlertingBuilder(actions);

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
@@ -61,6 +61,12 @@ const manageRuleSettingsOperations: Record<AlertingEntity, string[]> = {
   alert: [],
 };
 
+// Covers both per-alert snooze/unsnooze and muteAlert/unmuteAlert
+const muteAlertsOperations: Record<AlertingEntity, string[]> = {
+  rule: ['muteAlert', 'unmuteAlert'],
+  alert: [],
+};
+
 const writeOperations: Record<AlertingEntity, string[]> = {
   rule: [
     'create',
@@ -108,6 +114,7 @@ export class FeaturePrivilegeAlertingBuilder extends BaseFeaturePrivilegeBuilder
       const manualRun = get(privilegeDefinition.alerting, `${entity}.manual_run`) ?? [];
       const manageRuleSettings =
         get(privilegeDefinition.alerting, `${entity}.manage_rule_settings`) ?? [];
+      const muteAlerts = get(privilegeDefinition.alerting, `${entity}.mute_alerts`) ?? [];
       const read = get(privilegeDefinition.alerting, `${entity}.read`) ?? [];
 
       return uniq([
@@ -116,6 +123,7 @@ export class FeaturePrivilegeAlertingBuilder extends BaseFeaturePrivilegeBuilder
         ...getAlertingPrivilege(enableOperations[entity], enable, entity),
         ...getAlertingPrivilege(manualRunOperations[entity], manualRun, entity),
         ...getAlertingPrivilege(manageRuleSettingsOperations[entity], manageRuleSettings, entity),
+        ...getAlertingPrivilege(muteAlertsOperations[entity], muteAlerts, entity),
       ]);
     };
 

--- a/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
+++ b/x-pack/platform/plugins/shared/features/common/feature_kibana_privileges.ts
@@ -149,6 +149,12 @@ export interface FeatureKibanaPrivileges {
        * ```
        */
       manage_rule_settings?: AlertingKibanaPrivilege;
+      /**
+       * List of rule types and consumers for which users should have the ability to mute and unmute
+       * per-alert instances when granted this privilege. Per-alert snooze/unsnooze reuses the
+       * muteAlert/unmuteAlert operations internally and is therefore also covered.
+       */
+      mute_alerts?: AlertingKibanaPrivilege;
     };
     alert?: {
       /**

--- a/x-pack/platform/plugins/shared/features/server/feature_schema.ts
+++ b/x-pack/platform/plugins/shared/features/server/feature_schema.ts
@@ -77,6 +77,7 @@ const alertingRuleSchemaSpec = {
   enable: schema.maybe(alertingSchema),
   manual_run: schema.maybe(alertingSchema),
   manage_rule_settings: schema.maybe(alertingSchema),
+  mute_alerts: schema.maybe(alertingSchema),
   read: schema.maybe(alertingSchema),
 };
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/273245

Adds a new `mute_alerts` operation group to the alerting framework's privilege builder. This enables features to grant per-alert mute/unmute (and per-alert snooze, which reuses `muteAlert`/`unmuteAlert` internally) without also granting full `rule.all`.

- Defines `muteAlertsOperations` map emitting `rule/muteAlert` and `rule/unmuteAlert` action strings
- Adds `mute_alerts` to the `FeatureKibanaPrivileges` type under `alerting.rule`
- Adds `mute_alerts` to the feature schema validation (`alertingRuleSchemaSpec`)
- Includes unit test for the new operation group

This is additive — existing `rule.all` grants are unchanged. Framework prerequisite for enabling granular per-alert suppression privileges without requiring full rule write access.

## Test plan

- [ ] Unit test passes: `node scripts/jest x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts`
- [ ] Type check passes: `node scripts/type_check --project x-pack/platform/packages/private/security/authorization_core/tsconfig.json`
- [ ] Feature schema accepts `mute_alerts` in alerting rule privilege definitions


Made with [Cursor](https://cursor.com)