### PR TITLE
[Significant Events] Polish Knowledge Indicators & Rules tables 

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/knowledge_indicators_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/knowledge_indicators_table.tsx
@@ -301,11 +301,18 @@ export function KnowledgeIndicatorsTable() {
         <EuiInMemoryTable<KnowledgeIndicator>
           css={css`
             min-width: 700px;
+
+            & thead tr {
+              background-color: ${euiTheme.colors.backgroundBaseSubdued};
+            }
           `}
           items={filteredKnowledgeIndicators}
           itemId={getKnowledgeIndicatorItemId}
           columns={columns}
           loading={isOperationInProgress}
+          rowProps={(ki: KnowledgeIndicator) => ({
+            isSelected: selectedKnowledgeIndicatorId === getKnowledgeIndicatorItemId(ki),
+          })}
           selection={{
             selected: selectedKnowledgeIndicators,
             onSelectionChange: setSelectedKnowledgeIndicators,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
@@ -6,7 +6,14 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiBadge, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiToolTip,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { KnowledgeIndicator } from '@kbn/streams-ai';
 import { QUERY_TYPE_STATS } from '@kbn/streams-schema';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
@@ -58,12 +58,17 @@ export const useKnowledgeIndicatorsColumns = ({
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  data-test-subj="knowledgeIndicatorsDetailsButton"
-                  iconType={isExpanded ? 'minimize' : 'expand'}
-                  aria-label={isExpanded ? MINIMIZE_DETAILS_ARIA_LABEL : VIEW_DETAILS_ARIA_LABEL}
-                  onClick={() => toggleSelectedKnowledgeIndicator(ki)}
-                />
+                <EuiToolTip
+                  content={isExpanded ? MINIMIZE_DETAILS_ARIA_LABEL : VIEW_DETAILS_ARIA_LABEL}
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    data-test-subj="knowledgeIndicatorsDetailsButton"
+                    iconType={isExpanded ? 'minimize' : 'expand'}
+                    aria-label={isExpanded ? MINIMIZE_DETAILS_ARIA_LABEL : VIEW_DETAILS_ARIA_LABEL}
+                    onClick={() => toggleSelectedKnowledgeIndicator(ki)}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiLink onClick={() => toggleSelectedKnowledgeIndicator(ki)}>{title}</EuiLink>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
@@ -51,8 +51,6 @@ export const useKnowledgeIndicatorsColumns = ({
     () => [
       {
         name: TITLE_COLUMN_LABEL,
-        truncateText: true,
-        width: '20em',
         render: (ki: KnowledgeIndicator) => {
           const title = getKnowledgeIndicatorTitle(ki);
           const isExpanded = selectedKnowledgeIndicatorId === getKnowledgeIndicatorItemId(ki);
@@ -76,7 +74,8 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: EVENTS_COLUMN_LABEL,
-        width: '7em',
+        width: '160px',
+        align: 'center',
         render: (ki: KnowledgeIndicator) => {
           if (ki.kind !== 'query' || !ki.rule.backed) {
             return null;
@@ -101,7 +100,7 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: TYPE_COLUMN_LABEL,
-        width: '7.5em',
+        width: '192px',
         render: (ki: KnowledgeIndicator) => {
           if (ki.kind === 'feature') {
             return (
@@ -119,14 +118,14 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: STREAM_COLUMN_LABEL,
-        width: '9.5em',
+        width: '192px',
         render: (ki: KnowledgeIndicator) => {
           return <EuiBadge color="hollow">{getKnowledgeIndicatorStreamName(ki)}</EuiBadge>;
         },
       },
       {
         name: ACTIONS_COLUMN_LABEL,
-        width: '4em',
+        width: '96px',
         align: 'right',
         render: (ki: KnowledgeIndicator) => (
           <KnowledgeIndicatorActionsCell

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/queries_table/queries_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/queries_table/queries_table.tsx
@@ -244,7 +244,6 @@ export function QueriesTable() {
       {
         field: 'query.title',
         name: TITLE_COLUMN,
-        truncateText: true,
         render: (_: unknown, item: SignificantEventQueryRow) => (
           <EuiLink onClick={() => handleSelectQuery(item)}>{item.query.title}</EuiLink>
         ),
@@ -260,7 +259,7 @@ export function QueriesTable() {
       {
         field: 'occurrences',
         name: LAST_OCCURRED_COLUMN,
-        width: '240px',
+        width: '180px',
         render: (_: unknown, item: SignificantEventQueryRow) => {
           if (item.query.type === QUERY_TYPE_STATS && !item.rule_backed) {
             return (
@@ -275,8 +274,7 @@ export function QueriesTable() {
       {
         field: 'occurrences',
         name: OCCURRENCES_COLUMN,
-        width: '160px',
-        align: 'center',
+        width: '120px',
         render: (_: unknown, item: SignificantEventQueryRow) => {
           return (
             <SparkPlot

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/queries_table/queries_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/queries_table/queries_table.tsx
@@ -17,6 +17,7 @@ import {
   EuiPanel,
   EuiText,
   EuiTitle,
+  EuiToolTip,
   useEuiTheme,
   type CriteriaWithPagination,
   type EuiBasicTableColumn,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/queries_table/queries_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/queries_table/queries_table.tsx
@@ -232,12 +232,14 @@ export function QueriesTable() {
         render: (_: unknown, item: SignificantEventQueryRow) => {
           const isSelected = selectedQuery?.query.id === item.query.id;
           return (
-            <EuiButtonIcon
-              data-test-subj="queriesDiscoveryDetailsButton"
-              iconType={isSelected ? 'minimize' : 'maximize'}
-              aria-label={DETAILS_BUTTON_ARIA_LABEL}
-              onClick={() => handleSelectQuery(item)}
-            />
+            <EuiToolTip content={DETAILS_BUTTON_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                data-test-subj="queriesDiscoveryDetailsButton"
+                iconType={isSelected ? 'minimize' : 'maximize'}
+                aria-label={DETAILS_BUTTON_ARIA_LABEL}
+                onClick={() => handleSelectQuery(item)}
+              />
+            </EuiToolTip>
           );
         },
       },


### PR DESCRIPTION
## Summary

Visual improvement PR to align tables of KIs and Rules. Fixed:

- `Fix` the selection (checkbox) and other content columns no longer rescale with the viewport only the title column flexes.
- `Fix` long titles wrap to multiple lines instead of being truncated with an ellipsis.
- `Improvement` rows whose details flyout is open are now visually highlighted (selected-row state), matching the Rules table.
- `Improvement` sparkline (Events) column is sized and centered identically to the Trend column in the Rules table.
- `Cleanup` column widths use px consistently across both tables.


Final result:
<img width="7848" height="2568" alt="image" src="https://github.com/user-attachments/assets/89b8caff-d580-4915-9c26-298c5dac5b01" />
