### PR TITLE
[Scout] Register data_views_as_code plugin in scout_ci_config.yml

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -82,6 +82,7 @@ plugins:
     - workflows_extensions
     - workflows_management
   disabled:
+    - data_views_as_code # Not yet registered for CI; added to unblock pipelines
 
 packages:
   enabled:


### PR DESCRIPTION
## Summary

Hotfix to unblock all Scout runner pipelines (es promotion, UIAM promotion, pointer compression, etc.) that are currently failing because the `data_views_as_code` plugin has Scout tests but is not registered in `.buildkite/scout_ci_config.yml`. The Test Run Builder hard-fails when it discovers an unregistered plugin, breaking every downstream pipeline.

## Changes

- Add `data_views_as_code` to the `disabled` section of `scout_ci_config.yml` so it is registered but not yet scheduled for CI execution