### PR TITLE
[Synthetics] increase test timeout to fix flakiness for step_field_trend test

### DIFF
--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/synthetics/check_steps/step_field_trend.test.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/synthetics/check_steps/step_field_trend.test.tsx
@@ -46,7 +46,7 @@ describe('StepFieldTrend', () => {
     );
 
     expect(await findByText('Embeddable exploratory view')).toBeInTheDocument();
-  });
+  }, 30_000);
 });
 
 describe('getLast48Intervals', () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/268968

## Summary
This PR fixes the flaky test by increasing test's timeout. This is the proposed fix by the Failed Test Investigator (see the investigation analysis in the issue).