### PR TITLE
[9.4] [Search] [Homepage] Update default workflow UI setting value to true (#267814)

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/moon.yml
+++ b/x-pack/solutions/search/plugins/search_homepage/moon.yml
@@ -52,6 +52,7 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/cloud'
   - '@kbn/agent-builder-plugin'
+  - '@kbn/workflows-ui'
   - '@kbn/scout-search'
 tags:
   - plugin

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/metric_panels.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/metric_panels.tsx
@@ -21,6 +21,7 @@ import {
 import { css } from '@emotion/react';
 import type { SharePublicStart } from '@kbn/share-plugin/public/plugin';
 import type { ApplicationStart } from '@kbn/core/public';
+import { getWorkflowsCapabilities } from '@kbn/workflows-ui';
 import { WORKFLOWS_UI_SETTING_ENABLED_ID } from '../../../common';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useKibana } from '../../hooks/use_kibana';
@@ -203,23 +204,25 @@ const MetricPanelEmpty = ({ panel }: MetricPanelEmptyProps) => {
 export const MetricPanels = () => {
   const { hasEnterpriseLicense } = useGetLicenseInfo();
   const { services } = useKibana();
-  const { chrome, uiSettings } = services;
+  const { application, chrome, uiSettings } = services;
 
-  const isWorkflowsUiEnabled = uiSettings.get<boolean>(WORKFLOWS_UI_SETTING_ENABLED_ID, false);
+  const isWorkflowsUiEnabled = uiSettings.get<boolean>(WORKFLOWS_UI_SETTING_ENABLED_ID, true);
+  const { canReadWorkflow } = getWorkflowsCapabilities(application.capabilities);
 
   const panels = useMemo(() => {
     const capabilityChecks: Record<MetricPanelType, boolean> = {
       discover: chrome.navLinks.get('discover') !== undefined,
       dashboards: chrome.navLinks.get('dashboards') !== undefined,
       agentBuilder: chrome.navLinks.get('agent_builder') !== undefined && hasEnterpriseLicense,
-      workflows: isWorkflowsUiEnabled && chrome.navLinks.get('workflows') !== undefined,
+      workflows:
+        isWorkflowsUiEnabled && canReadWorkflow && chrome.navLinks.get('workflows') !== undefined,
       machineLearning:
         chrome.navLinks.get('ml:overview') !== undefined || chrome.navLinks.get('ml') !== undefined,
       dataManagement: chrome.navLinks.get('management:index_management') !== undefined,
     };
 
     return METRIC_PANEL_ITEMS.filter((panel) => capabilityChecks[panel.type]);
-  }, [chrome.navLinks, isWorkflowsUiEnabled, hasEnterpriseLicense]);
+  }, [chrome.navLinks, isWorkflowsUiEnabled, canReadWorkflow, hasEnterpriseLicense]);
 
   const gridColumns = useMemo(() => {
     const count = panels.length;

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_admin.spec.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_admin.spec.ts
@@ -104,7 +104,7 @@ test.describe(
     // === Navigation Cards Tests ===
     test('navigation cards should navigate to correct places', async ({ pageObjects, page }) => {
       const navigationCards = await pageObjects.homepage.getNavigationCards();
-      await expect(navigationCards).toHaveCount(5);
+      await expect(navigationCards).toHaveCount(6);
 
       const navCardTests = [
         {
@@ -126,6 +126,10 @@ test.describe(
         {
           cardTestId: 'searchHomepageNavLinks-dataManagement',
           expectedUrl: 'index_management',
+        },
+        {
+          cardTestId: 'searchHomepageNavLinks-workflows',
+          expectedUrl: 'workflows',
         },
       ];
 

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_data_management_user.spec.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_data_management_user.spec.ts
@@ -48,8 +48,7 @@ spaceTest.describe(
       }
     );
 
-    // TODO: Unskip when Workflows sidenav visibility bug is fixed
-    spaceTest.skip(
+    spaceTest(
       'should only see Data Management in primary sidenav',
       async ({ page, pageObjects }) => {
         const { collapsibleNav } = pageObjects;

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_viewer.spec.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_viewer.spec.ts
@@ -31,7 +31,7 @@ test.describe(
 
     test('Navigation cards should navigate to correct places', async ({ pageObjects, page }) => {
       const navigationCards = await pageObjects.homepage.getNavigationCards();
-      await expect(navigationCards).toHaveCount(4);
+      await expect(navigationCards).toHaveCount(5);
 
       const navCardTests = [
         {
@@ -49,6 +49,10 @@ test.describe(
         {
           cardTestId: 'searchHomepageNavLinks-machineLearning',
           expectedUrl: 'ml/overview',
+        },
+        {
+          cardTestId: 'searchHomepageNavLinks-workflows',
+          expectedUrl: 'workflows',
         },
       ];
 

--- a/x-pack/solutions/search/plugins/search_homepage/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_homepage/tsconfig.json
@@ -46,6 +46,7 @@
     "@kbn/data-views-plugin",
     "@kbn/cloud",
     "@kbn/agent-builder-plugin",
+    "@kbn/workflows-ui",
     "@kbn/scout-search",
   ],
   "exclude": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Search] [Homepage] Update default workflow UI setting value to true (#267814)](https://github.com/elastic/kibana/pull/267814)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2026-06-17T13:33:21Z","message":"[Search] [Homepage] Update default workflow UI setting value to true (#267814)\n\n## Summary\n\nThis PR updates the default value for the UI setting to show/hide the\nworkflow metric panel to `true`. It also updates the Workflows\ncapability check to use the `getWorkflowsCapabilities` hook, as\nWorkflows never sets `AppStatus.inaccessible` so\n`chrome.navLinks.get('workflows')` never equals `undefined`.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1dfcb50f10d01b3218dcdbb55ba9d0bd5689ed06","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:version","v9.4.0","v9.5.0"],"title":"[Search] [Homepage] Update default workflow UI setting value to true","number":267814,"url":"https://github.com/elastic/kibana/pull/267814","mergeCommit":{"message":"[Search] [Homepage] Update default workflow UI setting value to true (#267814)\n\n## Summary\n\nThis PR updates the default value for the UI setting to show/hide the\nworkflow metric panel to `true`. It also updates the Workflows\ncapability check to use the `getWorkflowsCapabilities` hook, as\nWorkflows never sets `AppStatus.inaccessible` so\n`chrome.navLinks.get('workflows')` never equals `undefined`.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1dfcb50f10d01b3218dcdbb55ba9d0bd5689ed06"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267814","number":267814,"mergeCommit":{"message":"[Search] [Homepage] Update default workflow UI setting value to true (#267814)\n\n## Summary\n\nThis PR updates the default value for the UI setting to show/hide the\nworkflow metric panel to `true`. It also updates the Workflows\ncapability check to use the `getWorkflowsCapabilities` hook, as\nWorkflows never sets `AppStatus.inaccessible` so\n`chrome.navLinks.get('workflows')` never equals `undefined`.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1dfcb50f10d01b3218dcdbb55ba9d0bd5689ed06"}}]}] BACKPORT-->