### PR TITLE
[SecuritySolution][AIAssistant] Unskip flaky Cypress conversations suite (#237487)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
@@ -117,10 +117,14 @@ describe('AI Assistant Conversations', { tags: ['@ess', '@serverless'] }, () => 
       cy.get(PROMPT_CONTEXT_BUTTON(0)).should('have.text', 'Alert (from summary)');
     });
     it('Shows empty connector callout when a conversation that had a connector no longer does', () => {
+      cy.intercept('PUT', '**/api/security_ai_assistant/current_user/conversations/**').as(
+        'updateConversation'
+      );
       visitGetStartedPage();
       openAssistant();
       selectConversation(mockConvo1.title);
       selectConnector(azureConnectorAPIPayload.name);
+      cy.wait('@updateConversation');
       closeAssistant();
       deleteConnectors();
       openAssistant();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
@@ -80,9 +80,9 @@ describe('AI Assistant Conversations', { tags: ['@ess', '@serverless'] }, () => 
       assertConnectorSelected('My OpenAI Connector');
     });
   });
-  // FLAKY: https://github.com/elastic/kibana/issues/237487
-  describe.skip('When no conversations exist but connectors do exist, show empty convo', () => {
+  describe('When no conversations exist but connectors do exist, show empty convo', () => {
     beforeEach(() => {
+      cy.clearLocalStorage();
       createAzureConnector();
     });
     it('When invoked on AI Assistant click', () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { RULE_MANAGEMENT_CONTEXT_DESCRIPTION } from '@kbn/security-solution-plugin/public/detection_engine/common/translations';
 import { IS_SERVERLESS } from '../../env_var_names_constants';
 import {
   assertConnectorSelected,
@@ -19,7 +18,6 @@ import {
   openAssistant,
   selectConnector,
   selectConversation,
-  selectRule,
   submitMessage,
   typeAndSendMessage,
 } from '../../tasks/assistant';
@@ -33,10 +31,9 @@ import {
 import { expandFirstAlert } from '../../tasks/alerts';
 import { ALERTS_URL } from '../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
-import { visitRulesManagementTable } from '../../tasks/rules_management';
 import { deleteAlertsAndRules, deleteConnectors } from '../../tasks/api_calls/common';
 import { createRule } from '../../tasks/api_calls/rules';
-import { getExistingRule, getNewRule } from '../../objects/rule';
+import { getNewRule } from '../../objects/rule';
 import { login } from '../../tasks/login';
 import {
   CONNECTOR_MISSING_CALLOUT,
@@ -92,18 +89,6 @@ describe('AI Assistant Conversations', { tags: ['@ess', '@serverless'] }, () => 
       selectConnector(azureConnectorAPIPayload.name);
       assertConnectorSelected(azureConnectorAPIPayload.name);
       cy.get(USER_PROMPT).should('not.have.text');
-    });
-    it('When invoked from rules page', () => {
-      createRule(getExistingRule({ rule_id: 'rule1', enabled: true })).then((createdRule) => {
-        visitRulesManagementTable();
-        cy.log('NEW RULE', createdRule);
-        selectRule(createdRule?.body?.id);
-        openAssistant('rule');
-        assertNewConversation(false, `Detection Rules - Rule 1`);
-        selectConnector(azureConnectorAPIPayload.name);
-        assertConnectorSelected(azureConnectorAPIPayload.name);
-        cy.get(PROMPT_CONTEXT_BUTTON(0)).should('have.text', RULE_MANAGEMENT_CONTEXT_DESCRIPTION);
-      });
     });
     it('When invoked from alert details', () => {
       createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/ai_assistant.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/ai_assistant.ts
@@ -10,7 +10,7 @@ export const ADD_QUICK_PROMPT = '[data-test-subj="addQuickPrompt"]';
 export const AI_ASSISTANT_BUTTON = '[data-test-subj="assistantNavLink"]';
 export const ASSISTANT_CHAT_BODY = '[data-test-subj="assistantChat"]';
 export const CHAT_CONTEXT_MENU = '[data-test-subj="chat-context-menu"]';
-export const CHAT_ICON = '[data-test-subj="newChat"]';
+export const CHAT_ICON = '[data-test-subj="plusCircle"]';
 export const CHAT_ICON_SM = '[data-test-subj="newChatByTitle"]';
 export const CLEAR_CHAT = '[data-test-subj="clear-chat"]';
 export const CLEAR_SYSTEM_PROMPT = '[data-test-subj="clearSystemPrompt"]';


### PR DESCRIPTION
# Summary

## What
Unskips the `conversations.cy.ts` Cypress suite (skipped 8 months ago via issue #237487) and fixes the three root causes that made it flaky or broken.

## Why
The suite was skipped due to a flaky "Shows empty connector callout" test. Investigation revealed three independent issues:

1. **Stale selector** — commit `f08c9dcc35f3` (EUI icon deprecation) changed `data-test-subj="newChat"` → `"plusCircle"` on the `NewChat` component, but the test screen file wasn't updated.
2. **Race condition** — `selectConnector()` triggers an optimistic UI update that satisfies `assertConnectorSelected()` before the server-side `PUT /conversations/:id` completes. Calling `closeAssistant()` immediately after navigated away before the connector was persisted, so reopening the assistant didn't show the missing-connector callout.
3. **Deleted feature** — the "When invoked from rules page" test clicks a bulk "Add to chat" button that was intentionally removed from the rules management table toolbar in PR #254009 (commit `a1ded728f2ad`). Because the test was already skipped at the time of removal, cleanup was missed.

Closes #237487

## Changes

- `screens/ai_assistant.ts`: Update `CHAT_ICON` selector from `newChat` → `plusCircle` to match the current `NewChat` component attribute
- `conversations.cy.ts` — "Shows empty connector callout" test: add `cy.intercept('PUT', ...)` + `cy.wait('@updateConversation')` to ensure the conversation is persisted server-side before navigating away
- `conversations.cy.ts` — "When invoked from rules page" test: remove entirely; the feature it tested (bulk "Add to chat" button in the rules table toolbar) was removed in PR #254009

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Identify risks

No significant risks. This PR only changes test code — no production code is modified. Removing the "When invoked from rules page" test mirrors a production change that was already shipped (PR #254009).

### Release note

> No user-facing changes.

**Suggested label:** `release_note:skip`