### PR TITLE
[8.19] fix: count temp SLO summary docs in overview no-data tile (#266315)

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/get_slo_stats_overview.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_slo_stats_overview.test.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '@kbn/alerting-plugin/server/rules_client.mock';
+import type { RulesClientApi } from '@kbn/alerting-plugin/server/types';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { Logger } from '@kbn/logging';
+import { alertsClientMock } from '@kbn/rule-registry-plugin/server/alert_data_client/alerts_client.mock';
+import type { AlertsClient } from '@kbn/rule-registry-plugin/server';
+import type { SLOSettings } from '../domain/models';
+import { SO_SLO_SETTINGS_TYPE, sloSettingsObjectId } from '../saved_objects/slo_settings';
+import { GetSLOStatsOverview } from './get_slo_stats_overview';
+
+const SETTINGS: SLOSettings = {
+  useAllRemoteClusters: false,
+  selectedRemoteClusters: [],
+  staleThresholdInHours: 48,
+  staleInstancesCleanupEnabled: false,
+};
+
+const emptyRulesFindResponse = {
+  page: 1,
+  perPage: 0,
+  total: 0,
+  data: [],
+};
+
+const emptyAlertSummary = {
+  activeAlertCount: 0,
+  recoveredAlertCount: 0,
+  activeAlerts: [],
+  recoveredAlerts: [],
+};
+
+describe('GetSLOStatsOverview', () => {
+  let mockSoClient: jest.Mocked<SavedObjectsClientContract>;
+  let mockEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockRulesClient: jest.Mocked<RulesClientApi>;
+  let mockRacClient: ReturnType<typeof alertsClientMock.create>;
+  let mockLogger: jest.Mocked<Logger>;
+
+  beforeEach(() => {
+    mockSoClient = savedObjectsClientMock.create();
+    mockSoClient.getCurrentNamespace.mockReturnValue('default');
+    mockSoClient.get.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError(
+        SO_SLO_SETTINGS_TYPE,
+        sloSettingsObjectId('default')
+      )
+    );
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+    mockRulesClient = rulesClientMock.create();
+    mockRacClient = alertsClientMock.create();
+    mockLogger = loggingSystemMock.create().get() as jest.Mocked<Logger>;
+
+    mockRulesClient.find.mockResolvedValue(emptyRulesFindResponse);
+    mockRacClient.getAlertSummary.mockResolvedValue(emptyAlertSummary);
+  });
+
+  const mockSloSettings = (settings: SLOSettings) => {
+    mockSoClient.get.mockResolvedValue({
+      id: sloSettingsObjectId('default'),
+      type: SO_SLO_SETTINGS_TYPE,
+      attributes: settings,
+      references: [],
+    });
+  };
+
+  const buildService = () =>
+    new GetSLOStatsOverview(
+      mockSoClient,
+      mockEsClient,
+      'default',
+      mockLogger,
+      mockRulesClient,
+      mockRacClient as unknown as AlertsClient
+    );
+
+  const mockSearchResponse = (counts: {
+    stale?: number;
+    not_stale?: {
+      total: number;
+      violated?: number;
+      degrading?: number;
+      healthy?: number;
+      noData?: number;
+    };
+  }) => {
+    mockEsClient.search.mockResolvedValueOnce({
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: { total: { value: 0, relation: 'eq' }, max_score: null, hits: [] },
+      aggregations: {
+        stale: { doc_count: counts.stale ?? 0 },
+        not_stale: {
+          doc_count: counts.not_stale?.total ?? 0,
+          violated: { doc_count: counts.not_stale?.violated ?? 0 },
+          degrading: { doc_count: counts.not_stale?.degrading ?? 0 },
+          healthy: { doc_count: counts.not_stale?.healthy ?? 0 },
+          noData: { doc_count: counts.not_stale?.noData ?? 0 },
+        },
+      },
+    } as never);
+  };
+
+  describe('aggregation shape', () => {
+    it('routes temp docs to not_stale and excludes them from stale', async () => {
+      mockSearchResponse({});
+
+      await buildService().execute({});
+
+      const params = mockEsClient.search.mock.calls[0][0] as {
+        body: { aggs: Record<string, unknown> };
+      };
+
+      // Source of the bug: the "stale" range alone routed temp docs (summaryUpdatedAt: null)
+      // into neither bucket. The fix splits them based on isTempDoc so temp docs always land
+      // in not_stale and never in stale, and the per-status counters always see them.
+      expect(params.body.aggs).toEqual({
+        stale: {
+          filter: {
+            bool: {
+              filter: [{ range: { summaryUpdatedAt: { lt: 'now-48h' } } }],
+              must_not: [{ term: { isTempDoc: true } }],
+            },
+          },
+        },
+        not_stale: {
+          filter: {
+            bool: {
+              should: [
+                { term: { isTempDoc: true } },
+                { range: { summaryUpdatedAt: { gte: 'now-48h' } } },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+          aggs: {
+            violated: { filter: { term: { status: 'VIOLATED' } } },
+            healthy: { filter: { term: { status: 'HEALTHY' } } },
+            degrading: { filter: { term: { status: 'DEGRADING' } } },
+            noData: { filter: { term: { status: 'NO_DATA' } } },
+          },
+        },
+      });
+    });
+
+    it('reflects the configured staleThresholdInHours in both buckets', async () => {
+      mockSloSettings({ ...SETTINGS, staleThresholdInHours: 12 });
+      mockSearchResponse({});
+
+      await buildService().execute({});
+
+      const params = mockEsClient.search.mock.calls[0][0] as {
+        body: {
+          aggs: {
+            stale: { filter: { bool: { filter: unknown[] } } };
+            not_stale: { filter: { bool: { should: unknown[] } } };
+          };
+        };
+      };
+
+      expect(params.body.aggs.stale.filter.bool.filter).toEqual([
+        { range: { summaryUpdatedAt: { lt: 'now-12h' } } },
+      ]);
+      expect(params.body.aggs.not_stale.filter.bool.should).toEqual([
+        { term: { isTempDoc: true } },
+        { range: { summaryUpdatedAt: { gte: 'now-12h' } } },
+      ]);
+    });
+  });
+
+  describe('counter mapping', () => {
+    it('returns the per-status counts from the not_stale sub-aggregations', async () => {
+      mockSearchResponse({
+        stale: 3,
+        not_stale: { total: 10, violated: 1, degrading: 2, healthy: 5, noData: 2 },
+      });
+
+      const result = await buildService().execute({});
+
+      expect(result).toEqual({
+        violated: 1,
+        degrading: 2,
+        healthy: 5,
+        noData: 2,
+        stale: 3,
+        burnRateRules: 0,
+        burnRateActiveAlerts: 0,
+        burnRateRecoveredAlerts: 0,
+      });
+    });
+
+    it('counts a brand-new SLO with only a temp doc as "noData", not lost in the void', async () => {
+      // Regression: a temp doc has summaryUpdatedAt: null and status: NO_DATA.
+      // It must end up in not_stale (via the isTempDoc OR clause) and be picked up
+      // by the noData sub-agg, matching what the per-row badge displays.
+      mockSearchResponse({
+        stale: 0,
+        not_stale: { total: 1, violated: 0, degrading: 0, healthy: 0, noData: 1 },
+      });
+
+      const result = await buildService().execute({});
+
+      expect(result.noData).toBe(1);
+      expect(result.stale).toBe(0);
+    });
+
+    it('forwards burn-rate rule and alert summary counts', async () => {
+      mockSearchResponse({});
+      mockRulesClient.find.mockResolvedValueOnce({ ...emptyRulesFindResponse, total: 4 });
+      mockRacClient.getAlertSummary.mockResolvedValueOnce({
+        ...emptyAlertSummary,
+        activeAlertCount: 7,
+        recoveredAlertCount: 2,
+      });
+
+      const result = await buildService().execute({});
+
+      expect(result.burnRateRules).toBe(4);
+      expect(result.burnRateActiveAlerts).toBe(7);
+      expect(result.burnRateRecoveredAlerts).toBe(2);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_slo_stats_overview.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_slo_stats_overview.test.ts
@@ -23,7 +23,6 @@ const SETTINGS: SLOSettings = {
   useAllRemoteClusters: false,
   selectedRemoteClusters: [],
   staleThresholdInHours: 48,
-  staleInstancesCleanupEnabled: false,
 };
 
 const emptyRulesFindResponse = {
@@ -114,44 +113,34 @@ describe('GetSLOStatsOverview', () => {
 
   describe('aggregation shape', () => {
     it('routes temp docs to not_stale and excludes them from stale', async () => {
+      mockSloSettings(SETTINGS);
       mockSearchResponse({});
 
       await buildService().execute({});
 
       const params = mockEsClient.search.mock.calls[0][0] as {
-        body: { aggs: Record<string, unknown> };
+        body: {
+          aggs: {
+            stale: { filter: { bool: { filter: unknown[]; must_not: unknown[] } } };
+            not_stale: {
+              filter: { bool: { should: unknown[]; minimum_should_match: number } };
+            };
+          };
+        };
       };
 
       // Source of the bug: the "stale" range alone routed temp docs (summaryUpdatedAt: null)
       // into neither bucket. The fix splits them based on isTempDoc so temp docs always land
       // in not_stale and never in stale, and the per-status counters always see them.
-      expect(params.body.aggs).toEqual({
-        stale: {
-          filter: {
-            bool: {
-              filter: [{ range: { summaryUpdatedAt: { lt: 'now-48h' } } }],
-              must_not: [{ term: { isTempDoc: true } }],
-            },
-          },
-        },
-        not_stale: {
-          filter: {
-            bool: {
-              should: [
-                { term: { isTempDoc: true } },
-                { range: { summaryUpdatedAt: { gte: 'now-48h' } } },
-              ],
-              minimum_should_match: 1,
-            },
-          },
-          aggs: {
-            violated: { filter: { term: { status: 'VIOLATED' } } },
-            healthy: { filter: { term: { status: 'HEALTHY' } } },
-            degrading: { filter: { term: { status: 'DEGRADING' } } },
-            noData: { filter: { term: { status: 'NO_DATA' } } },
-          },
-        },
-      });
+      expect(params.body.aggs.stale.filter.bool.filter).toEqual([
+        { range: { summaryUpdatedAt: { lt: 'now-48h' } } },
+      ]);
+      expect(params.body.aggs.stale.filter.bool.must_not).toEqual([{ term: { isTempDoc: true } }]);
+      expect(params.body.aggs.not_stale.filter.bool.should).toEqual([
+        { term: { isTempDoc: true } },
+        { range: { summaryUpdatedAt: { gte: 'now-48h' } } },
+      ]);
+      expect(params.body.aggs.not_stale.filter.bool.minimum_should_match).toBe(1);
     });
 
     it('reflects the configured staleThresholdInHours in both buckets', async () => {

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_slo_stats_overview.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_slo_stats_overview.ts
@@ -52,19 +52,34 @@ export class GetSLOStatsOverview {
         aggs: {
           stale: {
             filter: {
-              range: {
-                summaryUpdatedAt: {
-                  lt: `now-${settings.staleThresholdInHours}h`,
-                },
+              bool: {
+                filter: [
+                  {
+                    range: {
+                      summaryUpdatedAt: {
+                        lt: `now-${settings.staleThresholdInHours}h`,
+                      },
+                    },
+                  },
+                ],
+                must_not: [{ term: { isTempDoc: true } }],
               },
             },
           },
           not_stale: {
             filter: {
-              range: {
-                summaryUpdatedAt: {
-                  gte: `now-${settings.staleThresholdInHours}h`,
-                },
+              bool: {
+                should: [
+                  { term: { isTempDoc: true } },
+                  {
+                    range: {
+                      summaryUpdatedAt: {
+                        gte: `now-${settings.staleThresholdInHours}h`,
+                      },
+                    },
+                  },
+                ],
+                minimum_should_match: 1,
               },
             },
             aggs: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [fix: count temp SLO summary docs in overview no-data tile (#266315)](https://github.com/elastic/kibana/pull/266315)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":266315,"url":"https://github.com/elastic/kibana/pull/266315","title":"fix: count temp SLO summary docs in overview no-data tile"},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"sourceCommit":{"sha":"b002447168f5613b903ef8397f9937dbe53e76c1"}}] BACKPORT-->

### Conflict resolution
The cherry-pick conflicted in `get_slo_stats_overview.ts` because 8.19 still uses the pre-#224870 layout (soClient/esClient, typedSearch, body.aggs, settings.staleThresholdInHours from getSloSettings) while main uses the scoped-cluster-client refactor.

We kept the 8.19 structure and applied only the aggregation semantics from #266315:

- **stale**: `summaryUpdatedAt < now-Nh` **AND NOT** `isTempDoc: true`
- **not_stale**: `isTempDoc: true` **OR** `summaryUpdatedAt >= now-Nh`

The unit test was adapted for the 8.19 API (`savedObjectsClientMock`, `createElasticsearchClient`, `body.aggs` instead of top-level `aggs`).

Made with [Cursor](https://cursor.com)