### PR TITLE
[Entity Store] [POC ] Introduce KI-driven automated user entity resolution

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
@@ -70,6 +70,30 @@ Schema features describe the **log schema family** evident from field names and 
 - **Filter-evidence consistency**: every field/value used in `filter` must appear in, or be directly justified by, the feature's `evidence`.
 - **Keep rules generic**: Entity identification is not tied to specific technologies or log patterns. Any log evidence that reveals a distinct, named system component qualifies.
 
+### Identity Link (user / account entities)
+
+For `entity` features that represent a **user or account** (e.g. `subtype: "user"`, `subtype: "account"`), the stream may co-observe a low-trust local identity token (such as an endpoint/OS `user.name`) together with an authoritative directory identifier (such as a `user.email` / UPN) that refers to the **same real person**. When — and only when — both appear together in the evidence for the same identity, emit a `properties.identity_link` object so downstream entity resolution can link the two without re-scanning raw logs:
+
+- `properties.identity_link` shape (all keys are stable, low-cardinality strings):
+  - `user_name` (required): the local / endpoint identity token observed for the user (the value of `user.name`).
+  - `user_email` (required): the authoritative email / UPN observed for the same user (the value of `user.email`).
+  - `namespace_hint` (optional): the directory / IdP namespace the email belongs to when evident (e.g. `okta`, `entra_id`, `active_directory`).
+- **Strict co-occurrence**: only emit `identity_link` when the SAME documents tie `user_name` and `user_email` to one person. Never guess an email from a username, and never link two different people. If you are not certain both identifiers describe the same identity, omit `identity_link`.
+- **Evidence-backed**: both the `user_name` and `user_email` values used MUST appear in the feature's `evidence`.
+- **Applies to integration / IdP user entities too**, not only endpoint/OS accounts. When a SaaS or integration stream (e.g. a GitHub, SSO, or CI audit log) exposes both a service-local login (`user.name`, such as a GitHub handle) and the corporate email / UPN for the same person, emit `identity_link` with the login as `user_name`, the corporate email as `user_email`, and the directory it belongs to as `namespace_hint` (e.g. `okta`, `entra_id`). This lets downstream resolution bridge that service identity to the authoritative directory entity.
+- This is purely additive — it does not change any other property and is ignored for non-user entities.
+
+In addition to the per-identity `identity_link` above (which carries concrete *values* for one person), when the link between the local token and the authoritative email is carried by **stable, named fields** that hold the same relationship for EVERY user in the stream, also emit a `properties.identity_link_rule`. This lets downstream resolution deterministically materialize the link for all users in the stream by querying those fields directly, instead of relying on a per-user sample:
+
+- `properties.identity_link_rule` shape (all values are ECS-style dotted field NAMES, never concrete values):
+  - `user_name_field` (required): the field whose value is the local / service login (e.g. `user.name`).
+  - `user_email_field` (required): the field whose value is the authoritative email / UPN for the same person (e.g. `user.email`, or an SSO field such as `github.external_identity_nameid`).
+  - `namespace_hint` (optional): the directory / IdP namespace the email belongs to when evident (e.g. `okta`, `entra_id`, `active_directory`).
+- **Field names, not values**: every entry MUST be a field path that appears in the sample documents (and in the feature's `evidence`), NOT a concrete username or email. Emit the rule only when the two fields co-occur on the SAME documents and reliably describe one person per document across the sample.
+- **Use the most authoritative email-bearing field**: prefer a field that literally holds the corporate email / UPN (including SSO / SAML NameID fields like `github.external_identity_nameid`) over one that only holds a local login.
+- **Pair it with `filter` when the relationship only holds for a subset of documents** (e.g. only `iam` / SSO events carry the email): the same `filter` you emit for the entity scopes which documents the rule applies to. The rule is **stream-wide** — it describes the field relationship for EVERY user in the stream, so its scope should use broad, non-identity conditions (e.g. `data_stream.dataset`, `event.category`) and must NOT pin to a single user's value (do not rely on a `user.name == "<one user>"` style equality to scope the rule).
+- `identity_link_rule` is independent of `identity_link`: emit one, both, or neither. It is purely additive and ignored for non-user entities.
+
 ## Consolidation Rules
 
 **Consolidate** when properties belong to the same logical component and appear together in logs:
@@ -228,6 +252,41 @@ Version formatting rules (important for vulnerability analysis):
       { "field": "service.name", "eq": "checkout-api" },
       { "field": "event.dataset", "eq": "checkout-api.logs" }
     ]
