### PR TITLE
[9.4] [Security Solution] Fix: Attack Discovery Entity Badges Open Entity Store Flyout (#272762)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/helpers.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getOriginalAlertIds } from './helpers';
+
+describe('getOriginalAlertIds', () => {
+  it('should return original alert IDs based on replacements', () => {
+    const alertIds = ['alert-1', 'alert-2', 'alert-3'];
+    const replacements = {
+      'alert-1': 'original-1',
+      'alert-2': 'original-2',
+    };
+
+    const result = getOriginalAlertIds(alertIds, replacements);
+
+    expect(result).toEqual(['original-1', 'original-2', 'alert-3']);
+  });
+
+  it('should return the same IDs if no replacements provided', () => {
+    const alertIds = ['alert-1', 'alert-2'];
+
+    const result = getOriginalAlertIds(alertIds);
+
+    expect(result).toEqual(['alert-1', 'alert-2']);
+  });
+
+  it('should handle empty alertIds arrays', () => {
+    const alertIds: string[] = [];
+    const replacements = {
+      'alert-1': 'original-1',
+    };
+
+    const result = getOriginalAlertIds(alertIds, replacements);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle missing matches in replacements gracefully', () => {
+    const alertIds = ['alert-1', 'alert-2'];
+    const replacements = {
+      'alert-3': 'original-3',
+    };
+
+    const result = getOriginalAlertIds(alertIds, replacements);
+
+    expect(result).toEqual(['alert-1', 'alert-2']);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/helpers.ts
@@ -10,3 +10,8 @@ export {
   getTacticMetadata,
   replaceNewlineLiterals,
 } from '@kbn/elastic-assistant-common';
+import type { Replacements } from '@kbn/elastic-assistant-common';
+
+export const getOriginalAlertIds = (alertIds: string[], replacements?: Replacements): string[] => {
+  return alertIds.map((id) => replacements?.[id] ?? id);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/attack_discovery_markdown_parser/index.test.tsx
@@ -14,7 +14,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { TestProviders } from '../../../../../common/mock';
-import { getFieldMarkdownRenderer } from '../field_markdown_renderer';
+import { FieldMarkdownRenderer } from '../field_markdown_renderer';
+import { MarkdownFormatterContext } from '../context';
 import { AttackDiscoveryMarkdownParser } from '.';
 
 describe('AttackDiscoveryMarkdownParser', () => {
@@ -36,19 +37,21 @@ This appears to be a malware attack delivered via spearphishing, likely exploiti
     `;
 
     const processingPluginList = getDefaultEuiMarkdownProcessingPlugins();
-    processingPluginList[1][1].components.fieldPlugin = getFieldMarkdownRenderer(false);
+    processingPluginList[1][1].components.fieldPlugin = FieldMarkdownRenderer;
 
     render(
       <TestProviders>
-        <EuiMarkdownFormat
-          color="subdued"
-          data-test-subj="attackDiscoveryMarkdownFormatter"
-          parsingPluginList={attackDiscoveryParsingPluginList}
-          processingPluginList={processingPluginList}
-          textSize="xs"
-        >
-          {markdownWithValidFields}
-        </EuiMarkdownFormat>
+        <MarkdownFormatterContext.Provider value={{ disableActions: false }}>
+          <EuiMarkdownFormat
+            color="subdued"
+            data-test-subj="attackDiscoveryMarkdownFormatter"
+            parsingPluginList={attackDiscoveryParsingPluginList}
+            processingPluginList={processingPluginList}
+            textSize="xs"
+          >
+            {markdownWithValidFields}
+          </EuiMarkdownFormat>
+        </MarkdownFormatterContext.Provider>
       </TestProviders>
     );
 
@@ -77,19 +80,21 @@ This appears to be a malware attack delivered via spearphishing, likely exploiti
     `;
 
     const processingPluginList = getDefaultEuiMarkdownProcessingPlugins();
-    processingPluginList[1][1].components.fieldPlugin = getFieldMarkdownRenderer(false);
+    processingPluginList[1][1].components.fieldPlugin = FieldMarkdownRenderer;
 
     render(
       <TestProviders>
-        <EuiMarkdownFormat
-          color="subdued"
-          data-test-subj="attackDiscoveryMarkdownFormatter"
-          parsingPluginList={attackDiscoveryParsingPluginList}
-          processingPluginList={processingPluginList}
-          textSize="xs"
-        >
-          {markdownWithInvalidFields}
-        </EuiMarkdownFormat>
+        <MarkdownFormatterContext.Provider value={{ disableActions: false }}>
+          <EuiMarkdownFormat
+            color="subdued"
+            data-test-subj="attackDiscoveryMarkdownFormatter"
+            parsingPluginList={attackDiscoveryParsingPluginList}
+            processingPluginList={processingPluginList}
+            textSize="xs"
+          >
+            {markdownWithInvalidFields}
+          </EuiMarkdownFormat>
+        </MarkdownFormatterContext.Provider>
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/context.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface MarkdownFormatterContextValue {
+  disableActions: boolean;
+  scopeId?: string;
+  alertIds?: string[];
+}
+
+export const MarkdownFormatterContext = createContext<MarkdownFormatterContextValue>({
+  disableActions: false,
+});
+
+export const useMarkdownFormatterContext = () => useContext(MarkdownFormatterContext);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_host_flyout_panel_props.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_host_flyout_panel_props.ts
@@ -14,6 +14,7 @@ interface HostPanelProps extends Record<string, unknown> {
   contextID: string;
   scopeId: string;
   hostName: string;
+  entityId?: string;
 }
 
 interface HostPanelExpandableFlyoutProps extends FlyoutPanelProps {
@@ -27,14 +28,19 @@ export const isHostName = (fieldName: string) =>
 export const getHostFlyoutPanelProps = ({
   contextId,
   hostName,
+  entityId,
+  scopeId = TableId.alertsOnAlertsPage,
 }: {
   contextId: string;
   hostName: string;
+  entityId?: string;
+  scopeId?: string;
 }): FlyoutPanelProps => ({
   id: HostPanelKey,
   params: {
     hostName,
     contextID: contextId,
-    scopeId: TableId.alertsOnAlertsPage,
+    scopeId,
+    entityId,
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_user_flyout_panel_props.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_user_flyout_panel_props.ts
@@ -14,14 +14,19 @@ export const isUserName = (fieldName: string) => fieldName === 'user.name';
 export const getUserFlyoutPanelProps = ({
   contextId,
   userName,
+  entityId,
+  scopeId = TableId.alertsOnAlertsPage,
 }: {
   contextId: string;
   userName: string;
+  entityId?: string;
+  scopeId?: string;
 }): FlyoutPanelProps => ({
   id: UserPanelKey,
   params: {
     userName,
     contextID: contextId,
-    scopeId: TableId.alertsOnAlertsPage,
+    scopeId,
+    entityId,
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/helpers.ts
@@ -6,25 +6,36 @@
  */
 
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
+import type { EntityType } from '@kbn/entity-store/public';
 
 import { getHostFlyoutPanelProps, isHostName } from './get_host_flyout_panel_props';
 import { getUserFlyoutPanelProps, isUserName } from './get_user_flyout_panel_props';
+
+export const ENTITY_TYPE_BY_FIELD: Record<string, EntityType> = {
+  'host.name': 'host',
+  'host.hostname': 'host',
+  'user.name': 'user',
+};
 
 export const getFlyoutPanelProps = ({
   contextId,
   fieldName,
   value,
+  entityId,
+  scopeId,
 }: {
   contextId: string;
   fieldName: string;
   value: string | number | undefined;
+  entityId?: string;
+  scopeId?: string;
 }): FlyoutPanelProps | null => {
   if (isHostName(fieldName) && typeof value === 'string') {
-    return getHostFlyoutPanelProps({ contextId, hostName: value });
+    return getHostFlyoutPanelProps({ contextId, hostName: value, entityId, scopeId });
   }
 
   if (isUserName(fieldName) && typeof value === 'string') {
-    return getUserFlyoutPanelProps({ contextId, userName: value });
+    return getUserFlyoutPanelProps({ contextId, userName: value, entityId, scopeId });
   }
 
   return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
@@ -10,12 +10,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { TestProviders } from '../../../../../common/mock';
-import { getFieldMarkdownRenderer } from '.';
+import { FieldMarkdownRenderer } from '.';
+import { MarkdownFormatterContext } from '../context';
 import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 
 jest.mock('@kbn/expandable-flyout');
 
-describe('getFieldMarkdownRenderer', () => {
+describe('FieldMarkdownRenderer', () => {
   const mockOpenRightPanel = jest.fn();
   const mockUseExpandableFlyoutApi = useExpandableFlyoutApi as jest.MockedFunction<
     typeof useExpandableFlyoutApi
@@ -31,14 +32,15 @@ describe('getFieldMarkdownRenderer', () => {
   });
 
   it('renders the field value', () => {
-    const FieldMarkdownRenderer = getFieldMarkdownRenderer(false);
     const icon = '';
     const name = 'some.field';
     const value = 'some.value';
 
     render(
       <TestProviders>
-        <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        <MarkdownFormatterContext.Provider value={{ disableActions: false }}>
+          <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        </MarkdownFormatterContext.Provider>
       </TestProviders>
     );
 
@@ -48,14 +50,15 @@ describe('getFieldMarkdownRenderer', () => {
   });
 
   it('opens the right panel when the entity button is clicked', () => {
-    const FieldMarkdownRenderer = getFieldMarkdownRenderer(false);
     const icon = 'user';
     const name = 'user.name';
     const value = 'some.user';
 
     render(
       <TestProviders>
-        <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        <MarkdownFormatterContext.Provider value={{ disableActions: false }}>
+          <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        </MarkdownFormatterContext.Provider>
       </TestProviders>
     );
 
@@ -67,14 +70,15 @@ describe('getFieldMarkdownRenderer', () => {
   });
 
   it('does NOT render the entity button when flyoutPanelProps is null', () => {
-    const FieldMarkdownRenderer = getFieldMarkdownRenderer(false);
     const icon = '';
     const name = 'some.field';
     const value = 'some.value';
 
     render(
       <TestProviders>
-        <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        <MarkdownFormatterContext.Provider value={{ disableActions: false }}>
+          <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        </MarkdownFormatterContext.Provider>
       </TestProviders>
     );
 
@@ -84,14 +88,15 @@ describe('getFieldMarkdownRenderer', () => {
   });
 
   it('renders disabled actions badge when disableActions is true', () => {
-    const FieldMarkdownRenderer = getFieldMarkdownRenderer(true); // disable actions
     const icon = 'user';
     const name = 'user.name';
     const value = 'some.user';
 
     render(
       <TestProviders>
-        <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        <MarkdownFormatterContext.Provider value={{ disableActions: true }}>
+          <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+        </MarkdownFormatterContext.Provider>
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -5,74 +5,91 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiButtonEmpty, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { EuiBadge, EuiButtonEmpty, EuiToolTip, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
 import { DraggableBadge } from '../../../../../common/components/draggables';
-import { getFlyoutPanelProps } from './helpers';
+import { getFlyoutPanelProps, ENTITY_TYPE_BY_FIELD } from './helpers';
+import { useEntityEuidFromAlerts } from './use_entity_euid_from_alerts';
+import { useMarkdownFormatterContext } from '../context';
 import type { ParsedField } from '../types';
 
 const contextId = 'FieldMarkdownRenderer';
 
-export const getFieldMarkdownRenderer = (disableActions: boolean, scopeId?: string) => {
-  const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
-    const { openRightPanel } = useExpandableFlyoutApi();
-    const { euiTheme } = useEuiTheme();
+export const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
+  const { disableActions, scopeId, alertIds } = useMarkdownFormatterContext();
+  const { openRightPanel } = useExpandableFlyoutApi();
+  const { euiTheme } = useEuiTheme();
 
-    const flyoutPanelProps = useMemo(
-      () => getFlyoutPanelProps({ contextId, fieldName: name, value }),
-      [name, value]
-    );
+  const isEntityField = name in ENTITY_TYPE_BY_FIELD && typeof value === 'string';
 
-    const onEntityClick = useCallback(() => {
-      if (flyoutPanelProps != null) {
-        openRightPanel(flyoutPanelProps);
-      }
-    }, [flyoutPanelProps, openRightPanel]);
+  const { euid, isLoading } = useEntityEuidFromAlerts({
+    alertIds: alertIds ?? [],
+    fieldName: name,
+    fieldValue: typeof value === 'string' ? value : '',
+    enabled: !disableActions && isEntityField,
+  });
 
-    const entityButton: React.ReactElement | null = useMemo(
-      () =>
-        flyoutPanelProps != null ? (
-          <EuiButtonEmpty
-            css={css`
-              font-size: ${euiTheme.font.scale.s}rem;
-            `}
-            data-test-subj="entityButton"
-            flush="both"
-            onClick={onEntityClick}
-            size="xs"
-          >
-            {value}
-          </EuiButtonEmpty>
-        ) : null,
+  const flyoutPanelProps = useMemo(
+    () => getFlyoutPanelProps({ contextId, fieldName: name, value, entityId: euid, scopeId }),
+    [euid, name, value, scopeId]
+  );
 
-      [euiTheme.font.scale.s, flyoutPanelProps, onEntityClick, value]
-    );
+  const onEntityClick = useCallback(() => {
+    if (flyoutPanelProps != null) {
+      openRightPanel(flyoutPanelProps);
+    }
+  }, [flyoutPanelProps, openRightPanel]);
 
-    return (
-      <EuiToolTip content={name} data-test-subj="fieldMarkdownRendererToolTip" position="top">
-        {disableActions ? (
-          <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
-            {value}
-          </EuiBadge>
-        ) : (
-          <DraggableBadge
-            contextId="fieldMarkdownRenderer"
-            scopeId={scopeId}
-            eventId=""
-            iconType={icon}
-            isAggregatable={false}
-            field={name}
-            value={value}
-          >
-            {entityButton}
-          </DraggableBadge>
-        )}
-      </EuiToolTip>
-    );
-  };
+  const entityButton: React.ReactElement | null = useMemo(
+    () =>
+      flyoutPanelProps != null ? (
+        <EuiButtonEmpty
+          css={css`
+            font-size: ${euiTheme.font.scale.s}rem;
+          `}
+          data-test-subj="entityButton"
+          flush="both"
+          isDisabled={isLoading}
+          onClick={onEntityClick}
+          size="xs"
+        >
+          {value}
+          {isLoading && (
+            <EuiLoadingSpinner
+              size="s"
+              css={css`
+                margin-left: ${euiTheme.size.xs};
+              `}
+            />
+          )}
+        </EuiButtonEmpty>
+      ) : null,
 
-  return FieldMarkdownRenderer;
+    [euiTheme.font.scale.s, euiTheme.size.xs, flyoutPanelProps, isLoading, onEntityClick, value]
+  );
+
+  return (
+    <EuiToolTip content={name} data-test-subj="fieldMarkdownRendererToolTip" position="top">
+      {disableActions ? (
+        <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
+          {value}
+        </EuiBadge>
+      ) : (
+        <DraggableBadge
+          contextId="fieldMarkdownRenderer"
+          scopeId={scopeId}
+          eventId=""
+          iconType={icon}
+          isAggregatable={false}
+          field={name}
+          value={value}
+        >
+          {entityButton}
+        </DraggableBadge>
+      )}
+    </EuiToolTip>
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { of, throwError } from 'rxjs';
+import { useEntityEuidFromAlerts } from './use_entity_euid_from_alerts';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
+
+jest.mock('../../../../../common/lib/kibana');
+jest.mock('@kbn/entity-store/public', () => ({
+  useEntityStoreEuidApi: jest.fn(),
+}));
+
+describe('useEntityEuidFromAlerts', () => {
+  const searchMock: jest.Mock = jest.fn();
+  const getEuidRuntimeMappingMock: jest.Mock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: {
+          search: { search: searchMock },
+        },
+      },
+    });
+
+    (useEntityStoreEuidApi as jest.Mock).mockReturnValue({
+      euid: {
+        painless: {
+          getEuidRuntimeMapping: getEuidRuntimeMappingMock,
+        },
+      },
+    });
+  });
+
+  const defaultProps = {
+    alertIds: ['alert-1', 'alert-2'],
+    fieldName: 'host.name',
+    fieldValue: 'test-host',
+    enabled: true,
+  };
+
+  it('returns undefined euid and false isLoading when alertIds is empty', () => {
+    const { result } = renderHook(() => useEntityEuidFromAlerts({ ...defaultProps, alertIds: [] }));
+
+    expect(result.current).toEqual({ euid: undefined, isLoading: false });
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined euid and false isLoading when enabled is false', () => {
+    const { result } = renderHook(() =>
+      useEntityEuidFromAlerts({ ...defaultProps, enabled: false })
+    );
+
+    expect(result.current).toEqual({ euid: undefined, isLoading: false });
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined euid and false isLoading when euidApi is null or undefined', () => {
+    (useEntityStoreEuidApi as jest.Mock).mockReturnValueOnce(null);
+
+    const { result } = renderHook(() => useEntityEuidFromAlerts(defaultProps));
+
+    expect(result.current).toEqual({ euid: undefined, isLoading: false });
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns the correct EUID when a matching alert is found', async () => {
+    searchMock.mockReturnValueOnce(
+      of({
+        rawResponse: {
+          hits: {
+            hits: [
+              {
+                fields: { 'host.name': ['other-host'], entity_id: ['host:other-id'] },
+              },
+              {
+                fields: { 'host.name': ['test-host'], entity_id: ['host:test-id'] },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const { result } = renderHook(() => useEntityEuidFromAlerts(defaultProps));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.euid).toBe('host:test-id');
+    expect(searchMock).toHaveBeenCalledTimes(1);
+    expect(getEuidRuntimeMappingMock).toHaveBeenCalledWith('host');
+  });
+
+  it('returns undefined EUID when no alert matches the field value', async () => {
+    searchMock.mockReturnValueOnce(
+      of({
+        rawResponse: {
+          hits: {
+            hits: [
+              {
+                fields: { 'host.name': ['other-host-1'], entity_id: ['host:other-id-1'] },
+              },
+              {
+                fields: { 'host.name': ['other-host-2'], entity_id: ['host:other-id-2'] },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const { result } = renderHook(() => useEntityEuidFromAlerts(defaultProps));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.euid).toBeUndefined();
+  });
+
+  it('handles field values as single string correctly', async () => {
+    searchMock.mockReturnValueOnce(
+      of({
+        rawResponse: {
+          hits: {
+            hits: [
+              {
+                fields: { 'host.name': 'test-host', entity_id: ['host:test-id'] },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const { result } = renderHook(() => useEntityEuidFromAlerts(defaultProps));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.euid).toBe('host:test-id');
+  });
+
+  it('returns undefined when the ES query throws and swallows the error', async () => {
+    searchMock.mockReturnValueOnce(throwError(() => new Error('ES failure')));
+
+    const { result } = renderHook(() => useEntityEuidFromAlerts(defaultProps));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.euid).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lastValueFrom } from 'rxjs';
+import { useEffect, useState } from 'react';
+import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
+
+import { DEFAULT_ALERTS_INDEX } from '../../../../../../common/constants';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { ENTITY_TYPE_BY_FIELD } from './helpers';
+
+interface Params {
+  alertIds: string[]; // original (de-anonymized) alert document IDs
+  fieldName: string; // e.g. 'host.name' or 'user.name'
+  fieldValue: string; // e.g. 'SRVWIN01'
+  enabled: boolean; // only fetch when the badge is actually clickable
+}
+
+interface Result {
+  euid: string | undefined;
+  isLoading: boolean;
+}
+
+export const useEntityEuidFromAlerts = ({
+  alertIds,
+  fieldName,
+  fieldValue,
+  enabled,
+}: Params): Result => {
+  const { data } = useKibana().services;
+  const euidApi = useEntityStoreEuidApi();
+  const getEuidRuntimeMapping = euidApi?.euid?.painless?.getEuidRuntimeMapping;
+  const entityType = ENTITY_TYPE_BY_FIELD[fieldName];
+
+  const willFetch = enabled && !!entityType && alertIds.length > 0 && !!getEuidRuntimeMapping;
+  const [euid, setEuid] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(willFetch);
+
+  const alertIdsKey = alertIds.join(',');
+
+  useEffect(() => {
+    if (!willFetch || !getEuidRuntimeMapping || !entityType) {
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    const fetchEuid = async () => {
+      try {
+        const response = await lastValueFrom(
+          data.search.search({
+            params: {
+              index: `${DEFAULT_ALERTS_INDEX}-*`,
+              ignore_unavailable: true,
+              body: {
+                query: { ids: { values: alertIds } },
+                _source: false,
+                runtime_mappings: {
+                  entity_id: getEuidRuntimeMapping(entityType),
+                },
+                fields: ['entity_id', fieldName],
+                size: alertIds.length,
+              },
+            },
+          })
+        );
+
+        if (cancelled) return;
+
+        const hits =
+          (response?.rawResponse?.hits?.hits as Array<{
+            fields?: { entity_id?: string[]; [key: string]: unknown };
+          }>) ?? [];
+        // Find the first alert where the clicked field matches the badge value
+        const matchingHit = hits.find((hit) => {
+          const val = hit.fields?.[fieldName];
+          return val === fieldValue || (Array.isArray(val) && val.includes(fieldValue));
+        });
+
+        if (matchingHit) {
+          const computed = matchingHit.fields?.entity_id?.[0];
+          if (!cancelled && computed) setEuid(computed);
+        }
+      } catch {
+        // Silently swallow — caller falls back to Observed flyout when euid is undefined
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    fetchEuid();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    alertIdsKey,
+    alertIds,
+    data.search,
+    getEuidRuntimeMapping,
+    entityType,
+    fieldName,
+    fieldValue,
+    willFetch,
+  ]);
+
+  return { euid, isLoading };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/index.tsx
@@ -13,18 +13,21 @@ import {
 import React, { useMemo } from 'react';
 
 import { AttackDiscoveryMarkdownParser } from './attack_discovery_markdown_parser';
-import { getFieldMarkdownRenderer } from './field_markdown_renderer';
+import { MarkdownFormatterContext } from './context';
+import { FieldMarkdownRenderer } from './field_markdown_renderer';
 
 interface Props {
   scopeId?: string;
   disableActions?: boolean;
   markdown: string;
+  alertIds?: string[];
 }
 
 const AttackDiscoveryMarkdownFormatterComponent: React.FC<Props> = ({
   scopeId,
   disableActions = false,
   markdown,
+  alertIds,
 }) => {
   const attackDiscoveryParsingPluginList = useMemo(
     () => [...getDefaultEuiMarkdownParsingPlugins(), AttackDiscoveryMarkdownParser],
@@ -33,24 +36,28 @@ const AttackDiscoveryMarkdownFormatterComponent: React.FC<Props> = ({
 
   const attackDiscoveryProcessingPluginList = useMemo(() => {
     const processingPluginList = getDefaultEuiMarkdownProcessingPlugins();
-    processingPluginList[1][1].components.fieldPlugin = getFieldMarkdownRenderer(
-      disableActions,
-      scopeId
-    );
+    processingPluginList[1][1].components.fieldPlugin = FieldMarkdownRenderer;
 
     return processingPluginList;
-  }, [disableActions, scopeId]);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ disableActions, scopeId, alertIds }),
+    [alertIds, disableActions, scopeId]
+  );
 
   return (
-    <EuiMarkdownFormat
-      color="subdued"
-      data-test-subj="attackDiscoveryMarkdownFormatter"
-      parsingPluginList={attackDiscoveryParsingPluginList}
-      processingPluginList={attackDiscoveryProcessingPluginList}
-      textSize="xs"
-    >
-      {markdown}
-    </EuiMarkdownFormat>
+    <MarkdownFormatterContext.Provider value={contextValue}>
+      <EuiMarkdownFormat
+        color="subdued"
+        data-test-subj="attackDiscoveryMarkdownFormatter"
+        parsingPluginList={attackDiscoveryParsingPluginList}
+        processingPluginList={attackDiscoveryProcessingPluginList}
+        textSize="xs"
+      >
+        {markdown}
+      </EuiMarkdownFormat>
+    </MarkdownFormatterContext.Provider>
   );
 };
 AttackDiscoveryMarkdownFormatterComponent.displayName = 'AttackDiscoveryMarkdownFormatter';

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.test.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 
 import { ActionableSummary } from '.';
 import { TestProviders } from '../../../../../common/mock';
@@ -15,12 +17,36 @@ import { useKibana } from '../../../../../common/lib/kibana';
 import { SECURITY_FEATURE_ID } from '../../../../../../common';
 
 jest.mock('../../../../../common/lib/kibana');
+jest.mock('@kbn/expandable-flyout');
+
+jest.mock(
+  '../../attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts',
+  () => ({
+    useEntityEuidFromAlerts: jest.fn(() => ({ euid: undefined, isLoading: false })),
+    ENTITY_TYPE_BY_FIELD: jest.requireActual(
+      '../../attack_discovery_markdown_formatter/field_markdown_renderer/helpers'
+    ).ENTITY_TYPE_BY_FIELD,
+  })
+);
 
 describe('ActionableSummary', () => {
   const mockReplacements = {
     '5e454c38-439c-4096-8478-0a55511c76e3': 'foo.hostname',
     '3bdc7952-a334-4d95-8092-cd176546e18a': 'bar.username',
   };
+
+  const mockOpenRightPanel = jest.fn();
+  const mockUseExpandableFlyoutApi = useExpandableFlyoutApi as jest.MockedFunction<
+    typeof useExpandableFlyoutApi
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseExpandableFlyoutApi.mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openRightPanel: mockOpenRightPanel,
+    });
+  });
 
   describe('when entities with replacements are provided', () => {
     beforeEach(() => {
@@ -40,6 +66,12 @@ describe('ActionableSummary', () => {
 
     it('renders a username with the expected value from replacements', () => {
       expect(screen.getAllByTestId('entityButton')[1]).toHaveTextContent('bar.username');
+    });
+
+    it('opens the right panel when an entity badge is clicked', () => {
+      const entityButton = screen.getAllByTestId('entityButton')[0];
+      fireEvent.click(entityButton);
+      expect(mockOpenRightPanel).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
@@ -16,6 +16,7 @@ import React, { useMemo } from 'react';
 import { SECURITY_FEATURE_ID } from '../../../../../../common';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { AttackDiscoveryMarkdownFormatter } from '../../attack_discovery_markdown_formatter';
+import { getOriginalAlertIds } from '../../../../helpers';
 import { ViewInAiAssistant } from '../view_in_ai_assistant';
 import { useAgentBuilderAvailability } from '../../../../../agent_builder/hooks/use_agent_builder_availability';
 import { NewAgentBuilderAttachment } from '../../../../../agent_builder/components/new_agent_builder_attachment';
@@ -75,6 +76,11 @@ const ActionableSummaryComponent: React.FC<Props> = ({
 
   const openAgentBuilderFlyout = useAttackDiscoveryAttachment(attackDiscovery, replacements);
 
+  const originalAlertIds = useMemo(
+    () => getOriginalAlertIds(attackDiscovery.alertIds, replacements),
+    [attackDiscovery.alertIds, replacements]
+  );
+
   return (
     <EuiPanel color="subdued" data-test-subj="actionableSummary">
       <EuiFlexGroup alignItems="center" gutterSize="none" justifyContent="spaceBetween">
@@ -82,6 +88,7 @@ const ActionableSummaryComponent: React.FC<Props> = ({
           <AttackDiscoveryMarkdownFormatter
             disableActions={disabledActions}
             markdown={entitySummaryOrTitle}
+            alertIds={originalAlertIds}
           />
         </EuiFlexItem>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/shared_badge/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/shared_badge/index.test.tsx
@@ -66,6 +66,7 @@ jest.mock('../../../../../../utils/is_attack_discovery_alert', () => ({
 
 describe('SharedBadge', () => {
   const defaultProps = { attackDiscovery: mockAttackDiscoveryAlert };
+  const user = userEvent.setup({ pointerEventsCheck: 0 });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,7 +83,7 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
 
     expect(screen.getByTestId('sharedBadge')).toBeInTheDocument();
   });
@@ -94,7 +95,7 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
 
     expect(screen.getByTestId('shared')).toHaveAttribute('aria-disabled', 'true');
   });
@@ -106,7 +107,7 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
 
     expect(screen.getByTestId('notShared')).toHaveAttribute('aria-disabled', 'true');
   });
@@ -120,8 +121,8 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
-    await userEvent.click(screen.getByTestId('shared'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('shared'));
 
     expect(mockMutateAsync).toHaveBeenCalled();
   });
@@ -157,11 +158,11 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
     // Click the enabled shared option
-    await userEvent.click(screen.getByTestId('shared'));
+    await user.click(screen.getByTestId('shared'));
     // Re-open the popover to check the disabled state
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
     // Assert the shared option is disabled
     const sharedOption = await screen.findByTestId('shared');
 
@@ -177,11 +178,11 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
     // Click the enabled shared option
-    await userEvent.click(screen.getByTestId('shared'));
+    await user.click(screen.getByTestId('shared'));
     // Re-open the popover to check the disabled state
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
     // Assert the notShared option is disabled
     const notSharedOption = await screen.findByTestId('notShared');
     expect(notSharedOption).toHaveAttribute('aria-disabled', 'true');
@@ -196,8 +197,8 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
-    await userEvent.hover(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
+    await user.hover(screen.getByTestId('sharedBadgeButton'));
     const tooltip = await screen.findByText((content, element) =>
       content.includes('The visibility of shared')
     );
@@ -222,11 +223,11 @@ describe('SharedBadge', () => {
       </TestProviders>
     );
 
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
     // The popover should be open
     expect(screen.getByTestId('sharedBadge')).toBeInTheDocument();
     // Click the badge button again to close the popover
-    await userEvent.click(screen.getByTestId('sharedBadgeButton'));
+    await user.click(screen.getByTestId('sharedBadgeButton'));
     // Wait for the popover to close
     await waitFor(() => {
       expect(screen.queryByTestId('sharedBadge')).not.toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.test.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { createExpandableFlyoutApiMock } from '../../../../../../common/mock/expandable_flyout';
 
 import { AttackDiscoveryTab } from '.';
 import type { Replacements } from '@kbn/elastic-assistant-common';
@@ -17,6 +19,17 @@ import { SECURITY_FEATURE_ID } from '../../../../../../../common';
 import { useKibana } from '../../../../../../common/lib/kibana';
 
 jest.mock('../../../../../../common/lib/kibana');
+jest.mock('@kbn/expandable-flyout');
+
+jest.mock(
+  '../../../attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts',
+  () => ({
+    useEntityEuidFromAlerts: jest.fn(() => ({ euid: undefined, isLoading: false })),
+    ENTITY_TYPE_BY_FIELD: jest.requireActual(
+      '../../../attack_discovery_markdown_formatter/field_markdown_renderer/helpers'
+    ).ENTITY_TYPE_BY_FIELD,
+  })
+);
 
 describe('AttackDiscoveryTab', () => {
   const mockReplacements: Replacements = {
@@ -25,6 +38,19 @@ describe('AttackDiscoveryTab', () => {
     'c5ba13c4-2391-4045-962e-ec965fc1eb06': 'SRVWIN07',
     '2da30969-4127-4ddb-ba0c-2d8ac44d15d7': 'Administrator',
   };
+
+  const mockOpenRightPanel = jest.fn();
+  const mockUseExpandableFlyoutApi = useExpandableFlyoutApi as jest.MockedFunction<
+    typeof useExpandableFlyoutApi
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseExpandableFlyoutApi.mockReturnValue({
+      ...createExpandableFlyoutApiMock(),
+      openRightPanel: mockOpenRightPanel,
+    });
+  });
 
   describe('when showAnonymized is false', () => {
     const showAnonymized = false;
@@ -61,6 +87,12 @@ describe('AttackDiscoveryTab', () => {
       );
       expect(screen.getAllByTestId('entityButton')[0]).toHaveTextContent('foo.hostname');
       expect(screen.getAllByTestId('entityButton')[1]).toHaveTextContent('bar.username');
+    });
+
+    it('opens the right panel when an entity badge is clicked', () => {
+      const entityButton = screen.getAllByTestId('entityButton')[0];
+      fireEvent.click(entityButton);
+      expect(mockOpenRightPanel).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -206,6 +238,11 @@ The user Administrator opened a malicious Microsoft Word document (C:\\Program F
     beforeEach(() => {
       (useKibana as jest.Mock).mockReturnValue({
         services: {
+          data: {
+            search: {
+              search: jest.fn().mockReturnValue({ toPromise: jest.fn().mockResolvedValue({}) }),
+            },
+          },
           application: {
             capabilities: {
               [SECURITY_FEATURE_ID]: {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
@@ -15,7 +15,7 @@ import { useKibana } from '../../../../../../common/lib/kibana';
 import { AttackChain } from './attack/attack_chain';
 import { InvestigateInTimelineButton } from '../../../../../../common/components/event_details/investigate_in_timeline_button';
 import { buildAlertsKqlFilter } from '../../../../../../detections/components/alerts_table/actions';
-import { getTacticMetadata } from '../../../../../helpers';
+import { getTacticMetadata, getOriginalAlertIds } from '../../../../../helpers';
 import { AttackDiscoveryMarkdownFormatter } from '../../../attack_discovery_markdown_formatter';
 import * as i18n from './translations';
 import { ViewInAiAssistant } from '../../view_in_ai_assistant';
@@ -78,7 +78,7 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
   );
 
   const originalAlertIds = useMemo(
-    () => attackDiscovery.alertIds.map((id) => replacements?.[id] ?? id),
+    () => getOriginalAlertIds(attackDiscovery.alertIds, replacements),
     [attackDiscovery.alertIds, replacements]
   );
 
@@ -98,6 +98,7 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
         <AttackDiscoveryMarkdownFormatter
           disableActions={disabledActions}
           markdown={showAnonymized ? summaryMarkdown : summaryMarkdownWithReplacements}
+          alertIds={originalAlertIds}
         />
       </div>
 
@@ -112,6 +113,7 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
         <AttackDiscoveryMarkdownFormatter
           disableActions={disabledActions}
           markdown={showAnonymized ? detailsMarkdown : detailsMarkdownWithReplacements}
+          alertIds={originalAlertIds}
         />
       </div>
 
@@ -158,7 +160,7 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
               wrap={false}
             >
               <EuiFlexItem grow={false}>
-                <EuiIcon data-test-subj="timelineIcon" type="timeline" />
+                <EuiIcon aria-hidden={true} data-test-subj="timelineIcon" type="timeline" />
               </EuiFlexItem>
               <EuiFlexItem data-test-subj="investigateInTimelineLabel" grow={false}>
                 {i18n.INVESTIGATE_IN_TIMELINE}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.test.tsx
@@ -80,8 +80,23 @@ jest.mock('../../../../common/lib/kibana', () => ({
   })),
 }));
 
+jest.mock(
+  '../attack_discovery_markdown_formatter/field_markdown_renderer/use_entity_euid_from_alerts',
+  () => ({
+    useEntityEuidFromAlerts: jest.fn(() => ({ euid: undefined, isLoading: false })),
+    ENTITY_TYPE_BY_FIELD: jest.requireActual(
+      '../attack_discovery_markdown_formatter/field_markdown_renderer/helpers'
+    ).ENTITY_TYPE_BY_FIELD,
+  })
+);
+
 (mockUseKibana as jest.Mock).mockReturnValue({
   services: {
+    data: {
+      search: {
+        search: jest.fn().mockReturnValue({ toPromise: jest.fn().mockResolvedValue({}) }),
+      },
+    },
     application: {
       capabilities: {
         [SECURITY_FEATURE_ID]: { crud_alerts: true, read_alerts: true, configurations: true },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/summary_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/summary_tab.test.tsx
@@ -44,6 +44,7 @@ jest.mock('../../../alerts_table/actions', () => ({
 }));
 
 jest.mock('../../../../../attack_discovery/helpers', () => ({
+  ...jest.requireActual('../../../../../attack_discovery/helpers'),
   getTacticMetadata: jest.fn(() => []),
 }));
 
@@ -57,8 +58,10 @@ jest.mock(
 jest.mock(
   '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter',
   () => ({
-    AttackDiscoveryMarkdownFormatter: jest.fn(({ markdown }) => (
-      <div data-test-subj="mock-markdown-formatter">{markdown}</div>
+    AttackDiscoveryMarkdownFormatter: jest.fn(({ markdown, alertIds }) => (
+      <div data-test-subj="mock-markdown-formatter" data-alert-ids={JSON.stringify(alertIds)}>
+        {markdown}
+      </div>
     )),
   })
 );
@@ -194,5 +197,20 @@ describe('SummaryTab', () => {
       }),
       {}
     );
+  });
+
+  it('passes originalAlertIds to AttackDiscoveryMarkdownFormatter', () => {
+    mockAttack.alertIds = ['alert-1', 'alert-2'];
+    mockAttack.replacements = { 'alert-1': 'original-1' };
+    renderSummaryTab();
+
+    const formatters = screen.getAllByTestId('mock-markdown-formatter');
+    expect(formatters.length).toBeGreaterThan(0);
+    formatters.forEach((formatter) => {
+      expect(formatter).toHaveAttribute(
+        'data-alert-ids',
+        JSON.stringify(['original-1', 'alert-2'])
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/summary_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/summary_tab.tsx
@@ -13,7 +13,7 @@ import { replaceAnonymizedValuesWithOriginalValues } from '@kbn/elastic-assistan
 import { TableId } from '@kbn/securitysolution-data-table';
 
 import { InvestigateInTimelineButton } from '../../../../../common/components/event_details/investigate_in_timeline_button';
-import { getTacticMetadata } from '../../../../../attack_discovery/helpers';
+import { getTacticMetadata, getOriginalAlertIds } from '../../../../../attack_discovery/helpers';
 import { AttackChain } from '../../../../../attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/attack/attack_chain';
 import { AttackDiscoveryMarkdownFormatter } from '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter';
 import { buildAlertsKqlFilter } from '../../../alerts_table/actions';
@@ -66,7 +66,7 @@ export const SummaryTab = React.memo<SummaryTabProps>(({ attack, showAnonymized 
   const tacticMetadata = useMemo(() => getTacticMetadata(attack.mitreAttackTactics), [attack]);
 
   const originalAlertIds = useMemo(
-    () => attack.alertIds.map((id) => attack.replacements?.[id] ?? id),
+    () => getOriginalAlertIds(attack.alertIds, attack.replacements),
     [attack.alertIds, attack.replacements]
   );
 
@@ -84,6 +84,7 @@ export const SummaryTab = React.memo<SummaryTabProps>(({ attack, showAnonymized 
           scopeId={TableId.alertsOnAttacksPage}
           disableActions={showAnonymized}
           markdown={showAnonymized ? summaryMarkdown : summaryMarkdownWithReplacements}
+          alertIds={originalAlertIds}
         />
       </div>
 
@@ -99,6 +100,7 @@ export const SummaryTab = React.memo<SummaryTabProps>(({ attack, showAnonymized 
           scopeId={TableId.alertsOnAttacksPage}
           disableActions={showAnonymized}
           markdown={showAnonymized ? detailsMarkdown : detailsMarkdownWithReplacements}
+          alertIds={originalAlertIds}
         />
       </div>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.test.tsx
@@ -26,8 +26,10 @@ jest.mock('../../../../../common/lib/kibana', () => ({
 jest.mock(
   '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter',
   () => ({
-    AttackDiscoveryMarkdownFormatter: jest.fn(({ markdown }) => (
-      <div data-test-subj="mock-markdown-formatter">{markdown}</div>
+    AttackDiscoveryMarkdownFormatter: jest.fn(({ markdown, alertIds }) => (
+      <div data-test-subj="mock-markdown-formatter" data-alert-ids={JSON.stringify(alertIds)}>
+        {markdown}
+      </div>
     )),
   })
 );
@@ -69,5 +71,20 @@ describe('Subtitle', () => {
     );
     expect(getByTestId('mock-markdown-formatter')).not.toHaveTextContent('Detected on');
     expect(getByTestId('mock-markdown-formatter')).not.toHaveTextContent('•');
+  });
+
+  it('should pass originalAlertIds to AttackDiscoveryMarkdownFormatter', () => {
+    const scheduledAttack = {
+      ...mockAttack,
+      alertRuleUuid: 'some_other_rule_id',
+      alertIds: ['alert-1', 'alert-2'],
+      replacements: { 'alert-1': 'original-1' },
+    };
+    const { getByTestId } = render(<Subtitle attack={scheduledAttack} />);
+
+    expect(getByTestId('mock-markdown-formatter')).toHaveAttribute(
+      'data-alert-ids',
+      JSON.stringify(['original-1', 'alert-2'])
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/subtitle.tsx
@@ -13,6 +13,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { TableId } from '@kbn/securitysolution-data-table';
 
+import { getOriginalAlertIds } from '../../../../../attack_discovery/helpers';
 import { getFormattedDate } from '../../../../../attack_discovery/pages/loading_callout/loading_messages/get_formatted_time';
 import { useDateFormat } from '../../../../../common/lib/kibana';
 import { AttackDiscoveryMarkdownFormatter } from '../../../../../attack_discovery/pages/results/attack_discovery_markdown_formatter';
@@ -69,11 +70,17 @@ export const Subtitle = React.memo<SubtitleProps>(({ attack, showAnonymized = fa
     showAnonymized,
   ]);
 
+  const originalAlertIds = useMemo(
+    () => getOriginalAlertIds(attack.alertIds, attack.replacements),
+    [attack.alertIds, attack.replacements]
+  );
+
   return (
     <AttackDiscoveryMarkdownFormatter
       scopeId={TableId.alertsOnAttacksPage}
       disableActions={showAnonymized}
       markdown={subtitleMarkdownText}
+      alertIds={originalAlertIds}
     />
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section.test.tsx
@@ -45,7 +45,13 @@ jest.mock('../../../flyout_v2/shared/components/expandable_section', () => ({
 }));
 
 jest.mock('../../../attack_discovery/pages/results/attack_discovery_markdown_formatter', () => ({
-  AttackDiscoveryMarkdownFormatter: ({ markdown }: { markdown: string }) => <div>{markdown}</div>,
+  AttackDiscoveryMarkdownFormatter: ({
+    markdown,
+    alertIds,
+  }: {
+    markdown: string;
+    alertIds?: string[];
+  }) => <div data-alert-ids={JSON.stringify(alertIds)}>{markdown}</div>,
 }));
 
 const mockedUseOverviewTabData = jest.mocked(useOverviewTabData);
@@ -64,6 +70,7 @@ describe('AISummarySection', () => {
       summaryMarkdownWithReplacements: 'SUMMARY (WITH REPLACEMENTS)',
       detailsMarkdown: 'DETAILS (ANONYMIZED)',
       detailsMarkdownWithReplacements: 'DETAILS (WITH REPLACEMENTS)',
+      originalAlertIds: [],
     });
   });
 
@@ -145,6 +152,7 @@ describe('AISummarySection', () => {
       summaryMarkdownWithReplacements: 'SUMMARY (WITH REPLACEMENTS)',
       detailsMarkdown: '',
       detailsMarkdownWithReplacements: 'DETAILS (WITH REPLACEMENTS)',
+      originalAlertIds: [],
     });
 
     render(<AISummarySection />);
@@ -156,5 +164,23 @@ describe('AISummarySection', () => {
 
     expect(toggle).toBeTruthy();
     expect(toggle.disabled).toBe(true);
+  });
+
+  it('passes originalAlertIds to AttackDiscoveryMarkdownFormatter', () => {
+    mockedUseOverviewTabData.mockReturnValue({
+      summaryMarkdown: 'SUMMARY (ANONYMIZED)',
+      summaryMarkdownWithReplacements: 'SUMMARY (WITH REPLACEMENTS)',
+      detailsMarkdown: 'DETAILS (ANONYMIZED)',
+      detailsMarkdownWithReplacements: 'DETAILS (WITH REPLACEMENTS)',
+      originalAlertIds: ['alert-1', 'alert-2'],
+    });
+
+    render(<AISummarySection />);
+
+    const formatters = document.querySelectorAll('[data-alert-ids]');
+    expect(formatters.length).toBeGreaterThan(0);
+    formatters.forEach((formatter) => {
+      expect(formatter).toHaveAttribute('data-alert-ids', JSON.stringify(['alert-1', 'alert-2']));
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section.tsx
@@ -38,6 +38,7 @@ export const AISummarySection = memo(() => {
     summaryMarkdownWithReplacements,
     detailsMarkdown,
     detailsMarkdownWithReplacements,
+    originalAlertIds,
   } = useOverviewTabData();
 
   const hasAnonymizedContent = useMemo(
@@ -98,6 +99,7 @@ export const AISummarySection = memo(() => {
             scopeId={TableId.alertsOnAttacksPage}
             disableActions={showAnonymized}
             markdown={showAnonymized ? summaryMarkdown : summaryMarkdownWithReplacements}
+            alertIds={originalAlertIds}
           />
         </div>
 
@@ -119,6 +121,7 @@ export const AISummarySection = memo(() => {
             disableActions={showAnonymized}
             scopeId={TableId.alertsOnAttacksPage}
             markdown={showAnonymized ? detailsMarkdown : detailsMarkdownWithReplacements}
+            alertIds={originalAlertIds}
           />
         </div>
       </EuiPanel>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_overview_tab_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_overview_tab_data.test.ts
@@ -65,6 +65,7 @@ describe('useOverviewTabData', () => {
       summaryMarkdownWithReplacements: '',
       detailsMarkdown: '',
       detailsMarkdownWithReplacements: '',
+      originalAlertIds: [],
     });
   });
 
@@ -105,5 +106,21 @@ describe('useOverviewTabData', () => {
     expect(getFieldsDataMock).toHaveBeenCalledWith(
       'kibana.alert.attack_discovery.details_markdown_with_replacements'
     );
+  });
+
+  it('should return originalAlertIds when attack is provided', () => {
+    getFieldsDataMock.mockReturnValue(null);
+    (getField as jest.Mock).mockReturnValue(undefined);
+    (useAttackDetailsContext as jest.Mock).mockReturnValue({
+      getFieldsData: getFieldsDataMock,
+      attack: {
+        alertIds: ['alert-1', 'alert-2'],
+        replacements: { 'alert-1': 'original-1' },
+      },
+    });
+
+    const { result } = renderHook(() => useOverviewTabData());
+
+    expect(result.current.originalAlertIds).toEqual(['original-1', 'alert-2']);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_overview_tab_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_overview_tab_data.ts
@@ -8,6 +8,7 @@
 import { useMemo } from 'react';
 import { useAttackDetailsContext } from '../context';
 import { getField } from '../../document_details/shared/utils';
+import { getOriginalAlertIds } from '../../../attack_discovery/helpers';
 
 const FIELD_SUMMARY_MARKDOWN = 'kibana.alert.attack_discovery.summary_markdown' as const;
 const FIELD_SUMMARY_MARKDOWN_WITH_REPLACEMENTS =
@@ -16,11 +17,8 @@ const FIELD_DETAILS_MARKDOWN = 'kibana.alert.attack_discovery.details_markdown' 
 const FIELD_DETAILS_MARKDOWN_WITH_REPLACEMENTS =
   'kibana.alert.attack_discovery.details_markdown_with_replacements' as const;
 
-/**
- * Centralized hook for Attack overview tab only
- */
 export const useOverviewTabData = () => {
-  const { getFieldsData } = useAttackDetailsContext();
+  const { getFieldsData, attack } = useAttackDetailsContext();
 
   const summaryMarkdown = useMemo(
     () => getField(getFieldsData(FIELD_SUMMARY_MARKDOWN)) ?? '',
@@ -39,18 +37,25 @@ export const useOverviewTabData = () => {
     [getFieldsData]
   );
 
+  const originalAlertIds = useMemo(
+    () => (attack ? getOriginalAlertIds(attack.alertIds, attack.replacements) : []),
+    [attack]
+  );
+
   return useMemo(
     () => ({
       summaryMarkdown,
       summaryMarkdownWithReplacements,
       detailsMarkdown,
       detailsMarkdownWithReplacements,
+      originalAlertIds,
     }),
     [
       detailsMarkdown,
       detailsMarkdownWithReplacements,
       summaryMarkdown,
       summaryMarkdownWithReplacements,
+      originalAlertIds,
     ]
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] Fix: Attack Discovery Entity Badges Open Entity Store Flyout (#272762)](https://github.com/elastic/kibana/pull/272762)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2026-06-16T15:54:19Z","message":"[Security Solution] Fix: Attack Discovery Entity Badges Open Entity Store Flyout (#272762)\n\n## Summary\n\nThis PR fixes an issue where clicking on `host.name` or `user.name`\nentity badges within the Attack Discovery markdown (AI summaries,\ndetails, subtitles) would incorrectly open the legacy **Observed\nEntity** flyout instead of the newer **Entity Store** flyout.\n\n**Root cause:** The Entity Store flyout requires an `entityId` (EUID) to\nload the entity properly. Previously, the Attack Discovery markdown\nrenderer did not compute or pass the `entityId` because identity fields\nlike `host.id` or `user.id` were discarded after LLM generation, leaving\nonly the entity name. As a fallback, querying just by name hit the\nlegacy Observed Entity path.\n\n**Solution (On-the-fly enrichment):**\n\n- Introduced the `use_entity_euid_from_alerts` hook which dynamically\nfetches the original, de-anonymized alerts associated with the Attack\nDiscovery document.\n- The hook finds the specific alert matching the clicked badge value,\nextracts the necessary identity ECS fields (like `host.id`,\n`user.domain`, etc.), and computes the correct EUID via the Entity Store\nAPI.\n- Updated `getFieldMarkdownRenderer` and\n`AttackDiscoveryMarkdownFormatter` to thread the `alertIds` and use the\ncomputed EUID when opening the right flyout panel.\n- Successfully passed `alertIds` down from all parent views, including\nthe Attack Discovery pages (Tabs and Actionable Summary) and the Attacks\npage/Details flyout (`summary_tab.tsx`, `subtitle.tsx`,\n`ai_summary_section.tsx`).\n- Button displays a loading spinner state while resolving the EUID to\nprovide feedback.\n- Fails gracefully by falling back to the Observed Entity flyout if the\nalert data is aged out, unavailable, or the Entity Store is disabled.\n\n## Verification Steps\n\n1. Navigate to the **Security > Attack Discovery** page or the\n**Security > Alerts > Attacks** page.\n2. Select an Attack that contains AI-generated summary or details with\nrecognized entity badges (e.g., `host.name` or `user.name`).\n3. Click on a `host.name` or `user.name` badge.\n4. Verify that the button briefly shows a loading spinner.\n5. Verify that the **Entity Store** flyout opens (displaying enriched\nentity data, risk scores, asset criticality, etc.) instead of the legacy\nObserved Entity flyout.\n6. Verify this behavior across different areas:\n   - Attack Discovery main view (Actionable Summary and tabs)\n   - Attacks page table (Subtitle)\n- Attack Details Flyout (Overview / AI Summary section and Summary Tab)\n7. Check the behavior on an older Attack where alerts might be\nmissing/aged out to confirm it falls back correctly to the Observed\nEntity flyout.\n\n## Screenshots\n\n\nhttps://github.com/user-attachments/assets/2de69f46-c43a-450c-8fed-58e6cd1694c1\n\n---\n\n_PR developed with Cursor + Gemini 3.1 Pro_\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ebe9f630dc0320aad2c8d62be18879ae96a30a96","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Investigations","backport:version","v9.4.0","v9.5.0"],"title":"[Security Solution] Fix: Attack Discovery Entity Badges Open Entity Store Flyout","number":272762,"url":"https://github.com/elastic/kibana/pull/272762","mergeCommit":{"message":"[Security Solution] Fix: Attack Discovery Entity Badges Open Entity Store Flyout (#272762)\n\n## Summary\n\nThis PR fixes an issue where clicking on `host.name` or `user.name`\nentity badges within the Attack Discovery markdown (AI summaries,\ndetails, subtitles) would incorrectly open the legacy **Observed\nEntity** flyout instead of the newer **Entity Store** flyout.\n\n**Root cause:** The Entity Store flyout requires an `entityId` (EUID) to\nload the entity properly. Previously, the Attack Discovery markdown\nrenderer did not compute or pass the `entityId` because identity fields\nlike `host.id` or `user.id` were discarded after LLM generation, leaving\nonly the entity name. As a fallback, querying just by name hit the\nlegacy Observed Entity path.\n\n**Solution (On-the-fly enrichment):**\n\n- Introduced the `use_entity_euid_from_alerts` hook which dynamically\nfetches the original, de-anonymized alerts associated with the Attack\nDiscovery document.\n- The hook finds the specific alert matching the clicked badge value,\nextracts the necessary identity ECS fields (like `host.id`,\n`user.domain`, etc.), and computes the correct EUID via the Entity Store\nAPI.\n- Updated `getFieldMarkdownRenderer` and\n`AttackDiscoveryMarkdownFormatter` to thread the `alertIds` and use the\ncomputed EUID when opening the right flyout panel.\n- Successfully passed `alertIds` down from all parent views, including\nthe Attack Discovery pages (Tabs and Actionable Summary) and the Attacks\npage/Details flyout (`summary_tab.tsx`, `subtitle.tsx`,\n`ai_summary_section.tsx`).\n- Button displays a loading spinner state while resolving the EUID to\nprovide feedback.\n- Fails gracefully by falling back to the Observed Entity flyout if the\nalert data is aged out, unavailable, or the Entity Store is disabled.\n\n## Verification Steps\n\n1. Navigate to the **Security > Attack Discovery** page or the\n**Security > Alerts > Attacks** page.\n2. Select an Attack that contains AI-generated summary or details with\nrecognized entity badges (e.g., `host.name` or `user.name`).\n3. Click on a `host.name` or `user.name` badge.\n4. Verify that the button briefly shows a loading spinner.\n5. Verify that the **Entity Store** flyout opens (displaying enriched\nentity data, risk scores, asset criticality, etc.) instead of the legacy\nObserved Entity flyout.\n6. Verify this behavior across different areas:\n   - Attack Discovery main view (Actionable Summary and tabs)\n   - Attacks page table (Subtitle)\n- Attack Details Flyout (Overview / AI Summary section and Summary Tab)\n7. Check the behavior on an older Attack where alerts might be\nmissing/aged out to confirm it falls back correctly to the Observed\nEntity flyout.\n\n## Screenshots\n\n\nhttps://github.com/user-attachments/assets/2de69f46-c43a-450c-8fed-58e6cd1694c1\n\n---\n\n_PR developed with Cursor + Gemini 3.1 Pro_\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ebe9f630dc0320aad2c8d62be18879ae96a30a96"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272762","number":272762,"mergeCommit":{"message":"[Security Solution] Fix: Attack Discovery Entity Badges Open Entity Store Flyout (#272762)\n\n## Summary\n\nThis PR fixes an issue where clicking on `host.name` or `user.name`\nentity badges within the Attack Discovery markdown (AI summaries,\ndetails, subtitles) would incorrectly open the legacy **Observed\nEntity** flyout instead of the newer **Entity Store** flyout.\n\n**Root cause:** The Entity Store flyout requires an `entityId` (EUID) to\nload the entity properly. Previously, the Attack Discovery markdown\nrenderer did not compute or pass the `entityId` because identity fields\nlike `host.id` or `user.id` were discarded after LLM generation, leaving\nonly the entity name. As a fallback, querying just by name hit the\nlegacy Observed Entity path.\n\n**Solution (On-the-fly enrichment):**\n\n- Introduced the `use_entity_euid_from_alerts` hook which dynamically\nfetches the original, de-anonymized alerts associated with the Attack\nDiscovery document.\n- The hook finds the specific alert matching the clicked badge value,\nextracts the necessary identity ECS fields (like `host.id`,\n`user.domain`, etc.), and computes the correct EUID via the Entity Store\nAPI.\n- Updated `getFieldMarkdownRenderer` and\n`AttackDiscoveryMarkdownFormatter` to thread the `alertIds` and use the\ncomputed EUID when opening the right flyout panel.\n- Successfully passed `alertIds` down from all parent views, including\nthe Attack Discovery pages (Tabs and Actionable Summary) and the Attacks\npage/Details flyout (`summary_tab.tsx`, `subtitle.tsx`,\n`ai_summary_section.tsx`).\n- Button displays a loading spinner state while resolving the EUID to\nprovide feedback.\n- Fails gracefully by falling back to the Observed Entity flyout if the\nalert data is aged out, unavailable, or the Entity Store is disabled.\n\n## Verification Steps\n\n1. Navigate to the **Security > Attack Discovery** page or the\n**Security > Alerts > Attacks** page.\n2. Select an Attack that contains AI-generated summary or details with\nrecognized entity badges (e.g., `host.name` or `user.name`).\n3. Click on a `host.name` or `user.name` badge.\n4. Verify that the button briefly shows a loading spinner.\n5. Verify that the **Entity Store** flyout opens (displaying enriched\nentity data, risk scores, asset criticality, etc.) instead of the legacy\nObserved Entity flyout.\n6. Verify this behavior across different areas:\n   - Attack Discovery main view (Actionable Summary and tabs)\n   - Attacks page table (Subtitle)\n- Attack Details Flyout (Overview / AI Summary section and Summary Tab)\n7. Check the behavior on an older Attack where alerts might be\nmissing/aged out to confirm it falls back correctly to the Observed\nEntity flyout.\n\n## Screenshots\n\n\nhttps://github.com/user-attachments/assets/2de69f46-c43a-450c-8fed-58e6cd1694c1\n\n---\n\n_PR developed with Cursor + Gemini 3.1 Pro_\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ebe9f630dc0320aad2c8d62be18879ae96a30a96"}}]}] BACKPORT-->