### PR TITLE
[One Workflow] Add external waitForInput resume via publicApiAccess and API key routes - Approach II

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/examples/example_external_hitl.yml
+++ b/src/platform/packages/shared/kbn-workflows/spec/examples/example_external_hitl.yml
@@ -1,0 +1,47 @@
+name: External HITL approval demo
+description: Mint an external resume URL, notify via Slack, then pause on waitForInput.
+enabled: true
+tags: [demo, external-hitl]
+
+triggers:
+  - type: manual
+    inputs:
+      properties:
+        slackChannel:
+          type: string
+          default: '#one-workflows-playground'
+
+steps:
+  - name: mint-public-access
+    type: workflows.publicApiAccess
+    with:
+      ttl: 1h
+
+  - name: notify-slack
+    type: slack
+    connector-id: slack
+    with:
+      message: |
+        Workflow approval required.
+        <{{ steps.mint-public-access.output.resumeUrl }}&approved=true&comment=Approved|Approve>
+        <{{ steps.mint-public-access.output.resumeUrl }}&approved=false&comment=Declined|Decline>
+ 
+  - name: request-approval
+    type: waitForInput
+    with:
+      message: Approve this workflow run from an external link.
+      externalResumeApiKeyId: '{{ steps.mint-public-access.output.apiKeyId }}'
+      schema:
+        properties:
+          approved:
+            type: boolean
+          comment:
+            type: string
+        required:
+          - approved
+
+  - name: record-response
+    type: data.set
+    with:
+      approved: '{{ steps.request-approval.output.approved }}'
+      comment: '{{ steps.request-approval.output.comment }}'

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -201,6 +201,12 @@ export const WaitForInputStepInputSchema = z
     schema: JsonModelSchema.optional().describe(
       'JSON Schema describing the expected input payload. Used for validation, autocomplete, and default values in the resume UI'
     ),
+    externalResumeApiKeyId: z
+      .string()
+      .optional()
+      .describe(
+        'API key id from a workflows.publicApiAccess step output. Binds external resume requests to this waitForInput pause.'
+      ),
   })
   .optional();
 export const WaitForInputStepSchema = BaseStepSchema.extend({

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -1221,7 +1221,8 @@ export class WorkflowsExecutionEnginePlugin
       executionId,
       spaceId,
       input,
-      request
+      request,
+      options
     ) => {
       await checkLicense(plugins.licensing);
 
@@ -1257,17 +1258,16 @@ export class WorkflowsExecutionEnginePlugin
         );
       }
 
-      const resumedBy = await getAuthenticatedUser(
-        request,
-        coreStart.security,
-        coreStart.elasticsearch.client
-      );
+      const resumedAt = options?.resumedAt ?? new Date().toISOString();
+      const resumedBy =
+        options?.resumedBy ??
+        (await getAuthenticatedUser(request, coreStart.security, coreStart.elasticsearch.client));
 
       const resumeContext = {
         ...workflowExecution.context,
         resumeInput: input,
         resumedBy,
-        resumedAt: new Date().toISOString(),
+        resumedAt,
       };
 
       await internalResumeWorkflowExecution(executionId, spaceId, resumeContext, request);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_for_input_step/README.md
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_for_input_step/README.md
@@ -17,6 +17,7 @@ steps:
 - **`type`**: Must be `"waitForInput"`
 - **`with.message`**: Message displayed to the human reviewer (optional)
 - **`with.schema`**: JSON Schema describing the expected input payload (optional). When provided, the resume UI renders validation and autocomplete from the schema, and default values are pre-filled
+- **`with.externalResumeApiKeyId`**: API key id from a prior `workflows.publicApiAccess` step. Binds external resume requests to this pause (for example `{{ steps.mint-public-access.output.apiKeyId }}`).
 
 ## Execution Flow
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_for_input_step/wait_for_input_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_for_input_step/wait_for_input_step.test.ts
@@ -117,6 +117,31 @@ describe('WaitForInputStepImpl', () => {
       });
     });
 
