### PR TITLE
[kbn-ftr-common-functional-ui-services] Dismiss leaked beforeunload dialog before navigation and in suite hooks

### DIFF
--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser.test.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ToolingLog } from '@kbn/tooling-log';
+import { UnexpectedAlertOpenError } from 'selenium-webdriver/lib/error';
+import type { FtrProviderContext } from './ftr_provider_context';
+import { BrowserService } from './browser';
+
+describe('Browser#get', () => {
+  let log: ToolingLog;
+  let accept: jest.Mock;
+  let driver: { get: jest.Mock; switchTo: () => { alert: () => { accept: jest.Mock } } };
+
+  beforeEach(() => {
+    log = new ToolingLog();
+    jest.spyOn(log, 'warning').mockImplementation(() => {});
+    accept = jest.fn();
+    driver = { get: jest.fn(), switchTo: () => ({ alert: () => ({ accept }) }) };
+  });
+
+  const getBrowser = () => {
+    const ctx = { getService: () => log } as unknown as FtrProviderContext;
+    return new BrowserService(ctx, 'chrome', driver as any);
+  };
+
+  it('retries once and succeeds after dismissing a leaked dialog', async () => {
+    driver.get
+      .mockRejectedValueOnce(new UnexpectedAlertOpenError('unexpected alert open'))
+      .mockResolvedValueOnce(undefined);
+    accept.mockResolvedValue(undefined);
+
+    await getBrowser().get('http://localhost/app', false);
+
+    expect(driver.get).toHaveBeenCalledTimes(2);
+    expect(accept).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on an unrelated error', async () => {
+    driver.get.mockRejectedValueOnce(new Error('network error'));
+
+    await expect(getBrowser().get('http://localhost/app', false)).rejects.toThrow('network error');
+
+    expect(driver.get).toHaveBeenCalledTimes(1);
+    expect(accept).not.toHaveBeenCalled();
+  });
+
+  it('propagates the error if the dialog is still blocking after the retry', async () => {
+    driver.get.mockRejectedValue(new UnexpectedAlertOpenError('unexpected alert open'));
+    accept.mockResolvedValue(undefined);
+
+    await expect(getBrowser().get('http://localhost/app', false)).rejects.toThrow(
+      'unexpected alert open'
+    );
+
+    expect(driver.get).toHaveBeenCalledTimes(2);
+    expect(accept).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser.ts
@@ -35,7 +35,7 @@ export interface InterceptResponseFactory {
     responseOptions: Omit<Protocol.Fetch.FulfillRequestRequest, 'requestId'>
   ) => ['Fetch.fulfillRequest', Protocol.Fetch.FulfillRequestRequest];
 }
-class BrowserService extends FtrService {
+export class BrowserService extends FtrService {
   /**
    * Keyboard events
    */

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/dismiss_open_dialog.test.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/dismiss_open_dialog.test.ts
@@ -11,6 +11,7 @@ import type { WebDriver } from 'selenium-webdriver';
 import {
   InvalidArgumentError,
   NoSuchAlertError,
+  NoSuchSessionError,
   UnexpectedAlertOpenError,
 } from 'selenium-webdriver/lib/error';
 import { ToolingLog } from '@kbn/tooling-log';
@@ -41,6 +42,14 @@ describe('dismissOpenDialog', () => {
 
   it('is silent when there is no open dialog', async () => {
     const accept = jest.fn().mockRejectedValue(new NoSuchAlertError('no such alert'));
+
+    await dismissOpenDialog(makeDriver(accept), log);
+
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it('is silent when the session is already gone', async () => {
+    const accept = jest.fn().mockRejectedValue(new NoSuchSessionError('invalid session id'));
 
     await dismissOpenDialog(makeDriver(accept), log);
 

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/dismiss_open_dialog.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/dismiss_open_dialog.ts
@@ -8,7 +8,12 @@
  */
 
 import type { WebDriver } from 'selenium-webdriver';
-import { NoSuchAlertError, UnexpectedAlertOpenError } from 'selenium-webdriver/lib/error';
+import {
+  NoSuchAlertError,
+  NoSuchSessionError,
+  NoSuchWindowError,
+  UnexpectedAlertOpenError,
+} from 'selenium-webdriver/lib/error';
 import type { ToolingLog } from '@kbn/tooling-log';
 
 const UNEXPECTED_BEFOREUNLOAD_DIALOG = 'Unexpected dialog type beforeunload';
@@ -23,9 +28,15 @@ const UNEXPECTED_BEFOREUNLOAD_DIALOG = 'Unexpected dialog type beforeunload';
 export async function dismissOpenDialog(driver: WebDriver, log: ToolingLog): Promise<void> {
   try {
     await driver.switchTo().alert().accept();
-    log.warning('[webdriver] accepted an open browser dialog left behind by a previous spec');
+    log.warning('[webdriver] accepted an open browser dialog');
   } catch (error) {
-    if (!(error instanceof NoSuchAlertError)) {
+    if (
+      !(
+        error instanceof NoSuchAlertError ||
+        error instanceof NoSuchSessionError ||
+        error instanceof NoSuchWindowError
+      )
+    ) {
       log.warning(`[webdriver] failed to accept an open browser dialog: ${error.message}`);
     }
   }

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/remote.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/remote.ts
@@ -7,7 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { NoSuchSessionError, NoSuchWindowError } from 'selenium-webdriver/lib/error';
+import {
+  NoSuchAlertError,
+  NoSuchSessionError,
+  NoSuchWindowError,
+} from 'selenium-webdriver/lib/error';
 import type { FtrProviderContext } from '../ftr_provider_context';
 import type { BrowserConfig } from './webdriver';
 import { initWebDriver } from './webdriver';
@@ -95,6 +99,24 @@ export async function RemoteProvider({ getService }: FtrProviderContext) {
 
   lifecycle.afterTestSuite.add(async () => {
     await tryWebDriverCall(async () => {
+      // ChromeDriver 148+ throws InvalidArgumentError on any command when a
+      // beforeunload dialog is already open, even with unhandledPromptBehavior:
+      // 'accept' set (see #271881). Handle both cases:
+      //
+      // 1. Dialog is already open (triggered by a prior spec's cleanup
+      //    navigation) — dismiss it explicitly so subsequent commands can run.
+      try {
+        await driver.switchTo().alert().accept();
+      } catch (e) {
+        if (!(e instanceof NoSuchAlertError)) throw e;
+      }
+      // 2. No dialog yet but a leaked handler could fire — disarm it so the
+      //    commands below (setRect, clearBrowserStorage) can't trigger one.
+      try {
+        await driver.executeScript('window.onbeforeunload = null;');
+      } catch (_) {
+        // session may already be gone; ignore
+      }
       // global cleanup
       const { width, height } = windowSizeStack.shift()!;
       await driver.manage().window().setRect({ width, height });

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/remote.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/remote/remote.ts
@@ -91,9 +91,7 @@ export async function RemoteProvider({ getService }: FtrProviderContext) {
       return;
     }
     // a `beforeunload` dialog leaked by the previous suite blocks `getRect` below (#289092)
-    await tryWebDriverCall(async () => {
-      await dismissOpenDialog(driver, log);
-    });
+    await dismissOpenDialog(driver, log);
     windowSizeStack.unshift(await driver.manage().window().getRect());
   });
 


### PR DESCRIPTION
## Summary

ChromeDriver 148+ rejects every WebDriver window command with `InvalidArgumentError: Unexpected dialog type beforeunload` while a `beforeunload` dialog is open, even with `unhandledPromptBehavior: 'accept'` set. Once one spec leaks such a dialog the shared FTR session is wedged for the rest of the config. A single leak in `dashboard/group1` took down 11 suites in one run (https://github.com/elastic/kibana/issues/289085 to https://github.com/elastic/kibana/issues/289095).

### Root cause (ChromeDriver, branch 7977)

`prompt_behavior.h` defines the spec name `kBeforeUnload = "beforeUnload"`. CDP reports the dialog type as `"beforeunload"`. `PromptBehavior::GetConfiguration()` compares the two, never matches, and returns `"Unexpected dialog type " + dialog_type`. That check sits in `ExecuteWindowCommand`, which wraps navigate, refresh, getRect, executeScript and the CDP passthrough. Alert commands (`ExecuteAcceptAlert`) skip it and call `HandleDialog` directly, so accepting the dialog explicitly is the one command that can unwedge the session.

ChromeDriver normally auto-accepts `beforeunload` at dialog-open time (we do not use BiDi). The CI failure logs show the first navigation failing with `unexpected alert open: {Alert text : }` and every command after that with the broken error, so in CI that auto-accept did not take and the dialog stayed open.

### Where it bites

Not only teardown. In the `dashboard/group1` failures the previous suite left a dashboard in edit mode, its `after` hook only cleared cookies (`cookieLogin` path, no navigation), and the next suite's `navigateToApp()` was the first thing to trigger the dialog. `navigateToApp` then retried for its full 240s window before giving up.

## Changes

`kbn-ftr-common-functional-ui-services` only.

- New `dismissOpenDialog(driver, log)`: `switchTo().alert().accept()`, silent on `NoSuchAlertError`, logs a warning when a dialog was found or when accepting failed. The warning is deliberate: the next CI occurrence tells us whether accept works in the wedged state.
- `browser.get` / `browser.refresh` / `browser.navigateTo`: if the command fails with `UnexpectedAlertOpenError` or the ChromeDriver `Unexpected dialog type beforeunload` error, dismiss and retry once. Nothing else changes for other errors.
- `remote.ts`: dismiss in `beforeTestSuite` (protects `getRect`) as well as `afterTestSuite`. Both guarded by `lifecycle.isAborting` and `tryWebDriverCall`.
- Dropped the earlier `window.onbeforeunload = null` step. It does not remove `addEventListener` handlers, which is how Dashboard registers its handler, so it never did anything.

Happy path cost is two extra `alert()` probes per suite (before and after).

## Testing

- Unit tests for the helper and the error matcher (`dismiss_open_dialog.test.ts`).
- Type check, lint.
- Standalone selenium repro against chromedriver 152.0.7977.42 and the CI build 152.0.7977.75 confirmed the auto-accept path, and that `window.onbeforeunload = null` does not disarm `addEventListener` handlers.
- Flaky test runner on `x-pack/platform/test/functional/apps/dashboard/group1/config.ts` and `x-pack/platform/test/accessibility/apps/group3/config.ts` to be triggered from this PR.

Related: https://github.com/elastic/kibana/issues/271881, https://github.com/elastic/kibana/issues/273688, https://github.com/elastic/kibana/issues/289092, https://github.com/elastic/kibana/issues/257667



<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->