### PR TITLE
[9.3] [Fleet] Fix multiple data stream selectors in input packages with multiple policy templates (#273364)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -45,6 +45,7 @@ export {
   isIntegrationPolicyTemplate,
   getNormalizedInputs,
   getNormalizedDataStreams,
+  getPolicyTemplateDataStreamPaths,
   filterPolicyTemplatesTiles,
   hasMultipleEnabledPolicyTemplates,
 } from './policy_template';

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.test.ts
@@ -7,6 +7,8 @@
 
 import type { PackageInfo } from '../types';
 
+import { DATASET_VAR_NAME } from '../constants';
+
 import { packageToPackagePolicy, packageToPackagePolicyInputs } from './package_to_package_policy';
 import { AWS_PACKAGE } from './fixtures/aws_package';
 
@@ -72,6 +74,72 @@ describe('Fleet - packageToPackagePolicy', () => {
           policy_templates: [{ name: 'test_template', inputs: [] }],
         } as unknown as PackageInfo)
       ).toEqual([]);
+    });
+
+    it('scopes streams per policy template for input packages with multiple templates sharing an input type', () => {
+      const result = packageToPackagePolicyInputs({
+        ...mockPackage,
+        type: 'input',
+        name: 'aws_cloudwatch',
+        policy_templates: [
+          { name: 'ec2', type: 'metrics', input: 'otelcol', title: 'EC2', description: 'EC2' },
+          { name: 'rds', type: 'metrics', input: 'otelcol', title: 'RDS', description: 'RDS' },
+        ],
+      } as unknown as PackageInfo);
+
+      expect(result).toHaveLength(2);
+
+      // Each template's input must only carry its own data stream, not every template's.
+      // Before the fix every input received one stream per template, duplicating the
+      // data_stream.dataset var once for each policy template in the package.
+      expect(result[0].policy_template).toBe('ec2');
+      expect(result[0].streams).toHaveLength(1);
+      expect(result[0].streams[0].data_stream.dataset).toBe('aws_cloudwatch.ec2');
+      expect(result[0].streams[0].vars?.[DATASET_VAR_NAME]).toBeDefined();
+
+      expect(result[1].policy_template).toBe('rds');
+      expect(result[1].streams).toHaveLength(1);
+      expect(result[1].streams[0].data_stream.dataset).toBe('aws_cloudwatch.rds');
+      expect(result[1].streams[0].vars?.[DATASET_VAR_NAME]).toBeDefined();
+    });
+
+    it('does not leak template-specific vars across input templates sharing an input type', () => {
+      // In input packages each policy template's vars become stream-level vars on its
+      // synthesized data stream, so unscoped stream resolution leaked one template's vars
+      // (not just data_stream.dataset) into the other templates.
+      const result = packageToPackagePolicyInputs({
+        ...mockPackage,
+        type: 'input',
+        name: 'aws_cloudwatch',
+        policy_templates: [
+          {
+            name: 'ec2',
+            type: 'metrics',
+            input: 'otelcol',
+            title: 'EC2',
+            description: 'EC2',
+            vars: [{ name: 'region', type: 'text', title: 'Region' }],
+          },
+          {
+            name: 'lambda',
+            type: 'metrics',
+            input: 'otelcol',
+            title: 'Lambda',
+            description: 'Lambda',
+            vars: [{ name: 'function_name', type: 'text', title: 'Function name' }],
+          },
+        ],
+      } as unknown as PackageInfo);
+
+      expect(result).toHaveLength(2);
+
+      const ec2VarNames = Object.keys(result[0].streams[0].vars ?? {});
+      expect(ec2VarNames).toContain('region');
+      expect(ec2VarNames).not.toContain('function_name');
+
+      const lambdaVarNames = Object.keys(result[1].streams[0].vars ?? {});
+      expect(lambdaVarNames).toContain('function_name');
+      expect(lambdaVarNames).not.toContain('region');
     });
 
     it('returns inputs with no streams for packages with no streams', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
@@ -22,7 +22,7 @@ import { doesPackageHaveIntegrations } from '.';
 import {
   getNormalizedDataStreams,
   getNormalizedInputs,
-  isIntegrationPolicyTemplate,
+  getPolicyTemplateDataStreamPaths,
 } from './policy_template';
 
 type PackagePolicyStream = RegistryStream & {
@@ -114,13 +114,15 @@ export const packageToPackagePolicyInputs = (
 
   packageInfo.policy_templates?.forEach((packagePolicyTemplate) => {
     const normalizedInputs = getNormalizedInputs(packagePolicyTemplate);
+    // Scope stream resolution to this policy template's own data stream(s). For input packages
+    // with several templates that share the same input type, this prevents each template's input
+    // from picking up every template's stream (which duplicated stream vars like data_stream.dataset).
+    const dataStreamPaths = getPolicyTemplateDataStreamPaths(packageInfo, packagePolicyTemplate);
     normalizedInputs?.forEach((packageInput) => {
       const inputKey = `${packagePolicyTemplate.name}-${packageInput.type}`;
       const input = {
         ...packageInput,
-        ...(isIntegrationPolicyTemplate(packagePolicyTemplate) && packagePolicyTemplate.data_streams
-          ? { data_streams: packagePolicyTemplate.data_streams }
-          : {}),
+        ...(dataStreamPaths.length ? { data_streams: dataStreamPaths } : {}),
         policy_template: packagePolicyTemplate.name,
       };
       packageInputsByPolicyTemplateAndType[inputKey] = input;

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
@@ -21,6 +21,7 @@ import {
   isIntegrationPolicyTemplate,
   getNormalizedInputs,
   getNormalizedDataStreams,
+  getPolicyTemplateDataStreamPaths,
   filterPolicyTemplatesTiles,
   hasMultipleEnabledPolicyTemplates,
 } from './policy_template';
@@ -527,5 +528,47 @@ describe('hasMultipleEnabledPolicyTemplates', () => {
       { type: 'httpjson', policy_template: 'template_b', enabled: false },
     ]);
     expect(hasMultipleEnabledPolicyTemplates(packagePolicy)).toBe(false);
+  });
+});
+
+describe('getPolicyTemplateDataStreamPaths', () => {
+  it('returns the declared data_streams for integration templates', () => {
+    expect(
+      getPolicyTemplateDataStreamPaths({ name: 'nginx' }, {
+        name: 'nginx',
+        data_streams: ['access', 'error'],
+        inputs: [{ type: 'logfile' }],
+      } as any)
+    ).toEqual(['access', 'error']);
+  });
+
+  it('returns an empty array for integration templates without data_streams', () => {
+    expect(
+      getPolicyTemplateDataStreamPaths({ name: 'nginx' }, {
+        name: 'nginx',
+        inputs: [{ type: 'logfile' }],
+      } as any)
+    ).toEqual([]);
+  });
+
+  it('returns the synthesized data stream path for input-only templates', () => {
+    expect(
+      getPolicyTemplateDataStreamPaths({ name: 'aws_cloudwatch' }, {
+        name: 'ec2',
+        input: 'otelcol',
+        title: 'EC2',
+        description: 'EC2',
+      } as any)
+    ).toEqual(['aws_cloudwatch.ec2']);
+  });
+
+  it('scopes each input-only template to its own data stream path', () => {
+    const packageInfo = { name: 'aws_cloudwatch' };
+    expect(
+      getPolicyTemplateDataStreamPaths(packageInfo, { name: 'rds', input: 'otelcol' } as any)
+    ).toEqual(['aws_cloudwatch.rds']);
+    expect(
+      getPolicyTemplateDataStreamPaths(packageInfo, { name: 'sqs', input: 'otelcol' } as any)
+    ).toEqual(['aws_cloudwatch.sqs']);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
@@ -146,6 +146,25 @@ const createDefaultDatasetName = (
   policyTemplate: { name: string }
 ): string => packageInfo.name + '.' + policyTemplate.name;
 
+/**
+ * Returns the data stream paths that scope stream resolution to a single policy template.
+ *
+ * - Integration templates: the explicit `data_streams` declared on the template (an empty
+ *   list means "all data streams" to the stream resolvers).
+ * - Input-only templates: each template synthesizes exactly one data stream whose `path`
+ *   equals the template's default dataset name (see `getNormalizedDataStreams`). Returning that
+ *   single path prevents templates that share the same input type (e.g. several `otelcol`
+ *   templates in one input package) from each picking up every template's stream, which would
+ *   otherwise duplicate stream-level vars such as `data_stream.dataset`.
+ */
+export const getPolicyTemplateDataStreamPaths = (
+  packageInfo: Pick<PackageInfo | InstallablePackage, 'name'>,
+  policyTemplate: RegistryPolicyTemplate
+): string[] =>
+  isIntegrationPolicyTemplate(policyTemplate)
+    ? policyTemplate.data_streams ?? []
+    : [createDefaultDatasetName(packageInfo, policyTemplate)];
+
 export const hasMultipleEnabledPolicyTemplates = (packagePolicy: NewPackagePolicy): boolean => {
   const enabledPolicyTemplates = new Set(
     packagePolicy?.inputs

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -17,7 +17,8 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import {
   getNormalizedInputs,
-  isIntegrationPolicyTemplate,
+  isInputOnlyPolicyTemplate,
+  getPolicyTemplateDataStreamPaths,
   getRegistryStreamWithDataStreamForInputType,
 } from '../../../../../../../../common/services';
 import { isInputAllowedForDeploymentMode } from '../../../../../../../../common/services/agentless_policy_helper';
@@ -80,12 +81,18 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
                   input.type === packageInput.type &&
                   (hasIntegrations ? input.policy_template === policyTemplate.name : true)
               );
+              // Scope stream resolution to this policy template's own data stream(s) so that
+              // input packages with multiple templates sharing an input type don't duplicate
+              // each template's streams (and stream vars like data_stream.dataset). Single-template
+              // integration packages keep searching all data streams, preserving previous behavior.
+              const dataStreamPaths =
+                isInputOnlyPolicyTemplate(policyTemplate) || hasIntegrations
+                  ? getPolicyTemplateDataStreamPaths(packageInfo, policyTemplate)
+                  : [];
               const packageInputStreams = getRegistryStreamWithDataStreamForInputType(
                 packageInput.type,
                 packageInfo,
-                hasIntegrations && isIntegrationPolicyTemplate(policyTemplate)
-                  ? policyTemplate.data_streams
-                  : []
+                dataStreamPaths
               );
 
               const updatePackagePolicyInput = (updatedInput: Partial<NewPackagePolicyInput>) => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_template_inputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_template_inputs.ts
@@ -10,7 +10,7 @@ import { merge } from 'lodash';
 import { dump } from 'js-yaml';
 import yamlDoc from 'yaml';
 
-import { getNormalizedInputs, isIntegrationPolicyTemplate } from '../../../../common/services';
+import { getNormalizedInputs, getPolicyTemplateDataStreamPaths } from '../../../../common/services';
 
 import {
   getStreamsForInputType,
@@ -246,9 +246,7 @@ function buildIndexedPackage(packageInfo: PackageInfo): PackageWithInputAndStrea
           const streams = getStreamsForInputType(
             packageInput.type,
             packageInfo,
-            isIntegrationPolicyTemplate(policyTemplate) && policyTemplate.data_streams
-              ? policyTemplate.data_streams
-              : []
+            getPolicyTemplateDataStreamPaths(packageInfo, policyTemplate)
           ).reduce<
             Record<
               string,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[Fleet] Fix multiple data stream selectors in input packages with multiple policy templates (#273364)](https://github.com/elastic/kibana/pull/273364)

<!--BACKPORT [{"sourcePullRequest":{"number":273364,"url":"https://github.com/elastic/kibana/pull/273364","title":"[Fleet] Fix multiple data stream selectors in input packages with multiple policy templates"}}] BACKPORT-->
