### PR TITLE
[Core] Move telemetry opt-in status ownership to Core Analytics (server)

### DIFF
--- a/src/core/packages/analytics/server-internal/index.ts
+++ b/src/core/packages/analytics/server-internal/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { AnalyticsService } from './src/analytics_service';
+export type { InternalAnalyticsServiceSetup } from './src/contracts';

--- a/src/core/packages/analytics/server-internal/src/analytics_service.test.ts
+++ b/src/core/packages/analytics/server-internal/src/analytics_service.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { firstValueFrom, Observable } from 'rxjs';
+import { firstValueFrom, Observable, Subject } from 'rxjs';
 import { createTestEnv, createTestPackageInfo } from '@kbn/config-mocks';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
 import { analyticsClientMock } from './analytics_service.test.mocks';
@@ -208,14 +208,57 @@ describe('AnalyticsService', () => {
       reportEvent: expect.any(Function),
       optIn: expect.any(Function),
       telemetryCounter$: expect.any(Observable),
+      registerOptInStatus$: expect.any(Function),
     });
   });
 
-  test('setup should expose only the APIs report and opt-in', () => {
+  test('start should expose reportEvent, opt-in and the opt-in status observable', () => {
     expect(analyticsService.start()).toStrictEqual({
       reportEvent: expect.any(Function),
       optIn: expect.any(Function),
       telemetryCounter$: expect.any(Observable),
+      isOptedIn$: expect.any(Observable),
+    });
+  });
+
+  describe('opt-in status', () => {
+    test('drives the analytics client global consent from the registered observable', () => {
+      const { registerOptInStatus$ } = analyticsService.setup();
+      const isOptedIn$ = new Subject<boolean>();
+      registerOptInStatus$(isOptedIn$);
+
+      isOptedIn$.next(true);
+      expect(analyticsClientMock.optIn).toHaveBeenLastCalledWith({ global: { enabled: true } });
+
+      isOptedIn$.next(false);
+      expect(analyticsClientMock.optIn).toHaveBeenLastCalledWith({ global: { enabled: false } });
+    });
+
+    test('re-exposes the registered opt-in status via start().isOptedIn$', async () => {
+      const { registerOptInStatus$ } = analyticsService.setup();
+      const isOptedIn$ = new Subject<boolean>();
+      registerOptInStatus$(isOptedIn$);
+
+      isOptedIn$.next(true);
+
+      // Late subscribers (e.g. consumers reading at `start`) get the latest known value.
+      await expect(firstValueFrom(analyticsService.start().isOptedIn$)).resolves.toBe(true);
+    });
+
+    test('a second registration replaces the previous source of truth', () => {
+      const { registerOptInStatus$ } = analyticsService.setup();
+      const first$ = new Subject<boolean>();
+      const second$ = new Subject<boolean>();
+
+      registerOptInStatus$(first$);
+      registerOptInStatus$(second$);
+
+      // Emissions from the superseded observable are ignored.
+      first$.next(true);
+      expect(analyticsClientMock.optIn).not.toHaveBeenCalled();
+
+      second$.next(false);
+      expect(analyticsClientMock.optIn).toHaveBeenLastCalledWith({ global: { enabled: false } });
     });
   });
 });

--- a/src/core/packages/analytics/server-internal/src/analytics_service.ts
+++ b/src/core/packages/analytics/server-internal/src/analytics_service.ts
@@ -7,21 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { of } from 'rxjs';
+import { of, ReplaySubject, type Observable, type Subscription } from 'rxjs';
 import apm from 'elastic-apm-node';
 import { trace } from '@opentelemetry/api';
 import type { AnalyticsClient } from '@elastic/ebt/client';
 import { createAnalytics } from '@elastic/ebt/client';
 import { registerPerformanceMetricEventType } from '@kbn/ebt-tools';
 import type { CoreContext } from '@kbn/core-base-server-internal';
