### PR TITLE
[Scout][FTR migration] Encourage using Scout's default test server config

### DIFF
--- a/.agents/skills/scout-migrate-from-ftr/references/execute-plan.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/execute-plan.md
@@ -28,7 +28,7 @@ The plan answers _what_ and _why_; this file answers _how_.
 - `parallel_tests/`: ingest via `parallel_tests/global.setup.ts` + `globalSetupHook` (don't use `esArchiver` in spec files).
 - Use the correct Scout package for the test location (`@kbn/scout` vs `@kbn/scout-security`/`@kbn/scout-oblt`/`@kbn/scout-search`) and import `expect` from `/ui` or `/api`.
 - **TypeScript layout for Scout tests** (pick one; see **Where Scout tests are typechecked** under step 6): either fold `test/scout/**/*` into the **plugin root** `tsconfig.json` and add Scout `kbn_references` (like `discover_enhanced`), or keep **dedicated** `test/scout/{ui,api}/tsconfig.json` files. Only the latter forbids relative imports into `server/` / `public/`.
-- Replace FTR config nesting / per-suite server args with `uiSettings` / `scoutSpace.uiSettings` and (when needed) `apiServices.core.settings(...)`.
+- **Prefer Scout's default servers config**: replace FTR config nesting / per-suite server args with `uiSettings` / `scoutSpace.uiSettings` and (when needed) `apiServices.core.settings(...)` runtime settings. Only create a custom server config set when the plan calls for it (a setting that must apply at Kibana boot) — custom configs run only in local pipelines (no Cloud) and add CI cost.
 - Auth/roles are fixture-driven: `browserAuth` (UI), `requestAuth` (API key), `samlAuth` (cookie / `cookieHeader`), plus custom roles. Avoid FTR-style role mutation. For Scout **API** tests, see **Scout API auth (`cookieHeader` vs API key)** under step 4.
 
 ## Core workflow

--- a/.agents/skills/scout-migrate-from-ftr/references/generate-plan.md
+++ b/.agents/skills/scout-migrate-from-ftr/references/generate-plan.md
@@ -104,11 +104,13 @@ The execution step will decide the specific Scout auth API to use; the plan just
 
 ### 8. Server configuration and feature flags
 
+**Prefer Scout's default servers config.** It mirrors the Elastic Cloud (MKI/ECH) setup and is batched with other default-config suites in CI, so tests that pass locally on it are likely to pass on Cloud. A custom server config set runs only in local pipelines (no Cloud) and adds CI cost — treat it as a last resort, used only when a setting must be present at Kibana boot (e.g. registering HTTP routes at plugin `setup`). See [Can your tests reuse Scout's default servers config?](../../../../docs/extend/scout/migrate-tests.md#dont-migrate-blindly).
+
 1. **List every server arg** from `kbnTestServer.serverArgs` and `esTestCluster.serverArgs` across all relevant configs (including inherited base configs)
 2. **Classify each arg**:
    - **Already in Scout's default server config**: no action needed
-   - **Runtime-settable** (can be changed via API/UI settings without restarting servers): note which API or setting key
-   - **Requires server config**: needs a custom Scout server config set. Check if a matching one already exists under `src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/`
+   - **Runtime-settable** (can be changed via API/UI settings without restarting servers): note which API or setting key. Most FTR server args land here — map them to `apiServices.core.settings()` runtime feature flags, the `uiSettings` fixture, or data ingestion rather than a custom config
+   - **Requires a custom server config set**: only when the arg must apply at Kibana boot. Check if a matching one already exists under `src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/`
 3. **Flag experimental feature flags** and note whether they're compile-time or runtime-settable
 
 ### 9. Deployment targets and Cloud portability
@@ -127,7 +129,7 @@ For each test group, answer all four:
    - Node topology assumptions (single-node, specific port)
    - Cluster settings unavailable on Elastic Cloud
    - Custom server args / feature flags set in FTR configs (these need to become runtime settings or move to a Scout server config set)
-4. **Custom servers config or default?** State whether the migrated tests can use Scout's default test servers config, or whether they need a [custom servers config](../../../../docs/extend/scout/feature-flags.md#scout-feature-flags-custom-servers). If custom, list which args force the choice and whether a matching config set already exists.
+4. **Custom servers config or default?** Default to Scout's default test servers config (see step 8 for why); only call for a [custom servers config](../../../../docs/extend/scout/feature-flags.md#scout-feature-flags-custom-servers) when a server arg must apply at Kibana boot. If custom, list which args force the choice and whether a matching config set already exists.
 
 ### 10. FTR test smells
 


### PR DESCRIPTION
## Summary

Addresses [elastic/appex-qa-team#933](https://github.com/elastic/appex-qa-team/issues/933): the FTR-to-Scout migration skill describes the default-vs-custom server config choice **neutrally**, when most migrated Playwright configs should reuse Scout's **default** test servers config.

Per the [migration guide](https://www.elastic.co/docs/extend/kibana/scout/migrate-tests#dont-migrate-blindly), the default config is recommended because:
- It mirrors the Elastic Cloud (MKI/ECH) setup, so tests passing locally are likely to pass on Cloud and can run in the Elastic Cloud pipelines.
- Default-config suites are batched together via the lanes test-distribution strategy — no dedicated custom server setup needed.
- Easier to understand — no need to track which custom server args a suite requires.

Changes (skill docs only — no code/tests):
- **generate-plan 8**: lead with a "prefer Scout's default servers config" principle (with rationale + the boot-time criterion + a link to the guide) and tighten arg classification so most FTR args map to runtime settings (`apiServices.core.settings()`, `uiSettings`, data ingestion) rather than a custom config.
- **generate-plan 9.4**: default to the default servers config; only call for a custom config when a server arg must apply at Kibana boot.
- **execute-plan**: reinforce default-first when replacing FTR config nesting / per-suite server args; custom config sets are a last resort.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->