### PR TITLE
[Security Solution] Fix flyout scroll jump when hover cell actions popover closes

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
@@ -139,7 +139,7 @@ export const HoverActionsPopover: React.FC<Props> = ({
           offset={0}
           // Avoid scrolling scrollable ancestors (e.g. flyout body) when focus moves into the panel;
           // react-focus-on maps this to focusOptions: { preventScroll: true } on react-focus-lock.
-          focusTrapProps={{ preventScrollOnFocus: true }}
+          focusTrapProps={{ preventScrollOnFocus: true, returnFocus: false }}
           panelPaddingSize="none"
           repositionOnScroll
           panelProps={{ 'data-test-subj': 'hoverActionsPopover' }}


### PR DESCRIPTION
## Summary

Fixes a persistent scroll-position jump in the Security alert/document details flyout **Table** tab. After hovering a cell with actions and moving the cursor away, the flyout body would jump to an unrelated scroll position — typically the bottom of the table, where the "Rows per page" pagination button lives.

This is a follow-up to [PR #262682](https://github.com/elastic/kibana/pull/262682), which partially fixed the issue by adding `preventScrollOnFocus: true` to the hover popover's focus trap. That prevented the scroll when focus *entered* the trap (popover open), but did not address the scroll when focus was *returned* (popover close).

## Root cause

`EuiPopover` uses a `react-focus-lock` focus trap (`ownFocus: true` by default). When the trap activates, it records the currently focused element as `originalFocusedElement`. When the trap deactivates, it calls `originalFocusedElement.focus()` to return focus.

The sequence that caused the jump:

1. User clicks **"Rows per page"** → that button gains keyboard focus.
2. User scrolls up through the table. Scrolling does not move focus — the "Rows per page" button at the bottom of the flyout remains the active element.
3. User hovers a cell → hover popover opens → focus trap activates → `originalFocusedElement = "Rows per page" button`.
4. User moves the cursor away → `onMouseLeave` → popover closes → focus trap deactivates → `react-focus-lock` calls `focus()` on the "Rows per page" button.
5. The button is off-screen (below the viewport). The browser scrolls the flyout body to reveal it → **jump to bottom**.

EUI already passes `returnFocus: { preventScroll: true }` to the focus trap, which should call `focus({ preventScroll: true })` on the return element. However, `react-focus-lock` defers this call via `Promise.resolve()` (to let React finish its render cycle first). By the time that microtask runs, the element is off-screen and some browsers still scroll to it despite `preventScroll: true`.

## Fix

Add `returnFocus: false` to `focusTrapProps` on the hover popover in `HoverActionsPopover`.

`EuiPopover` spreads `focusTrapProps` **after** setting its own `returnFocus` on `EuiFocusTrap`, so any `returnFocus` key in `focusTrapProps` overrides EUI's default. Setting it to `false` tells `react-focus-lock` not to return focus to any element when the trap deactivates — no element is focused, no browser scroll is triggered.

This is safe because the hover popover is **always mouse-opened** (via the `onMouseEnter` debounce in `HoverActionsPopover`). There is no keyboard path that opens it, so returning focus on close is never needed. The existing `preventScrollOnFocus: true` (from PR #262682) is kept to continue preventing the scroll when focus enters on open.

```tsx
// src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx

// Before
focusTrapProps={{ preventScrollOnFocus: true }}

// After
focusTrapProps={{ preventScrollOnFocus: true, returnFocus: false }}
```

## Before / After

**Before**

https://github.com/user-attachments/assets/22f1b76c-0c5f-4f12-adca-d8958ade0f6b

**After**

https://github.com/user-attachments/assets/2421dc38-006f-423a-9611-deb95d7394c6

## Affected scope

Any UI that uses `CellActionsMode.HOVER_DOWN` or `HOVER_RIGHT`, including the Security alert flyout **Table** tab.

## Release note

Fixed a scroll-position jump in the Security alert flyout Table tab that occurred when moving the cursor off a cell with hover actions after previously interacting with the "Rows per page" control.

---

🤖 Developed with [Claude Code](https://claude.ai/code) + Claude Sonnet 4.6


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->