### PR TITLE
[Security Solution][Detection Engine] Adding optional refresh query param to exception list item API endpoints

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.gen.ts
@@ -168,6 +168,22 @@ export type CreateExceptionListItemBlocklistMac = z.infer<
   typeof CreateExceptionListItemBlocklistMac
 >;
 
+export const CreateExceptionListItemRequestQuery = lazySchema(() =>
+  z.object({
+    /**
+      * Controls when changes become visible to search operations. `false` (default) means no immediate refresh; `wait_for` waits for the next scheduled refresh cycle.
+
+      */
+    refresh: z.enum(['false', 'wait_for']).optional(),
+  })
+);
+export type CreateExceptionListItemRequestQuery = z.infer<
+  typeof CreateExceptionListItemRequestQuery
+>;
+export type CreateExceptionListItemRequestQueryInput = z.input<
+  typeof CreateExceptionListItemRequestQuery
+>;
+
 export const CreateExceptionListItemRequestBody = lazySchema(() =>
   z.union([
     CreateExceptionListItemGeneric,

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.schema.yaml
@@ -13,6 +13,18 @@ paths:
         Create an exception item and associate it with the specified exception list.
         > info
         > Before creating exception items, you must create an exception list.
+      parameters:
+        - name: refresh
+          in: query
+          required: false
+          description: >
+            Controls when changes become visible to search operations. `false` (default) means no immediate refresh;
+            `wait_for` waits for the next scheduled refresh cycle.
+          schema:
+            type: string
+            enum:
+              - 'false'
+              - wait_for
       requestBody:
         description: Exception list item's properties
         required: true

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list_item/delete_exception_list_item.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list_item/delete_exception_list_item.gen.ts
@@ -38,6 +38,11 @@ export const DeleteExceptionListItemRequestQuery = lazySchema(() =>
 
       */
     namespace_type: ExceptionNamespaceType.optional().default('single'),
+    /**
+      * Controls when changes become visible to search operations. `false` (default) means no immediate refresh; `wait_for` waits for the next scheduled refresh cycle.
+
+      */
+    refresh: z.enum(['false', 'wait_for']).optional(),
   })
 );
 export type DeleteExceptionListItemRequestQuery = z.infer<

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list_item/delete_exception_list_item.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list_item/delete_exception_list_item.schema.yaml
@@ -36,6 +36,17 @@ paths:
               value: single
             agnostic:
               value: agnostic
+        - name: refresh
+          in: query
+          required: false
+          description: >
+            Controls when changes become visible to search operations. `false` (default) means no immediate refresh;
+            `wait_for` waits for the next scheduled refresh cycle.
+          schema:
+            type: string
+            enum:
+              - 'false'
+              - wait_for
       responses:
         200:
           description: Successful response

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/quickstart_client.gen.ts
@@ -21,6 +21,7 @@ import { replaceParams } from '@kbn/openapi-common/shared';
 import { catchAxiosErrorFormatAndThrow } from '@kbn/securitysolution-utils';
 
 import type {
+  CreateExceptionListItemRequestQueryInput,
   CreateExceptionListItemRequestBodyInput,
   CreateExceptionListItemResponse,
 } from './create_exception_list_item/create_exception_list_item.gen';
@@ -75,6 +76,7 @@ import type {
   ReadExceptionListResponse,
 } from './read_exception_list/read_exception_list.gen';
 import type {
+  UpdateExceptionListItemRequestQueryInput,
   UpdateExceptionListItemRequestBodyInput,
   UpdateExceptionListItemResponse,
 } from './update_exception_list_item/update_exception_list_item.gen';
@@ -131,6 +133,7 @@ export class Client {
         },
         method: 'POST',
         body: props.body,
+        query: props.query,
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
@@ -368,6 +371,7 @@ export class Client {
         },
         method: 'PUT',
         body: props.body,
+        query: props.query,
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
@@ -377,6 +381,7 @@ export interface CreateExceptionListProps {
   body: CreateExceptionListRequestBodyInput;
 }
 export interface CreateExceptionListItemProps {
+  query: CreateExceptionListItemRequestQueryInput;
   body: CreateExceptionListItemRequestBodyInput;
 }
 export interface CreateRuleExceptionListItemsProps {
@@ -421,5 +426,6 @@ export interface UpdateExceptionListProps {
   body: UpdateExceptionListRequestBodyInput;
 }
 export interface UpdateExceptionListItemProps {
+  query: UpdateExceptionListItemRequestQueryInput;
   body: UpdateExceptionListItemRequestBodyInput;
 }

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.gen.ts
@@ -181,6 +181,22 @@ export type UpdateExceptionListItemBlocklistMac = z.infer<
   typeof UpdateExceptionListItemBlocklistMac
 >;
 
+export const UpdateExceptionListItemRequestQuery = lazySchema(() =>
+  z.object({
+    /**
+      * Controls when changes become visible to search operations. `false` (default) means no immediate refresh; `wait_for` waits for the next scheduled refresh cycle.
+
+      */
+    refresh: z.enum(['false', 'wait_for']).optional(),
+  })
+);
+export type UpdateExceptionListItemRequestQuery = z.infer<
+  typeof UpdateExceptionListItemRequestQuery
+>;
+export type UpdateExceptionListItemRequestQueryInput = z.input<
+  typeof UpdateExceptionListItemRequestQuery
+>;
+
 export const UpdateExceptionListItemRequestBody = lazySchema(() =>
   z.union([
     UpdateExceptionListItemGeneric,

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.schema.yaml
@@ -10,6 +10,18 @@ paths:
       x-codegen-enabled: true
       summary: Update an exception list item
       description: Update an exception list item using the `id` or `item_id` field.
+      parameters:
+        - name: refresh
+          in: query
+          required: false
+          description: >
+            Controls when changes become visible to search operations. `false` (default) means no immediate refresh;
+            `wait_for` waits for the next scheduled refresh cycle.
+          schema:
+            type: string
+            enum:
+              - 'false'
+              - wait_for
       requestBody:
         description: Exception list item's properties
         required: true

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -1500,6 +1500,18 @@ paths:
           schema:
             $ref: '#/components/schemas/ExceptionNamespaceType'
             default: single
+        - description: >
+            Controls when changes become visible to search operations. `false`
+            (default) means no immediate refresh; `wait_for` waits for the next
+            scheduled refresh cycle.
+          in: query
+          name: refresh
+          required: false
+          schema:
+            enum:
+              - 'false'
+              - wait_for
+            type: string
       responses:
         '200':
           content:
@@ -1760,6 +1772,19 @@ paths:
 
         > Before creating exception items, you must create an exception list.
       operationId: CreateExceptionListItem
+      parameters:
+        - description: >
+            Controls when changes become visible to search operations. `false`
+            (default) means no immediate refresh; `wait_for` waits for the next
+            scheduled refresh cycle.
+          in: query
+          name: refresh
+          required: false
+          schema:
+            enum:
+              - 'false'
+              - wait_for
+            type: string
       requestBody:
         content:
           application/json:
@@ -2058,6 +2083,19 @@ paths:
     put:
       description: Update an exception list item using the `id` or `item_id` field.
       operationId: UpdateExceptionListItem
+      parameters:
+        - description: >
+            Controls when changes become visible to search operations. `false`
+            (default) means no immediate refresh; `wait_for` waits for the next
+            scheduled refresh cycle.
+          in: query
+          name: refresh
+          required: false
+          schema:
+            enum:
+              - 'false'
+              - wait_for
+            type: string
       requestBody:
         content:
           application/json:

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -1500,6 +1500,18 @@ paths:
           schema:
             $ref: '#/components/schemas/ExceptionNamespaceType'
             default: single
+        - description: >
+            Controls when changes become visible to search operations. `false`
+            (default) means no immediate refresh; `wait_for` waits for the next
+            scheduled refresh cycle.
+          in: query
+          name: refresh
+          required: false
+          schema:
+            enum:
+              - 'false'
+              - wait_for
+            type: string
       responses:
         '200':
           content:
@@ -1760,6 +1772,19 @@ paths:
 
         > Before creating exception items, you must create an exception list.
       operationId: CreateExceptionListItem
+      parameters:
+        - description: >
+            Controls when changes become visible to search operations. `false`
+            (default) means no immediate refresh; `wait_for` waits for the next
+            scheduled refresh cycle.
+          in: query
+          name: refresh
+          required: false
+          schema:
+            enum:
+              - 'false'
+              - wait_for
+            type: string
       requestBody:
         content:
           application/json:
@@ -2058,6 +2083,19 @@ paths:
     put:
       description: Update an exception list item using the `id` or `item_id` field.
       operationId: UpdateExceptionListItem
+      parameters:
+        - description: >
+            Controls when changes become visible to search operations. `false`
+            (default) means no immediate refresh; `wait_for` waits for the next
+            scheduled refresh cycle.
+          in: query
+          name: refresh
+          required: false
+          schema:
+            enum:
+              - 'false'
+              - wait_for
+            type: string
       requestBody:
         content:
           application/json:

--- a/x-pack/solutions/security/packages/kbn-securitysolution-io-ts-list-types/src/common/refresh/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-io-ts-list-types/src/common/refresh/index.ts
@@ -13,5 +13,7 @@ export const refreshWithWaitFor = t.union([
   t.literal('false'),
   t.literal('wait_for'),
 ]);
+export const refreshFalseOrWaitFor = t.union([t.literal('false'), t.literal('wait_for')]);
 export type Refresh = t.TypeOf<typeof refresh>;
 export type RefreshWithWaitFor = t.TypeOf<typeof refreshWithWaitFor>;
+export type RefreshFalseOrWaitFor = t.TypeOf<typeof refreshFalseOrWaitFor>;

--- a/x-pack/solutions/security/packages/test-api-clients/supertest/exceptions.gen.ts
+++ b/x-pack/solutions/security/packages/test-api-clients/supertest/exceptions.gen.ts
@@ -24,7 +24,10 @@ import {
 import { replaceParams } from '@kbn/openapi-common/shared';
 
 import type { CreateExceptionListRequestBodyInput } from '@kbn/securitysolution-exceptions-common/api/create_exception_list/create_exception_list.gen';
-import type { CreateExceptionListItemRequestBodyInput } from '@kbn/securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.gen';
+import type {
+  CreateExceptionListItemRequestQueryInput,
+  CreateExceptionListItemRequestBodyInput,
+} from '@kbn/securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.gen';
 import type {
   CreateRuleExceptionListItemsRequestParamsInput,
   CreateRuleExceptionListItemsRequestBodyInput,
@@ -41,7 +44,10 @@ import type { ReadExceptionListRequestQueryInput } from '@kbn/securitysolution-e
 import type { ReadExceptionListItemRequestQueryInput } from '@kbn/securitysolution-exceptions-common/api/read_exception_list_item/read_exception_list_item.gen';
 import type { ReadExceptionListSummaryRequestQueryInput } from '@kbn/securitysolution-exceptions-common/api/read_exception_list_summary/read_exception_list_summary.gen';
 import type { UpdateExceptionListRequestBodyInput } from '@kbn/securitysolution-exceptions-common/api/update_exception_list/update_exception_list.gen';
-import type { UpdateExceptionListItemRequestBodyInput } from '@kbn/securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.gen';
+import type {
+  UpdateExceptionListItemRequestQueryInput,
+  UpdateExceptionListItemRequestBodyInput,
+} from '@kbn/securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.gen';
 
 import type { FtrProviderContext } from '@kbn/ftr-common-functional-services';
 import { getRouteUrlForSpace } from '@kbn/spaces-plugin/common';
@@ -73,7 +79,8 @@ const securitySolutionApiServiceFactory = (supertest: SuperTest.Agent) => ({
       .set('kbn-xsrf', 'true')
       .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
-      .send(props.body as object);
+      .send(props.body as object)
+      .query(props.query);
   },
   /**
    * Create exception items that apply to a single detection rule.
@@ -241,7 +248,8 @@ const securitySolutionApiServiceFactory = (supertest: SuperTest.Agent) => ({
       .set('kbn-xsrf', 'true')
       .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
-      .send(props.body as object);
+      .send(props.body as object)
+      .query(props.query);
   },
 });
 
@@ -265,6 +273,7 @@ export interface CreateExceptionListProps {
   body: CreateExceptionListRequestBodyInput;
 }
 export interface CreateExceptionListItemProps {
+  query: CreateExceptionListItemRequestQueryInput;
   body: CreateExceptionListItemRequestBodyInput;
 }
 export interface CreateRuleExceptionListItemsProps {
@@ -308,5 +317,6 @@ export interface UpdateExceptionListProps {
   body: UpdateExceptionListRequestBodyInput;
 }
 export interface UpdateExceptionListItemProps {
+  query: UpdateExceptionListItemRequestQueryInput;
   body: UpdateExceptionListItemRequestBodyInput;
 }

--- a/x-pack/solutions/security/plugins/lists/server/routes/create_exception_list_item_route.ts
+++ b/x-pack/solutions/security/plugins/lists/server/routes/create_exception_list_item_route.ts
@@ -16,7 +16,7 @@ import {
   CreateExceptionListItemResponse,
 } from '@kbn/securitysolution-exceptions-common/api';
 import { EXCEPTIONS_API_ALL } from '@kbn/security-solution-features/constants';
-import type { OsTypeArray, RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
+import type { OsTypeArray } from '@kbn/securitysolution-io-ts-list-types';
 
 import type { ListsPluginRouter } from '../types';
 
@@ -122,7 +122,7 @@ export const createExceptionListItemRoute = (router: ListsPluginRouter): void =>
             name,
             namespaceType,
             osTypes: osTypesArray,
-            refresh: refresh as RefreshFalseOrWaitFor | undefined,
+            refresh,
             tags: tagsArray,
             type,
           });

--- a/x-pack/solutions/security/plugins/lists/server/routes/create_exception_list_item_route.ts
+++ b/x-pack/solutions/security/plugins/lists/server/routes/create_exception_list_item_route.ts
@@ -12,10 +12,11 @@ import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
 import type { ExceptionListItemEntryArray } from '@kbn/securitysolution-exceptions-common/api';
 import {
   CreateExceptionListItemRequestBody,
+  CreateExceptionListItemRequestQuery,
   CreateExceptionListItemResponse,
 } from '@kbn/securitysolution-exceptions-common/api';
 import { EXCEPTIONS_API_ALL } from '@kbn/security-solution-features/constants';
-import type { OsTypeArray } from '@kbn/securitysolution-io-ts-list-types';
+import type { OsTypeArray, RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 
 import type { ListsPluginRouter } from '../types';
 
@@ -40,6 +41,7 @@ export const createExceptionListItemRoute = (router: ListsPluginRouter): void =>
         validate: {
           request: {
             body: buildRouteValidationWithZod(CreateExceptionListItemRequestBody),
+            query: buildRouteValidationWithZod(CreateExceptionListItemRequestQuery),
           },
         },
         version: '2023-10-31',
@@ -47,6 +49,7 @@ export const createExceptionListItemRoute = (router: ListsPluginRouter): void =>
       async (context, request, response) => {
         const siemResponse = buildSiemResponse(response);
         try {
+          const { refresh } = request.query;
           const {
             namespace_type: namespaceType,
             name,
@@ -119,6 +122,7 @@ export const createExceptionListItemRoute = (router: ListsPluginRouter): void =>
             name,
             namespaceType,
             osTypes: osTypesArray,
+            refresh: refresh as RefreshFalseOrWaitFor | undefined,
             tags: tagsArray,
             type,
           });

--- a/x-pack/solutions/security/plugins/lists/server/routes/delete_exception_list_item_route.ts
+++ b/x-pack/solutions/security/plugins/lists/server/routes/delete_exception_list_item_route.ts
@@ -13,6 +13,7 @@ import {
   DeleteExceptionListItemResponse,
 } from '@kbn/securitysolution-exceptions-common/api';
 import { EXCEPTIONS_API_ALL } from '@kbn/security-solution-features/constants';
+import type { RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 
 import type { ListsPluginRouter } from '../types';
 
@@ -46,7 +47,7 @@ export const deleteExceptionListItemRoute = (router: ListsPluginRouter): void =>
         const siemResponse = buildSiemResponse(response);
         try {
           const exceptionLists = await getExceptionListClient(context);
-          const { item_id: itemId, id, namespace_type: namespaceType } = request.query;
+          const { item_id: itemId, id, namespace_type: namespaceType, refresh } = request.query;
 
           if (itemId == null && id == null) {
             return siemResponse.error({
@@ -59,6 +60,7 @@ export const deleteExceptionListItemRoute = (router: ListsPluginRouter): void =>
             id,
             itemId,
             namespaceType,
+            refresh: refresh as RefreshFalseOrWaitFor | undefined,
           });
 
           if (deleted == null) {

--- a/x-pack/solutions/security/plugins/lists/server/routes/delete_exception_list_item_route.ts
+++ b/x-pack/solutions/security/plugins/lists/server/routes/delete_exception_list_item_route.ts
@@ -13,8 +13,6 @@ import {
   DeleteExceptionListItemResponse,
 } from '@kbn/securitysolution-exceptions-common/api';
 import { EXCEPTIONS_API_ALL } from '@kbn/security-solution-features/constants';
-import type { RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
-
 import type { ListsPluginRouter } from '../types';
 
 import {
@@ -60,7 +58,7 @@ export const deleteExceptionListItemRoute = (router: ListsPluginRouter): void =>
             id,
             itemId,
             namespaceType,
-            refresh: refresh as RefreshFalseOrWaitFor | undefined,
+            refresh,
           });
 
           if (deleted == null) {

--- a/x-pack/solutions/security/plugins/lists/server/routes/update_exception_list_item_route.ts
+++ b/x-pack/solutions/security/plugins/lists/server/routes/update_exception_list_item_route.ts
@@ -14,7 +14,7 @@ import {
   UpdateExceptionListItemRequestQuery,
   UpdateExceptionListItemResponse,
 } from '@kbn/securitysolution-exceptions-common/api';
-import type { OsTypeArray, RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
+import type { OsTypeArray } from '@kbn/securitysolution-io-ts-list-types';
 import { EXCEPTIONS_API_ALL } from '@kbn/security-solution-features/constants';
 
 import type { ListsPluginRouter } from '../types';
@@ -95,7 +95,7 @@ export const updateExceptionListItemRoute = (router: ListsPluginRouter): void =>
             name,
             namespaceType,
             osTypes: osTypesArray,
-            refresh: refresh as RefreshFalseOrWaitFor | undefined,
+            refresh,
             tags: tagsArray,
             type,
           });

--- a/x-pack/solutions/security/plugins/lists/server/routes/update_exception_list_item_route.ts
+++ b/x-pack/solutions/security/plugins/lists/server/routes/update_exception_list_item_route.ts
@@ -11,9 +11,10 @@ import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
 import type { ExceptionListItemEntryArray } from '@kbn/securitysolution-exceptions-common/api';
 import {
   UpdateExceptionListItemRequestBody,
+  UpdateExceptionListItemRequestQuery,
   UpdateExceptionListItemResponse,
 } from '@kbn/securitysolution-exceptions-common/api';
-import type { OsTypeArray } from '@kbn/securitysolution-io-ts-list-types';
+import type { OsTypeArray, RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 import { EXCEPTIONS_API_ALL } from '@kbn/security-solution-features/constants';
 
 import type { ListsPluginRouter } from '../types';
@@ -39,6 +40,7 @@ export const updateExceptionListItemRoute = (router: ListsPluginRouter): void =>
         validate: {
           request: {
             body: buildRouteValidationWithZod(UpdateExceptionListItemRequestBody),
+            query: buildRouteValidationWithZod(UpdateExceptionListItemRequestQuery),
           },
         },
         version: '2023-10-31',
@@ -51,6 +53,7 @@ export const updateExceptionListItemRoute = (router: ListsPluginRouter): void =>
         }
 
         try {
+          const { refresh } = request.query;
           const {
             description,
             id,
@@ -92,6 +95,7 @@ export const updateExceptionListItemRoute = (router: ListsPluginRouter): void =>
             name,
             namespaceType,
             osTypes: osTypesArray,
+            refresh: refresh as RefreshFalseOrWaitFor | undefined,
             tags: tagsArray,
             type,
           });

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/create_exception_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/create_exception_list_item.ts
@@ -23,10 +23,12 @@ import type {
   Tags,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { getSavedObjectType } from '@kbn/securitysolution-list-utils';
+import type { RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 
 import type { ExceptionListSoSchema } from '../../schemas/saved_objects';
 
 import {
+  toSavedObjectRefresh,
   transformCreateCommentsToComments,
   transformSavedObjectToExceptionListItem,
 } from './utils';
@@ -47,6 +49,7 @@ interface CreateExceptionListItemOptions {
   type: ExceptionListItemType;
   osTypes: OsTypeArray;
   expireTime: ExpireTimeOrUndefined;
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 export const createExceptionListItem = async ({
@@ -65,6 +68,7 @@ export const createExceptionListItem = async ({
   tags,
   tieBreaker,
   type,
+  refresh,
 }: CreateExceptionListItemOptions): Promise<ExceptionListItemSchema> => {
   const savedObjectType = getSavedObjectType({ namespaceType });
   const dateNow = new Date().toISOString();
@@ -72,25 +76,29 @@ export const createExceptionListItem = async ({
     incomingComments: comments,
     user,
   });
-  const savedObject = await savedObjectsClient.create<ExceptionListSoSchema>(savedObjectType, {
-    comments: transformedComments,
-    created_at: dateNow,
-    created_by: user,
-    description,
-    entries,
-    expire_time: expireTime,
-    immutable: undefined,
-    item_id: itemId,
-    list_id: listId,
-    list_type: 'item',
-    meta,
-    name,
-    os_types: osTypes as OsTypeArray,
-    tags,
-    tie_breaker_id: tieBreaker ?? uuidv4(),
-    type,
-    updated_by: user,
-    version: undefined,
-  });
+  const savedObject = await savedObjectsClient.create<ExceptionListSoSchema>(
+    savedObjectType,
+    {
+      comments: transformedComments,
+      created_at: dateNow,
+      created_by: user,
+      description,
+      entries,
+      expire_time: expireTime,
+      immutable: undefined,
+      item_id: itemId,
+      list_id: listId,
+      list_type: 'item',
+      meta,
+      name,
+      os_types: osTypes as OsTypeArray,
+      tags,
+      tie_breaker_id: tieBreaker ?? uuidv4(),
+      type,
+      updated_by: user,
+      version: undefined,
+    },
+    { refresh: toSavedObjectRefresh(refresh) }
+  );
   return transformSavedObjectToExceptionListItem({ savedObject });
 };

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/delete_exception_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/delete_exception_list_item.ts
@@ -14,20 +14,24 @@ import type {
   NamespaceType,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { getSavedObjectType } from '@kbn/securitysolution-list-utils';
+import type { RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 
 import { getExceptionListItem } from './get_exception_list_item';
+import { toSavedObjectRefresh } from './utils';
 
 interface DeleteExceptionListItemOptions {
   itemId: ItemIdOrUndefined;
   id: IdOrUndefined;
   namespaceType: NamespaceType;
   savedObjectsClient: SavedObjectsClientContract;
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 interface DeleteExceptionListItemByIdOptions {
   id: Id;
   namespaceType: NamespaceType;
   savedObjectsClient: SavedObjectsClientContract;
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 export const deleteExceptionListItem = async ({
@@ -35,6 +39,7 @@ export const deleteExceptionListItem = async ({
   id,
   namespaceType,
   savedObjectsClient,
+  refresh,
 }: DeleteExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
   const savedObjectType = getSavedObjectType({ namespaceType });
   const exceptionListItem = await getExceptionListItem({
@@ -46,7 +51,9 @@ export const deleteExceptionListItem = async ({
   if (exceptionListItem == null) {
     return null;
   } else {
-    await savedObjectsClient.delete(savedObjectType, exceptionListItem.id);
+    await savedObjectsClient.delete(savedObjectType, exceptionListItem.id, {
+      refresh: toSavedObjectRefresh(refresh),
+    });
     return exceptionListItem;
   }
 };
@@ -55,7 +62,8 @@ export const deleteExceptionListItemById = async ({
   id,
   namespaceType,
   savedObjectsClient,
+  refresh,
 }: DeleteExceptionListItemByIdOptions): Promise<void> => {
   const savedObjectType = getSavedObjectType({ namespaceType });
-  await savedObjectsClient.delete(savedObjectType, id);
+  await savedObjectsClient.delete(savedObjectType, id, { refresh: toSavedObjectRefresh(refresh) });
 };

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -587,6 +587,7 @@ export class ExceptionListClient {
     osTypes,
     tags,
     type,
+    refresh,
   }: CreateExceptionListItemOptions): Promise<ExceptionListItemSchema> => {
     const { savedObjectsClient, user } = this;
     let itemData: CreateExceptionListItemOptions = {
@@ -600,6 +601,7 @@ export class ExceptionListClient {
       name,
       namespaceType,
       osTypes,
+      refresh,
       tags,
       type,
     };
@@ -661,6 +663,7 @@ export class ExceptionListClient {
     osTypes,
     tags,
     type,
+    refresh,
   }: UpdateExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient, user } = this;
     let updatedItem: UpdateExceptionListItemOptions = {
@@ -675,6 +678,7 @@ export class ExceptionListClient {
       name,
       namespaceType,
       osTypes,
+      refresh,
       tags,
       type,
     };
@@ -736,6 +740,7 @@ export class ExceptionListClient {
     osTypes,
     tags,
     type,
+    refresh,
   }: UpdateExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient, user } = this;
     let updatedItem: UpdateExceptionListItemOptions = {
@@ -750,6 +755,7 @@ export class ExceptionListClient {
       name,
       namespaceType,
       osTypes,
+      refresh,
       tags,
       type,
     };
@@ -787,6 +793,7 @@ export class ExceptionListClient {
     id,
     itemId,
     namespaceType,
+    refresh,
   }: DeleteExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
 
@@ -802,6 +809,7 @@ export class ExceptionListClient {
       id,
       itemId,
       namespaceType,
+      refresh,
       savedObjectsClient,
     });
   };
@@ -815,6 +823,7 @@ export class ExceptionListClient {
   public deleteExceptionListItemById = async ({
     id,
     namespaceType,
+    refresh,
   }: DeleteExceptionListItemByIdOptions): Promise<void> => {
     const { savedObjectsClient } = this;
 
@@ -829,6 +838,7 @@ export class ExceptionListClient {
     return deleteExceptionListItemById({
       id,
       namespaceType,
+      refresh,
       savedObjectsClient,
     });
   };

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client_types.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client_types.ts
@@ -47,6 +47,7 @@ import type {
   PerPageOrUndefined,
   PitId,
   PitOrUndefined,
+  RefreshFalseOrWaitFor,
   SearchAfterOrUndefined,
   SearchOrUndefined,
   SortFieldOrUndefined,
@@ -189,6 +190,8 @@ export interface DeleteExceptionListItemOptions {
   itemId: ItemIdOrUndefined;
   /** saved object namespace (single | agnostic) */
   namespaceType: NamespaceType;
+  /** The Elasticsearch Refresh setting for this operation */
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 /**
@@ -200,6 +203,8 @@ export interface DeleteExceptionListItemByIdOptions {
   id: Id;
   /** saved object namespace (single | agnostic) */
   namespaceType: NamespaceType;
+  /** The Elasticsearch Refresh setting for this operation */
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 /**
@@ -278,6 +283,8 @@ export interface CreateExceptionListItemOptions {
   tags: Tags;
   /** container type */
   type: ExceptionListItemType;
+  /** The Elasticsearch Refresh setting for this operation */
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 /**
@@ -349,6 +356,8 @@ export interface UpdateExceptionListItemOptions {
   tags: TagsOrUndefined;
   /** container type */
   type: ExceptionListItemTypeOrUndefined;
+  /** The Elasticsearch Refresh setting for this operation */
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/update_exception_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/update_exception_list_item.ts
@@ -23,10 +23,12 @@ import type {
   _VersionOrUndefined,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { getSavedObjectType } from '@kbn/securitysolution-list-utils';
+import type { RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 
 import type { ExceptionListSoSchema } from '../../schemas/saved_objects';
 
 import {
+  toSavedObjectRefresh,
   transformSavedObjectUpdateToExceptionListItem,
   transformUpdateCommentsToComments,
 } from './utils';
@@ -49,6 +51,7 @@ export interface UpdateExceptionListItemOptions {
   tags: TagsOrUndefined;
   tieBreaker?: string;
   type: ExceptionListItemTypeOrUndefined;
+  refresh?: RefreshFalseOrWaitFor;
 }
 
 export const updateExceptionListItem = async ({
@@ -67,6 +70,7 @@ export const updateExceptionListItem = async ({
   user,
   tags,
   type,
+  refresh,
 }: UpdateExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
   const savedObjectType = getSavedObjectType({ namespaceType });
   const exceptionListItem = await getExceptionListItem({
@@ -99,6 +103,7 @@ export const updateExceptionListItem = async ({
         updated_by: user,
       },
       {
+        refresh: toSavedObjectRefresh(refresh),
         version: _version,
       }
     );

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/update_overwrite_exception_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/update_overwrite_exception_list_item.ts
@@ -11,6 +11,7 @@ import { getSavedObjectType } from '@kbn/securitysolution-list-utils';
 import type { ExceptionListSoSchema } from '../../schemas/saved_objects';
 
 import {
+  toSavedObjectRefresh,
   transformSavedObjectUpdateToExceptionListItem,
   transformUpdateCommentsToComments,
 } from './utils';
@@ -33,6 +34,7 @@ export const updateOverwriteExceptionListItem = async ({
   user,
   tags,
   type,
+  refresh,
 }: UpdateExceptionListItemOptions): Promise<ExceptionListItemSchema | null> => {
   const savedObjectType = getSavedObjectType({ namespaceType });
   const exceptionListItem = await getExceptionListItem({
@@ -74,6 +76,7 @@ export const updateOverwriteExceptionListItem = async ({
       {
         id: id ?? exceptionListItem.id,
         overwrite: true,
+        refresh: toSavedObjectRefresh(refresh),
         version: _version,
       }
     );

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/utils/index.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/utils/index.ts
@@ -7,6 +7,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type {
+  MutatingOperationRefreshSetting,
   SavedObject,
   SavedObjectsFindResponse,
   SavedObjectsUpdateResponse,
@@ -25,12 +26,21 @@ import type {
 } from '@kbn/securitysolution-io-ts-list-types';
 import { exceptionListItemType, exceptionListType } from '@kbn/securitysolution-io-ts-list-types';
 import { getExceptionListType } from '@kbn/securitysolution-list-utils';
+import type { RefreshFalseOrWaitFor } from '@kbn/securitysolution-io-ts-list-types';
 
 import type { ExceptionListSoSchema } from '../../../schemas/saved_objects';
 import type {
   CreateExceptionListItemOptions,
   UpdateExceptionListItemOptions,
 } from '../exception_list_client_types';
+
+export const toSavedObjectRefresh = (
+  refresh: RefreshFalseOrWaitFor | undefined
+): MutatingOperationRefreshSetting | undefined => {
+  if (refresh === undefined) return undefined;
+  if (refresh === 'wait_for') return 'wait_for';
+  return false;
+};
 
 export { validateData } from './validate_data';
 
@@ -307,44 +317,66 @@ export const transformCreateCommentsToComments = ({
 };
 
 export const transformCreateExceptionListItemOptionsToCreateExceptionListItemSchema = ({
+  comments,
+  description,
+  entries,
   expireTime,
-  listId,
   itemId,
+  listId,
+  meta,
+  name,
   namespaceType,
   osTypes,
-  ...rest
+  tags,
+  type,
 }: CreateExceptionListItemOptions): CreateExceptionListItemSchema => {
   return {
-    ...rest,
+    comments,
+    description,
+    entries,
     expire_time: expireTime,
     item_id: itemId,
     list_id: listId,
+    meta,
+    name,
     namespace_type: namespaceType,
     os_types: osTypes,
+    tags,
+    type,
   };
 };
 
 export const transformUpdateExceptionListItemOptionsToUpdateExceptionListItemSchema = ({
+  _version,
+  comments,
+  entries,
+  id,
   itemId,
+  meta,
   namespaceType,
   osTypes,
   expireTime,
+  tags,
   // The `UpdateExceptionListItemOptions` type differs from the schema in that some properties are
   // marked as having `undefined` as a valid value, where the schema, however, requires it.
   // So we assign defaults here
   description = '',
   name = '',
   type = 'simple',
-  ...rest
 }: UpdateExceptionListItemOptions): UpdateExceptionListItemSchema => {
   return {
-    ...rest,
+    _version,
+    comments,
     description,
+    entries,
     expire_time: expireTime,
+    id,
     item_id: itemId,
+    meta,
     name,
     namespace_type: namespaceType,
     os_types: osTypes,
+    tags,
     type,
   };
 };


### PR DESCRIPTION
> Note: this is WIP

### TL;DR
Adds an optional refresh query parameter ('false' | 'wait_for') to the exception list item create, update, and delete HTTP endpoints. This is a prerequisite for the upcoming bulk/batch exception list APIs (#266239), which need refresh: false to avoid the ~1s-per-item wait_for bottleneck that currently makes large-scale IaC (Infrastructure as Code) deployments take hours.

# Summary
Added refresh as an optional query parameter to three public API endpoints:
 - `POST /api/exception_lists/items` (create)
 - `PUT /api/exception_lists/items` (update)
 - `DELETE /api/exception_lists/items` (delete)

Allowing the following values: `false` (no immediate index refresh) and `wait_for` (wait for next index refresh cycle).
> Note: the 'true' is intentionally excluded, since forced refreshes are expensive, and on the specific scenario of the Terraform Provider with 1000+ items it might cause unwanted performance issues.

We are drilling down the `refresh` query param all through the route handler up until the savedObjectClient options, we needed to add some small transform layer in between.

> Note: No behavioral change for existing callers, when refresh is omitted, the SavedObject client uses its default behavior (`wait_for` as defined in [the Core Constants](https://github.com/elastic/kibana/blob/main/src/core/packages/saved-objects/api-server-internal/src/lib/constants.ts))

## Context
Has been evident for customers using the [terraform-provider-elasticstack](https://github.com/elastic/terraform-provider-elasticstack) to manage security solution exception and value lists at scale (1000+ items) experience several minutes up until few hours of plan / apply cycles. 

While running some synthetic benchmarks we confirmed the behavior of our individual exception and value lists endpoints taking _~1000ms per item_, dominated by the implicit refresh: 'wait_for' on each write forcing a 1s ES shard refresh.

## Motivation
This PR makes that possible by exposing refresh as a controllable parameter throughout the exception list item write path, to avoid long waits on single item endpoint calls.

We ideally would want to expose bulk endpoints to allow the TF provider to collapse the creation of items and avoid the sequential the refresh cycle problem entirely.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...