-import type {
-  AnalyticsServiceSetup,
-  AnalyticsServiceStart,
-  AnalyticsServicePreboot,
-} from '@kbn/core-analytics-server';
+import type { AnalyticsServiceStart, AnalyticsServicePreboot } from '@kbn/core-analytics-server';
+import type { InternalAnalyticsServiceSetup } from './contracts';
 
 export class AnalyticsService {
   private readonly analyticsClient: AnalyticsClient;
+  /**
+   * Source of truth for the user's global opt-in preference, fed by the registered producer
+   * (the platform-owned telemetry service). Exposed via `isOptedIn$` on the start contract.
+   */
+  private readonly isOptedIn$ = new ReplaySubject<boolean>(1);
+  private optInStatusSubscription?: Subscription;
 
   constructor(core: CoreContext) {
     this.analyticsClient = createAnalytics({
@@ -36,6 +39,21 @@ export class AnalyticsService {
     registerPerformanceMetricEventType(this.analyticsClient);
   }
 
+  /**
+   * Registers the observable that becomes the source of truth for the global opt-in status.
+   * Each emission both feeds the consumer-facing `isOptedIn$` and drives the analytics client's
+   * global consent.
+   * @internal Only meant to be called by the platform-owned telemetry producer.
+   */
+  private registerOptInStatus$ = (isOptedIn$: Observable<boolean>): void => {
+    // A new registration replaces any previous source of truth.
+    this.optInStatusSubscription?.unsubscribe();
+    this.optInStatusSubscription = isOptedIn$.subscribe((isOptedIn) => {
+      this.analyticsClient.optIn({ global: { enabled: isOptedIn } });
+      this.isOptedIn$.next(isOptedIn);
+    });
+  };
+
   public preboot(): AnalyticsServicePreboot {
     return {
       optIn: this.analyticsClient.optIn,
@@ -48,7 +66,7 @@ export class AnalyticsService {
     };
   }
 
-  public setup(): AnalyticsServiceSetup {
+  public setup(): InternalAnalyticsServiceSetup {
     return {
       optIn: this.analyticsClient.optIn,
       registerContextProvider: this.analyticsClient.registerContextProvider,
@@ -57,6 +75,7 @@ export class AnalyticsService {
       registerShipper: this.analyticsClient.registerShipper,
       reportEvent: this.analyticsClient.reportEvent,
       telemetryCounter$: this.analyticsClient.telemetryCounter$,
+      registerOptInStatus$: this.registerOptInStatus$,
     };
   }
 
@@ -65,10 +84,13 @@ export class AnalyticsService {
       optIn: this.analyticsClient.optIn,
       reportEvent: this.analyticsClient.reportEvent,
       telemetryCounter$: this.analyticsClient.telemetryCounter$,
+      isOptedIn$: this.isOptedIn$.asObservable(),
     };
   }
 
   public async stop() {
+    this.optInStatusSubscription?.unsubscribe();
+    this.isOptedIn$.complete();
     await this.analyticsClient.shutdown();
   }
 

--- a/src/core/packages/analytics/server-internal/src/contracts.ts
+++ b/src/core/packages/analytics/server-internal/src/contracts.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Observable } from 'rxjs';
+import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+
+/**
+ * Internal-only extension of the analytics setup contract.
+ *
+ * Exposes the registration of the opt-in status source of truth, which is intentionally kept off
+ * the public {@link AnalyticsServiceSetup} so regular plugins cannot drive the global consent.
+ *
+ * @internal
+ */
+export interface InternalAnalyticsServiceSetup extends AnalyticsServiceSetup {
+  /**
+   * Registers the observable that becomes the source of truth for the global opt-in status.
+   *
+   * The provided observable both feeds the consumer-facing {@link AnalyticsServiceStart.isOptedIn$}
+   * and drives the analytics client's global consent.
+   *
+   * It is expected to emit only once the opt-in status is known (i.e. it should withhold emissions
+   * while the user has not made a decision yet, e.g. after a major/minor upgrade), and to emit again
+   * whenever the preference changes. Registering more than once overrides the previous source of truth.
+   *
+   * @remark Intended to be called by the platform-owned telemetry producer only.
+   * @param isOptedIn$ An observable emitting the global opt-in status.
+   */
+  registerOptInStatus$: (isOptedIn$: Observable<boolean>) => void;
+}

--- a/src/core/packages/analytics/server-mocks/src/analytics_service.mock.ts
+++ b/src/core/packages/analytics/server-mocks/src/analytics_service.mock.ts
@@ -9,12 +9,11 @@
 
 import { Subject } from 'rxjs';
 import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { AnalyticsServiceStart, AnalyticsServicePreboot } from '@kbn/core-analytics-server';
 import type {
-  AnalyticsServiceSetup,
-  AnalyticsServiceStart,
-  AnalyticsServicePreboot,
-} from '@kbn/core-analytics-server';
-import type { AnalyticsService } from '@kbn/core-analytics-server-internal';
+  AnalyticsService,
+  InternalAnalyticsServiceSetup,
+} from '@kbn/core-analytics-server-internal';
 import { lazyObject } from '@kbn/lazy-object';
 
 type AnalyticsServiceContract = PublicMethodsOf<AnalyticsService>;
@@ -31,7 +30,7 @@ const createAnalyticsServicePreboot = (): jest.Mocked<AnalyticsServicePreboot> =
   });
 };
 
-const createAnalyticsServiceSetup = (): jest.Mocked<AnalyticsServiceSetup> => {
+const createAnalyticsServiceSetup = (): jest.Mocked<InternalAnalyticsServiceSetup> => {
   return lazyObject({
     optIn: jest.fn(),
     reportEvent: jest.fn(),
@@ -40,6 +39,7 @@ const createAnalyticsServiceSetup = (): jest.Mocked<AnalyticsServiceSetup> => {
     removeContextProvider: jest.fn(),
     registerShipper: jest.fn(),
     telemetryCounter$: new Subject(),
+    registerOptInStatus$: jest.fn(),
   });
 };
 
@@ -48,6 +48,7 @@ const createAnalyticsServiceStart = (): jest.Mocked<AnalyticsServiceStart> => {
     optIn: jest.fn(),
     reportEvent: jest.fn(),
     telemetryCounter$: new Subject(),
+    isOptedIn$: new Subject(),
   });
 };
 

--- a/src/core/packages/analytics/server/src/contracts.ts
+++ b/src/core/packages/analytics/server/src/contracts.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Observable } from 'rxjs';
 import type { AnalyticsClient } from '@elastic/ebt/client';
 
 /**
@@ -31,4 +32,15 @@ export type AnalyticsServiceSetup = Omit<AnalyticsClient, 'flush' | 'shutdown'>;
 export type AnalyticsServiceStart = Pick<
   AnalyticsClient,
   'optIn' | 'reportEvent' | 'telemetryCounter$'
->;
+> & {
+  /**
+   * An Observable that emits the user's global opt-in preference.
+   *
+   * Pushes `true` when sending usage to Elastic is enabled, and `false` when the user explicitly
+   * opted out. It withholds emissions until the opt-in status is known (e.g. while a previously
+   * opted-out user has not chosen yet after a major/minor upgrade).
+   *
+   * @track-adoption
+   */
+  isOptedIn$: Observable<boolean>;
+};

