### PR TITLE
[Synthetics] [CCS] Preserve remoteName in monitor detail breadcrumb links

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_details_breadcrumbs.ts
@@ -9,6 +9,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_location';
 import { useTestRunDetailsBreadcrumbs } from '../../test_run_details/hooks/use_test_run_details_breadcrumbs';
 import { useSelectedMonitor } from '../../monitor_details/hooks/use_selected_monitor';
+import { useGetUrlParams } from '../../../hooks';
 import { ConfigKey } from '../../../../../../common/runtime_types';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
 import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
@@ -23,14 +24,22 @@ export const useErrorDetailsBreadcrumbs = (
 
   const selectedLocation = useSelectedLocation();
   const spaceId = useUrlSpaceId();
+  // Carry `remoteName` so the errors crumb stays on the remote (CCS) cluster
+  // path; otherwise the local errors page 404s against missing saved objects.
+  const { remoteName } = useGetUrlParams();
 
-  const spaceIdQuery = spaceId ? `&spaceId=${spaceId}` : '';
+  const errorsHrefParams = new URLSearchParams();
+  if (selectedLocation?.id) errorsHrefParams.set('locationId', selectedLocation.id);
+  if (spaceId) errorsHrefParams.set('spaceId', spaceId);
+  if (remoteName) errorsHrefParams.set('remoteName', remoteName);
+  const errorsHrefSearch = errorsHrefParams.toString();
+
   const errorsBreadcrumbs = [
     {
       text: ERRORS_CRUMB,
-      href: `${appPath}/monitor/${monitor?.[ConfigKey.CONFIG_ID]}/errors?locationId=${
-        selectedLocation?.id
-      }${spaceIdQuery}`,
+      href: `${appPath}/monitor/${monitor?.[ConfigKey.CONFIG_ID]}/errors${
+        errorsHrefSearch ? `?${errorsHrefSearch}` : ''
+      }`,
     },
     ...(extraCrumbs ?? []),
   ];

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/hooks/use_error_details_breadcrumbs.ts
@@ -13,6 +13,7 @@ import { useGetUrlParams } from '../../../hooks';
 import { ConfigKey } from '../../../../../../common/runtime_types';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
 import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
+import { buildMonitorParamsSearch } from '../../../utils/url_params';
 
 export const useErrorDetailsBreadcrumbs = (
   extraCrumbs?: Array<{ text: string; href?: string }>
@@ -28,18 +29,16 @@ export const useErrorDetailsBreadcrumbs = (
   // path; otherwise the local errors page 404s against missing saved objects.
   const { remoteName } = useGetUrlParams();
 
-  const errorsHrefParams = new URLSearchParams();
-  if (selectedLocation?.id) errorsHrefParams.set('locationId', selectedLocation.id);
-  if (spaceId) errorsHrefParams.set('spaceId', spaceId);
-  if (remoteName) errorsHrefParams.set('remoteName', remoteName);
-  const errorsHrefSearch = errorsHrefParams.toString();
+  const errorsSearch = buildMonitorParamsSearch({
+    locationId: selectedLocation?.id,
+    spaceId,
+    remoteName,
+  });
 
   const errorsBreadcrumbs = [
     {
       text: ERRORS_CRUMB,
-      href: `${appPath}/monitor/${monitor?.[ConfigKey.CONFIG_ID]}/errors${
-        errorsHrefSearch ? `?${errorsHrefSearch}` : ''
-      }`,
+      href: `${appPath}/monitor/${monitor?.[ConfigKey.CONFIG_ID]}/errors${errorsSearch}`,
     },
     ...(extraCrumbs ?? []),
   ];

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -11,6 +11,7 @@ import { EuiLink, EuiIcon } from '@elastic/eui';
 import { InPortal } from 'react-reverse-portal';
 import { useSelectedLocation } from '../monitor_details/hooks/use_selected_location';
 import { useUrlSpaceId } from '../../hooks/use_url_space_id';
+import { buildMonitorParamsSearch } from '../../utils/url_params';
 import { MonitorDetailsLinkPortalNode } from './portals';
 
 interface Props {
@@ -64,7 +65,7 @@ const MonitorDetailsLinkWithLocation = ({
   const history = useHistory();
   const href = history.createHref({
     pathname: `monitor/${configId}`,
-    search: buildSearch({ locationId: locId, spaceId, remoteName }),
+    search: buildMonitorParamsSearch({ locationId: locId, spaceId, remoteName }),
   });
   return <MonitorLink href={href} name={name} />;
 };
@@ -74,26 +75,9 @@ const MonitorDetailsLink = ({ name, configId, remoteName }: Props) => {
   const history = useHistory();
   const href = history.createHref({
     pathname: `monitor/${configId}`,
-    search: buildSearch({ spaceId, remoteName }),
+    search: buildMonitorParamsSearch({ spaceId, remoteName }),
   });
   return <MonitorLink href={href} name={name} />;
-};
-
-const buildSearch = ({
-  locationId,
-  spaceId,
-  remoteName,
-}: {
-  locationId?: string;
-  spaceId?: string;
-  remoteName?: string;
-}): string | undefined => {
-  const params = new URLSearchParams();
-  if (locationId) params.set('locationId', locationId);
-  if (spaceId) params.set('spaceId', spaceId);
-  if (remoteName) params.set('remoteName', remoteName);
-  const qs = params.toString();
-  return qs ? `?${qs}` : undefined;
 };
 
 const MonitorLink = ({ href, name }: { href: string; name: string }) => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -18,9 +18,6 @@ interface Props {
   configId: string;
   locationId?: string;
   updateUrl?: boolean;
-  // Forwarded to the breadcrumb URL so the monitor detail page knows the
-  // monitor lives on a remote (CCS) cluster and skips the local saved-object
-  // fetch that would otherwise 404.
   remoteName?: string;
 }
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -18,9 +18,19 @@ interface Props {
   configId: string;
   locationId?: string;
   updateUrl?: boolean;
+  // Forwarded to the breadcrumb URL so the monitor detail page knows the
+  // monitor lives on a remote (CCS) cluster and skips the local saved-object
+  // fetch that would otherwise 404.
+  remoteName?: string;
 }
 
-export const MonitorDetailsLinkPortal = ({ name, configId, locationId, updateUrl }: Props) => {
+export const MonitorDetailsLinkPortal = ({
+  name,
+  configId,
+  locationId,
+  updateUrl,
+  remoteName,
+}: Props) => {
   return (
     <InPortal node={MonitorDetailsLinkPortalNode}>
       {locationId ? (
@@ -29,15 +39,22 @@ export const MonitorDetailsLinkPortal = ({ name, configId, locationId, updateUrl
           configId={configId}
           locationId={locationId}
           updateUrl={updateUrl}
+          remoteName={remoteName}
         />
       ) : (
-        <MonitorDetailsLink name={name} configId={configId} />
+        <MonitorDetailsLink name={name} configId={configId} remoteName={remoteName} />
       )}
     </InPortal>
   );
 };
 
-const MonitorDetailsLinkWithLocation = ({ name, configId, locationId, updateUrl }: Props) => {
+const MonitorDetailsLinkWithLocation = ({
+  name,
+  configId,
+  locationId,
+  updateUrl,
+  remoteName,
+}: Props) => {
   const selectedLocation = useSelectedLocation({ updateUrl });
   const spaceId = useUrlSpaceId();
 
@@ -50,17 +67,17 @@ const MonitorDetailsLinkWithLocation = ({ name, configId, locationId, updateUrl 
   const history = useHistory();
   const href = history.createHref({
     pathname: `monitor/${configId}`,
-    search: buildSearch({ locationId: locId, spaceId }),
+    search: buildSearch({ locationId: locId, spaceId, remoteName }),
   });
   return <MonitorLink href={href} name={name} />;
 };
 
-const MonitorDetailsLink = ({ name, configId }: Props) => {
+const MonitorDetailsLink = ({ name, configId, remoteName }: Props) => {
   const spaceId = useUrlSpaceId();
   const history = useHistory();
   const href = history.createHref({
     pathname: `monitor/${configId}`,
-    search: buildSearch({ spaceId }),
+    search: buildSearch({ spaceId, remoteName }),
   });
   return <MonitorLink href={href} name={name} />;
 };
@@ -68,13 +85,16 @@ const MonitorDetailsLink = ({ name, configId }: Props) => {
 const buildSearch = ({
   locationId,
   spaceId,
+  remoteName,
 }: {
   locationId?: string;
   spaceId?: string;
+  remoteName?: string;
 }): string | undefined => {
   const params = new URLSearchParams();
   if (locationId) params.set('locationId', locationId);
   if (spaceId) params.set('spaceId', spaceId);
+  if (remoteName) params.set('remoteName', remoteName);
   const qs = params.toString();
   return qs ? `?${qs}` : undefined;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_details_breadcrumbs.ts
@@ -11,6 +11,7 @@ import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_lo
 import { TEST_RUN_DETAILS_ROUTE } from '../../../../../../common/constants/ui';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
 import { useTestRunDetailsBreadcrumbs } from '../../test_run_details/hooks/use_test_run_details_breadcrumbs';
+import { useGetUrlParams } from '../../../hooks';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
 
 export const useStepDetailsBreadcrumbs = (extraCrumbs?: Array<{ text: string; href?: string }>) => {
@@ -24,12 +25,20 @@ export const useStepDetailsBreadcrumbs = (extraCrumbs?: Array<{ text: string; hr
   }>();
 
   const selectedLocation = useSelectedLocation();
+  // Preserve `remoteName` so the test-run-details breadcrumb stays on the
+  // remote (CCS) cluster path and doesn't 404 against local indices.
+  const { remoteName } = useGetUrlParams();
+
+  const testRunHrefParams = new URLSearchParams();
+  if (selectedLocation?.id) testRunHrefParams.set('locationId', selectedLocation.id);
+  if (remoteName) testRunHrefParams.set('remoteName', remoteName);
+  const testRunHrefSearch = testRunHrefParams.toString();
 
   useTestRunDetailsBreadcrumbs([
     {
       text: data ? moment(data.details?.timestamp).format('LLL') : '',
-      href: `${appPath}/${generatePath(TEST_RUN_DETAILS_ROUTE, params)}?locationId=${
-        selectedLocation?.id ?? ''
+      href: `${appPath}/${generatePath(TEST_RUN_DETAILS_ROUTE, params)}${
+        testRunHrefSearch ? `?${testRunHrefSearch}` : ''
       }`,
     },
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_details_breadcrumbs.ts
@@ -12,6 +12,7 @@ import { TEST_RUN_DETAILS_ROUTE } from '../../../../../../common/constants/ui';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
 import { useTestRunDetailsBreadcrumbs } from '../../test_run_details/hooks/use_test_run_details_breadcrumbs';
 import { useGetUrlParams } from '../../../hooks';
+import { buildMonitorParamsSearch } from '../../../utils/url_params';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
 
 export const useStepDetailsBreadcrumbs = (extraCrumbs?: Array<{ text: string; href?: string }>) => {
@@ -29,17 +30,15 @@ export const useStepDetailsBreadcrumbs = (extraCrumbs?: Array<{ text: string; hr
   // remote (CCS) cluster path and doesn't 404 against local indices.
   const { remoteName } = useGetUrlParams();
 
-  const testRunHrefParams = new URLSearchParams();
-  if (selectedLocation?.id) testRunHrefParams.set('locationId', selectedLocation.id);
-  if (remoteName) testRunHrefParams.set('remoteName', remoteName);
-  const testRunHrefSearch = testRunHrefParams.toString();
+  const testRunSearch = buildMonitorParamsSearch({
+    locationId: selectedLocation?.id,
+    remoteName,
+  });
 
   useTestRunDetailsBreadcrumbs([
     {
       text: data ? moment(data.details?.timestamp).format('LLL') : '',
-      href: `${appPath}/${generatePath(TEST_RUN_DETAILS_ROUTE, params)}${
-        testRunHrefSearch ? `?${testRunHrefSearch}` : ''
-      }`,
+      href: `${appPath}/${generatePath(TEST_RUN_DETAILS_ROUTE, params)}${testRunSearch}`,
     },
 
     {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_detail_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_detail_page.tsx
@@ -56,6 +56,7 @@ export const StepDetailPage = () => {
         <MonitorDetailsLinkPortal
           configId={data.details.journey.config_id}
           name={data.details.journey.monitor.name!}
+          remoteName={remoteName}
         />
       )}
       <EuiFlexGroup gutterSize="m">

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
@@ -11,6 +11,7 @@ import { useSelectedMonitor } from '../../monitor_details/hooks/use_selected_mon
 import { useBreadcrumbs } from '../../../hooks/use_breadcrumbs';
 import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
 import { useGetUrlParams } from '../../../hooks';
+import { buildMonitorParamsSearch } from '../../../utils/url_params';
 import { ConfigKey } from '../../../../../../common/runtime_types';
 import { MONITOR_ROUTE, MONITORS_ROUTE } from '../../../../../../common/constants';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
@@ -28,11 +29,11 @@ export const useTestRunDetailsBreadcrumbs = (
   // doesn't drop into the local saved-object 404 page.
   const { remoteName } = useGetUrlParams();
 
-  const monitorHrefParams = new URLSearchParams();
-  if (selectedLocation?.id) monitorHrefParams.set('locationId', selectedLocation.id);
-  if (spaceId) monitorHrefParams.set('spaceId', spaceId);
-  if (remoteName) monitorHrefParams.set('remoteName', remoteName);
-  const monitorHrefSearch = monitorHrefParams.toString();
+  const monitorSearch = buildMonitorParamsSearch({
+    locationId: selectedLocation?.id,
+    spaceId,
+    remoteName,
+  });
 
   useBreadcrumbs([
     {
@@ -46,7 +47,7 @@ export const useTestRunDetailsBreadcrumbs = (
             href: `${appPath}${MONITOR_ROUTE.replace(
               ':monitorId',
               monitor?.[ConfigKey.CONFIG_ID] ?? ''
-            )}${monitorHrefSearch ? `?${monitorHrefSearch}` : ''}`,
+            )}${monitorSearch}`,
           },
         ]
       : []),

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
@@ -10,6 +10,7 @@ import { useSelectedLocation } from '../../monitor_details/hooks/use_selected_lo
 import { useSelectedMonitor } from '../../monitor_details/hooks/use_selected_monitor';
 import { useBreadcrumbs } from '../../../hooks/use_breadcrumbs';
 import { useUrlSpaceId } from '../../../hooks/use_url_space_id';
+import { useGetUrlParams } from '../../../hooks';
 import { ConfigKey } from '../../../../../../common/runtime_types';
 import { MONITOR_ROUTE, MONITORS_ROUTE } from '../../../../../../common/constants';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
@@ -23,10 +24,14 @@ export const useTestRunDetailsBreadcrumbs = (
   const { monitor } = useSelectedMonitor();
   const selectedLocation = useSelectedLocation();
   const spaceId = useUrlSpaceId();
+  // Carry `remoteName` so the monitor breadcrumb on remote (CCS) test runs
+  // doesn't drop into the local saved-object 404 page.
+  const { remoteName } = useGetUrlParams();
 
   const monitorHrefParams = new URLSearchParams();
   if (selectedLocation?.id) monitorHrefParams.set('locationId', selectedLocation.id);
   if (spaceId) monitorHrefParams.set('spaceId', spaceId);
+  if (remoteName) monitorHrefParams.set('remoteName', remoteName);
   const monitorHrefSearch = monitorHrefParams.toString();
 
   useBreadcrumbs([

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
@@ -20,6 +20,7 @@ import { StepTabs } from './step_tabs';
 import { useJourneySteps } from '../monitor_details/hooks/use_journey_steps';
 import { StepDurationPanel } from '../monitor_details/monitor_summary/step_duration_panel';
 import { TestRunSteps } from './test_run_steps';
+import { useGetUrlParams } from '../../hooks';
 import { useTestRunDetailsBreadcrumbs } from './hooks/use_test_run_details_breadcrumbs';
 
 export const TestRunDetails = () => {
@@ -38,6 +39,7 @@ export const TestRunDetails = () => {
 
   const { monitorId } = useParams<{ monitorId: string }>();
   const selectedLocation = useSelectedLocation();
+  const { remoteName } = useGetUrlParams();
 
   const stateId = stepsData?.details?.summary?.state?.id;
 
@@ -106,6 +108,7 @@ export const TestRunDetails = () => {
         configId={monitorId}
         name={stepsData?.details?.journey.monitor.name ?? ''}
         locationId={selectedLocation?.id}
+        remoteName={remoteName}
       />
     </>
   );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/build_monitor_params_search.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/build_monitor_params_search.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Builds the URL search string used by monitor-scoped links and breadcrumbs.
+ *
+ * `remoteName` must be preserved on remote (CCS) clusters so links don't drop
+ * into the local saved-object 404 page; `locationId` and `spaceId` keep the
+ * destination scoped to the user's current context.
+ *
+ * Returns a string with a leading `?` when any param is set, or an empty
+ * string otherwise (safe to interpolate directly into an href template).
+ */
+export const buildMonitorParamsSearch = ({
+  locationId,
+  spaceId,
+  remoteName,
+}: {
+  locationId?: string;
+  spaceId?: string;
+  remoteName?: string;
+}): string => {
+  const params = new URLSearchParams();
+  if (locationId) params.set('locationId', locationId);
+  if (spaceId) params.set('spaceId', spaceId);
+  if (remoteName) params.set('remoteName', remoteName);
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/index.ts
@@ -8,3 +8,4 @@
 export type { SyntheticsUrlParams } from './get_supported_url_params';
 export { getSupportedUrlParams } from './get_supported_url_params';
 export * from './stringify_url_params';
+export { buildMonitorParamsSearch } from './build_monitor_params_search';


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/273609

Threading `remoteName` through the test-run, step, and error details breadcrumbs so the monitor-name crumb stays on the remote (CCS) cluster path. Without it, clicking the monitor breadcrumb from a remote test run dropped the param, hit `monitor/{configId}` against local indices, and 404'd with "Monitor not found".

- `MonitorDetailsLinkPortal` now accepts and forwards `remoteName` into its generated href.
- `TestRunDetails` and `StepDetailPage` read `remoteName` from the URL and pass it to the portal.
- `useTestRunDetailsBreadcrumbs`, `useStepDetailsBreadcrumbs`, and `useErrorDetailsBreadcrumbs` carry `remoteName` in the breadcrumb hrefs they build so the chain stays remote-aware all the way up.

