### PR TITLE
[Fleet] Fix multiple data stream selectors in input packages with multiple policy templates

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/documentation_page_inputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/documentation_page_inputs.ts
@@ -8,7 +8,7 @@
 import type { PackageInfo, RegistryInput, RegistryStream } from '../types';
 
 import { doesPackageHaveIntegrations } from './packages_with_integrations';
-import { getNormalizedInputs, isIntegrationPolicyTemplate } from './policy_template';
+import { getNormalizedInputs, getPolicyTemplateDataStreamPaths } from './policy_template';
 import {
   buildInputKey,
   getInputEffectiveName,
@@ -42,10 +42,7 @@ export const getDocumentationPageInputs = (
     }
 
     const normalizedInputs = getNormalizedInputs(policyTemplate);
-    const dataStreamPaths =
-      isIntegrationPolicyTemplate(policyTemplate) && policyTemplate.data_streams?.length
-        ? policyTemplate.data_streams
-        : [];
+    const dataStreamPaths = getPolicyTemplateDataStreamPaths(packageInfo, policyTemplate);
 
     normalizedInputs.forEach((input) => {
       const effectiveName = getInputEffectiveName(input);

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -62,6 +62,7 @@ export {
   isIntegrationPolicyTemplate,
   getNormalizedInputs,
   getNormalizedDataStreams,
+  getPolicyTemplateDataStreamPaths,
   filterPolicyTemplatesTiles,
   hasMultipleEnabledPolicyTemplates,
   getPolicyTemplateInputDefinition,

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.test.ts
@@ -7,6 +7,8 @@
 
 import type { NewPackagePolicyInput, PackageInfo, RegistryDataStream } from '../types';
 
+import { DATASET_VAR_NAME } from '../constants';
+
 import {
   packageToPackagePolicy,
   packageToPackagePolicyInputs,
@@ -158,6 +160,72 @@ describe('Fleet - packageToPackagePolicy', () => {
         policy_template: 'nginx',
         enabled: true,
       });
+    });
+
+    it('scopes streams per policy template for input packages with multiple templates sharing an input type', () => {
+      const result = packageToPackagePolicyInputs({
+        ...mockPackage,
+        type: 'input',
+        name: 'aws_cloudwatch',
+        policy_templates: [
+          { name: 'ec2', type: 'metrics', input: 'otelcol', title: 'EC2', description: 'EC2' },
+          { name: 'rds', type: 'metrics', input: 'otelcol', title: 'RDS', description: 'RDS' },
+        ],
+      } as unknown as PackageInfo);
+
+      expect(result).toHaveLength(2);
+
+      // Each template's input must only carry its own data stream, not every template's.
+      // Before the fix every input received one stream per template, duplicating the
+      // data_stream.dataset var once for each policy template in the package.
+      expect(result[0].policy_template).toBe('ec2');
+      expect(result[0].streams).toHaveLength(1);
+      expect(result[0].streams[0].data_stream.dataset).toBe('aws_cloudwatch.ec2');
+      expect(result[0].streams[0].vars?.[DATASET_VAR_NAME]).toBeDefined();
+
+      expect(result[1].policy_template).toBe('rds');
+      expect(result[1].streams).toHaveLength(1);
+      expect(result[1].streams[0].data_stream.dataset).toBe('aws_cloudwatch.rds');
+      expect(result[1].streams[0].vars?.[DATASET_VAR_NAME]).toBeDefined();
+    });
+
+    it('does not leak template-specific vars across input templates sharing an input type', () => {
+      // In input packages each policy template's vars become stream-level vars on its
+      // synthesized data stream, so unscoped stream resolution leaked one template's vars
+      // (not just data_stream.dataset) into the other templates.
+      const result = packageToPackagePolicyInputs({
+        ...mockPackage,
+        type: 'input',
+        name: 'aws_cloudwatch',
+        policy_templates: [
+          {
+            name: 'ec2',
+            type: 'metrics',
+            input: 'otelcol',
+            title: 'EC2',
+            description: 'EC2',
+            vars: [{ name: 'region', type: 'text', title: 'Region' }],
+          },
+          {
+            name: 'lambda',
+            type: 'metrics',
+            input: 'otelcol',
+            title: 'Lambda',
+            description: 'Lambda',
+            vars: [{ name: 'function_name', type: 'text', title: 'Function name' }],
+          },
+        ],
+      } as unknown as PackageInfo);
+
+      expect(result).toHaveLength(2);
+
+      const ec2VarNames = Object.keys(result[0].streams[0].vars ?? {});
+      expect(ec2VarNames).toContain('region');
+      expect(ec2VarNames).not.toContain('function_name');
+
+      const lambdaVarNames = Object.keys(result[1].streams[0].vars ?? {});
+      expect(lambdaVarNames).toContain('function_name');
+      expect(lambdaVarNames).not.toContain('region');
     });
 
     it('does not set name when registry input has no id', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
@@ -25,7 +25,7 @@ import { doesPackageHaveIntegrations } from '.';
 import {
   getNormalizedDataStreams,
   getNormalizedInputs,
-  isIntegrationPolicyTemplate,
+  getPolicyTemplateDataStreamPaths,
 } from './policy_template';
 
 type PackagePolicyStream = RegistryStream & {
@@ -168,13 +168,15 @@ export const packageToPackagePolicyInputs = (
 
   packageInfo.policy_templates?.forEach((packagePolicyTemplate) => {
     const normalizedInputs = getNormalizedInputs(packagePolicyTemplate);
+    // Scope stream resolution to this policy template's own data stream(s). For input packages
+    // with several templates that share the same input type, this prevents each template's input
+    // from picking up every template's stream (which duplicated stream vars like data_stream.dataset).
+    const dataStreamPaths = getPolicyTemplateDataStreamPaths(packageInfo, packagePolicyTemplate);
     normalizedInputs?.forEach((packageInput) => {
       const inputKey = `${packagePolicyTemplate.name}-${getInputEffectiveName(packageInput)}`;
       const input = {
         ...packageInput,
-        ...(isIntegrationPolicyTemplate(packagePolicyTemplate) && packagePolicyTemplate.data_streams
-          ? { data_streams: packagePolicyTemplate.data_streams }
-          : {}),
+        ...(dataStreamPaths.length ? { data_streams: dataStreamPaths } : {}),
         policy_template: packagePolicyTemplate.name,
       };
       packageInputsByPolicyTemplateAndType[inputKey] = input;

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
@@ -23,6 +23,7 @@ import {
   isIntegrationPolicyTemplate,
   getNormalizedInputs,
   getNormalizedDataStreams,
+  getPolicyTemplateDataStreamPaths,
   filterPolicyTemplatesTiles,
   hasMultipleEnabledPolicyTemplates,
   getPolicyTemplateInputDefinition,
@@ -628,6 +629,48 @@ describe('getNormalizedDataStreams', () => {
     // dynamic_signal_types: false / absent — same behaviour
     expect(makePkg('mysqlreceiver', false)[0].dataset).toEqual('nginx.mysqlreceiver');
     expect(makePkg('mysqlreceiver')[0].dataset).toEqual('nginx.mysqlreceiver');
+  });
+});
+
+describe('getPolicyTemplateDataStreamPaths', () => {
+  it('returns the declared data_streams for integration templates', () => {
+    expect(
+      getPolicyTemplateDataStreamPaths({ name: 'nginx' }, {
+        name: 'nginx',
+        data_streams: ['access', 'error'],
+        inputs: [{ type: 'logfile' }],
+      } as any)
+    ).toEqual(['access', 'error']);
+  });
+
+  it('returns an empty array for integration templates without data_streams', () => {
+    expect(
+      getPolicyTemplateDataStreamPaths({ name: 'nginx' }, {
+        name: 'nginx',
+        inputs: [{ type: 'logfile' }],
+      } as any)
+    ).toEqual([]);
+  });
+
+  it('returns the synthesized data stream path for input-only templates', () => {
+    expect(
+      getPolicyTemplateDataStreamPaths({ name: 'aws_cloudwatch' }, {
+        name: 'ec2',
+        input: 'otelcol',
+        title: 'EC2',
+        description: 'EC2',
+      } as any)
+    ).toEqual(['aws_cloudwatch.ec2']);
+  });
+
+  it('scopes each input-only template to its own data stream path', () => {
+    const packageInfo = { name: 'aws_cloudwatch' };
+    expect(
+      getPolicyTemplateDataStreamPaths(packageInfo, { name: 'rds', input: 'otelcol' } as any)
+    ).toEqual(['aws_cloudwatch.rds']);
+    expect(
+      getPolicyTemplateDataStreamPaths(packageInfo, { name: 'sqs', input: 'otelcol' } as any)
+    ).toEqual(['aws_cloudwatch.sqs']);
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
@@ -332,6 +332,25 @@ const createDefaultDatasetName = (
   policyTemplate: { name: string }
 ): string => packageInfo.name + '.' + policyTemplate.name;
 
+/**
+ * Returns the data stream paths that scope stream resolution to a single policy template.
+ *
+ * - Integration templates: the explicit `data_streams` declared on the template (an empty
+ *   list means "all data streams" to the stream resolvers).
+ * - Input-only templates: each template synthesizes exactly one data stream whose `path`
+ *   equals the template's default dataset name (see `getNormalizedDataStreams`). Returning that
+ *   single path prevents templates that share the same input type (e.g. several `otelcol`
+ *   templates in one input package) from each picking up every template's stream, which would
+ *   otherwise duplicate stream-level vars such as `data_stream.dataset`.
+ */
+export const getPolicyTemplateDataStreamPaths = (
+  packageInfo: Pick<PackageInfo | InstallablePackage, 'name'>,
+  policyTemplate: RegistryPolicyTemplate
+): string[] =>
+  isIntegrationPolicyTemplate(policyTemplate)
+    ? policyTemplate.data_streams ?? []
+    : [createDefaultDatasetName(packageInfo, policyTemplate)];
+
 export const hasMultipleEnabledPolicyTemplates = (packagePolicy: NewPackagePolicy): boolean => {
   const enabledPolicyTemplates = new Set(
     packagePolicy?.inputs

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -20,7 +20,8 @@ import { i18n } from '@kbn/i18n';
 
 import {
   getNormalizedInputs,
-  isIntegrationPolicyTemplate,
+  isInputOnlyPolicyTemplate,
+  getPolicyTemplateDataStreamPaths,
   getRegistryStreamWithDataStreamForInputType,
   getInputEffectiveName,
   buildInputKey,
@@ -103,12 +104,19 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
                     (hasIntegrations ? input.policy_template === policyTemplate.name : true)
                 );
 
+                // Scope stream resolution to this policy template's own data stream(s) so that
+                // input packages with multiple templates sharing an input type don't duplicate
+                // each template's streams (and stream vars like data_stream.dataset). Single-template
+                // integration packages keep searching all data streams, preserving previous behavior.
+                const dataStreamPaths =
+                  isInputOnlyPolicyTemplate(policyTemplate) || hasIntegrations
+                    ? getPolicyTemplateDataStreamPaths(packageInfo, policyTemplate)
+                    : [];
+
                 const packageInputStreams = getRegistryStreamWithDataStreamForInputType(
                   registryEffectiveName,
                   packageInfo,
-                  hasIntegrations && isIntegrationPolicyTemplate(policyTemplate)
-                    ? policyTemplate.data_streams
-                    : []
+                  dataStreamPaths
                 );
 
                 if (

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_template_inputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_template_inputs.ts
@@ -11,7 +11,7 @@ import yaml, { type Pair } from 'yaml';
 
 import {
   getNormalizedInputs,
-  isIntegrationPolicyTemplate,
+  getPolicyTemplateDataStreamPaths,
   createYamlKeysSorter,
 } from '../../../../common/services';
 
@@ -311,9 +311,7 @@ function buildIndexedPackage(packageInfo: PackageInfo): PackageWithInputAndStrea
           const streams = getStreamsForInputType(
             inputEffectiveName,
             packageInfo,
-            isIntegrationPolicyTemplate(policyTemplate) && policyTemplate.data_streams
-              ? policyTemplate.data_streams
-              : []
+            getPolicyTemplateDataStreamPaths(packageInfo, policyTemplate)
           ).reduce<
             Record<
               string,


### PR DESCRIPTION
## Summary

Fix data stream selectors in input packages with multiple policy templates.

This fixes a number of issues where variables can be leaked and/or duplicated between different policy templates defined in the same input package, as seen for datasets in https://github.com/elastic/integrations/pull/19468#discussion_r3395971168.

This should not change anything for integration packages or input packages with a single policy template.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk as there are no GA input packages with multiple policy templates yet.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->