### PR TITLE
[ResponseOps][PerAlertSnooze] Handle atomic snooze updates via Painless script, update snooze evaluation to handle array/objects

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
@@ -2198,13 +2198,13 @@ describe('Alerts Client', () => {
           expect(clusterClient.updateByQuery).not.toHaveBeenCalled();
         });
 
-        test('logs error and rethrows when updateByQuery fails', async () => {
+        test('logs error and swallows when updateByQuery fails', async () => {
           clusterClient.updateByQuery.mockRejectedValueOnce(new Error('ES unavailable'));
           const alertsClient = await setupAndPersist();
 
           await expect(
             alertsClient.clearSnoozedStatusForAlerts([snoozedInstanceId])
-          ).rejects.toThrow('ES unavailable');
+          ).resolves.toBeUndefined();
 
           expect(logger.error).toHaveBeenCalledWith(
             expect.stringContaining('Error clearing snoozed status for condition-expired alerts'),

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
@@ -526,11 +526,12 @@ export class AlertsClient<
         { logger: this.options.logger }
       );
     } catch (err) {
+      // Swallow the error — clearing kibana.alert.snoozed is best-effort.
+      // A failure here must not interrupt rule execution or the SO update.
       this.options.logger.error(
         `Error clearing snoozed status for condition-expired alerts ${this.ruleInfoMessage}: ${err}`,
         this.logTags
       );
-      throw err;
     }
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
@@ -526,8 +526,7 @@ export class AlertsClient<
         { logger: this.options.logger }
       );
     } catch (err) {
-      // Swallow the error — clearing kibana.alert.snoozed is best-effort.
-      // A failure here must not interrupt rule execution or the SO update.
+      // Swallow the error
       this.options.logger.error(
         `Error clearing snoozed status for condition-expired alerts ${this.ruleInfoMessage}: ${err}`,
         this.logTags

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/alerts_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/alerts_service.test.ts
@@ -2985,9 +2985,9 @@ describe('Alerts Service', () => {
                 {
                   _index: '.alerts-default',
                   _id: 'alert-1',
-                  fields: {
-                    'host.name': ['web-01'],
-                    'kibana.alert.severity': ['high'],
+                  _source: {
+                    'host.name': 'web-01',
+                    'kibana.alert.severity': 'high',
                   },
                 },
               ],
@@ -3022,8 +3022,7 @@ describe('Alerts Service', () => {
             index: ['.alerts-default'],
             allow_no_indices: true,
             size: 1,
-            fields: ['host.name', 'kibana.alert.severity'],
-            _source: false,
+            _source: ['host.name', 'kibana.alert.severity'],
             query: {
               bool: {
                 must: [

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/get_alert_snooze_snapshot.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/get_alert_snooze_snapshot.test.ts
@@ -9,7 +9,7 @@ import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mo
 import { getAlertSnoozeSnapshot } from './get_alert_snooze_snapshot';
 
 describe('getAlertSnoozeSnapshot', () => {
-  test('searches with the correct params using the fields API', async () => {
+  test('searches with the correct params using _source filtering', async () => {
     const logger = loggingSystemMock.createLogger();
     const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
@@ -26,8 +26,7 @@ describe('getAlertSnoozeSnapshot', () => {
       index: ['test-index'],
       allow_no_indices: true,
       size: 1,
-      fields: ['host.name', 'kibana.alert.severity'],
-      _source: false,
+      _source: ['host.name', 'kibana.alert.severity'],
       query: {
         bool: {
           must: [
@@ -40,7 +39,7 @@ describe('getAlertSnoozeSnapshot', () => {
     });
   });
 
-  test('returns snapshot values from the fields API response', async () => {
+  test('returns snapshot values from _source in their original stored form', async () => {
     const logger = loggingSystemMock.createLogger();
     const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
@@ -51,9 +50,9 @@ describe('getAlertSnoozeSnapshot', () => {
           {
             _index: 'test-index',
             _id: 'test-alert-id',
-            fields: {
-              'host.name': ['web-01'],
-              'kibana.alert.severity': ['high'],
+            _source: {
+              'host.name': 'web-01',
+              'kibana.alert.severity': 'high',
             },
           },
         ],
@@ -76,6 +75,80 @@ describe('getAlertSnoozeSnapshot', () => {
       'host.name': 'web-01',
       'kibana.alert.severity': 'high',
     });
+  });
+
+  test('preserves array values without unwrapping (e.g. kibana.alert.rule.tags)', async () => {
+    const logger = loggingSystemMock.createLogger();
+    const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    clusterClient.search.mockResponseOnce({
+      hits: {
+        total: 1,
+        hits: [
+          {
+            _index: 'test-index',
+            _id: 'test-alert-id',
+            _source: {
+              // Stored as a single-element array — must NOT be unwrapped to scalar
+              'kibana.alert.rule.tags': ['web'],
+            },
+          },
+        ],
+      },
+      took: 0,
+      timed_out: false,
+      _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
+    });
+
+    const result = await getAlertSnoozeSnapshot({
+      logger,
+      esClient: clusterClient,
+      indices: ['test-index'],
+      alertId: 'test-alert-id',
+      ruleId: 'test-rule-id',
+      fields: ['kibana.alert.rule.tags'],
+    });
+
+    // Must stay as array to match what AlertBuilder produces in-memory
+    expect(result).toEqual({ 'kibana.alert.rule.tags': ['web'] });
+  });
+
+  test('preserves object fields with nested arrays (e.g. kibana.alert.rule.parameters)', async () => {
+    const logger = loggingSystemMock.createLogger();
+    const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    const params = { threshold: [1], size: 100, aggType: 'count' };
+
+    clusterClient.search.mockResponseOnce({
+      hits: {
+        total: 1,
+        hits: [
+          {
+            _index: 'test-index',
+            _id: 'test-alert-id',
+            _source: {
+              // Object field stored exactly as the alert builder produced it
+              'kibana.alert.rule.parameters': params,
+            },
+          },
+        ],
+      },
+      took: 0,
+      timed_out: false,
+      _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
+    });
+
+    const result = await getAlertSnoozeSnapshot({
+      logger,
+      esClient: clusterClient,
+      indices: ['test-index'],
+      alertId: 'test-alert-id',
+      ruleId: 'test-rule-id',
+      fields: ['kibana.alert.rule.parameters'],
+    });
+
+    // Must preserve {threshold: [1]} — not normalize to {threshold: 1}
+    expect(result).toEqual({ 'kibana.alert.rule.parameters': params });
   });
 
   test('returns null when the alert does not exist', async () => {
@@ -115,9 +188,9 @@ describe('getAlertSnoozeSnapshot', () => {
           {
             _index: 'test-index',
             _id: 'test-alert-id',
-            // kibana.alert.severity not present in fields response
-            fields: {
-              'host.name': ['web-01'],
+            _source: {
+              // kibana.alert.severity not present
+              'host.name': 'web-01',
             },
           },
         ],
@@ -140,40 +213,6 @@ describe('getAlertSnoozeSnapshot', () => {
       'host.name': 'web-01',
       'kibana.alert.severity': null,
     });
-  });
-
-  test('preserves array for multi-value fields', async () => {
-    const logger = loggingSystemMock.createLogger();
-    const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-
-    clusterClient.search.mockResponseOnce({
-      hits: {
-        total: 1,
-        hits: [
-          {
-            _index: 'test-index',
-            _id: 'test-alert-id',
-            fields: {
-              tags: ['production', 'critical'],
-            },
-          },
-        ],
-      },
-      took: 0,
-      timed_out: false,
-      _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
-    });
-
-    const result = await getAlertSnoozeSnapshot({
-      logger,
-      esClient: clusterClient,
-      indices: ['test-index'],
-      alertId: 'test-alert-id',
-      ruleId: 'test-rule-id',
-      fields: ['tags'],
-    });
-
-    expect(result).toEqual({ tags: ['production', 'critical'] });
   });
 
   test('logs an error when search fails with an Error instance', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/get_alert_snooze_snapshot.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/get_alert_snooze_snapshot.ts
@@ -39,7 +39,6 @@ export async function getAlertSnoozeSnapshot({
       index: indices,
       allow_no_indices: true,
       size: 1,
-      // Use _source with source filtering rather than the `fields` API.
       _source: fields,
       query: {
         bool: {
@@ -57,8 +56,7 @@ export async function getAlertSnoozeSnapshot({
       return null;
     }
 
-    // Alert documents use flat dot-notation keys in _source, so direct bracket
-    // access is correct here — no lodash path traversal needed.
+    // Alert documents use flat dot-notation keys in _source
     const source = (hit._source ?? {}) as Record<string, unknown>;
     return fields.reduce<Record<string, unknown>>((snapshot, field) => {
       const value = source[field];

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/get_alert_snooze_snapshot.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/get_alert_snooze_snapshot.ts
@@ -39,8 +39,8 @@ export async function getAlertSnoozeSnapshot({
       index: indices,
       allow_no_indices: true,
       size: 1,
-      fields,
-      _source: false,
+      // Use _source with source filtering rather than the `fields` API.
+      _source: fields,
       query: {
         bool: {
           must: [
@@ -57,15 +57,12 @@ export async function getAlertSnoozeSnapshot({
       return null;
     }
 
-    const hitFields = hit.fields ?? {};
+    // Alert documents use flat dot-notation keys in _source, so direct bracket
+    // access is correct here — no lodash path traversal needed.
+    const source = (hit._source ?? {}) as Record<string, unknown>;
     return fields.reduce<Record<string, unknown>>((snapshot, field) => {
-      const values = hitFields[field] as unknown[] | undefined;
-      if (values && values.length > 0) {
-        // Return single value for scalar fields; keep array for multi-value fields.
-        snapshot[field] = values.length === 1 ? values[0] : values;
-      } else {
-        snapshot[field] = null;
-      }
+      const value = source[field];
+      snapshot[field] = value !== undefined ? value : null;
       return snapshot;
     }, {});
   } catch (error) {

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/index.ts
@@ -28,7 +28,11 @@ import type { RawRule, RawRuleTemplate } from '../types';
 import { getImportWarnings } from './get_import_warnings';
 import { isRuleExportable } from './is_rule_exportable';
 import type { RuleTypeRegistry } from '../rule_type_registry';
-export { partiallyUpdateRule, partiallyUpdateRuleWithEs } from './partially_update_rule';
+export {
+  atomicRemoveSnoozedInstancesWithEs,
+  partiallyUpdateRule,
+  partiallyUpdateRuleWithEs,
+} from './partially_update_rule';
 import { RULES_SETTINGS_SAVED_OBJECT_TYPE } from '../../common';
 import {
   adHocRunParamsModelVersions,

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/partially_update_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/partially_update_rule.test.ts
@@ -8,7 +8,11 @@
 import type { SavedObjectsClientContract, ISavedObjectsRepository } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { PartiallyUpdateableRuleAttributes } from './partially_update_rule';
-import { partiallyUpdateRule, partiallyUpdateRuleWithEs } from './partially_update_rule';
+import {
+  atomicRemoveSnoozedInstancesWithEs,
+  partiallyUpdateRule,
+  partiallyUpdateRuleWithEs,
+} from './partially_update_rule';
 import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { RULE_SAVED_OBJECT_TYPE } from '.';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
@@ -196,6 +200,92 @@ describe('partiallyUpdateRuleWithEs', () => {
       },
       refresh: 'wait_for',
     });
+  });
+});
+
+describe('atomicRemoveSnoozedInstancesWithEs', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('should call update with a Painless script (not a doc) and retry_on_conflict', async () => {
+    esClient.update.mockResolvedValueOnce(MockEsUpdateResponse(MockRuleId));
+
+    await atomicRemoveSnoozedInstancesWithEs(esClient, MockRuleId, ['alert-1', 'alert-2']);
+
+    expect(esClient.update).toHaveBeenCalledTimes(1);
+    expect(esClient.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `alert:${MockRuleId}`,
+        index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+        retry_on_conflict: 3,
+        script: expect.objectContaining({
+          lang: 'painless',
+          params: { expiredInstanceIds: ['alert-1', 'alert-2'] },
+        }),
+      })
+    );
+    // Must not send a `doc` field — otherwise it would replace the whole array
+    expect(esClient.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ doc: expect.anything() }),
+      expect.anything()
+    );
+  });
+
+  test('should pass ignore: [404] when ignore404 option is set', async () => {
+    esClient.update.mockResolvedValueOnce(MockEsUpdateResponse(MockRuleId));
+
+    await atomicRemoveSnoozedInstancesWithEs(esClient, MockRuleId, ['alert-1'], {
+      ignore404: true,
+    });
+
+    expect(esClient.update).toHaveBeenCalledWith(
+      expect.objectContaining({ retry_on_conflict: 3 }),
+      { ignore: [404] }
+    );
+  });
+
+  test('should include the refresh option when set', async () => {
+    esClient.update.mockResolvedValueOnce(MockEsUpdateResponse(MockRuleId));
+
+    await atomicRemoveSnoozedInstancesWithEs(esClient, MockRuleId, ['alert-1'], {
+      refresh: 'wait_for',
+    });
+
+    expect(esClient.update).toHaveBeenCalledWith(expect.objectContaining({ refresh: 'wait_for' }));
+  });
+
+  test('should not include refresh when the option is not set', async () => {
+    esClient.update.mockResolvedValueOnce(MockEsUpdateResponse(MockRuleId));
+
+    await atomicRemoveSnoozedInstancesWithEs(esClient, MockRuleId, ['alert-1']);
+
+    const [callArgs] = esClient.update.mock.calls[0];
+    expect(callArgs).not.toHaveProperty('refresh');
+  });
+
+  test('should work with an empty expiredInstanceIds array (idempotent noop)', async () => {
+    esClient.update.mockResolvedValueOnce(MockEsUpdateResponse(MockRuleId));
+
+    await atomicRemoveSnoozedInstancesWithEs(esClient, MockRuleId, []);
+
+    expect(esClient.update).toHaveBeenCalledTimes(1);
+    expect(esClient.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        script: expect.objectContaining({
+          params: { expiredInstanceIds: [] },
+        }),
+      })
+    );
+  });
+
+  test('should propagate ES errors', async () => {
+    esClient.update.mockRejectedValueOnce(new Error('es error'));
+
+    await expect(
+      atomicRemoveSnoozedInstancesWithEs(esClient, MockRuleId, ['alert-1'])
+    ).rejects.toThrowError('es error');
   });
 });
 

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/partially_update_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/partially_update_rule.ts
@@ -75,6 +75,46 @@ const RuleAttributesAllowedForPartialUpdate = [
   'snoozedInstances',
 ];
 
+// Painless script that atomically removes snoozed instance entries by ID.
+// Using removeIf avoids a full-array replacement and is safe to run concurrently
+// with user snooze API writes: entries added between SO load and post-run write
+// are preserved because only the specified IDs are removed, not the whole array.
+const REMOVE_SNOOZED_INSTANCES_SCRIPT = `
+  if (ctx._source.alert.snoozedInstances != null) {
+    ctx._source.alert.snoozedInstances.removeIf(
+      instance -> params.expiredInstanceIds.contains(instance.instanceId)
+    );
+  }
+`;
+
+// Atomically removes per-alert snooze entries whose IDs are in expiredInstanceIds.
+// Uses retry_on_conflict instead of version-based OCC because the script is idempotent:
+// removing an already-absent entry is a no-op, so retrying on a version conflict is safe.
+export async function atomicRemoveSnoozedInstancesWithEs(
+  esClient: ElasticsearchClient,
+  id: string,
+  expiredInstanceIds: string[],
+  options: Pick<PartiallyUpdateRuleSavedObjectOptions, 'ignore404' | 'refresh'> = {}
+): Promise<void> {
+  const updateParams = {
+    id: `alert:${id}`,
+    index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+    retry_on_conflict: 3,
+    script: {
+      lang: 'painless' as const,
+      source: REMOVE_SNOOZED_INSTANCES_SCRIPT,
+      params: { expiredInstanceIds },
+    },
+    ...(options.refresh ? { refresh: options.refresh } : {}),
+  };
+
+  if (options.ignore404) {
+    await esClient.update(updateParams, { ignore: [404] });
+  } else {
+    await esClient.update(updateParams);
+  }
+}
+
 // direct, partial update to a rule saved object via ElasticsearchClient
 
 // we do this direct partial update to avoid the overhead of the SavedObjectsClient for

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/partially_update_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/partially_update_rule.ts
@@ -76,9 +76,7 @@ const RuleAttributesAllowedForPartialUpdate = [
 ];
 
 // Painless script that atomically removes snoozed instance entries by ID.
-// Using removeIf avoids a full-array replacement and is safe to run concurrently
-// with user snooze API writes: entries added between SO load and post-run write
-// are preserved because only the specified IDs are removed, not the whole array.
+// Using removeIf avoids a full-array replacement
 const REMOVE_SNOOZED_INSTANCES_SCRIPT = `
   if (ctx._source.alert.snoozedInstances != null) {
     ctx._source.alert.snoozedInstances.removeIf(
@@ -88,8 +86,7 @@ const REMOVE_SNOOZED_INSTANCES_SCRIPT = `
 `;
 
 // Atomically removes per-alert snooze entries whose IDs are in expiredInstanceIds.
-// Uses retry_on_conflict instead of version-based OCC because the script is idempotent:
-// removing an already-absent entry is a no-op, so retrying on a version conflict is safe.
+// Uses retry_on_conflict - removing an already-absent entry is a no-op, retrying on a version conflict is safe.
 export async function atomicRemoveSnoozedInstancesWithEs(
   esClient: ElasticsearchClient,
   id: string,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/evaluate_per_alert_snooze_conditions.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/evaluate_per_alert_snooze_conditions.test.ts
@@ -111,6 +111,190 @@ describe('evaluatePerAlertSnoozeConditions', () => {
       );
       expect(result.conditionExpiredInstances).toHaveLength(0);
     });
+
+    it('keeps instance snoozed when field was absent at snooze time (null) and is still absent (undefined)', () => {
+      // Rule type does not produce kibana.alert.severity. The snapshot captures
+      // null for the missing field; the alert builder returns undefined at
+      // evaluation time. null and undefined must be treated as equivalent.
+      const instance = makeInstance({
+        instanceId: 'alert-1',
+        conditions: [{ type: 'severity_change' }],
+        snoozeSnapshot: { [ALERT_SEVERITY]: null },
+      });
+      const alertAsData = { 'kibana.alert.rule.tags': ['test', '1'] }; // no severity field
+      const result = evaluatePerAlertSnoozeConditions(
+        [instance],
+        buildMap([['alert-1', alertAsData]])
+      );
+      expect(result.conditionExpiredInstances).toHaveLength(0);
+    });
+
+    it('unsnoozes when field transitions from absent (null snapshot) to a real value', () => {
+      const instance = makeInstance({
+        instanceId: 'alert-1',
+        conditions: [{ type: 'field_change', field: 'kibana.alert.severity' }],
+        snoozeSnapshot: { [ALERT_SEVERITY]: null },
+      });
+      const alertAsData = { 'kibana.alert.severity': 'high' };
+      const result = evaluatePerAlertSnoozeConditions(
+        [instance],
+        buildMap([['alert-1', alertAsData]])
+      );
+      expect(result.conditionExpiredInstances).toHaveLength(1);
+    });
+
+    it('keeps instance snoozed with any-operator when no condition actually fires (null/undefined absent field)', () => {
+      // Regression: severity_change on a non-severity rule must NOT fire just
+      // because the snapshot stored null and the alert builder returns undefined.
+      const instance = makeInstance({
+        instanceId: 'alert-1',
+        conditionOperator: 'any',
+        conditions: [
+          { type: 'field_change', field: 'kibana.alert.rule.tags' },
+          { type: 'severity_change' },
+          { type: 'severity_equals', value: 'critical' },
+        ],
+        snoozeSnapshot: {
+          'kibana.alert.rule.tags': ['test', '1'],
+          [ALERT_SEVERITY]: null,
+        },
+      });
+      // Tags unchanged, severity absent both at snooze and now
+      const alertAsData = { 'kibana.alert.rule.tags': ['test', '1'] };
+      const result = evaluatePerAlertSnoozeConditions(
+        [instance],
+        buildMap([['alert-1', alertAsData]])
+      );
+      expect(result.conditionExpiredInstances).toHaveLength(0);
+    });
+
+    describe('array-typed fields (e.g. kibana.alert.rule.tags)', () => {
+      // getAlertSnoozeSnapshot now uses _source (not the fields API) so snapshots
+      // capture the exact stored structure. Tags are always arrays in the source,
+      // so both snapshot and current alert data carry the array form.
+
+      it('keeps instance snoozed when single-element array tag is unchanged', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.tags' }],
+          snoozeSnapshot: { 'kibana.alert.rule.tags': ['1'] },
+        });
+        const alertAsData = { 'kibana.alert.rule.tags': ['1'] };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(0);
+      });
+
+      it('unsnoozes when the tag value actually changed', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.tags' }],
+          snoozeSnapshot: { 'kibana.alert.rule.tags': ['tag-a'] },
+        });
+        const alertAsData = { 'kibana.alert.rule.tags': ['tag-b'] };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(1);
+      });
+
+      it('unsnoozes when a tag is added', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.tags' }],
+          snoozeSnapshot: { 'kibana.alert.rule.tags': ['tag-a'] },
+        });
+        const alertAsData = { 'kibana.alert.rule.tags': ['tag-a', 'tag-b'] };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(1);
+      });
+
+      it('keeps instance snoozed when multi-element array tags are unchanged', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.tags' }],
+          snoozeSnapshot: { 'kibana.alert.rule.tags': ['tag-a', 'tag-b'] },
+        });
+        const alertAsData = { 'kibana.alert.rule.tags': ['tag-a', 'tag-b'] };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(0);
+      });
+
+      it('unsnoozes when multi-element array tags change', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.tags' }],
+          snoozeSnapshot: { 'kibana.alert.rule.tags': ['tag-a', 'tag-b'] },
+        });
+        const alertAsData = { 'kibana.alert.rule.tags': ['tag-a', 'tag-c'] };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(1);
+      });
+    });
+
+    describe('object fields (e.g. kibana.alert.rule.parameters)', () => {
+      // getAlertSnoozeSnapshot uses _source so object field values (including
+      // nested arrays like threshold:[1]) are captured exactly as stored.
+      // isEqual is used instead of JSON.stringify to handle key-order differences
+      // between the snapshot and the in-memory alert builder output.
+
+      it('keeps instance snoozed when object field is unchanged', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.parameters' }],
+          // Snapshot from _source preserves threshold as an array [1]
+          snoozeSnapshot: { 'kibana.alert.rule.parameters': { threshold: [1], size: 100 } },
+        });
+        const alertAsData = { 'kibana.alert.rule.parameters': { threshold: [1], size: 100 } };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(0);
+      });
+
+      it('keeps instance snoozed when object field is unchanged but key order differs', () => {
+        // Snapshot captured keys in one order, alert builder produces them in another.
+        // isEqual correctly sees them as equal regardless of key ordering.
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.parameters' }],
+          snoozeSnapshot: { 'kibana.alert.rule.parameters': { threshold: [1], size: 100 } },
+        });
+        const alertAsData = { 'kibana.alert.rule.parameters': { size: 100, threshold: [1] } };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(0);
+      });
+
+      it('unsnoozes when object field actually changes', () => {
+        const instance = makeInstance({
+          instanceId: 'alert-1',
+          conditions: [{ type: 'field_change', field: 'kibana.alert.rule.parameters' }],
+          snoozeSnapshot: { 'kibana.alert.rule.parameters': { threshold: [1], size: 100 } },
+        });
+        const alertAsData = { 'kibana.alert.rule.parameters': { threshold: [5], size: 100 } };
+        const result = evaluatePerAlertSnoozeConditions(
+          [instance],
+          buildMap([['alert-1', alertAsData]])
+        );
+        expect(result.conditionExpiredInstances).toHaveLength(1);
+      });
+    });
   });
 
   describe('severity_change condition', () => {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/evaluate_per_alert_snooze_conditions.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/evaluate_per_alert_snooze_conditions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { get } from 'lodash';
+import { get, isEqual } from 'lodash';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import type { RawRuleSnoozedInstance } from '../../saved_objects/schemas/raw_rule';
 
@@ -114,8 +114,8 @@ const evaluateFieldChange = (
   if (!snoozeSnapshot || !(fieldPath in snoozeSnapshot)) {
     return false;
   }
-  const current = getAlertFieldValue(alertAsData, fieldPath);
+
+  const current = getAlertFieldValue(alertAsData, fieldPath) ?? null;
   const snapshot = snoozeSnapshot[fieldPath];
-  // Use JSON.stringify for structural comparison to handle objects and arrays correctly.
-  return JSON.stringify(current) !== JSON.stringify(snapshot);
+  return !isEqual(current, snapshot);
 };

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -3613,7 +3613,7 @@ describe('Task Runner', () => {
     );
   });
 
-  test('should write back pruned snoozedInstances when expired entries are removed', async () => {
+  test('should atomically remove expired snoozedInstances using a Painless script', async () => {
     const expiredSnooze = {
       instanceId: 'alert-1',
       expiresAt: '1969-12-31T23:59:59.000Z',
@@ -3647,12 +3647,24 @@ describe('Task Runner', () => {
 
     await taskRunner.run();
 
+    // The script-based atomic remove should have been called with the expired ID only.
+    // The surviving active snooze ('alert-2') should NOT be listed — it is preserved
+    // in ES because the script only removes the specified IDs, not the whole array.
     expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
       expect.objectContaining({
+        script: expect.objectContaining({
+          lang: 'painless',
+          params: { expiredInstanceIds: ['alert-1'] },
+        }),
+      }),
+      expect.anything()
+    );
+
+    // Must not replace the whole array via a doc update — that would cause the race condition
+    expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({
         doc: expect.objectContaining({
-          alert: expect.objectContaining({
-            snoozedInstances: [activeSnooze],
-          }),
+          alert: expect.objectContaining({ snoozedInstances: expect.anything() }),
         }),
       }),
       expect.anything()
@@ -3678,7 +3690,45 @@ describe('Task Runner', () => {
     );
   });
 
-  test('should remove snoozed instance when field_change condition is met', async () => {
+  test('should not call the atomic remove script when no snooze entries have expired', async () => {
+    const activeSnooze = {
+      instanceId: 'alert-2',
+      snoozedAt: '1969-12-01T00:00:00.000Z',
+      snoozedBy: 'user',
+    };
+    const rawRuleSOWithSnooze: SavedObject<RawRule> = {
+      ...mockedRawRuleSO,
+      attributes: {
+        ...mockedRawRuleSO.attributes,
+        enabled: true,
+        snoozedInstances: [activeSnooze],
+      },
+    };
+
+    const taskRunner = new TaskRunner({
+      ruleType,
+      taskInstance: mockedTaskInstance,
+      context: taskRunnerFactoryInitializerParams,
+      inMemoryMetrics,
+      internalSavedObjectsRepository,
+    });
+
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
+
+    await taskRunner.run();
+
+    // No expired entries → the atomic script should not be called
+    expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ script: expect.anything() }),
+      expect.anything()
+    );
+    expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ script: expect.anything() })
+    );
+  });
+
+  test('should atomically remove snoozed instance when field_change condition is met', async () => {
     const conditionSnooze = {
       instanceId: 'alert-1',
       snoozedAt: '1969-12-01T00:00:00.000Z',
@@ -3720,10 +3770,9 @@ describe('Task Runner', () => {
 
     expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        doc: expect.objectContaining({
-          alert: expect.objectContaining({
-            snoozedInstances: [],
-          }),
+        script: expect.objectContaining({
+          lang: 'painless',
+          params: { expiredInstanceIds: ['alert-1'] },
         }),
       }),
       expect.anything()
@@ -3832,7 +3881,7 @@ describe('Task Runner', () => {
     expect(alertsClient.clearSnoozedStatusForAlerts).not.toHaveBeenCalled();
   });
 
-  test('should NOT remove snoozed instance when field_change condition is not met', async () => {
+  test('should NOT call the atomic remove script when field_change condition is not met', async () => {
     const conditionSnooze = {
       instanceId: 'alert-1',
       snoozedAt: '1969-12-01T00:00:00.000Z',
@@ -3872,15 +3921,13 @@ describe('Task Runner', () => {
 
     await taskRunner.run();
 
+    // No entries expired → the atomic script should not be called
     expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        doc: expect.objectContaining({
-          alert: expect.objectContaining({
-            snoozedInstances: expect.anything(),
-          }),
-        }),
-      }),
+      expect.objectContaining({ script: expect.anything() }),
       expect.anything()
+    );
+    expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ script: expect.anything() })
     );
 
     expect(auditService.withoutRequest.log).not.toHaveBeenCalled();
@@ -3924,15 +3971,13 @@ describe('Task Runner', () => {
 
     await taskRunner.run();
 
+    // No entries expired → the atomic script should not be called
     expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        doc: expect.objectContaining({
-          alert: expect.objectContaining({
-            snoozedInstances: expect.anything(),
-          }),
-        }),
-      }),
+      expect.objectContaining({ script: expect.anything() }),
       expect.anything()
+    );
+    expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ script: expect.anything() })
     );
 
     expect(auditService.withoutRequest.log).not.toHaveBeenCalled();
@@ -3989,12 +4034,18 @@ describe('Task Runner', () => {
 
     await taskRunner.run();
 
+    // Both expired IDs should be passed together to the atomic script,
+    // while 'alert-still-snoozed' is untouched in ES.
     expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        doc: expect.objectContaining({
-          alert: expect.objectContaining({
-            snoozedInstances: [stillActiveSnooze],
-          }),
+        script: expect.objectContaining({
+          lang: 'painless',
+          params: {
+            expiredInstanceIds: expect.arrayContaining([
+              'alert-expired-time',
+              'alert-condition-change',
+            ]),
+          },
         }),
       }),
       expect.anything()
@@ -4059,6 +4110,73 @@ describe('Task Runner', () => {
     await taskRunner.run();
 
     expect(auditService.withoutRequest.log).not.toHaveBeenCalled();
+  });
+
+  test('concurrent snooze: atomic script preserves user-added entry despite concurrent TTL expiry', async () => {
+    // Simulates the race condition described in kibana-team#3176:
+    //   T0: rule run loads SO with snoozedInstances = [A, B_expired]
+    //   T1: user API adds C → SO now has [A, B_expired, C]
+    //   T2: rule run finishes, should only remove B_expired (not overwrite with [A])
+    //
+    // Because we use a Painless removeIf script instead of a full-array doc update,
+    // the script only removes the IDs we found expired at T0, so C is preserved by ES.
+    // This test verifies the correct IDs are sent and that no doc-level array write happens.
+    const expiredSnooze = {
+      instanceId: 'alert-expired',
+      expiresAt: '1969-12-31T23:59:59.000Z',
+      snoozedAt: '1969-12-01T00:00:00.000Z',
+      snoozedBy: 'user',
+    };
+    const stillActiveSnooze = {
+      instanceId: 'alert-active',
+      snoozedAt: '1969-12-01T00:00:00.000Z',
+      snoozedBy: 'user',
+    };
+    // The rule SO loaded at the start of the run (before the concurrent user snooze)
+    const rawRuleSOAtRunStart: SavedObject<RawRule> = {
+      ...mockedRawRuleSO,
+      attributes: {
+        ...mockedRawRuleSO.attributes,
+        enabled: true,
+        snoozedInstances: [expiredSnooze, stillActiveSnooze],
+      },
+    };
+
+    const taskRunner = new TaskRunner({
+      ruleType,
+      taskInstance: mockedTaskInstance,
+      context: taskRunnerFactoryInitializerParams,
+      inMemoryMetrics,
+      internalSavedObjectsRepository,
+    });
+
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOAtRunStart);
+
+    await taskRunner.run();
+
+    // The post-run write must use the Painless script with only the expired ID.
+    // Even if a user concurrently added 'alert-concurrent' to the SO, that entry
+    // remains untouched in ES because we never replace the full array.
+    expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        script: expect.objectContaining({
+          lang: 'painless',
+          params: { expiredInstanceIds: ['alert-expired'] },
+        }),
+      }),
+      expect.anything()
+    );
+
+    // Confirm no full-array doc replacement was made for snoozedInstances
+    expect(elasticsearchService.client.asInternalUser.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        doc: expect.objectContaining({
+          alert: expect.objectContaining({ snoozedInstances: expect.anything() }),
+        }),
+      }),
+      expect.anything()
+    );
   });
 
   function testAlertingEventLogCalls({

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -253,8 +253,6 @@ export class TaskRunner<
       );
       if (snoozedInstanceIdsToRemove?.length) {
         // Per-alert snooze expiry is applied via an atomic Painless script.
-        // This prevents the race condition where a user snooze added between SO load
-        // and post-run write would be silently overwritten.
         await atomicRemoveSnoozedInstancesWithEs(client, ruleId, snoozedInstanceIdsToRemove, {
           ignore404: true,
           refresh: false,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -38,7 +38,11 @@ import { RuleExecutionStatusErrorReasons } from '../types';
 import type { Result } from '../lib/result_type';
 import { asErr, asOk, isOk } from '../lib/result_type';
 import { taskInstanceToAlertTaskInstance } from './alert_task_instance';
-import { partiallyUpdateRuleWithEs, RULE_SAVED_OBJECT_TYPE } from '../saved_objects';
+import {
+  atomicRemoveSnoozedInstancesWithEs,
+  partiallyUpdateRuleWithEs,
+  RULE_SAVED_OBJECT_TYPE,
+} from '../saved_objects';
 import { AlertAuditAction, alertAuditSystemEvent } from '../lib/alert_audit_events';
 import type {
   AlertInstanceContext,
@@ -214,8 +218,7 @@ export class TaskRunner<
   }
 
   /**
-   * Persists the post-run rule attributes (including any pruned per-alert
-   * snoozes) to Elasticsearch.
+   * Persists the post-run rule attributes to Elasticsearch.
    */
   private async updateRuleSavedObjectPostRun(
     ruleId: string,
@@ -224,9 +227,10 @@ export class TaskRunner<
       monitoring?: RawRuleMonitoring;
       nextRun?: string | null;
       lastRun?: RawRuleLastRun | null;
-      snoozedInstances?: RawRuleSnoozedInstance[];
+      snoozedInstanceIdsToRemove?: string[];
     }
   ): Promise<boolean> {
+    const { snoozedInstanceIdsToRemove, ...docAttributes } = attributes;
     const client = this.context.elasticsearch.client.asInternalUser;
     try {
       // Future engineer -> Here we are just checking if we need to wait for
@@ -241,12 +245,21 @@ export class TaskRunner<
       await partiallyUpdateRuleWithEs(
         client,
         ruleId,
-        { ...attributes, running: false },
+        { ...docAttributes, running: false },
         {
           ignore404: true,
           refresh: false,
         }
       );
+      if (snoozedInstanceIdsToRemove?.length) {
+        // Per-alert snooze expiry is applied via an atomic Painless script.
+        // This prevents the race condition where a user snooze added between SO load
+        // and post-run write would be silently overwritten.
+        await atomicRemoveSnoozedInstancesWithEs(client, ruleId, snoozedInstanceIdsToRemove, {
+          ignore404: true,
+          refresh: false,
+        });
+      }
       return true;
     } catch (err) {
       this.logger.error(`error updating rule for ${this.ruleType.id}:${ruleId} ${err.message}`);
@@ -556,9 +569,12 @@ export class TaskRunner<
         alertRecoveredInstances: recoveredAlertsToReturn,
         summaryActions: actionSchedulerResult.throttledSummaryActions,
       },
-      prunedSnoozedInstances:
-        updatedActiveInstances.length < (rule.snoozedInstances?.length ?? 0)
-          ? updatedActiveInstances
+      expiredSnoozedInstanceIds:
+        expiredInstances.length > 0 || conditionExpiredInstances.length > 0
+          ? [
+              ...expiredInstances.map((i) => i.instanceId),
+              ...conditionExpiredInstances.map((i) => i.instanceId),
+            ]
           : undefined,
       ...(expiredInstances.length > 0 || conditionExpiredInstances.length > 0
         ? {
@@ -779,8 +795,8 @@ export class TaskRunner<
         });
       }
 
-      const prunedSnoozedInstances = isOk(runRuleResult)
-        ? runRuleResult.value.prunedSnoozedInstances
+      const expiredSnoozedInstanceIds = isOk(runRuleResult)
+        ? runRuleResult.value.expiredSnoozedInstanceIds
         : undefined;
       const autoUnsnoozeAudit = isOk(runRuleResult)
         ? runRuleResult.value.autoUnsnoozeAudit
@@ -804,8 +820,8 @@ export class TaskRunner<
           nextRun,
           lastRun: lastRunToRaw(lastRun),
           monitoring: this.ruleMonitoring.getMonitoring() as RawRuleMonitoring,
-          ...(prunedSnoozedInstances !== undefined
-            ? { snoozedInstances: prunedSnoozedInstances }
+          ...(expiredSnoozedInstanceIds !== undefined
+            ? { snoozedInstanceIdsToRemove: expiredSnoozedInstanceIds }
             : {}),
         });
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
@@ -78,7 +78,10 @@ export const getDeleteRuleTaskRunResult = (): RuleTaskRunResult => ({
 export interface RunRuleResult {
   metrics: RuleRunMetrics;
   state: RuleTaskState;
-  prunedSnoozedInstances?: RawRuleSnoozedInstance[];
+  /**
+   * Instance IDs of per-alert snooze entries that expired (TTL or condition met) during this run.
+   */
+  expiredSnoozedInstanceIds?: string[];
   /**
    * Audit context for `alert_auto_unsnooze`
    */


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana-team/issues/3176

This PR replaces the full-array replacement in `updateRuleSavedObjectPostRun` with an atomic Painless `removeIf` script and `retry_on_conflict: 3`. This prevents the race condition where a user snooze added between SO load and the post-run write was silently overwritten.

It also addresses some issues:

**1. Use `_source` instead of `fields` API in getAlertSnoozeSnapshot** - The fields API normalises values incompatibly with AlertBuilder output:
- Single-element arrays are unwrapped to scalars (`kibana.alert.rule.tags: ["1"] → "1"`)
- Sub-fields of object/flattened types also lose array wrappers (`parameters: {threshold: [1]} → {threshold: 1}`)

These mismatches caused false "field changed" detections on every run, lifting the snooze even when nothing changed.

**2. Replace `JSON.stringify` with `lodash.isEqual`** - `JSON.stringify` is sensitive to object key ordering. ES _source and the alert builder may produce the same kibana.alert.rule.parameters object with different key orders, causing false unsnooze. `isEqual` performs deep structural comparison independent of key order.

**3. Fix null vs undefined mismatch for absent fields** - The snapshot stores null for missing fields; the alert builder returns undefined for absent fields. `isEqual(undefined, null)` is false, so `severity_change` conditions falsely fired on rules that don't produce a severity field.

**4. Swallow error in `clearSnoozedStatusForAlerts`** -  A failure while clearing `kibana.alert.snoozed ` should not interrupt rule execution or the SO update.

### How to test

- Create an Elasticsearch query rule that fires continuously
- Snooze an alert instance with field_change on `kibana.alert.rule.tags` or `kibana.alert.rule.parameters` and `severity_change`, conditionOperator: any
- Verify the snooze is not lifted on subsequent runs when nothing has changed
- Change the rule tags or rule params → verify the snooze is lifted on the next run

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
