### PR TITLE
[Management] Gate performance link when user doesnt have cloud priv

### DIFF
--- a/x-pack/solutions/search/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/serverless_search/kibana.jsonc
@@ -23,6 +23,7 @@
       "dashboard",
       "devTools",
       "discover",
+      "features",
       "management",
       "searchprofiler",
       "security",

--- a/x-pack/solutions/search/plugins/serverless_search/moon.yml
+++ b/x-pack/solutions/search/plugins/serverless_search/moon.yml
@@ -60,6 +60,7 @@ dependsOn:
   - '@kbn/react-query'
   - '@kbn/ai-assistant-common'
   - '@kbn/management-settings-ids'
+  - '@kbn/features-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.test.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.test.ts
@@ -103,4 +103,52 @@ describe('Navigation Tree', () => {
       })
     );
   });
+
+  it('shows Performance link in Organization section when showPerformanceLink is true', () => {
+    const { footer } = createNavigationTree({ ...mockApplication, showPerformanceLink: true });
+
+    const adminAndSettingsNode = footer?.find((item: any) => item.id === 'admin_and_settings');
+    const orgSection = adminAndSettingsNode?.children?.find(
+      (item: any) => item.id === 'organization'
+    );
+
+    expect(orgSection).toBeDefined();
+    expect(orgSection?.children).toContainEqual(
+      expect.objectContaining({
+        id: 'cloudLinkDeployment',
+        cloudLink: 'deployment',
+      })
+    );
+  });
+
+  it('hides Performance link in Organization section when showPerformanceLink is false', () => {
+    const { footer } = createNavigationTree({ ...mockApplication, showPerformanceLink: false });
+
+    const adminAndSettingsNode = footer?.find((item: any) => item.id === 'admin_and_settings');
+    const orgSection = adminAndSettingsNode?.children?.find(
+      (item: any) => item.id === 'organization'
+    );
+
+    expect(orgSection).toBeDefined();
+    expect(orgSection?.children).not.toContainEqual(
+      expect.objectContaining({
+        id: 'cloudLinkDeployment',
+      })
+    );
+  });
+
+  it('hides Performance link by default (no manage cluster privilege)', () => {
+    const { footer } = createNavigationTree(mockApplication);
+
+    const adminAndSettingsNode = footer?.find((item: any) => item.id === 'admin_and_settings');
+    const orgSection = adminAndSettingsNode?.children?.find(
+      (item: any) => item.id === 'organization'
+    );
+
+    expect(orgSection?.children).not.toContainEqual(
+      expect.objectContaining({
+        id: 'cloudLinkDeployment',
+      })
+    );
+  });
 });

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -62,9 +62,11 @@ export function createNavigationTree({
   isAppRegistered,
   showAiAssistant = true,
   showAlertingV2 = false,
+  showPerformanceLink = false,
 }: ApplicationStart & {
   showAiAssistant?: boolean;
   showAlertingV2?: boolean;
+  showPerformanceLink?: boolean;
 }): NavigationTreeDefinition {
   return {
     body: [
@@ -246,11 +248,15 @@ export function createNavigationTree({
                 id: 'cloudLinkBilling',
                 cloudLink: 'billingAndSub',
               },
-              {
-                id: 'cloudLinkDeployment',
-                cloudLink: 'deployment',
-                title: PERFORMANCE_TITLE,
-              },
+              ...(showPerformanceLink
+                ? [
+                    {
+                      id: 'cloudLinkDeployment',
+                      cloudLink: 'deployment' as const,
+                      title: PERFORMANCE_TITLE,
+                    },
+                  ]
+                : []),
               {
                 cloudLink: 'userAndRoles',
               },

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -143,6 +143,7 @@ export class ServerlessSearchPlugin
           ...application,
           showAiAssistant,
           showAlertingV2: Boolean(application.capabilities.alertingVTwo),
+          showPerformanceLink: Boolean(application.capabilities.serverlessSearch?.manageCluster),
         });
       })
     );

--- a/x-pack/solutions/search/plugins/serverless_search/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/plugin.ts
@@ -79,7 +79,7 @@ export class ServerlessSearchPlugin
 
   public setup(
     { getStartServices, http }: CoreSetup<StartDependencies>,
-    { serverless, usageCollection }: SetupDependencies
+    { features, serverless, usageCollection }: SetupDependencies
   ) {
     const router = http.createRouter();
     const dependencies = {
@@ -101,6 +101,16 @@ export class ServerlessSearchPlugin
     if (usageCollection) {
       registerTelemetryUsageCollector(usageCollection, this.logger);
     }
+
+    features.registerElasticsearchFeature({
+      id: 'serverlessSearch',
+      privileges: [
+        {
+          requiredClusterPrivileges: ['manage'],
+          ui: ['manageCluster'],
+        },
+      ],
+    });
 
     serverless.setupProjectSettings(SEARCH_PROJECT_SETTINGS);
     return {};

--- a/x-pack/solutions/search/plugins/serverless_search/server/types.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { ServerlessPluginSetup } from '@kbn/serverless/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
@@ -20,6 +21,7 @@ export interface StartDependencies {
   security: SecurityPluginStart;
 }
 export interface SetupDependencies {
+  features: FeaturesPluginSetup;
   serverless: ServerlessPluginSetup;
   usageCollection?: UsageCollectionSetup;
 }

--- a/x-pack/solutions/search/plugins/serverless_search/tsconfig.json
+++ b/x-pack/solutions/search/plugins/serverless_search/tsconfig.json
@@ -57,6 +57,7 @@
     "@kbn/deeplinks-management",
     "@kbn/react-query",
     "@kbn/ai-assistant-common",
-    "@kbn/management-settings-ids"
+    "@kbn/management-settings-ids",
+    "@kbn/features-plugin"
   ]
 }


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/270449

## Summary

The Performance link in the `Admin and Settings` navbar (Organization section) was visible to all users on Search serverless projects, including those with the Cloud viewer role who can't actually access it. It should only appear for users with the Elasticsearch manage cluster privilege.
