### PR TITLE
[Alerting v2] Remove alerting:v2:experimentalFeatures advanced setting

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/observability_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/observability_complete.serverless.config.ts
@@ -17,7 +17,6 @@ export const servers: ScoutServerConfig = {
     serverArgs: [
       ...defaultConfig.kbnTestServer.serverArgs,
       '--xpack.alerting_v2.enabled=true',
-      '--uiSettings.overrides.alerting:v2:experimentalFeatures=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/observability_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/observability_complete.serverless.config.ts
@@ -14,9 +14,6 @@ export const servers: ScoutServerConfig = {
   ...defaultConfig,
   kbnTestServer: {
     ...defaultConfig.kbnTestServer,
-    serverArgs: [
-      ...defaultConfig.kbnTestServer.serverArgs,
-      '--xpack.alerting_v2.enabled=true',
-    ],
+    serverArgs: [...defaultConfig.kbnTestServer.serverArgs, '--xpack.alerting_v2.enabled=true'],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/search.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/search.serverless.config.ts
@@ -17,7 +17,6 @@ export const servers: ScoutServerConfig = {
     serverArgs: [
       ...defaultConfig.kbnTestServer.serverArgs,
       '--xpack.alerting_v2.enabled=true',
-      '--uiSettings.overrides.alerting:v2:experimentalFeatures=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/search.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/search.serverless.config.ts
@@ -14,9 +14,6 @@ export const servers: ScoutServerConfig = {
   ...defaultConfig,
   kbnTestServer: {
     ...defaultConfig.kbnTestServer,
-    serverArgs: [
-      ...defaultConfig.kbnTestServer.serverArgs,
-      '--xpack.alerting_v2.enabled=true',
-    ],
+    serverArgs: [...defaultConfig.kbnTestServer.serverArgs, '--xpack.alerting_v2.enabled=true'],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/security_complete.serverless.config.ts
@@ -17,7 +17,6 @@ export const servers: ScoutServerConfig = {
     serverArgs: [
       ...defaultConfig.kbnTestServer.serverArgs,
       '--xpack.alerting_v2.enabled=true',
-      '--uiSettings.overrides.alerting:v2:experimentalFeatures=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/serverless/security_complete.serverless.config.ts
@@ -14,9 +14,6 @@ export const servers: ScoutServerConfig = {
   ...defaultConfig,
   kbnTestServer: {
     ...defaultConfig.kbnTestServer,
-    serverArgs: [
-      ...defaultConfig.kbnTestServer.serverArgs,
-      '--xpack.alerting_v2.enabled=true',
-    ],
+    serverArgs: [...defaultConfig.kbnTestServer.serverArgs, '--xpack.alerting_v2.enabled=true'],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/stateful/classic.stateful.config.ts
@@ -17,7 +17,6 @@ export const servers: ScoutServerConfig = {
     serverArgs: [
       ...defaultConfig.kbnTestServer.serverArgs,
       '--xpack.alerting_v2.enabled=true',
-      '--uiSettings.overrides.alerting:v2:experimentalFeatures=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/alerting_v2/stateful/classic.stateful.config.ts
@@ -14,9 +14,6 @@ export const servers: ScoutServerConfig = {
   ...defaultConfig,
   kbnTestServer: {
     ...defaultConfig.kbnTestServer,
-    serverArgs: [
-      ...defaultConfig.kbnTestServer.serverArgs,
-      '--xpack.alerting_v2.enabled=true',
-    ],
+    serverArgs: [...defaultConfig.kbnTestServer.serverArgs, '--xpack.alerting_v2.enabled=true'],
   },
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/common/advanced_settings.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/advanced_settings.ts
@@ -5,6 +5,4 @@
  * 2.0.
  */
 
-export const ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID = 'alerting:v2:experimentalFeatures';
-
 export const ALERTING_V2_DISPATCHER_ENABLED_SETTING_ID = 'observability:alerting:dispatcherEnabled';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -25,7 +25,6 @@ import {
   ALERTING_V2_EPISODES_APP_ID,
   ALERTING_V2_EXECUTION_HISTORY_APP_ID,
 } from './constants';
-import { ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID } from '../common/advanced_settings';
 import { ActionPoliciesApi } from './services/action_policies_api';
 import { ExecutionHistoryApi } from './services/execution_history_api';
 import { RulesApi } from './services/rules_api';
@@ -68,13 +67,8 @@ export const module = new ContainerModule(({ bind }) => {
         uiActions: diContainer.get(PluginStart('uiActions')) as UiActionsStart,
       });
 
-      const experimentalEnabled = coreStart.settings.globalClient.get<boolean>(
-        ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID,
-        false
-      );
-
       const agentBuilderToken = PluginStart('agentBuilder');
-      if (experimentalEnabled && diContainer.isBound(agentBuilderToken)) {
+      if (diContainer.isBound(agentBuilderToken)) {
         const agentBuilder = diContainer.get(agentBuilderToken) as AgentBuilderPluginStart;
         import(
           /* webpackChunkName: "alerting_v2_rule_attachment" */

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -9,7 +9,6 @@ import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachm
 import { Logger, OnSetup, OnStart, PluginSetup } from '@kbn/core-di';
 import { CoreStart } from '@kbn/core-di-server';
 import type { Container, ContainerModuleLoadOptions } from 'inversify';
-import { ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID } from '../../common/advanced_settings';
 import { createActionPolicyAttachmentType } from '../agent_builder/attachments/action_policy_attachment_type';
 import { createRuleAttachmentType } from '../agent_builder/attachments/rule_attachment_type';
 import { resolveRequestScoped } from '../agent_builder/resolve_request_scoped';
@@ -42,8 +41,7 @@ function getAgentBuilder(container: Container): AgentBuilderSetup | undefined {
  *   layer can schedule their crawler tasks during its own start phase. Gated on
  *   the optional `agentContextLayer` plugin.
  * - Attachment types are bound to {@link AttachmentTypeToken} (deps resolved via
- *   DI) and registered during start, gated on the experimental features advanced
- *   setting. Skills are registered alongside them.
+ *   DI) and registered during start. Skills are registered alongside them.
  *
  * Both resolve request-scoped clients on demand via {@link resolveRequestScoped},
  * since they run outside the HTTP route scope.
@@ -114,39 +112,17 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
       return;
     }
 
-    const logger = container.get(Logger);
-
-    try {
-      const soClient = container.get(CoreStart('savedObjects')).createInternalRepository();
-      const uiSettingsClient = container
-        .get(CoreStart('uiSettings'))
-        .globalAsScopedToClient(soClient);
-      const enabled = await uiSettingsClient.get<boolean>(
-        ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID
-      );
-
-      if (!enabled) {
-        return;
-      }
-
-      for (const attachmentType of container.getAll(AttachmentTypeToken)) {
-        agentBuilder.attachments.registerType(attachmentType);
-      }
-
-      const workflowsManagementApi = container.get(WorkflowsManagementApiToken);
-      registerSkills(agentBuilder, {
-        getWorkflow: (id, sid) => workflowsManagementApi.getWorkflow(id, sid),
-        getAvailableConnectors: (sid, req) =>
-          workflowsManagementApi.getAvailableConnectors(sid, req),
-      });
-
-      logger.info(
-        'Rule management skill and attachments registered (experimental features enabled)'
-      );
-    } catch (err) {
-      logger.warn(
-        `Failed to read alerting V2 experimental features setting; rule management skill not registered: ${err}`
-      );
+    for (const attachmentType of container.getAll(AttachmentTypeToken)) {
+      agentBuilder.attachments.registerType(attachmentType);
     }
+
+    const workflowsManagementApi = container.get(WorkflowsManagementApiToken);
+    registerSkills(agentBuilder, {
+      getWorkflow: (id, sid) => workflowsManagementApi.getWorkflow(id, sid),
+      getAvailableConnectors: (sid, req) =>
+        workflowsManagementApi.getAvailableConnectors(sid, req),
+    });
+
+    container.get(Logger).debug('Rule management skill and attachments registered');
   });
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -119,8 +119,7 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
     const workflowsManagementApi = container.get(WorkflowsManagementApiToken);
     registerSkills(agentBuilder, {
       getWorkflow: (id, sid) => workflowsManagementApi.getWorkflow(id, sid),
-      getAvailableConnectors: (sid, req) =>
-        workflowsManagementApi.getAvailableConnectors(sid, req),
+      getAvailableConnectors: (sid, req) => workflowsManagementApi.getAvailableConnectors(sid, req),
     });
 
     container.get(Logger).debug('Rule management skill and attachments registered');

--- a/x-pack/platform/plugins/shared/alerting_v2/server/ui_settings/advanced_settings.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/ui_settings/advanced_settings.ts
@@ -8,27 +8,9 @@
 import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 import type { UiSettingsParams } from '@kbn/core/types';
-import {
-  ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID,
-  ALERTING_V2_DISPATCHER_ENABLED_SETTING_ID,
-} from '../../common/advanced_settings';
+import { ALERTING_V2_DISPATCHER_ENABLED_SETTING_ID } from '../../common/advanced_settings';
 
 export const alertingV2UiSettings: Record<string, UiSettingsParams> = {
-  [ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID]: {
-    category: ['observability'],
-    name: i18n.translate('xpack.alertingVTwo.experimentalFeaturesSettingName', {
-      defaultMessage: 'Alerting v2: Experimental features',
-    }),
-    type: 'boolean',
-    value: false,
-    description: i18n.translate('xpack.alertingVTwo.experimentalFeaturesSettingDescription', {
-      defaultMessage:
-        'Enables experimental alerting v2 features such as Agent Builder rule management.',
-    }),
-    schema: schema.boolean(),
-    requiresPageReload: false,
-    technicalPreview: true,
-  },
   [ALERTING_V2_DISPATCHER_ENABLED_SETTING_ID]: {
     category: ['observability'],
     name: i18n.translate('xpack.alertingVTwo.dispatcherEnabledSettingName', {


### PR DESCRIPTION
## Summary

Removes the `alerting:v2:experimentalFeatures` advanced setting that was gating the Agent Builder integration (rule management skill, attachment types) behind a UI toggle defaulting to `false`.

This setting prevented the rule management skill and attachment types from registering on Kibana startup, which is incorrect — they should always register when the `agentBuilder` plugin is available, just like every other Agent Builder skill. The setting served no useful purpose since the V2 management apps (Rules, Alerts, Action Policies, Execution History) were already registered unconditionally.

### Changes

- **`common/advanced_settings.ts`** — Removed the `ALERTING_V2_EXPERIMENTAL_FEATURES_SETTING_ID` constant
- **`server/ui_settings/advanced_settings.ts`** — Removed the experimental features setting definition (the dispatcher enabled setting remains)
- **`server/setup/bind_agent_builder.ts`** — Removed the setting gate from the `OnStart` handler; attachment types and skills now register unconditionally when the `agentBuilder` plugin is available
- **`public/index.ts`** — Removed the setting gate; client-side attachment renderers now register whenever the `agentBuilder` plugin is bound in the DI container
- **4 Scout test configs** — Removed the `--uiSettings.overrides.alerting:v2:experimentalFeatures=true` server arg (no longer needed)

## Testing

### Manual verification

1. Start Kibana locally with `alerting_v2` enabled (`--xpack.alerting_v2.enabled=true`)
2. Navigate to the Agents page (Agent Builder)
3. Ask the agent to create a rule via alerting V2 (e.g. "Create an alerting V2 rule that monitors error logs")
4. Confirm that the `rule-management` skill loads and the agent can compose a rule attachment — **without** needing to toggle any advanced setting

### Verify setting removal

1. Navigate to **Stack Management → Advanced Settings**
2. Search for "experimental" in the Observability category
3. Confirm the `Alerting v2: Experimental features` toggle no longer appears
4. Confirm the `Alerting v2 dispatcher` setting still appears and functions correctly

### Regression check

1. Confirm V2 management apps (Rules, Alerts, Action Policies, Execution History) still load under **Stack Management → V2 Alerting Preview**
2. If the `agentBuilder` plugin is not available (e.g. disabled), confirm Kibana starts without errors — the registration is a no-op in that case