+    it('should persist externalResumeApiKeyId from the with block', async () => {
+      node.configuration.with = {
+        message: 'Approve',
+        externalResumeApiKeyId: '{{ steps.mint.output.apiKeyId }}',
+      } as WaitForInputStep['with'];
+      (
+        mockStepExecutionRuntime.contextManager.renderValueAccordingToContext as jest.Mock
+      ).mockImplementation((v: unknown) =>
+        v === '{{ steps.mint.output.apiKeyId }}' ? 'api-key-id' : v
+      );
+
+      underTest = new WaitForInputStepImpl(
+        node,
+        mockStepExecutionRuntime,
+        mockWorkflowRuntime,
+        workflowLogger
+      );
+      await underTest.run();
+
+      expect(mockStepExecutionRuntime.setInput).toHaveBeenCalledWith({
+        message: 'Approve',
+        externalResumeApiKeyId: 'api-key-id',
+      });
+    });
+
     it('should not call setInput when the with block is absent', async () => {
       node.configuration = {
         name: 'wait-for-input-step',
@@ -338,6 +363,17 @@ describe('WaitForInputStepSchema', () => {
     const result = WaitForInputStepSchema.safeParse({
       name: 'approve',
       type: 'waitForInput',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept externalResumeApiKeyId on the with block', () => {
+    const result = WaitForInputStepSchema.safeParse({
+      name: 'approve',
+      type: 'waitForInput',
+      with: {
+        externalResumeApiKeyId: '{{ steps.mint.output.apiKeyId }}',
+      },
     });
     expect(result.success).toBe(true);
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_for_input_step/wait_for_input_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_for_input_step/wait_for_input_step.ts
@@ -50,6 +50,11 @@ export class WaitForInputStepImpl implements NodeImplementation {
             message: ctx.renderValueAccordingToContext(withConfig.message),
           }),
           ...(withConfig.schema !== undefined && { schema: withConfig.schema }),
+          ...(withConfig.externalResumeApiKeyId !== undefined && {
+            externalResumeApiKeyId: ctx.renderValueAccordingToContext(
+              withConfig.externalResumeApiKeyId
+            ),
+          }),
         });
       }
       this.workflowLogger.logDebug(`Step '${this.node.stepId}' is waiting for human input`, {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -42,6 +42,11 @@ export interface ResumeWorkflowExecutionResponse {
   resumedBy: string;
 }
 
+export interface ResumeWorkflowExecutionOptions {
+  resumedBy?: string;
+  resumedAt?: string;
+}
+
 export interface WorkflowsExecutionEnginePluginSetup {
   // No setup contract exposed yet. Extend this interface when other plugins need to configure the engine during setup.
   [key: string]: unknown;
@@ -114,7 +119,8 @@ export type ResumeWorkflowExecution = (
   executionId: string,
   spaceId: string,
   input: Record<string, unknown>,
-  request: KibanaRequest
+  request: KibanaRequest,
+  options?: ResumeWorkflowExecutionOptions
 ) => Promise<ResumeWorkflowExecutionResponse>;
 
 export type InternalResumeWorkflowExecution = (

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -193,6 +193,10 @@ export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; definitionHash: stri
     definitionHash: '6773f5c609999c0e8da36397dc1243aa94c2392a1f00ca2f084fd4d1fd2235e2',
   },
   {
+    id: 'workflows.publicApiAccess',
+    definitionHash: 'f50346b6b4f1fa5e087456baf0360b34304e33198b23980c4214496ff6834b54',
+  },
+  {
     id: 'search.rerank',
     definitionHash: '9e032776f7f7342dd252eee237e17a89adf5185f515d4fa890560bb8a42d4601',
   },

--- a/src/platform/plugins/shared/workflows_management/common/external_resume/build_external_resume_url.ts
+++ b/src/platform/plugins/shared/workflows_management/common/external_resume/build_external_resume_url.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export function buildExternalResumeUrl({
+  kibanaUrl,
+  spaceId,
+  executionId,
+  encodedApiKey,
+}: {
+  kibanaUrl: string;
+  spaceId: string;
+  executionId: string;
+  encodedApiKey: string;
+}): string {
+  const spacePrefix = spaceId === 'default' ? '' : `/s/${spaceId}`;
+  const url = new URL(
+    `${kibanaUrl}${spacePrefix}/api/workflows/executions/${executionId}/resume/external`
+  );
+  url.searchParams.set('apiKey', encodedApiKey);
+  return url.toString();
+}

--- a/src/platform/plugins/shared/workflows_management/common/external_resume/constants.ts
+++ b/src/platform/plugins/shared/workflows_management/common/external_resume/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const EXTERNAL_RESUME_API_PATH =
+  '/api/workflows/executions/{executionId}/resume/external' as const;
+
+export const WORKFLOW_EXTERNAL_RESUME_ROLE = 'workflow_external_resume' as const;
+
+export const WORKFLOW_EXTERNAL_RESUME_APPLICATION = 'kibana-workflows' as const;
+
+export const DEFAULT_EXTERNAL_RESUME_TTL = '1h' as const;
+
+export const MAX_EXTERNAL_RESUME_TTL_MS = 24 * 60 * 60 * 1000;

--- a/src/platform/plugins/shared/workflows_management/common/lib/parse_duration.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/parse_duration.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export function parseDuration(duration: string): number {
+  const units = {
+    ms: 1,
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+    w: 7 * 24 * 60 * 60 * 1000,
+  };
+
+  let total = 0;
+  const validDurationRegex = /^(?:(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?(\d+ms)?)$/;
+  const orderValidationRegex = /^(?:\d+w)?(?:\d+d)?(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$/;
+
+  if (
+    !duration ||
+    typeof duration !== 'string' ||
+    !validDurationRegex.test(duration) ||
+    !orderValidationRegex.test(duration)
+  ) {
+    throw new Error(
+      `Invalid duration format: ${duration}. Use format like "1w2d3h4m5s6ms" with units in descending order.`
+    );
+  }
+
+  const durationComponentsRegex = /(\d+)(ms|s|m|h|d|w)(?![a-zA-Z])/g;
+  let match;
+  while ((match = durationComponentsRegex.exec(duration)) !== null) {
+    const value = Number(match[1]);
+    const unit = match[2];
+    const multiplier = units[unit as keyof typeof units];
+    total += value * multiplier;
+  }
+  return total;
+}

--- a/src/platform/plugins/shared/workflows_management/common/steps/public_api_access_step.ts
+++ b/src/platform/plugins/shared/workflows_management/common/steps/public_api_access_step.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { StepCategory } from '@kbn/workflows';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { z } from '@kbn/zod/v4';
+
+export const PublicApiAccessStepTypeId = 'workflows.publicApiAccess' as const;
+
+export const PublicApiAccessInputSchema = z.object({
+  ttl: z
+    .string()
+    .optional()
+    .describe('Short-lived API key lifetime (for example "1h"). Defaults to 1h, max 24h.'),
+});
+
+export const PublicApiAccessOutputSchema = z.object({
+  apiKeyId: z.string(),
+  resumeUrl: z.string(),
+  ttl: z.string(),
+  expiresAt: z.string().optional(),
+});
+
+export type PublicApiAccessStepInput = z.infer<typeof PublicApiAccessInputSchema>;
+export type PublicApiAccessStepOutput = z.infer<typeof PublicApiAccessOutputSchema>;
+
+export const publicApiAccessStepCommonDefinition: CommonStepDefinition<
+  typeof PublicApiAccessInputSchema,
+  typeof PublicApiAccessOutputSchema
+> = {
+  id: PublicApiAccessStepTypeId,
+  category: StepCategory.Kibana,
+  label: i18n.translate('workflowsManagement.publicApiAccessStep.label', {
+    defaultMessage: 'Public API access',
+  }),
+  description: i18n.translate('workflowsManagement.publicApiAccessStep.description', {
+    defaultMessage:
+      'Create short-lived credentials for unauthenticated public Workflows API access (for example external resume links).',
+  }),
+  inputSchema: PublicApiAccessInputSchema,
+  outputSchema: PublicApiAccessOutputSchema,
+  documentation: {
+    details: `# Public API access
+
+Mint a short-lived API key and external resume URL for the current workflow execution.
+
+## Example
+
+\`\`\`yaml
+- name: mint-public-access
+  type: workflows.publicApiAccess
+  with:
+    ttl: 1h
+
+- name: notify-slack
+  type: slack_api
+  with:
+    message: "Approve: {{ steps.mint-public-access.output.resumeUrl }}&approved=true"
+
+- name: approval
+  type: waitForInput
+  with:
+    externalResumeApiKeyId: "{{ steps.mint-public-access.output.apiKeyId }}"
+    schema:
+      properties:
+        approved:
+          type: boolean
+      required:
+        - approved
+\`\`\`
+`,
+  },
+};

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -112,6 +112,9 @@ dependsOn:
   - '@kbn/inbox-plugin'
   - '@kbn/inbox-common'
   - '@kbn/datemath'
+  - '@kbn/core-http-server-utils'
+  - '@kbn/core-spaces-common'
+  - '@kbn/crypto'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_management/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.ts
@@ -35,6 +35,7 @@ import type {
   WorkflowsPublicPluginStartDependencies,
   WorkflowsServices,
 } from './types';
+import { registerWorkflowManagementSteps } from './workflows';
 import { getWorkflowsAppDeepLinks } from './workflows_app_deep_links';
 import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { stepSchemas } from '../common/step_schemas';
@@ -71,6 +72,8 @@ export class WorkflowsPlugin
     core: CoreSetup<WorkflowsPublicPluginStartDependencies, WorkflowsPublicPluginStart>,
     plugins: WorkflowsPublicPluginSetupDependencies
   ): WorkflowsPublicPluginSetup {
+    registerWorkflowManagementSteps(plugins.workflowsExtensions);
+
     // Initialize telemetry service
     this.telemetryService.setup({ analytics: core.analytics });
 

--- a/src/platform/plugins/shared/workflows_management/public/steps/public_api_access_step.ts
+++ b/src/platform/plugins/shared/workflows_management/public/steps/public_api_access_step.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { publicApiAccessStepCommonDefinition } from '../../common/steps/public_api_access_step';
+
+export const publicApiAccessStepDefinition = createPublicStepDefinition({
+  ...publicApiAccessStepCommonDefinition,
+});

--- a/src/platform/plugins/shared/workflows_management/public/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/types.ts
@@ -25,7 +25,10 @@ import type {
   TriggersAndActionsUIPublicPluginStart,
 } from '@kbn/triggers-actions-ui-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
-import type { WorkflowsExtensionsPublicPluginStart } from '@kbn/workflows-extensions/public';
+import type {
+  WorkflowsExtensionsPublicPluginSetup,
+  WorkflowsExtensionsPublicPluginStart,
+} from '@kbn/workflows-extensions/public';
 import type {
   AvailabilityService,
   ServerlessTierRequiredProducts,
@@ -38,6 +41,7 @@ export interface WorkflowsPublicPluginSetup {}
 
 export interface WorkflowsPublicPluginSetupDependencies {
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
 }
 
 export interface WorkflowsPublicPluginStart {

--- a/src/platform/plugins/shared/workflows_management/public/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/workflows/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+
+export function registerWorkflowManagementSteps(
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
+) {
+  workflowsExtensions.registerStepDefinition(() =>
+    import('../steps/public_api_access_step').then((m) => m.publicApiAccessStepDefinition)
+  );
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/external_resume/external_resume_error.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/external_resume/external_resume_error.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export class ExternalResumeError extends Error {
+  constructor(message: string, public readonly statusCode: 400 | 401 | 403 | 404 | 409) {
+    super(message);
+    this.name = 'ExternalResumeError';
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/external_resume/external_resume_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/external_resume/external_resume_service.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { coreMock } from '@kbn/core/server/mocks';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { WorkflowExecutionDto, WorkflowStepExecutionDto } from '@kbn/workflows';
+import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
+import { ExternalResumeError } from './external_resume_error';
+import { resumeWorkflowExecutionExternally } from './external_resume_service';
+import type { WorkflowsService } from '../workflows_management_service';
+
+describe('resumeWorkflowExecutionExternally', () => {
+  const encodedApiKey = Buffer.from('api-key-id:secret').toString('base64');
+  const workflowsService = {
+    getCoreStart: jest.fn(),
+    getWorkflowExecution: jest.fn(),
+    getWorkflowsExecutionEngine: jest.fn(),
+  } as unknown as jest.Mocked<WorkflowsService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const coreStart = coreMock.createStart();
+    coreStart.elasticsearch.client.asScoped = jest.fn().mockReturnValue({
+      asCurrentUser: {
+        security: {
+          authenticate: jest.fn().mockResolvedValue({
+            api_key: { id: 'api-key-id' },
+          }),
+        },
+      },
+    });
+    coreStart.elasticsearch.client.asInternalUser.security.invalidateApiKey = jest
+      .fn()
+      .mockResolvedValue({});
+    workflowsService.getCoreStart.mockResolvedValue(coreStart);
+    workflowsService.getWorkflowExecution.mockResolvedValue({
+      id: 'exec-1',
+      stepExecutions: [
+        {
+          workflowRunId: 'exec-1',
+          stepType: 'waitForInput',
+          status: ExecutionStatus.WAITING_FOR_INPUT,
+          input: {
+            externalResumeApiKeyId: 'api-key-id',
+            schema: {
+              properties: {
+                approved: { type: 'boolean' },
+              },
+              required: ['approved'],
+            },
+          },
+        } as unknown as WorkflowStepExecutionDto,
+      ],
+    } as unknown as WorkflowExecutionDto);
+    workflowsService.getWorkflowsExecutionEngine.mockResolvedValue({
+      resumeWorkflowExecution: jest.fn().mockResolvedValue({ resumedBy: 'api_key:api-key-id' }),
+    } as unknown as WorkflowsExecutionEnginePluginStart);
+  });
+
+  it('resumes a waiting step when the API key matches externalResumeApiKeyId', async () => {
+    await resumeWorkflowExecutionExternally(workflowsService, {
+      apiKey: encodedApiKey,
+      coerceInput: true,
+      executionId: 'exec-1',
+      input: { approved: 'true' },
+      spaceId: 'default',
+    });
+
+    const engine = await workflowsService.getWorkflowsExecutionEngine();
+    expect(engine.resumeWorkflowExecution).toHaveBeenCalledWith(
+      'exec-1',
+      'default',
+      { approved: true },
+      expect.any(Object),
+      {
+        resumedAt: expect.any(String),
+        resumedBy: 'api_key:api-key-id',
+      }
+    );
+    const coreStart = await workflowsService.getCoreStart();
+    expect(
+      coreStart.elasticsearch.client.asInternalUser.security.invalidateApiKey
+    ).toHaveBeenCalledWith({ ids: ['api-key-id'] });
+  });
+
+  it('throws when the API key does not match any waiting step', async () => {
+    workflowsService.getWorkflowExecution.mockResolvedValue({
+      id: 'exec-1',
+      stepExecutions: [
+        {
+          workflowRunId: 'exec-1',
+          stepType: 'waitForInput',
+          status: ExecutionStatus.WAITING_FOR_INPUT,
+          input: {
+            externalResumeApiKeyId: 'different-api-key-id',
+          },
+        } as unknown as WorkflowStepExecutionDto,
+      ],
+    } as unknown as WorkflowExecutionDto);
+
+    await expect(
+      resumeWorkflowExecutionExternally(workflowsService, {
+        apiKey: encodedApiKey,
+        executionId: 'exec-1',
+        input: {},
+        spaceId: 'default',
+      })
+    ).rejects.toEqual(
+      new ExternalResumeError('API key does not match this workflow execution', 403)
+    );
+  });
+
+  it('throws when the execution is not waiting for input', async () => {
+    workflowsService.getWorkflowExecution.mockResolvedValue({
+      id: 'exec-1',
+      stepExecutions: [
+        {
+          workflowRunId: 'exec-1',
+          stepType: 'waitForInput',
+          status: ExecutionStatus.COMPLETED,
+          input: {
+            externalResumeApiKeyId: 'api-key-id',
+          },
+        } as unknown as WorkflowStepExecutionDto,
+      ],
+    } as unknown as WorkflowExecutionDto);
+
+    await expect(
+      resumeWorkflowExecutionExternally(workflowsService, {
+        apiKey: encodedApiKey,
+        executionId: 'exec-1',
+        input: {},
+        spaceId: 'default',
+      })
+    ).rejects.toEqual(
+      new ExternalResumeError('Workflow execution is not waiting for external input', 409)
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/server/api/external_resume/external_resume_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/external_resume/external_resume_service.ts
@@ -1,0 +1,260 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { FakeRawRequest, Headers } from '@kbn/core-http-server';
+import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
+import { asSpaceId } from '@kbn/core-spaces-common';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { ResumeWorkflowExecutionResponseDto, WorkflowStepExecutionDto } from '@kbn/workflows';
+import { buildFieldsZodValidator } from '@kbn/workflows/spec/lib/build_fields_zod_validator';
+import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
+import { ExternalResumeError } from './external_resume_error';
+import type { WorkflowsService } from '../workflows_management_service';
+
+export interface ExternalResumeWorkflowExecutionParams {
+  apiKey: string;
+  coerceInput?: boolean;
+  executionId: string;
+  input: Record<string, unknown>;
+  spaceId: string;
+}
+
+interface ApiKeyAuthenticateResponse {
+  api_key?: {
+    id?: string;
+    name?: string;
+  };
+}
+
+export async function resumeWorkflowExecutionExternally(
+  workflowsService: WorkflowsService,
+  {
+    apiKey,
+    coerceInput = false,
+    executionId,
+    input,
+    spaceId,
+  }: ExternalResumeWorkflowExecutionParams
+): Promise<ResumeWorkflowExecutionResponseDto> {
+  const coreStart = await workflowsService.getCoreStart();
+  const apiKeyRequest = createApiKeyRequest(apiKey, spaceId);
+  let authentication: ApiKeyAuthenticateResponse;
+  try {
+    authentication = (await coreStart.elasticsearch.client
+      .asScoped(apiKeyRequest)
+      .asCurrentUser.security.authenticate()) as ApiKeyAuthenticateResponse;
+  } catch {
+    throw new ExternalResumeError('Invalid external resume API key', 401);
+  }
+
+  const apiKeyId = getAuthenticatedApiKeyId(authentication, apiKey);
+  const stepExecution = await getExternalResumeStepExecution(workflowsService, {
+    apiKeyId,
+    executionId,
+    spaceId,
+  });
+
+  if (!stepExecution) {
+    throw new ExternalResumeError('API key does not match this workflow execution', 403);
+  }
+
+  if (
+    stepExecution.status !== ExecutionStatus.WAITING_FOR_INPUT ||
+    stepExecution.stepType !== 'waitForInput'
+  ) {
+    throw new ExternalResumeError('Workflow execution is not waiting for external input', 409);
+  }
+
+  if (stepExecution.finishedAt || stepExecution.error) {
+    throw new ExternalResumeError('This workflow response link is no longer valid', 409);
+  }
+
+  const schema = getWaitForInputSchema(stepExecution.input);
+  const validatedInput = validateExternalResumeInput(input, schema, coerceInput);
+  const workflowsExecutionEngine = await workflowsService.getWorkflowsExecutionEngine();
+  const resumedAt = new Date().toISOString();
+  const result = await workflowsExecutionEngine.resumeWorkflowExecution(
+    executionId,
+    spaceId,
+    validatedInput,
+    apiKeyRequest,
+    {
+      resumedAt,
+      resumedBy: `api_key:${apiKeyId}`,
+    }
+  );
+
+  await coreStart.elasticsearch.client.asInternalUser.security.invalidateApiKey({
+    ids: [apiKeyId],
+  });
+
+  return result;
+}
+
+function createApiKeyRequest(apiKey: string, spaceId: string): KibanaRequest {
+  const requestHeaders: Headers = {
+    authorization: `ApiKey ${apiKey}`,
+  };
+  const fakeRawRequest: FakeRawRequest = {
+    headers: requestHeaders,
+    spaceId: asSpaceId(spaceId),
+  };
+  return kibanaRequestFactory(fakeRawRequest);
+}
+
+function getAuthenticatedApiKeyId(
+  authentication: ApiKeyAuthenticateResponse,
+  encodedApiKey: string
+): string {
+  const id = authentication.api_key?.id ?? decodeApiKeyId(encodedApiKey);
+
+  if (!id) {
+    throw new ExternalResumeError('Invalid external resume API key', 401);
+  }
+
+  return id;
+}
+
+function decodeApiKeyId(encodedApiKey: string): string | undefined {
+  try {
+    const decoded = Buffer.from(encodedApiKey, 'base64').toString('utf8');
+    const [id] = decoded.split(':');
+    return id || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getExternalResumeStepExecution(
+  workflowsService: WorkflowsService,
+  {
+    apiKeyId,
+    executionId,
+    spaceId,
+  }: {
+    apiKeyId: string;
+    executionId: string;
+    spaceId: string;
+  }
+): Promise<WorkflowStepExecutionDto | undefined> {
+  const execution = await workflowsService.getWorkflowExecution(executionId, spaceId, {
+    includeInput: true,
+  });
+
+  if (!execution) {
+    throw new ExternalResumeError('Workflow execution not found', 404);
+  }
+
+  return execution.stepExecutions.find(
+    (stepExecution) =>
+      stepExecution.workflowRunId === executionId &&
+      stepExecution.stepType === 'waitForInput' &&
+      getExternalResumeApiKeyId(stepExecution.input) === apiKeyId
+  );
+}
+
+export function getExternalResumeApiKeyId(input: unknown): string | undefined {
+  if (input == null || typeof input !== 'object' || !('externalResumeApiKeyId' in input)) {
+    return undefined;
+  }
+
+  const apiKeyId = (input as { externalResumeApiKeyId?: unknown }).externalResumeApiKeyId;
+  return typeof apiKeyId === 'string' && apiKeyId.length > 0 ? apiKeyId : undefined;
+}
+
+function getWaitForInputSchema(input: unknown): JsonModelSchemaType | undefined {
+  if (input == null || typeof input !== 'object' || !('schema' in input)) {
+    return undefined;
+  }
+
+  const schema = (input as { schema?: unknown }).schema;
+  if (schema == null || typeof schema !== 'object' || Array.isArray(schema)) {
+    return undefined;
+  }
+
+  return schema as JsonModelSchemaType;
+}
+
+function validateExternalResumeInput(
+  input: Record<string, unknown>,
+  jsonSchema: JsonModelSchemaType | undefined,
+  coerceInput: boolean
+): Record<string, unknown> {
+  const inputToValidate = coerceInput ? coerceInputFromSchema(input, jsonSchema) : input;
+  const result = buildFieldsZodValidator(jsonSchema).safeParse(inputToValidate);
+
+  if (!result.success) {
+    throw new ExternalResumeError(
+      `Resume input does not match waitForInput schema: ${result.error.message}`,
+      400
+    );
+  }
+
+  return result.data;
+}
+
+function coerceInputFromSchema(
+  input: Record<string, unknown>,
+  jsonSchema: JsonModelSchemaType | undefined
+): Record<string, unknown> {
+  if (!jsonSchema?.properties) {
+    return input;
+  }
+
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [
+      key,
+      coerceValue(value, jsonSchema.properties?.[key]),
+    ])
+  );
+}
+
+function coerceValue(value: unknown, propertySchema: unknown): unknown {
+  if (
+    propertySchema == null ||
+    typeof propertySchema !== 'object' ||
+    Array.isArray(propertySchema)
+  ) {
+    return value;
+  }
+
+  const { type, items } = propertySchema as { items?: unknown; type?: string | string[] };
+  const targetTypes = Array.isArray(type) ? type : type ? [type] : [];
+
+  if (Array.isArray(value)) {
+    return value.map((item) => coerceValue(item, items));
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  if (targetTypes.includes('boolean')) {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+  }
+
+  if (targetTypes.includes('number') || targetTypes.includes('integer')) {
+    const numberValue = Number(value);
+    if (!Number.isNaN(numberValue)) {
+      return numberValue;
+    }
+  }
+
+  if (targetTypes.includes('object') || targetTypes.includes('array')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return value;
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/external_resume/render_external_resume_page.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/external_resume/render_external_resume_page.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+
+const PAGE_TITLE = i18n.translate('workflowsManagement.externalResume.pageTitle', {
+  defaultMessage: 'Workflow response',
+});
+
+const SUCCESS_TITLE = i18n.translate('workflowsManagement.externalResume.successTitle', {
+  defaultMessage: 'Thank you',
+});
+
+const SUCCESS_MESSAGE = i18n.translate('workflowsManagement.externalResume.successMessage', {
+  defaultMessage: 'Your response was received. You can close this window.',
+});
+
+const ERROR_TITLE = i18n.translate('workflowsManagement.externalResume.errorTitle', {
+  defaultMessage: 'Unable to submit response',
+});
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderPage({
+  title,
+  message,
+  isError,
+}: {
+  title: string;
+  message: string;
+  isError: boolean;
+}): string {
+  const accent = isError ? '#BD271E' : '#006BB4';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(PAGE_TITLE)}</title>
+    <style>
+      *, *::before, *::after {
+        box-sizing: border-box;
+      }
+      :root {
+        color-scheme: light;
+        font-family: Inter, BlinkMacSystemFont, Helvetica, Arial, sans-serif;
+        background: #F5F7FA;
+        color: #343741;
+      }
+      html {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        min-height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .card {
+        width: 100%;
+        max-width: 480px;
+        background: #FFFFFF;
+        border: 1px solid #D3DAE6;
+        border-radius: 6px;
+        box-shadow: 0 2px 2px -1px rgba(152, 162, 179, 0.3);
+        padding: 32px;
+      }
+      .brand {
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #69707D;
+        margin-bottom: 16px;
+      }
+      .status {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        background: ${accent}14;
+        color: ${accent};
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 24px;
+        line-height: 1.25;
+        font-weight: 600;
+      }
+      p {
+        margin: 0;
+        font-size: 16px;
+        line-height: 1.5;
+        color: #535966;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <div class="brand">Elastic Workflows</div>
+      <div class="status" aria-hidden="true">${isError ? '!' : '✓'}</div>
+      <h1>${escapeHtml(title)}</h1>
+      <p>${escapeHtml(message)}</p>
+    </main>
+  </body>
+</html>`;
+}
+
+export function renderExternalResumeSuccessPage(): string {
+  return renderPage({
+    title: SUCCESS_TITLE,
+    message: SUCCESS_MESSAGE,
+    isError: false,
+  });
+}
+
+export function renderExternalResumeErrorPage(message: string): string {
+  return renderPage({
+    title: ERROR_TITLE,
+    message,
+    isError: true,
+  });
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts
@@ -14,6 +14,7 @@ import {
   WorkflowNotFoundError,
 } from '@kbn/workflows/common/errors';
 import { registerExecutionRoutes } from '.';
+import { ExternalResumeError } from '../../external_resume/external_resume_error';
 import type { RouteDependencies } from '../types';
 import { createWorkflowManagementAuditLogMock } from '../utils/workflow_audit_logging.mock';
 
@@ -58,6 +59,11 @@ describe('Execution Routes', () => {
     ok: jest.fn((params?: any) => ({ type: 'ok', ...params })),
     notFound: jest.fn((params?: any) => ({ type: 'notFound', ...params })),
     badRequest: jest.fn((params?: any) => ({ type: 'badRequest', ...params })),
+    custom: jest.fn(({ statusCode, body, headers, bypassErrorFormat }: any) => ({
+      status: statusCode,
+      body,
+      options: { headers, bypassErrorFormat },
+    })),
     customError: jest.fn((params?: any) => ({ type: 'customError', ...params })),
     forbidden: jest.fn((params?: any) => ({ type: 'forbidden', ...params })),
     conflict: jest.fn((params?: any) => ({ type: 'conflict', ...params })),
@@ -89,6 +95,7 @@ describe('Execution Routes', () => {
       cancelAllActiveWorkflowExecutions: jest.fn(),
       getStepExecution: jest.fn(),
       resumeWorkflowExecution: jest.fn(),
+      resumeWorkflowExecutionExternally: jest.fn(),
       getChildWorkflowExecutions: jest.fn(),
     };
 
@@ -607,6 +614,118 @@ describe('Execution Routes', () => {
         { resume: true },
         request
       );
+      expect(result).toMatchObject({
+        type: 'ok',
+        body: {
+          success: true,
+          executionId: 'ex-1',
+          message: 'Workflow resume scheduled',
+        },
+      });
+    });
+  });
+
+  describe('external resume routes', () => {
+    const path = '/api/workflows/executions/{executionId}/resume/external';
+
+    it('should register GET and POST route handlers', () => {
+      expect(handler('GET', path)).toBeDefined();
+      expect(handler('POST', path)).toBeDefined();
+    });
+
+    it('should pass GET query params as coerced input candidates and return HTML', async () => {
+      mockApi.resumeWorkflowExecutionExternally.mockResolvedValue({ resumedBy: 'api_key:key-1' });
+      const h = handler('GET', path)!;
+      const request = {
+        params: { executionId: 'ex-1' },
+        query: {
+          apiKey: 'encoded-key',
+          approved: 'true',
+          comment: 'LGTM',
+        },
+      };
+
+      const result = await h(mockContext, request as any, mockResponse as any);
+
+      expect(mockApi.resumeWorkflowExecutionExternally).toHaveBeenCalledWith({
+        apiKey: 'encoded-key',
+        coerceInput: true,
+        executionId: 'ex-1',
+        input: {
+          approved: 'true',
+          comment: 'LGTM',
+        },
+        spaceId: 'default',
+      });
+      expect(result).toMatchObject({
+        type: 'ok',
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+      expect(typeof result.body).toBe('string');
+      expect(result.body).toContain('Thank you');
+    });
+
+    it('should return HTML error page for GET when resume fails', async () => {
+      mockApi.resumeWorkflowExecutionExternally.mockRejectedValue(
+        new ExternalResumeError('Invalid external resume API key', 401)
+      );
+      const h = handler('GET', path)!;
+      const request = {
+        params: { executionId: 'ex-1' },
+        query: { apiKey: 'expired-key', approved: 'true' },
+      };
+
+      const result = await h(mockContext, request as any, mockResponse as any);
+
+      expect(result).toMatchObject({
+        status: 401,
+        options: {
+          bypassErrorFormat: true,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        },
+      });
+      expect(typeof result.body).toBe('string');
+      expect(result.body).toContain('<!DOCTYPE html>');
+      expect(result.body).toContain('Unable to submit response');
+      expect(result.body).toContain('Invalid external resume API key');
+    });
+
+    it('should return JSON error for POST when resume fails', async () => {
+      mockApi.resumeWorkflowExecutionExternally.mockRejectedValue(
+        new ExternalResumeError('Invalid external resume API key', 401)
+      );
+      const h = handler('POST', path)!;
+      const request = {
+        params: { executionId: 'ex-1' },
+        query: { apiKey: 'expired-key' },
+        body: { input: { approved: true } },
+      };
+
+      const result = await h(mockContext, request as any, mockResponse as any);
+
+      expect(result).toMatchObject({
+        status: 401,
+        body: { message: 'Invalid external resume API key' },
+      });
+    });
+
+    it('should support POST body input and query apiKey', async () => {
+      mockApi.resumeWorkflowExecutionExternally.mockResolvedValue({ resumedBy: 'api_key:key-1' });
+      const h = handler('POST', path)!;
+      const request = {
+        params: { executionId: 'ex-1' },
+        query: { apiKey: 'encoded-key' },
+        body: { input: { approved: true } },
+      };
+
+      const result = await h(mockContext, request as any, mockResponse as any);
+
+      expect(mockApi.resumeWorkflowExecutionExternally).toHaveBeenCalledWith({
+        apiKey: 'encoded-key',
+        executionId: 'ex-1',
+        input: { approved: true },
+        spaceId: 'default',
+      });
       expect(result).toMatchObject({
         type: 'ok',
         body: {

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/index.ts
@@ -16,6 +16,7 @@ import { registerGetStepExecutionRoute } from './get_step_execution';
 import { registerGetWorkflowExecutionsRoute } from './get_workflow_executions';
 import { registerGetWorkflowStepExecutionsRoute } from './get_workflow_step_executions';
 import { registerResumeExecutionRoute } from './resume_execution';
+import { registerExternalResumeExecutionRoute } from './resume_execution_external';
 import { registerRunWorkflowRoute } from './run_workflow';
 import { registerTestStepRoute } from './test_step';
 import { registerTestWorkflowRoute } from './test_workflow';
@@ -33,5 +34,6 @@ export function registerExecutionRoutes(deps: RouteDependencies) {
   registerCancelWorkflowExecutionsRoute(deps);
   registerGetStepExecutionRoute(deps);
   registerResumeExecutionRoute(deps);
+  registerExternalResumeExecutionRoute(deps);
   registerGetChildrenExecutionsRoute(deps);
 }

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/resume_execution_external.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/resume_execution_external.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { KibanaResponseFactory } from '@kbn/core/server';
+import { EXTERNAL_RESUME_API_PATH } from '../../../../common/external_resume/constants';
+import { ExternalResumeError } from '../../external_resume/external_resume_error';
+import {
+  renderExternalResumeErrorPage,
+  renderExternalResumeSuccessPage,
+} from '../../external_resume/render_external_resume_page';
+import type { RouteDependencies } from '../types';
+import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
+import { executionIdParamSchema } from '../utils/schemas';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
+
+const EXTERNAL_RESUME_SECURITY = {
+  authc: {
+    enabled: false,
+    reason: 'External resume uses a short-lived API key token instead of a Kibana session.',
+  },
+  authz: {
+    enabled: false,
+    reason:
+      'External resume authorizes by matching the API key id to the waiting waitForInput step.',
+  },
+} as const;
+
+const externalResumeInputSchema = schema.object({
+  input: schema.recordOf(schema.string(), schema.any(), {
+    defaultValue: {},
+    meta: { description: 'Input data to resume the execution with.' },
+  }),
+});
+
+export function registerExternalResumeExecutionRoute(deps: RouteDependencies) {
+  registerExternalResumeGetRoute(deps);
+  registerExternalResumePostRoute(deps);
+}
+
+function registerExternalResumeGetRoute(deps: RouteDependencies) {
+  const { router, api, spaces, audit } = deps;
+  router.versioned
+    .get({
+      path: EXTERNAL_RESUME_API_PATH,
+      access: 'public',
+      security: EXTERNAL_RESUME_SECURITY,
+      summary: 'Resume a workflow execution from an external link',
+      description:
+        'Resume a paused workflow execution using an external resume API key. Returns an HTML confirmation page for browser clients.',
+      options: {
+        tags: [OAS_TAG],
+        availability: AVAILABILITY,
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSION,
+        validate: {
+          request: {
+            params: executionIdParamSchema,
+            query: schema.object(
+              {
+                apiKey: schema.string({
+                  meta: { description: 'External resume API key credential.' },
+                }),
+              },
+              { unknowns: 'allow' }
+            ),
+          },
+        },
+      },
+      withAvailabilityCheck(async (context, request, response) => {
+        try {
+          const { executionId } = request.params;
+          const { apiKey, ...input } = request.query as { apiKey: string } & Record<
+            string,
+            unknown
+          >;
+          const { resumedBy } = await api.resumeWorkflowExecutionExternally({
+            apiKey,
+            coerceInput: true,
+            executionId,
+            input,
+            spaceId: spaces.getSpaceId(request),
+          });
+
+          audit.logExecutionResumed(request, {
+            executionId,
+            resumedBy,
+          });
+
+          return htmlOk(response, renderExternalResumeSuccessPage());
+        } catch (error) {
+          audit.logExecutionResumed(request, {
+            executionId: request.params.executionId,
+            error,
+          });
+          return handleExternalResumeError(response, error);
+        }
+      })
+    );
+}
+
+function registerExternalResumePostRoute(deps: RouteDependencies) {
+  const { router, api, spaces, audit } = deps;
+  router.versioned
+    .post({
+      path: EXTERNAL_RESUME_API_PATH,
+      access: 'public',
+      security: EXTERNAL_RESUME_SECURITY,
+      summary: 'Resume a workflow execution with external API key',
+      description: 'Resume a paused workflow execution using an external resume API key.',
+      options: {
+        tags: [OAS_TAG],
+        availability: AVAILABILITY,
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSION,
+        validate: {
+          request: {
+            params: executionIdParamSchema,
+            query: schema.object({
+              apiKey: schema.string({
+                meta: { description: 'External resume API key credential.' },
+              }),
+            }),
+            body: externalResumeInputSchema,
+          },
+        },
+      },
+      withAvailabilityCheck(async (context, request, response) => {
+        try {
+          const { executionId } = request.params;
+          const { apiKey } = request.query;
+          const { input } = request.body;
+          const { resumedBy } = await api.resumeWorkflowExecutionExternally({
+            apiKey,
+            executionId,
+            input,
+            spaceId: spaces.getSpaceId(request),
+          });
+
+          audit.logExecutionResumed(request, {
+            executionId,
+            resumedBy,
+          });
+
+          return response.ok({
+            body: {
+              success: true,
+              executionId,
+              message: 'Workflow resume scheduled',
+            },
+          });
+        } catch (error) {
+          audit.logExecutionResumed(request, {
+            executionId: request.params.executionId,
+            error,
+          });
+          return handleExternalResumeError(response, error, { preferJson: true });
+        }
+      })
+    );
+}
+
+function htmlOk(response: KibanaResponseFactory, body: string) {
+  return response.ok({
+    body,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+}
+
+function handleExternalResumeError(
+  response: KibanaResponseFactory,
+  error: unknown,
+  options?: { preferJson?: boolean }
+) {
+  if (error instanceof ExternalResumeError) {
+    if (options?.preferJson) {
+      return response.custom({
+        statusCode: error.statusCode,
+        body: { message: error.message },
+      });
+    }
+
+    return response.custom({
+      statusCode: error.statusCode,
+      bypassErrorFormat: true,
+      body: renderExternalResumeErrorPage(error.message),
+      headers: {
+        'content-type': 'text/html; charset=utf-8',
+      },
+    });
+  }
+
+  throw error;
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -54,6 +54,10 @@ import {
   WorkflowValidationError,
 } from '@kbn/workflows-yaml';
 import type { z } from '@kbn/zod/v4';
+import {
+  type ExternalResumeWorkflowExecutionParams,
+  resumeWorkflowExecutionExternally,
+} from './external_resume/external_resume_service';
 import type { StepExecutionListResult } from './lib/search_step_executions';
 import { ManagedWorkflowDeleteForbiddenError } from './managed_workflow_delete_error';
 import { ManagedWorkflowUpdateForbiddenError } from './managed_workflow_errors';
@@ -853,6 +857,12 @@ export class WorkflowsManagementApi {
   ): Promise<ResumeWorkflowExecutionResponseDto> {
     const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
     return workflowsExecutionEngine.resumeWorkflowExecution(executionId, spaceId, input, request);
+  }
+
+  public async resumeWorkflowExecutionExternally(
+    params: ExternalResumeWorkflowExecutionParams
+  ): Promise<ResumeWorkflowExecutionResponseDto> {
+    return resumeWorkflowExecutionExternally(this.workflowsService, params);
   }
 
   /**

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -38,6 +38,7 @@ import type {
   WorkflowsServerPluginStartDeps,
 } from './types';
 import { registerUISettings } from './ui_settings';
+import { registerWorkflowManagementSteps } from './workflows';
 import { stepSchemas } from '../common/step_schemas';
 
 export class WorkflowsPlugin
@@ -92,6 +93,7 @@ export class WorkflowsPlugin
     plugins.workflowsExtensions.registerManagedWorkflowsSystemApiProvider(
       createManagedWorkflowsSystemApiProvider(workflowsService, this.config, this.logger)
     );
+    registerWorkflowManagementSteps(plugins.workflowsExtensions);
 
     const spaces = plugins.spaces.spacesService;
 

--- a/src/platform/plugins/shared/workflows_management/server/steps/public_api_access_step.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/steps/public_api_access_step.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createSHA256Hash } from '@kbn/crypto';
+import { publicApiAccessStepDefinition } from './public_api_access_step';
+
+describe('publicApiAccessStepDefinition', () => {
+  it('has a stable handler hash for APPROVED_STEP_DEFINITIONS', () => {
+    expect(createSHA256Hash(publicApiAccessStepDefinition.handler.toString())).toBe(
+      'f50346b6b4f1fa5e087456baf0360b34304e33198b23980c4214496ff6834b54'
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/server/steps/public_api_access_step.ts
+++ b/src/platform/plugins/shared/workflows_management/server/steps/public_api_access_step.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { buildExternalResumeUrl } from '../../common/external_resume/build_external_resume_url';
+import {
+  DEFAULT_EXTERNAL_RESUME_TTL,
+  MAX_EXTERNAL_RESUME_TTL_MS,
+  WORKFLOW_EXTERNAL_RESUME_APPLICATION,
+  WORKFLOW_EXTERNAL_RESUME_ROLE,
+} from '../../common/external_resume/constants';
+import { parseDuration } from '../../common/lib/parse_duration';
+import {
+  publicApiAccessStepCommonDefinition,
+  type PublicApiAccessStepInput,
+} from '../../common/steps/public_api_access_step';
+
+function getValidatedTtl(ttl: string | undefined): string {
+  const resolvedTtl = ttl ?? DEFAULT_EXTERNAL_RESUME_TTL;
+  const ttlMs = parseDuration(resolvedTtl);
+
+  if (ttlMs > MAX_EXTERNAL_RESUME_TTL_MS) {
+    throw new Error('workflows.publicApiAccess ttl cannot exceed 24h');
+  }
+
+  return resolvedTtl;
+}
+
+export const publicApiAccessStepDefinition = createServerStepDefinition({
+  ...publicApiAccessStepCommonDefinition,
+  handler: async (context) => {
+    try {
+      const { ttl }: PublicApiAccessStepInput = context.input;
+      const validatedTtl = getValidatedTtl(ttl);
+      const workflowContext = context.contextManager.getContext();
+      const executionId = workflowContext.execution.id;
+      const spaceId = workflowContext.workflow.spaceId;
+      const kibanaUrl = workflowContext.kibanaUrl;
+
+      const esClient = context.contextManager.getScopedEsClient();
+      const apiKey = await esClient.security.createApiKey({
+        name: `workflow-public-resume-${executionId}-${context.stepId}`,
+        expiration: validatedTtl,
+        role_descriptors: {
+          [WORKFLOW_EXTERNAL_RESUME_ROLE]: {
+            cluster: [],
+            indices: [],
+            applications: [],
+            run_as: [],
+          },
+        },
+        metadata: {
+          application: WORKFLOW_EXTERNAL_RESUME_APPLICATION,
+          workflow_execution_id: executionId,
+          workflow_id: workflowContext.workflow.id,
+          workflow_space_id: spaceId,
+        },
+      });
+
+      const resumeUrl = buildExternalResumeUrl({
+        kibanaUrl,
+        spaceId,
+        executionId,
+        encodedApiKey: apiKey.encoded,
+      });
+
+      context.logger.debug(
+        `Created public API access credentials for external resume (execution=${executionId}, apiKeyId=${apiKey.id})`
+      );
+
+      return {
+        output: {
+          apiKeyId: apiKey.id,
+          resumeUrl,
+          ttl: validatedTtl,
+          ...(apiKey.expiration !== undefined && {
+            expiresAt: new Date(apiKey.expiration).toISOString(),
+          }),
+        },
+      };
+    } catch (error) {
+      context.logger.error('workflows.publicApiAccess step failed', error);
+      return {
+        error: error instanceof Error ? error : new Error('Failed to create public API access'),
+      };
+    }
+  },
+});

--- a/src/platform/plugins/shared/workflows_management/server/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import { publicApiAccessStepDefinition } from '../steps/public_api_access_step';
+
+export function registerWorkflowManagementSteps(
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup
+) {
+  workflowsExtensions.registerStepDefinition(publicApiAccessStepDefinition);
+}

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -109,7 +109,10 @@
     "@kbn/esql-utils",
     "@kbn/inbox-plugin",
     "@kbn/inbox-common",
-    "@kbn/datemath"
+    "@kbn/datemath",
+    "@kbn/core-http-server-utils",
+    "@kbn/core-spaces-common",
+    "@kbn/crypto"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Adds external human-in-the-loop (HITL) resume for `waitForInput` without requiring a Kibana session. A new `workflows.publicApiAccess` step mints a short-lived Elasticsearch API key and resume URL; a subsequent `waitForInput` step binds to that key via `externalResumeApiKeyId`. External actors resume the workflow through unauthenticated GET/POST routes - GET returns an HTML confirmation page for link clicks (e.g. Slack), POST returns JSON for programmatic callers.

Fixes https://github.com/elastic/security-team/issues/16140

## Design

Steps are **flat and decoupled**:

1. **`workflows.publicApiAccess`** - creates a scoped API key (default TTL `1h`, max `24h`) and builds a resume URL
2. **Notify** (e.g. Slack/email/etc...) - sends approve/decline links using `steps.<mint>.output.resumeUrl`
3. **`waitForInput`** - pauses with `externalResumeApiKeyId: '{{ steps.<mint>.output.apiKeyId }}'`

Authorization is credential-based: the external route authenticates the API key, finds the waiting `waitForInput` step whose stored `externalResumeApiKeyId` matches, validates input against the step schema, resumes execution, and invalidates the key.

### Workflow flow

```mermaid
flowchart LR
  A[workflows.publicApiAccess] -->|apiKeyId, resumeUrl| B[Notify e.g. Slack]
  B --> C[waitForInput]
  C -->|WAITING_FOR_INPUT| D{External actor clicks link}
  D -->|GET /resume/external| E[Validate key + schema]
  E --> F[Resume execution]
  F --> G[Invalidate API key]
  G --> H[Continue workflow]
```

### External resume sequence

```mermaid
sequenceDiagram
  participant Ext as External actor
  participant Kibana
  participant ES as Elasticsearch
  participant WFE as Workflows engine
  Ext->>Kibana: GET external resume URL
  Kibana->>ES: Authenticate API key
  ES-->>Kibana: Return api key id
  Kibana->>Kibana: Match key to waiting step
  Kibana->>Kibana: Validate resume input
  Kibana->>WFE: Resume execution
  Kibana->>ES: Invalidate API key
  Kibana-->>Ext: HTML thank-you page
```

## Changes

- **`workflows.publicApiAccess` step** — common/server/public definitions; outputs `{ apiKeyId, resumeUrl, ttl, expiresAt? }`
- **`waitForInput.with.externalResumeApiKeyId`** — persisted on step input when entering wait; used to bind external resume requests
- **External resume API**
  - `GET /api/workflows/executions/{executionId}/resume/external` — query-param input coercion; HTML success/error pages (`bypassErrorFormat` for error HTML)
  - `POST` same path — JSON body input for programmatic callers
  - Authc/authz disabled on route; API key is the credential
- **Example workflow** — `example_external_hitl.yml` (mint → Slack webhook links → waitForInput → record response)
- **Tests** — external resume service, route handlers, waitForInput schema persistence, handler hash guard

## Test WF
```
name: External HITL approval demo
description: Mint an external resume URL, notify via Slack, then pause on waitForInput.
enabled: true
tags: [demo, external-hitl]

triggers:
  - type: manual
    inputs:
      properties:
        slackChannel:
          type: string
          default: '#one-workflows-playground'

steps:
  - name: mint-public-access
    type: workflows.publicApiAccess
    with:
      ttl: 1h

  - name: notify-slack
    type: slack
    connector-id: slack
    with:
      message: |
        Workflow approval required.
        <{{ steps.mint-public-access.output.resumeUrl }}&approved=true&comment=Approved|Approve>
        <{{ steps.mint-public-access.output.resumeUrl }}&approved=false&comment=Declined|Decline>
 
  - name: request-approval
    type: waitForInput
    with:
      message: Approve this workflow run from an external link.
      externalResumeApiKeyId: '{{ steps.mint-public-access.output.apiKeyId }}'
      schema:
        properties:
          approved:
            type: boolean
          comment:
            type: string
        required:
          - approved

  - name: record-response
    type: data.set
    with:
      approved: '{{ steps.request-approval.output.approved }}'
      comment: '{{ steps.request-approval.output.comment }}'
```


https://github.com/user-attachments/assets/9af7d7a0-15b3-46c5-9553-9657744b0313


