### PR TITLE
[9.4] [Cloud Connect] Treat missing isSaasContainer as ECE (#273067)

### DIFF
--- a/x-pack/platform/plugins/shared/cloud/common/get_is_ece.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/common/get_is_ece.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getIsEce } from './get_is_ece';
+
+describe('getIsEce', () => {
+  it.each([
+    {
+      name: 'defaults to true for cloud-enabled non-serverless deployments',
+      params: {
+        isCloudEnabled: true,
+        isServerlessEnabled: false,
+      },
+      expected: true,
+    },
+    {
+      name: 'returns false when the deployment is explicitly a SaaS container',
+      params: {
+        isCloudEnabled: true,
+        isServerlessEnabled: false,
+        isSaasContainer: true,
+      },
+      expected: false,
+    },
+    {
+      name: 'returns true when the deployment is explicitly not a SaaS container',
+      params: {
+        isCloudEnabled: true,
+        isServerlessEnabled: false,
+        isSaasContainer: false,
+      },
+      expected: true,
+    },
+    {
+      name: 'keeps serverless deployments undefined when isSaasContainer is missing',
+      params: {
+        isCloudEnabled: true,
+        isServerlessEnabled: true,
+      },
+      expected: undefined,
+    },
+    {
+      name: 'keeps self-managed deployments undefined when isSaasContainer is missing',
+      params: {
+        isCloudEnabled: false,
+        isServerlessEnabled: false,
+      },
+      expected: undefined,
+    },
+  ])('$name', ({ params, expected }) => {
+    expect(getIsEce(params)).toBe(expected);
+  });
+});

--- a/x-pack/platform/plugins/shared/cloud/common/get_is_ece.ts
+++ b/x-pack/platform/plugins/shared/cloud/common/get_is_ece.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+interface GetIsEceParams {
+  isCloudEnabled: boolean;
+  isServerlessEnabled: boolean;
+  isSaasContainer?: boolean;
+}
+
+export function getIsEce({
+  isCloudEnabled,
+  isServerlessEnabled,
+  isSaasContainer,
+}: GetIsEceParams): boolean | undefined {
+  if (isSaasContainer != null) {
+    return !isSaasContainer;
+  }
+
+  if (isCloudEnabled && !isServerlessEnabled) {
+    return true;
+  }
+
+  return undefined;
+}

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.test.ts
@@ -58,6 +58,43 @@ describe('Cloud Plugin', () => {
         expect(setup.isCloudEnabled).toBe(true);
       });
 
