### PR TITLE
Fix flaky feature_control FTR test: check bulk action existence before closing menu

### DIFF
--- a/x-pack/platform/test/functional/page_objects/tag_management_page.ts
+++ b/x-pack/platform/test/functional/page_objects/tag_management_page.ts
@@ -464,17 +464,11 @@ export class TagManagementPageObject extends FtrService {
     if (!(await this.isActionMenuButtonDisplayed())) {
       return false;
     }
-    const menuWasOpened = await this.isActionMenuOpened();
-    if (!menuWasOpened) {
+    if (!(await this.isActionMenuOpened())) {
       await this.openActionMenu();
     }
 
-    if (!menuWasOpened) {
-      await this.toggleActionMenu();
-    }
-
-    const actionExists = await this.testSubjects.exists(`actionBar-button-${actionId}`);
-    return actionExists;
+    return await this.testSubjects.exists(`actionBar-button-${actionId}`);
   }
 
   /**
@@ -496,7 +490,7 @@ export class TagManagementPageObject extends FtrService {
    * Return true if the bulk action menu is opened, false otherwise.
    */
   async isActionMenuOpened() {
-    return this.testSubjects.exists('actionBar-contextMenuPopover');
+    return this.testSubjects.exists('actionBar-contextMenu');
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes flaky FTR test: `saved objects tagging - functional tests feature controls base write privileges can bulk delete tags` (#234592).
I merged the same [fix](https://github.com/elastic/kibana/pull/250891) for 9.4 in February, and failures stopped there. Basically this is a backport for 8.19 branch.
### Root cause

`isBulkActionPresent` in `tag_management_page.ts` closed the bulk action menu **before** checking whether the target action button existed. The EUI popover element (`actionBar-contextMenuPopover`) remained in the DOM briefly during the close animation, so `isActionMenuOpened()` returned `true`. The subsequent `clickOnBulkAction('clear_selection')` → `openActionMenu()` then skipped re-opening (thinking the menu was open), and `testSubjects.click('actionBar-button-clear_selection')` timed out.

### Fix


Move the `actionExists` check to run while the menu is still open, before `toggleActionMenu()` restores the closed state.

Closes #234592