### PR TITLE
[Query Streams] Fix query streams references being dropped when updating "ingest"

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/ingest_upsert.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/ingest_upsert.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Streams } from '@kbn/streams-schema';
+import { updateClassicIngest, updateWiredIngest } from './ingest_upsert';
+
+const now = '2026-06-15T12:14:50.416Z';
+const queryStreams = [{ name: 'logs.ecs.android.pixel1qs' }];
+
+const createMockClients = (definition: Streams.ingest.all.Definition) => {
+  const upsertStream = jest.fn().mockResolvedValue({ acknowledged: true, result: 'updated' });
+
+  return {
+    streamsClient: {
+      getStream: jest.fn().mockResolvedValue(definition),
+      upsertStream,
+    },
+    queryClient: {
+      getAssets: jest.fn().mockResolvedValue([]),
+    },
+    attachmentClient: {
+      getAttachments: jest.fn().mockResolvedValue([]),
+    },
+    upsertStream,
+  };
+};
+
+describe('ingest_upsert', () => {
+  it('preserves query_streams when updating wired ingest', async () => {
+    const definition: Streams.WiredStream.Definition = {
+      type: 'wired',
+      name: 'logs.ecs.android',
+      description: '',
+      updated_at: now,
+      query_streams: queryStreams,
+      ingest: {
+        lifecycle: { inherit: {} },
+        processing: { steps: [], updated_at: now },
+        settings: {},
+        wired: {
+          fields: {},
+          routing: [],
+        },
+        failure_store: { inherit: {} },
+      },
+    };
+    const { streamsClient, queryClient, attachmentClient, upsertStream } =
+      createMockClients(definition);
+
+    await updateWiredIngest({
+      streamsClient: streamsClient as never,
+      queryClient: queryClient as never,
+      attachmentClient: attachmentClient as never,
+      name: definition.name,
+      ingest: {
+        ...definition.ingest,
+        processing: { steps: [] },
+      },
+    });
+
+    expect(upsertStream).toHaveBeenCalledWith({
+      name: definition.name,
+      request: expect.objectContaining({
+        stream: expect.objectContaining({
+          query_streams: queryStreams,
+        }),
+      }),
+    });
+  });
+
+  it('preserves query_streams when updating classic ingest', async () => {
+    const definition: Streams.ClassicStream.Definition = {
+      type: 'classic',
+      name: 'logs-classic-android',
+      description: '',
+      updated_at: now,
+      query_streams: queryStreams,
+      ingest: {
+        lifecycle: { inherit: {} },
+        processing: { steps: [], updated_at: now },
+        settings: {},
+        classic: {},
+        failure_store: { inherit: {} },
+      },
+    };
+    const { streamsClient, queryClient, attachmentClient, upsertStream } =
+      createMockClients(definition);
+
+    await updateClassicIngest({
+      streamsClient: streamsClient as never,
+      queryClient: queryClient as never,
+      attachmentClient: attachmentClient as never,
+      name: definition.name,
+      ingest: {
+        ...definition.ingest,
+        processing: { steps: [] },
+      },
+    });
+
+    expect(upsertStream).toHaveBeenCalledWith({
+      name: definition.name,
+      request: expect.objectContaining({
+        stream: expect.objectContaining({
+          query_streams: queryStreams,
+        }),
+      }),
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/ingest_upsert.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/ingest_upsert.ts
@@ -75,7 +75,7 @@ export async function updateWiredIngest({
   const {
     name: _name,
     updated_at: _updatedAt,
-    query_streams: _queryStreams,
+    query_streams: queryStreams,
     ...stream
   } = definition;
 
@@ -84,6 +84,7 @@ export async function updateWiredIngest({
     queries,
     stream: {
       ...stream,
+      ...(queryStreams !== undefined && { query_streams: queryStreams }),
       ...(description !== undefined && { description }),
       ingest,
     },
@@ -126,7 +127,7 @@ export async function updateClassicIngest({
   const {
     name: _name,
     updated_at: _updatedAt,
-    query_streams: _queryStreams,
+    query_streams: queryStreams,
     ...stream
   } = definition;
 
@@ -135,6 +136,7 @@ export async function updateClassicIngest({
     queries,
     stream: {
       ...stream,
+      ...(queryStreams !== undefined && { query_streams: queryStreams }),
       ...(description !== undefined && { description }),
       ingest,
     },


### PR DESCRIPTION
## Summary

Fixes a bug whereby query streams references would be dropped when attempting to update `ingest` on classic and wired streams.

This could be reproduced by:

- Creating a query stream 
- Then going back to the parent (the classic / wired stream with the `query_streams` property) and trying to update it's `ingest` property (a schema update for example)

This would produce an error:

<img width="650" height="495" alt="Screenshot 2026-06-15 at 13 17 40" src="https://github.com/user-attachments/assets/09b784db-49fd-4109-85e7-20aeac9c8223" />

as the original destructuring would remove `query_streams`. This property is still fully validated during the state management cascade.

