### PR TITLE
[Spacetime][Obs a11y] Describe chart — AI + fallback text for screen readers (APM)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart/index.tsx
@@ -7,16 +7,17 @@
 
 import { EuiPanel, EuiTitle, EuiIconTip, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useEffect } from 'react';
+import { ChartDescriptionButton } from '@kbn/observability-agent-builder-plugin/public';
+import React, { useEffect, useMemo } from 'react';
 
 import { usePreviousPeriodLabel } from '../../../../hooks/use_previous_period_text';
 import { isTimeComparison } from '../../../shared/time_comparison/get_comparison_options';
 import { AnomalyDetectorType } from '../../../../../common/anomaly_detection/apm_ml_detectors';
-import { asExactTransactionRate } from '../../../../../common/utils/formatters';
+import { asAbsoluteDateTime, asExactTransactionRate } from '../../../../../common/utils/formatters';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useEnvironmentsContext } from '../../../../context/environments_context/use_environments_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
-import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
+import { FETCH_STATUS, isPending, useFetcher } from '../../../../hooks/use_fetcher';
 import { usePreferredServiceAnomalyTimeseries } from '../../../../hooks/use_preferred_service_anomaly_timeseries';
 import { useTimeRange } from '../../../../hooks/use_time_range';
 import { TimeseriesChartWithContext } from '../../../shared/charts/timeseries_chart_with_context';
@@ -30,11 +31,19 @@ import { OpenInDiscover } from '../../../shared/links/discover_links/open_in_dis
 import { APM_CHART_EBT_ELEMENTS } from '../../../shared/charts/ebt_constants';
 import { useLicenseContext } from '../../../../context/license/use_license_context';
 import { OpenAnomalies } from '../../../shared/links/machine_learning_links/open_anomalies';
+import { toChartDescriptionSeries } from '../../../shared/charts/helper/to_chart_description_series';
 
 const INITIAL_STATE = {
   currentPeriod: [],
   previousPeriod: [],
 };
