### PR TITLE
[Scout][FTR migration] Make migration skill conservative with constants

### DIFF
--- a/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -50,6 +50,7 @@ Checklist items are tagged with the document they're detailed in:
 Open only the docs relevant to the test type(s) under review.
 
 - **[general]** **Reuse-first**: prefer existing `pageObjects`, fixtures, and `apiServices`; if adding helpers/page objects, place them in the right scope (plugin vs solution vs `@kbn/scout`) and register via fixtures.
+- **[general]** **No unused constants**: flag constants that are unused or used in only one place — prefer inlining them.
 - **[api]** **Fixture boundaries**: `apiClient` for the endpoint under test; `apiServices`/`kbnClient` for setup/teardown only; correct auth + common headers.
 - **[api]** **Correctness**: guardrail assertions before dereferencing response fields; validate contract + side effects; stable error assertions.
 - **[ui]** **UI scope**: UI tests should focus on user interactions and rendering; avoid “data correctness” assertions (for example exact API response shapes or exact table cell values) unless the UI behavior depends on them. Prefer Scout API tests (or unit/integration) for data correctness coverage.

--- a/.agents/skills/scout-migrate-from-ftr/references/execute-plan.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/execute-plan.md
@@ -59,7 +59,7 @@ FTR **deployment-agnostic** configs often load the same files under both statefu
 
 API and UI specs should both carry tags that match the intended `run-tests` / CI targets; see step 9.
 
-**Tags are always inline.** Never wrap tags in a named constant. Never change an existing tag constant's value to fit a different suite. Apply per-issue tag instructions inline and only to the tests specified.
+**Prefer tags inline.** Avoid wrapping tags in a named constant unless the same tag set is reused across multiple suites. Never change an existing tag constant's value to fit a different suite. Apply per-issue tag instructions inline and only to the tests specified.
 
 ### 3) Translate the test structure
 

--- a/.agents/skills/scout-migrate-from-ftr/references/execute-plan.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/execute-plan.md
@@ -59,6 +59,8 @@ FTR **deployment-agnostic** configs often load the same files under both statefu
 
 API and UI specs should both carry tags that match the intended `run-tests` / CI targets; see step 9.
 
