### PR TITLE
[CI] Avoid fixing warnings to align different lint logic implementations

### DIFF
--- a/src/dev/eslint/lint_files.ts
+++ b/src/dev/eslint/lint_files.ts
@@ -23,6 +23,9 @@ export interface LintFilesResult {
   warningCount: number;
 }
 
+// Mirrors ESLint CLI's `--quiet` behavior: only autofix errors, never warnings.
+const errorOnlyFixPredicate = (message: { severity: number }) => message.severity === 2;
+
 /**
  * Lints a list of files with eslint. Reports are written to the log.
  * Returns a result with `failedFiles` populated when errors are found.
@@ -35,7 +38,7 @@ export async function lintFiles(
   const eslint = new ESLint({
     cache: true,
     cwd: REPO_ROOT,
-    fix,
+    fix: fix ? errorOnlyFixPredicate : false,
   });
 
   const paths = files.map((file) => file.getRelativePath());


### PR DESCRIPTION
## Summary
The logic we're using in the `Lint` steps of CI ignore warnings through `--quiet`, whereas the logic described in `lint_files.ts` is also fixing warnings. This creates divergence between the two checks, and forces warning-fixes on developers who are using this local check.

This PR defuses the warning-fixing, making the two implementations behave the same.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->