### PR TITLE
[SigEvents] Make Significant Events agents available conditionally

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/index.ts
@@ -6,15 +6,20 @@
  */
 
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
-import { sigEventsInvestigatorAgent } from './investigator';
-import { sigEventsJudgeAgent } from './judge';
+import type { StreamsServer } from '../../../types';
+import { createSigEventsInvestigatorAgent } from './investigator';
+import { createSigEventsJudgeAgent } from './judge';
 
 export { SIGEVENTS_INVESTIGATOR_AGENT_ID } from './investigator';
 export { SIGEVENTS_JUDGE_AGENT_ID } from './judge';
 
-export const registerSignificantEventsDiscoveryAgents = (
-  agentBuilder: AgentBuilderPluginSetup
-): void => {
-  agentBuilder.agents.register(sigEventsInvestigatorAgent);
-  agentBuilder.agents.register(sigEventsJudgeAgent);
+export const registerSignificantEventsDiscoveryAgents = ({
+  agentBuilder,
+  server,
+}: {
+  agentBuilder: AgentBuilderPluginSetup;
+  server: StreamsServer;
+}): void => {
+  agentBuilder.agents.register(createSigEventsInvestigatorAgent({ server }));
+  agentBuilder.agents.register(createSigEventsJudgeAgent({ server }));
 };

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/investigator.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/investigator.ts
@@ -7,29 +7,51 @@
 
 import type { BuiltInAgentDefinition } from '@kbn/agent-builder-server/agents';
 import { platformCoreTools, platformStreamsSigEventsTools } from '@kbn/agent-builder-common/tools';
+import type { StreamsServer } from '../../../types';
+import { getSignificantEventsAvailability } from '../../../routes/utils/assert_significant_events_access';
 import instructions from './instructions/investigator.md.text';
 import { OBSERVABILITY_GET_LOGS_TOOL_ID } from './constants';
 
 export const SIGEVENTS_INVESTIGATOR_AGENT_ID =
   'platform.streams.significant-events.discovery.investigator';
 
-export const sigEventsInvestigatorAgent = {
-  id: SIGEVENTS_INVESTIGATOR_AGENT_ID,
-  name: 'Significant Events Investigator',
-  description:
-    'Triages statistical detection signals across rules, correlates related detections into incident candidates using shared infrastructure, temporal proximity, and causal plausibility, and drafts structured discovery documents with root-cause hypotheses and supporting evidence.',
-  labels: ['observability', 'streams', 'significant-events', 'discovery', 'investigator'],
-  avatar_icon: 'logoElastic',
-  configuration: {
-    instructions,
-    tools: [
-      {
-        tool_ids: [
-          platformStreamsSigEventsTools.searchKnowledgeIndicators,
-          platformCoreTools.executeEsql,
-          OBSERVABILITY_GET_LOGS_TOOL_ID,
-        ],
+export function createSigEventsInvestigatorAgent({
+  server,
+}: {
+  server: StreamsServer;
+}): BuiltInAgentDefinition {
+  return {
+    id: SIGEVENTS_INVESTIGATOR_AGENT_ID,
+    name: 'Significant Events Investigator',
+    description:
+      'Triages statistical detection signals across rules, correlates related detections into incident candidates using shared infrastructure, temporal proximity, and causal plausibility, and drafts structured discovery documents with root-cause hypotheses and supporting evidence.',
+    labels: ['observability', 'streams', 'significant-events', 'discovery', 'investigator'],
+    avatar_icon: 'logoElastic',
+    availability: {
+      cacheMode: 'space',
+      handler: async (context) => {
+        const availability = await getSignificantEventsAvailability({
+          server,
+          licensing: server.licensing,
+          uiSettingsClient: context.uiSettings,
+        });
+
+        return availability.available
+          ? { status: 'available' }
+          : { status: 'unavailable', reason: availability.reason };
       },
-    ],
-  },
-} as const satisfies BuiltInAgentDefinition;
+    },
+    configuration: {
+      instructions,
+      tools: [
+        {
+          tool_ids: [
+            platformStreamsSigEventsTools.searchKnowledgeIndicators,
+            platformCoreTools.executeEsql,
+            OBSERVABILITY_GET_LOGS_TOOL_ID,
+          ],
+        },
+      ],
+    },
+  } as const;
+}

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/judge.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/agents/discovery/judge.ts
@@ -9,26 +9,47 @@ import type { BuiltInAgentDefinition } from '@kbn/agent-builder-server/agents';
 import { platformCoreTools, platformStreamsSigEventsTools } from '@kbn/agent-builder-common/tools';
 import instructions from './instructions/judge.md.text';
 import { OBSERVABILITY_GET_LOGS_TOOL_ID } from './constants';
+import type { StreamsServer } from '../../../types';
+import { getSignificantEventsAvailability } from '../../../routes/utils/assert_significant_events_access';
 
 export const SIGEVENTS_JUDGE_AGENT_ID = 'platform.streams.significant-events.discovery.judge';
 
-export const sigEventsJudgeAgent = {
-  id: SIGEVENTS_JUDGE_AGENT_ID,
-  name: 'Significant Events Discovery Judge',
-  description:
-    'Reviews proposed discoveries and decides whether to promote, acknowledge, or demote a significant event.',
-  labels: ['observability', 'streams', 'significant-events', 'discovery', 'judge'],
-  avatar_icon: 'logoElastic',
-  configuration: {
-    instructions,
-    tools: [
-      {
-        tool_ids: [
-          platformStreamsSigEventsTools.searchKnowledgeIndicators,
-          platformCoreTools.executeEsql,
-          OBSERVABILITY_GET_LOGS_TOOL_ID,
-        ],
+export const createSigEventsJudgeAgent = ({
+  server,
+}: {
+  server: StreamsServer;
+}): BuiltInAgentDefinition =>
+  ({
+    id: SIGEVENTS_JUDGE_AGENT_ID,
+    name: 'Significant Events Discovery Judge',
+    description:
+      'Reviews proposed discoveries and decides whether to promote, acknowledge, or demote a significant event.',
+    labels: ['observability', 'streams', 'significant-events', 'discovery', 'judge'],
+    avatar_icon: 'logoElastic',
+    availability: {
+      cacheMode: 'space',
+      handler: async (context) => {
+        const availability = await getSignificantEventsAvailability({
+          server,
+          licensing: server.licensing,
+          uiSettingsClient: context.uiSettings,
+        });
+
+        return availability.available
+          ? { status: 'available' }
+          : { status: 'unavailable', reason: availability.reason };
       },
-    ],
-  },
-} as const satisfies BuiltInAgentDefinition;
+    },
+    configuration: {
+      instructions,
+      tools: [
+        {
+          tool_ids: [
+            platformStreamsSigEventsTools.searchKnowledgeIndicators,
+            platformCoreTools.executeEsql,
+            OBSERVABILITY_GET_LOGS_TOOL_ID,
+          ],
+        },
+      ],
+    },
+  } as const);

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
@@ -65,5 +65,5 @@ export const registerStreamsAgentBuilder = async ({
   registerAgentBuilderSmlTypes({ agentContextLayer, getScopedClients });
   registerAgentBuilderTools({ agentBuilder, getScopedClients, server, logger, telemetry });
   registerAgentBuilderSkills({ agentBuilder, telemetry, streamsKIsOnboardingClient });
-  registerSignificantEventsDiscoveryAgents(agentBuilder);
+  registerSignificantEventsDiscoveryAgents({ agentBuilder, server });
 };


### PR DESCRIPTION
## 📓 Summary

Refactor the Significant Events agents  registration step to check for the feature availability and show up only when the user effectively have access and all the requirements are met, using the existing centralized guard about Significant Events feature availability.