--- a/src/core/packages/lifecycle/server-internal/moon.yml
+++ b/src/core/packages/lifecycle/server-internal/moon.yml
@@ -19,6 +19,7 @@ project:
 dependsOn:
   - '@kbn/core-logging-server-internal'
   - '@kbn/core-analytics-server'
+  - '@kbn/core-analytics-server-internal'
   - '@kbn/core-preboot-server-internal'
   - '@kbn/core-http-context-server-internal'
   - '@kbn/core-http-server-internal'

--- a/src/core/packages/lifecycle/server-internal/src/internal_core_setup.ts
+++ b/src/core/packages/lifecycle/server-internal/src/internal_core_setup.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+import type { InternalAnalyticsServiceSetup } from '@kbn/core-analytics-server-internal';
 import type { CapabilitiesSetup } from '@kbn/core-capabilities-server';
 import type { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import type { I18nServiceSetup } from '@kbn/core-i18n-server';
@@ -38,7 +38,7 @@ import type { UserStorageServiceSetup } from '@kbn/core-user-storage-server';
 
 /** @internal */
 export interface InternalCoreSetup {
-  analytics: AnalyticsServiceSetup;
+  analytics: InternalAnalyticsServiceSetup;
   capabilities: CapabilitiesSetup;
   context: InternalContextSetup;
   docLinks: DocLinksServiceSetup;

--- a/src/core/packages/lifecycle/server-internal/tsconfig.json
+++ b/src/core/packages/lifecycle/server-internal/tsconfig.json
@@ -13,6 +13,7 @@
   "kbn_references": [
     "@kbn/core-logging-server-internal",
     "@kbn/core-analytics-server",
+    "@kbn/core-analytics-server-internal",
     "@kbn/core-preboot-server-internal",
     "@kbn/core-http-context-server-internal",
     "@kbn/core-http-server-internal",

--- a/src/core/packages/plugins/server-internal/moon.yml
+++ b/src/core/packages/plugins/server-internal/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/utils'
   - '@kbn/core-base-common'
   - '@kbn/core-base-server-internal'
+  - '@kbn/core-analytics-server-internal'
   - '@kbn/core-elasticsearch-server-internal'
   - '@kbn/core-node-server'
   - '@kbn/core-saved-objects-base-server-internal'

--- a/src/core/packages/plugins/server-internal/src/plugin_context.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_context.ts
@@ -20,6 +20,7 @@ import type {
 } from '@kbn/core-http-request-handler-context-server';
 import { CoreRouteHandlerContext } from '@kbn/core-http-request-handler-context-server-internal';
 import type { InternalCoreStart } from '@kbn/core-lifecycle-server-internal';
+import type { InternalAnalyticsServiceSetup } from '@kbn/core-analytics-server-internal';
 import type { PluginWrapper } from './plugin';
 import type {
   PluginsServicePrebootSetupDeps,
@@ -197,6 +198,9 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>({
   const router = deps.http.createRouter('', plugin.opaqueId);
 
   return {
+    // `registerOptInStatus$` is intentionally absent from the public `AnalyticsServiceSetup`, but it
+    // is carried at runtime so the platform-owned telemetry producer can reach it by casting to
+    // `InternalAnalyticsServiceSetup`. The cast keeps the public `CoreSetup.analytics` type clean.
     analytics: {
       optIn: deps.analytics.optIn,
       registerContextProvider: deps.analytics.registerContextProvider,
@@ -205,7 +209,8 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>({
       registerShipper: deps.analytics.registerShipper,
       reportEvent: deps.analytics.reportEvent,
       telemetryCounter$: deps.analytics.telemetryCounter$,
-    },
+      registerOptInStatus$: deps.analytics.registerOptInStatus$,
+    } as InternalAnalyticsServiceSetup,
     capabilities: {
       registerProvider: deps.capabilities.registerProvider,
       registerSwitcher: deps.capabilities.registerSwitcher,
@@ -358,6 +363,7 @@ export function createPluginStartContext<TPlugin, TPluginDependencies>({
       optIn: deps.analytics.optIn,
       reportEvent: deps.analytics.reportEvent,
       telemetryCounter$: deps.analytics.telemetryCounter$,
+      isOptedIn$: deps.analytics.isOptedIn$,
     },
     capabilities: {
       resolveCapabilities: deps.capabilities.resolveCapabilities,

--- a/src/core/packages/plugins/server-internal/tsconfig.json
+++ b/src/core/packages/plugins/server-internal/tsconfig.json
@@ -18,6 +18,7 @@
     "@kbn/utils",
     "@kbn/core-base-common",
     "@kbn/core-base-server-internal",
+    "@kbn/core-analytics-server-internal",
     "@kbn/core-elasticsearch-server-internal",
     "@kbn/core-node-server",
     "@kbn/core-saved-objects-base-server-internal",

--- a/src/platform/plugins/shared/telemetry/moon.yml
+++ b/src/platform/plugins/shared/telemetry/moon.yml
@@ -42,6 +42,7 @@ dependsOn:
   - '@kbn/core-user-profile-browser-mocks'
   - '@kbn/core-analytics-browser'
   - '@kbn/core-analytics-server'
+  - '@kbn/core-analytics-server-internal'
   - '@kbn/core-elasticsearch-server'
   - '@kbn/logging'
   - '@kbn/core-security-server'

--- a/src/platform/plugins/shared/telemetry/server/plugin.test.ts
+++ b/src/platform/plugins/shared/telemetry/server/plugin.test.ts
@@ -15,12 +15,13 @@ import { telemetryCollectionManagerPluginMock } from '@kbn/telemetry-collection-
 import { buildShipperHeaders } from '../common/ebt_v3_endpoint';
 import { TelemetryPlugin } from './plugin';
 import type { NodeRoles } from '@kbn/core-node-server';
-import { Observable } from 'rxjs';
+import type { InternalAnalyticsServiceSetup } from '@kbn/core-analytics-server-internal';
+import { firstValueFrom, Observable } from 'rxjs';
 
 describe('TelemetryPlugin', () => {
   describe('setup', () => {
     describe('when initial config does not allow changing opt in status', () => {
-      it('calls analytics optIn', () => {
+      it('registers the opt-in status as the source of truth for Core Analytics', async () => {
         const initializerContext = coreMock.createPluginInitializerContext({
           optIn: true,
           allowChangingOptInStatus: false,
@@ -32,10 +33,17 @@ describe('TelemetryPlugin', () => {
           telemetryCollectionManager: telemetryCollectionManagerPluginMock.createSetupContract(),
         });
 
-        expect(coreSetupMock.analytics.optIn).toHaveBeenCalledTimes(1);
-        expect(coreSetupMock.analytics.optIn).toHaveBeenCalledWith({
-          global: { enabled: true },
-        });
+        // The plugin no longer drives `analytics.optIn` directly: it hands its opt-in observable
+        // to Core, which owns the consent and re-exposes it via `analytics.isOptedIn$`.
+        // `registerOptInStatus$` lives on the internal-only contract, so we cast to reach it.
+        const analytics =
+          coreSetupMock.analytics as unknown as jest.Mocked<InternalAnalyticsServiceSetup>;
+        expect(analytics.optIn).not.toHaveBeenCalled();
+        expect(analytics.registerOptInStatus$).toHaveBeenCalledTimes(1);
+
+        const registeredIsOptedIn$ = analytics.registerOptInStatus$.mock
+          .calls[0][0] as Observable<boolean>;
+        await expect(firstValueFrom(registeredIsOptedIn$)).resolves.toBe(true);
       });
     });
 

--- a/src/platform/plugins/shared/telemetry/server/plugin.ts
+++ b/src/platform/plugins/shared/telemetry/server/plugin.ts
@@ -40,6 +40,7 @@ import type {
   Logger,
 } from '@kbn/core/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type { InternalAnalyticsServiceSetup } from '@kbn/core-analytics-server-internal';
 import { SavedObjectsClient } from '@kbn/core/server';
 
 import apm from 'elastic-apm-node';
@@ -92,7 +93,8 @@ export interface TelemetryPluginStart {
    * Resolves `false` if the user explicitly opted out of sending usage data to Elastic
    * or did not choose to opt-in or out -yet- after a minor or major upgrade (only when previously opted-out).
    *
-   * @deprecated Use {@link TelemetryPluginStart.isOptedIn$ | isOptedIn$} instead.
+   * @deprecated Subscribe to `core.analytics.isOptedIn$` instead. The opt-in status is now owned by
+   * the Core Analytics service, so consumers no longer need to depend on the `telemetry` plugin.
    */
   getIsOptedIn: () => Promise<boolean>;
 
@@ -106,7 +108,8 @@ export interface TelemetryPluginStart {
    * haven't chosen yet to opt-in or out after a minor or major upgrade. In that case, pushing the new
    * value waits until the user decides.
    *
-   * @track-adoption
+   * @deprecated Subscribe to `core.analytics.isOptedIn$` instead. The opt-in status is now owned by
+   * the Core Analytics service, so consumers no longer need to depend on the `telemetry` plugin.
    */
   isOptedIn$: Observable<boolean>;
 }
@@ -184,9 +187,14 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
       );
     });
 
-    if (this.isOptedIn !== undefined) {
-      analytics.optIn({ global: { enabled: this.isOptedIn } });
-    }
+    // Register the telemetry opt-in status as the source of truth for the Core Analytics service.
+    // Core both re-exposes it via `analytics.isOptedIn$` and uses it to drive the analytics client's
+    // global consent, so the telemetry plugin no longer needs to call `analytics.optIn` directly.
+    //
+    // `registerOptInStatus$` is intentionally kept off the public `AnalyticsServiceSetup` contract:
+    // only this platform-owned producer is meant to drive the global opt-in status, so we reach it by
+    // casting to the internal contract.
+    (analytics as InternalAnalyticsServiceSetup).registerOptInStatus$(this.isOptedIn$);
 
     const currentKibanaVersion = this.currentKibanaVersion;
 
@@ -267,8 +275,6 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
   ) {
     const { analytics, savedObjects } = core;
 
-    this.isOptedIn$.subscribe((enabled) => analytics.optIn({ global: { enabled } }));
-
     const savedObjectsInternalRepository = savedObjects.createInternalRepository([
       TELEMETRY_SAVED_OBJECT_TYPE,
     ]);
@@ -284,7 +290,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
 
     return {
       getIsOptedIn: async () => this.isOptedIn === true,
-      isOptedIn$: this.isOptedIn$,
+      isOptedIn$: analytics.isOptedIn$,
     };
   }
 

--- a/src/platform/plugins/shared/telemetry/tsconfig.json
+++ b/src/platform/plugins/shared/telemetry/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/core-user-profile-browser-mocks",
     "@kbn/core-analytics-browser",
     "@kbn/core-analytics-server",
+    "@kbn/core-analytics-server-internal",
     "@kbn/core-elasticsearch-server",
     "@kbn/logging",
     "@kbn/core-security-server",


### PR DESCRIPTION
## Summary

The Core Analytics service (server) now **owns the global opt-in status**:

- `core.analytics.isOptedIn$` is exposed on the **start** contract for consumers to subscribe to.
- An internal-only `registerOptInStatus$` is added to the **setup** contract via a new `InternalAnalyticsServiceSetup` (kept off the public `AnalyticsServiceSetup`).

The `telemetry` plugin keeps computing the opt-in value (telemetry saved-object polling + version-aware re-prompt logic) but now **registers its observable with Core** instead of calling `analytics.optIn(...)` directly. Core uses the registered observable to both:

1. drive the analytics client's global consent, and
2. re-expose it via `core.analytics.isOptedIn$`.

This **reverses the dependency**: `analytics` no longer relies on the `telemetry` plugin to set the opt-in status, and consumers can read the opt-in status from `core.analytics` rather than depending on the `telemetry` plugin.

### Deprecations

- `TelemetryPluginStart.getIsOptedIn` and `TelemetryPluginStart.isOptedIn$` are deprecated in favor of `core.analytics.isOptedIn$`. They still work (the latter now re-exposes the Core observable).

### Notes / scope

- **Server-side only.** Migrating existing consumers (`security_solution`, `indices_metadata`, `otel_telemetry_collection`, `fleet`, `synthetics`) off the deprecated telemetry APIs and the browser-side equivalent are intended as **follow-ups**.
- `registerOptInStatus$` is intentionally not on the public `AnalyticsServiceSetup`; the platform-owned telemetry producer reaches it by casting to `InternalAnalyticsServiceSetup`. It is carried at runtime on the per-plugin `CoreSetup.analytics` but hidden from the public type. This is transitional coupling, in line with the plan to fold `telemetry` into core.

## How to test

- Existing unit tests:
  - `node scripts/jest src/core/packages/analytics/server-internal/src/analytics_service.test.ts`
  - `node scripts/jest src/core/packages/plugins/server-internal/src/plugin_context.test.ts`
  - `node scripts/jest src/platform/plugins/shared/telemetry/server/plugin.test.ts`

## Checklist

- [ ] Follow-up: migrate server consumers to `core.analytics.isOptedIn$`
- [ ] Follow-up: browser-side `isOptedIn$` (addresses #256746)

Made with [Cursor](https://cursor.com)