### PR TITLE
[One Workflow] Add GCP Cloud Functions tool descriptions

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/gcp_cloud_functions/gcp_cloud_functions.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/gcp_cloud_functions/gcp_cloud_functions.test.ts
@@ -59,6 +59,21 @@ describe('GcpCloudFunctionsConnector', () => {
       expect(GcpCloudFunctionsConnector.metadata.supportedFeatureIds).toContain('agentBuilder');
       expect(GcpCloudFunctionsConnector.auth?.types).toEqual(['gcp_service_account']);
     });
+
+    it('should describe all agent-facing actions', () => {
+      const toolActions = Object.entries(GcpCloudFunctionsConnector.actions).filter(
+        ([, action]) => action.isTool
+      );
+
+      expect(toolActions.map(([actionName]) => actionName)).toEqual([
+        'invoke',
+        'listFunctions',
+        'getFunction',
+      ]);
+      toolActions.forEach(([, action]) => {
+        expect(action.description?.trim().length).toBeGreaterThan(0);
+      });
+    });
   });
 
   describe('schema', () => {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/gcp_cloud_functions/gcp_cloud_functions.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/gcp_cloud_functions/gcp_cloud_functions.ts
@@ -160,6 +160,8 @@ export const GcpCloudFunctionsConnector: ConnectorSpec = {
   actions: {
     invoke: {
       isTool: true,
+      description:
+        'Invoke a GCP Cloud Function or Cloud Run function by name using its HTTP trigger URL. Use this when you need to run a known function with an optional JSON payload and return the function response.',
       input: lazySchema(() =>
         z.object({
           functionName: z.string().min(1).describe('Cloud Function or Cloud Run service name'),
@@ -210,6 +212,8 @@ export const GcpCloudFunctionsConnector: ConnectorSpec = {
 
     listFunctions: {
       isTool: true,
+      description:
+        'List GCP Cloud Functions and Cloud Run functions in the configured project and region. Use this to discover available function names before invoking or inspecting a function.',
       input: lazySchema(() =>
         z.object({
           pageSize: z
@@ -276,6 +280,8 @@ export const GcpCloudFunctionsConnector: ConnectorSpec = {
 
     getFunction: {
       isTool: true,
+      description:
+        'Get details for a single GCP Cloud Function or Cloud Run function by name. Use this when you already know the function name and need its endpoint or deployment configuration before deciding what to invoke.',
       input: lazySchema(() =>
         z.object({
           functionName: z.string().min(1).describe('Cloud Function or Cloud Run service name'),


### PR DESCRIPTION
## Summary

- Adds agent-facing descriptions for the GCP Cloud Functions connector `invoke`, `listFunctions`, and `getFunction` actions.
- Covers the Agent Builder routing invariant with a regression test that all exposed GCP Cloud Functions tools have non-empty descriptions.

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/kbn-connector-specs/src/specs/gcp_cloud_functions/gcp_cloud_functions.test.ts`
- [x] `node scripts/check`


Made with [Cursor](https://cursor.com)