### PR TITLE
[One Workflow] Avoid hashing handlers for the custom step approval process

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/server/routes/get_step_definitions.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/routes/get_step_definitions.test.ts
@@ -72,8 +72,9 @@ describe('registerGetStepDefinitionsRoute', () => {
     expect((body as { steps: unknown[] }).steps).toEqual([]);
   });
 
-  it('produces different hashes for different handler implementations', async () => {
+  it('ignores handler implementation when computing the hash', async () => {
     const stepRegistry = new ServerStepRegistry(logger);
+    // Same contract (no schemas/metadata), different handler implementations.
     stepRegistry.register({ id: 'a.step', handler: async () => ({ output: 'a' }) } as any);
     stepRegistry.register({ id: 'b.step', handler: async () => ({ output: 'b' }) } as any);
 
@@ -86,7 +87,7 @@ describe('registerGetStepDefinitionsRoute', () => {
 
     const { body } = response.ok.mock.calls[0][0]!;
     const { steps } = body as { steps: Array<{ id: string; definitionHash: string }> };
-    expect(steps[0].definitionHash).not.toBe(steps[1].definitionHash);
+    expect(steps[0].definitionHash).toBe(steps[1].definitionHash);
   });
 
   it('produces different hashes when only the schema differs', async () => {
@@ -115,12 +116,25 @@ describe('registerGetStepDefinitionsRoute', () => {
     expect(steps[0].definitionHash).not.toBe(steps[1].definitionHash);
   });
 
-  it('logs an error when failed to compute definition hash', async () => {
+  it('logs an error and returns a fallback hash when hashing fails', async () => {
     const stepRegistry = new ServerStepRegistry(logger);
-    stepRegistry.register({ id: 'a.step', handler: async () => ({ output: 'a' }) } as any);
-    stepRegistry.register({ id: 'b.step', handler: async () => ({ output: 'b' }) } as any);
+    // z.date() is unrepresentable in JSON Schema and makes z.toJSONSchema throw.
+    stepRegistry.register({
+      id: 'a.step',
+      handler: async () => ({ output: 'a' }),
+      inputSchema: z.date(),
+    } as any);
 
     const testRouter = httpServiceMock.createRouter();
     registerGetStepDefinitionsRoute(testRouter, stepRegistry, logger);
+
+    const [, handler] = testRouter.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { steps } = body as { steps: Array<{ id: string; definitionHash: string }> };
+    expect(steps[0].definitionHash).toBe('definition-hashing-error');
+    expect(logger.error).toHaveBeenCalled();
   });
 });

--- a/src/platform/plugins/shared/workflows_extensions/server/routes/get_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/routes/get_step_definitions.ts
@@ -29,9 +29,15 @@ function schemaToJson(schema?: z.ZodType): unknown {
 }
 
 /**
- * Computes a hash over the entire step definition so changes to the schemas
- * (inputSchema/outputSchema/configSchema), handler/onCancel implementations, or
- * metadata are all detected. `id` is excluded since it's the lookup key.
+ * Computes a hash over the serializable contract of a step definition: its
+ * schemas (inputSchema/outputSchema/configSchema) and metadata. `id` is excluded
+ * since it's the lookup key.
+ *
+ * Function (handler/onCancel) implementations are intentionally NOT hashed: there is no
+ * reliable way to hash function behavior at runtime. `fn.toString()` misses logic
+ * in closed-over wrappers (e.g. `createCasesStepHandler`) and changes across
+ * builds/transpilation. Plugins own their implementations; the first registration
+ * is reviewed manually, and contract (schema/metadata) changes are caught here.
  */
 function computeDefinitionHash(definition: ServerStepDefinition, logger: Logger): string {
   const {
@@ -40,12 +46,9 @@ function computeDefinitionHash(definition: ServerStepDefinition, logger: Logger)
     category,
     stability,
     deprecation,
-    documentation,
     inputSchema,
     outputSchema,
     configSchema,
-    handler,
-    onCancel,
   } = definition;
 
   try {
@@ -55,12 +58,9 @@ function computeDefinitionHash(definition: ServerStepDefinition, logger: Logger)
       category,
       stability,
       deprecation,
-      documentation,
       inputSchema: schemaToJson(inputSchema),
       outputSchema: schemaToJson(outputSchema),
       configSchema: schemaToJson(configSchema),
-      handler: handler?.toString(),
-      onCancel: onCancel?.toString(),
     };
     return createSHA256Hash(stableStringify(canonical));
   } catch (error) {
@@ -96,7 +96,7 @@ export function registerGetStepDefinitionsRoute(
     async (_context, _request, response) => {
       const allStepDefinitions = registry.getAll();
       const steps = allStepDefinitions
-        // create a hash of the full definition to detect changes in schemas or implementation
+        // hash the serializable contract (schemas + metadata) to detect changes
         .map((definition) => ({
           id: definition.id,
           definitionHash: computeDefinitionHash(definition, logger),

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -26,174 +26,174 @@
 export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; definitionHash: string }> = [
   {
     id: 'ai.agent',
-    definitionHash: '61369039c2fe1fe7d1c32f9b378c3042d267200e6640a7a0f35de42fd2d98350',
+    definitionHash: '3cc20b70cda1a2ee2574acffc6ac28adb4a811b2c48dee3fc654a59f283877e3',
   },
   {
     id: 'ai.classify',
-    definitionHash: '8407ff204c11e5a92e8abf80ef4107055fca368c0db955f1ca282ad1120f90b7',
+    definitionHash: '42a6e085b66c6498204cb7f7667eebcef638e4fe8c591ae1ca73c301adc38fd5',
   },
   {
     id: 'ai.prompt',
-    definitionHash: '55e06b9c76f49b058af63146454d61f49b5c8f5055b34a2d2473825f67cfa95c',
+    definitionHash: '295d71e1ce9c2a28896122111efd68f0f4f321a8518bd8d7f12e28d30429d72c',
   },
   {
     id: 'ai.summarize',
-    definitionHash: 'e9e8f647b159477f7a86c66ad4360f99ecbe8e5a04a3dd890241c82e047f9f1c',
+    definitionHash: '491907dfcc9e2f3b5cffbe76fd085d12b1b4c2718abacc3725d1de00d73b8f0c',
   },
   {
     id: 'cases.addAlerts',
-    definitionHash: 'e7af7342bb64c98d6f800d9bd087895b190665fafa62dec4bbe7a9011eccbe63',
+    definitionHash: 'fd18727e9f55bad3a04cbb4b1bf9ff3eb183cb04e3d2d1e813773a15225199b3',
   },
   {
     id: 'cases.addComment',
-    definitionHash: 'b23896df7ed1d1b822ecc1a13d4f3870b522b1fb0e9f0e8b00830586b48cf865',
+    definitionHash: '103f1047c301f889627dfb1f7ae4b1697f8ba22116f39fc3f63083a7c956ea97',
   },
   {
     id: 'cases.addEvents',
-    definitionHash: '1ac93d32f2b9dbb846631d6a70a116eaf4aa5f63575fe266d3cc61e9c3e08cf3',
+    definitionHash: '67b7c36699c1ecf5e690da66830fc3639aa277df6c8f05921b15ac4e137b2893',
   },
   {
     id: 'cases.addObservables',
-    definitionHash: 'c48517c8bcd1bb522b3d2f26c548addccdf9380e053038ee461be01588870e10',
+    definitionHash: '71aefd7eab1c08d27aa92aed06e68ae1202b39062fbf3f0aaf9aeee59499d31d',
   },
   {
     id: 'cases.addTags',
-    definitionHash: '2712c32e51937cec6cd345d66199f2124552575cd62c82228e301e6e61556ee7',
+    definitionHash: 'eabdee1df0b39965f1b5118d54c600e3c9ff6329cd92920a0d53c2546a7411d5',
   },
   {
     id: 'cases.assignCase',
-    definitionHash: 'ea0a58b6b67da252a03da3b98f4f8a623898df562fb9d457067dbbd06b61a3f8',
+    definitionHash: '40a44fbce1272fa091f407b1901591ebb987aad867d37a50d4b1e5a870a3c5ce',
   },
   {
     id: 'cases.closeCase',
-    definitionHash: '14f14abe3112cc15825ea87ef3fbb4b83efd9c741a80470afabebac70fd22631',
+    definitionHash: 'bd7916c990b86b62b2574c1d49b831bdfd39e80f3d29ff3cb598fc7109d40a8d',
   },
   {
     id: 'cases.createCase',
-    definitionHash: '672366fbfea17a4cd1925cf670f54b88dff7fab1bc533310c82155a25c0633b1',
+    definitionHash: '92d92ccff73282eec34843f37cf3273ba6de77b023a546d0df1cac72c5dd101e',
   },
   {
     id: 'cases.createCaseFromTemplate',
-    definitionHash: '6d181f590abe24ed2bd90a96d9e9b550d69f91bf12483c6fe39131374a80f317',
+    definitionHash: 'bdf2bd00216b002143163f2ea80b4b274cf18a8c0347c790ae6cb2bb2c5355bf',
   },
   {
     id: 'cases.deleteCases',
-    definitionHash: '965740f2f3404fe6f6c6bbc00aee286d953979efde71ef70e6af6bb40471be11',
+    definitionHash: '99cb4b9014e4db6889b1b925a6da6c66e5c01e48b05a364449052500ef7e2b1e',
   },
   {
     id: 'cases.deleteObservable',
-    definitionHash: '6f487f2ebdcdd64c744d9ee12f3b568be6aa02fc1bf0cefe659dd6bca8fc7e7e',
+    definitionHash: '967d52e604185ae79718b5fa6264137dbd3cedabfd53af4027cea2ab41119b05',
   },
   {
     id: 'cases.findCases',
-    definitionHash: '965ebe10b4fa8a8eaf9b25a148d45f241f91641fc7a946e20828d86932d37faf',
+    definitionHash: 'c4edc5ca3dd6108e2d2b2b2b3d81a97201a6ab35a81f84b872dc9aa365ed7462',
   },
   {
     id: 'cases.findSimilarCases',
-    definitionHash: '7726628309927cae609e46418b58a74b6b561fd2e8201e4e35e70c3dfcb502a5',
+    definitionHash: '5501802c1b00ff42e81d419e976834cc2104f0be4515239eb6da9ce5ec9990c9',
   },
   {
     id: 'cases.getAllAttachments',
-    definitionHash: 'a0e3d2d3a13f7a7cbda809fbd229263a0eeb750d7d649eb413553d683b6dc4aa',
+    definitionHash: 'e61101efb7f75c14beff99452e368e57f42a6f3c0df76293c046f99314a23b13',
   },
   {
     id: 'cases.getCase',
-    definitionHash: 'f9c74d3d87ae6f2831ee6683630dfc8c5941af57f8a199c6348a561d34b7c1ca',
+    definitionHash: '334a5ce30df1b08feab7df9033643e9c9f65c53d0984adb57021800669652b89',
   },
   {
     id: 'cases.getCases',
-    definitionHash: '5d82b91d9026a593bdd4feb217b6d95806e4767c95057f6632fb05c886abc20d',
+    definitionHash: 'bbfa8fdd41c752db25cac0e57e1ff38274b439b88f2c038d53a8b7bd0d9eaa9c',
   },
   {
     id: 'cases.getCasesByAlertId',
-    definitionHash: 'bd5681887038f8f9f12925d5937e949b292249aa07e8c38ff3eb4853911a0fb6',
+    definitionHash: '01ef121556e7628fc07b81502f07e2c3239bbb1085fb26555d0c3a3e3f365806',
   },
   {
     id: 'cases.setCategory',
-    definitionHash: 'a78432b7b4396bb8ad9a6821ffbfdeef12135525e849ff48c70f5830ab6a18dc',
+    definitionHash: 'e80dd980810d77938866ef49418c7cd92cfaf2c0b529c59ea73518061ae8351c',
   },
   {
     id: 'cases.setCustomField',
-    definitionHash: '4743e7ebb05a662caa089c2596edf6887b0665f67073dede6de28fc696e108e1',
+    definitionHash: 'd8dd2ce700cc0258abb2f35d549c5afa317153f6dd8c36eb219c9ce0eb21d818',
   },
   {
     id: 'cases.setDescription',
-    definitionHash: '9a0c215cc18d148bb5adebaf05c0b5dccdfe19d2d23ce1e0a65ffad4319e1cc3',
+    definitionHash: '8040bdf85373f0ec1194b16d8de33e2f8b7fa573e0d0d61f0deb913e36890090',
   },
   {
     id: 'cases.setSeverity',
-    definitionHash: 'fd56121168eb7a421ae1abb7df157c1fa4caaf580c3237d3a1c049d3279c3e4d',
+    definitionHash: '544c5920b599ef08f5bcb977ef367cb8391d4a17f17b1f7e1650338a071d81d5',
   },
   {
     id: 'cases.setStatus',
-    definitionHash: '4aca8036029f78ff80f03d570bee29b99d80c1fbb3a6f852faab173f1d1f5f0c',
+    definitionHash: '838d840359dac89ceced05fa9800a19abe0bd2f1d217b6c0591fa343e71ba0c2',
   },
   {
     id: 'cases.setTitle',
-    definitionHash: '8801e5a666bb602080902eb3dbeb7f1f3ac30b8ade25d9b8970bebe4dda9e686',
+    definitionHash: '1106a298e8e5932d29dc1c6e19d9b0a21f472f9f4e17884e0ecf9d4fb0bcf8ce',
   },
   {
     id: 'cases.unassignCase',
-    definitionHash: '72528fca13e6d700b9f4b427f34fcd663de7544987d56b81f7c736ec29a0be9d',
+    definitionHash: 'e6b835da63bf370696bc596072fe9ef9bbcf1a2d3c39257df6575add2c1a3eda',
   },
   {
     id: 'cases.updateCase',
-    definitionHash: '60b60a7c5297bed7eb972023b0d9c79473e4fd74a3884003b5699897f2e723e4',
+    definitionHash: '8867b90de837c553df87760f5dc0dc04d9ec9f1308a53b389bfdc9c3369e05b5',
   },
   {
     id: 'cases.updateCases',
-    definitionHash: '449a100444a79338810d35c980ffd7bea989994c2f0b985a93dac55055a88d46',
+    definitionHash: '4628e05a3898d18b236fae1aae00e3eb8841c5b17960a2fe62f799f02dd3d981',
   },
   {
     id: 'cases.updateObservable',
-    definitionHash: 'f869b6ec966f20dea5849a5dc3704a260acf5adb2f405b2abd982220ac4d5cee',
+    definitionHash: '8ea2eb35798e8d96c5fa72e09f2d972f90f559328a2f21ada7f22911764f2611',
   },
   {
     id: 'contextEngine.addEntry',
-    definitionHash: 'fa99a999886acaf3f1d265deca68a061b6f3faff5a4660a51b53251d4034ba09',
+    definitionHash: '27066f4163f528c6fad426f1f8010303c61a067aa13014a2eb667b70adfd6a4a',
   },
   {
     id: 'data.aggregate',
-    definitionHash: '0bc378ad029c1bda64f5cccbf2eea1b49ab39d97edbc10e5c5eec738225d9fb6',
+    definitionHash: '2e91a3dc65f717b90c805e28b7e17c8229434647e3548a35900832f046a518ff',
   },
   {
     id: 'data.concat',
-    definitionHash: '1f0823873f56f116471918bba33ef23a0d74bd113e7622eebac379435bf75b89',
+    definitionHash: '1c3411a3433b1a051fc6ff24b89bf655ccfd6758f97732ee18f04e45f0013e03',
   },
   {
     id: 'data.dedupe',
-    definitionHash: 'a38e8a91e37074ca26888c2e6031b6cea5074aa7d2b688145edc4a72a5882b92',
+    definitionHash: '8885829b29be280571db6989965056bef7d4f938053b71c3a0ef4a4c152f07fd',
   },
   {
     id: 'data.filter',
-    definitionHash: '3f0453765900a7bd9efb2caaab696a1407de1dc15e7746a95079d55c9b70fdac',
+    definitionHash: 'ae5f130a3597dd9e26b771a7e53963e2c488dafcb1dd377902a857dcbbc222fa',
   },
   {
     id: 'data.find',
-    definitionHash: '5ef06fe7654b638c6889ec96a7a646f78c3628378bede1564d2a8c612f4372ff',
+    definitionHash: 'e0e415be61efab115ff3d2b4851ad7932554a19a58ca760cdde38aabb235ed33',
   },
   {
     id: 'data.map',
-    definitionHash: '01a51fe7acf4f5cf427059440ec31598d68c0e46ef11d82e45e151150556cad8',
+    definitionHash: '29af91190145cbc9b4a4e61f4c5176822422496890a9b7bae511a93db6d5261b',
   },
   {
     id: 'data.parseJson',
-    definitionHash: 'f2354927ea46792aeeeff4fa1861af49656e0bffb4c09cbfa590431f29c9cd1f',
+    definitionHash: 'd238d5ff4e8f0d64ee1a1e90fc6d3f93bb7ae9c23913506b1194c7cd7199b1a2',
   },
   {
     id: 'data.regexExtract',
-    definitionHash: '0312bd460e7ff8d2f7725d3e8f4c7d5d96ae606a9cc5901f02d09108466d596a',
+    definitionHash: 'ef999e26cd8b48149191a25319f0f2399ce921afedea5ef9218a442dc0bd710d',
   },
   {
     id: 'data.regexReplace',
-    definitionHash: '7cd36dc8b3f4f37bc87f7d2ca8b3588c37ff538fdf6925804ae3ca60fc1f9f6e',
+    definitionHash: '2ff24e8982417d09526c47659268add9210fb8b157201477ca074804fffae765',
   },
   {
     id: 'data.stringifyJson',
-    definitionHash: '6773f5c609999c0e8da36397dc1243aa94c2392a1f00ca2f084fd4d1fd2235e2',
+    definitionHash: 'ae09a6d6b6a815e50f039caef5ee8d403cc11c94f6b5ffb09eb04982645aaccd',
   },
   {
     id: 'search.rerank',
-    definitionHash: '9e032776f7f7342dd252eee237e17a89adf5185f515d4fa890560bb8a42d4601',
+    definitionHash: 'c989f0b20019b12079d797d11b122285552e3b863ef96aaddad81640f0c2a951',
   },
 ];

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/tests/step_definitions_approval.spec.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/tests/step_definitions_approval.spec.ts
@@ -13,8 +13,7 @@ import { expect } from '@kbn/scout/api';
 import { APPROVED_STEP_DEFINITIONS } from '../fixtures/approved_step_definitions';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
-// Failing: See https://github.com/elastic/kibana/issues/265012
-apiTest.describe.skip(
+apiTest.describe(
   'Workflows Extensions - Custom Step Definitions Approval',
   {
     tag: [


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/kibana/issues/265012

Fixes the custom step definitions approval check by avoiding hashing the step's _functions_, and relying only on the step's "contract" (input/output/config zod schemas + metadata).

Functions (`handler`/`onCancel`) **not** hashed: there's no reliable way to hash function behavior at runtime. The `fn.toString()` approach misses logic in closed-over wrappers (e.g. `createCasesStepHandler`) and changes across builds/transpilation. 
Plugins will now completely own their implementations. Only the first registration will be reviewed manually, and only contract (schema/metadata) changes will need to go through the approval process again.

## Changes

- `get_step_definitions.ts`: hash schemas (via `z.toJSONSchema`) + metadata with `stableStringify` + SHA-256; log + fallback hash on failure.
- Updated unit tests (handler changes are ignored, schema changes are detected, error path covered).
- Regenerated hashes in `approved_step_definitions.ts`.