### PR TITLE
[Security Solution] Add Respond to Take action button

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
@@ -39,6 +39,7 @@ import type { MiddlewareActionSpyHelper } from '../../store/test_utils';
 import { createSpyMiddleware } from '../../store/test_utils';
 import type { State } from '../../store';
 import { AppRootProvider } from './app_root_provider';
+import { resetConsoleManagerStateForTesting } from '../../../management/components/console/components/console_manager/console_manager';
 import { managementMiddlewareFactory } from '../../../management/store/middleware';
 import { createStartServicesMock } from '../../lib/kibana/kibana_react.mock';
 import { SUB_PLUGINS_REDUCER, mockGlobalState, createMockStore } from '..';
@@ -252,6 +253,11 @@ const experimentalFeaturesReducer: Reducer<State['app'], UpdateExperimentalFeatu
  * for further customization.
  */
 export const createAppRootMockRenderer = (): AppContextTestRender => {
+  // The console manager keeps its running consoles in a module-level store that intentionally
+  // outlives `<ConsoleManager>` unmounts (so console state survives navigation/flyouts in the app).
+  // Reset it per renderer creation so console state does not leak between test cases.
+  resetConsoleManagerStateForTesting();
+
   const history = createMemoryHistory<never>();
   const coreStart = createCoreStartMock(history);
   const middlewareSpy = createSpyMiddleware();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
-import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { useEventDetails } from '../../../../flyout/document_details/shared/hooks/use_event_details';
 import { TakeActionButton } from './take_action_button';
 import { TakeAction } from './take_action';
@@ -23,11 +22,14 @@ jest.mock('./take_action_button', () => ({
 const mockUseEventDetails = useEventDetails as jest.Mock;
 const mockTakeActionButton = TakeActionButton as unknown as jest.Mock;
 
-const createMockHit = (raw: Partial<DataTableRecord['raw']> = {}): DataTableRecord =>
+const createMockHit = (
+  raw: Partial<DataTableRecord['raw']> = {},
+  flattened: DataTableRecord['flattened'] = { 'host.name': 'test-host', 'user.name': null }
+): DataTableRecord =>
   ({
     id: 'test-id',
     raw: { _id: 'test-event-id', _index: 'test-index', ...raw },
-    flattened: {},
+    flattened,
     isAnchor: false,
   } as DataTableRecord);
 
@@ -36,18 +38,12 @@ const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
 const mockOnAlertUpdated = jest.fn();
 const mockOnShowNotes = jest.fn();
 
-const mockDataFormattedForFieldBrowser: TimelineEventsDetailsItem[] = [
-  { field: 'host.name', values: ['test-host'], originalValue: ['test-host'], isObjectArray: false },
-  { field: 'user.name', values: null, originalValue: null, isObjectArray: false },
-];
-
 describe('<TakeAction />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseEventDetails.mockReturnValue({
       loading: false,
       dataAsNestedObject: mockEcsData,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
       refetchFlyoutData: mockRefetchFlyoutData,
     });
   });
@@ -78,7 +74,6 @@ describe('<TakeAction />', () => {
     mockUseEventDetails.mockReturnValue({
       loading: false,
       dataAsNestedObject: null,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
       refetchFlyoutData: mockRefetchFlyoutData,
     });
 
@@ -95,7 +90,7 @@ describe('<TakeAction />', () => {
     expect(queryByTestId('take-action-button-mock')).not.toBeInTheDocument();
   });
 
-  it('should render a disabled Take action button when dataFormattedForFieldBrowser is null', () => {
+  it('should render TakeActionButton when dataFormattedForFieldBrowser is null', () => {
     mockUseEventDetails.mockReturnValue({
       loading: false,
       dataAsNestedObject: mockEcsData,
@@ -111,9 +106,8 @@ describe('<TakeAction />', () => {
       />
     );
 
-    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
-    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toHaveTextContent('Take action');
-    expect(queryByTestId('take-action-button-mock')).not.toBeInTheDocument();
+    expect(getByTestId('take-action-button-mock')).toBeInTheDocument();
+    expect(queryByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should render TakeActionButton when data is available', () => {
@@ -157,41 +151,6 @@ describe('<TakeAction />', () => {
         onAlertUpdated,
         onShowNotes: mockOnShowNotes,
       }),
-      expect.anything()
-    );
-  });
-
-  it('should compute nonEcsData from dataFormattedForFieldBrowser and pass it to TakeActionButton', () => {
-    render(
-      <TakeAction
-        hit={createMockHit()}
-        onAlertUpdated={mockOnAlertUpdated}
-        onShowNotes={mockOnShowNotes}
-      />
-    );
-
-    expect(mockTakeActionButton).toHaveBeenCalledWith(
-      expect.objectContaining({
-        nonEcsData: [
-          { field: 'host.name', value: ['test-host'] },
-          { field: 'user.name', value: null },
-        ],
-      }),
-      expect.anything()
-    );
-  });
-
-  it('should forward dataFormattedForFieldBrowser as detailsData to TakeActionButton', () => {
-    render(
-      <TakeAction
-        hit={createMockHit()}
-        onAlertUpdated={mockOnAlertUpdated}
-        onShowNotes={mockOnShowNotes}
-      />
-    );
-
-    expect(mockTakeActionButton).toHaveBeenCalledWith(
-      expect.objectContaining({ detailsData: mockDataFormattedForFieldBrowser }),
       expect.anything()
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
@@ -43,23 +43,17 @@ export interface TakeActionProps {
  * We show a loading button while we fetch the document.
  * If the call succeeds we show the Take action button.
  * If the call fails, we show a disabled button.
- * We're doing all of this to avoid having to refactor all the actions that are currently using dataAsNestedObject and dataFormattedForFieldBrowser/
+ * We're doing all of this to avoid having to refactor all the actions that are currently using dataAsNestedObject.
  * // TODO: refactor all actions to take a DataTableRecord as input.
  */
 export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated, onShowNotes }) => {
   const eventId = hit.raw._id;
   const indexName = hit.raw._index;
 
-  const { dataAsNestedObject, dataFormattedForFieldBrowser, refetchFlyoutData, loading } =
-    useEventDetails({
-      eventId,
-      indexName,
-    });
-
-  const nonEcsData = useMemo(
-    () => dataFormattedForFieldBrowser?.map((d) => ({ field: d.field, value: d.values ?? null })),
-    [dataFormattedForFieldBrowser]
-  );
+  const { dataAsNestedObject, refetchFlyoutData, loading } = useEventDetails({
+    eventId,
+    indexName,
+  });
 
   if (loading) {
     return (
@@ -69,7 +63,7 @@ export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated, onShowNot
     );
   }
 
-  if (!dataAsNestedObject || !nonEcsData || !dataFormattedForFieldBrowser) {
+  if (!dataAsNestedObject) {
     return (
       <EuiButton data-test-subj={FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID} fill isDisabled>
         {TAKE_ACTION}
@@ -81,8 +75,6 @@ export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated, onShowNot
     <TakeActionButton
       hit={hit}
       ecsData={dataAsNestedObject}
-      nonEcsData={nonEcsData}
-      detailsData={dataFormattedForFieldBrowser}
       refetchFlyoutData={refetchFlyoutData}
       onAlertUpdated={onAlertUpdated}
       onShowNotes={onShowNotes}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
-import type { TimelineNonEcsData } from '../../../../../common/search_strategy';
 import { useAddToCaseActions } from '../../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertsActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
@@ -54,6 +53,11 @@ jest.mock(
     ),
   })
 );
+
+const mockUseResponderActionItem = jest.fn().mockReturnValue([]);
+jest.mock('../../../../common/components/endpoint/responder', () => ({
+  useResponderActionItem: (...args: unknown[]) => mockUseResponderActionItem(...args),
+}));
 
 const mockUseExploreActions = jest.fn().mockReturnValue({ exploreActionItems: [] });
 jest.mock('../hooks/use_explore_actions', () => ({
@@ -110,7 +114,6 @@ const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.Mock;
 const mockUseIsInSecurityApp = useIsInSecurityApp as jest.Mock;
 const mockUseHostIsolationAction = useHostIsolationAction as jest.Mock;
 const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
-const mockNonEcsData: TimelineNonEcsData[] = [{ field: 'host.name', value: ['test-host'] }];
 const mockDetailsData = [
   {
     category: 'host',
@@ -124,10 +127,8 @@ const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
 const mockOnAlertUpdated = jest.fn();
 const mockOnShowNotes = jest.fn();
 const defaultProps = {
-  hit: createMockHit(),
+  hit: createMockHit({ 'host.name': ['test-host'] }),
   ecsData: mockEcsData,
-  nonEcsData: mockNonEcsData,
-  detailsData: mockDetailsData,
   refetchFlyoutData: mockRefetchFlyoutData,
   onAlertUpdated: mockOnAlertUpdated,
   onShowNotes: mockOnShowNotes,
@@ -152,6 +153,7 @@ describe('<TakeActionButton />', () => {
       runAlertWorkflowPanel: [],
     });
     mockUseExploreActions.mockReturnValue({ exploreActionItems: [] });
+    mockUseResponderActionItem.mockReturnValue([]);
     mockUseHostIsolationAction.mockReturnValue([]);
   });
 
@@ -194,7 +196,7 @@ describe('<TakeActionButton />', () => {
     expect(mockUseAddToCaseActions).toHaveBeenCalledWith(
       expect.objectContaining({
         ecsData: mockEcsData,
-        nonEcsData: mockNonEcsData,
+        nonEcsData: [{ field: 'host.name', value: ['test-host'] }],
         onSuccess: mockRefetchFlyoutData,
       })
     );
@@ -327,6 +329,32 @@ describe('<TakeActionButton />', () => {
         documents: [expect.objectContaining({ _id: 'test-id', _index: 'test-index' })],
       })
     );
+  });
+
+  it('should call useResponderActionItem with field-browser data and closePopover', () => {
+    renderTakeActionButton();
+
+    expect(mockUseResponderActionItem).toHaveBeenCalledWith(mockDetailsData, expect.any(Function));
+  });
+
+  it('should include the Respond action for local documents in Discover', () => {
+    mockUseIsInSecurityApp.mockReturnValue(false);
+    mockUseResponderActionItem.mockReturnValue([
+      {
+        key: 'endpointResponseActions-action-item',
+        name: 'Respond',
+        onClick: jest.fn(),
+      },
+    ]);
+
+    const { getByTestId, getByText } = renderTakeActionButton({
+      ...defaultProps,
+      hit: createMockHit({ 'event.kind': 'signal' }),
+    });
+
+    fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+    expect(getByText('Respond')).toBeInTheDocument();
   });
 
   it('should not include run workflow menu item when hook returns empty (no permissions)', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.tsx
@@ -13,9 +13,7 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALERT_WORKFLOW_STATUS, EVENT_KIND } from '@kbn/rule-data-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
-import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { EventKind } from '../constants/event_kinds';
-import type { TimelineNonEcsData } from '../../../../../common/search_strategy';
 import type { Status } from '../../../../../common/api/detection_engine';
 import { useAddToCaseActions } from '../../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertsActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
@@ -28,12 +26,21 @@ import { useRunDocumentWorkflowPanel } from '../../../../detections/components/a
 import type { HostIsolationAction } from '../../../../common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action';
 import { useHostIsolationAction } from '../../../../common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action';
 import { HostIsolationFlyout } from '../../../../common/components/endpoint/host_isolation/from_alerts/host_isolation_flyout';
+import { useResponderActionItem } from '../../../../common/components/endpoint/responder';
 import { useExploreActions } from '../hooks/use_explore_actions';
+import { getTimelineEventsDetailsFromRecord } from '../utils/get_timeline_events_details_from_record';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
 const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
   defaultMessage: 'Take action',
 });
+
+const TAKE_ACTION_MENU = i18n.translate(
+  'xpack.securitySolution.flyoutV2.footer.takeActionMenuLabel',
+  {
+    defaultMessage: 'Take action menu',
+  }
+);
 
 const ADD_NOTE = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeAction.addNoteLabel', {
   defaultMessage: 'Add note',
@@ -48,15 +55,6 @@ export interface TakeActionButtonProps {
    * ECS data for the document
    */
   ecsData: Ecs;
-  /**
-   * Non-ECS data for the document
-   */
-  nonEcsData: TimelineNonEcsData[];
-  /**
-   * Field-browser shaped data for the document, used to drive endpoint response actions
-   * (e.g. host isolation) that still consume the legacy `TimelineEventsDetailsItem[]` shape.
-   */
-  detailsData: TimelineEventsDetailsItem[];
   /**
    * Callback to refetch flyout data
    */
@@ -76,27 +74,13 @@ export interface TakeActionButtonProps {
  * // TODO: refactor all actions to take a DataTableRecord as input.
  */
 export const TakeActionButton = memo(
-  ({
-    hit,
-    ecsData,
-    nonEcsData,
-    detailsData,
-    refetchFlyoutData,
-    onAlertUpdated,
-    onShowNotes,
-  }: TakeActionButtonProps) => {
+  ({ hit, ecsData, refetchFlyoutData, onAlertUpdated, onShowNotes }: TakeActionButtonProps) => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const togglePopoverHandler = useCallback(() => setIsPopoverOpen((open) => !open), []);
     const closePopoverHandler = useCallback(() => setIsPopoverOpen(false), []);
     const [isolateAction, setIsolateAction] = useState<HostIsolationAction | null>(null);
 
     const isInSecurityApp = useIsInSecurityApp();
-
-    const hostIsolationActionItems = useHostIsolationAction({
-      closePopover: closePopoverHandler,
-      detailsData,
-      onAddIsolationStatusClick: setIsolateAction,
-    });
 
     const documentId = hit.raw._id ?? '';
     const isRemoteDocument = useMemo(
@@ -111,6 +95,22 @@ export const TakeActionButton = memo(
       const rawStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
       return (Array.isArray(rawStatus) ? rawStatus[0] : rawStatus) as Status;
     }, [hit]);
+
+    const dataFormattedForFieldBrowser = useMemo(
+      () => getTimelineEventsDetailsFromRecord(hit),
+      [hit]
+    );
+
+    const nonEcsData = useMemo(
+      () => dataFormattedForFieldBrowser.map((d) => ({ field: d.field, value: d.values ?? null })),
+      [dataFormattedForFieldBrowser]
+    );
+
+    const hostIsolationActionItems = useHostIsolationAction({
+      closePopover: closePopoverHandler,
+      detailsData: dataFormattedForFieldBrowser,
+      onAddIsolationStatusClick: setIsolateAction,
+    });
 
     const { addToCaseActionItems } = useAddToCaseActions({
       ecsData,
@@ -186,6 +186,11 @@ export const TakeActionButton = memo(
       closePopover: closePopoverHandler,
     });
 
+    const endpointResponseActionsConsoleItems = useResponderActionItem(
+      dataFormattedForFieldBrowser,
+      closePopoverHandler
+    );
+
     const items = useMemo(
       () => [
         ...(!isRemoteDocument ? addToCaseActionItems : []),
@@ -194,6 +199,7 @@ export const TakeActionButton = memo(
         ...(!isRemoteDocument && isAlert ? alertAssigneesItems : []),
         ...(!isRemoteDocument && isAlert ? hostIsolationActionItems : []),
         ...(!isRemoteDocument ? (isAlert ? runWorkflowMenuItem : documentWorkflowMenuItem) : []),
+        ...(!isRemoteDocument ? endpointResponseActionsConsoleItems : []),
         ...(!isRemoteDocument && !isAlert ? noteItems : []),
         ...(isInSecurityApp ? investigateInTimelineActionItems : []),
         ...(!isInSecurityApp ? exploreActionItems : []),
@@ -203,6 +209,7 @@ export const TakeActionButton = memo(
         alertAssigneesItems,
         alertTagsItems,
         documentWorkflowMenuItem,
+        endpointResponseActionsConsoleItems,
         exploreActionItems,
         hostIsolationActionItems,
         investigateInTimelineActionItems,
@@ -253,14 +260,14 @@ export const TakeActionButton = memo(
         {isolateAction !== null && (
           <HostIsolationFlyout
             hit={hit}
-            detailsData={detailsData}
+            detailsData={dataFormattedForFieldBrowser}
             isolateAction={isolateAction}
             onClose={() => setIsolateAction(null)}
           />
         )}
         <EuiPopover
-          aria-label={TAKE_ACTION}
           id="AlertTakeActionPanel"
+          aria-label={TAKE_ACTION_MENU}
           button={takeActionButton}
           isOpen={isPopoverOpen}
           closePopover={closePopoverHandler}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/hooks/use_highlighted_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/hooks/use_highlighted_fields.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useMemo } from 'react';
 import { find, isEmpty } from 'lodash/fp';
@@ -15,6 +14,7 @@ import { useAlertResponseActionsSupport } from '../../../../common/hooks/endpoin
 import { isResponseActionsAlertAgentIdField } from '../../../../common/lib/endpoint';
 import { getHighlightedFieldsToDisplay } from '../../../../common/components/event_details/get_alert_summary_rows';
 import { EVENT_SOURCE_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
+import { getTimelineEventsDetailsFromRecord } from '../utils/get_timeline_events_details_from_record';
 
 export interface UseHighlightedFieldsParams {
   /**
@@ -55,22 +55,12 @@ export const useHighlightedFields = ({
   investigationFields,
   type,
 }: UseHighlightedFieldsParams): UseHighlightedFieldsResult => {
-  // Build TimelineEventsDetailsItem[] from DataTableRecord for internal use
+  // Build TimelineEventsDetailsItem[] from DataTableRecord for internal use.
   // We do this to avoid increasing scope as useAlertResponseActionsSupport is used in many places
-  const dataFormattedForFieldBrowser = useMemo<TimelineEventsDetailsItem[]>(() => {
-    return Object.entries(hit.flattened).map(([field, value]) => ({
-      field,
-      values: Array.isArray(value)
-        ? value.map(String)
-        : value != null
-        ? [String(value)]
-        : undefined,
-      originalValue: value,
-      isObjectArray: Array.isArray(value) && value.length > 0 && typeof value[0] === 'object',
-      // Derive category from field path to keep downstream category lookups working.
-      category: field.split('.')[0],
-    }));
-  }, [hit]);
+  const dataFormattedForFieldBrowser = useMemo(
+    () => getTimelineEventsDetailsFromRecord(hit),
+    [hit]
+  );
 
   // TODO eventually convert useAlertResponseActionsSupport to support hit
   const responseActionsSupport = useAlertResponseActionsSupport(dataFormattedForFieldBrowser);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_timeline_events_details_from_record.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_timeline_events_details_from_record.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getTimelineEventsDetailsFromRecord } from './get_timeline_events_details_from_record';
+
+const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+  ({
+    id: 'test-id',
+    raw: { _id: 'test-id', _index: 'test-index' },
+    flattened,
+    isAnchor: false,
+  } as DataTableRecord);
+
+describe('getTimelineEventsDetailsFromRecord', () => {
+  it('converts flattened record fields to timeline event details items', () => {
+    expect(
+      getTimelineEventsDetailsFromRecord(
+        createMockHit({
+          'host.name': 'test-host',
+          'event.category': ['process', 'network'],
+          'user.name': null,
+          'process.args': [{ value: 'test' }],
+        })
+      )
+    ).toEqual([
+      {
+        category: 'host',
+        field: 'host.name',
+        isObjectArray: false,
+        originalValue: 'test-host',
+        values: ['test-host'],
+      },
+      {
+        category: 'event',
+        field: 'event.category',
+        isObjectArray: false,
+        originalValue: ['process', 'network'],
+        values: ['process', 'network'],
+      },
+      {
+        category: 'user',
+        field: 'user.name',
+        isObjectArray: false,
+        originalValue: null,
+        values: undefined,
+      },
+      {
+        category: 'process',
+        field: 'process.args',
+        isObjectArray: true,
+        originalValue: [{ value: 'test' }],
+        values: ['[object Object]'],
+      },
+    ]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_timeline_events_details_from_record.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/utils/get_timeline_events_details_from_record.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+
+/**
+ * Converts a `DataTableRecord` into the `TimelineEventsDetailsItem[]` format expected by legacy
+ * action hooks (e.g. responder, add-to-case). Each flattened field is mapped to its category,
+ * stringified values, and original value.
+ *
+ * @deprecated This adapter exists only to bridge the gap while legacy hooks still require
+ * `TimelineEventsDetailsItem[]`. It should be removed once all actions and downstream logic
+ * have been updated to accept `DataTableRecord` directly.
+ */
+export const getTimelineEventsDetailsFromRecord = (
+  hit: DataTableRecord
+): TimelineEventsDetailsItem[] => {
+  return Object.entries(hit.flattened).map(([field, value]) => ({
+    field,
+    values: Array.isArray(value) ? value.map(String) : value != null ? [String(value)] : undefined,
+    originalValue: value,
+    isObjectArray: Array.isArray(value) && value.length > 0 && typeof value[0] === 'object',
+    category: field.split('.')[0],
+  }));
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
@@ -9,11 +9,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { Router } from '@kbn/shared-ux-router';
 import { useLocation } from 'react-router-dom';
 import { createStore } from 'redux';
 import { UpsellingService } from '@kbn/security-solution-upselling/service';
+import { of } from 'rxjs';
 import type { StartServices } from '../../../types';
 import { SECURITY_FEATURE_ID } from '../../../../common/constants';
+import { useConsoleManager } from '../../../management/components/console/components/console_manager';
 import { flyoutProviders } from './flyout_provider';
 
 jest.mock('../../../common/components/user_privileges/user_privileges_context', () => ({
@@ -69,6 +72,10 @@ const services = {
       remove: jest.fn(),
     },
   },
+  theme: {
+    getTheme: jest.fn().mockReturnValue({ darkMode: false }),
+    theme$: of({ darkMode: false }),
+  },
   http: {},
 } as unknown as StartServices;
 
@@ -82,6 +89,12 @@ const ExpandableFlyoutApiProbe = () => {
   const { openPreviewPanel } = useExpandableFlyoutApi();
 
   return <div>{typeof openPreviewPanel}</div>;
+};
+
+const ConsoleManagerProbe = () => {
+  const consoleManager = useConsoleManager();
+
+  return <div data-test-subj="console-manager-probe">{typeof consoleManager.register}</div>;
 };
 
 describe('flyoutProviders', () => {
@@ -101,18 +114,35 @@ describe('flyoutProviders', () => {
     expect(screen.getByText('/security?foo=bar')).toBeInTheDocument();
   });
 
-  it('renders children without a router when no history is provided', () => {
+  it('provides router context when no history is provided', () => {
     const store = createStore(() => ({}));
 
     render(
       flyoutProviders({
         services,
         store,
-        children: <div>{'NoRouterFallback'}</div>,
+        children: <LocationProbe />,
       })
     );
 
-    expect(screen.getByText('NoRouterFallback')).toBeInTheDocument();
+    expect(screen.getByText('/')).toBeInTheDocument();
+  });
+
+  it('uses the existing router context when no history is provided', () => {
+    const history = createMemoryHistory({ initialEntries: ['/existing-router'] });
+    const store = createStore(() => ({}));
+
+    render(
+      <Router history={history}>
+        {flyoutProviders({
+          services,
+          store,
+          children: <LocationProbe />,
+        })}
+      </Router>
+    );
+
+    expect(screen.getByText('/existing-router')).toBeInTheDocument();
   });
 
   it('provides expandable flyout context to children', () => {
@@ -127,5 +157,19 @@ describe('flyoutProviders', () => {
     );
 
     expect(screen.getByText('function')).toBeInTheDocument();
+  });
+
+  it('provides console manager context to children', () => {
+    const store = createStore(() => ({}));
+
+    render(
+      flyoutProviders({
+        services,
+        store,
+        children: <ConsoleManagerProbe />,
+      })
+    );
+
+    expect(screen.getByTestId('console-manager-probe')).toHaveTextContent('function');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
@@ -6,9 +6,11 @@
  */
 
 import type { FC, ReactElement, ReactNode } from 'react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { History } from 'history';
+import { createMemoryHistory } from 'history';
 import { Router } from '@kbn/shared-ux-router';
+import { useLocation } from 'react-router-dom';
 import type { Store } from 'redux';
 import { Provider, useStore } from 'react-redux';
 import { CellActionsProvider } from '@kbn/cell-actions';
@@ -26,6 +28,7 @@ import { CaseProvider } from '../../../cases/components/provider/provider';
 import { MlCapabilitiesProvider } from '../../../common/components/ml/permissions/ml_capabilities_provider';
 import { setAbsoluteRangeDatePicker } from '../../../common/store/inputs/actions';
 import { InputsModelId } from '../../../common/store/inputs/constants';
+import { ConsoleManager } from '../../../management/components/console/components/console_manager';
 
 /**
  * Syncs Kibana's global time filter to the Security Solution Redux store on mount.
@@ -43,6 +46,28 @@ const TimeRangeSync: FC<{ children: ReactNode }> = ({ children }) => {
   return <>{children}</>;
 };
 
+const useHasRouterContext = (): boolean => {
+  try {
+    useLocation();
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const FlyoutRouter: FC<{ children: ReactNode; history?: History }> = ({ children, history }) => {
+  const hasRouterContext = useHasRouterContext();
+  const fallbackHistory = useMemo(() => createMemoryHistory(), []);
+
+  // Security app flyouts can be opened from inside an existing Router, while Discover can
+  // render this provider without one. Reuse the host Router when present to avoid nesting.
+  return hasRouterContext ? (
+    <>{children}</>
+  ) : (
+    <Router history={history ?? fallbackHistory}>{children}</Router>
+  );
+};
+
 export const flyoutProviders = ({
   services,
   store,
@@ -56,12 +81,16 @@ export const flyoutProviders = ({
 }): ReactElement => {
   // This is currently necessary because of Analyzer (which internally has the logic to open other flyouts)
   // TODO remove ExpandableFlyoutProvider when we're ready to drop the expandable flyout
-  const flyoutContent = history ? (
-    <Router history={history}>
-      <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
-    </Router>
-  ) : (
-    <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+  // ConsoleManager and AssistantProvider must live inside the Router because the Respond
+  // PageOverlay they render calls `useLocation()` (for `hideOnUrlPathnameChange`).
+  const flyoutContent = (
+    <FlyoutRouter history={history}>
+      <ConsoleManager>
+        <AssistantProvider>
+          <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+        </AssistantProvider>
+      </ConsoleManager>
+    </FlyoutRouter>
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_list.tsx
@@ -202,9 +202,7 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
   const getTableItems = useCallback(
     (
       commandsByGroup: CommandDefinition[]
-    ): Array<{
-      [key: string]: { name: string; about: React.ReactNode | string };
-    }> => {
+    ): Array<Record<string, { name: string; about: React.ReactNode | string }>> => {
       if (commandsByGroup[0].helpGroupLabel === HELP_GROUPS.supporting.label) {
         return [...COMMON_ARGS, ...commandsByGroup].map((command) => ({
           [commandsByGroup[0]?.helpGroupLabel ?? otherCommandsGroupLabel]: command,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_list.tsx
@@ -202,7 +202,9 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
   const getTableItems = useCallback(
     (
       commandsByGroup: CommandDefinition[]
-    ): Array<Record<string, { name: string; about: React.ReactNode | string }>> => {
+    ): Array<{
+      [key: string]: { name: string; about: React.ReactNode | string };
+    }> => {
       if (commandsByGroup[0].helpGroupLabel === HELP_GROUPS.supporting.label) {
         return [...COMMON_ARGS, ...commandsByGroup].map((command) => ({
           [commandsByGroup[0]?.helpGroupLabel ?? otherCommandsGroupLabel]: command,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.tsx
@@ -110,7 +110,7 @@ const consoleStore = {
 // that, each manager registers a token on mount and only the "primary" (first-registered) one renders
 // the overlay. When the primary unmounts, the next registered manager takes over.
 // -------------------------------------------------------------------------------------------------
-let primaryElectionTokens: object[] = [];
+let primaryElectionTokens: symbol[] = [];
 const primaryElectionListeners = new Set<() => void>();
 
 const emitPrimaryElectionChange = (): void => {
@@ -124,15 +124,15 @@ const rendererElection = {
       primaryElectionListeners.delete(listener);
     };
   },
-  register: (token: object): void => {
+  register: (token: symbol): void => {
     primaryElectionTokens = [...primaryElectionTokens, token];
     emitPrimaryElectionChange();
   },
-  unregister: (token: object): void => {
+  unregister: (token: symbol): void => {
     primaryElectionTokens = primaryElectionTokens.filter((current) => current !== token);
     emitPrimaryElectionChange();
   },
-  isPrimary: (token: object): boolean => primaryElectionTokens[0] === token,
+  isPrimary: (token: symbol): boolean => primaryElectionTokens[0] === token,
 };
 
 /**
@@ -162,9 +162,9 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
 
   // Renderer election: a stable per-instance token, registered on mount. Only the primary instance
   // renders the `ConsolePageOverlay` so we never render duplicate overlays from multiple managers.
-  const electionTokenRef = useRef<object>();
+  const electionTokenRef = useRef<symbol>();
   if (!electionTokenRef.current) {
-    electionTokenRef.current = {};
+    electionTokenRef.current = Symbol('consoleManagerRendererToken');
   }
   const electionToken = electionTokenRef.current;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.tsx
@@ -6,7 +6,15 @@
  */
 
 import type { PropsWithChildren } from 'react';
-import React, { memo, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import type { ConsoleDataState } from '../console_state/types';
 import { ConsolePageOverlay } from './components/console_page_overlay';
 import type {
@@ -56,6 +64,89 @@ const ConsoleManagerContext = React.createContext<ConsoleManagerContextClients |
   undefined
 );
 
+// -------------------------------------------------------------------------------------------------
+// Module-level shared console store
+//
+// The running consoles and their internal state live OUTSIDE React, at module scope, so that EVERY
+// mounted `<ConsoleManager>` - the one in the Security app shell AND the ones mounted inside each
+// detached flyout React tree (including Discover doc-viewer fragments) - reads from and writes to the
+// SAME data. This is what allows a console (and its in-memory state, e.g. command/input history) to
+// survive across pages, flyouts, and the Security-app/Discover boundary, instead of each manager
+// owning its own isolated copy that is lost the moment that particular tree unmounts.
+// -------------------------------------------------------------------------------------------------
+let currentConsoleStorage: RunningConsoleStorage = {};
+const consoleStateStorage = new Map<ManagedConsole['key'], ConsoleDataState>();
+const consoleStorageListeners = new Set<() => void>();
+
+const emitConsoleStorageChange = (): void => {
+  consoleStorageListeners.forEach((listener) => listener());
+};
+
+const consoleStore = {
+  subscribe: (listener: () => void): (() => void) => {
+    consoleStorageListeners.add(listener);
+    return () => {
+      consoleStorageListeners.delete(listener);
+    };
+  },
+  getStorage: (): RunningConsoleStorage => currentConsoleStorage,
+  setStorage: (updater: (prev: RunningConsoleStorage) => RunningConsoleStorage): void => {
+    currentConsoleStorage = updater(currentConsoleStorage);
+    emitConsoleStorageChange();
+  },
+  getManagedConsoleState: (key: ManagedConsole['key']): ConsoleDataState | undefined =>
+    consoleStateStorage.get(key),
+  storeManagedConsoleState: (key: ManagedConsole['key'], state: ConsoleDataState): void => {
+    consoleStateStorage.set(key, state);
+  },
+};
+
+// -------------------------------------------------------------------------------------------------
+// Renderer election
+//
+// Because the console store is shared, every mounted `<ConsoleManager>` would otherwise render the
+// `ConsolePageOverlay` for the visible console - producing duplicate overlays whenever more than one
+// manager is mounted (e.g. the app shell + a flyout, or several Discover fragments at once). To avoid
+// that, each manager registers a token on mount and only the "primary" (first-registered) one renders
+// the overlay. When the primary unmounts, the next registered manager takes over.
+// -------------------------------------------------------------------------------------------------
+let primaryElectionTokens: object[] = [];
+const primaryElectionListeners = new Set<() => void>();
+
+const emitPrimaryElectionChange = (): void => {
+  primaryElectionListeners.forEach((listener) => listener());
+};
+
+const rendererElection = {
+  subscribe: (listener: () => void): (() => void) => {
+    primaryElectionListeners.add(listener);
+    return () => {
+      primaryElectionListeners.delete(listener);
+    };
+  },
+  register: (token: object): void => {
+    primaryElectionTokens = [...primaryElectionTokens, token];
+    emitPrimaryElectionChange();
+  },
+  unregister: (token: object): void => {
+    primaryElectionTokens = primaryElectionTokens.filter((current) => current !== token);
+    emitPrimaryElectionChange();
+  },
+  isPrimary: (token: object): boolean => primaryElectionTokens[0] === token,
+};
+
+/**
+ * Test-only helper that clears the module-level console store + renderer election between test cases.
+ * The store intentionally outlives individual `<ConsoleManager>` unmounts in production (so console
+ * state survives navigation/flyouts), which means tests must reset it explicitly to avoid leaking
+ * state across cases. This is wired into `createAppRootMockRenderer()`.
+ */
+export const resetConsoleManagerStateForTesting = (): void => {
+  currentConsoleStorage = {};
+  consoleStateStorage.clear();
+  primaryElectionTokens = [];
+};
+
 export type ConsoleManagerProps = PropsWithChildren<{
   storage?: RunningConsoleStorage;
 }>;
@@ -65,17 +156,37 @@ export type ConsoleManagerProps = PropsWithChildren<{
  * command history while running in "hidden" mode.
  */
 export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, children }) => {
-  const [consoleStorage, setConsoleStorage] = useState<RunningConsoleStorage>(storage);
-  const [consoleStateStorage] = useState(new Map<ManagedConsole['key'], ConsoleDataState>());
+  // Subscribe to the module-level shared store (see above) so every manager re-renders together when
+  // a console is registered/shown/hidden/terminated, regardless of which manager applied the change.
+  const consoleStorage = useSyncExternalStore(consoleStore.subscribe, consoleStore.getStorage);
 
-  // `consoleStorageRef` keeps a copy (reference) to the latest copy of the `consoleStorage` so that
-  // some exposed methods (ex. `RegisteredConsoleClient`) are guaranteed to be immutable and function
-  // as expected between state updates without having to re-update every record stored in the `ConsoleStorage`
-  const consoleStorageRef = useRef<RunningConsoleStorage>();
-  consoleStorageRef.current = consoleStorage;
+  // Renderer election: a stable per-instance token, registered on mount. Only the primary instance
+  // renders the `ConsolePageOverlay` so we never render duplicate overlays from multiple managers.
+  const electionTokenRef = useRef<object>();
+  if (!electionTokenRef.current) {
+    electionTokenRef.current = {};
+  }
+  const electionToken = electionTokenRef.current;
+
+  useEffect(() => {
+    rendererElection.register(electionToken);
+    return () => rendererElection.unregister(electionToken);
+  }, [electionToken]);
+
+  const isPrimaryRenderer = useSyncExternalStore(rendererElection.subscribe, () =>
+    rendererElection.isPrimary(electionToken)
+  );
+
+  // Seed the shared store from the `storage` prop the first time a manager mounts with one. Guarded
+  // on the store being empty so additional (e.g. flyout-mounted) managers don't clobber live state.
+  useEffect(() => {
+    if (Object.keys(storage).length > 0 && Object.keys(consoleStore.getStorage()).length === 0) {
+      consoleStore.setStorage(() => ({ ...storage }));
+    }
+  }, [storage]);
 
   const validateIdOrThrow = useCallback((id: string) => {
-    if (!consoleStorageRef.current?.[id]) {
+    if (!consoleStore.getStorage()[id]) {
       throw new Error(`Console with id ${id} not found`);
     }
   }, []); // << IMPORTANT: this callback should have no dependencies
@@ -84,7 +195,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
     (id) => {
       validateIdOrThrow(id);
 
-      setConsoleStorage((prevState) => {
+      consoleStore.setStorage((prevState) => {
         const newState = { ...prevState };
 
         // if any is visible, hide it
@@ -112,7 +223,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
     (id) => {
       validateIdOrThrow(id);
 
-      setConsoleStorage((prevState) => {
+      consoleStore.setStorage((prevState) => {
         const newState = { ...prevState };
         newState[id].isOpen = false;
         return newState;
@@ -125,7 +236,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
     (id) => {
       validateIdOrThrow(id);
 
-      setConsoleStorage((prevState) => {
+      consoleStore.setStorage((prevState) => {
         const newState = { ...prevState };
         delete newState[id];
 
@@ -137,8 +248,9 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
 
   const getOne = useCallback<ConsoleManagerClient['getOne']>(
     <Meta extends object = Record<string, unknown>>(id: string) => {
-      if (consoleStorageRef.current?.[id]) {
-        return consoleStorageRef.current[id].client as Readonly<RegisteredConsoleClient<Meta>>;
+      const managedConsole = consoleStore.getStorage()[id];
+      if (managedConsole) {
+        return managedConsole.client as Readonly<RegisteredConsoleClient<Meta>>;
       }
     },
     [] // << IMPORTANT: this callback should have no dependencies or only immutable dependencies
@@ -153,16 +265,12 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
   }, [consoleStorage]); // << This callback should always use `consoleStorage`
 
   const isVisible = useCallback((id: string): boolean => {
-    if (consoleStorageRef.current?.[id]) {
-      return consoleStorageRef.current[id].isOpen;
-    }
-
-    return false;
+    return consoleStore.getStorage()[id]?.isOpen ?? false;
   }, []); // << IMPORTANT: this callback should have no dependencies
 
   const register = useCallback<ConsoleManagerClient['register']>(
     ({ id, meta, consoleProps, ...otherRegisterProps }) => {
-      if (consoleStorage[id]) {
+      if (consoleStore.getStorage()[id]) {
         throw new Error(`Console with id ${id} already registered`);
       }
 
@@ -203,7 +311,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
         key: managedKey,
       };
 
-      setConsoleStorage((prevState) => {
+      consoleStore.setStorage((prevState) => {
         return {
           ...prevState,
           [id]: managedConsole,
@@ -212,7 +320,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
 
       return managedConsole.client;
     },
-    [consoleStorage, hide, isVisible, show, terminate]
+    [hide, isVisible, show, terminate]
   );
 
   const consoleManagerClient = useMemo<ConsoleManagerClient>(() => {
@@ -236,15 +344,15 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
         },
 
         getManagedConsoleState(key: ManagedConsole['key']): ConsoleDataState | undefined {
-          return consoleStateStorage.get(key);
+          return consoleStore.getManagedConsoleState(key);
         },
 
         storeManagedConsoleState(key: ManagedConsole['key'], state: ConsoleDataState) {
-          consoleStateStorage.set(key, state);
+          consoleStore.storeManagedConsoleState(key, state);
         },
       },
     };
-  }, [consoleManagerClient, consoleStateStorage, consoleStorage]);
+  }, [consoleManagerClient, consoleStorage]);
 
   const visibleConsole = useMemo(() => {
     return Object.values(consoleStorage).find((managedConsole) => managedConsole.isOpen);
@@ -264,7 +372,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
     <ConsoleManagerContext.Provider value={consoleManageContextClients}>
       {children}
 
-      {visibleConsole && (
+      {isPrimaryRenderer && visibleConsole && (
         <ConsolePageOverlay
           onHide={handleOnHide}
           console={

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/components/action_log_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/components/action_log_button.tsx
@@ -12,14 +12,17 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiTitle,
+  useEuiTheme,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EndpointResponderExtensionComponentProps } from '../types';
 import { ResponseActionsLog } from '../../endpoint_response_actions_list/response_actions_log';
 import { UX_MESSAGES } from '../../endpoint_response_actions_list/translations';
 
 export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((props) => {
+  const { euiTheme } = useEuiTheme();
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [showActionLogFlyout, setShowActionLogFlyout] = useState<boolean>(false);
   const toggleActionLog = useCallback(() => {
@@ -36,6 +39,11 @@ export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((p
   const responderActionLogFlyoutTitleId = useGeneratedHtmlId({
     prefix: 'responderActionLogFlyoutTitle',
   });
+
+  // This flyout is opened from within the console `PageOverlay` (which sits at `levels.flyout + 500`),
+  // so it must be raised above the overlay to remain visible. The `+ 503` keeps both the flyout panel
+  // and its mask (`flyoutZIndex - 2`) above the overlay so the overlay is dimmed behind the flyout.
+  const flyoutZIndex = (euiTheme.levels.flyout as number) + 503;
 
   return (
     <>
@@ -59,6 +67,10 @@ export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((p
           aria-labelledby={responderActionLogFlyoutTitleId}
           data-test-subj="responderActionLogFlyout"
           session="never"
+          css={css`
+            z-index: ${flyoutZIndex} !important;
+          `}
+          maskProps={{ style: `z-index: ${flyoutZIndex - 2} !important` }}
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/components/action_log_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/components/action_log_button.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useRef, useState } from 'react';
 import {
   EuiButton,
   EuiFlyout,
@@ -20,9 +20,15 @@ import { ResponseActionsLog } from '../../endpoint_response_actions_list/respons
 import { UX_MESSAGES } from '../../endpoint_response_actions_list/translations';
 
 export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((props) => {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [showActionLogFlyout, setShowActionLogFlyout] = useState<boolean>(false);
   const toggleActionLog = useCallback(() => {
     setShowActionLogFlyout((prevState) => {
+      // When closing, restore focus to the trigger button so EUI's focus trap
+      // doesn't return focus to <body> (which surfaces the global SkipLink).
+      if (prevState) {
+        window.requestAnimationFrame(() => buttonRef.current?.focus());
+      }
       return !prevState;
     });
   }, []);
@@ -34,6 +40,7 @@ export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((p
   return (
     <>
       <EuiButton
+        buttonRef={buttonRef}
         onClick={toggleActionLog}
         disabled={showActionLogFlyout}
         iconType="listBullet"
@@ -51,6 +58,7 @@ export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((p
           paddingSize="l"
           aria-labelledby={responderActionLogFlyoutTitleId}
           data-test-subj="responderActionLogFlyout"
+          session="never"
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.test.tsx
@@ -15,7 +15,7 @@ import {
   PAGE_OVERLAY_DOCUMENT_BODY_LOCK_CLASSNAME,
   PageOverlay,
 } from './page_overlay';
-import { act, waitFor } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 
 describe('When using PageOverlay component', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
@@ -144,6 +144,56 @@ describe('When using PageOverlay component', () => {
 
     expect(overlay.classList.contains('eui-scrollBar')).toBe(false);
     expect(overlay.classList.contains('scrolling')).toBe(false);
+  });
+
+  it('should call `onHide` on Escape and stop it from reaching underlying window-level handlers', () => {
+    // Mirrors an underlying layer (e.g. EuiFlyout) that closes itself via a window-level keydown
+    // listener. While the overlay is visible, its Escape must not reach that handler.
+    const underlyingWindowHandler = jest.fn();
+    window.addEventListener('keydown', underlyingWindowHandler);
+
+    try {
+      render();
+
+      fireEvent.keyDown(renderResult.getByTestId('test-body'), { key: 'Escape' });
+
+      expect(renderProps.onHide).toHaveBeenCalledTimes(1);
+      expect(underlyingWindowHandler).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', underlyingWindowHandler);
+    }
+  });
+
+  it('should let Escape reach underlying window-level handlers (and not call `onHide`) when hidden', () => {
+    const underlyingWindowHandler = jest.fn();
+    window.addEventListener('keydown', underlyingWindowHandler);
+
+    try {
+      renderProps.isHidden = true;
+      render();
+
+      fireEvent.keyDown(renderResult.getByTestId('test-body'), { key: 'Escape' });
+
+      expect(renderProps.onHide).not.toHaveBeenCalled();
+      expect(underlyingWindowHandler).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', underlyingWindowHandler);
+    }
+  });
+
+  it('should ignore an Escape that was already handled (defaultPrevented) by an inner widget', () => {
+    render();
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    event.preventDefault(); // simulate an inner widget (e.g. a popover) having handled it
+
+    renderResult.getByTestId('test-body').dispatchEvent(event);
+
+    expect(renderProps.onHide).not.toHaveBeenCalled();
   });
 
   it.each`

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
@@ -321,6 +321,36 @@ export const PageOverlay = memo<PageOverlayProps>(
       });
     }, []);
 
+    // Close the overlay on Escape, revealing whatever is behind it (e.g. a flyout).
+    // The listener is attached to `document`, which sits below `window` in the DOM bubble path, so
+    // `stopPropagation()` prevents the Escape from reaching the window-level `keydown` handlers of
+    // underlying layers - notably `EuiFlyout` (via `EuiWindowEvent`), which would otherwise close the
+    // flyout instead. Because we stop the event below `window`, this works regardless of which layer
+    // mounted first. Inner widgets that handle Escape themselves (e.g. the console's input popover,
+    // via `EuiPopover`) call `stopPropagation()` before the event bubbles to `document`, so they keep
+    // precedence. Only active while the overlay is actually visible.
+    useEffect(() => {
+      if (isHidden) {
+        return;
+      }
+
+      const onKeyDown = (ev: KeyboardEvent) => {
+        if (ev.key !== 'Escape' || ev.defaultPrevented) {
+          return;
+        }
+
+        ev.stopPropagation();
+        ev.preventDefault();
+        onHide();
+      };
+
+      document.addEventListener('keydown', onKeyDown);
+
+      return () => {
+        document.removeEventListener('keydown', onKeyDown);
+      };
+    }, [isHidden, onHide]);
+
     return (
       <EuiPortal portalRef={setPortalEleRef}>
         <OverlayRootContainer

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
@@ -33,7 +33,10 @@ const OverlayRootContainer = styled.div`
 
   border-left: 1px solid ${({ theme }) => theme.euiTheme.colors.backgroundBaseSubdued};
 
-  z-index: ${({ theme }) => theme.euiTheme.levels.flyout};
+  // We're adding 500 to ensure that the overlay sits above the EUI flyout stacking range (each stacked flyout bumps its z-index by 3).
+  // Users would have to go through over 150 flyouts before getting into a position where the overlay would be behind the flyouts.
+  // We also want to ensure that popovers, dropdowns, and tooltips still render on top of the overlay, those are at 2000.
+  z-index: ${({ theme }) => (theme.euiTheme.levels.flyout as number) + 500};
 
   background-color: ${({ theme }) => theme.euiTheme.colors.backgroundBasePlain};
 


### PR DESCRIPTION
## Summary

This PR is starting over from [this prior work](https://github.com/elastic/kibana/pull/268881). It got split into 2 PRs:
- [this one](https://github.com/elastic/kibana/pull/273607) that converts all the `styled-components` to `@emotion`
- this current one which actually adds the `Respond` action to the new flyout system

The Respond action is now available in Discover

https://github.com/user-attachments/assets/62df56f4-a78e-4a88-899d-94981aa6bc60

The legacy expandable flyout experience remains unchanged (`newFlyoutSystemEnabled` feature flag is `false`)

https://github.com/user-attachments/assets/7be754e1-fdf6-4951-a06f-2cb361921d97

And the new flyout also now has Respond in Security Solution (`newFlyoutSystemEnabled` feature flag is set to `true`)

https://github.com/user-attachments/assets/9adeee3f-155d-4c0b-b82b-ac5557238703

## How to test

1. Add `xpack.securitySolution.enableExperimental: ['newFlyoutSystemEnabled']` to `config/kibana.dev.yml` and start Kibana.
2. Ensure the **Endpoint Security (Elastic Defend)** prebuilt detection rule is enabled (Security → Rules), so seeded raw endpoint alerts get promoted into SIEM alerts.
3. Seed an endpoint host (metadata + raw alerts + enrolled Fleet agent) using the resolver generator. Pure synthetic `data-generator` alerts may leave Respond disabled because they have no matching endpoint metadata. From the repo root:

   ```bash
   node x-pack/solutions/security/plugins/security_solution/scripts/endpoint/resolver_generator.js \
     --node http://elastic:changeme@127.0.0.1:9200 \
     --kibana http://elastic:changeme@127.0.0.1:5601 \
     --numHosts 3 --alertsPerHost 1 \
     --fleet \
     --withNewUser=fleet_loader:changeme
   ```

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/251791