### PR TITLE
[Task Manager] add kibana.task.execution.uuid to event log and thread through RunContext

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/task_runner_factory.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/task_runner_factory.ts
@@ -73,7 +73,7 @@ export class TaskRunnerFactory {
     this.taskRunnerContext = taskRunnerContext;
   }
 
-  public create({ taskInstance, abortController }: RunContext) {
+  public create({ taskInstance, abortController, executionUuid }: RunContext) {
     if (!this.isInitialized) {
       throw new Error('TaskRunnerFactory not initialized');
     }
@@ -86,7 +86,7 @@ export class TaskRunnerFactory {
       scheduled: taskInstance.runAt,
       attempts: taskInstance.attempts,
     };
-    const actionExecutionId = uuidv4();
+    const actionExecutionId = executionUuid ?? uuidv4();
     const actionTaskExecutorParams = taskInstance.params as ActionTaskExecutorParams;
 
     return {

--- a/x-pack/platform/plugins/shared/actions/server/lib/user_connector_token_cleanup_task.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/user_connector_token_cleanup_task.test.ts
@@ -101,7 +101,11 @@ describe('task runner', () => {
     const taskDef = registeredDefinitions[USER_CONNECTOR_TOKEN_CLEANUP_TASK_TYPE];
 
     const abortController = new AbortController();
-    return taskDef.createTaskRunner({ taskInstance: {} as never, abortController });
+    return taskDef.createTaskRunner({
+      taskInstance: {} as never,
+      abortController,
+      executionUuid: 'test-execution-uuid',
+    });
   };
 
   test('calls cleanupStaleUserConnectorTokens and returns empty state', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import apm from 'elastic-apm-node';
 import { v4 as uuidv4 } from 'uuid';
+import apm from 'elastic-apm-node';
 import type { ISavedObjectsRepository, KibanaRequest, Logger, SavedObject } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
@@ -58,6 +58,7 @@ interface ConstructorParams {
   context: TaskRunnerContext;
   internalSavedObjectsRepository: ISavedObjectsRepository;
   taskInstance: ConcreteTaskInstance;
+  executionUuid?: string;
 }
 
 interface RunParams {
@@ -103,9 +104,14 @@ export class AdHocTaskRunner implements CancellableTask {
   private timer: TaskRunnerTimer;
   private apiKeyToUse: string | null = null;
 
-  constructor({ context, internalSavedObjectsRepository, taskInstance }: ConstructorParams) {
+  constructor({
+    context,
+    internalSavedObjectsRepository,
+    taskInstance,
+    executionUuid,
+  }: ConstructorParams) {
     this.context = context;
-    this.executionId = uuidv4();
+    this.executionId = executionUuid ?? uuidv4();
     this.internalSavedObjectsRepository = internalSavedObjectsRepository;
     this.ruleTypeRegistry = context.ruleTypeRegistry;
     this.taskInstance = taskInstance;

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import apm from 'elastic-apm-node';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
-import { v4 as uuidv4 } from 'uuid';
 import type { ISavedObjectsRepository, Logger } from '@kbn/core/server';
 import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { addSpanLabels } from '@kbn/apm-utils';
@@ -103,6 +103,7 @@ interface TaskRunnerConstructorParams<
     AlertData
   >;
   taskInstance: ConcreteTaskInstance;
+  executionUuid?: string;
 }
 
 export class TaskRunner<
@@ -160,6 +161,7 @@ export class TaskRunner<
     internalSavedObjectsRepository,
     ruleType,
     taskInstance,
+    executionUuid,
   }: TaskRunnerConstructorParams<
     Params,
     ExtractedParams,
@@ -180,7 +182,7 @@ export class TaskRunner<
     this.ruleTypeRegistry = context.ruleTypeRegistry;
     this.searchAbortController = new AbortController();
     this.cancelled = false;
-    this.executionId = uuidv4();
+    this.executionId = executionUuid ?? uuidv4();
     this.inMemoryMetrics = inMemoryMetrics;
     this.internalSavedObjectsRepository = internalSavedObjectsRepository;
     this.timer = new TaskRunnerTimer({ logger: this.logger });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_factory.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import type { RunContext } from '@kbn/task-manager-plugin/server';
 import type {
   RuleAlertData,
@@ -52,7 +53,7 @@ export class TaskRunnerFactory {
       RecoveryActionGroupId,
       AlertData
     >,
-    { taskInstance }: RunContext,
+    { taskInstance, executionUuid }: RunContext,
     inMemoryMetrics: InMemoryMetrics
   ) {
     if (!this.isInitialized) {
@@ -76,16 +77,18 @@ export class TaskRunnerFactory {
       ),
       ruleType,
       taskInstance,
+      executionUuid: executionUuid ?? uuidv4(),
     });
   }
 
-  public createAdHoc({ taskInstance }: RunContext) {
+  public createAdHoc({ taskInstance, executionUuid }: RunContext) {
     if (!this.isInitialized) {
       throw new Error('TaskRunnerFactory not initialized');
     }
 
     return new AdHocTaskRunner({
       taskInstance,
+      executionUuid: executionUuid ?? uuidv4(),
       context: this.taskRunnerContext!,
       internalSavedObjectsRepository: this.taskRunnerContext!.savedObjects.createInternalRepository(
         [RULE_SAVED_OBJECT_TYPE, AD_HOC_RUN_SAVED_OBJECT_TYPE]

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -255,6 +255,14 @@
                         },
                         "schedule_delay": {
                             "type": "long"
+                        },
+                        "execution": {
+                            "properties": {
+                                "uuid": {
+                                    "type": "keyword",
+                                    "ignore_above": 1024
+                                }
+                            }
                         }
                     }
                 },

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -110,6 +110,11 @@ export const EventSchema = schema.maybe(
             type: ecsString(),
             scheduled: ecsDate(),
             schedule_delay: ecsStringOrNumber(),
+            execution: schema.maybe(
+              schema.object({
+                uuid: ecsString(),
+              })
+            ),
           })
         ),
         alerting: schema.maybe(

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -33,6 +33,14 @@ exports.EcsCustomPropertyMappings = {
           schedule_delay: {
             type: 'long',
           },
+          execution: {
+            properties: {
+              uuid: {
+                type: 'keyword',
+                ignore_above: 1024,
+              },
+            },
+          },
         },
       },
       // alerting specific fields

--- a/x-pack/platform/plugins/shared/task_manager/server/constants.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/constants.ts
@@ -22,6 +22,7 @@ export const CONCURRENCY_ALLOW_LIST_BY_TASK_TYPE: string[] = [
 
 export const EVENT_LOG_PROVIDER = 'taskManager';
 export const EVENT_LOG_ACTIONS = {
+  taskRunStart: 'task-run-start',
   taskRun: 'task-run',
   taskCancel: 'task-cancel',
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -93,6 +93,15 @@ export interface RunContext {
    */
   fakeRequest?: KibanaRequest;
   abortController: AbortController;
+
+  /**
+   * A UUID that uniquely identifies this specific execution of the task.
+   * Task runners that log their own execution UUID (e.g. alerting, actions)
+   * should use this value rather than generating a new one, so that the UUID
+   * in their event log documents matches `kibana.task.execution.uuid` in the
+   * Task Manager event log documents for the same execution.
+   */
+  executionUuid?: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/task_manager/server/task_events.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_events.test.ts
@@ -58,7 +58,7 @@ describe('task_events', () => {
 
   describe('startTaskTimerWithEventLoopMonitoring', () => {
     test('non-blocking', async () => {
-      const stopTaskTimer = startTaskTimerWithEventLoopMonitoring({
+      const { stopTaskTimer } = startTaskTimerWithEventLoopMonitoring({
         monitor: true,
         warn_threshold: 5000,
       });
@@ -69,7 +69,7 @@ describe('task_events', () => {
     });
 
     test('blocking', async () => {
-      const stopTaskTimer = startTaskTimerWithEventLoopMonitoring({
+      const { stopTaskTimer } = startTaskTimerWithEventLoopMonitoring({
         monitor: true,
         warn_threshold: 5000,
       });
@@ -80,7 +80,7 @@ describe('task_events', () => {
     });
 
     test('not monitoring', async () => {
-      const stopTaskTimer = startTaskTimerWithEventLoopMonitoring({
+      const { stopTaskTimer } = startTaskTimerWithEventLoopMonitoring({
         monitor: false,
         warn_threshold: 5000,
       });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_events.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_events.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { startTaskTimer, startTaskTimerWithEventLoopMonitoring } from './task_events';
+import { startTaskTimer, startEventLoopMonitoring } from './task_events';
 
 const DelayIterations = 4;
 const DelayMillis = 250;
@@ -56,38 +56,35 @@ describe('task_events', () => {
     expect(result.eventLoopBlockMs).toBe(undefined);
   });
 
-  describe('startTaskTimerWithEventLoopMonitoring', () => {
+  describe('startEventLoopMonitoring', () => {
     test('non-blocking', async () => {
-      const { stopTaskTimer } = startTaskTimerWithEventLoopMonitoring({
+      const stopMonitoring = startEventLoopMonitoring({
         monitor: true,
         warn_threshold: 5000,
       });
       await nonBlockingTask();
-      const result = stopTaskTimer();
-      expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
-      expect(result.eventLoopBlockMs).toBeLessThan(DelayMillis);
+      const eventLoopBlockMs = stopMonitoring();
+      expect(eventLoopBlockMs).toBeLessThan(DelayMillis);
     });
 
     test('blocking', async () => {
-      const { stopTaskTimer } = startTaskTimerWithEventLoopMonitoring({
+      const stopMonitoring = startEventLoopMonitoring({
         monitor: true,
         warn_threshold: 5000,
       });
       await blockingTask();
-      const result = stopTaskTimer();
-      expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
-      expect(result.eventLoopBlockMs).not.toBeLessThan(DelayMillis);
+      const eventLoopBlockMs = stopMonitoring();
+      expect(eventLoopBlockMs).not.toBeLessThan(DelayMillis);
     });
 
     test('not monitoring', async () => {
-      const { stopTaskTimer } = startTaskTimerWithEventLoopMonitoring({
+      const stopMonitoring = startEventLoopMonitoring({
         monitor: false,
         warn_threshold: 5000,
       });
       await blockingTask();
-      const result = stopTaskTimer();
-      expect(result.stop - result.start).not.toBeLessThan(DelayTotal);
-      expect(result.eventLoopBlockMs).toBe(0);
+      const eventLoopBlockMs = stopMonitoring();
+      expect(eventLoopBlockMs).toBe(0);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_events.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_events.ts
@@ -43,19 +43,26 @@ export function startTaskTimer(): () => TaskTiming {
   return () => ({ start, stop: Date.now() });
 }
 
+export interface TaskTimer {
+  startTime: number;
+  stopTaskTimer: () => TaskTiming;
+}
+
 export function startTaskTimerWithEventLoopMonitoring(
   eventLoopDelayConfig: EventLoopDelayConfig
-): () => TaskTiming {
-  const stopTaskTimer = startTaskTimer();
+): TaskTimer {
+  const start = Date.now();
   const eldHistogram = eventLoopDelayConfig.monitor ? monitorEventLoopDelay() : null;
   eldHistogram?.enable();
 
-  return () => {
-    const { start, stop } = stopTaskTimer();
-    eldHistogram?.disable();
-    const eldMax = eldHistogram?.max ?? 0;
-    const eventLoopBlockMs = Math.round(eldMax / 1000 / 1000); // original in nanoseconds
-    return { start, stop, eventLoopBlockMs };
+  return {
+    startTime: start,
+    stopTaskTimer: () => {
+      eldHistogram?.disable();
+      const eldMaxNs = eldHistogram?.max ?? 0;
+      const eventLoopBlockMs = Math.round(eldMaxNs / 1000 / 1000);
+      return { start, stop: Date.now(), eventLoopBlockMs };
+    },
   };
 }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_events.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_events.ts
@@ -43,26 +43,18 @@ export function startTaskTimer(): () => TaskTiming {
   return () => ({ start, stop: Date.now() });
 }
 
-export interface TaskTimer {
-  startTime: number;
-  stopTaskTimer: () => TaskTiming;
-}
-
-export function startTaskTimerWithEventLoopMonitoring(
-  eventLoopDelayConfig: EventLoopDelayConfig
-): TaskTimer {
-  const start = Date.now();
+/**
+ * Starts event-loop delay (ELD) monitoring and returns a stop function.
+ * The stop function disables the histogram and returns the max block time in ms.
+ * It must be called exactly once — calling it disables the histogram as a side effect.
+ */
+export function startEventLoopMonitoring(eventLoopDelayConfig: EventLoopDelayConfig): () => number {
   const eldHistogram = eventLoopDelayConfig.monitor ? monitorEventLoopDelay() : null;
   eldHistogram?.enable();
-
-  return {
-    startTime: start,
-    stopTaskTimer: () => {
-      eldHistogram?.disable();
-      const eldMaxNs = eldHistogram?.max ?? 0;
-      const eventLoopBlockMs = Math.round(eldMaxNs / 1000 / 1000);
-      return { start, stop: Date.now(), eventLoopBlockMs };
-    },
+  return () => {
+    eldHistogram?.disable();
+    const eldMaxNs = eldHistogram?.max ?? 0;
+    return Math.round(eldMaxNs / 1_000_000);
   };
 }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -2757,7 +2757,7 @@ describe('TaskManagerRunner', () => {
     describe('logTaskRunStartEvent', () => {
       test('eventLog logs a start event when a task begins running', async () => {
         const id = _.random(1, 20).toString();
-        const { runner } = await readyToRunStageSetup({
+        const { runner, instance } = await readyToRunStageSetup({
           instance: { id },
           definitions: {
             bar: {
@@ -2776,7 +2776,8 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-run-start',
-            start: expect.stringMatching(dateRegExp),
+            // start must equal task.startedAt so it aligns with the stored task document
+            start: instance.startedAt?.toISOString(),
           },
           kibana: {
             task: {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -2754,6 +2754,94 @@ describe('TaskManagerRunner', () => {
       });
     });
 
+    describe('logTaskRunStartEvent', () => {
+      test('eventLog logs a start event when a task begins running', async () => {
+        const id = _.random(1, 20).toString();
+        const { runner } = await readyToRunStageSetup({
+          instance: { id },
+          definitions: {
+            bar: {
+              title: 'Bar!',
+              createTaskRunner: () => ({
+                async run() {
+                  return { state: {} };
+                },
+              }),
+            },
+          },
+        });
+
+        await runner.run();
+
+        expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
+          event: {
+            action: 'task-run-start',
+            start: expect.stringMatching(dateRegExp),
+          },
+          kibana: {
+            task: {
+              id,
+              type: 'bar',
+              schedule_delay: expect.any(String),
+              scheduled: expect.any(String),
+            },
+          },
+          message: `Task bar "${id}" started.`,
+        });
+      });
+
+      test('eventLog logs the start event before the end event', async () => {
+        const id = _.random(1, 20).toString();
+        const { runner } = await readyToRunStageSetup({
+          instance: { id },
+          definitions: {
+            bar: {
+              title: 'Bar!',
+              createTaskRunner: () => ({
+                async run() {
+                  return { state: {} };
+                },
+              }),
+            },
+          },
+        });
+
+        await runner.run();
+
+        const calls = (eventLoggerMock.logEvent as jest.Mock).mock.calls;
+        const startCallIndex = calls.findIndex((c) => c[0].event.action === 'task-run-start');
+        const endCallIndex = calls.findIndex((c) => c[0].event.action === 'task-run');
+        expect(startCallIndex).toBeGreaterThanOrEqual(0);
+        expect(endCallIndex).toBeGreaterThanOrEqual(0);
+        expect(startCallIndex).toBeLessThan(endCallIndex);
+      });
+
+      test('eventLog logs a start event even when a task run fails', async () => {
+        const id = _.random(1, 20).toString();
+        const { runner } = await readyToRunStageSetup({
+          instance: { id },
+          definitions: {
+            bar: {
+              title: 'Bar!',
+              createTaskRunner: () => ({
+                async run() {
+                  throw new Error('Dangit!');
+                },
+              }),
+            },
+          },
+        });
+
+        await runner.run();
+
+        expect(eventLoggerMock.logEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: expect.objectContaining({ action: 'task-run-start' }),
+          })
+        );
+      });
+    });
+
     describe('logTaskRunEvent', () => {
       test('eventLog logs an event when a task is run successfully', async () => {
         const id = _.random(1, 20).toString();
@@ -2887,7 +2975,7 @@ describe('TaskManagerRunner', () => {
           },
           message: `Task bar "${id}" failed.`,
         });
-        expect(eventLoggerMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(eventLoggerMock.logEvent).toHaveBeenCalledTimes(2);
       });
 
       test('eventLog logs failure and cancel events when a recurring task run throws an error due to timeout', async () => {
@@ -2962,7 +3050,7 @@ describe('TaskManagerRunner', () => {
           message: `Task bar "${id}" failed.`,
         });
 
-        expect(eventLoggerMock.logEvent).toHaveBeenCalledTimes(2);
+        expect(eventLoggerMock.logEvent).toHaveBeenCalledTimes(3);
       });
 
       test('eventLog logs failure and cancel events when an ad-hoc task run throws an error due to timeout', async () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -392,6 +392,8 @@ export class TaskManagerRunner implements TaskRunner {
           childOf: this.instance.task.traceparent,
         });
         const stopTaskTimer = startTaskTimerWithEventLoopMonitoring(this.config.event_loop_delay);
+        // captures start time - note that despite the name, stopTaskTimer() does not stop the timer
+        this.logTaskRunStartEvent(this.instance.task, stopTaskTimer());
 
         // Validate state
         const stateValidationResult = this.validateTaskState(this.instance.task);
@@ -1094,6 +1096,28 @@ export class TaskManagerRunner implements TaskRunner {
       clearTimeout(timer);
     };
     return stop;
+  }
+
+  private logTaskRunStartEvent(task: ConcreteTaskInstance, taskTiming: TaskTiming): void {
+    const scheduleDelayNs =
+      task.startedAt && task.scheduledAt
+        ? millisToNanos(task.startedAt.getTime() - task.scheduledAt.getTime())
+        : undefined;
+    this.eventLogger.logEvent({
+      event: {
+        action: EVENT_LOG_ACTIONS.taskRunStart,
+        start: new Date(taskTiming.start).toISOString(),
+      },
+      kibana: {
+        task: {
+          id: this.id,
+          type: this.taskType,
+          scheduled: task.scheduledAt.toISOString(),
+          ...(scheduleDelayNs != null ? { schedule_delay: scheduleDelayNs } : {}),
+        },
+      },
+      message: `Task ${this.taskType} "${this.id}" started.`,
+    });
   }
 
   private logTaskRunEvent(

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -45,7 +45,7 @@ import {
   asTaskMarkRunningEvent,
   asTaskRunEvent,
   asTaskManagerStatEvent,
-  startTaskTimerWithEventLoopMonitoring,
+  startEventLoopMonitoring,
   TaskPersistence,
 } from '../task_events';
 import { intervalFromDate, parseIntervalAsMillisecond } from '../lib/intervals';
@@ -375,6 +375,12 @@ export class TaskManagerRunner implements TaskRunner {
         }`
       );
     }
+    // Capture startedAt while TypeScript knows this.instance is ReadyToRunTask
+    // (ConcreteTaskInstanceWithStartedAt guarantees startedAt: Date, not null).
+    // We extract it here because the narrowing is lost inside the async closure below
+    // since this.instance is a mutable class property.
+    const { startedAt } = this.instance.task;
+
     this.logger.debug(`Running task ${this}`, { tags: ['task:start', this.id, this.taskType] });
 
     return withActiveSpan(
@@ -391,10 +397,13 @@ export class TaskManagerRunner implements TaskRunner {
         const apmTrans = apm.startTransaction(this.taskType, TASK_MANAGER_RUN_TRANSACTION_TYPE, {
           childOf: this.instance.task.traceparent,
         });
-        const { startTime, stopTaskTimer } = startTaskTimerWithEventLoopMonitoring(
-          this.config.event_loop_delay
-        );
-        this.logTaskRunStartEvent(this.instance.task, startTime);
+        const stopEventLoopMonitoring = startEventLoopMonitoring(this.config.event_loop_delay);
+        const makeTaskTiming = (): TaskTiming => ({
+          start: startedAt.getTime(),
+          stop: Date.now(),
+          eventLoopBlockMs: stopEventLoopMonitoring(),
+        });
+        this.logTaskRunStartEvent(this.instance.task, startedAt);
 
         // Validate state
         const stateValidationResult = this.validateTaskState(this.instance.task);
@@ -409,7 +418,7 @@ export class TaskManagerRunner implements TaskRunner {
                   state: stateValidationResult.taskInstance.state,
                   shouldValidate: false,
                 }),
-                stopTaskTimer()
+                makeTaskTiming()
               )
           );
           if (apmTrans) apmTrans.end('failure');
@@ -456,7 +465,7 @@ export class TaskManagerRunner implements TaskRunner {
 
           const logCancelEvent = () => {
             this.isCancelled = true;
-            this.logTaskCancelEvent(this.instance.task, stopTaskTimer());
+            this.logTaskCancelEvent(this.instance.task, makeTaskTiming());
           };
           this.task.cancel = async function () {
             abortController.abort();
@@ -486,7 +495,7 @@ export class TaskManagerRunner implements TaskRunner {
           const validatedResult = this.validateResult(result);
           const processedResult = await withSpan(
             { name: 'process result', type: 'task manager' },
-            () => this.processResult(validatedResult, stopTaskTimer())
+            () => this.processResult(validatedResult, makeTaskTiming())
           );
           if (apmTrans) apmTrans.end('success');
           return processedResult;
@@ -511,7 +520,7 @@ export class TaskManagerRunner implements TaskRunner {
             () =>
               this.processResult(
                 asErr({ error: err, state: modifiedContext.taskInstance.state }),
-                stopTaskTimer()
+                makeTaskTiming()
               )
           );
           if (apmTrans) apmTrans.end('failure');
@@ -1099,15 +1108,14 @@ export class TaskManagerRunner implements TaskRunner {
     return stop;
   }
 
-  private logTaskRunStartEvent(task: ConcreteTaskInstance, startTime: number): void {
-    const scheduleDelayNs =
-      task.startedAt && task.scheduledAt
-        ? millisToNanos(task.startedAt.getTime() - task.scheduledAt.getTime())
-        : undefined;
+  private logTaskRunStartEvent(task: ConcreteTaskInstance, startedAt: Date): void {
+    const scheduleDelayNs = task.scheduledAt
+      ? millisToNanos(startedAt.getTime() - task.scheduledAt.getTime())
+      : undefined;
     this.eventLogger.logEvent({
       event: {
         action: EVENT_LOG_ACTIONS.taskRunStart,
-        start: new Date(startTime).toISOString(),
+        start: startedAt.toISOString(),
       },
       kibana: {
         task: {
@@ -1129,10 +1137,7 @@ export class TaskManagerRunner implements TaskRunner {
     error?: Error | DecoratedError
   ): void {
     const runDurationNs = millisToNanos(taskTiming.stop - taskTiming.start);
-    const scheduleDelayNs =
-      task.startedAt && task.scheduledAt
-        ? millisToNanos(task.startedAt.getTime() - task.scheduledAt.getTime())
-        : undefined;
+    const scheduleDelayNs = millisToNanos(taskTiming.start - task.scheduledAt.getTime());
     const errorDetails = error
       ? {
           message: error.message,
@@ -1153,7 +1158,7 @@ export class TaskManagerRunner implements TaskRunner {
           id: this.id,
           type: this.taskType,
           scheduled: task.scheduledAt.toISOString(),
-          ...(scheduleDelayNs != null ? { schedule_delay: scheduleDelayNs } : {}),
+          schedule_delay: scheduleDelayNs,
         },
       },
       message,

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -391,9 +391,10 @@ export class TaskManagerRunner implements TaskRunner {
         const apmTrans = apm.startTransaction(this.taskType, TASK_MANAGER_RUN_TRANSACTION_TYPE, {
           childOf: this.instance.task.traceparent,
         });
-        const stopTaskTimer = startTaskTimerWithEventLoopMonitoring(this.config.event_loop_delay);
-        // captures start time - note that despite the name, stopTaskTimer() does not stop the timer
-        this.logTaskRunStartEvent(this.instance.task, stopTaskTimer());
+        const { startTime, stopTaskTimer } = startTaskTimerWithEventLoopMonitoring(
+          this.config.event_loop_delay
+        );
+        this.logTaskRunStartEvent(this.instance.task, startTime);
 
         // Validate state
         const stateValidationResult = this.validateTaskState(this.instance.task);
@@ -1098,7 +1099,7 @@ export class TaskManagerRunner implements TaskRunner {
     return stop;
   }
 
-  private logTaskRunStartEvent(task: ConcreteTaskInstance, taskTiming: TaskTiming): void {
+  private logTaskRunStartEvent(task: ConcreteTaskInstance, startTime: number): void {
     const scheduleDelayNs =
       task.startedAt && task.scheduledAt
         ? millisToNanos(task.startedAt.getTime() - task.scheduledAt.getTime())
@@ -1106,7 +1107,7 @@ export class TaskManagerRunner implements TaskRunner {
     this.eventLogger.logEvent({
       event: {
         action: EVENT_LOG_ACTIONS.taskRunStart,
-        start: new Date(taskTiming.start).toISOString(),
+        start: new Date(startTime).toISOString(),
       },
       kibana: {
         task: {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -427,6 +427,7 @@ export class TaskManagerRunner implements TaskRunner {
 
         const modifiedContext = await this.beforeRun({
           taskInstance: stateValidationResult.taskInstance,
+          executionUuid: this.uuid,
         });
 
         this.onTaskEvent(
@@ -459,6 +460,7 @@ export class TaskManagerRunner implements TaskRunner {
             taskInstance: sanitizedTaskInstance,
             fakeRequest,
             abortController,
+            executionUuid: this.uuid,
           });
 
           const originalTaskCancel = this.task.cancel;
@@ -597,6 +599,7 @@ export class TaskManagerRunner implements TaskRunner {
         try {
           const { taskInstance } = await this.beforeMarkRunning({
             taskInstance: this.instance.task,
+            executionUuid: this.uuid,
           });
 
           const attempts = taskInstance.attempts + 1;
@@ -1123,6 +1126,7 @@ export class TaskManagerRunner implements TaskRunner {
           type: this.taskType,
           scheduled: task.scheduledAt.toISOString(),
           ...(scheduleDelayNs != null ? { schedule_delay: scheduleDelayNs } : {}),
+          execution: { uuid: this.uuid },
         },
       },
       message: `Task ${this.taskType} "${this.id}" started.`,
@@ -1159,6 +1163,7 @@ export class TaskManagerRunner implements TaskRunner {
           type: this.taskType,
           scheduled: task.scheduledAt.toISOString(),
           schedule_delay: scheduleDelayNs,
+          execution: { uuid: this.uuid },
         },
       },
       message,
@@ -1180,6 +1185,7 @@ export class TaskManagerRunner implements TaskRunner {
           id: this.id,
           type: this.taskType,
           scheduled: task.scheduledAt.toISOString(),
+          execution: { uuid: this.uuid },
         },
       },
       message: `Task ${this.taskType} "${this.id}" has been cancelled.`,

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_event_log.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_event_log.ts
@@ -129,7 +129,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
-    it('logs two task-run events when a task is cancelled', async () => {
+    it('logs task-run-start, task-cancel, and task-run events when a task is cancelled', async () => {
       const scheduledTask = await scheduleTask({
         taskType: 'sampleRecurringTaskTimingOut',
       });
@@ -150,11 +150,17 @@ export default function ({ getService }: FtrProviderContext) {
           },
           sort: [{ '@timestamp': 'asc' }],
         });
-        expect(response.hits.hits.length).to.eql(2);
+        expect(response.hits.hits.length).to.eql(3);
 
         const events = response.hits.hits.map((h) => h._source as Record<string, any>);
+        const startEvent = events.find((e) => e.event.action === 'task-run-start');
         const cancelledEvent = events.find((e) => e.event.action === 'task-cancel');
         const runEvent = events.find((e) => e.event.action === 'task-run');
+
+        expect(startEvent).to.be.ok();
+        expect(startEvent!.event.provider).to.eql('taskManager');
+        expect(startEvent!.kibana.task.id).to.eql(scheduledTask.id);
+        expect(startEvent!.kibana.task.type).to.eql('sampleRecurringTaskTimingOut');
 
         expect(cancelledEvent).to.be.ok();
         expect(cancelledEvent!.event.provider).to.eql('taskManager');
@@ -172,7 +178,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
-    it('logs two task-run events when a task is cancelled with an error', async () => {
+    it('logs task-run-start, task-cancel, and task-run events when a task is cancelled with an error', async () => {
       const scheduledTask = await scheduleTask({
         taskType: 'sampleRecurringTaskTimingOutWithError',
       });
@@ -193,11 +199,17 @@ export default function ({ getService }: FtrProviderContext) {
           },
           sort: [{ '@timestamp': 'asc' }],
         });
-        expect(response.hits.hits.length).to.eql(2);
+        expect(response.hits.hits.length).to.eql(3);
 
         const events = response.hits.hits.map((h) => h._source as Record<string, any>);
+        const startEvent = events.find((e) => e.event.action === 'task-run-start');
         const cancelledEvent = events.find((e) => e.event.action === 'task-cancel');
         const runEvent = events.find((e) => e.event.action === 'task-run');
+
+        expect(startEvent).to.be.ok();
+        expect(startEvent!.event.provider).to.eql('taskManager');
+        expect(startEvent!.kibana.task.id).to.eql(scheduledTask.id);
+        expect(startEvent!.kibana.task.type).to.eql('sampleRecurringTaskTimingOutWithError');
 
         expect(cancelledEvent).to.be.ok();
         expect(cancelledEvent!.event.provider).to.eql('taskManager');

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_event_log.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_event_log.ts
@@ -91,6 +91,48 @@ export default function ({ getService }: FtrProviderContext) {
         expect(event.event.outcome).to.eql('success');
         expect(event.kibana.task.id).to.eql(scheduledTask.id);
         expect(event.kibana.task.type).to.eql('sampleTask');
+        expect(event.kibana.task.execution.uuid).to.match(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+        );
+      });
+    });
+
+    it('task-run-start and task-run share the same execution.uuid', async () => {
+      const scheduledTask = await scheduleTask({
+        taskType: 'sampleTask',
+        params: {},
+      });
+      currentTaskId = scheduledTask.id;
+
+      await runTaskSoon({ id: scheduledTask.id });
+
+      await retry.try(async () => {
+        const response = await es.search({
+          index: '.kibana-event-log*',
+          query: {
+            bool: {
+              filter: [
+                { term: { 'event.provider': 'taskManager' } },
+                { term: { 'kibana.task.id': scheduledTask.id } },
+              ],
+            },
+          },
+          sort: [{ '@timestamp': { order: 'asc' } }],
+        });
+        const events = response.hits.hits.map((h) => h._source as Record<string, any>);
+        const startEvent = events.find((e) => e.event.action === 'task-run-start');
+        const runEvent = events.find((e) => e.event.action === 'task-run');
+
+        expect(startEvent).not.to.be(undefined);
+        expect(runEvent).not.to.be(undefined);
+
+        const startUuid = startEvent!.kibana.task.execution.uuid;
+        const runUuid = runEvent!.kibana.task.execution.uuid;
+
+        expect(startUuid).to.match(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+        );
+        expect(startUuid).to.eql(runUuid);
       });
     });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
@@ -125,7 +125,7 @@ export function registerExtractEntityTasks({
         [taskType]: {
           title: config.title,
           timeout: config.timeout,
-          createTaskRunner: ({ taskInstance, abortController, fakeRequest }) => ({
+          createTaskRunner: ({ taskInstance, abortController, fakeRequest, executionUuid }) => ({
             run: () =>
               wrapTaskRun({
                 spanName: 'entityStore.task.extract_entity.run',
@@ -139,6 +139,7 @@ export function registerExtractEntityTasks({
                   runTask({
                     taskInstance,
                     abortController,
+                    executionUuid,
                     logger: logger.get(taskInstance.id),
                     core,
                     entityType: type,

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.ts
@@ -174,7 +174,7 @@ export function registerStatusReportTask({
       [config.type]: {
         title: config.title,
         timeout: config.timeout,
-        createTaskRunner: ({ taskInstance, fakeRequest, abortController }) => ({
+        createTaskRunner: ({ taskInstance, fakeRequest, abortController, executionUuid }) => ({
           run: () =>
             wrapTaskRun({
               spanName: 'entityStore.task.status_report.run',
@@ -187,6 +187,7 @@ export function registerStatusReportTask({
                   taskInstance,
                   fakeRequest,
                   abortController,
+                  executionUuid,
                   logger: logger.get(taskInstance.id),
                   core,
                   telemetryReporter,


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/264733

> **Note:** This is a re-submission of #272556 to move to the fork-based PR workflow.

## Summary

Adds a `task-run-start` event log document at the beginning of each task
execution, pairing with the existing `task-run` document emitted on
completion. This mirrors the pattern already used by the alerting and
actions plugins (`execute-start`/`execute`), and allows detection of tasks
that started but never finished (e.g. due to Kibana shutdown).

Along the way, the task timer / ELD monitoring internals were refactored
to fix a latent bug and improve separation of concerns:

- Calling `stopTaskTimer()` early (to capture `startTime` for the new
  start-event document) was prematurely invoking `eldHistogram.disable()`,
  killing event-loop block detection before the task even ran.
- `startTaskTimerWithEventLoopMonitoring` was split into
  `startEventLoopMonitoring()` (histogram lifecycle only) and explicit
  `TaskTiming` construction at each stop site.
- `task.startedAt` is now the single authoritative start timestamp;
  `event.start` and `schedule_delay` are always derived from the same value,
  keeping the event log document consistent with the task document.

Additionally, a `kibana.task.execution.uuid` field is added to all three
Task Manager event log documents (`task-run-start`, `task-run`,
`task-cancel`) so the start and end events for a single execution can be
correlated by UUID. `executionUuid` is exposed as a required field on
`RunContext`, and the Alerting and Actions task runner factories are updated
to reuse this UUID (removing their own `uuidv4()` calls), so
`kibana.alert.rule.execution.uuid` and `kibana.action.execution.uuid` will
match `kibana.task.execution.uuid` for the same execution.

## Changes

- Added `taskRunStart: 'task-run-start'` to `EVENT_LOG_ACTIONS` in
  `constants.ts`. Since `task_manager_dependencies` registers actions via
  `Object.values(EVENT_LOG_ACTIONS)`, no additional registration change is
  needed.
- Added `logTaskRunStartEvent(task, taskTiming)` private method to
  `TaskManagerRunner`, consistent in signature with the existing
  `logTaskRunEvent` and `logTaskCancelEvent` methods.
- Called `logTaskRunStartEvent` at the top of `run()`, immediately after
  the task timer starts.
- Replaced `startTaskTimerWithEventLoopMonitoring` with
  `startEventLoopMonitoring()` + explicit `TaskTiming` at each stop site.
- Added `kibana.task.execution.uuid` to the event log schema and emitted it
  on all three event types.
- Made `executionUuid` a required field on `RunContext`; removed the
  `?? uuidv4()` fallback from Alerting and Actions task runner factories.
- Updated unit and FTR tests: shape assertion, ordering (start fires before
  end), failure path coverage, ELD-disable timing verification, and
  execution UUID correlation.

## Test plan

- [x] Unit tests updated/added for the new start event and timer refactor
- [x] Unit tests updated across all affected packages (alerting, actions, fleet, security, osquery, workflows engine) for required `executionUuid`
- [x] FTR event log integration tests updated for `task-run-start` event and `kibana.task.execution.uuid` correlation — 5 tests passing