### PR TITLE
[9.4] fix(agent-builder): prevent proxy timeouts from large index mappings and improve abort error UX (#273388)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_error/request_aborted_round_error.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_error/request_aborted_round_error.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const RequestAbortedRoundError: React.FC = () => {
+  return (
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      data-test-subj="agentBuilderRoundErrorRequestAborted"
+    >
+      <EuiFlexItem grow={false}>
+        <EuiText size="s">
+          <p>
+            <FormattedMessage
+              id="xpack.agentBuilder.round.error.requestAborted.description"
+              defaultMessage="The request was interrupted before the model could complete its response. This typically happens when a tool returns a very large amount of data, such as index mappings with many fields. Try narrowing your question or using a more specific index pattern."
+            />
+          </p>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_error/round_error.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_error/round_error.test.tsx
@@ -14,6 +14,7 @@ import {
   HookLifecycle,
 } from '@kbn/agent-builder-common';
 import {
+  createRequestAbortedError,
   createWorkflowAbortedError,
   createWorkflowExecutionError,
 } from '@kbn/agent-builder-common/base/errors';
@@ -72,6 +73,16 @@ describe('RoundError', () => {
     expect(screen.getByTestId('agentBuilderErrorWorkflow')).toBeInTheDocument();
     expect(screen.queryByTestId('thinkingPanel')).not.toBeInTheDocument();
     expect(screen.queryByTestId('roundSteps')).not.toBeInTheDocument();
+  });
+
+  it('shows request aborted error inside the reasoning error panel', () => {
+    const error = createRequestAbortedError('Converse request was aborted');
+
+    renderWithIntl(<RoundError error={error} onRetry={onRetry} />);
+
+    expect(screen.getByTestId('agentBuilderRoundErrorRequestAborted')).toBeInTheDocument();
+    expect(screen.getByTestId('reasoningErrorPanel')).toBeInTheDocument();
+    expect(screen.queryByTestId('agentBuilderGenericRoundError')).not.toBeInTheDocument();
   });
 
   it('shows generic errors inside the thinking panel', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_error/round_error.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_error/round_error.tsx
@@ -10,6 +10,7 @@ import type { ConversationRoundStep } from '@kbn/agent-builder-common';
 import {
   isContextLengthExceededAgentError,
   isHooksExecutionError,
+  isRequestAbortedError,
   isWorkflowAbortedError,
   isWorkflowExecutionError,
 } from '@kbn/agent-builder-common';
@@ -17,6 +18,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { ContextExceededRoundError } from './context_exceeded_round_error';
+import { RequestAbortedRoundError } from './request_aborted_round_error';
 import { WorkflowError } from './workflow_error';
 import { HookError } from './hook_error';
 import { GenericRoundError } from './generic_round_error';
@@ -33,6 +35,7 @@ const shouldShowThinkingPanel = (error: unknown): boolean => {
 
 const renderErrorContent = (error: unknown): React.ReactNode => {
   if (isContextLengthExceededAgentError(error)) return <ContextExceededRoundError />;
+  if (isRequestAbortedError(error)) return <RequestAbortedRoundError />;
   if (isHooksExecutionError(error)) return <HookError error={error} />;
   if (isWorkflowExecutionError(error)) {
     return (

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts
@@ -28,6 +28,34 @@ const formatField = (field: MappingField): string => {
   return `- ${field.path} [${field.type}]${description}`;
 };
 
+const toFlatField = ({ path, type, tsDimension, tsMetric }: MappingField) => ({
+  path,
+  type,
+  ...(tsDimension === true ? { tsDimension: true } : {}),
+  ...(tsMetric != null ? { tsMetric } : {}),
+});
+
+const FIELD_LIMIT = 500;
+
+const truncationNote = (totalFields: number): string =>
+  `Truncated: showing ${FIELD_LIMIT} of ${totalFields} fields. Use a more specific index pattern to retrieve full mappings.`;
+
+interface MappingNodeProps {
+  properties?: Record<string, MappingNodeProps>;
+  fields?: Record<string, MappingNodeProps>;
+}
+
+const countMappingNodes = (properties: Record<string, MappingNodeProps> | undefined): number => {
+  if (!properties) return 0;
+  let count = 0;
+  for (const value of Object.values(properties)) {
+    count++;
+    count += countMappingNodes(value.properties);
+    count += countMappingNodes(value.fields);
+  }
+  return count;
+};
+
 export const getIndexMappingsTool = (): BuiltinToolDefinition<typeof getIndexMappingsSchema> => {
   return {
     id: platformCoreTools.getIndexMapping,
@@ -45,16 +73,45 @@ export const getIndexMappingsTool = (): BuiltinToolDefinition<typeof getIndexMap
 
       const resources = Object.fromEntries(
         Object.entries(indexFields).map(([name, v]) => {
-          if (raw && v.rawMapping) {
-            return [name, { type: v.type, mappings: v.rawMapping }];
-          }
+          const totalFields = v.fields.length;
+          const truncated = totalFields > FIELD_LIMIT;
+          const cappedFields = truncated ? v.fields.slice(0, FIELD_LIMIT) : v.fields;
+
           if (raw) {
+            if (v.rawMapping) {
+              const rawNodeCount = countMappingNodes(
+                v.rawMapping.properties as Record<string, MappingNodeProps>
+              );
+              if (rawNodeCount <= FIELD_LIMIT) {
+                return [name, { type: v.type, mappings: v.rawMapping }];
+              }
+              return [
+                name,
+                {
+                  type: v.type,
+                  fields: cappedFields.map(toFlatField),
+                  warning: truncated
+                    ? truncationNote(totalFields)
+                    : `Raw mapping tree has ${rawNodeCount} nodes (limit: ${FIELD_LIMIT}). Showing flat field list instead.`,
+                },
+              ];
+            }
+
             return [
               name,
-              { type: v.type, fields: v.fields.map(({ path, type }) => ({ path, type })) },
+              {
+                type: v.type,
+                fields: v.fields.map(({ path, type }) => ({ path, type })),
+                ...(truncated ? { warning: truncationNote(totalFields) } : {}),
+              },
             ];
           }
-          return [name, { type: v.type, fields: v.fields.map(formatField).join('\n') }];
+
+          const formatted = cappedFields.map(formatField).join('\n');
+          const fieldString = truncated
+            ? `${formatted}\n[${truncationNote(totalFields)}]`
+            : formatted;
+          return [name, { type: v.type, fields: fieldString }];
         })
       );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(agent-builder): prevent proxy timeouts from large index mappings and improve abort error UX (#273388)](https://github.com/elastic/kibana/pull/273388)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexandra Shatova","email":"alexandra.shatova@elastic.co"},"sourceCommit":{"committedDate":"2026-06-16T15:52:02Z","message":"fix(agent-builder): prevent proxy timeouts from large index mappings and improve abort error UX (#273388)\n\n## Summary\n\nFixes a production incident ([SDH\n#1891](https://github.com/elastic/sdh-search/issues/1891)) where users\nbuilding dashboards in Discover received a generic \"model freeze\" error\nwith no actionable information.\n\n**Root cause chain:**\n1. The AI agent called `get_index_mapping` with `raw: true` on an index\nwith a 131,217-line mapping (`logs-gcp.audit-default`)\n2. Kibana took 24–42 seconds to process and stream the response\n3. The Cloud proxy dropped the connection due to timeout\n4. `AbortMonitor` detected the disconnect and propagated `\"Converse\nrequest was aborted\"`\n5. The frontend had no handler for `requestAborted` errors and fell\nthrough to the generic \"model freeze\" fallback\n\nTwo independent bugs, both fixed here.\n\n---\n\n## Changes\n\n### 1. `get_index_mapping` tool — cap response at 500 fields\n\n**File:**\n`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts`\n\n- Added `FIELD_LIMIT = 500` cap on all mapping responses\n- For `raw: false`: formatted field string is truncated to 500 entries\nwith an appended note\n- For `raw: true`: the raw mapping tree is returned only when its total\nnode count is ≤ 500; otherwise falls back to a flat field list with a\nwarning\n- **Critical fix:** the guard uses `countMappingNodes` (counts ALL tree\nnodes including intermediate `object`/`nested` containers) rather than\n`v.fields.length` (which only counts typed leaf nodes via\n`flattenMapping`). An index with 400 leaf fields and 1,000 nested object\ncontainers has `v.fields.length = 400` but `countMappingNodes = 1,400` —\nusing `v.fields.length` alone would bypass the guard and return the full\ntree\n\n**Supporting helpers added:**\n- `truncationNote(totalFields)` — shared warning string, used in both\nraw and non-raw branches\n- `toFlatField(field)` — extracted projection lambda, eliminates\nduplication across raw branches\n- `countMappingNodes(properties)` — recursive node counter that includes\ntypeless intermediate containers\n\n### 2. `get_index_mapping` tool — tests\n\n**File:**\n`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.test.ts`\n\n12 tests covering:\n- Under/over/at-exactly FIELD_LIMIT for both `raw: true` and `raw:\nfalse`\n- `rawMapping` node-count gate: index with 510 intermediate containers\nbut 1 leaf field correctly falls back to flat list\n- Intermediate containers within limit: returns raw tree as expected\n- `tsDimension`, `tsMetric`, and `meta.description` field variants\npreserved through truncation paths\n\n### 3. Frontend — dedicated error component for `requestAborted`\n\n**Files:**\n- `request_aborted_round_error.tsx` *(new)*\n- `round_error.tsx` — added `isRequestAbortedError` check before generic\nfallback\n- `round_error.test.tsx` — added test verifying routing and panel\nwrapping\n\n**Before:** any connection drop → \"Something in the query caused the\nmodel to freeze mid-thought\"\n\n**After:** connection drop → \"The request was interrupted before the\nmodel could complete its response. This typically happens when a tool\nreturns a very large amount of data, such as index mappings with many\nfields. Try narrowing your question or using a more specific index\npattern.\"\n\nThe `requestAborted` error code already existed in\n`AgentBuilderErrorCode` and `isRequestAbortedError` was already exported\nfrom `@kbn/agent-builder-common` — it was simply never wired into the\nfrontend error router.\n\n## Notes\n\n- `getIndexFields()` in `@kbn/agent-builder-genai-utils` still fetches\nthe full `_mapping` response from ES unconditionally before truncation\noccurs. For extremely large indices this causes a memory spike and slow\nES response. This is a separate architectural concern tracked as a\nfollow-up.\n- `FIELD_LIMIT = 500` was chosen conservatively. A formatted flat field\nlist at 500 entries is ~12 kB — well within any proxy timeout threshold.\nThe constant is named and can be adjusted based on observed LLM\nreasoning quality.\n\nCloses: [SDH #1891](https://github.com/elastic/sdh-search/issues/1891)\nRelated: https://github.com/elastic/kibana/issues/256074","sha":"2b8bd1cfaf7a835f58cb3a0c772931e9104d7695","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:agent-builder","v9.5.0","v9.4.1"],"title":"fix(agent-builder): prevent proxy timeouts from large index mappings and improve abort error UX","number":273388,"url":"https://github.com/elastic/kibana/pull/273388","mergeCommit":{"message":"fix(agent-builder): prevent proxy timeouts from large index mappings and improve abort error UX (#273388)\n\n## Summary\n\nFixes a production incident ([SDH\n#1891](https://github.com/elastic/sdh-search/issues/1891)) where users\nbuilding dashboards in Discover received a generic \"model freeze\" error\nwith no actionable information.\n\n**Root cause chain:**\n1. The AI agent called `get_index_mapping` with `raw: true` on an index\nwith a 131,217-line mapping (`logs-gcp.audit-default`)\n2. Kibana took 24–42 seconds to process and stream the response\n3. The Cloud proxy dropped the connection due to timeout\n4. `AbortMonitor` detected the disconnect and propagated `\"Converse\nrequest was aborted\"`\n5. The frontend had no handler for `requestAborted` errors and fell\nthrough to the generic \"model freeze\" fallback\n\nTwo independent bugs, both fixed here.\n\n---\n\n## Changes\n\n### 1. `get_index_mapping` tool — cap response at 500 fields\n\n**File:**\n`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts`\n\n- Added `FIELD_LIMIT = 500` cap on all mapping responses\n- For `raw: false`: formatted field string is truncated to 500 entries\nwith an appended note\n- For `raw: true`: the raw mapping tree is returned only when its total\nnode count is ≤ 500; otherwise falls back to a flat field list with a\nwarning\n- **Critical fix:** the guard uses `countMappingNodes` (counts ALL tree\nnodes including intermediate `object`/`nested` containers) rather than\n`v.fields.length` (which only counts typed leaf nodes via\n`flattenMapping`). An index with 400 leaf fields and 1,000 nested object\ncontainers has `v.fields.length = 400` but `countMappingNodes = 1,400` —\nusing `v.fields.length` alone would bypass the guard and return the full\ntree\n\n**Supporting helpers added:**\n- `truncationNote(totalFields)` — shared warning string, used in both\nraw and non-raw branches\n- `toFlatField(field)` — extracted projection lambda, eliminates\nduplication across raw branches\n- `countMappingNodes(properties)` — recursive node counter that includes\ntypeless intermediate containers\n\n### 2. `get_index_mapping` tool — tests\n\n**File:**\n`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.test.ts`\n\n12 tests covering:\n- Under/over/at-exactly FIELD_LIMIT for both `raw: true` and `raw:\nfalse`\n- `rawMapping` node-count gate: index with 510 intermediate containers\nbut 1 leaf field correctly falls back to flat list\n- Intermediate containers within limit: returns raw tree as expected\n- `tsDimension`, `tsMetric`, and `meta.description` field variants\npreserved through truncation paths\n\n### 3. Frontend — dedicated error component for `requestAborted`\n\n**Files:**\n- `request_aborted_round_error.tsx` *(new)*\n- `round_error.tsx` — added `isRequestAbortedError` check before generic\nfallback\n- `round_error.test.tsx` — added test verifying routing and panel\nwrapping\n\n**Before:** any connection drop → \"Something in the query caused the\nmodel to freeze mid-thought\"\n\n**After:** connection drop → \"The request was interrupted before the\nmodel could complete its response. This typically happens when a tool\nreturns a very large amount of data, such as index mappings with many\nfields. Try narrowing your question or using a more specific index\npattern.\"\n\nThe `requestAborted` error code already existed in\n`AgentBuilderErrorCode` and `isRequestAbortedError` was already exported\nfrom `@kbn/agent-builder-common` — it was simply never wired into the\nfrontend error router.\n\n## Notes\n\n- `getIndexFields()` in `@kbn/agent-builder-genai-utils` still fetches\nthe full `_mapping` response from ES unconditionally before truncation\noccurs. For extremely large indices this causes a memory spike and slow\nES response. This is a separate architectural concern tracked as a\nfollow-up.\n- `FIELD_LIMIT = 500` was chosen conservatively. A formatted flat field\nlist at 500 entries is ~12 kB — well within any proxy timeout threshold.\nThe constant is named and can be adjusted based on observed LLM\nreasoning quality.\n\nCloses: [SDH #1891](https://github.com/elastic/sdh-search/issues/1891)\nRelated: https://github.com/elastic/kibana/issues/256074","sha":"2b8bd1cfaf7a835f58cb3a0c772931e9104d7695"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273388","number":273388,"mergeCommit":{"message":"fix(agent-builder): prevent proxy timeouts from large index mappings and improve abort error UX (#273388)\n\n## Summary\n\nFixes a production incident ([SDH\n#1891](https://github.com/elastic/sdh-search/issues/1891)) where users\nbuilding dashboards in Discover received a generic \"model freeze\" error\nwith no actionable information.\n\n**Root cause chain:**\n1. The AI agent called `get_index_mapping` with `raw: true` on an index\nwith a 131,217-line mapping (`logs-gcp.audit-default`)\n2. Kibana took 24–42 seconds to process and stream the response\n3. The Cloud proxy dropped the connection due to timeout\n4. `AbortMonitor` detected the disconnect and propagated `\"Converse\nrequest was aborted\"`\n5. The frontend had no handler for `requestAborted` errors and fell\nthrough to the generic \"model freeze\" fallback\n\nTwo independent bugs, both fixed here.\n\n---\n\n## Changes\n\n### 1. `get_index_mapping` tool — cap response at 500 fields\n\n**File:**\n`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts`\n\n- Added `FIELD_LIMIT = 500` cap on all mapping responses\n- For `raw: false`: formatted field string is truncated to 500 entries\nwith an appended note\n- For `raw: true`: the raw mapping tree is returned only when its total\nnode count is ≤ 500; otherwise falls back to a flat field list with a\nwarning\n- **Critical fix:** the guard uses `countMappingNodes` (counts ALL tree\nnodes including intermediate `object`/`nested` containers) rather than\n`v.fields.length` (which only counts typed leaf nodes via\n`flattenMapping`). An index with 400 leaf fields and 1,000 nested object\ncontainers has `v.fields.length = 400` but `countMappingNodes = 1,400` —\nusing `v.fields.length` alone would bypass the guard and return the full\ntree\n\n**Supporting helpers added:**\n- `truncationNote(totalFields)` — shared warning string, used in both\nraw and non-raw branches\n- `toFlatField(field)` — extracted projection lambda, eliminates\nduplication across raw branches\n- `countMappingNodes(properties)` — recursive node counter that includes\ntypeless intermediate containers\n\n### 2. `get_index_mapping` tool — tests\n\n**File:**\n`x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.test.ts`\n\n12 tests covering:\n- Under/over/at-exactly FIELD_LIMIT for both `raw: true` and `raw:\nfalse`\n- `rawMapping` node-count gate: index with 510 intermediate containers\nbut 1 leaf field correctly falls back to flat list\n- Intermediate containers within limit: returns raw tree as expected\n- `tsDimension`, `tsMetric`, and `meta.description` field variants\npreserved through truncation paths\n\n### 3. Frontend — dedicated error component for `requestAborted`\n\n**Files:**\n- `request_aborted_round_error.tsx` *(new)*\n- `round_error.tsx` — added `isRequestAbortedError` check before generic\nfallback\n- `round_error.test.tsx` — added test verifying routing and panel\nwrapping\n\n**Before:** any connection drop → \"Something in the query caused the\nmodel to freeze mid-thought\"\n\n**After:** connection drop → \"The request was interrupted before the\nmodel could complete its response. This typically happens when a tool\nreturns a very large amount of data, such as index mappings with many\nfields. Try narrowing your question or using a more specific index\npattern.\"\n\nThe `requestAborted` error code already existed in\n`AgentBuilderErrorCode` and `isRequestAbortedError` was already exported\nfrom `@kbn/agent-builder-common` — it was simply never wired into the\nfrontend error router.\n\n## Notes\n\n- `getIndexFields()` in `@kbn/agent-builder-genai-utils` still fetches\nthe full `_mapping` response from ES unconditionally before truncation\noccurs. For extremely large indices this causes a memory spike and slow\nES response. This is a separate architectural concern tracked as a\nfollow-up.\n- `FIELD_LIMIT = 500` was chosen conservatively. A formatted flat field\nlist at 500 entries is ~12 kB — well within any proxy timeout threshold.\nThe constant is named and can be adjusted based on observed LLM\nreasoning quality.\n\nCloses: [SDH #1891](https://github.com/elastic/sdh-search/issues/1891)\nRelated: https://github.com/elastic/kibana/issues/256074","sha":"2b8bd1cfaf7a835f58cb3a0c772931e9104d7695"}},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->