+  }
+}
+```
+
+**Example 2c — Entity: a user/account with an identity link**
+```
+{
+  "type": "entity",
+  "subtype": "user",
+  "id": "user-jdoe",
+  "title": "jdoe",
+  "description": "Endpoint user account 'jdoe' observed on Windows hosts; the same sign-in events expose the corporate email john.doe@corp.com",
+  "properties": {
+    "name": "jdoe",
+    "identity_link": {
+      "user_name": "jdoe",
+      "user_email": "john.doe@corp.com",
+      "namespace_hint": "okta"
+    },
+    "identity_link_rule": {
+      "user_name_field": "user.name",
+      "user_email_field": "user.email",
+      "namespace_hint": "okta"
+    }
+  },
+  "confidence": 92,
+  "evidence": [
+    "user.name=jdoe",
+    "user.email=john.doe@corp.com",
+    "winlog.event_data.TargetUserName=jdoe"
+  ],
+  "evidence_doc_ids": ["a91c0d2", "5f0b7ae"],
+  "tags": ["entity", "user"],
+  "meta": {
+    "hosts_observed": ["WIN-HOST-01"]
   }
 }
 ```

--- a/x-pack/platform/plugins/shared/streams/server/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/index.ts
@@ -7,11 +7,21 @@
 
 import type { PluginInitializerContext } from '@kbn/core-plugins-server';
 import type { StreamsConfig } from '../common/config';
-import type { StreamsPluginSetup, StreamsPluginStart } from './plugin';
+import type {
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginSetup,
+  StreamsPluginStart,
+} from './plugin';
 import type { StreamsRouteRepository } from './routes';
 import { config } from './config';
 
-export type { StreamsConfig, StreamsPluginSetup, StreamsPluginStart, StreamsRouteRepository };
+export type {
+  StreamsConfig,
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginSetup,
+  StreamsPluginStart,
+  StreamsRouteRepository,
+};
 export { config };
 
 export const plugin = async (context: PluginInitializerContext<StreamsConfig>) => {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FeatureClient } from '../feature/feature_client';
+import type { StreamsClient } from '../client';
+import { DefinitionNotFoundError } from '../errors/definition_not_found_error';
+import { createKnowledgeIndicatorsReader } from './knowledge_indicators_reader';
+
+const makeStreamsClient = (
+  streamNames: string[],
+  getStreamImpl?: (name: string) => Promise<unknown>
+): StreamsClient =>
+  ({
+    listStreams: jest.fn(async () => streamNames.map((name) => ({ name }))),
+    getStream: jest.fn(getStreamImpl ?? (async () => ({}))),
+  } as unknown as StreamsClient);
+
+const makeFeatureClient = (hits: unknown[] = []): FeatureClient =>
+  ({
+    getFeatures: jest.fn(async () => ({ hits, total: hits.length })),
+  } as unknown as FeatureClient);
+
+describe('createKnowledgeIndicatorsReader', () => {
+  it('pushes the schema type + minConfidence into the feature query', async () => {
+    const streamsClient = makeStreamsClient(['logs.a', 'logs.b']);
+    const featureClient = makeFeatureClient([{ uuid: 'x' }]);
+    const reader = createKnowledgeIndicatorsReader({ featureClient, streamsClient });
+
+    const result = await reader.listSchemaFeatures({ minConfidence: 60 });
+
+    expect(streamsClient.listStreams).toHaveBeenCalledTimes(1);
+    expect(featureClient.getFeatures).toHaveBeenCalledWith(['logs.a', 'logs.b'], {
+      type: ['schema'],
+      minConfidence: 60,
+    });
+    expect(result).toEqual([{ uuid: 'x' }]);
+  });
+
+  it('returns [] without querying features when there are no streams', async () => {
+    const streamsClient = makeStreamsClient([]);
+    const featureClient = makeFeatureClient();
+    const reader = createKnowledgeIndicatorsReader({ featureClient, streamsClient });
+
+    expect(await reader.listEntityFeatures()).toEqual([]);
+    expect(featureClient.getFeatures).not.toHaveBeenCalled();
+  });
+
+  it('resolves a present stream to a single-element pattern array', async () => {
+    const streamsClient = makeStreamsClient(['logs.a']);
+    const reader = createKnowledgeIndicatorsReader({
+      featureClient: makeFeatureClient(),
+      streamsClient,
+    });
+    expect(await reader.resolveIndexPatterns('logs.a')).toEqual(['logs.a']);
+  });
+
+  it('returns [] for a missing stream instead of throwing', async () => {
+    const streamsClient = makeStreamsClient(['logs.a'], async () => {
+      throw new DefinitionNotFoundError('nope');
+    });
+    const reader = createKnowledgeIndicatorsReader({
+      featureClient: makeFeatureClient(),
+      streamsClient,
+    });
+    expect(await reader.resolveIndexPatterns('logs.gone')).toEqual([]);
+  });
+
+  it('rethrows non-not-found errors from getStream', async () => {
+    const streamsClient = makeStreamsClient(['logs.a'], async () => {
+      throw new Error('boom');
+    });
+    const reader = createKnowledgeIndicatorsReader({
+      featureClient: makeFeatureClient(),
+      streamsClient,
+    });
+    await expect(reader.resolveIndexPatterns('logs.a')).rejects.toThrow('boom');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Feature } from '@kbn/streams-schema';
+import { isDefinitionNotFoundError } from '../errors/definition_not_found_error';
+import type { FeatureClient } from '../feature/feature_client';
+import type { StreamsClient } from '../client';
+
+/**
+ * Options shared by the per-class list methods on
+ * `StreamsKnowledgeIndicatorsReader`. Kept deliberately small: this surface
+ * only exposes knobs cross-plugin consumers should reach for. Pagination,
+ * excluded-feature inclusion, and arbitrary type selection are NOT exposed
+ * — those are properties of the internal `FeatureClient` that the integration
+ * has no business depending on.
+ */
+export interface StreamsKnowledgeIndicatorsListOptions {
+  /**
+   * Drops features below the given confidence (0–100). Entity store should
+   * pass its configured threshold here so changes are honored without code
+   * changes. Omit to receive every confidence level.
+   */
+  minConfidence?: number;
+}
+
+/**
+ * Read-only Knowledge Indicators surface intentionally narrowed for
+ * cross-plugin consumers (currently Entity Store v2's KI integration).
+ *
+ * Design constraints:
+ * - One method per feature class the integration consumes. No `type` filter
+ *   is exposed to callers; each method hardwires its single value so a
+ *   future consumer cannot accidentally read feature classes outside the
+ *   integration's scope through this surface.
+ * - No `limit` and no `includeExcluded`. Excluded features must never be
+ *   returned here, and pagination is an internal concern of the underlying
+ *   storage client.
+ * - Stale / expired features are filtered server-side by the underlying
+ *   `FeatureClient` defaults; this surface inherits that behavior.
+ *
+ * If a future use case genuinely needs broader access, extend this interface
+ * with another narrow, intent-named method rather than adding escape hatches
+ * to the existing methods.
+ */
+export interface StreamsKnowledgeIndicatorsReader {
+  /**
+   * Lists `type: 'entity'` Knowledge Indicators across all streams the
+   * caller is authorized to read. Filters are pushed into the underlying
+   * storage query — they are not applied client-side.
+   */
+  listEntityFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Lists `type: 'dependency'` Knowledge Indicators across all streams the
+   * caller is authorized to read. Each dependency feature carries
+   * `properties.source`, `properties.target`, and `properties.protocol`
+   * naming the two endpoints of a relationship. Filters are pushed into
+   * the underlying storage query — they are not applied client-side.
+   */
+  listDependencyFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Lists `type: 'schema'` Knowledge Indicators across all streams the caller
+   * is authorized to read. Schema features describe the log schema family
+   * evident in a stream (`properties.schema_family` ∈ `'ecs' | 'otel' |
+   * 'custom'`). Cross-plugin consumers (currently entity_store) read these
+   * to discover which streams carry entity-identity fields, and for their
+   * `properties.ecs_identity_aliases` table when present.
+   *
+   * Filters are pushed into the underlying storage query — they are not
+   * applied client-side.
+   */
+  listSchemaFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Resolves a stream name to the Elasticsearch index pattern(s) backing it.
+   *
+   * For wired streams the stream name equals the data-stream name, and
+   * Elasticsearch resolves the data-stream name in `FROM` clauses, so a
+   * single-element array `[streamName]` is sufficient. For classic
+   * (unmanaged) streams the same convention holds — the stream is itself
+   * the pre-existing data stream.
+   *
+   * Returns an empty array when the stream does not exist (rather than
+   * throwing) so callers can skip missing streams without try/catch.
+   */
+  resolveIndexPatterns(streamName: string): Promise<string[]>;
+}
+
+/**
+ * Builds a `StreamsKnowledgeIndicatorsReader` over already-scoped underlying
+ * clients. Pass the `FeatureClient` and `StreamsClient` you obtained from
+ * the streams plugin's `getScopedClients({ request })` (or, for tests, mocks
+ * matching the same interface).
+ */
+export const createKnowledgeIndicatorsReader = (deps: {
+  featureClient: FeatureClient;
+  streamsClient: StreamsClient;
+}): StreamsKnowledgeIndicatorsReader => {
+  const { featureClient, streamsClient } = deps;
+
+  const listFeaturesOfType = async (
+    type: 'entity' | 'dependency' | 'schema',
+    options?: StreamsKnowledgeIndicatorsListOptions
+  ): Promise<Feature[]> => {
+    const streams = await streamsClient.listStreams();
+    const streamNames = streams.map((stream) => stream.name);
+    if (streamNames.length === 0) {
+      return [];
+    }
+    const { hits } = await featureClient.getFeatures(streamNames, {
+      type: [type],
+      minConfidence: options?.minConfidence,
+    });
+    return hits;
+  };
+
+  return {
+    listEntityFeatures: (options) => listFeaturesOfType('entity', options),
+    listDependencyFeatures: (options) => listFeaturesOfType('dependency', options),
+    listSchemaFeatures: (options) => listFeaturesOfType('schema', options),
+
+    resolveIndexPatterns: async (streamName) => {
+      try {
+        await streamsClient.getStream(streamName);
+      } catch (error) {
+        if (isDefinitionNotFoundError(error)) {
+          return [];
+        }
+        throw error;
+      }
+      // Wired and classic streams alike: the stream name resolves directly to
+      // its backing data-stream pattern. Future variants (e.g. group streams
+      // composing multiple data streams) can extend this without breaking
+      // callers that only care about the array shape.
+      return [streamName];
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -88,13 +88,30 @@ import {
 import { installMemoryWorkflows } from './lib/memory/install_managed_workflows';
 import { StreamsKIsOnboardingClient } from './lib/workflows/onboarding_workflow_client';
 import { STREAMS_SIGNIFICANT_EVENTS_MEMORY_ENABLED_FLAG } from '../common/feature_flags';
+import {
+  createKnowledgeIndicatorsReader,
+  type StreamsKnowledgeIndicatorsReader,
+} from './lib/streams/cross_plugin/knowledge_indicators_reader';
 
 const STREAMS_MANAGED_WORKFLOW_OWNER = 'streams';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface StreamsPluginStart {}
+
+export interface StreamsPluginStart {
+  /**
+   * Builds a request-scoped, read-only reader exposing the subset of stream
+   * Knowledge Indicators APIs intended for cross-plugin consumers. The
+   * reader is intentionally narrower than the internal `FeatureClient` /
+   * `StreamsClient` and never grants write access. See
+   * `StreamsKnowledgeIndicatorsReader` for the full surface.
+   */
+  getKnowledgeIndicatorsReader(args: {
+    request: KibanaRequest;
+  }): Promise<StreamsKnowledgeIndicatorsReader>;
+}
+
+export type { StreamsKnowledgeIndicatorsReader };
 
 export class StreamsPlugin
   implements
@@ -666,7 +683,24 @@ export class StreamsPlugin
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);
 
-    return {};
+    const streamsGetScopedClients = this.streamsGetScopedClients;
+    if (!streamsGetScopedClients) {
+      // Defensive: setup() always assigns this.streamsGetScopedClients before
+      // start() runs. Throwing surfaces a programming error rather than a
+      // silently broken cross-plugin reader.
+      throw new Error('Streams plugin: streamsGetScopedClients was not initialised in setup()');
+    }
+
+    return {
+      getKnowledgeIndicatorsReader: async ({ request }) => {
+        const scopedClients = await streamsGetScopedClients({ request });
+        const featureClient = await scopedClients.getFeatureClient();
+        return createKnowledgeIndicatorsReader({
+          featureClient,
+          streamsClient: scopedClients.streamsClient,
+        });
+      },
+    };
   }
 
   private async installMemoryWorkflowsIfEnabled(

--- a/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
@@ -17,7 +17,8 @@
       "licensing"
     ],
     "optionalPlugins": [
-      "encryptedSavedObjects"
+      "encryptedSavedObjects",
+      "streams"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -22,6 +22,23 @@ export const LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT = '15m';
 export const LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT = 100_000;
 export const LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT = 'drop' as const;
 
+// KI entity resolution (POC): opt-in maintainer that links medium-confidence
+// user entities to high-confidence IdP entities using Streams Knowledge
+// Indicators. Off by default so behavior is byte-identical until opted in.
+export const USE_KI_ENTITY_RESOLUTION_DEFAULT = false;
+// Confidence floor (0-100) for KI `entity` features consumed by the resolver.
+// Defaults high so the maintainer "only resolves when confidence is high".
+export const KI_ENTITY_RESOLUTION_MIN_CONFIDENCE_DEFAULT = 90;
+// Opt-in extension: also resolve a high-confidence IdP entity in a lower-priority
+// namespace (e.g. GitHub) to a higher-priority IdP target (Okta/AD). Independent
+// of `useKiEntityResolution`; off by default so medium->high stays separable.
+export const KI_ENTITY_RESOLUTION_RESOLVE_IDP_TO_IDP_DEFAULT = false;
+// Opt-in extension: also load `identity_link_rule` KI features and execute them
+// deterministically over their streams (one ES|QL aggregation per stream) to
+// materialize a clue for every user, closing the LLM-sampling coverage gap.
+// Off by default so the LLM-only per-user clue path stays the baseline.
+export const KI_ENTITY_RESOLUTION_USE_RULES_DEFAULT = false;
+
 export type LogExtractionConfig = z.infer<typeof LogExtractionConfig>;
 export const LogExtractionConfig = z.object({
   additionalIndexPatterns: z.array(z.string()).default([]),
@@ -53,6 +70,17 @@ export const LogExtractionConfig = z.object({
   maxLogsPerWindowCapBehavior: z
     .enum(['defer', 'drop'])
     .default(LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT),
+  useKiEntityResolution: z.boolean().default(USE_KI_ENTITY_RESOLUTION_DEFAULT),
+  kiEntityResolutionMinConfidence: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .default(KI_ENTITY_RESOLUTION_MIN_CONFIDENCE_DEFAULT),
+  kiEntityResolutionResolveIdpToIdp: z
+    .boolean()
+    .default(KI_ENTITY_RESOLUTION_RESOLVE_IDP_TO_IDP_DEFAULT),
+  kiEntityResolutionUseRules: z.boolean().default(KI_ENTITY_RESOLUTION_USE_RULES_DEFAULT),
 });
 
 export type HistorySnapshotStatus = z.infer<typeof HistorySnapshotStatus>;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
@@ -12,6 +12,10 @@ import {
   LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT,
   LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT,
   LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT,
+  USE_KI_ENTITY_RESOLUTION_DEFAULT,
+  KI_ENTITY_RESOLUTION_MIN_CONFIDENCE_DEFAULT,
+  KI_ENTITY_RESOLUTION_RESOLVE_IDP_TO_IDP_DEFAULT,
+  KI_ENTITY_RESOLUTION_USE_RULES_DEFAULT,
 } from './constants';
 
 export const EntityStoreGlobalStateTypeName = 'entity-store-global-state';
@@ -120,11 +124,69 @@ const version3: SavedObjectsFullModelVersion = {
   },
 };
 
+const logExtractionSchemaV4 = logExtractionSchemaV3.extends({
+  useKiEntityResolution: schema.maybe(schema.boolean()),
+  kiEntityResolutionMinConfidence: schema.maybe(schema.number()),
+  kiEntityResolutionResolveIdpToIdp: schema.maybe(schema.boolean()),
+});
+
+const globalStateSchemaV4 = globalStateSchemaV3.extends({
+  logsExtraction: logExtractionSchemaV4,
+});
+
+const version4: SavedObjectsFullModelVersion = {
+  changes: [
+    {
+      type: 'data_backfill',
+      backfillFn: () => ({
+        attributes: {
+          logsExtraction: {
+            useKiEntityResolution: USE_KI_ENTITY_RESOLUTION_DEFAULT,
+            kiEntityResolutionMinConfidence: KI_ENTITY_RESOLUTION_MIN_CONFIDENCE_DEFAULT,
+            kiEntityResolutionResolveIdpToIdp: KI_ENTITY_RESOLUTION_RESOLVE_IDP_TO_IDP_DEFAULT,
+          },
+        },
+      }),
+    },
+  ],
+  schemas: {
+    create: globalStateSchemaV4,
+    forwardCompatibility: globalStateSchemaV4.extends({}, { unknowns: 'ignore' }),
+  },
+};
+
+const logExtractionSchemaV5 = logExtractionSchemaV4.extends({
+  kiEntityResolutionUseRules: schema.maybe(schema.boolean()),
+});
+
+const globalStateSchemaV5 = globalStateSchemaV4.extends({
+  logsExtraction: logExtractionSchemaV5,
+});
+
+const version5: SavedObjectsFullModelVersion = {
+  changes: [
+    {
+      type: 'data_backfill',
+      backfillFn: () => ({
+        attributes: {
+          logsExtraction: {
+            kiEntityResolutionUseRules: KI_ENTITY_RESOLUTION_USE_RULES_DEFAULT,
+          },
+        },
+      }),
+    },
+  ],
+  schemas: {
+    create: globalStateSchemaV5,
+    forwardCompatibility: globalStateSchemaV5.extends({}, { unknowns: 'ignore' }),
+  },
+};
+
 export const EntityStoreGlobalStateType: SavedObjectsType = {
   name: EntityStoreGlobalStateTypeName,
   hidden: false,
   namespaceType: 'multiple-isolated',
   mappings: EntityStoreGlobalStateTypeMappings,
-  modelVersions: { 1: version1, 2: version2, 3: version3 },
+  modelVersions: { 1: version1, 2: version2, 3: version3, 4: version4, 5: version5 },
   hiddenFromHttpApis: true,
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/extract_identity_links.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/extract_identity_links.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import {
+  buildIdentityLinkExtractionEsql,
+  extractIdentityLinkClues,
+  isSafeFieldName,
+  stripIdentityFieldConditions,
+} from './extract_identity_links';
+import type { IdentityLinkRule } from './load_identity_link_rules';
+
+const logger = { debug: jest.fn(), warn: jest.fn() } as unknown as Logger;
+
+const makeRule = (overrides: Partial<IdentityLinkRule> = {}): IdentityLinkRule => ({
+  userNameField: 'user.name',
+  userEmailField: 'github.external_identity_nameid',
+  namespaceHint: 'okta',
+  featureUuid: 'uuid-1',
+  streamName: 'logs-github.audit-default',
+  confidence: 95,
+  ...overrides,
+});
+
+const makeReader = (
+  indexPatterns: string[] = ['logs-github.audit-default']
+): StreamsKnowledgeIndicatorsReader => ({
+  listEntityFeatures: jest.fn(async () => []),
+  listDependencyFeatures: jest.fn(async () => []),
+  listSchemaFeatures: jest.fn(async () => []),
+  resolveIndexPatterns: jest.fn(async () => indexPatterns),
+});
+
+interface FakeEsOpts {
+  fields?: Record<string, unknown>;
+  columns?: Array<{ name: string; type: string }>;
+  values?: unknown[][];
+  fieldCapsThrows?: boolean;
+  esqlThrows?: boolean;
+}
+
+const defaultColumns = [
+  { name: 'doc_count', type: 'long' },
+  { name: 'user_name', type: 'keyword' },
+  { name: 'user_email', type: 'keyword' },
+];
+
+const makeEsClient = (opts: FakeEsOpts = {}): ElasticsearchClient => {
+  const fieldCaps = jest.fn(async () => {
+    if (opts.fieldCapsThrows) {
+      throw new Error('field_caps boom');
+    }
+    return {
+      fields: opts.fields ?? {
+        'user.name': { keyword: {} },
+        'github.external_identity_nameid': { keyword: {} },
+      },
+    };
+  });
+  const query = jest.fn(async () => {
+    if (opts.esqlThrows) {
+      throw new Error('esql boom');
+    }
+    return { columns: opts.columns ?? defaultColumns, values: opts.values ?? [] };
+  });
+  return { fieldCaps, esql: { query } } as unknown as ElasticsearchClient;
+};
+
+describe('isSafeFieldName', () => {
+  it('accepts plain dotted ECS field paths', () => {
+    expect(isSafeFieldName('user.name')).toBe(true);
+    expect(isSafeFieldName('github.external_identity_nameid')).toBe(true);
+    expect(isSafeFieldName('user.target.email-1')).toBe(true);
+  });
+
+  it('rejects field names with ES|QL syntax / injection characters', () => {
+    expect(isSafeFieldName('user.name)')).toBe(false);
+    expect(isSafeFieldName('TO_STRING(x')).toBe(false);
+    expect(isSafeFieldName('a"b')).toBe(false);
+    expect(isSafeFieldName('a b')).toBe(false);
+    expect(isSafeFieldName('')).toBe(false);
+  });
+});
+
+describe('buildIdentityLinkExtractionEsql', () => {
+  it('builds FROM / WHERE not-null / STATS BY / LIMIT', () => {
+    const esql = buildIdentityLinkExtractionEsql(makeRule({ namespaceHint: undefined }), [
+      'logs-github.audit-default',
+    ]);
+    expect(esql).toContain('FROM logs-github.audit-default');
+    expect(esql).toContain('TO_STRING(user.name) IS NOT NULL');
+    expect(esql).toContain('TO_STRING(github.external_identity_nameid) IS NOT NULL');
+    expect(esql).toContain(
+      'STATS doc_count = COUNT(*) BY user_name = TO_STRING(user.name), user_email = TO_STRING(github.external_identity_nameid)'
+    );
+    expect(esql).toContain('LIMIT 10000');
+  });
+
+  it('includes the scope filter when present', () => {
+    const esql = buildIdentityLinkExtractionEsql(
+      makeRule({ filter: { field: 'event.category', eq: 'iam' } }),
+      ['logs-github.audit-default']
+    );
+    expect(esql).toContain('(TO_STRING(event.category) == "iam")');
+  });
+
+  it('strips a per-user identity pin from the filter, keeping the stream-wide scope', () => {
+    const esql = buildIdentityLinkExtractionEsql(
+      makeRule({
+        filter: {
+          and: [
+            { field: 'data_stream.dataset', eq: 'github.audit' },
+            { field: 'user.name', eq: 'opauloh' },
+          ],
+        },
+      }),
+      ['logs-github.audit-default']
+    );
+    expect(esql).toContain('(TO_STRING(data_stream.dataset) == "github.audit")');
+    // The per-user pin must NOT scope the WHERE clause (only the IS NOT NULL guard remains).
+    expect(esql).not.toContain('== "opauloh"');
+  });
+
+  it('drops the filter entirely when it only pins the identity', () => {
+    const esql = buildIdentityLinkExtractionEsql(
+      makeRule({ filter: { field: 'user.name', eq: 'opauloh' } }),
+      ['logs-github.audit-default']
+    );
+    expect(esql).not.toContain('== "opauloh"');
+    expect(esql).toContain('| WHERE TO_STRING(user.name) IS NOT NULL');
+  });
+
+  it('throws on unsafe field names', () => {
+    expect(() =>
+      buildIdentityLinkExtractionEsql(makeRule({ userNameField: 'x")' }), ['logs-x'])
+    ).toThrow(/unsafe field name/);
+  });
+});
+
+describe('stripIdentityFieldConditions', () => {
+  const fields = new Set(['user.name', 'github.external_identity_nameid']);
+
+  it('returns undefined for a lone identity-field leaf', () => {
+    expect(
+      stripIdentityFieldConditions({ field: 'user.name', eq: 'opauloh' }, fields)
+    ).toBeUndefined();
+  });
+
+  it('keeps a non-identity leaf untouched', () => {
+    const cond = { field: 'event.category', eq: 'iam' };
+    expect(stripIdentityFieldConditions(cond, fields)).toEqual(cond);
+  });
+
+  it('collapses an AND down to its non-identity members', () => {
+    expect(
+      stripIdentityFieldConditions(
+        {
+          and: [
+            { field: 'data_stream.dataset', eq: 'github.audit' },
+            { field: 'user.name', eq: 'opauloh' },
+          ],
+        },
+        fields
+      )
+    ).toEqual({ field: 'data_stream.dataset', eq: 'github.audit' });
+  });
+
+  it('preserves an AND with multiple non-identity members', () => {
+    expect(
+      stripIdentityFieldConditions(
+        {
+          and: [
+            { field: 'data_stream.dataset', eq: 'github.audit' },
+            { field: 'event.category', eq: 'iam' },
+            { field: 'github.external_identity_nameid', eq: 'x@y.com' },
+          ],
+        },
+        fields
+      )
+    ).toEqual({
+      and: [
+        { field: 'data_stream.dataset', eq: 'github.audit' },
+        { field: 'event.category', eq: 'iam' },
+      ],
+    });
+  });
+
+  it('drops a NOT wrapping only an identity condition', () => {
+    expect(
+      stripIdentityFieldConditions({ not: { field: 'user.name', eq: 'svc' } }, fields)
+    ).toBeUndefined();
+  });
+});
+
+describe('extractIdentityLinkClues', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const run = (rules: IdentityLinkRule[], esClient: ElasticsearchClient, reader = makeReader()) =>
+    extractIdentityLinkClues({
+      esClient,
+      reader,
+      rules,
+      logger,
+      abortController: new AbortController(),
+    });
+
+  it('materializes a clue per (user_name, user_email) pair, normalized', async () => {
+    const esClient = makeEsClient({
+      values: [
+        [3, 'opauloh', 'paulo.henriquedasilva@elastic.co'],
+        [1, 'OtherUser', 'Other.User@elastic.co'],
+      ],
+    });
+    const clues = await run([makeRule()], esClient);
+    expect(clues).toHaveLength(2);
+    expect(clues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userName: 'opauloh',
+          userEmail: 'paulo.henriquedasilva@elastic.co',
+          namespaceHint: 'okta',
+          streamName: 'logs-github.audit-default',
+          confidence: 95,
+        }),
+        expect.objectContaining({ userName: 'otheruser', userEmail: 'other.user@elastic.co' }),
+      ])
+    );
+  });
+
+  it('drops rows whose email lacks an @ and rows with blank names', async () => {
+    const esClient = makeEsClient({
+      values: [
+        [1, 'opauloh', 'not-an-email'],
+        [1, '', 'paulo@elastic.co'],
+      ],
+    });
+    const clues = await run([makeRule()], esClient);
+    expect(clues).toHaveLength(0);
+  });
+
+  it('expands multivalue cells into the cross product of pairs', async () => {
+    const esClient = makeEsClient({
+      values: [[2, 'opauloh', ['paulo@elastic.co', 'p.silva@elastic.co']]],
+    });
+    const clues = await run([makeRule()], esClient);
+    expect(new Set(clues.map((c) => c.userEmail))).toEqual(
+      new Set(['paulo@elastic.co', 'p.silva@elastic.co'])
+    );
+  });
+
+  it('skips a rule whose fields are missing from the mapping (stale rule)', async () => {
+    const esClient = makeEsClient({ fields: { 'user.name': { keyword: {} } } });
+    const clues = await run([makeRule()], esClient);
+    expect(clues).toHaveLength(0);
+    expect(esClient.esql.query as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('skips a rule whose stream has no backing index', async () => {
+    const esClient = makeEsClient({ values: [[1, 'opauloh', 'paulo@elastic.co']] });
+    const clues = await run([makeRule()], esClient, makeReader([]));
+    expect(clues).toHaveLength(0);
+    expect(esClient.fieldCaps as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('skips a rule with unsafe field names without querying', async () => {
+    const esClient = makeEsClient();
+    const clues = await run([makeRule({ userEmailField: 'email")' })], esClient);
+    expect(clues).toHaveLength(0);
+    expect(esClient.fieldCaps as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('continues when the extraction query throws', async () => {
+    const esClient = makeEsClient({ esqlThrows: true });
+    const clues = await run([makeRule()], esClient);
+    expect(clues).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('deduplicates identical pairs across rules, keeping the highest confidence', async () => {
+    const esClient = makeEsClient({ values: [[1, 'opauloh', 'paulo@elastic.co']] });
+    const clues = await run(
+      [
+        makeRule({ featureUuid: 'low', confidence: 80 }),
+        makeRule({ featureUuid: 'high', confidence: 99 }),
+      ],
+      esClient
+    );
+    expect(clues).toHaveLength(1);
+    expect(clues[0]).toMatchObject({ featureUuid: 'high', confidence: 99 });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/extract_identity_links.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/extract_identity_links.ts
@@ -1,0 +1,327 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { ESQLSearchResponse } from '@kbn/es-types';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import {
+  isAndCondition,
+  isOrCondition,
+  isNotCondition,
+  isFilterCondition,
+  isAlwaysCondition,
+  isNeverCondition,
+  type Condition,
+  type FilterCondition,
+} from '@kbn/streamlang';
+import { entityStoreConditionToESQL } from '../../../common/esql/condition_to_esql';
+import { castField } from '../../../common/esql/cast';
+import { esqlIsNotNullOrEmpty } from '../../../common/esql/strings';
+import { executeEsqlQuery } from '../../infra/elasticsearch/esql';
+import type { IdentityLinkClue } from './load_entity_resolution_clues';
+import type { IdentityLinkRule } from './load_identity_link_rules';
+
+/**
+ * Maximum distinct `(user_name, user_email)` pairs materialized per rule per
+ * run. Bounds the ES|QL result and the downstream clue set; matches the
+ * order-of-magnitude of the log-extraction `docsLimit` / feature-store limits.
+ */
+export const DEFAULT_MAX_LINK_PAIRS = 10_000;
+
+/** Output column aliases used by the extraction query. */
+const USER_NAME_COLUMN = 'user_name';
+const USER_EMAIL_COLUMN = 'user_email';
+const DOC_COUNT_COLUMN = 'doc_count';
+
+/**
+ * Safe ES field-path pattern. Rule field names are interpolated directly into
+ * the ES|QL string, so they must be a plain dotted identifier — never a
+ * function call, quote, or other ES|QL syntax. Anything else is rejected (the
+ * rule is skipped) rather than escaped.
+ */
+const SAFE_FIELD_NAME = /^[a-zA-Z_][a-zA-Z0-9_.@-]*$/;
+
+export const isSafeFieldName = (field: string): boolean => SAFE_FIELD_NAME.test(field);
+
+/**
+ * Removes every condition that references one of `fields` from a filter tree,
+ * recomposing the surrounding `and` / `or` / `not` groups.
+ *
+ * The LLM attaches the *entity's* filter to the rule, and that filter is usually
+ * scoped to the single discovered identity (e.g. `data_stream.dataset ==
+ * "github.audit" AND user.name == "opauloh"`). Reusing it verbatim would pin the
+ * deterministic extraction to one user, defeating the "every user in the stream"
+ * goal. Stripping the identity-field conditions keeps the broad, stream-wide
+ * scope (dataset / event.category) while dropping the per-user pin. The
+ * identity fields are still required to be non-null by the extraction WHERE, so
+ * removing them here never broadens beyond "rows that carry both identifiers".
+ *
+ * Returns `undefined` when nothing remains (i.e. the filter was only an identity
+ * pin), meaning the extraction runs unscoped over the stream.
+ */
+export const stripIdentityFieldConditions = (
+  condition: Condition,
+  fields: ReadonlySet<string>
+): Condition | undefined => {
+  if (isAlwaysCondition(condition) || isNeverCondition(condition)) {
+    return condition;
+  }
+  if (isFilterCondition(condition)) {
+    return fields.has((condition as FilterCondition).field) ? undefined : condition;
+  }
+  if (isNotCondition(condition)) {
+    const inner = stripIdentityFieldConditions(condition.not, fields);
+    return inner ? { not: inner } : undefined;
+  }
+  if (isAndCondition(condition)) {
+    const kept = condition.and
+      .map((child) => stripIdentityFieldConditions(child, fields))
+      .filter((child): child is Condition => child !== undefined);
+    if (kept.length === 0) return undefined;
+    return kept.length === 1 ? kept[0] : { and: kept };
+  }
+  if (isOrCondition(condition)) {
+    const kept = condition.or
+      .map((child) => stripIdentityFieldConditions(child, fields))
+      .filter((child): child is Condition => child !== undefined);
+    if (kept.length === 0) return undefined;
+    return kept.length === 1 ? kept[0] : { or: kept };
+  }
+  return condition;
+};
+
+/**
+ * Builds the deterministic identity-link extraction ES|QL for one rule:
+ *
+ * ```
+ * FROM <indexPatterns>
+ * | WHERE (<filter>) AND <nameField> not null/empty AND <emailField> not null/empty
+ * | STATS doc_count = COUNT(*) BY user_name = TO_STRING(<nameField>), user_email = TO_STRING(<emailField>)
+ * | LIMIT <limit>
+ * ```
+ *
+ * Returns the unique `(user_name, user_email)` pairs (with an observation count)
+ * across the whole stream — the deterministic equivalent of the per-user
+ * `identity_link` clue, for every user.
+ *
+ * Throws if either field name is unsafe; callers should pre-filter with
+ * {@link isSafeFieldName}.
+ */
+export const buildIdentityLinkExtractionEsql = (
+  rule: IdentityLinkRule,
+  indexPatterns: string[],
+  limit: number = DEFAULT_MAX_LINK_PAIRS
+): string => {
+  if (!isSafeFieldName(rule.userNameField) || !isSafeFieldName(rule.userEmailField)) {
+    throw new Error(
+      `[buildIdentityLinkExtractionEsql] unsafe field name(s): ` +
+        `${rule.userNameField} / ${rule.userEmailField}`
+    );
+  }
+
+  const whereParts: string[] = [];
+  if (rule.filter) {
+    // Strip the per-identity pin (e.g. `user.name == "opauloh"`) so the rule
+    // applies to every user in the stream, keeping only the broad scope.
+    const scopeFilter = stripIdentityFieldConditions(
+      rule.filter,
+      new Set([rule.userNameField, rule.userEmailField])
+    );
+    if (scopeFilter) {
+      whereParts.push(`(${entityStoreConditionToESQL(scopeFilter)})`);
+    }
+  }
+  whereParts.push(esqlIsNotNullOrEmpty(rule.userNameField));
+  whereParts.push(esqlIsNotNullOrEmpty(rule.userEmailField));
+
+  return [
+    `FROM ${indexPatterns.join(', ')}`,
+    `| WHERE ${whereParts.join(' AND ')}`,
+    `| STATS ${DOC_COUNT_COLUMN} = COUNT(*) BY ${USER_NAME_COLUMN} = ${castField(
+      rule.userNameField
+    )}, ${USER_EMAIL_COLUMN} = ${castField(rule.userEmailField)}`,
+    `| LIMIT ${limit}`,
+  ].join('\n');
+};
+
+export interface ExtractIdentityLinkCluesDeps {
+  esClient: ElasticsearchClient;
+  reader: StreamsKnowledgeIndicatorsReader;
+  rules: IdentityLinkRule[];
+  logger: Logger;
+  abortController: AbortController;
+  /** Per-rule cap on materialized pairs. Defaults to {@link DEFAULT_MAX_LINK_PAIRS}. */
+  maxPairsPerRule?: number;
+}
+
+const asStringValues = (cell: unknown): string[] => {
+  if (cell === null || cell === undefined) {
+    return [];
+  }
+  const values = Array.isArray(cell) ? cell : [cell];
+  return values.filter((value): value is string => typeof value === 'string');
+};
+
+/**
+ * Confirms both rule fields exist in the stream's mapping before querying, so a
+ * stale rule (the field was renamed/removed) is skipped instead of producing an
+ * ES|QL error or — worse — silently matching nothing.
+ */
+const ruleFieldsExist = async (
+  esClient: ElasticsearchClient,
+  indexPatterns: string[],
+  rule: IdentityLinkRule,
+  logger: Logger
+): Promise<boolean> => {
+  try {
+    const caps = await esClient.fieldCaps({
+      index: indexPatterns,
+      fields: [rule.userNameField, rule.userEmailField],
+      ignore_unavailable: true,
+    });
+    const present = caps.fields ?? {};
+    const missing = [rule.userNameField, rule.userEmailField].filter(
+      (field) => present[field] === undefined
+    );
+    if (missing.length > 0) {
+      logger.warn(
+        `extractIdentityLinkClues: rule on '${rule.streamName}' references field(s) ` +
+          `not present in the mapping: ${missing.join(', ')} — skipping`
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    logger.warn(
+      `extractIdentityLinkClues: field_caps check failed for '${rule.streamName}': ` +
+        `${err?.message ?? err} — skipping rule`
+    );
+    return false;
+  }
+};
+
+/**
+ * Executes identity-link *rules* deterministically against their streams and
+ * returns materialized {@link IdentityLinkClue}s — one per distinct, valid
+ * `(user_name, user_email)` pair observed across the entire stream, for EVERY
+ * user (no sampling).
+ *
+ * Per rule: validates field names, confirms both fields exist (field_caps),
+ * builds + runs the extraction ES|QL, then maps rows to clues reusing the same
+ * normalization as the per-user clue loader (lower-case both sides, require an
+ * `@` in the email). Results are deduplicated by `(userName, userEmail)`,
+ * keeping the highest-confidence source rule.
+ */
+export const extractIdentityLinkClues = async (
+  deps: ExtractIdentityLinkCluesDeps
+): Promise<IdentityLinkClue[]> => {
+  const { esClient, reader, rules, logger, abortController, maxPairsPerRule } = deps;
+  const limit = maxPairsPerRule ?? DEFAULT_MAX_LINK_PAIRS;
+
+  const byPair = new Map<string, IdentityLinkClue>();
+
+  for (const rule of rules) {
+    if (abortController.signal.aborted) {
+      logger.debug('extractIdentityLinkClues: aborted mid-run');
+      break;
+    }
+
+    if (!isSafeFieldName(rule.userNameField) || !isSafeFieldName(rule.userEmailField)) {
+      logger.warn(
+        `extractIdentityLinkClues: rule on '${rule.streamName}' has unsafe field name(s) ` +
+          `('${rule.userNameField}' / '${rule.userEmailField}') — skipping`
+      );
+      continue;
+    }
+
+    const indexPatterns = await reader.resolveIndexPatterns(rule.streamName);
+    if (indexPatterns.length === 0) {
+      logger.debug(
+        `extractIdentityLinkClues: stream '${rule.streamName}' has no backing index — skipping rule`
+      );
+      continue;
+    }
+
+    if (!(await ruleFieldsExist(esClient, indexPatterns, rule, logger))) {
+      continue;
+    }
+
+    const query = buildIdentityLinkExtractionEsql(rule, indexPatterns, limit);
+    let response: ESQLSearchResponse;
+    try {
+      response = await executeEsqlQuery({ esClient, query, abortController });
+    } catch (err) {
+      logger.warn(
+        `extractIdentityLinkClues: extraction query failed for '${rule.streamName}': ` +
+          `${err?.message ?? err} — skipping rule`
+      );
+      continue;
+    }
+
+    const nameIdx = response.columns.findIndex((col) => col.name === USER_NAME_COLUMN);
+    const emailIdx = response.columns.findIndex((col) => col.name === USER_EMAIL_COLUMN);
+    if (nameIdx === -1 || emailIdx === -1) {
+      logger.warn(
+        `extractIdentityLinkClues: extraction response for '${rule.streamName}' missing expected columns — skipping`
+      );
+      continue;
+    }
+
+    let pairsFromRule = 0;
+    const usersFromRule = new Set<string>();
+
+    for (const row of response.values) {
+      for (const rawName of asStringValues(row[nameIdx])) {
+        const userName = rawName.trim().toLowerCase();
+        if (!userName) {
+          continue;
+        }
+        for (const rawEmail of asStringValues(row[emailIdx])) {
+          const userEmail = rawEmail.trim().toLowerCase();
+          if (!userEmail || !userEmail.includes('@')) {
+            continue;
+          }
+
+          const key = `${userName}\u0000${userEmail}`;
+          const existing = byPair.get(key);
+          if (
+            !existing ||
+            rule.confidence > existing.confidence ||
+            (rule.confidence === existing.confidence && rule.featureUuid < existing.featureUuid)
+          ) {
+            byPair.set(key, {
+              userName,
+              userEmail,
+              ...(rule.namespaceHint ? { namespaceHint: rule.namespaceHint } : {}),
+              featureUuid: rule.featureUuid,
+              streamName: rule.streamName,
+              confidence: rule.confidence,
+            });
+          }
+          pairsFromRule++;
+          usersFromRule.add(userName);
+        }
+      }
+    }
+
+    // Dry-run-style visibility: a rule that would link many users at once is the
+    // high-blast-radius case operators care about.
+    logger.debug(
+      `extractIdentityLinkClues: rule on '${rule.streamName}' ` +
+        `(${rule.userNameField} -> ${rule.userEmailField}) yielded ${pairsFromRule} pair(s) ` +
+        `across ${usersFromRule.size} username(s)`
+    );
+  }
+
+  const clues = Array.from(byPair.values());
+  logger.debug(
+    `extractIdentityLinkClues: ${clues.length} deterministic clue(s) from ${rules.length} rule(s)`
+  );
+
+  return clues;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  createKnowledgeIndicatorsReader,
+  createKnowledgeIndicatorsReaderFromStreamsStart,
+} from './knowledge_indicators_reader_factory';
+export { loadEntityResolutionClues, parseIdentityLinkClue } from './load_entity_resolution_clues';
+export type {
+  IdentityLinkClue,
+  LoadEntityResolutionCluesOptions,
+} from './load_entity_resolution_clues';
+export { loadIdentityLinkRules, parseIdentityLinkRule } from './load_identity_link_rules';
+export type { IdentityLinkRule, LoadIdentityLinkRulesOptions } from './load_identity_link_rules';
+export {
+  extractIdentityLinkClues,
+  buildIdentityLinkExtractionEsql,
+  stripIdentityFieldConditions,
+} from './extract_identity_links';
+export type { ExtractIdentityLinkCluesDeps } from './extract_identity_links';

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { StreamsPluginStart } from '@kbn/streams-plugin/server';
+import {
+  __NO_OP_KI_READER_FOR_TESTING,
+  createKnowledgeIndicatorsReaderFromStreamsStart,
+} from './knowledge_indicators_reader_factory';
+
+const logger = { debug: jest.fn(), warn: jest.fn() } as unknown as Logger;
+const request = {} as KibanaRequest;
+
+describe('createKnowledgeIndicatorsReaderFromStreamsStart', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns the shared no-op reader when streams is undefined', async () => {
+    const reader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+      streams: undefined,
+      request,
+      logger,
+    });
+    expect(reader).toBe(__NO_OP_KI_READER_FOR_TESTING);
+    expect(await reader.listSchemaFeatures()).toEqual([]);
+    expect(await reader.resolveIndexPatterns('any')).toEqual([]);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to streams.getKnowledgeIndicatorsReader when streams is present', async () => {
+    const delegateReader = { listSchemaFeatures: jest.fn() };
+    const streams = {
+      getKnowledgeIndicatorsReader: jest.fn(async () => delegateReader),
+    } as unknown as StreamsPluginStart;
+
+    const reader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+      streams,
+      request,
+      logger,
+    });
+
+    expect(streams.getKnowledgeIndicatorsReader).toHaveBeenCalledWith({ request });
+    expect(reader).toBe(delegateReader);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type {
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginStart,
+} from '@kbn/streams-plugin/server';
+import type { EntityStoreCoreSetup } from '../../types';
+
+/**
+ * No-op reader returned when the streams plugin is not enabled in the
+ * deployment (it's an optional dependency in entity_store's `kibana.jsonc`).
+ *
+ * Returning empty arrays — rather than `null` or throwing — lets callers in
+ * the extract task drive a uniform "no Knowledge Indicators to process" branch
+ * without scattering `if (reader)` guards through the task flow. The semantics
+ * also align with `resolveIndexPatterns`'s documented behavior of returning
+ * `[]` for missing streams.
+ */
+const NO_OP_KI_READER: StreamsKnowledgeIndicatorsReader = {
+  listEntityFeatures: async () => [],
+  listDependencyFeatures: async () => [],
+  listSchemaFeatures: async () => [],
+  resolveIndexPatterns: async () => [],
+};
+
+/**
+ * Resolves a request-scoped `StreamsKnowledgeIndicatorsReader` for the given
+ * `fakeRequest`. Use this from any entity-store flow that needs to read
+ * Knowledge Indicators or resolve stream-backed index patterns.
+ *
+ * Behavior:
+ * - When streams is enabled, delegates to
+ *   `streamsStart.getKnowledgeIndicatorsReader({ request })`. The returned
+ *   reader inherits the request's auth / space scoping.
+ * - When streams is NOT enabled (optional dependency missing), returns
+ *   `NO_OP_KI_READER` and logs a single debug line. Entity store keeps
+ *   functioning without stream-derived sources.
+ */
+export const createKnowledgeIndicatorsReader = async ({
+  core,
+  fakeRequest,
+  logger,
+}: {
+  core: EntityStoreCoreSetup;
+  fakeRequest: KibanaRequest;
+  logger: Logger;
+}): Promise<StreamsKnowledgeIndicatorsReader> => {
+  const [, pluginsStart] = await core.getStartServices();
+  if (!pluginsStart.streams) {
+    logger.debug(
+      'Streams plugin not available; Knowledge Indicators reader will return empty results'
+    );
+    return NO_OP_KI_READER;
+  }
+  return pluginsStart.streams.getKnowledgeIndicatorsReader({ request: fakeRequest });
+};
+
+/**
+ * Request-scoped variant of {@link createKnowledgeIndicatorsReader} for callers
+ * that already hold a started `StreamsPluginStart` (typical in route handlers,
+ * which receive the start contract via the request context). Skips the
+ * `coreSetup.getStartServices()` round-trip that the background-task variant
+ * needs.
+ *
+ * Behavior matches the background-task factory: returns the no-op reader when
+ * `streams` is `undefined` (streams plugin not enabled in the deployment).
+ */
+export const createKnowledgeIndicatorsReaderFromStreamsStart = async ({
+  streams,
+  request,
+  logger,
+}: {
+  streams: StreamsPluginStart | undefined;
+  request: KibanaRequest;
+  logger: Logger;
+}): Promise<StreamsKnowledgeIndicatorsReader> => {
+  if (!streams) {
+    logger.debug(
+      'Streams plugin not available; Knowledge Indicators reader will return empty results'
+    );
+    return NO_OP_KI_READER;
+  }
+  return streams.getKnowledgeIndicatorsReader({ request });
+};
+
+/** Exported for tests so they can assert reference-equality against the fallback. */
+export const __NO_OP_KI_READER_FOR_TESTING = NO_OP_KI_READER;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_entity_resolution_clues.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_entity_resolution_clues.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import { loadEntityResolutionClues, parseIdentityLinkClue } from './load_entity_resolution_clues';
+
+const logger = { debug: jest.fn(), warn: jest.fn() } as unknown as Logger;
+
+const makeFeature = (overrides: Partial<Feature> = {}): Feature =>
+  ({
+    uuid: 'uuid-1',
+    id: 'user-jdoe',
+    stream_name: 'logs-windows.default',
+    type: 'entity',
+    subtype: 'user',
+    title: 'jdoe',
+    description: 'Endpoint user jdoe',
+    properties: {
+      name: 'jdoe',
+      identity_link: {
+        user_name: 'jdoe',
+        user_email: 'john.doe@corp.com',
+        namespace_hint: 'okta',
+      },
+    },
+    confidence: 95,
+    evidence: ['user.name=jdoe', 'user.email=john.doe@corp.com'],
+    status: 'active',
+    last_seen: '2026-06-10T00:00:00.000Z',
+    ...overrides,
+  } as Feature);
+
+const makeReader = (features: Feature[]): StreamsKnowledgeIndicatorsReader => ({
+  listEntityFeatures: jest.fn(async () => features),
+  listDependencyFeatures: jest.fn(async () => []),
+  listSchemaFeatures: jest.fn(async () => []),
+  resolveIndexPatterns: jest.fn(async () => []),
+});
+
+describe('parseIdentityLinkClue', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('parses and lower-cases a well-formed identity_link', () => {
+    const clue = parseIdentityLinkClue(
+      makeFeature({
+        properties: {
+          identity_link: {
+            user_name: 'JDoe',
+            user_email: 'John.Doe@Corp.com',
+            namespace_hint: 'Okta',
+          },
+        },
+      })
+    );
+    expect(clue).toEqual({
+      userName: 'jdoe',
+      userEmail: 'john.doe@corp.com',
+      namespaceHint: 'okta',
+      featureUuid: 'uuid-1',
+      streamName: 'logs-windows.default',
+      confidence: 95,
+    });
+  });
+
+  it('omits namespaceHint when not provided', () => {
+    const clue = parseIdentityLinkClue(
+      makeFeature({
+        properties: {
+          identity_link: { user_name: 'jdoe', user_email: 'john.doe@corp.com' },
+        },
+      })
+    );
+    expect(clue?.namespaceHint).toBeUndefined();
+  });
+
+  it('returns undefined when identity_link is missing', () => {
+    expect(parseIdentityLinkClue(makeFeature({ properties: { name: 'jdoe' } }))).toBeUndefined();
+  });
+
+  it('returns undefined when user_name or user_email is blank', () => {
+    expect(
+      parseIdentityLinkClue(
+        makeFeature({ properties: { identity_link: { user_name: '', user_email: 'a@b.com' } } })
+      )
+    ).toBeUndefined();
+    expect(
+      parseIdentityLinkClue(
+        makeFeature({ properties: { identity_link: { user_name: 'jdoe', user_email: '   ' } } })
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when email has no @', () => {
+    expect(
+      parseIdentityLinkClue(
+        makeFeature({
+          properties: { identity_link: { user_name: 'jdoe', user_email: 'not-an-email' } },
+        })
+      )
+    ).toBeUndefined();
+  });
+});
+
+describe('loadEntityResolutionClues', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns validated clues and pushes minConfidence into the reader', async () => {
+    const reader = makeReader([makeFeature()]);
+    const clues = await loadEntityResolutionClues(reader, { minConfidence: 90 }, logger);
+    expect(reader.listEntityFeatures).toHaveBeenCalledWith({ minConfidence: 90 });
+    expect(clues).toHaveLength(1);
+    expect(clues[0].userEmail).toBe('john.doe@corp.com');
+  });
+
+  it('re-applies the confidence floor client-side (defensive against non-filtering readers)', async () => {
+    const reader = makeReader([
+      makeFeature({ uuid: 'low', confidence: 50 }),
+      makeFeature({ uuid: 'high', confidence: 99 }),
+    ]);
+    const clues = await loadEntityResolutionClues(reader, { minConfidence: 90 }, logger);
+    expect(clues).toHaveLength(1);
+    expect(clues[0].featureUuid).toBe('high');
+  });
+
+  it('skips malformed features without throwing', async () => {
+    const reader = makeReader([
+      makeFeature({ uuid: 'bad', properties: { name: 'jdoe' } }),
+      makeFeature({ uuid: 'good' }),
+    ]);
+    const clues = await loadEntityResolutionClues(reader, {}, logger);
+    expect(clues).toHaveLength(1);
+    expect(clues[0].featureUuid).toBe('good');
+  });
+
+  it('deduplicates by (userName, userEmail), keeping the highest confidence', async () => {
+    const reader = makeReader([
+      makeFeature({ uuid: 'a', confidence: 80 }),
+      makeFeature({ uuid: 'b', confidence: 95 }),
+    ]);
+    const clues = await loadEntityResolutionClues(reader, {}, logger);
+    expect(clues).toHaveLength(1);
+    expect(clues[0].featureUuid).toBe('b');
+    expect(clues[0].confidence).toBe(95);
+  });
+
+  it('keeps distinct clues for the same userName with different emails (caller resolves ambiguity)', async () => {
+    const reader = makeReader([
+      makeFeature({
+        uuid: 'a',
+        properties: { identity_link: { user_name: 'jdoe', user_email: 'a@corp.com' } },
+      }),
+      makeFeature({
+        uuid: 'b',
+        properties: { identity_link: { user_name: 'jdoe', user_email: 'b@corp.com' } },
+      }),
+    ]);
+    const clues = await loadEntityResolutionClues(reader, {}, logger);
+    expect(clues).toHaveLength(2);
+    expect(new Set(clues.map((c) => c.userEmail))).toEqual(new Set(['a@corp.com', 'b@corp.com']));
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_entity_resolution_clues.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_entity_resolution_clues.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+
+/**
+ * A deterministic, evidence-backed identity link parsed from a `type: 'entity'`
+ * Knowledge Indicator's `properties.identity_link` (see the Streams feature
+ * system prompt). It ties a low-trust local identity token (`userName`,
+ * typically an endpoint/OS `user.name`) to an authoritative directory
+ * identifier (`userEmail`, a `user.email` / UPN) for the same real person.
+ *
+ * The KI entity-resolution maintainer consumes these clues to bridge
+ * medium-confidence (`local`) user entities that lack a clean `user.email`
+ * join key to their high-confidence IdP counterparts — links the existing
+ * email-based resolver cannot make on its own.
+ */
+export interface IdentityLinkClue {
+  /** Local identity token, lower-cased for case-insensitive matching. */
+  userName: string;
+  /** Authoritative email / UPN, lower-cased for case-insensitive matching. */
+  userEmail: string;
+  /** Optional IdP / directory namespace hint (e.g. `okta`), lower-cased. */
+  namespaceHint?: string;
+  /** Stable feature identifier (for provenance / telemetry / logs). */
+  featureUuid: string;
+  /** Stream the clue was observed on. */
+  streamName: string;
+  /** KI confidence (0–100) of the source feature. */
+  confidence: number;
+}
+
+export interface LoadEntityResolutionCluesOptions {
+  /**
+   * Confidence floor (0–100). Features below this are dropped. The floor is
+   * pushed down into the Streams query AND re-applied client-side so a mocked
+   * or non-filtering reader cannot leak low-confidence clues.
+   */
+  minConfidence?: number;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asNonEmptyString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+/**
+ * Parses and validates the `properties.identity_link` object of a single
+ * `entity` feature. Returns `undefined` when the feature does not carry a
+ * well-formed link (missing object, missing/blank `user_name` / `user_email`,
+ * or an email without an `@`). Malformed links are skipped, never guessed.
+ */
+export const parseIdentityLinkClue = (feature: Feature): IdentityLinkClue | undefined => {
+  const properties = asRecord(feature.properties);
+  const link = asRecord(properties?.identity_link);
+  if (!link) {
+    return undefined;
+  }
+
+  const userName = asNonEmptyString(link.user_name);
+  const userEmail = asNonEmptyString(link.user_email);
+  if (!userName || !userEmail || !userEmail.includes('@')) {
+    return undefined;
+  }
+
+  const namespaceHint = asNonEmptyString(link.namespace_hint);
+
+  return {
+    userName: userName.toLowerCase(),
+    userEmail: userEmail.toLowerCase(),
+    ...(namespaceHint ? { namespaceHint: namespaceHint.toLowerCase() } : {}),
+    featureUuid: feature.uuid,
+    streamName: feature.stream_name,
+    confidence: feature.confidence,
+  };
+};
+
+/**
+ * Reads `type: 'entity'` Knowledge Indicators across the authorized streams and
+ * returns the deterministic identity-link clues they carry, confidence-gated
+ * and deduplicated.
+ *
+ * Behavior:
+ * - Pushes `minConfidence` into the reader query and re-applies it client-side.
+ * - Skips features whose `properties.identity_link` is absent or malformed.
+ * - Deduplicates by `(userName, userEmail)`, keeping the highest-confidence
+ *   source feature (alphabetical `featureUuid` tiebreaker for determinism).
+ *
+ * Conflict handling (one `userName` mapping to different emails) is left to the
+ * caller: this loader returns every distinct, valid clue so the maintainer can
+ * detect ambiguity against the live entity index and skip rather than mislink.
+ */
+export const loadEntityResolutionClues = async (
+  reader: StreamsKnowledgeIndicatorsReader,
+  options: LoadEntityResolutionCluesOptions,
+  logger: Logger
+): Promise<IdentityLinkClue[]> => {
+  const { minConfidence } = options;
+  const features = await reader.listEntityFeatures({ minConfidence });
+
+  const byPair = new Map<string, IdentityLinkClue>();
+  let skippedMalformed = 0;
+  let skippedLowConfidence = 0;
+
+  for (const feature of features) {
+    if (typeof minConfidence === 'number' && feature.confidence < minConfidence) {
+      skippedLowConfidence++;
+      continue;
+    }
+
+    const clue = parseIdentityLinkClue(feature);
+    if (!clue) {
+      skippedMalformed++;
+      continue;
+    }
+
+    const key = `${clue.userName}\u0000${clue.userEmail}`;
+    const existing = byPair.get(key);
+    if (
+      !existing ||
+      clue.confidence > existing.confidence ||
+      (clue.confidence === existing.confidence && clue.featureUuid < existing.featureUuid)
+    ) {
+      byPair.set(key, clue);
+    }
+  }
+
+  const clues = Array.from(byPair.values());
+  logger.debug(
+    `loadEntityResolutionClues: ${clues.length} clue(s) from ${features.length} entity feature(s) ` +
+      `(skipped ${skippedMalformed} malformed, ${skippedLowConfidence} below confidence floor)`
+  );
+
+  return clues;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_identity_link_rules.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_identity_link_rules.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import { loadIdentityLinkRules, parseIdentityLinkRule } from './load_identity_link_rules';
+
+const logger = { debug: jest.fn(), warn: jest.fn() } as unknown as Logger;
+
+const makeFeature = (overrides: Partial<Feature> = {}): Feature =>
+  ({
+    uuid: 'uuid-1',
+    id: 'user-github',
+    stream_name: 'logs-github.audit-default',
+    type: 'entity',
+    subtype: 'user',
+    title: 'github users',
+    description: 'GitHub audit users with SSO email',
+    properties: {
+      identity_link_rule: {
+        user_name_field: 'user.name',
+        user_email_field: 'github.external_identity_nameid',
+        namespace_hint: 'okta',
+      },
+    },
+    confidence: 95,
+    evidence: ['user.name', 'github.external_identity_nameid'],
+    status: 'active',
+    last_seen: '2026-06-10T00:00:00.000Z',
+    ...overrides,
+  } as Feature);
+
+const makeReader = (features: Feature[]): StreamsKnowledgeIndicatorsReader => ({
+  listEntityFeatures: jest.fn(async () => features),
+  listDependencyFeatures: jest.fn(async () => []),
+  listSchemaFeatures: jest.fn(async () => []),
+  resolveIndexPatterns: jest.fn(async () => []),
+});
+
+describe('parseIdentityLinkRule', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('parses a well-formed rule, preserving field-name case and capturing the filter', () => {
+    const rule = parseIdentityLinkRule(
+      makeFeature({
+        filter: { field: 'event.category', eq: 'iam' },
+        properties: {
+          identity_link_rule: {
+            user_name_field: 'user.name',
+            user_email_field: 'github.external_identity_nameid',
+            namespace_hint: 'Okta',
+          },
+        },
+      })
+    );
+    expect(rule).toEqual({
+      userNameField: 'user.name',
+      userEmailField: 'github.external_identity_nameid',
+      namespaceHint: 'okta',
+      filter: { field: 'event.category', eq: 'iam' },
+      featureUuid: 'uuid-1',
+      streamName: 'logs-github.audit-default',
+      confidence: 95,
+    });
+  });
+
+  it('omits namespaceHint and filter when not provided', () => {
+    const rule = parseIdentityLinkRule(
+      makeFeature({
+        filter: undefined,
+        properties: {
+          identity_link_rule: { user_name_field: 'user.name', user_email_field: 'user.email' },
+        },
+      })
+    );
+    expect(rule?.namespaceHint).toBeUndefined();
+    expect(rule?.filter).toBeUndefined();
+  });
+
+  it('returns undefined when identity_link_rule is missing', () => {
+    expect(parseIdentityLinkRule(makeFeature({ properties: { name: 'x' } }))).toBeUndefined();
+  });
+
+  it('returns undefined when a field name is blank', () => {
+    expect(
+      parseIdentityLinkRule(
+        makeFeature({
+          properties: {
+            identity_link_rule: { user_name_field: '', user_email_field: 'user.email' },
+          },
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      parseIdentityLinkRule(
+        makeFeature({
+          properties: {
+            identity_link_rule: { user_name_field: 'user.name', user_email_field: '  ' },
+          },
+        })
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when both fields are identical (no link to make)', () => {
+    expect(
+      parseIdentityLinkRule(
+        makeFeature({
+          properties: {
+            identity_link_rule: { user_name_field: 'user.name', user_email_field: 'user.name' },
+          },
+        })
+      )
+    ).toBeUndefined();
+  });
+});
+
+describe('loadIdentityLinkRules', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns validated rules and pushes minConfidence into the reader', async () => {
+    const reader = makeReader([makeFeature()]);
+    const rules = await loadIdentityLinkRules(reader, { minConfidence: 90 }, logger);
+    expect(reader.listEntityFeatures).toHaveBeenCalledWith({ minConfidence: 90 });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].userEmailField).toBe('github.external_identity_nameid');
+  });
+
+  it('re-applies the confidence floor client-side', async () => {
+    const reader = makeReader([
+      makeFeature({ uuid: 'low', confidence: 50 }),
+      makeFeature({ uuid: 'high', confidence: 99 }),
+    ]);
+    const rules = await loadIdentityLinkRules(reader, { minConfidence: 90 }, logger);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].featureUuid).toBe('high');
+  });
+
+  it('skips malformed features without throwing', async () => {
+    const reader = makeReader([
+      makeFeature({ uuid: 'bad', properties: { name: 'x' } }),
+      makeFeature({ uuid: 'good' }),
+    ]);
+    const rules = await loadIdentityLinkRules(reader, {}, logger);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].featureUuid).toBe('good');
+  });
+
+  it('deduplicates by (stream, nameField, emailField), keeping the highest confidence', async () => {
+    const reader = makeReader([
+      makeFeature({ uuid: 'a', confidence: 80 }),
+      makeFeature({ uuid: 'b', confidence: 95 }),
+    ]);
+    const rules = await loadIdentityLinkRules(reader, {}, logger);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].featureUuid).toBe('b');
+    expect(rules[0].confidence).toBe(95);
+  });
+
+  it('keeps distinct rules for different email fields on the same stream', async () => {
+    const reader = makeReader([
+      makeFeature({
+        uuid: 'a',
+        properties: {
+          identity_link_rule: { user_name_field: 'user.name', user_email_field: 'user.email' },
+        },
+      }),
+      makeFeature({
+        uuid: 'b',
+        properties: {
+          identity_link_rule: {
+            user_name_field: 'user.name',
+            user_email_field: 'github.external_identity_nameid',
+          },
+        },
+      }),
+    ]);
+    const rules = await loadIdentityLinkRules(reader, {}, logger);
+    expect(rules).toHaveLength(2);
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_identity_link_rules.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_identity_link_rules.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { Condition } from '@kbn/streamlang';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+
+/**
+ * A deterministic, evidence-backed identity-link *rule* parsed from a
+ * `type: 'entity'` Knowledge Indicator's `properties.identity_link_rule` (see
+ * the Streams feature system prompt).
+ *
+ * Where {@link IdentityLinkClue} carries the concrete `(user_name, user_email)`
+ * values for a single person, a rule names the *fields* that carry that
+ * relationship for EVERY user in the stream:
+ *  - `userNameField` holds the local / service login (e.g. `user.name`);
+ *  - `userEmailField` holds the authoritative email / UPN for the same person
+ *    (e.g. `user.email`, or an SSO field such as `github.external_identity_nameid`).
+ *
+ * Downstream resolution executes the rule deterministically (one ES|QL
+ * aggregation over the whole stream) to materialize a clue for every user,
+ * closing the coverage gap left by LLM sampling.
+ */
+export interface IdentityLinkRule {
+  /** Field whose value is the local / service login (e.g. `user.name`). */
+  userNameField: string;
+  /** Field whose value is the authoritative email / UPN for the same person. */
+  userEmailField: string;
+  /** Optional IdP / directory namespace hint (e.g. `okta`), lower-cased. */
+  namespaceHint?: string;
+  /**
+   * Optional scope condition (the feature's `filter`) restricting which
+   * documents the rule applies to (e.g. only `iam` / SSO events carry the
+   * email). Undefined means the rule applies to every document in the stream.
+   */
+  filter?: Condition;
+  /** Stable feature identifier (for provenance / telemetry / logs). */
+  featureUuid: string;
+  /** Stream the rule was observed on. */
+  streamName: string;
+  /** KI confidence (0–100) of the source feature. */
+  confidence: number;
+}
+
+export interface LoadIdentityLinkRulesOptions {
+  /**
+   * Confidence floor (0–100). Features below this are dropped. The floor is
+   * pushed down into the Streams query AND re-applied client-side so a mocked
+   * or non-filtering reader cannot leak low-confidence rules.
+   */
+  minConfidence?: number;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asNonEmptyString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+/**
+ * Parses and validates the `properties.identity_link_rule` object of a single
+ * `entity` feature. Returns `undefined` when the feature does not carry a
+ * well-formed rule (missing object, or missing/blank `user_name_field` /
+ * `user_email_field`). Malformed rules are skipped, never guessed.
+ *
+ * Field *names* are intentionally NOT lower-cased — ES field paths are
+ * case-sensitive — but the optional `namespace_hint` is, to match the
+ * case-insensitive matching used elsewhere in the resolver.
+ */
+export const parseIdentityLinkRule = (feature: Feature): IdentityLinkRule | undefined => {
+  const properties = asRecord(feature.properties);
+  const rule = asRecord(properties?.identity_link_rule);
+  if (!rule) {
+    return undefined;
+  }
+
+  const userNameField = asNonEmptyString(rule.user_name_field);
+  const userEmailField = asNonEmptyString(rule.user_email_field);
+  if (!userNameField || !userEmailField || userNameField === userEmailField) {
+    return undefined;
+  }
+
+  const namespaceHint = asNonEmptyString(rule.namespace_hint);
+
+  return {
+    userNameField,
+    userEmailField,
+    ...(namespaceHint ? { namespaceHint: namespaceHint.toLowerCase() } : {}),
+    ...(feature.filter ? { filter: feature.filter } : {}),
+    featureUuid: feature.uuid,
+    streamName: feature.stream_name,
+    confidence: feature.confidence,
+  };
+};
+
+/**
+ * Reads `type: 'entity'` Knowledge Indicators across the authorized streams and
+ * returns the deterministic identity-link rules they carry, confidence-gated
+ * and deduplicated.
+ *
+ * Behavior:
+ * - Pushes `minConfidence` into the reader query and re-applies it client-side.
+ * - Skips features whose `properties.identity_link_rule` is absent or malformed.
+ * - Deduplicates by `(streamName, userNameField, userEmailField)`, keeping the
+ *   highest-confidence source feature (alphabetical `featureUuid` tiebreaker for
+ *   determinism). A given stream rarely needs more than one rule, but the same
+ *   rule can be re-discovered across runs.
+ */
+export const loadIdentityLinkRules = async (
+  reader: StreamsKnowledgeIndicatorsReader,
+  options: LoadIdentityLinkRulesOptions,
+  logger: Logger
+): Promise<IdentityLinkRule[]> => {
+  const { minConfidence } = options;
+  const features = await reader.listEntityFeatures({ minConfidence });
+
+  const byKey = new Map<string, IdentityLinkRule>();
+  let skippedMalformed = 0;
+  let skippedLowConfidence = 0;
+
+  for (const feature of features) {
+    if (typeof minConfidence === 'number' && feature.confidence < minConfidence) {
+      skippedLowConfidence++;
+      continue;
+    }
+
+    const rule = parseIdentityLinkRule(feature);
+    if (!rule) {
+      skippedMalformed++;
+      continue;
+    }
+
+    const key = `${rule.streamName}\u0000${rule.userNameField}\u0000${rule.userEmailField}`;
+    const existing = byKey.get(key);
+    if (
+      !existing ||
+      rule.confidence > existing.confidence ||
+      (rule.confidence === existing.confidence && rule.featureUuid < existing.featureUuid)
+    ) {
+      byKey.set(key, rule);
+    }
+  }
+
+  const rules = Array.from(byKey.values());
+  logger.debug(
+    `loadIdentityLinkRules: ${rules.length} rule(s) from ${features.length} entity feature(s) ` +
+      `(skipped ${skippedMalformed} malformed, ${skippedLowConfidence} below confidence floor)`
+  );
+
+  return rules;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/maintainers/automated_resolution/run.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/maintainers/automated_resolution/run.ts
@@ -25,7 +25,7 @@ import type { AutomatedResolutionState, MatchBucket, EntityHit } from './types';
 
 const MATCH_FIELD = 'user.email';
 const ENTITY_TYPE = 'user';
-const NAMESPACE_PRIORITY = ['active_directory', 'okta', 'entra_id'];
+export const NAMESPACE_PRIORITY = ['active_directory', 'okta', 'entra_id'];
 const PAGE_SIZE = 10_000;
 const ENGINE_METADATA_TYPE_FIELD = 'entity.EngineMetadata.Type';
 const RESOLVED_TO_FIELD = 'entity.relationships.resolution.resolved_to';

--- a/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/__tests__/index.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/__tests__/index.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+
+jest.mock('../run', () => ({
+  runKiAutomatedResolution: jest.fn(async () => ({ lastRun: { resolutionsCreated: 1 } })),
+}));
+jest.mock('../../../domain/streams_features', () => ({
+  createKnowledgeIndicatorsReader: jest.fn(async () => ({ listEntityFeatures: jest.fn() })),
+}));
+jest.mock('../../../domain/saved_objects', () => ({
+  EntityStoreGlobalStateClient: jest.fn(),
+}));
+jest.mock('../../../domain/resolution', () => ({
+  ResolutionClient: jest.fn(),
+}));
+
+import { createKiAutomatedResolutionMaintainerConfig } from '..';
+import { runKiAutomatedResolution } from '../run';
+import { createKnowledgeIndicatorsReader } from '../../../domain/streams_features';
+import { EntityStoreGlobalStateClient } from '../../../domain/saved_objects';
+
+const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn() } as unknown as Logger;
+
+const makeCore = () =>
+  ({
+    getStartServices: jest.fn(async () => [
+      { savedObjects: { getScopedClient: jest.fn(() => ({})) } },
+    ]),
+  } as any);
+
+const makeContext = () => ({
+  status: { metadata: { namespace: 'default' }, state: { lastRun: null } },
+  abortController: new AbortController(),
+  logger,
+  esClient: {},
+  cpsEsClient: {},
+  crudClient: {},
+  fakeRequest: {},
+  telemetry: { report: jest.fn() },
+});
+
+const mockGlobalStateFind = (config: unknown) => {
+  (EntityStoreGlobalStateClient as unknown as jest.Mock).mockImplementation(() => ({
+    find: jest.fn(async () => config),
+  }));
+};
+
+describe('createKiAutomatedResolutionMaintainerConfig', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('exposes the expected maintainer identity', () => {
+    const config = createKiAutomatedResolutionMaintainerConfig({ core: makeCore() });
+    expect(config.id).toBe('ki-automated-resolution');
+    expect(config.minLicense).toBe('enterprise');
+  });
+
+  it('is a no-op when the flag is disabled', async () => {
+    mockGlobalStateFind({
+      logsExtraction: { useKiEntityResolution: false, kiEntityResolutionMinConfidence: 90 },
+    });
+    const config = createKiAutomatedResolutionMaintainerConfig({ core: makeCore() });
+
+    const result = await config.run(makeContext() as any);
+
+    expect(result).toEqual({ lastRun: null });
+    expect(createKnowledgeIndicatorsReader).not.toHaveBeenCalled();
+    expect(runKiAutomatedResolution).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no global state exists for the namespace', async () => {
+    mockGlobalStateFind(undefined);
+    const config = createKiAutomatedResolutionMaintainerConfig({ core: makeCore() });
+
+    const result = await config.run(makeContext() as any);
+
+    expect(result).toEqual({ lastRun: null });
+    expect(runKiAutomatedResolution).not.toHaveBeenCalled();
+  });
+
+  it('delegates to runKiAutomatedResolution with the configured floor and flags when enabled', async () => {
+    mockGlobalStateFind({
+      logsExtraction: {
+        useKiEntityResolution: true,
+        kiEntityResolutionMinConfidence: 80,
+        kiEntityResolutionResolveIdpToIdp: true,
+        kiEntityResolutionUseRules: true,
+      },
+    });
+    const config = createKiAutomatedResolutionMaintainerConfig({ core: makeCore() });
+
+    await config.run(makeContext() as any);
+
+    expect(createKnowledgeIndicatorsReader).toHaveBeenCalledTimes(1);
+    expect(runKiAutomatedResolution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: 'default',
+        minConfidence: 80,
+        resolveIdpToIdp: true,
+        useRules: true,
+      })
+    );
+  });
+
+  it('passes useRules=false through when the rules sub-flag is off', async () => {
+    mockGlobalStateFind({
+      logsExtraction: {
+        useKiEntityResolution: true,
+        kiEntityResolutionMinConfidence: 90,
+        kiEntityResolutionResolveIdpToIdp: false,
+        kiEntityResolutionUseRules: false,
+      },
+    });
+    const config = createKiAutomatedResolutionMaintainerConfig({ core: makeCore() });
+
+    await config.run(makeContext() as any);
+
+    expect(runKiAutomatedResolution).toHaveBeenCalledWith(
+      expect.objectContaining({ useRules: false })
+    );
+  });
+
+  it('passes resolveIdpToIdp=false through when the sub-flag is off', async () => {
+    mockGlobalStateFind({
+      logsExtraction: {
+        useKiEntityResolution: true,
+        kiEntityResolutionMinConfidence: 90,
+        kiEntityResolutionResolveIdpToIdp: false,
+      },
+    });
+    const config = createKiAutomatedResolutionMaintainerConfig({ core: makeCore() });
+
+    await config.run(makeContext() as any);
+
+    expect(runKiAutomatedResolution).toHaveBeenCalledWith(
+      expect.objectContaining({ resolveIdpToIdp: false })
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/__tests__/run.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/__tests__/run.test.ts
@@ -1,0 +1,563 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import type { ResolutionClient } from '../../../domain/resolution';
+import { runKiAutomatedResolution } from '../run';
+
+const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn() } as unknown as Logger;
+
+const makeFeature = (
+  userName: string,
+  userEmail: string,
+  overrides: Partial<Feature> = {}
+): Feature =>
+  ({
+    uuid: `uuid-${userName}-${userEmail}`,
+    id: `user-${userName}`,
+    stream_name: 'logs-windows.default',
+    type: 'entity',
+    subtype: 'user',
+    title: userName,
+    description: 'Endpoint user',
+    properties: { identity_link: { user_name: userName, user_email: userEmail } },
+    confidence: 95,
+    evidence: [`user.name=${userName}`, `user.email=${userEmail}`],
+    status: 'active',
+    last_seen: '2026-06-10T00:00:00.000Z',
+    ...overrides,
+  } as Feature);
+
+const makeReader = (features: Feature[]): StreamsKnowledgeIndicatorsReader => ({
+  listEntityFeatures: jest.fn(async () => features),
+  listDependencyFeatures: jest.fn(async () => []),
+  listSchemaFeatures: jest.fn(async () => []),
+  resolveIndexPatterns: jest.fn(async () => []),
+});
+
+interface FakeEntity {
+  entityId: string;
+  namespace: string;
+  confidence: 'high' | 'medium';
+  userName?: string;
+  userEmail?: string;
+}
+
+const filterValue = (params: any, field: string): unknown => {
+  const filters = params.query?.bool?.filter ?? [];
+  for (const f of filters) {
+    const term = f.term?.[field];
+    if (term === undefined) continue;
+    return typeof term === 'object' && term !== null && 'value' in term ? term.value : term;
+  }
+  return undefined;
+};
+
+interface FakeEsqlOpts {
+  fields?: Record<string, unknown>;
+  columns?: Array<{ name: string; type: string }>;
+  values?: unknown[][];
+}
+
+const makeEsClient = (entities: FakeEntity[], esqlOpts: FakeEsqlOpts = {}): ElasticsearchClient => {
+  const search = jest.fn(async (params: any) => {
+    const confidence = filterValue(params, 'entity.confidence');
+    const userName = filterValue(params, 'user.name');
+    const userEmail = filterValue(params, 'user.email');
+
+    const matches = entities.filter((e) => {
+      if (e.confidence !== confidence) return false;
+      if (userName !== undefined && e.userName?.toLowerCase() !== String(userName).toLowerCase()) {
+        return false;
+      }
+      if (
+        userEmail !== undefined &&
+        e.userEmail?.toLowerCase() !== String(userEmail).toLowerCase()
+      ) {
+        return false;
+      }
+      return true;
+    });
+
+    return {
+      hits: {
+        hits: matches.map((e) => ({
+          _source: { 'entity.id': e.entityId, 'entity.namespace': e.namespace },
+        })),
+      },
+    };
+  });
+
+  // Deterministic rule path (only exercised when useRules is true).
+  const fieldCaps = jest.fn(async () => ({
+    fields: esqlOpts.fields ?? {
+      'user.name': { keyword: {} },
+      'github.external_identity_nameid': { keyword: {} },
+    },
+  }));
+  const query = jest.fn(async () => ({
+    columns: esqlOpts.columns ?? [
+      { name: 'doc_count', type: 'long' },
+      { name: 'user_name', type: 'keyword' },
+      { name: 'user_email', type: 'keyword' },
+    ],
+    values: esqlOpts.values ?? [],
+  }));
+
+  return { search, fieldCaps, esql: { query } } as unknown as ElasticsearchClient;
+};
+
+const makeResolutionClient = () =>
+  ({
+    linkEntities: jest.fn(async (targetId: string, ids: string[]) => ({
+      linked: ids,
+      skipped: [],
+      target_id: targetId,
+    })),
+  } as unknown as ResolutionClient & { linkEntities: jest.Mock });
+
+const baseDeps = () => ({
+  state: { lastRun: null },
+  namespace: 'default',
+  logger,
+  minConfidence: 90,
+  resolveIdpToIdp: false,
+  useRules: false,
+  telemetry: { report: jest.fn() },
+  abortController: new AbortController(),
+});
+
+describe('runKiAutomatedResolution', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('links a medium candidate to the high IdP target (primary success metric)', async () => {
+    const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+    const esClient = makeEsClient([
+      {
+        entityId: 'user:jdoe@host1@local',
+        namespace: 'local',
+        confidence: 'medium',
+        userName: 'jdoe',
+      },
+      {
+        entityId: 'user:john.doe@corp.com@okta',
+        namespace: 'okta',
+        confidence: 'high',
+        userEmail: 'john.doe@corp.com',
+      },
+    ]);
+    const resolutionClient = makeResolutionClient();
+
+    const result = await runKiAutomatedResolution({
+      ...baseDeps(),
+      esClient,
+      resolutionClient,
+      reader,
+    });
+
+    expect(resolutionClient.linkEntities).toHaveBeenCalledWith('user:john.doe@corp.com@okta', [
+      'user:jdoe@host1@local',
+    ]);
+    expect(result.lastRun).toMatchObject({ cluesLoaded: 1, resolutionsCreated: 1, failed: 0 });
+  });
+
+  it('links every medium candidate (multiple hosts) to the same target', async () => {
+    const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+    const esClient = makeEsClient([
+      {
+        entityId: 'user:jdoe@host1@local',
+        namespace: 'local',
+        confidence: 'medium',
+        userName: 'jdoe',
+      },
+      {
+        entityId: 'user:jdoe@host2@local',
+        namespace: 'local',
+        confidence: 'medium',
+        userName: 'jdoe',
+      },
+      {
+        entityId: 'user:john.doe@corp.com@okta',
+        namespace: 'okta',
+        confidence: 'high',
+        userEmail: 'john.doe@corp.com',
+      },
+    ]);
+    const resolutionClient = makeResolutionClient();
+
+    const result = await runKiAutomatedResolution({
+      ...baseDeps(),
+      esClient,
+      resolutionClient,
+      reader,
+    });
+
+    expect(resolutionClient.linkEntities).toHaveBeenCalledWith('user:john.doe@corp.com@okta', [
+      'user:jdoe@host1@local',
+      'user:jdoe@host2@local',
+    ]);
+    expect(result.lastRun?.resolutionsCreated).toBe(2);
+  });
+
+  it('skips an ambiguous username (one token mapped to multiple emails)', async () => {
+    const reader = makeReader([
+      makeFeature('jdoe', 'john.doe@corp.com', { uuid: 'a' }),
+      makeFeature('jdoe', 'jane.doe@corp.com', { uuid: 'b' }),
+    ]);
+    const esClient = makeEsClient([]);
+    const resolutionClient = makeResolutionClient();
+
+    const result = await runKiAutomatedResolution({
+      ...baseDeps(),
+      esClient,
+      resolutionClient,
+      reader,
+    });
+
+    expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+    expect(result.lastRun).toMatchObject({ skippedAmbiguous: 1, resolutionsCreated: 0 });
+  });
+
+  it('skips when no high-confidence target matches the email', async () => {
+    const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+    const esClient = makeEsClient([
+      {
+        entityId: 'user:jdoe@host1@local',
+        namespace: 'local',
+        confidence: 'medium',
+        userName: 'jdoe',
+      },
+    ]);
+    const resolutionClient = makeResolutionClient();
+
+    const result = await runKiAutomatedResolution({
+      ...baseDeps(),
+      esClient,
+      resolutionClient,
+      reader,
+    });
+
+    expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+    expect(result.lastRun).toMatchObject({ skippedNoTarget: 1, resolutionsCreated: 0 });
+  });
+
+  it('skips when no medium candidate matches the username', async () => {
+    const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+    const esClient = makeEsClient([
+      {
+        entityId: 'user:john.doe@corp.com@okta',
+        namespace: 'okta',
+        confidence: 'high',
+        userEmail: 'john.doe@corp.com',
+      },
+    ]);
+    const resolutionClient = makeResolutionClient();
+
+    const result = await runKiAutomatedResolution({
+      ...baseDeps(),
+      esClient,
+      resolutionClient,
+      reader,
+    });
+
+    expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+    expect(result.lastRun).toMatchObject({ skippedNoCandidate: 1, resolutionsCreated: 0 });
+  });
+
+  it('is a no-op when all KI features are below the confidence floor', async () => {
+    const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com', { confidence: 50 })]);
+    const esClient = makeEsClient([
+      {
+        entityId: 'user:jdoe@host1@local',
+        namespace: 'local',
+        confidence: 'medium',
+        userName: 'jdoe',
+      },
+      {
+        entityId: 'user:john.doe@corp.com@okta',
+        namespace: 'okta',
+        confidence: 'high',
+        userEmail: 'john.doe@corp.com',
+      },
+    ]);
+    const resolutionClient = makeResolutionClient();
+
+    const result = await runKiAutomatedResolution({
+      ...baseDeps(),
+      esClient,
+      resolutionClient,
+      reader,
+    });
+
+    expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+    expect(result.lastRun).toMatchObject({ cluesLoaded: 0, resolutionsCreated: 0 });
+  });
+
+  it('picks the IdP-priority target when several high targets share the email', async () => {
+    const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+    const esClient = makeEsClient([
+      {
+        entityId: 'user:jdoe@host1@local',
+        namespace: 'local',
+        confidence: 'medium',
+        userName: 'jdoe',
+      },
+      {
+        entityId: 'user:john.doe@corp.com@okta',
+        namespace: 'okta',
+        confidence: 'high',
+        userEmail: 'john.doe@corp.com',
+      },
+      {
+        entityId: 'user:john.doe@corp.com@active_directory',
+        namespace: 'active_directory',
+        confidence: 'high',
+        userEmail: 'john.doe@corp.com',
+      },
+    ]);
+    const resolutionClient = makeResolutionClient();
+
+    await runKiAutomatedResolution({ ...baseDeps(), esClient, resolutionClient, reader });
+
+    // selectTarget prioritizes active_directory over okta.
+    expect(resolutionClient.linkEntities).toHaveBeenCalledWith(
+      'user:john.doe@corp.com@active_directory',
+      ['user:jdoe@host1@local']
+    );
+  });
+
+  describe('IdP -> IdP (cross-namespace)', () => {
+    it('links a lower-priority IdP candidate (github) to the higher-priority target when enabled', async () => {
+      const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+      const esClient = makeEsClient([
+        {
+          entityId: 'user:jdoe@github',
+          namespace: 'github',
+          confidence: 'high',
+          userName: 'jdoe',
+        },
+        {
+          entityId: 'user:john.doe@corp.com@okta',
+          namespace: 'okta',
+          confidence: 'high',
+          userEmail: 'john.doe@corp.com',
+        },
+      ]);
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        resolveIdpToIdp: true,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(resolutionClient.linkEntities).toHaveBeenCalledWith('user:john.doe@corp.com@okta', [
+        'user:jdoe@github',
+      ]);
+      expect(result.lastRun).toMatchObject({ resolutionsCreated: 1, idpResolutionsCreated: 1 });
+    });
+
+    it('does NOT link the IdP candidate when the sub-flag is off', async () => {
+      const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+      const esClient = makeEsClient([
+        { entityId: 'user:jdoe@github', namespace: 'github', confidence: 'high', userName: 'jdoe' },
+        {
+          entityId: 'user:john.doe@corp.com@okta',
+          namespace: 'okta',
+          confidence: 'high',
+          userEmail: 'john.doe@corp.com',
+        },
+      ]);
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        resolveIdpToIdp: false,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+      expect(result.lastRun).toMatchObject({ skippedNoCandidate: 1, idpResolutionsCreated: 0 });
+    });
+
+    it('skips a higher-priority candidate (wrong direction) and never demotes it', async () => {
+      const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+      const esClient = makeEsClient([
+        // AD matches by user.name but NOT by the clue email; it ranks above okta.
+        {
+          entityId: 'user:jdoe@active_directory',
+          namespace: 'active_directory',
+          confidence: 'high',
+          userName: 'jdoe',
+        },
+        {
+          entityId: 'user:john.doe@corp.com@okta',
+          namespace: 'okta',
+          confidence: 'high',
+          userEmail: 'john.doe@corp.com',
+        },
+      ]);
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        resolveIdpToIdp: true,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+      expect(result.lastRun).toMatchObject({
+        skippedWrongDirection: 1,
+        skippedNoCandidate: 1,
+        idpResolutionsCreated: 0,
+      });
+    });
+
+    it('skips a same-namespace candidate (equal rank, dedup is out of scope)', async () => {
+      const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+      const esClient = makeEsClient([
+        { entityId: 'user:jdoe@okta', namespace: 'okta', confidence: 'high', userName: 'jdoe' },
+        {
+          entityId: 'user:john.doe@corp.com@okta',
+          namespace: 'okta',
+          confidence: 'high',
+          userEmail: 'john.doe@corp.com',
+        },
+      ]);
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        resolveIdpToIdp: true,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(resolutionClient.linkEntities).not.toHaveBeenCalled();
+      expect(result.lastRun).toMatchObject({ skippedWrongDirection: 1, idpResolutionsCreated: 0 });
+    });
+
+    it('links medium and IdP candidates together to the same target', async () => {
+      const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+      const esClient = makeEsClient([
+        {
+          entityId: 'user:jdoe@host1@local',
+          namespace: 'local',
+          confidence: 'medium',
+          userName: 'jdoe',
+        },
+        { entityId: 'user:jdoe@github', namespace: 'github', confidence: 'high', userName: 'jdoe' },
+        {
+          entityId: 'user:john.doe@corp.com@okta',
+          namespace: 'okta',
+          confidence: 'high',
+          userEmail: 'john.doe@corp.com',
+        },
+      ]);
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        resolveIdpToIdp: true,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(resolutionClient.linkEntities).toHaveBeenCalledWith('user:john.doe@corp.com@okta', [
+        'user:jdoe@host1@local',
+        'user:jdoe@github',
+      ]);
+      expect(result.lastRun).toMatchObject({ resolutionsCreated: 2, idpResolutionsCreated: 1 });
+    });
+  });
+
+  describe('deterministic rule path (useRules)', () => {
+    const makeRuleFeature = (): Feature =>
+      makeFeature('opauloh', 'unused@corp.com', {
+        uuid: 'rule-1',
+        stream_name: 'logs-github.audit-default',
+        // Only a rule, no per-user identity_link, so the per-user loader yields nothing.
+        properties: {
+          identity_link_rule: {
+            user_name_field: 'user.name',
+            user_email_field: 'github.external_identity_nameid',
+          },
+        },
+      });
+
+    it('does not query the deterministic path when useRules is false', async () => {
+      const reader = makeReader([makeFeature('jdoe', 'john.doe@corp.com')]);
+      const esClient = makeEsClient([]);
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        useRules: false,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(esClient.esql.query as jest.Mock).not.toHaveBeenCalled();
+      expect(result.lastRun).toMatchObject({ rulesLoaded: 0, deterministicCluesExtracted: 0 });
+    });
+
+    it('materializes a clue from a rule and links the github entity to the okta target', async () => {
+      const reader = makeReader([makeRuleFeature()]);
+      (reader.resolveIndexPatterns as jest.Mock).mockResolvedValue(['logs-github.audit-default']);
+
+      const esClient = makeEsClient(
+        [
+          {
+            entityId: 'user:opauloh@github',
+            namespace: 'github',
+            confidence: 'high',
+            userName: 'opauloh',
+          },
+          {
+            entityId: 'user:paulo@elastic.co@okta',
+            namespace: 'okta',
+            confidence: 'high',
+            userEmail: 'paulo@elastic.co',
+          },
+        ],
+        { values: [[5, 'opauloh', 'paulo@elastic.co']] }
+      );
+      const resolutionClient = makeResolutionClient();
+
+      const result = await runKiAutomatedResolution({
+        ...baseDeps(),
+        useRules: true,
+        resolveIdpToIdp: true,
+        esClient,
+        resolutionClient,
+        reader,
+      });
+
+      expect(resolutionClient.linkEntities).toHaveBeenCalledWith('user:paulo@elastic.co@okta', [
+        'user:opauloh@github',
+      ]);
+      expect(result.lastRun).toMatchObject({
+        rulesLoaded: 1,
+        deterministicCluesExtracted: 1,
+        resolutionsCreated: 1,
+        idpResolutionsCreated: 1,
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/index.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegisterEntityMaintainerConfig } from '../../tasks/entity_maintainers/types';
+import type { EntityStoreCoreSetup } from '../../types';
+import { ResolutionClient } from '../../domain/resolution';
+import { EntityStoreGlobalStateClient } from '../../domain/saved_objects';
+import { createKnowledgeIndicatorsReader } from '../../domain/streams_features';
+import type { KiAutomatedResolutionState } from './types';
+import { runKiAutomatedResolution } from './run';
+
+const MAINTAINER_ID = 'ki-automated-resolution';
+
+const initialState: KiAutomatedResolutionState = {
+  lastRun: null,
+};
+
+/**
+ * Builds the registration config for the KI entity-resolution maintainer.
+ *
+ * Registered alongside (never replacing) the email-based `automated-resolution`
+ * maintainer, so enabling KI resolution is purely additive. The maintainer is
+ * always registered, but each run is **gated at runtime** on the per-space
+ * `logsExtraction.useKiEntityResolution` flag — disabled ⇒ immediate no-op,
+ * matching the runtime-flag pattern used by the other KI POCs. It needs the
+ * `core` setup contract to resolve the Streams Knowledge Indicators reader and
+ * to read the global-state config from the maintainer's `fakeRequest`.
+ */
+export const createKiAutomatedResolutionMaintainerConfig = ({
+  core,
+}: {
+  core: EntityStoreCoreSetup;
+}): RegisterEntityMaintainerConfig => ({
+  id: MAINTAINER_ID,
+  description:
+    'Resolves medium-confidence user entities to high-confidence IdP entities using Streams Knowledge Indicators (opt-in)',
+  interval: '5m',
+  initialState,
+  minLicense: 'enterprise',
+  run: async ({ status, abortController, logger, esClient, fakeRequest, telemetry }) => {
+    const namespace = status.metadata.namespace;
+    const state = status.state as KiAutomatedResolutionState;
+
+    const [coreStart] = await core.getStartServices();
+    const soClient = coreStart.savedObjects.getScopedClient(fakeRequest);
+    const globalStateClient = new EntityStoreGlobalStateClient(soClient, namespace, logger);
+    const config = await globalStateClient.find();
+
+    if (!config?.logsExtraction.useKiEntityResolution) {
+      logger.debug('KI entity resolution is disabled for this namespace; skipping run');
+      return { lastRun: null };
+    }
+
+    const reader = await createKnowledgeIndicatorsReader({ core, fakeRequest, logger });
+    const resolutionClient = new ResolutionClient({ logger, esClient, namespace });
+
+    return runKiAutomatedResolution({
+      state,
+      namespace,
+      esClient,
+      logger,
+      resolutionClient,
+      reader,
+      minConfidence: config.logsExtraction.kiEntityResolutionMinConfidence,
+      resolveIdpToIdp: config.logsExtraction.kiEntityResolutionResolveIdpToIdp,
+      useRules: config.logsExtraction.kiEntityResolutionUseRules,
+      telemetry,
+      abortController,
+    });
+  },
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/run.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/run.ts
@@ -1,0 +1,347 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import { getLatestEntitiesIndexName } from '../../../common';
+import type { ResolutionClient } from '../../domain/resolution';
+import { getFieldValue } from '../../../common/domain/euid/commons';
+import { ENTITY_ID_FIELD } from '../../../common/domain/definitions/common_fields';
+import { ENTITY_CONFIDENCE } from '../../../common/domain/definitions/user_entity_constants';
+import {
+  loadEntityResolutionClues,
+  loadIdentityLinkRules,
+  extractIdentityLinkClues,
+} from '../../domain/streams_features';
+import type { IdentityLinkClue } from '../../domain/streams_features';
+import type { MaintainerTelemetryClient } from '../../tasks/entity_maintainers/maintainer_telemetry_client';
+import { NAMESPACE_PRIORITY, selectTarget } from '../automated_resolution/run';
+import type { EntityHit } from '../automated_resolution/types';
+import type { EntityConfidence } from '../../../common/domain/definitions/user_entity_constants';
+import type { KiAutomatedResolutionState } from './types';
+
+const ENGINE_METADATA_TYPE_FIELD = 'entity.EngineMetadata.Type';
+const RESOLVED_TO_FIELD = 'entity.relationships.resolution.resolved_to';
+const ENTITY_NAMESPACE_FIELD = 'entity.namespace';
+const ENTITY_CONFIDENCE_FIELD = 'entity.confidence';
+const USER_NAME_FIELD = 'user.name';
+const USER_EMAIL_FIELD = 'user.email';
+const ENTITY_TYPE = 'user';
+const SEARCH_SIZE = 100;
+
+export interface RunDeps {
+  state: KiAutomatedResolutionState;
+  namespace: string;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  resolutionClient: ResolutionClient;
+  reader: StreamsKnowledgeIndicatorsReader;
+  minConfidence: number;
+  /**
+   * When true, also resolves high-confidence IdP entities in a lower-priority
+   * namespace (e.g. GitHub) to a higher-priority IdP target (Okta / AD) for the
+   * same person. When false, only medium -> high resolution runs.
+   */
+  resolveIdpToIdp: boolean;
+  /**
+   * When true, also loads `identity_link_rule` Knowledge Indicators and executes
+   * them deterministically over their streams (one ES|QL aggregation per stream)
+   * to materialize a clue for EVERY user — not just the LLM-sampled ones. Merged
+   * with the per-user `identity_link` clues before resolution. When false, only
+   * the per-user clues are used.
+   */
+  useRules: boolean;
+  telemetry?: MaintainerTelemetryClient;
+  abortController: AbortController;
+}
+
+const emptyLastRun: NonNullable<KiAutomatedResolutionState['lastRun']> = {
+  cluesLoaded: 0,
+  rulesLoaded: 0,
+  deterministicCluesExtracted: 0,
+  resolutionsCreated: 0,
+  idpResolutionsCreated: 0,
+  skippedAmbiguous: 0,
+  skippedNoTarget: 0,
+  skippedNoCandidate: 0,
+  skippedWrongDirection: 0,
+  failed: 0,
+};
+
+/**
+ * Priority rank for a namespace: lower number = higher priority. Reuses the
+ * email resolver's `NAMESPACE_PRIORITY` so target selection and the IdP -> IdP
+ * directionality guard agree. Namespaces outside the list rank lowest
+ * (`Infinity`), so a non-priority integration (e.g. GitHub) always resolves
+ * toward a known IdP rather than the other way around.
+ */
+const namespacePriorityRank = (namespace: string): number => {
+  const index = NAMESPACE_PRIORITY.indexOf(namespace);
+  return index === -1 ? Infinity : index;
+};
+
+/**
+ * KI-driven entity resolution (POC).
+ *
+ * Reads `type: 'entity'` Knowledge Indicators that carry a deterministic
+ * `identity_link` clue (`user_name` → `user_email`), then for each unambiguous
+ * username:
+ *  1. finds the high-confidence IdP user entity matching the linked email
+ *     (the target / golden entity, chosen by namespace priority);
+ *  2. finds the medium-confidence `local` user entities matching that username
+ *     (the candidates the existing email resolver cannot link — they lack a
+ *     clean `user.email`);
+ *  3. when `resolveIdpToIdp` is on, ALSO finds high-confidence IdP entities
+ *     matching that username whose namespace ranks strictly lower than the
+ *     target's (e.g. GitHub → Okta/AD), guarding direction so a higher-priority
+ *     IdP is never demoted and same-namespace pairs are skipped;
+ *  4. links the candidates to the target via the existing `ResolutionClient`,
+ *     writing only `entity.relationships.resolution.resolved_to`.
+ *
+ * Idempotent: re-evaluates all clues each run; `linkEntities` skips entities
+ * already resolved to the target, so there is no watermark to advance.
+ */
+export async function runKiAutomatedResolution(deps: RunDeps): Promise<KiAutomatedResolutionState> {
+  const {
+    namespace,
+    esClient,
+    logger,
+    resolutionClient,
+    reader,
+    minConfidence,
+    resolveIdpToIdp,
+    useRules,
+    telemetry,
+    abortController,
+  } = deps;
+  const index = getLatestEntitiesIndexName(namespace);
+
+  const perUserClues = await loadEntityResolutionClues(reader, { minConfidence }, logger);
+
+  // Deterministic path: load identity-link rules and execute them over their
+  // streams to materialize a clue for every user, closing the LLM-sampling gap.
+  let rulesLoaded = 0;
+  let deterministicClues: IdentityLinkClue[] = [];
+  if (useRules) {
+    const rules = await loadIdentityLinkRules(reader, { minConfidence }, logger);
+    rulesLoaded = rules.length;
+    deterministicClues = await extractIdentityLinkClues({
+      esClient,
+      reader,
+      rules,
+      logger,
+      abortController,
+    });
+  }
+  const deterministicCluesExtracted = deterministicClues.length;
+
+  // Both sources feed the same resolution logic; ambiguity/dedup is handled
+  // below via the per-username email set, so overlapping pairs are harmless.
+  const clues = [...perUserClues, ...deterministicClues];
+  if (clues.length === 0) {
+    logger.debug('KI entity resolution: no identity-link clues found, nothing to resolve');
+    telemetry?.report({ funnel: { scanned: 0, qualified: 0, applied: 0, skipped: 0, failed: 0 } });
+    return { lastRun: { ...emptyLastRun, rulesLoaded, deterministicCluesExtracted } };
+  }
+
+  // Group clues by username and detect ambiguity (one token → several emails).
+  const emailsByUserName = new Map<string, Set<string>>();
+  for (const clue of clues) {
+    const set = emailsByUserName.get(clue.userName) ?? new Set<string>();
+    set.add(clue.userEmail);
+    emailsByUserName.set(clue.userName, set);
+  }
+
+  let resolutionsCreated = 0;
+  let idpResolutionsCreated = 0;
+  let skippedAmbiguous = 0;
+  let skippedNoTarget = 0;
+  let skippedNoCandidate = 0;
+  let skippedWrongDirection = 0;
+  let failed = 0;
+
+  for (const [userName, emails] of emailsByUserName) {
+    if (abortController.signal.aborted) {
+      logger.debug('KI entity resolution: aborted mid-run');
+      break;
+    }
+
+    if (emails.size !== 1) {
+      logger.warn(
+        `KI entity resolution: skipping ambiguous username '${userName}' (mapped to ${emails.size} distinct emails)`
+      );
+      skippedAmbiguous++;
+      continue;
+    }
+
+    const userEmail = [...emails][0];
+
+    try {
+      const targets = await findHighTargets(esClient, index, userEmail);
+      if (targets.length === 0) {
+        skippedNoTarget++;
+        continue;
+      }
+
+      const target = targets.length === 1 ? targets[0] : selectTarget(targets);
+      const targetRank = namespacePriorityRank(target.namespace);
+
+      const mediumCandidates = await findCandidatesByUserName(
+        esClient,
+        index,
+        userName,
+        ENTITY_CONFIDENCE.Medium
+      );
+
+      // IdP -> IdP: high-confidence entities matching the username whose
+      // namespace ranks strictly lower than the target's. Equal/higher rank
+      // (same namespace, or a higher-priority IdP) is the wrong direction.
+      const idpCandidates: EntityHit[] = [];
+      if (resolveIdpToIdp) {
+        const highMatches = await findCandidatesByUserName(
+          esClient,
+          index,
+          userName,
+          ENTITY_CONFIDENCE.High
+        );
+        for (const candidate of highMatches) {
+          if (candidate.entityId === target.entityId) {
+            continue;
+          }
+          if (namespacePriorityRank(candidate.namespace) > targetRank) {
+            idpCandidates.push(candidate);
+          } else {
+            skippedWrongDirection++;
+          }
+        }
+      }
+
+      const aliasIds = [...mediumCandidates, ...idpCandidates]
+        .map((candidate) => candidate.entityId)
+        .filter((entityId) => entityId !== target.entityId);
+
+      if (aliasIds.length === 0) {
+        skippedNoCandidate++;
+        continue;
+      }
+
+      const idpAliasIds = new Set(idpCandidates.map((candidate) => candidate.entityId));
+      const result = await resolutionClient.linkEntities(target.entityId, aliasIds);
+      resolutionsCreated += result.linked.length;
+      idpResolutionsCreated += result.linked.filter((entityId) => idpAliasIds.has(entityId)).length;
+      logger.debug(
+        `KI entity resolution: linked ${result.linked.length} candidate(s) for '${userName}' → '${target.entityId}'`
+      );
+    } catch (err) {
+      failed++;
+      logger.warn(
+        `KI entity resolution: failed to resolve username '${userName}': ${err?.message ?? err}`
+      );
+    }
+  }
+
+  logger.info(
+    `KI entity resolution: ${resolutionsCreated} resolution(s) created (${idpResolutionsCreated} IdP→IdP), ` +
+      `${skippedAmbiguous} ambiguous, ${skippedNoTarget} without target, ` +
+      `${skippedNoCandidate} without candidate, ${skippedWrongDirection} wrong-direction, ${failed} failed`
+  );
+
+  telemetry?.report({
+    funnel: {
+      scanned: clues.length,
+      qualified: emailsByUserName.size,
+      applied: resolutionsCreated,
+      skipped: skippedAmbiguous + skippedNoTarget + skippedNoCandidate + skippedWrongDirection,
+      failed,
+    },
+  });
+
+  return {
+    lastRun: {
+      cluesLoaded: clues.length,
+      rulesLoaded,
+      deterministicCluesExtracted,
+      resolutionsCreated,
+      idpResolutionsCreated,
+      skippedAmbiguous,
+      skippedNoTarget,
+      skippedNoCandidate,
+      skippedWrongDirection,
+      failed,
+    },
+  };
+}
+
+const toEntityHit = (hit: SearchHit): EntityHit => ({
+  entityId: getFieldValue(hit._source as Record<string, unknown>, ENTITY_ID_FIELD) ?? '',
+  namespace: getFieldValue(hit._source as Record<string, unknown>, ENTITY_NAMESPACE_FIELD) ?? '',
+});
+
+/**
+ * User entities at the given confidence whose `user.name` matches the clue
+ * (case-insensitive) and that are not already aliases.
+ *
+ * - `medium` → the EDR/Windows/Linux `user@host@local` rows the email resolver
+ *   cannot link.
+ * - `high` → IdP/integration entities (e.g. GitHub login) used as IdP -> IdP
+ *   candidates; the caller still applies the namespace-priority direction guard.
+ */
+async function findCandidatesByUserName(
+  esClient: ElasticsearchClient,
+  index: string,
+  userName: string,
+  confidence: EntityConfidence
+): Promise<EntityHit[]> {
+  const response = await esClient.search({
+    index,
+    size: SEARCH_SIZE,
+    _source: [ENTITY_ID_FIELD, ENTITY_NAMESPACE_FIELD],
+    query: {
+      bool: {
+        filter: [
+          { term: { [ENGINE_METADATA_TYPE_FIELD]: ENTITY_TYPE } },
+          { term: { [ENTITY_CONFIDENCE_FIELD]: confidence } },
+          { term: { [USER_NAME_FIELD]: { value: userName, case_insensitive: true } } },
+        ],
+        must_not: [{ exists: { field: RESOLVED_TO_FIELD } }],
+      },
+    },
+  });
+
+  return response.hits.hits.map(toEntityHit).filter((hit) => hit.entityId !== '');
+}
+
+/**
+ * High-confidence (`entity.confidence: high`) IdP user entities whose
+ * `user.email` matches the clue (case-insensitive) and that are not already
+ * aliases. These are the directory-backed golden entities to resolve toward.
+ */
+async function findHighTargets(
+  esClient: ElasticsearchClient,
+  index: string,
+  userEmail: string
+): Promise<EntityHit[]> {
+  const response = await esClient.search({
+    index,
+    size: SEARCH_SIZE,
+    _source: [ENTITY_ID_FIELD, ENTITY_NAMESPACE_FIELD],
+    query: {
+      bool: {
+        filter: [
+          { term: { [ENGINE_METADATA_TYPE_FIELD]: ENTITY_TYPE } },
+          { term: { [ENTITY_CONFIDENCE_FIELD]: ENTITY_CONFIDENCE.High } },
+          { term: { [USER_EMAIL_FIELD]: { value: userEmail, case_insensitive: true } } },
+        ],
+        must_not: [{ exists: { field: RESOLVED_TO_FIELD } }],
+      },
+    },
+  });
+
+  return response.hits.hits.map(toEntityHit).filter((hit) => hit.entityId !== '');
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/maintainers/ki_automated_resolution/types.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityMaintainerState } from '../../tasks/entity_maintainers/types';
+
+export interface KiAutomatedResolutionState extends EntityMaintainerState {
+  lastRun: {
+    /** Distinct identity-link clues loaded from KI entity features this run. */
+    cluesLoaded: number;
+    /** Identity-link rules loaded from KI entity features this run (deterministic path). */
+    rulesLoaded: number;
+    /** Deterministic clues materialized by executing rules over their streams this run. */
+    deterministicCluesExtracted: number;
+    /** Alias entities linked to a high-confidence target this run (all classes). */
+    resolutionsCreated: number;
+    /** Subset of `resolutionsCreated` that were IdP -> IdP (high candidate) links. */
+    idpResolutionsCreated: number;
+    /** Usernames skipped because the same token mapped to multiple emails. */
+    skippedAmbiguous: number;
+    /** Clues skipped because no high-confidence IdP target matched the email. */
+    skippedNoTarget: number;
+    /** Clues skipped because no candidate matched the username. */
+    skippedNoCandidate: number;
+    /** High candidates skipped because their namespace ranked equal/higher than the target. */
+    skippedWrongDirection: number;
+    /** Clues whose link write threw. */
+    failed: number;
+  } | null;
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/plugin.ts
@@ -30,6 +30,7 @@ import { CRUDClient } from './domain/crud';
 import { ResolutionClient } from './domain/resolution';
 import { registerTelemetry, createReportEvent } from './telemetry/events';
 import { automatedResolutionMaintainerConfig } from './maintainers/automated_resolution';
+import { createKiAutomatedResolutionMaintainerConfig } from './maintainers/ki_automated_resolution';
 
 export class EntityStorePlugin
   implements
@@ -87,6 +88,17 @@ export class EntityStorePlugin
       taskManager: plugins.taskManager,
       logger: this.logger,
       config: automatedResolutionMaintainerConfig,
+      core,
+      analytics: createReportEvent(core.analytics),
+    });
+
+    // KI entity resolution (POC). Registered alongside the email-based resolver
+    // above; each run is gated on the per-space `useKiEntityResolution` flag, so
+    // this is a no-op until an operator opts in.
+    registerEntityMaintainerTask({
+      taskManager: plugins.taskManager,
+      logger: this.logger,
+      config: createKiAutomatedResolutionMaintainerConfig({ core }),
       core,
       analytics: createReportEvent(core.analytics),
     });

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
@@ -32,6 +32,10 @@ export const LogExtractionInstallParams = LogExtractionConfig.pick({
   maxTimeWindowSize: true,
   maxLogsPerWindow: true,
   maxLogsPerWindowCapBehavior: true,
+  useKiEntityResolution: true,
+  kiEntityResolutionMinConfidence: true,
+  kiEntityResolutionResolveIdpToIdp: true,
+  kiEntityResolutionUseRules: true,
 }).partial();
 
 export type LogExtractionUpdateParams = z.infer<typeof LogExtractionUpdateParams>;
@@ -60,6 +64,10 @@ export const LogExtractionUpdateParams = z.object({
     .optional(),
   maxLogsPerWindow: z.number().int().min(0).optional(),
   maxLogsPerWindowCapBehavior: z.enum(['defer', 'drop']).optional(),
+  useKiEntityResolution: z.boolean().optional(),
+  kiEntityResolutionMinConfidence: z.number().int().min(0).max(100).optional(),
+  kiEntityResolutionResolveIdpToIdp: z.boolean().optional(),
+  kiEntityResolutionUseRules: z.boolean().optional(),
 });
 
 export type LogExtractionBodyParams = LogExtractionInstallParams | LogExtractionUpdateParams;

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -28,6 +28,7 @@ import type {
 import type { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { CoreSetup } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { StreamsPluginStart } from '@kbn/streams-plugin/server';
 import type { AssetManagerClient } from './domain/asset_manager';
 import type { EntityMaintainersClient } from './domain/entity_maintainers';
 import type { FeatureFlags } from './infra/feature_flags';
@@ -50,6 +51,13 @@ export interface EntityStoreStartPlugins {
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   licensing: LicensingPluginStart;
+  /**
+   * Optional, declared in `kibana.jsonc` as `optionalPlugins.streams` so the
+   * entity store keeps working in deployments that don't have streams enabled.
+   * Consumers must guard against `undefined` at the call site (the no-op reader
+   * in `createKnowledgeIndicatorsReader` is the canonical fallback).
+   */
+  streams?: StreamsPluginStart;
 }
 
 export interface EntityStoreApiRequestHandlerContext {

--- a/x-pack/solutions/security/plugins/entity_store/tsconfig.json
+++ b/x-pack/solutions/security/plugins/entity_store/tsconfig.json
@@ -39,6 +39,8 @@
     "@kbn/es-query",
     "@kbn/security-plugin",
     "@kbn/streamlang",
+    "@kbn/streams-plugin",
+    "@kbn/streams-schema",
     "@kbn/safer-lodash-set",
     "@kbn/tracing-utils",
     "@kbn/esql-language",


### PR DESCRIPTION
## Summary

This change adds an opt-in automated resolution maintainer to Entity Store that leverages Streams Knowledge Indicators (KIs) to link user identities.

The new `ki-automated-resolution` maintainer identifies relationships between low-trust local identities (e.g., `user.name` from endpoint logs) and authoritative IdP identities (e.g., `user.email` / UPN) using two new KI entity feature properties:
- `properties.identity_link`: carries concrete `(user_name, user_email)` values for individual users, typically derived from LLM-generated KIs.
- `properties.identity_link_rule`: specifies field names (`user_name_field`, `user_email_field`) that deterministically hold this relationship for *all* users in a stream via ES|QL extraction.

Key aspects of this feature:
- A new, narrow `StreamsKnowledgeIndicatorsReader` API is exposed by the Streams plugin for cross-plugin consumption, ensuring controlled access to KIs.
- The `entity_store` plugin now declares `streams` as an optional dependency, allowing the maintainer to gracefully no-op if Streams is not enabled.
- The feature is gated by a `logsExtraction.useKiEntityResolution` flag in Entity Store's global state, with configurable confidence thresholds and flags for enabling IdP-to-IdP resolution and deterministic rule execution.
- Updates the Streams AI system prompt to document the new `identity_link` and `identity_link_rule` feature structures.

## Recording


https://github.com/user-attachments/assets/4b9411fc-b7d0-419f-b065-66c3239becb8

