### PR TITLE
[Security][Evals] Disable Entity Store V2 for v1 entity-analytics evals

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_entity_analytics/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_entity_analytics/stateful/classic.stateful.config.ts
@@ -25,6 +25,11 @@ export const servers: ScoutServerConfig = {
       '--xpack.actions.responseTimeout=120s',
       '--feature_flags.overrides.aiAssistant.aiAgents.enabled=true',
       `--uiSettings.overrides.agentBuilder:experimentalFeatures=true`,
+      // Entity Store V2 is now enabled by default (since #269976). The v1 evals
+      // use the legacy risk engine APIs (/internal/risk_score/engine/init) which
+      // return 400 when V2 is active. Explicitly disable V2 for these evals.
+      `--uiSettings.overrides.securitySolution:entityStoreEnableV2=false`,
+      `--xpack.securitySolution.enableExperimental=["disable:entityAnalyticsEntityStoreV2"]`,
     ],
   },
 };


### PR DESCRIPTION
## Summary

Entity Store V2 was enabled by default in #269976 (May 22). The v1 entity-analytics eval suite uses legacy risk engine APIs (`/internal/risk_score/engine/init`, `/api/risk_score/engine/dangerously_delete_data`) which return 400 when V2 is active.

This PR explicitly disables V2 via both the UI setting and the experimental feature flag in the `evals_entity_analytics` Scout config set, so v1 evals can initialize and clean up the legacy risk engine without errors.

Extracted from #271346 to isolate the entity analytics fix.

## Test plan

- [ ] Trigger on-demand evals via [Buildkite](https://buildkite.com/elastic/kibana-evals-on-demand) with `EVAL_SUITE_ID=entity-analytics` and `EVAL_SERVER_CONFIG_SET=evals_entity_analytics` against this branch
- [ ] Verify `risk_score_engine_on` and `risk_score_engine_off` specs pass without 400 errors from legacy risk engine APIs


Made with [Cursor](https://cursor.com)