### PR TITLE
fix(evals): switch entity analytics weekly run to v2 suite

### DIFF
--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -293,11 +293,11 @@ steps:
         env:
           KBN_EVALS: '1'
           FTR_EIS_CCM: '1'
-          EVAL_SUITE_ID: 'entity-analytics'
+          EVAL_SUITE_ID: 'entity-analytics-v2'
           EVAL_FANOUT: '1'
           EVAL_INCLUDE_EIS_MODELS: '1'
           EVAL_MODEL_GROUPS: *weekly_eis_core_models
-          EVAL_SERVER_CONFIG_SET: 'evals_entity_analytics'
+          EVAL_SERVER_CONFIG_SET: 'evals_entity_analytics_v2'
         timeout_in_minutes: 60
         agents:
           image: family/kibana-ubuntu-2404


### PR DESCRIPTION
## Summary

- Switches the weekly LLM evals pipeline from `entity-analytics` (v1) to `entity-analytics-v2`
- Updates `EVAL_SERVER_CONFIG_SET` from `evals_entity_analytics` to `evals_entity_analytics_v2`

The v2 server config enables the Entity Store V2 experimental flags:
- `securitySolution:entityStoreEnableV2=true`
- `enableExperimental=["entityAnalyticsEntityStoreV2"]`

Without these flags the weekly run was executing v1 tests against a v1-configured server instead of the v2 test suite (`evals/v2/`) with the required feature flags.

## Test plan

- [ ] Verify weekly pipeline triggers correctly on next Monday run
- [ ] Confirm `entity-analytics-v2` suite resolves via `evals.suites.json` (`playwright.v2.config.ts` → `evals/v2/`)
- [ ] Confirm Scout server starts with v2 feature flags enabled