### PR TITLE
chore: switch RSPack e2e test every 3 hours

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-rspack-e2e-test.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-rspack-e2e-test.yml
@@ -43,9 +43,9 @@ spec:
         build_tags: false
       schedules:
         Every 12 hours (main):
-          message: Rspack e2e test (every 12 hours)
+          message: Rspack e2e test (every 3 hours)
           branch: main
-          cronline: 0 */12 * * * America/New_York
+          cronline: 0 */3 * * * America/New_York
       teams:
         everyone:
           access_level: BUILD_AND_READ


### PR DESCRIPTION
## Summary 

Fixed problematic FTR and scout configs, so tests should be a bit more stable. Running them every 3 hours will provide us more data on any more flakiness. 