### PR TITLE
Update dependency re2js to v2 (main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1498,7 +1498,7 @@
     "puppeteer": "25.1.0",
     "query-string": "6.13.2",
     "rbush": "4.0.1",
-    "re2js": "0.4.3",
+    "re2js": "2.8.3",
     "react": "18.2.0",
     "react-day-picker": "9.13.2",
     "react-diff-view": "3.3.1",

--- a/renovate.json
+++ b/renovate.json
@@ -2399,7 +2399,7 @@
     {
       "groupName": "re2js",
       "matchDepNames": ["re2js"],
-      "reviewers": ["team:kibana-visualizations", "dej611"],
+      "reviewers": ["team:kibana-visualizations"],
       "matchBaseBranches": ["main"],
       "addLabels": ["Team:Visualizations"],
       "enabled": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -31168,10 +31168,10 @@ re-reselect@^4.0.1:
   resolved "https://registry.yarnpkg.com/re-reselect/-/re-reselect-4.0.1.tgz#21a2306d11bbf377ac78687aa46e1a8848974194"
   integrity sha512-xVTNGQy/dAxOolunBLmVMGZ49VUUR1s8jZUiJQb+g1sI63GAv9+a5Jas9yHvdxeUgiZkU9r3gDExDorxHzOgRA==
 
-re2js@0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/re2js/-/re2js-0.4.3.tgz#1318cd0c12aa6ed3ba56d5e012311ffbfb2aef35"
-  integrity sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==
+re2js@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-2.8.3.tgz#37d185b949b5da4ce7eb00c5c16e620db2f7e5c3"
+  integrity sha512-lUKeXVwMqU302DM/WaOm33XF2hhzjGUZ8CbLg4zSAMpW2PPkJ2+is25AROevNiw+DytFmKU5gsQ92cB1Kxy+fA==
 
 react-clientside-effect@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
This PR contains the following updates and keep just the visualization team as owner of the dependency in renovate.json

| Package | Type | Update | Change |
|---|---|---|---|
| [re2js](https://redirect.github.com/le0pard/re2js) | dependencies | major | [`0.4.3` -> `2.8.3`](https://renovatebot.com/diffs/npm/re2js/0.4.3/2.8.3) |
