### PR TITLE
[9.3] [Discover] Render Background searches “Extend” action icon as inline SVG (#272754)

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/delete_button.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/delete_button.tsx
@@ -75,7 +75,7 @@ export const createDeleteActionDescriptor = (
   uiSession: UISession,
   core: CoreStart
 ): IClickActionDescriptor => ({
-  iconType: 'trash',
+  icon: 'trash',
   label: <FormattedMessage id="data.mgmt.searchSessions.actionDelete" defaultMessage="Delete" />,
   onClick: async () => {
     const ref = core.overlays.openModal(

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/extend_button.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/extend_button.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
+import { EuiConfirmModal, EuiIcon, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState } from 'react';
@@ -17,7 +17,7 @@ import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { SearchSessionsMgmtAPI } from '../../../lib/api';
 import type { IClickActionDescriptor } from './types';
 import type { OnActionDismiss } from './types';
-import extendSessionIcon from './icons/extend_session.svg';
+import { ExtendSessionSvg } from './icons/extend_session.svg';
 import type { UISession } from '../../../types';
 interface ExtendButtonProps {
   searchSession: UISession;
@@ -80,7 +80,7 @@ export const createExtendActionDescriptor = (
   uiSession: UISession,
   core: CoreStart
 ): IClickActionDescriptor => ({
-  iconType: extendSessionIcon,
+  icon: <EuiIcon type={ExtendSessionSvg} size="m" color="inherit" aria-hidden={true} />,
   label: <FormattedMessage id="data.mgmt.searchSessions.actionExtend" defaultMessage="Extend" />,
   onClick: async () => {
     const ref = core.overlays.openModal(

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/icons/extend_session.svg
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/icons/extend_session.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="#343741" fill-rule="evenodd" d="m14 5-3-2v1.333H4v1.334h7V7zM0 11.5A1.5 1.5 0 0 1 1.5 10h13a1.5 1.5 0 1 1 0 3h-13A1.5 1.5 0 0 1 0 11.5m14.5-.5H11v1h3.5a.5.5 0 1 0 0-1" clip-rule="evenodd"/></svg>

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/icons/extend_session.svg.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/icons/extend_session.svg.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FunctionComponent, SVGProps } from 'react';
+import React from 'react';
+
+export const ExtendSessionSvg: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" {...props}>
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="m14 5-3-2v1.333H4v1.334h7V7zM0 11.5A1.5 1.5 0 0 1 1.5 10h13a1.5 1.5 0 1 1 0 3h-13A1.5 1.5 0 0 1 0 11.5m14.5-.5H11v1h3.5a.5.5 0 1 0 0-1"
+      clipRule="evenodd"
+    />
+  </svg>
+);

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/inspect_button.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/inspect_button.tsx
@@ -108,7 +108,7 @@ export const createInspectActionDescriptor = (
   uiSession: UISession,
   core: CoreStart
 ): IClickActionDescriptor => ({
-  iconType: 'document',
+  icon: 'document',
   label: (
     <FormattedMessage
       id="data.mgmt.searchSessions.flyoutTitle"

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/popover_actions.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/popover_actions.tsx
@@ -73,7 +73,7 @@ export const PopoverActionsMenu = ({
   const items = actions.reduce((itemSet, actionType) => {
     const actionDef = getAction(api, actionType, session, core);
     if (actionDef) {
-      const { label, iconType, onClick } = actionDef;
+      const { label, icon, onClick } = actionDef;
 
       // add a line above the delete action (when there are multiple)
       // NOTE: Delete action MUST be the final action[] item
@@ -86,7 +86,7 @@ export const PopoverActionsMenu = ({
         {
           key: `action-${actionType}`,
           name: label,
-          icon: iconType,
+          icon,
           'data-test-subj': `sessionManagementPopoverAction-${actionType}`,
           onClick: async () => {
             closePopover();

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/rename_button.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/rename_button.tsx
@@ -118,7 +118,7 @@ export const createRenameActionDescriptor = (
   uiSession: UISession,
   core: CoreStart
 ): IClickActionDescriptor => ({
-  iconType: 'pencil',
+  icon: 'pencil',
   label: <FormattedMessage id="data.mgmt.searchSessions.actionRename" defaultMessage="Edit name" />,
   onClick: async () => {
     const ref = core.overlays.openModal(

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/types.ts
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/components/table/actions/types.ts
@@ -6,13 +6,14 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import type extendSessionIcon from './icons/extend_session.svg';
+
+import type { EuiContextMenuItemIcon } from '@elastic/eui';
 
 export type OnActionComplete = () => void;
 export type OnActionDismiss = () => void;
 
 export interface IClickActionDescriptor {
   label: React.ReactNode;
-  iconType: 'trash' | 'cancel' | typeof extendSessionIcon;
+  icon: EuiContextMenuItemIcon;
   onClick: () => Promise<void> | void;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Render Background searches “Extend” action icon as inline SVG (#272754)](https://github.com/elastic/kibana/pull/272754)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-16T19:14:04Z","message":"[Discover] Render Background searches “Extend” action icon as inline SVG (#272754)\n\nThe **Extend** action in the Background searches row-actions menu was\nusing a custom SVG asset that EUI rendered via `img`, so it did not\ninherit theme color and became effectively invisible in dark mode. This\nchange keeps the existing action wiring intact while rendering the icon\ninline as SVG so it follows surrounding text/icon color.\n\n- **Icon rendering**\n- Replaced the raw `extend_session.svg` asset import with a React SVG\ncomponent.\n- Kept the icon markup effectively unchanged, only updating it to render\nas inline SVG and inherit `currentColor`.\n\n- **Action integration**\n- Updated the Extend action descriptor to render an `EuiIcon` with the\nReact SVG component through the action menu icon slot.\n- No behavioral changes to the action itself or the surrounding menu\nstructure.\n\n### Before\n\n![Before: Extend icon invisible in dark\nmode](https://github.com/user-attachments/assets/69d31674-c372-4f79-a5e0-3484251a460b)\n\n### After\n\n![After: Extend icon visible in dark\nmode](https://github.com/user-attachments/assets/4a144bf1-7828-456f-b1cc-985a205b9515)\n\n```tsx\nimport { EuiIcon } from '@elastic/eui';\nimport { ExtendSessionSvg } from './icons/extend_session.svg';\n\nexport const createExtendActionDescriptor = (\n  api,\n  uiSession,\n  core\n) => ({\n  icon: <EuiIcon type={ExtendSessionSvg} size=\"m\" color=\"inherit\" aria-hidden={true} />,\n  label: <FormattedMessage id=\"data.mgmt.searchSessions.actionExtend\" defaultMessage=\"Extend\" />,\n  onClick: async () => {\n    // unchanged\n  },\n});\n```\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"c41785ec0cf9c2f06583ff434e6614e107986361","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","💝community","Team:DataDiscovery","backport:version","v9.5.0","v9.4.3","v9.3.6"],"title":"[Discover] Render Background searches “Extend” action icon as inline SVG","number":272754,"url":"https://github.com/elastic/kibana/pull/272754","mergeCommit":{"message":"[Discover] Render Background searches “Extend” action icon as inline SVG (#272754)\n\nThe **Extend** action in the Background searches row-actions menu was\nusing a custom SVG asset that EUI rendered via `img`, so it did not\ninherit theme color and became effectively invisible in dark mode. This\nchange keeps the existing action wiring intact while rendering the icon\ninline as SVG so it follows surrounding text/icon color.\n\n- **Icon rendering**\n- Replaced the raw `extend_session.svg` asset import with a React SVG\ncomponent.\n- Kept the icon markup effectively unchanged, only updating it to render\nas inline SVG and inherit `currentColor`.\n\n- **Action integration**\n- Updated the Extend action descriptor to render an `EuiIcon` with the\nReact SVG component through the action menu icon slot.\n- No behavioral changes to the action itself or the surrounding menu\nstructure.\n\n### Before\n\n![Before: Extend icon invisible in dark\nmode](https://github.com/user-attachments/assets/69d31674-c372-4f79-a5e0-3484251a460b)\n\n### After\n\n![After: Extend icon visible in dark\nmode](https://github.com/user-attachments/assets/4a144bf1-7828-456f-b1cc-985a205b9515)\n\n```tsx\nimport { EuiIcon } from '@elastic/eui';\nimport { ExtendSessionSvg } from './icons/extend_session.svg';\n\nexport const createExtendActionDescriptor = (\n  api,\n  uiSession,\n  core\n) => ({\n  icon: <EuiIcon type={ExtendSessionSvg} size=\"m\" color=\"inherit\" aria-hidden={true} />,\n  label: <FormattedMessage id=\"data.mgmt.searchSessions.actionExtend\" defaultMessage=\"Extend\" />,\n  onClick: async () => {\n    // unchanged\n  },\n});\n```\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"c41785ec0cf9c2f06583ff434e6614e107986361"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272754","number":272754,"mergeCommit":{"message":"[Discover] Render Background searches “Extend” action icon as inline SVG (#272754)\n\nThe **Extend** action in the Background searches row-actions menu was\nusing a custom SVG asset that EUI rendered via `img`, so it did not\ninherit theme color and became effectively invisible in dark mode. This\nchange keeps the existing action wiring intact while rendering the icon\ninline as SVG so it follows surrounding text/icon color.\n\n- **Icon rendering**\n- Replaced the raw `extend_session.svg` asset import with a React SVG\ncomponent.\n- Kept the icon markup effectively unchanged, only updating it to render\nas inline SVG and inherit `currentColor`.\n\n- **Action integration**\n- Updated the Extend action descriptor to render an `EuiIcon` with the\nReact SVG component through the action menu icon slot.\n- No behavioral changes to the action itself or the surrounding menu\nstructure.\n\n### Before\n\n![Before: Extend icon invisible in dark\nmode](https://github.com/user-attachments/assets/69d31674-c372-4f79-a5e0-3484251a460b)\n\n### After\n\n![After: Extend icon visible in dark\nmode](https://github.com/user-attachments/assets/4a144bf1-7828-456f-b1cc-985a205b9515)\n\n```tsx\nimport { EuiIcon } from '@elastic/eui';\nimport { ExtendSessionSvg } from './icons/extend_session.svg';\n\nexport const createExtendActionDescriptor = (\n  api,\n  uiSession,\n  core\n) => ({\n  icon: <EuiIcon type={ExtendSessionSvg} size=\"m\" color=\"inherit\" aria-hidden={true} />,\n  label: <FormattedMessage id=\"data.mgmt.searchSessions.actionExtend\" defaultMessage=\"Extend\" />,\n  onClick: async () => {\n    // unchanged\n  },\n});\n```\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"c41785ec0cf9c2f06583ff434e6614e107986361"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->