### PR TITLE
Declare .css files in ambient declarations

### DIFF
--- a/src/platform/packages/shared/kbn-ambient-ui-types/index.d.ts
+++ b/src/platform/packages/shared/kbn-ambient-ui-types/index.d.ts
@@ -68,3 +68,5 @@ declare module '*?raw' {
   // eslint-disable-next-line import/no-default-export
   export default string;
 }
+
+declare module '*.css' {}


### PR DESCRIPTION
# Summary

## Why this change is needed

### Background: TypeScript's silent treatment of side-effect imports

Before TypeScript 5.6, the compiler applied a double standard to imports. A named
import like `import { something } from './file.css'` would fail with TS2307 if the
module couldn't be resolved, but a side-effect import like `import './file.css'` was
**silently ignored** when unresolvable. The downside was that typos like
`import './sytles.css'` passed unnoticed — TypeScript just discarded the import
without checking.

### TypeScript 5.6: `--noUncheckedSideEffectImports`

TypeScript 5.6 introduced the `--noUncheckedSideEffectImports` compiler option to
close this gap. When enabled, the compiler checks side-effect imports the same way it
checks named imports — if it can't resolve the module to a source file or a type
declaration, it raises **TS2882**: _"Cannot find module or type declarations for
side-effect import of '…'"_.

In 5.6 the option is **opt-in**, giving the ecosystem time to adapt.

### TypeScript 6.0: enforced by default

TypeScript 6.0 made `noUncheckedSideEffectImports` **enabled by default** as a
deliberate breaking change. Every project that upgrades to TS6 — or that uses an IDE
shipping TS6 as its built-in (VS Code now does) — will immediately see TS2882 for any
CSS side-effect import that lacks a type declaration.

TS6 also deprecated `moduleResolution: "node"` (to be removed in TS7), requiring
migration to `"bundler"` or `"node16"`. `moduleResolution: "bundler"` respects
`package.json` `exports` fields, and packages like `@xyflow/react` expose their CSS
files with no `types` entry — another path to TS2882 even without the default change.

### Affected files today

Kibana currently uses TypeScript 5.9.3 with `moduleResolution: "node"`, so
`node scripts/type_check` passes today. However, the following files all contain CSS
side-effect imports that will fail the moment Kibana migrates to TS6:

- `x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx`
- `x-pack/solutions/observability/plugins/apm/public/agent_builder/attachment_types/agent_service_map.tsx`
- `x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/graph_view/index.tsx`
- `x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/job_map/components/job_map_react_flow.tsx`
- `x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx`
- `x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/graph_attachment/graph_flow_canvas.tsx`
- `src/platform/packages/private/kbn-mapbox-gl/index.ts`
- `x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx`
- `x-pack/solutions/security/plugins/session_view/public/components/tty_player/hooks.ts`
- `src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/calendar/calendar_view.tsx`

### The fix

The TypeScript team's own [5.6 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/)
explicitly recommend the empty ambient wildcard declaration as the solution:

```ts
declare module '*.css' {}
```

Adding this to `kbn-ambient-ui-types/index.d.ts` is the right location because that
package is already loaded globally via `"types": ["@kbn/ambient-ui-types"]` in
`tsconfig.base.json`, making it available to every plugin in Kibana without any
per-plugin change.

The empty body is intentional and accurate: CSS files have no exports, so the
declaration correctly describes a module that exists but produces nothing importable.
This follows the same pattern as the existing declarations in that file for `.html`,
`.svg`, `.png`, and other asset types — with the distinction that those types export a
value (a URL string) whereas CSS is imported purely for its bundler side effect of
injecting styles into the DOM.