+**Tags are always inline.** Never wrap tags in a named constant. Never change an existing tag constant's value to fit a different suite. Apply per-issue tag instructions inline and only to the tests specified.
+
 ### 3) Translate the test structure
 
 - `describe/it` -> `test.describe/test` or `apiTest.describe/apiTest` (but don't assume 1:1 `it` -> `test`).
@@ -130,7 +132,7 @@ For general Scout API auth patterns (`requestAuth`, `samlAuth`, common headers, 
 ### 6) Add helpers and constants
 
 - Put shared helpers in `test/scout*/ui/fixtures/helpers.ts` (or API helpers in API fixtures).
-- Add test-subject constants in `fixtures/constants.ts` for reuse across tests and page objects.
+- Add test-subject constants in `fixtures/constants.ts` for reuse across tests and page objects. For other shared values (archive paths, time ranges, etc.), follow the plan's "Shared constants to extract" list rather than introducing new constants during execution.
 - For `parallel_tests/` ingestion, use `parallel_tests/global.setup.ts` + `globalSetupHook` (no `esArchiver` in spec files).
 - For suite-wide Elasticsearch/Kibana state reset (e.g. reverting feature flags or global `uiSettings`, dropping hand-indexed data that affects other Scout configs sharing the cluster), use the **optional** `globalTeardownHook` in `parallel_tests/global.teardown.ts`. Picked up automatically when `runGlobalSetup: true` — no extra config flag. Use `esClient.indices.delete` / `deleteDataStream` / `deleteByQuery`, `kbnClient.uiSettings.unset(...)`, and `apiServices.core.settings(...)` to reset state. Per-test/per-suite cleanup still belongs in `afterEach`/`afterAll`.
 

--- a/.agents/skills/scout-migrate-from-ftr/references/generate-plan.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/generate-plan.md
@@ -81,7 +81,7 @@ For each archive, data fixture, or setup pattern found:
 3. **Classify setup timing**: can data be loaded once (shared across all tests) or does each test need fresh data?
 4. **Flag fresh-server tests**: tests that require a completely clean ES/Kibana state (candidates for a dedicated server config)
 5. **Catalog UI settings mutations**: list every `kibanaServer.uiSettings.replace`, `uiSettings.update`, `uiSettings.delete` call, which tests use them, and whether they use replace-all semantics (wipes all settings) vs selective set
-6. **Catalog repeated magic values**: archive paths, index names, time ranges, saved object IDs that appear in multiple files. These are candidates for a shared constants file.
+6. **Catalog repeated magic values**: archive paths, index names, time ranges, saved object IDs that appear in multiple files. These are candidates for a shared constants file. Never propose constants for deployment tags; they are always used inline.
 
 ### 6. Auth and roles
 

--- a/.agents/skills/scout-migrate-from-ftr/references/generate-plan.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/generate-plan.md
@@ -81,7 +81,7 @@ For each archive, data fixture, or setup pattern found:
 3. **Classify setup timing**: can data be loaded once (shared across all tests) or does each test need fresh data?
 4. **Flag fresh-server tests**: tests that require a completely clean ES/Kibana state (candidates for a dedicated server config)
 5. **Catalog UI settings mutations**: list every `kibanaServer.uiSettings.replace`, `uiSettings.update`, `uiSettings.delete` call, which tests use them, and whether they use replace-all semantics (wipes all settings) vs selective set
-6. **Catalog repeated magic values**: archive paths, index names, time ranges, saved object IDs that appear in multiple files. These are candidates for a shared constants file. Never propose constants for deployment tags; they are always used inline.
+6. **Catalog repeated magic values**: archive paths, index names, time ranges, saved object IDs that appear in multiple files. Be conservative: only propose a constant when the value is genuinely reused and extracting it removes real duplication; prefer inline otherwise. Avoid proposing constants for deployment tags unless the same tag set is reused across multiple suites.
 
 ### 6. Auth and roles
 

--- a/.agents/skills/scout-migrate-from-ftr/references/plan-template.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/plan-template.md
@@ -109,7 +109,7 @@ Files that test multiple roles or unrelated flows and should become separate spe
 
 ### Shared constants to extract (omit if empty)
 
-Values that appear in ≥2 files and should live in a shared constants file:
+Values reused across ≥2 files **where extracting removes real duplication** (multi-file occurrence alone isn't enough — prefer inline). Exclude deployment tags and values already exported from a plugin's `common/`/`server/` (import those instead):
 
 | Value | Occurrences | Current locations |
 |-------|-------------|-------------------|

--- a/.agents/skills/scout-migrate-from-ftr/references/plan-template.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/plan-template.md
@@ -107,7 +107,7 @@ Files that test multiple roles or unrelated flows and should become separate spe
 | `kibanaServer.uiSettings.replace({...})` | Wipes all settings, then sets new values | `index.ts:15` |
 | `kibanaServer.uiSettings.update({timepicker: ...})` | Merges into existing settings | `time_filter.ts:8` |
 
-### Shared constants to extract
+### Shared constants to extract (omit if empty)
 
 Values that appear in ≥2 files and should live in a shared constants file:
 


### PR DESCRIPTION
## Summary

Addresses [elastic/appex-qa-team#932](https://github.com/elastic/appex-qa-team/issues/932): feedback that the FTR-to-Scout migration skill was "constant-happy".

Reported problems:
- Proposed tag-alias constants, e.g. `DISCOVER_DEPLOYMENT_AGNOSTIC = tags.deploymentAgnostic`.
- Created constants that were not actually shared between tests.
- Mutated an existing tag constant's value to satisfy a per-issue tag instruction, silently re-tagging every spec importing it (and re-tagging all suites when only a restricted set was intended).

Changes (skill docs only — no code/tests):
- **generate-plan**: never propose constants for deployment tags; they are always used inline.
- **plan-template**: mark the "Shared constants to extract" section `(omit if empty)`, matching the template's existing optional-section convention.
- **execute-plan 2**: tags are always inline — never wrap tags in a named constant, never change an existing tag constant's value, and apply per-issue tag instructions only to the specified tests.
- **execute-plan 6**: follow the plan's reviewed "Shared constants to extract" list rather than introducing new constants during execution (preserves the human plan-review step).

Constants intentionally **stay in the migration plan** so they remain reviewable before execution, per the discussion in the linked issue's thread.