### PR TITLE
[Fleet] Deduplicate dataset names in AutoInstallContentPackagesTask

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/data_streams.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/data_streams.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+
+import { dataStreamService } from './data_streams';
+
+describe('DataStreamService', () => {
+  describe('getAllFleetDataStreamNames', () => {
+    it('returns the names of all Fleet data streams', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.transport.request.mockResolvedValue({
+        data_streams: [{ name: 'logs-system.cpu-default' }, { name: 'logs-system.cpu-production' }],
+      });
+
+      const result = await dataStreamService.getAllFleetDataStreamNames(esClient);
+
+      expect(result).toEqual(['logs-system.cpu-default', 'logs-system.cpu-production']);
+    });
+
+    it('calls the data streams API with filter_path=data_streams.name', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.transport.request.mockResolvedValue({ data_streams: [] });
+
+      await dataStreamService.getAllFleetDataStreamNames(esClient);
+
+      expect(esClient.transport.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          querystring: { filter_path: 'data_streams.name' },
+        })
+      );
+    });
+
+    it('returns an empty array when the response contains no data streams', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.transport.request.mockResolvedValue({});
+
+      const result = await dataStreamService.getAllFleetDataStreamNames(esClient);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/data_streams.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/data_streams.ts
@@ -19,6 +19,12 @@ export interface MeteringStats {
   size_in_bytes: number;
 }
 
+export interface DataStreamNamesResponse {
+  data_streams: Array<{
+    name: string;
+  }>;
+}
+
 class DataStreamService {
   public async getAllFleetDataStreams(esClient: ElasticsearchClient) {
     const { data_streams: dataStreamsInfo } = await esClient.indices.getDataStream({
@@ -38,6 +44,15 @@ class DataStreamService {
     });
 
     return res.datastreams ?? [];
+  }
+
+  public async getAllFleetDataStreamNames(esClient: ElasticsearchClient): Promise<string[]> {
+    const res = await esClient.transport.request<DataStreamNamesResponse>({
+      path: `/_data_streams/${DATA_STREAM_INDEX_PATTERN}`,
+      method: 'GET',
+      querystring: { filter_path: 'data_streams.name' },
+    });
+    return (res.data_streams ?? []).map(({ name }) => name);
   }
 
   public async getAllFleetDataStreamsStats(esClient: ElasticsearchClient) {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
@@ -121,16 +121,10 @@ describe('AutoInstallContentPackagesTask', () => {
     beforeEach(async () => {
       const [{ elasticsearch }] = await mockCore.getStartServices();
       esClient = elasticsearch.client.asInternalUser as ElasticsearchClientMock;
-      (dataStreamService.getAllFleetDataStreams as jest.Mock).mockResolvedValue([
-        {
-          name: 'logs-system.cpu-default',
-        } as any,
-        {
-          name: 'logs-system.memory-default',
-        } as any,
-        {
-          name: 'logs-system.test-default',
-        } as any,
+      (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+        'logs-system.cpu-default',
+        'logs-system.memory-default',
+        'logs-system.test-default',
       ]);
       jest
         .spyOn(appContextService, 'getExperimentalFeatures')
@@ -246,7 +240,7 @@ describe('AutoInstallContentPackagesTask', () => {
       await runTask();
 
       expect(packageClientMock.installPackage).not.toHaveBeenCalled();
-      expect(dataStreamService.getAllFleetDataStreams).not.toHaveBeenCalled();
+      expect(dataStreamService.getAllFleetDataStreamNames).not.toHaveBeenCalled();
     });
 
     it('should not downgrade package when a newer prerelease version is installed', async () => {
@@ -298,6 +292,30 @@ describe('AutoInstallContentPackagesTask', () => {
       expect(packageClientMock.installPackage).not.toHaveBeenCalledWith(
         expect.objectContaining({ pkgName: 'kubernetes_otel' })
       );
+    });
+
+    describe('getDatasetsWithData', () => {
+      it('should deduplicate datasets when multiple data streams share the same dataset but have different namespaces', async () => {
+        (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+          'logs-system.cpu-default',
+          'logs-system.cpu-production',
+        ]);
+
+        const result: string[] = await (mockTask as any).getDatasetsWithData(esClient, []);
+
+        expect(result).toEqual(['system.cpu']);
+      });
+
+      it('should deduplicate datasets when multiple data streams share the same dataset but have different types', async () => {
+        (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+          'logs-system.cpu-default',
+          'metrics-system.cpu-default',
+        ]);
+
+        const result: string[] = await (mockTask as any).getDatasetsWithData(esClient, []);
+
+        expect(result).toEqual(['system.cpu']);
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.ts
@@ -292,12 +292,13 @@ export class AutoInstallContentPackagesTask {
     esClient: ElasticsearchClient,
     datasetsOfInstalledContentPackages: string[]
   ): Promise<string[]> {
-    const allFleetDataStreams = await dataStreamService.getAllFleetDataStreams(esClient);
-    const datasetsWithData: string[] = allFleetDataStreams
-      .map((dataStream: any) => dataStream.name.split('-')[1])
-      .filter((dataset) => !datasetsOfInstalledContentPackages.includes(dataset));
+    const installedSet = new Set(datasetsOfInstalledContentPackages);
+    const allDataStreamNames = await dataStreamService.getAllFleetDataStreamNames(esClient);
+    const datasetsWithData = [
+      ...new Set(allDataStreamNames.map((name) => name.split('-')[1])),
+    ].filter((dataset) => !installedSet.has(dataset));
     this.logger.info(
-      `[AutoInstallContentPackagesTask] Found datasets with data: ${datasetsWithData.join(', ')}`
+      `[AutoInstallContentPackagesTask] Found ${datasetsWithData.length} datasets with data`
     );
     return datasetsWithData;
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/273305

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->