### PR TITLE
[Synthetics] Bump the timeout to fix no monitor found test flakiness

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/no_monitors_found.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/no_monitors_found.test.tsx
@@ -33,5 +33,5 @@ describe('NoMonitorsFound', () => {
     await waitFor(() => {
       expect(updateUrlParamsMock).toBeCalledWith(null);
     });
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/269496

## Summary

This PR fixes the flaky test by increasing test's timeout. This is the proposed fix by the Failed Test Investigator (see the investigation analysis in the issue)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->