+      describe('isEce', () => {
+        it('defaults to true for cloud-enabled non-serverless deployments when isSaasContainer is missing', () => {
+          const { setup } = setupPlugin();
+          expect(setup.isEce).toBe(true);
+        });
+
+        it('is false when isSaasContainer is true', () => {
+          const { setup } = setupPlugin({
+            isSaasContainer: true,
+          });
+          expect(setup.isEce).toBe(false);
+        });
+
+        it('is true when isSaasContainer is false', () => {
+          const { setup } = setupPlugin({
+            isSaasContainer: false,
+          });
+          expect(setup.isEce).toBe(true);
+        });
+
+        it('is undefined for self-managed deployments when isSaasContainer is missing', () => {
+          const { setup } = setupPlugin({
+            id: undefined,
+          });
+          expect(setup.isEce).toBeUndefined();
+        });
+
+        it('is undefined for serverless deployments when isSaasContainer is missing', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+            },
+          });
+          expect(setup.isEce).toBeUndefined();
+        });
+      });
+
       it('exposes cloudId', () => {
         const { setup } = setupPlugin();
         expect(setup.cloudId).toBe('cloudId');

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.tsx
@@ -14,6 +14,7 @@ import type { KibanaProductTier, KibanaSolution } from '@kbn/projects-solutions-
 import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal';
 import { registerCloudDeploymentMetadataAnalyticsContext } from '../common/register_cloud_deployment_id_analytics_context';
 import { getIsCloudEnabled } from '../common/is_cloud_enabled';
+import { getIsEce } from '../common/get_is_ece';
 import { parseDeploymentIdFromDeploymentUrl } from '../common/parse_deployment_id_from_deployment_url';
 import { ELASTICSEARCH_CONFIG_ROUTE } from '../common/constants';
 import { decodeCloudId, type DecodedCloudId } from '../common/decode_cloud_id';
@@ -82,6 +83,11 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
     const kibanaUrl = decodedId?.kibanaUrl;
 
     this.cloudUrls.setup(this.config, core, kibanaUrl);
+    const isEce = getIsEce({
+      isCloudEnabled: this.isCloudEnabled,
+      isServerlessEnabled: this.isServerlessEnabled,
+      isSaasContainer: this.config.isSaasContainer,
+    });
 
     return {
       cloudId: id,
@@ -94,7 +100,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       trialEndDate: this.config.trial_end_date ? new Date(this.config.trial_end_date) : undefined,
       isElasticStaffOwned,
       isCloudEnabled: this.isCloudEnabled,
-      isEce: this.config.isSaasContainer != null ? !this.config.isSaasContainer : undefined,
+      isEce,
       onboarding: {
         defaultSolution: parseOnboardingSolution(this.config.onboarding?.default_solution),
       },

--- a/x-pack/platform/plugins/shared/cloud/public/types.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/types.ts
@@ -184,7 +184,8 @@ export interface CloudSetup extends CloudBasicUrls {
   isCloudEnabled: boolean;
   /**
    * `true` when running on ECE (Elastic Cloud Enterprise).
-   * `false` or `undefined` on ESS or self-managed.
+   * When `isSaasContainer` is missing, cloud-enabled non-serverless deployments are assumed to
+   * be ECE. Self-managed and serverless deployments remain `undefined` unless explicitly set.
    */
   isEce?: boolean;
   /**

--- a/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
+++ b/x-pack/platform/plugins/shared/cloud/server/__snapshots__/plugin.test.ts.snap
@@ -15,7 +15,7 @@ Object {
   "elasticsearchUrl": undefined,
   "instanceSizeMb": undefined,
   "isCloudEnabled": true,
-  "isEce": undefined,
+  "isEce": true,
   "isElasticStaffOwned": undefined,
   "isInTrial": [Function],
   "isServerlessEnabled": false,

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.test.ts
@@ -53,6 +53,43 @@ describe('Cloud Plugin', () => {
         expect(setup.isCloudEnabled).toBe(true);
       });
 
+      describe('isEce', () => {
+        it('defaults to true for cloud-enabled non-serverless deployments when isSaasContainer is missing', () => {
+          const { setup } = setupPlugin();
+          expect(setup.isEce).toBe(true);
+        });
+
+        it('is false when isSaasContainer is true', () => {
+          const { setup } = setupPlugin({
+            isSaasContainer: true,
+          });
+          expect(setup.isEce).toBe(false);
+        });
+
+        it('is true when isSaasContainer is false', () => {
+          const { setup } = setupPlugin({
+            isSaasContainer: false,
+          });
+          expect(setup.isEce).toBe(true);
+        });
+
+        it('is undefined for self-managed deployments when isSaasContainer is missing', () => {
+          const { setup } = setupPlugin({
+            id: undefined,
+          });
+          expect(setup.isEce).toBeUndefined();
+        });
+
+        it('is undefined for serverless deployments when isSaasContainer is missing', () => {
+          const { setup } = setupPlugin({
+            serverless: {
+              project_id: 'my-awesome-project',
+            },
+          });
+          expect(setup.isEce).toBeUndefined();
+        });
+      });
+
       it('exposes cloudId', () => {
         const { setup } = setupPlugin();
         expect(setup.cloudId).toBe('cloudId');

--- a/x-pack/platform/plugins/shared/cloud/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/plugin.ts
@@ -20,6 +20,7 @@ import type { CloudConfigType } from './config';
 import { registerCloudDeploymentMetadataAnalyticsContext } from '../common/register_cloud_deployment_id_analytics_context';
 import { registerCloudUsageCollector } from './collectors';
 import { getIsCloudEnabled } from '../common/is_cloud_enabled';
+import { getIsEce } from '../common/get_is_ece';
 import { parseDeploymentIdFromDeploymentUrl } from '../common/parse_deployment_id_from_deployment_url';
 import type { DecodedCloudId } from '../common/decode_cloud_id';
 import { decodeCloudId } from '../common/decode_cloud_id';
@@ -123,7 +124,8 @@ export interface CloudSetup {
   };
   /**
    * `true` when running on ECE (Elastic Cloud Enterprise).
-   * `false` or `undefined` on ESS or self-managed.
+   * When `isSaasContainer` is missing, cloud-enabled non-serverless deployments are assumed to
+   * be ECE. Self-managed and serverless deployments remain `undefined` unless explicitly set.
    */
   isEce?: boolean;
   /**
@@ -224,6 +226,11 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
     const productTier = this.config.serverless?.product_tier;
     const orchestratorTarget = this.config.serverless?.orchestrator_target;
     const isServerlessEnabled = !!projectId;
+    const isEce = getIsEce({
+      isCloudEnabled,
+      isServerlessEnabled,
+      isSaasContainer: this.config.isSaasContainer,
+    });
     const deploymentId = parseDeploymentIdFromDeploymentUrl(this.config.deployment_url);
 
     registerCloudDeploymentMetadataAnalyticsContext(core.analytics, this.config);
@@ -381,7 +388,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       cloudHost: decodedId?.host,
       cloudDefaultPort: decodedId?.defaultPort,
       isCloudEnabled,
-      isEce: this.config.isSaasContainer != null ? !this.config.isSaasContainer : undefined,
+      isEce,
       trialEndDate: this.trialEndDate,
       isElasticStaffOwned: this.config.is_elastic_staff_owned,
       apm: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Cloud Connect] Treat missing isSaasContainer as ECE (#273067)](https://github.com/elastic/kibana/pull/273067)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2026-06-15T11:54:52Z","message":"[Cloud Connect] Treat missing isSaasContainer as ECE (#273067)","sha":"a1c62ec1b615d089adbe20c08695ea8c8efb5d54","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:version","Feature:Cloud Connect","v9.5.0","v9.4.3"],"title":"[Cloud Connect] Treat missing isSaasContainer as ECE","number":273067,"url":"https://github.com/elastic/kibana/pull/273067","mergeCommit":{"message":"[Cloud Connect] Treat missing isSaasContainer as ECE (#273067)","sha":"a1c62ec1b615d089adbe20c08695ea8c8efb5d54"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273067","number":273067,"mergeCommit":{"message":"[Cloud Connect] Treat missing isSaasContainer as ECE (#273067)","sha":"a1c62ec1b615d089adbe20c08695ea8c8efb5d54"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->