+
+const throughputChartTitle = i18n.translate('xpack.apm.serviceOverview.throughtputChartTitle', {
+  defaultMessage: 'Throughput',
+});
+
+const formatThroughputChartTimestamp = (timestamp: number) =>
+  asAbsoluteDateTime(timestamp, 'minutes');
 
 export function ServiceOverviewThroughputChart({
   height,
@@ -123,9 +132,7 @@ export function ServiceOverviewThroughputChart({
       data: data?.currentPeriod ?? [],
       type: 'linemark',
       color: currentPeriodColor,
-      title: i18n.translate('xpack.apm.serviceOverview.throughtputChartTitle', {
-        defaultMessage: 'Throughput',
-      }),
+      title: throughputChartTitle,
     },
     ...(comparisonEnabled
       ? [
@@ -138,6 +145,8 @@ export function ServiceOverviewThroughputChart({
         ]
       : []),
   ];
+
+  const chartDescriptionSeries = useMemo(() => toChartDescriptionSeries(timeseries), [timeseries]);
 
   const setScreenContext = useApmPluginContext().observabilityAIAssistant?.service.setScreenContext;
 
@@ -169,11 +178,7 @@ export function ServiceOverviewThroughputChart({
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiTitle size="xs">
-                <h2>
-                  {i18n.translate('xpack.apm.serviceOverview.throughtputChartTitle', {
-                    defaultMessage: 'Throughput',
-                  })}
-                </h2>
+                <h2>{throughputChartTitle}</h2>
               </EuiTitle>
             </EuiFlexItem>
 
@@ -190,6 +195,19 @@ export function ServiceOverviewThroughputChart({
 
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <ChartDescriptionButton
+                chartTitle={throughputChartTitle}
+                series={chartDescriptionSeries}
+                start={start}
+                end={end}
+                timestampFormatter={formatThroughputChartTimestamp}
+                valueFormatter={asExactTransactionRate}
+                isLoading={isPending(status)}
+                hasError={status === FETCH_STATUS.FAILURE}
+                dataTestSubj="apmThroughputChartDescriptionButton"
+              />
+            </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <OpenAnomalies
                 dataTestSubj="apmServiceOverviewThroughputChartOpenAnomalies"

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/failed_transaction_rate_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/failed_transaction_rate_chart/index.tsx
@@ -7,14 +7,15 @@
 
 import { EuiPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { ChartDescriptionButton } from '@kbn/observability-agent-builder-plugin/public';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
 import { usePreviousPeriodLabel } from '../../../../hooks/use_previous_period_text';
 import { isTimeComparison } from '../../time_comparison/get_comparison_options';
 import type { APIReturnType } from '../../../../services/rest/create_call_apm_api';
-import { asPercent } from '../../../../../common/utils/formatters';
-import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
+import { asAbsoluteDateTime, asPercent } from '../../../../../common/utils/formatters';
+import { FETCH_STATUS, isPending, useFetcher } from '../../../../hooks/use_fetcher';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { TimeseriesChartWithContext } from '../timeseries_chart_with_context';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
@@ -31,10 +32,18 @@ import { OpenInDiscover } from '../../links/discover_links/open_in_discover';
 import { APM_CHART_EBT_ELEMENTS } from '../ebt_constants';
 import { useLicenseContext } from '../../../../context/license/use_license_context';
 import { OpenAnomalies } from '../../links/machine_learning_links/open_anomalies';
+import { toChartDescriptionSeries } from '../helper/to_chart_description_series';
 
 function yLabelFormat(y?: number | null) {
   return asPercent(y || 0, 1);
 }
+
+const failedTransactionRateChartTitle = i18n.translate('xpack.apm.errorRate', {
+  defaultMessage: 'Failed transaction rate',
+});
+
+const formatFailedTransactionRateChartTimestamp = (timestamp: number) =>
+  asAbsoluteDateTime(timestamp, 'minutes');
 
 interface Props {
   height?: number;
@@ -164,6 +173,8 @@ export function FailedTransactionRateChart({ height, showAnnotations = true, kue
       : []),
   ];
 
+  const chartDescriptionSeries = useMemo(() => toChartDescriptionSeries(timeseries), [timeseries]);
+
   return (
     <EuiPanel hasBorder={true}>
       <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
@@ -171,11 +182,7 @@ export function FailedTransactionRateChart({ height, showAnnotations = true, kue
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiTitle size="xs">
-                <h2>
-                  {i18n.translate('xpack.apm.errorRate', {
-                    defaultMessage: 'Failed transaction rate',
-                  })}
-                </h2>
+                <h2>{failedTransactionRateChartTitle}</h2>
               </EuiTitle>
             </EuiFlexItem>
 
@@ -187,6 +194,19 @@ export function FailedTransactionRateChart({ height, showAnnotations = true, kue
 
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <ChartDescriptionButton
+                chartTitle={failedTransactionRateChartTitle}
+                series={chartDescriptionSeries}
+                start={start}
+                end={end}
+                timestampFormatter={formatFailedTransactionRateChartTimestamp}
+                valueFormatter={yLabelFormat}
+                isLoading={isPending(status)}
+                hasError={status === FETCH_STATUS.FAILURE}
+                dataTestSubj="apmFailedTransactionRateChartDescriptionButton"
+              />
+            </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <OpenAnomalies
                 dataTestSubj="apmFailedTransactionRateChartOpenAnomalies"

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/helper/to_chart_description_series.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/helper/to_chart_description_series.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ChartDescriptionSeries } from '@kbn/observability-agent-builder-plugin/public';
+import type { Coordinate, TimeSeries } from '@kbn/apm-types';
+
+export const toChartDescriptionSeries = (
+  timeseries: Array<TimeSeries<Coordinate>>
+): ChartDescriptionSeries[] =>
+  timeseries.map((series) => ({
+    title: series.title,
+    data: series.data.map(({ x, y }) => ({ x, y: y ?? null })),
+  }));

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
@@ -7,12 +7,13 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useEffect } from 'react';
+import { ChartDescriptionButton } from '@kbn/observability-agent-builder-plugin/public';
+import React, { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { isTimeComparison } from '../../time_comparison/get_comparison_options';
 import { getLatencyAggregationType } from '../../../../../common/latency_aggregation_types';
-import { getDurationFormatter } from '../../../../../common/utils/formatters';
+import { asAbsoluteDateTime, getDurationFormatter } from '../../../../../common/utils/formatters';
 import { useTransactionLatencyChartsFetcher } from '../../../../hooks/use_transaction_latency_chart_fetcher';
 import { TimeseriesChartWithContext } from '../timeseries_chart_with_context';
 import { getMaxY, getResponseTimeTickFormatter } from '../transaction_charts/helper';
@@ -30,6 +31,14 @@ import { LatencyAggregationTypeSelect } from './latency_aggregation_type_select'
 import { OpenInDiscover } from '../../links/discover_links/open_in_discover';
 import { APM_CHART_EBT_ELEMENTS } from '../ebt_constants';
 import { useLicenseContext } from '../../../../context/license/use_license_context';
+import { FETCH_STATUS, isPending } from '../../../../hooks/use_fetcher';
+import { toChartDescriptionSeries } from '../helper/to_chart_description_series';
+
+const latencyChartTitle = i18n.translate('xpack.apm.serviceOverview.latencyChartTitle', {
+  defaultMessage: 'Latency',
+});
+
+const formatLatencyChartTimestamp = (timestamp: number) => asAbsoluteDateTime(timestamp, 'minutes');
 
 interface Props {
   height?: number;
@@ -86,6 +95,8 @@ export function LatencyChart({ height, kuery }: Props) {
     comparisonEnabled && isTimeComparison(offset) ? previousPeriod : undefined,
   ].filter(filterNil);
 
+  const chartDescriptionSeries = useMemo(() => toChartDescriptionSeries(timeseries), [timeseries]);
+
   const latencyMaxY = getMaxY(timeseries);
   const latencyFormatter = getDurationFormatter(latencyMaxY);
 
@@ -120,11 +131,7 @@ export function LatencyChart({ height, kuery }: Props) {
             <EuiFlexGroup alignItems="center" wrap>
               <EuiFlexItem grow={false}>
                 <EuiTitle size="xs">
-                  <h2>
-                    {i18n.translate('xpack.apm.serviceOverview.latencyChartTitle', {
-                      defaultMessage: 'Latency',
-                    })}
-                  </h2>
+                  <h2>{latencyChartTitle}</h2>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
@@ -143,6 +150,19 @@ export function LatencyChart({ height, kuery }: Props) {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <ChartDescriptionButton
+                  chartTitle={latencyChartTitle}
+                  series={chartDescriptionSeries}
+                  start={start}
+                  end={end}
+                  timestampFormatter={formatLatencyChartTimestamp}
+                  valueFormatter={getResponseTimeTickFormatter(latencyFormatter)}
+                  isLoading={isPending(latencyChartsStatus)}
+                  hasError={latencyChartsStatus === FETCH_STATUS.FAILURE}
+                  dataTestSubj="apmLatencyChartDescriptionButton"
+                />
+              </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <OpenAnomalies
                   dataTestSubj="apmLatencyChartOpenAnomalies"

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/index.tsx
@@ -7,10 +7,25 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import { ChartDescriptionButton } from '@kbn/observability-agent-builder-plugin/public';
+import React, { useMemo } from 'react';
+import { asAbsoluteDateTime, asPercent } from '../../../../../common/utils/formatters';
+import { FETCH_STATUS, isPending } from '../../../../hooks/use_fetcher';
 import { useAnnotationsContext } from '../../../../context/annotations/use_annotations_context';
+import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 import { useTransactionBreakdown } from './use_transaction_breakdown';
 import { BreakdownChart } from '../breakdown_chart';
+import { toChartDescriptionSeries } from '../helper/to_chart_description_series';
+
+const transactionBreakdownChartTitle = i18n.translate('xpack.apm.transactionBreakdown.chartTitle', {
+  defaultMessage: 'Time spent by span type',
+});
+
+const formatTransactionBreakdownChartTimestamp = (timestamp: number) =>
+  asAbsoluteDateTime(timestamp, 'minutes');
+
+const formatTransactionBreakdownValue = (value: number) => asPercent(value, 1);
 
 export function TransactionBreakdownChart({
   height,
@@ -27,27 +42,51 @@ export function TransactionBreakdownChart({
   const { annotations } = useAnnotationsContext();
   const { timeseries } = data;
 
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useAnyOfApmParams('/services/{serviceName}', '/mobile-services/{serviceName}');
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
+  const chartDescriptionSeries = useMemo(
+    () => toChartDescriptionSeries(timeseries ?? []),
+    [timeseries]
+  );
+
   return (
     <EuiPanel hasBorder={true}>
       <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiTitle size="xs">
-              <h3>
-                {i18n.translate('xpack.apm.transactionBreakdown.chartTitle', {
-                  defaultMessage: 'Time spent by span type',
-                })}
-              </h3>
-            </EuiTitle>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiTitle size="xs">
+                  <h3>{transactionBreakdownChartTitle}</h3>
+                </EuiTitle>
+              </EuiFlexItem>
+
+              <EuiFlexItem grow={false}>
+                <EuiIconTip
+                  content={i18n.translate('xpack.apm.transactionBreakdown.chartHelp', {
+                    defaultMessage:
+                      'The average duration of each span type. "app" indicates something was happening within the service. This could mean that the time was spent in application code and not in database or external requests, or that APM agent auto-instrumentation doesn\'t cover the executed code.',
+                  })}
+                  position="right"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
-            <EuiIconTip
-              content={i18n.translate('xpack.apm.transactionBreakdown.chartHelp', {
-                defaultMessage:
-                  'The average duration of each span type. "app" indicates something was happening within the service. This could mean that the time was spent in application code and not in database or external requests, or that APM agent auto-instrumentation doesn\'t cover the executed code.',
-              })}
-              position="right"
+            <ChartDescriptionButton
+              chartTitle={transactionBreakdownChartTitle}
+              series={chartDescriptionSeries}
+              start={start}
+              end={end}
+              timestampFormatter={formatTransactionBreakdownChartTimestamp}
+              valueFormatter={formatTransactionBreakdownValue}
+              isLoading={isPending(status)}
+              hasError={status === FETCH_STATUS.FAILURE}
+              dataTestSubj="apmTransactionBreakdownChartDescriptionButton"
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/common/chart_description/build_deterministic_chart_summary.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/common/chart_description/build_deterministic_chart_summary.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildDeterministicChartSummary } from './build_deterministic_chart_summary';
+
+describe('buildDeterministicChartSummary', () => {
+  const mayFirst2024Noon = Date.parse('2024-05-01T12:00:00.000Z');
+  const mayFirst2024One = Date.parse('2024-05-01T13:00:00.000Z');
+  const formatTimestamp = (timestamp: number) => `t:${timestamp}`;
+
+  it('summarizes a single series with peak and low values', () => {
+    const summary = buildDeterministicChartSummary({
+      chartTitle: 'Throughput',
+      locale: 'en-US',
+      timestampFormatter: formatTimestamp,
+      series: [
+        {
+          title: 'Current period',
+          data: [
+            { x: mayFirst2024Noon, y: 100 },
+            { x: mayFirst2024One, y: 300 },
+          ],
+        },
+      ],
+      valueFormatter: (value) => `${value} tpm`,
+    });
+
+    expect(summary).toContain('Summary for Throughput.');
+    expect(summary).toContain('Current period');
+    expect(summary).toContain('100 tpm');
+    expect(summary).toContain('300 tpm');
+    expect(summary).toContain('average of 200 tpm');
+    expect(summary).toContain(`t:${mayFirst2024Noon}`);
+    expect(summary).toContain(`t:${mayFirst2024One}`);
+  });
+
+  it('includes comparison text when a second series is present', () => {
+    const summary = buildDeterministicChartSummary({
+      chartTitle: 'Latency',
+      locale: 'en-US',
+      timestampFormatter: formatTimestamp,
+      series: [
+        {
+          title: 'Current period',
+          data: [
+            { x: mayFirst2024Noon, y: 200 },
+            { x: mayFirst2024One, y: 200 },
+          ],
+        },
+        {
+          title: 'Previous period',
+          data: [
+            { x: mayFirst2024Noon, y: 100 },
+            { x: mayFirst2024One, y: 100 },
+          ],
+        },
+      ],
+      valueFormatter: (value) => `${value} ms`,
+    });
+
+    expect(summary).toContain('Previous period');
+    expect(summary).toContain('average increased by 100%');
+  });
+
+  it('returns a no-data message when all series are empty', () => {
+    const summary = buildDeterministicChartSummary({
+      chartTitle: 'Failed transaction rate',
+      series: [
+        {
+          title: 'Current period',
+          data: [],
+        },
+      ],
+    });
+
+    expect(summary).toContain('no data in the selected time range');
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/common/chart_description/build_deterministic_chart_summary.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/common/chart_description/build_deterministic_chart_summary.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type {
+  BuildDeterministicChartSummaryParams,
+  ChartDescriptionPoint,
+  ChartDescriptionSeries,
+} from './types';
+
+interface NumericPoint {
+  x: number;
+  y: number;
+}
+
+const getNumericPoints = (data: ChartDescriptionPoint[]): NumericPoint[] =>
+  data.flatMap((point) =>
+    point.y != null && Number.isFinite(point.y) ? [{ x: point.x, y: point.y }] : []
+  );
+
+const average = (points: NumericPoint[]): number =>
+  points.reduce((sum, point) => sum + point.y, 0) / points.length;
+
+const getPeakPoint = (points: NumericPoint[]): NumericPoint =>
+  points.reduce((peak, point) => (point.y > peak.y ? point : peak), points[0]);
+
+const getLowPoint = (points: NumericPoint[]): NumericPoint =>
+  points.reduce((low, point) => (point.y < low.y ? point : low), points[0]);
+
+const defaultTimestampFormatter = (timestamp: number): string => new Date(timestamp).toISOString();
+
+const formatValue = ({
+  value,
+  valueFormatter,
+  locale,
+}: {
+  value: number;
+  valueFormatter?: (value: number) => string;
+  locale: string;
+}): string => valueFormatter?.(value) ?? new Intl.NumberFormat(locale).format(value);
+
+const summarizeSeries = ({
+  series,
+  timestampFormatter,
+  locale,
+  valueFormatter,
+}: {
+  series: ChartDescriptionSeries;
+  timestampFormatter: (timestamp: number) => string;
+  locale: string;
+  valueFormatter?: (value: number) => string;
+}): string => {
+  const points = getNumericPoints(series.data);
+
+  if (points.length === 0) {
+    return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.seriesNoData', {
+      defaultMessage: '{seriesTitle} has no data in the selected time range.',
+      values: { seriesTitle: series.title },
+    });
+  }
+
+  const peak = getPeakPoint(points);
+  const low = getLowPoint(points);
+  const avg = average(points);
+
+  return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.seriesSummary', {
+    defaultMessage:
+      '{seriesTitle} ranges from {lowValue} at {lowTime} to {peakValue} at {peakTime}, with an average of {averageValue}.',
+    values: {
+      seriesTitle: series.title,
+      lowValue: formatValue({ value: low.y, valueFormatter, locale }),
+      lowTime: timestampFormatter(low.x),
+      peakValue: formatValue({ value: peak.y, valueFormatter, locale }),
+      peakTime: timestampFormatter(peak.x),
+      averageValue: formatValue({ value: avg, valueFormatter, locale }),
+    },
+  });
+};
+
+const summarizeComparison = ({
+  currentSeries,
+  comparisonSeries,
+  locale,
+  valueFormatter,
+}: {
+  currentSeries: ChartDescriptionSeries;
+  comparisonSeries: ChartDescriptionSeries;
+  locale: string;
+  valueFormatter?: (value: number) => string;
+}): string | undefined => {
+  const currentPoints = getNumericPoints(currentSeries.data);
+  const comparisonPoints = getNumericPoints(comparisonSeries.data);
+
+  if (currentPoints.length === 0 || comparisonPoints.length === 0) {
+    return undefined;
+  }
+
+  const currentAverage = average(currentPoints);
+  const comparisonAverage = average(comparisonPoints);
+
+  if (comparisonAverage === 0) {
+    return undefined;
+  }
+
+  const percentChange = ((currentAverage - comparisonAverage) / comparisonAverage) * 100;
+  const roundedPercentChange = Math.round(percentChange);
+
+  if (roundedPercentChange === 0) {
+    return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.comparisonUnchanged', {
+      defaultMessage: 'Compared to {comparisonTitle}, the average is about the same.',
+      values: { comparisonTitle: comparisonSeries.title },
+    });
+  }
+
+  if (roundedPercentChange > 0) {
+    return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.comparisonIncrease', {
+      defaultMessage: 'Compared to {comparisonTitle}, the average increased by {percentChange}%.',
+      values: {
+        comparisonTitle: comparisonSeries.title,
+        percentChange: Math.abs(roundedPercentChange),
+      },
+    });
+  }
+
+  return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.comparisonDecrease', {
+    defaultMessage: 'Compared to {comparisonTitle}, the average decreased by {percentChange}%.',
+    values: {
+      comparisonTitle: comparisonSeries.title,
+      percentChange: Math.abs(roundedPercentChange),
+    },
+  });
+};
+
+export const buildDeterministicChartSummary = ({
+  chartTitle,
+  series,
+  timestampFormatter = defaultTimestampFormatter,
+  locale = 'en-US',
+  valueFormatter,
+}: BuildDeterministicChartSummaryParams): string => {
+  if (series.length === 0) {
+    return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.noSeries', {
+      defaultMessage: '{chartTitle} has no data in the selected time range.',
+      values: { chartTitle },
+    });
+  }
+
+  const parts = [
+    i18n.translate('xpack.observabilityAgentBuilder.chartDescription.intro', {
+      defaultMessage: 'Summary for {chartTitle}.',
+      values: { chartTitle },
+    }),
+    summarizeSeries({
+      series: series[0],
+      timestampFormatter,
+      locale,
+      valueFormatter,
+    }),
+  ];
+
+  if (series.length > 1) {
+    parts.push(
+      summarizeSeries({
+        series: series[1],
+        timestampFormatter,
+        locale,
+        valueFormatter,
+      })
+    );
+
+    const comparisonSummary = summarizeComparison({
+      currentSeries: series[0],
+      comparisonSeries: series[1],
+      locale,
+      valueFormatter,
+    });
+
+    if (comparisonSummary) {
+      parts.push(comparisonSummary);
+    }
+  }
+
+  return parts.join(' ');
+};

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/common/chart_description/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/common/chart_description/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface ChartDescriptionPoint {
+  x: number;
+  y: number | null | undefined;
+}
+
+export interface ChartDescriptionSeries {
+  title: string;
+  data: ChartDescriptionPoint[];
+}
+
+export interface BuildDeterministicChartSummaryParams {
+  chartTitle: string;
+  series: ChartDescriptionSeries[];
+  timestampFormatter?: (timestamp: number) => string;
+  locale?: string;
+  valueFormatter?: (value: number) => string;
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/common/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/common/index.ts
@@ -20,3 +20,10 @@ export {
 } from './constants';
 
 export type { ConnectorInfo } from './types';
+
+export { buildDeterministicChartSummary } from './chart_description/build_deterministic_chart_summary';
+export type {
+  BuildDeterministicChartSummaryParams,
+  ChartDescriptionPoint,
+  ChartDescriptionSeries,
+} from './chart_description/types';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/analytics/schemas/ai_insight_events.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/analytics/schemas/ai_insight_events.ts
@@ -10,7 +10,7 @@ import type { ConnectorInfo } from '../../../common';
 import type { Feedback } from '../../components/ai_insight/feedback_buttons';
 import { ObservabilityAgentBuilderTelemetryEventType } from '../telemetry_event_type';
 
-export type InsightType = 'log' | 'alert' | 'error';
+export type InsightType = 'log' | 'alert' | 'error' | 'chart';
 
 export type { ConnectorInfo };
 
@@ -34,7 +34,7 @@ export interface InsightFailedEvent {
 const insightTypeSchema = {
   type: 'keyword' as const,
   _meta: {
-    description: 'Type of AI insight: log, alert, or error',
+    description: 'Type of AI insight: log, alert, error, or chart',
   },
 };
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.test.tsx
@@ -105,6 +105,10 @@ describe('ChartDescriptionButton', () => {
     await user.click(screen.getByTestId('observabilityChartDescriptionButton'));
 
     expect(screen.getByTestId('observabilityChartDescriptionButtonPanel')).toBeInTheDocument();
+    expect(screen.getByTestId('observabilityChartDescriptionButtonPanel')).toHaveAttribute(
+      'aria-describedby',
+      expect.any(String)
+    );
     expect(screen.getByText(/Summary for Throughput/i)).toBeInTheDocument();
     expect(screen.getByText(/Basic summary generated from chart data/i)).toBeInTheDocument();
   });
@@ -117,5 +121,53 @@ describe('ChartDescriptionButton', () => {
     await user.click(screen.getByTestId('observabilityChartDescriptionButton'));
 
     expect(screen.getByText('Loading chart summary.')).toBeInTheDocument();
+  });
+
+  it('does not announce streaming AI chunks in the visible summary live region', async () => {
+    const user = userEvent.setup();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        agentBuilder: {},
+        application: {
+          capabilities: {
+            agentBuilder: {
+              show: true,
+            },
+          },
+        },
+      },
+    });
+    mockUseLicense.mockReturnValue({
+      getLicense: () => ({
+        hasAtLeast: () => true,
+      }),
+    });
+    mockUseGenAIConnectors.mockReturnValue({
+      hasConnectors: true,
+      connectors: [],
+      loading: false,
+    });
+    mockUseStreamingAiInsight.mockReturnValue({
+      ...baseStreamingState(),
+      isLoading: true,
+      summary: 'Partial AI summary chunk',
+    });
+
+    renderComponent();
+
+    await user.click(screen.getByTestId('observabilityChartDescriptionButton'));
+
+    expect(screen.getByText('Partial AI summary chunk')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('observabilityChartDescriptionButtonScreenReaderStatus')
+    ).toHaveTextContent('Generating AI summary.');
+    expect(screen.getByText('Partial AI summary chunk').closest('p')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+    expect(screen.getByTestId('observabilityChartDescriptionButtonPanel')).not.toHaveAttribute(
+      'aria-live'
+    );
   });
 });

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EuiThemeProvider } from '@elastic/eui';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import { ChartDescriptionButton } from './chart_description_button';
+import { useApiClient } from '../../hooks/use_api_client';
+import { useKibana } from '../../hooks/use_kibana';
+import { useLicense } from '../../hooks/use_license';
+import { useGenAIConnectors } from '../../hooks/use_genai_connectors';
+import { useStreamingAiInsight } from '../../hooks/use_streaming_ai_insight';
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useUiSetting$: jest.fn(),
+}));
+
+jest.mock('../../hooks/use_api_client');
+jest.mock('../../hooks/use_kibana');
+jest.mock('../../hooks/use_license');
+jest.mock('../../hooks/use_genai_connectors');
+jest.mock('../../hooks/use_streaming_ai_insight');
+
+const mockUseUiSetting$ = useUiSetting$ as jest.Mock;
+const mockUseApiClient = useApiClient as jest.Mock;
+const mockUseKibana = useKibana as jest.Mock;
+const mockUseLicense = useLicense as jest.Mock;
+const mockUseGenAIConnectors = useGenAIConnectors as jest.Mock;
+const mockUseStreamingAiInsight = useStreamingAiInsight as jest.Mock;
+
+const baseStreamingState = () => ({
+  isLoading: false,
+  error: undefined as string | undefined,
+  summary: '',
+  fetch: jest.fn(),
+  stop: jest.fn(),
+  regenerate: jest.fn(),
+});
+
+const renderComponent = (
+  props: Partial<React.ComponentProps<typeof ChartDescriptionButton>> = {}
+) =>
+  render(
+    <EuiThemeProvider>
+      <ChartDescriptionButton
+        chartTitle="Throughput"
+        series={[
+          {
+            title: 'Current period',
+            data: [
+              { x: Date.parse('2024-05-01T12:00:00.000Z'), y: 100 },
+              { x: Date.parse('2024-05-01T13:00:00.000Z'), y: 200 },
+            ],
+          },
+        ]}
+        timestampFormatter={(timestamp) => `t:${timestamp}`}
+        valueFormatter={(value) => `${value} tpm`}
+        {...props}
+      />
+    </EuiThemeProvider>
+  );
+
+describe('ChartDescriptionButton', () => {
+  beforeEach(() => {
+    mockUseApiClient.mockReturnValue({
+      stream: jest.fn(),
+    });
+    mockUseKibana.mockReturnValue({
+      services: {
+        agentBuilder: undefined,
+        application: {
+          capabilities: {
+            agentBuilder: {
+              show: false,
+            },
+          },
+        },
+      },
+    });
+    mockUseLicense.mockReturnValue({
+      getLicense: () => ({
+        hasAtLeast: () => false,
+      }),
+    });
+    mockUseGenAIConnectors.mockReturnValue({
+      hasConnectors: false,
+      connectors: [],
+      loading: false,
+    });
+    mockUseStreamingAiInsight.mockReturnValue(baseStreamingState());
+    mockUseUiSetting$.mockReturnValue(['agent']);
+  });
+
+  it('opens a popover with a deterministic chart summary', async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.click(screen.getByTestId('observabilityChartDescriptionButton'));
+
+    expect(screen.getByTestId('observabilityChartDescriptionButtonPanel')).toBeInTheDocument();
+    expect(screen.getByText(/Summary for Throughput/i)).toBeInTheDocument();
+    expect(screen.getByText(/Basic summary generated from chart data/i)).toBeInTheDocument();
+  });
+
+  it('shows a loading message while chart data is loading', async () => {
+    const user = userEvent.setup();
+
+    renderComponent({ isLoading: true, series: [] });
+
+    await user.click(screen.getByTestId('observabilityChartDescriptionButton'));
+
+    expect(screen.getByText('Loading chart summary.')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.tsx
@@ -12,6 +12,7 @@ import {
   EuiHorizontalRule,
   EuiPopover,
   EuiPopoverTitle,
+  EuiScreenReaderOnly,
   EuiSpacer,
   EuiText,
   EuiToolTip,
@@ -152,18 +153,49 @@ export function ChartDescriptionButton({
 
   const isUsingAiSummary = hasAiInsightAccess && Boolean(aiSummary) && !aiError;
   const isAwaitingAiSummary = hasAiInsightAccess && !chartDataMessage && !aiError && !aiSummary;
+  const isStreamingAiSummary = hasAiInsightAccess && isAiLoading && !chartDataMessage;
   const isUsingDeterministicFallback =
     !chartDataMessage &&
     (!hasAiInsightAccess || Boolean(aiError) || (!isAwaitingAiSummary && !aiSummary));
+
+  const generatingAiSummaryMessage = i18n.translate(
+    'xpack.observabilityAgentBuilder.chartDescription.generatingAiSummary',
+    {
+      defaultMessage: 'Generating AI summary.',
+    }
+  );
+
+  const showScreenReaderLiveRegion =
+    hasAiInsightAccess &&
+    !chartDataMessage &&
+    (isStreamingAiSummary || isAwaitingAiSummary || isUsingAiSummary);
+
+  const screenReaderStatus = useMemo(() => {
+    if (!showScreenReaderLiveRegion) {
+      return undefined;
+    }
+
+    if (isStreamingAiSummary || isAwaitingAiSummary) {
+      return generatingAiSummaryMessage;
+    }
+
+    return aiSummary;
+  }, [
+    aiSummary,
+    generatingAiSummaryMessage,
+    isAwaitingAiSummary,
+    isStreamingAiSummary,
+    showScreenReaderLiveRegion,
+  ]);
+
+  const hideStreamingSummaryFromScreenReader = isStreamingAiSummary && Boolean(aiSummary);
 
   const summary = chartDataMessage
     ? chartDataMessage
     : isUsingAiSummary
     ? aiSummary
     : isAwaitingAiSummary
-    ? i18n.translate('xpack.observabilityAgentBuilder.chartDescription.generatingAiSummary', {
-        defaultMessage: 'Generating AI summary.',
-      })
+    ? generatingAiSummaryMessage
     : deterministicSummary;
 
   const summaryNote = chartDataMessage
@@ -188,19 +220,25 @@ export function ChartDescriptionButton({
   const popover = (
     <div
       role="region"
-      aria-live="polite"
       aria-labelledby={popoverTitleId}
       aria-describedby={summaryId}
       data-test-subj={`${dataTestSubj}Panel`}
     >
+      {screenReaderStatus ? (
+        <EuiScreenReaderOnly>
+          <p aria-live="polite" data-test-subj={`${dataTestSubj}ScreenReaderStatus`}>
+            {screenReaderStatus}
+          </p>
+        </EuiScreenReaderOnly>
+      ) : null}
       <EuiPopoverTitle id={popoverTitleId}>
         {i18n.translate('xpack.observabilityAgentBuilder.chartDescription.popoverTitle', {
           defaultMessage: 'Chart summary',
         })}
       </EuiPopoverTitle>
       <EuiText size="s" id={summaryId}>
-        <p>{summary}</p>
-        {isAiLoading && isAwaitingAiSummary && <LoadingCursor />}
+        <p aria-hidden={hideStreamingSummaryFromScreenReader}>{summary}</p>
+        {isAiLoading && hasAiInsightAccess && !chartDataMessage && <LoadingCursor />}
       </EuiText>
       {summaryNote ? (
         <EuiText size="xs" color="subdued">

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/chart_description/chart_description_button.tsx
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiHorizontalRule,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import { AIChatExperience } from '@kbn/ai-assistant-common';
+import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
+import { buildDeterministicChartSummary } from '../../../common/chart_description/build_deterministic_chart_summary';
+import type { ChartDescriptionSeries } from '../../../common/chart_description/types';
+import { useApiClient } from '../../hooks/use_api_client';
+import { useGenAIConnectors } from '../../hooks/use_genai_connectors';
+import { useKibana } from '../../hooks/use_kibana';
+import { useLicense } from '../../hooks/use_license';
+import { useStreamingAiInsight } from '../../hooks/use_streaming_ai_insight';
+import { LoadingCursor } from '../ai_insight/loading_cursor';
+
+export interface ChartDescriptionButtonProps {
+  chartTitle: string;
+  series: ChartDescriptionSeries[];
+  start?: string;
+  end?: string;
+  timestampFormatter?: (timestamp: number) => string;
+  valueFormatter?: (value: number) => string;
+  isLoading?: boolean;
+  hasError?: boolean;
+  dataTestSubj?: string;
+}
+
+export function ChartDescriptionButton({
+  chartTitle,
+  series,
+  start,
+  end,
+  timestampFormatter,
+  valueFormatter,
+  isLoading = false,
+  hasError = false,
+  dataTestSubj = 'observabilityChartDescriptionButton',
+}: ChartDescriptionButtonProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId({ prefix: 'chartDescriptionTitle' });
+  const summaryId = useId();
+
+  const {
+    services: { agentBuilder, application },
+  } = useKibana();
+  const apiClient = useApiClient();
+  const { getLicense } = useLicense();
+  const license = getLicense();
+  const [chatExperience] = useUiSetting$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE);
+  const { hasConnectors } = useGenAIConnectors();
+
+  const hasEnterpriseLicense = license?.hasAtLeast('enterprise');
+  const hasAgentBuilderAccess = application?.capabilities.agentBuilder?.show === true;
+  const isAgentChatExperienceEnabled = chatExperience === AIChatExperience.Agent;
+  const hasAiInsightAccess = Boolean(
+    hasConnectors &&
+      agentBuilder &&
+      isAgentChatExperienceEnabled &&
+      hasAgentBuilderAccess &&
+      hasEnterpriseLicense
+  );
+
+  const createStream = useCallback(
+    (signal: AbortSignal) =>
+      apiClient.stream('POST /internal/observability_agent_builder/ai_insights/chart', {
+        signal,
+        params: {
+          body: {
+            chartTitle,
+            series,
+            start,
+            end,
+          },
+        },
+      }),
+    [apiClient, chartTitle, end, series, start]
+  );
+
+  const {
+    isLoading: isAiLoading,
+    error: aiError,
+    summary: aiSummary,
+    fetch: fetchAiSummary,
+    stop: stopAiSummary,
+    regenerate: regenerateAiSummary,
+  } = useStreamingAiInsight(createStream);
+
+  const deterministicSummary = useMemo(() => {
+    return buildDeterministicChartSummary({
+      chartTitle,
+      series,
+      timestampFormatter,
+      locale: i18n.getLocale(),
+      valueFormatter,
+    });
+  }, [chartTitle, series, timestampFormatter, valueFormatter]);
+
+  const closePopover = useCallback(() => {
+    setIsPopoverOpen(false);
+    stopAiSummary();
+  }, [stopAiSummary]);
+
+  useEffect(() => {
+    if (!isPopoverOpen || hasError || isLoading || !hasAiInsightAccess) {
+      return;
+    }
+
+    fetchAiSummary();
+  }, [fetchAiSummary, hasAiInsightAccess, hasError, isLoading, isPopoverOpen]);
+
+  const buttonLabel = i18n.translate(
+    'xpack.observabilityAgentBuilder.chartDescription.buttonLabel',
+    {
+      defaultMessage: 'Describe chart: {chartTitle}',
+      values: { chartTitle },
+    }
+  );
+
+  const chartDataMessage = useMemo(() => {
+    if (hasError) {
+      return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.loadError', {
+        defaultMessage:
+          'The chart data could not be loaded. Try refreshing the page or changing the time range.',
+      });
+    }
+
+    if (isLoading) {
+      return i18n.translate('xpack.observabilityAgentBuilder.chartDescription.loading', {
+        defaultMessage: 'Loading chart summary.',
+      });
+    }
+
+    return undefined;
+  }, [hasError, isLoading]);
+
+  const isUsingAiSummary = hasAiInsightAccess && Boolean(aiSummary) && !aiError;
+  const isAwaitingAiSummary = hasAiInsightAccess && !chartDataMessage && !aiError && !aiSummary;
+  const isUsingDeterministicFallback =
+    !chartDataMessage &&
+    (!hasAiInsightAccess || Boolean(aiError) || (!isAwaitingAiSummary && !aiSummary));
+
+  const summary = chartDataMessage
+    ? chartDataMessage
+    : isUsingAiSummary
+    ? aiSummary
+    : isAwaitingAiSummary
+    ? i18n.translate('xpack.observabilityAgentBuilder.chartDescription.generatingAiSummary', {
+        defaultMessage: 'Generating AI summary.',
+      })
+    : deterministicSummary;
+
+  const summaryNote = chartDataMessage
+    ? undefined
+    : isUsingAiSummary
+    ? i18n.translate('xpack.observabilityAgentBuilder.chartDescription.aiSummaryNote', {
+        defaultMessage: 'AI-generated summary from chart data.',
+      })
+    : isUsingDeterministicFallback
+    ? hasAiInsightAccess && aiError
+      ? i18n.translate(
+          'xpack.observabilityAgentBuilder.chartDescription.basicSummaryFallbackNote',
+          {
+            defaultMessage: 'Showing basic summary because the AI summary could not be generated.',
+          }
+        )
+      : i18n.translate('xpack.observabilityAgentBuilder.chartDescription.basicSummaryNote', {
+          defaultMessage: 'Basic summary generated from chart data.',
+        })
+    : undefined;
+
+  const popover = (
+    <div
+      role="region"
+      aria-live="polite"
+      aria-labelledby={popoverTitleId}
+      aria-describedby={summaryId}
+      data-test-subj={`${dataTestSubj}Panel`}
+    >
+      <EuiPopoverTitle id={popoverTitleId}>
+        {i18n.translate('xpack.observabilityAgentBuilder.chartDescription.popoverTitle', {
+          defaultMessage: 'Chart summary',
+        })}
+      </EuiPopoverTitle>
+      <EuiText size="s" id={summaryId}>
+        <p>{summary}</p>
+        {isAiLoading && isAwaitingAiSummary && <LoadingCursor />}
+      </EuiText>
+      {summaryNote ? (
+        <EuiText size="xs" color="subdued">
+          {summaryNote}
+        </EuiText>
+      ) : null}
+      {hasAiInsightAccess && !chartDataMessage && (isAiLoading || aiSummary || aiError) ? (
+        <>
+          <EuiSpacer size="s" />
+          <EuiHorizontalRule margin="none" />
+          <EuiSpacer size="xs" />
+          {isAiLoading ? (
+            <EuiButtonEmpty
+              data-test-subj={`${dataTestSubj}StopGeneratingButton`}
+              color="text"
+              iconType="stop"
+              size="s"
+              onClick={stopAiSummary}
+            >
+              {i18n.translate('xpack.observabilityAgentBuilder.chartDescription.stopGenerating', {
+                defaultMessage: 'Stop generating',
+              })}
+            </EuiButtonEmpty>
+          ) : (
+            <EuiButtonEmpty
+              data-test-subj={`${dataTestSubj}RegenerateButton`}
+              color="text"
+              iconType="sparkles"
+              size="s"
+              onClick={regenerateAiSummary}
+            >
+              {i18n.translate('xpack.observabilityAgentBuilder.chartDescription.regenerate', {
+                defaultMessage: 'Regenerate AI summary',
+              })}
+            </EuiButtonEmpty>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <EuiPopover
+      aria-labelledby={popoverTitleId}
+      button={
+        <EuiToolTip content={buttonLabel} disableScreenReaderOutput>
+          <EuiButtonIcon
+            data-test-subj={dataTestSubj}
+            iconType="inspect"
+            aria-label={buttonLabel}
+            aria-expanded={isPopoverOpen}
+            onClick={() => setIsPopoverOpen((open) => !open)}
+          />
+        </EuiToolTip>
+      }
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="m"
+      anchorPosition="downLeft"
+    >
+      {popover}
+    </EuiPopover>
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/index.ts
@@ -28,6 +28,14 @@ export type {
 } from './types';
 
 export type { AlertAiInsightProps, ErrorSampleAiInsightProps } from './components/insights';
+export type { ChartDescriptionButtonProps } from './components/chart_description/chart_description_button';
+export { ChartDescriptionButton } from './components/chart_description/chart_description_button';
+export {
+  buildDeterministicChartSummary,
+  type BuildDeterministicChartSummaryParams,
+  type ChartDescriptionPoint,
+  type ChartDescriptionSeries,
+} from '../common';
 
 export const plugin = (initializerContext: PluginInitializerContext) =>
   new ObservabilityAgentBuilderPlugin(initializerContext);

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/chart/generate_chart_ai_insight.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/chart/generate_chart_ai_insight.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { of } from 'rxjs';
+import { MessageRole, InferenceConnectorType } from '@kbn/inference-common';
+import type { BoundInferenceClient, InferenceConnector } from '@kbn/inference-common';
+import { generateChartAiInsight } from './generate_chart_ai_insight';
+
+describe('generateChartAiInsight', () => {
+  const connector: InferenceConnector = {
+    connectorId: 'test-connector',
+    name: 'Test connector',
+    type: InferenceConnectorType.Inference,
+    config: {},
+    capabilities: {},
+    isInferenceEndpoint: true,
+    isPreconfigured: false,
+    isEis: false,
+    isDeprecated: false,
+    isConnectorTypeDeprecated: false,
+    isMissingSecrets: false,
+  };
+
+  it('streams chart context and chat completion events', async () => {
+    const chatComplete = jest.fn().mockReturnValue(
+      of({
+        type: 'chatCompletionMessage',
+        content: 'Throughput peaked at noon.',
+      })
+    );
+
+    const inferenceClient = {
+      chatComplete,
+    } as unknown as BoundInferenceClient;
+
+    const result = generateChartAiInsight({
+      chartTitle: 'Latency',
+      start: '2024-05-01T00:00:00.000Z',
+      end: '2024-05-01T23:59:59.999Z',
+      series: [
+        {
+          title: 'Average',
+          data: [
+            { x: 1_714_531_200_000, y: 100 },
+            { x: 1_714_534_800_000, y: 250 },
+          ],
+        },
+      ],
+      inferenceClient,
+      connector,
+    });
+
+    expect(chatComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            role: MessageRole.User,
+            content: expect.stringContaining('Latency'),
+          }),
+        ],
+        stream: true,
+      })
+    );
+
+    const events: Array<{ type: string; content?: string; context?: string }> = [];
+    await new Promise<void>((resolve, reject) => {
+      result.events$.subscribe({
+        next: (event) => events.push(event),
+        error: reject,
+        complete: resolve,
+      });
+    });
+
+    expect(events[0]).toEqual(expect.objectContaining({ type: 'context' }));
+    expect(events[1]).toEqual(expect.objectContaining({ type: 'connectorInfo' }));
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        type: 'chatCompletionMessage',
+        content: 'Throughput peaked at noon.',
+      })
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/chart/generate_chart_ai_insight.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/chart/generate_chart_ai_insight.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BoundInferenceClient, InferenceConnector } from '@kbn/inference-common';
+import { MessageRole } from '@kbn/inference-common';
+import dedent from 'dedent';
+import type { ChartDescriptionSeries } from '../../../../common/chart_description/types';
+import { createAiInsightResult, type AiInsightResult } from '../types';
+
+function getChartAiInsightSystemPrompt() {
+  return dedent(`
+    You are an accessibility assistant for Observability charts in Elastic Kibana.
+    Summarize chart time series data for screen reader users using ONLY the provided JSON context.
+
+    Output requirements:
+    - Write 2-4 short plain-text paragraphs
+    - No markdown, links, bullet lists, tables, or headings
+    - Describe trends, peaks, troughs, and step changes using the timestamps and values in the data
+    - When multiple series are present, explain how the current period compares to the comparison series
+    - If a series has no numeric values, state that there is no data in the selected time range
+    - Do not speculate or invent values that are not supported by the data
+    - Be concise and direct; avoid flowery language
+  `);
+}
+
+const buildUserPrompt = ({
+  chartTitle,
+  start,
+  end,
+  series,
+}: {
+  chartTitle: string;
+  start?: string;
+  end?: string;
+  series: ChartDescriptionSeries[];
+}) => {
+  const chartContext = JSON.stringify(
+    {
+      chartTitle,
+      start,
+      end,
+      series,
+    },
+    null,
+    2
+  );
+
+  return dedent(`
+    <ChartContext>
+    ${chartContext}
+    </ChartContext>
+
+    Summarize this chart for a screen reader user. Each data point uses x as epoch milliseconds and y as the metric value (y may be null when data is missing).
+  `);
+};
+
+export interface GenerateChartAiInsightParams {
+  chartTitle: string;
+  start?: string;
+  end?: string;
+  series: ChartDescriptionSeries[];
+  inferenceClient: BoundInferenceClient;
+  connector: InferenceConnector;
+}
+
+export function generateChartAiInsight({
+  chartTitle,
+  start,
+  end,
+  series,
+  inferenceClient,
+  connector,
+}: GenerateChartAiInsightParams): AiInsightResult {
+  const context = buildUserPrompt({ chartTitle, start, end, series });
+
+  const events$ = inferenceClient.chatComplete({
+    system: getChartAiInsightSystemPrompt(),
+    messages: [
+      {
+        role: MessageRole.User,
+        content: context,
+      },
+    ],
+    stream: true,
+  });
+
+  return createAiInsightResult(context, connector, events$);
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/route.ts
@@ -27,6 +27,7 @@ import {
   getAlertAiInsight,
   type AlertDocForInsight,
 } from './alert_ai_insights/generate_alert_ai_insight';
+import { generateChartAiInsight } from './chart/generate_chart_ai_insight';
 import { OBSERVABILITY_AI_INSIGHTS_SUBFEATURE_ID } from '../../../common/constants';
 import { resolveConnectorForFeature } from '../../utils/resolve_connector_for_feature';
 
@@ -338,9 +339,84 @@ export function getObservabilityAgentBuilderAiInsightsRouteRepository(): ServerR
     },
   });
 
+  const chartDescriptionPointRt = t.type({
+    x: t.number,
+    y: t.union([t.number, t.null]),
+  });
+
+  const chartDescriptionSeriesRt = t.type({
+    title: t.string,
+    data: t.array(chartDescriptionPointRt),
+  });
+
+  const chartAiInsightsRoute = createObservabilityAgentBuilderServerRoute({
+    endpoint: 'POST /internal/observability_agent_builder/ai_insights/chart',
+    options: {
+      access: 'internal',
+    },
+    security: {
+      authz: {
+        requiredPrivileges: [apiPrivileges.readAgentBuilder],
+      },
+    },
+    params: t.type({
+      body: t.type({
+        chartTitle: t.string,
+        series: t.array(chartDescriptionSeriesRt),
+        start: t.union([t.string, t.undefined]),
+        end: t.union([t.string, t.undefined]),
+      }),
+    }),
+    handler: async ({ request, core, params, response, logger, plugins }) => {
+      const { chartTitle, series, start, end } = params.body;
+      const isCloudEnabled = Boolean(plugins.cloud?.isCloudEnabled);
+
+      const [, startDeps] = await core.getStartServices();
+      const { inference, searchInferenceEndpoints } = startDeps;
+
+      try {
+        const { connectorId, connector } = await resolveConnectorForFeature({
+          searchInferenceEndpoints,
+          featureId: OBSERVABILITY_AI_INSIGHTS_SUBFEATURE_ID,
+          request,
+          logger,
+        });
+
+        const inferenceClient = inference.getClient({ request, bindTo: { connectorId } });
+
+        const result = generateChartAiInsight({
+          chartTitle,
+          series,
+          start,
+          end,
+          inferenceClient,
+          connector,
+        });
+
+        return response.ok({
+          headers: getSSEResponseHeaders(isCloudEnabled),
+          body: observableIntoEventSourceStream(result.events$, {
+            logger,
+            signal: getRequestAbortedSignal(request),
+          }),
+        });
+      } catch (error) {
+        logger.error(error);
+        return routeAiInsightError({
+          error,
+          response,
+          isCloudEnabled,
+          logger,
+          request,
+        });
+      }
+    },
+  });
+
   return {
     ...logAiInsightsRoute,
     ...errorAiInsightsRoute,
     ...getAlertAiInsightRoute,
+    ...chartAiInsightsRoute,
   };
 }


### PR DESCRIPTION
## Summary
Adds an accessible Describe chart control for Observability charts so keyboard and screen reader users get a text summary of chart data — without relying on the chart canvas itself.

This is a complementary accessibility bridge for [#221361](https://github.com/elastic/kibana/issues/221361) (inaccessible graphs via keyboard). It does not replace making elastic-charts/Lens keyboard-operable upstream.

### First integration: APM Service Overview charts.

### How it works

1. User activates Describe chart: Latency (keyboard or screen reader).
2. Popover opens with a summary:
    - Without AI: deterministic text from series data immediately
    - With AI: streams an AI-generated summary; falls back to deterministic text on failure
3. Screen reader behavior:
    - Deterministic summaries announced via aria-describedby on popover open
    - During AI streaming: announces "Generating AI summary." once; partial chunks are visually shown but hidden from screen readers (aria-hidden); final summary announced once when complete

### Out of scope (follow-ups)

- Infra / Lens charts (explored separately; deferred)
- Read anomaly detection
- API integration test for the chart AI endpoint

https://github.com/user-attachments/assets/778fe51f-b59b-48f1-aaee-f01ccb720a3a


