### PR TITLE
Fixes missed monitor_inference priviledge to editor and viewer oblt role

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/oblt/roles.yml
+++ b/src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/oblt/roles.yml
@@ -2,7 +2,7 @@
 # Copy from internal roles config in elasticsearch-controller
 # -----
 viewer:
-  cluster: []
+  cluster: ['monitor_inference']
   indices:
     - names:
         - '/~(([.]|ilm-history-).*)/'
@@ -39,7 +39,7 @@ viewer:
         - '*'
   run_as: []
 editor:
-  cluster: []
+  cluster: ['monitor_inference']
   indices:
     - names:
         - '/~(([.]|ilm-history-).*)/'

--- a/src/platform/packages/shared/kbn-es/src/stateful_resources/roles.yml
+++ b/src/platform/packages/shared/kbn-es/src/stateful_resources/roles.yml
@@ -4,7 +4,7 @@
 # Note: inconsistency between these roles definition and the same roles of serverless project may break FTR deployment-agnostic tests
 # -----
 viewer:
-  cluster: []
+  cluster: ['monitor_inference']
   indices:
     - names:
         - '.alerts*'
@@ -44,7 +44,7 @@ viewer:
   run_as: []
 
 editor:
-  cluster: []
+  cluster: ['monitor_inference']
   indices:
     - names:
         - 'observability-annotations'


### PR DESCRIPTION
## Backport
This will backport the following commits from main to 9.4:

https://github.com/elastic/kibana/pull/272366
### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

