### PR TITLE
[Lens as code] replace skipped integration tests with jest todos

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/integrations/charts.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/integrations/charts.test.ts
@@ -68,20 +68,16 @@ describe('Integration panels', () => {
             );
           }
 
-          if (skipped.length > 0) {
-            it.skip.each(skipped.map(({ panel_title: title, attributes }) => [title, attributes]))(
-              'should convert the panel - %s',
-              () => {}
-            );
-          }
+          skipped.forEach(({ panel_title: title }) => {
+            it.todo(`should convert the panel - ${title}`);
+          });
         });
       });
     } else {
       describe(`Type ${chartType}`, () => {
-        it.skip.each(panelsOfType.map(({ panel_title: title, attributes }) => [title, attributes]))(
-          'should convert the panel - %s',
-          () => {}
-        );
+        panelsOfType.forEach(({ panel_title: title }) => {
+          it.todo(`should convert the panel - ${title}`);
+        });
       });
     }
   }


### PR DESCRIPTION
## Summary

To avoid having more then 6k tests appears as skipped, we replaced those with todos tests.

There is no `it.todo.each` in Jest (unlike it.skip.each) so I used a loop instead.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->