### PR TITLE
[Cloud Security][Graph] Make graph layout topsort cycle-tolerant

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.test.ts
@@ -418,4 +418,98 @@ describe('layoutGraph', () => {
       expect(entity2!.position.x).toBeGreaterThan(relNode!.position.x);
     });
   });
+
+  describe('cyclic graphs', () => {
+    it('should not throw and should position all nodes for an actor===target self-loop reachable from a sink', () => {
+      // Reproduces the CycleException scenario: an event whose actor and target resolve to the
+      // same entity (self-loop entity <-> label), plus a resolution relationship that introduces
+      // a sink. Traversing predecessors from the sink reaches the self-loop.
+      //
+      //   label <-> user:1049@auditd -> rel(...resolved_to) -> user:...@local (sink)
+      const nodes: Array<Node<NodeViewModel>> = [
+        {
+          id: 'user:1049@auditd',
+          type: 'entity',
+          position: { x: 0, y: 0 },
+          data: {
+            id: 'user:1049@auditd',
+            label: 'chaison_griffin',
+            color: 'primary',
+            shape: 'ellipse',
+            icon: 'user',
+          },
+        },
+        {
+          id: 'label(modified-user-account)',
+          type: 'label',
+          position: { x: 0, y: 0 },
+          data: {
+            id: 'label(modified-user-account)',
+            label: 'modified-user-account',
+            color: 'primary',
+            shape: 'label',
+          },
+        },
+        {
+          id: 'rel(user:1049@auditd-resolution.resolved_to)',
+          type: 'relationship',
+          position: { x: 0, y: 0 },
+          data: {
+            id: 'rel(user:1049@auditd-resolution.resolved_to)',
+            label: 'Resolved to',
+            shape: 'relationship',
+          },
+        },
+        {
+          id: 'user:chaison_griffin@host@local',
+          type: 'entity',
+          position: { x: 0, y: 0 },
+          data: {
+            id: 'user:chaison_griffin@host@local',
+            label: 'chaison_griffin@host',
+            color: 'primary',
+            shape: 'ellipse',
+            icon: 'user',
+          },
+        },
+      ];
+
+      const edges: Array<Edge<EdgeViewModel>> = [
+        // Self-loop: actor and target are the same entity
+        {
+          id: 'user-label',
+          source: 'user:1049@auditd',
+          target: 'label(modified-user-account)',
+        },
+        {
+          id: 'label-user',
+          source: 'label(modified-user-account)',
+          target: 'user:1049@auditd',
+        },
+        // Resolution relationship introduces a sink reachable from the self-loop
+        {
+          id: 'user-rel',
+          source: 'user:1049@auditd',
+          target: 'rel(user:1049@auditd-resolution.resolved_to)',
+        },
+        {
+          id: 'rel-local',
+          source: 'rel(user:1049@auditd-resolution.resolved_to)',
+          target: 'user:chaison_griffin@host@local',
+        },
+      ];
+
+      let result: ReturnType<typeof layoutGraph> | undefined;
+      expect(() => {
+        result = layoutGraph(nodes, edges);
+      }).not.toThrow();
+
+      // Every input node should be present with numeric positions
+      expect(result!.nodes).toHaveLength(nodes.length);
+      result!.nodes.forEach((node) => {
+        expect(typeof node.position.x).toBe('number');
+        expect(typeof node.position.y).toBe('number');
+      });
+    });
+  });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.ts
@@ -454,9 +454,13 @@ const alignNodesCenterInPlace = (
   }
 };
 
+// Cycle-tolerant: a directed cycle (e.g. an event self-loop where actor === target, or a
+// relationship cycle) has no valid topological order, but this ordering only feeds the cosmetic
+// `alignNodesCenterInPlace` pass and Dagre's own `layout()` already breaks cycles before positions
+// are computed. Termination is guaranteed by `visited`; back-edges are simply skipped instead of
+// throwing, so cyclic graphs render rather than failing the whole view.
 const topsort = (g: Dagre.graphlib.Graph, filter: (node: string) => boolean): string[] => {
   const visited: Record<string, boolean> = {};
-  const stack: Record<string, boolean> = {};
   const results: string[] = [];
 
   function visit(node: string): void {
@@ -464,17 +468,13 @@ const topsort = (g: Dagre.graphlib.Graph, filter: (node: string) => boolean): st
       return;
     }
 
-    if (Object.hasOwn(stack, node)) {
-      throw new Error('CycleException');
+    if (Object.hasOwn(visited, node)) {
+      return;
     }
 
-    if (!Object.hasOwn(visited, node)) {
-      stack[node] = true;
-      visited[node] = true;
-      g.predecessors(node)?.forEach((preNode) => visit(preNode.toString()));
-      delete stack[node];
-      results.push(node);
-    }
+    visited[node] = true;
+    g.predecessors(node)?.forEach((preNode) => visit(preNode.toString()));
+    results.push(node);
   }
 
   g.sinks().forEach((node) => visit(node.toString()));


### PR DESCRIPTION


Closes #273195

## Summary
The frontend layout's `topsort` (used by the cosmetic `alignNodesCenterInPlace` pass) threw `CycleException` on any directed cycle, crashing the entire graph view. Cycles legitimately occur — e.g. an event whose actor and target resolve to the same entity (a self-loop), or a relationship cycle. Dagre's own `layout()` already breaks cycles before positions are computed, so the throw only turned a renderable graph into a hard failure.

Skip back-edges instead of throwing; termination is guaranteed by the `visited` set. Adds a layout test reproducing the actor===target self-loop reachable from a resolution sink.



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



