### PR TITLE
[Security AI Assistant][8.19] Fix Elastic Managed LLM connector missing from AI Settings connector dropdown

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/search_ai_lake_configurations_settings_management.tsx
@@ -67,6 +67,7 @@ export const SearchAILakeConfigurationsSettingsManagement: React.FC<Props> = Rea
 
     const { data: connectors } = useLoadConnectors({
       http,
+      inferenceEnabled: true,
       settings,
     });
     const defaultConnector = useMemo(


### PR DESCRIPTION
## Summary

Fixes the Elastic Managed LLM connector not appearing in the **Security → Security AI Settings → Connectors** dropdown on 8.19.x deployments.

### Root cause

`useLoadConnectors` filters connectors by `actionTypes`, a module-level array initialised to `['.bedrock', '.gen-ai', '.gemini']`. The `.inference` action type (used by the Elastic Managed LLM preconfigured connector) is only appended to that array when `inferenceEnabled: true` is passed as a prop.

`SearchAILakeConfigurationsSettingsManagement` was calling the hook without that flag, so the connector was silently excluded before even reaching the `isInferenceEndpointExists` check.

The Observability AI Assistant is unaffected because it uses a completely different hook (`useGenAIConnectors`) that has no `actionTypes` gate.

### Fix

Pass `inferenceEnabled: true` to `useLoadConnectors` in the Security AI Settings component — matching what `use_chat_complete.ts` and `evaluation_settings.tsx` already do.

### Verification

Confirmed on a Cloud 8.19.x deployment:
- **Before**: `GET /api/actions/connectors` returns the Elastic Managed LLM connector (`connector_type_id: ".inference"`) but the dropdown is empty
- **After**: connector appears in the Default AI Connector dropdown immediately

## Test plan

- [ ] Deploy to a Cloud 8.19.x environment with EIS enabled (Elastic Managed LLM preconfigured connector present)
- [ ] Navigate to Security → Security AI Settings → Connectors tab
- [ ] Confirm "Elastic Managed LLM" appears in the Default AI Connector dropdown without any workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)