### PR TITLE
[Obs][Nightshift] RCA eval: investigation workflow benchmark

### DIFF
--- a/.buildkite/pipelines/evals/evals.suites.json
+++ b/.buildkite/pipelines/evals/evals.suites.json
@@ -120,6 +120,19 @@
       ]
     },
     {
+      "id": "rca-benchmark",
+      "name": "RCA Benchmark",
+      "slackChannel": "#obs-nightshift",
+      "configPath": "x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/playwright.config.ts",
+      "tags": [
+        "observability",
+        "rca-benchmark"
+      ],
+      "ciLabels": [
+        "evals:rca-benchmark"
+      ]
+    },
+    {
       "id": "security-ai-rules",
       "name": "Security AI Rules",
       "slackChannel": "#security-detection-engine-alerts",

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/evals/re2ob_investigation_workflow.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/evals/re2ob_investigation_workflow.spec.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * RE2-OB RCA Benchmark — investigation workflow.
+ *
+ * Evaluates the managed investigation workflow (system-streams-sigevents-investigation)
+ * on Online Boutique fault-injection scenarios from the RCAEval RE2-OB dataset.
+ *
+ * Data isolation: each scenario is indexed just before its workflow run and cleaned
+ * up immediately after (concurrency:1) to prevent MCP observability tools from
+ * picking up cross-scenario signals.
+ *
+ * Prerequisites:
+ *   - RCAEVAL_DATA_DIR pointing at the extracted RE2-OB dataset directory
+ *   - Kibana running with the investigation workflow registered
+ *   - xpack.evals.enabled=true
+ *
+ * Run:
+ *   RCAEVAL_DATA_DIR=/path/to/re2ob \
+ *   EVALUATION_CONNECTOR_ID=<judge-connector-id> \
+ *   node scripts/evals run --suite rca-benchmark \
+ *     --config playwright.workflow.config.ts \
+ *     --grep "investigates root cause"
+ *
+ * Override agent model (defaults to workflow YAML connector):
+ *   WORKFLOW_AGENT_CONNECTOR_ID=.anthropic-claude-4.6-sonnet-chat_completion
+ *
+ * Limit scenarios (quick validation):
+ *   RCAEVAL_MAX_SCENARIOS=1
+ */
+
+import { tags } from '@kbn/scout';
+import type { Evaluator } from '@kbn/evals';
+import { evaluate } from '../src/evaluate';
+import { RE2OB_SCENARIOS } from '../src/scenarios/re2ob_scenarios';
+import type { RcaScenario } from '../src/scenarios/types';
+import {
+  indexLocalScenario,
+  cleanLocalScenario,
+  resolveLocalCaseDir,
+} from '../src/data_generators/local_replay';
+import { createCriteriaEvaluator } from '../src/criteria_evaluator';
+import { SimpleWorkflowClient } from '../src/simple_workflow_client';
+import type { ConverseUsage } from '../src/agent_builder_client';
+
+const RCAEVAL_DATA_DIR = process.env.RCAEVAL_DATA_DIR;
+const RCAEVAL_MAX_SCENARIOS = process.env.RCAEVAL_MAX_SCENARIOS
+  ? parseInt(process.env.RCAEVAL_MAX_SCENARIOS, 10)
+  : undefined;
+const WORKFLOW_AGENT_CONNECTOR_ID = process.env.WORKFLOW_AGENT_CONNECTOR_ID;
+
+const INVESTIGATION_WORKFLOW_ID = 'system-streams-sigevents-investigation';
+
+interface ScenarioToRun {
+  scenario: RcaScenario;
+  caseDir: string;
+}
+
+function createUsageEvaluator(name: string, field: keyof ConverseUsage): Evaluator {
+  return {
+    name,
+    kind: 'CODE',
+    evaluate: async ({ output }) => {
+      const usage = (output as { usage?: ConverseUsage } | undefined)?.usage;
+      const value = usage?.[field] ?? null;
+      return { score: value };
+    },
+  };
+}
+
+function buildRcaCriteria(scenario: RcaScenario): string[] {
+  return [
+    `The final conclusion identifies "${scenario.service}" (or a recognizable variant of the name) as the PRIMARY root cause component — FAIL if the service appears only as a downstream victim of another service, only in a hypothesis that is explicitly refuted or ranked below another conclusion, or if the output concludes that no fault was detected`,
+    `Does NOT name a frontend or gateway service (e.g. "frontend", "ingress", "API gateway") as the primary root cause — mentions of such services purely as downstream victims of a cascading failure do NOT violate this criterion`,
+    `Cites at least one concrete piece of evidence (error log, anomalous trace latency, error rate spike, or specific tool output)`,
+    `The failure mechanism described in the final conclusion is specifically consistent with "${scenario.faultDescription}" — a conclusion of "no fault detected" automatically FAILS; a description of an unrelated resource class (e.g. CPU/memory pressure when the fault is socket exhaustion, or resource exhaustion when the fault is packet loss) also FAILS`,
+  ];
+}
+
+evaluate.describe(
+  'RE2-OB RCA Benchmark (investigation workflow)',
+  { tag: tags.serverless.observability.complete },
+  () => {
+    evaluate.setTimeout(720 * 60_000);
+
+    const scenariosToRun: ScenarioToRun[] = [];
+
+    evaluate.beforeAll(async ({ log }) => {
+      if (!RCAEVAL_DATA_DIR) {
+        log.info('RCAEVAL_DATA_DIR not set — skipping investigation workflow RE2-OB suite');
+        evaluate.skip();
+        return;
+      }
+
+      const scenarios = RCAEVAL_MAX_SCENARIOS
+        ? RE2OB_SCENARIOS.slice(0, RCAEVAL_MAX_SCENARIOS)
+        : RE2OB_SCENARIOS;
+
+      for (const scenario of scenarios) {
+        const caseDir = resolveLocalCaseDir(RCAEVAL_DATA_DIR, scenario);
+        if (!caseDir) {
+          log.warning(`Skipping ${scenario.snapshotName}: no local data found under ${RCAEVAL_DATA_DIR}`);
+          continue;
+        }
+        scenariosToRun.push({ scenario, caseDir });
+      }
+
+      if (scenariosToRun.length === 0) {
+        log.info('No local scenarios available — skipping');
+        evaluate.skip();
+      }
+    });
+
+    evaluate(
+      'investigates root cause via investigation workflow across fault-injected Online Boutique scenarios',
+      async ({ executorClient, esClient, fetch, log, evaluators }: any) => {
+        const client = new SimpleWorkflowClient(fetch, log, INVESTIGATION_WORKFLOW_ID);
+
+        await executorClient.runExperiment(
+          {
+            datasets: [
+              {
+                name: 'RE2-OB Root Cause Analysis (investigation workflow)',
+                description:
+                  'Evaluates the managed investigation workflow on Online Boutique fault-injection ' +
+                  'scenarios from the RCAEval benchmark, using locally extracted CSV data. ' +
+                  'Data is indexed fresh per scenario and cleaned up immediately after to ' +
+                  'prevent cross-scenario contamination in MCP observability tools.',
+                examples: scenariosToRun.map(({ scenario, caseDir }) => ({
+                  input: { scenario, caseDir },
+                  output: { criteria: buildRcaCriteria(scenario) },
+                  metadata: {
+                    service: scenario.service,
+                    faultType: scenario.faultType,
+                    dataset: 're2ob-investigation-workflow',
+                  },
+                })),
+              },
+            ],
+            concurrency: 1,
+            task: async ({ input }: any) => {
+              const { scenario, caseDir } = input as ScenarioToRun;
+              const handle = await indexLocalScenario(esClient, log, scenario, caseDir);
+              const { logsIndex, tracesIndex, metricsIndex } = handle;
+
+              try {
+                const response = await client.run({
+                  streamNames: [logsIndex, tracesIndex, metricsIndex],
+                  scenarioId: scenario.snapshotName,
+                  scenarioTitle: `${scenario.service} / ${scenario.faultType}`,
+                  service: scenario.service,
+                  faultType: scenario.faultType,
+                  connectorId: WORKFLOW_AGENT_CONNECTOR_ID,
+                });
+                return {
+                  errors: response.errors,
+                  messages: response.messages,
+                  steps: response.steps,
+                  traceId: response.traceId,
+                  usage: response.usage,
+                };
+              } finally {
+                await cleanLocalScenario(esClient, handle, log);
+              }
+            },
+          },
+          [
+            createCriteriaEvaluator({ evaluators }),
+            createUsageEvaluator('Input Tokens', 'input_tokens'),
+            createUsageEvaluator('Output Tokens', 'output_tokens'),
+            createUsageEvaluator('LLM Calls', 'llm_calls'),
+          ]
+        );
+      }
+    );
+  }
+);

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "functional-tests",
+  "id": "@kbn/evals-suite-rca-benchmark",
+  "owner": "@elastic/obs-nightshift",
+  "group": "observability",
+  "visibility": "private"
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/package.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/evals-suite-rca-benchmark",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0"
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/playwright.config.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/playwright.config.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import Path from 'path';
+import { createPlaywrightEvalsConfig } from '@kbn/evals';
+
+export default createPlaywrightEvalsConfig({
+  testDir: Path.resolve(__dirname, './evals'),
+  timeout: 45 * 60_000,
+});

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/playwright.workflow.config.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/playwright.workflow.config.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Playwright config for the RCA benchmark investigation workflow spec.
+ *
+ * Uses singleProject: true because the workflow's agent model is set via
+ * WORKFLOW_AGENT_CONNECTOR_ID (or the workflow YAML default) — the eval
+ * framework's per-connector project multiplexing is not needed here.
+ *
+ * Run:
+ *   RCAEVAL_DATA_DIR=/path/to/re2ob \
+ *   EVALUATION_CONNECTOR_ID=<judge-connector-id> \
+ *   node scripts/evals run --suite rca-benchmark \
+ *     --config playwright.workflow.config.ts
+ */
+import Path from 'path';
+import { createPlaywrightEvalsConfig } from '@kbn/evals';
+
+export default createPlaywrightEvalsConfig({
+  testDir: Path.resolve(__dirname, './evals'),
+  timeout: 45 * 60_000,
+  singleProject: true,
+});

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/scripts/capture_re2ob_snapshot/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/scripts/capture_re2ob_snapshot/index.ts
@@ -1,0 +1,363 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Captures a GCS snapshot from a local RCAEval case directory.
+ *
+ * Workflow:
+ *   1. Parse metadata from case directory path (service, fault type, inject_time)
+ *   2. Index logs.csv + traces.csv into Elasticsearch, shifting timestamps to "now-10min"
+ *   3. Snapshot the resulting data streams to GCS
+ *   4. Clean up the indexed data
+ *
+ * Prerequisites:
+ *   - Elasticsearch running with GCS credentials in keystore:
+ *       yarn es snapshot --license trial \
+ *         --secure-files gcs.client.default.credentials_file=/path/to/gcs-creds.json
+ *   - The GCS bucket "rca-bench-datasets" must exist and the credentials must have write access
+ *
+ * Usage:
+ *   node scripts/capture_rcabench_snapshot.js \
+ *     --case-dir /path/to/RE2-OB/currencyservice_loss/1
+ *
+ * The snapshot name is derived from the case directory: {service}-{fault_type}
+ * (e.g., "currencyservice-loss"). Multiple instances of the same fault are averaged
+ * into a single snapshot; run this for each instance and the first one wins.
+ */
+
+import { createReadStream } from 'fs';
+import { readFile, access } from 'fs/promises';
+import { createInterface } from 'readline';
+import { basename, dirname, join } from 'path';
+import { run } from '@kbn/dev-cli-runner';
+import { Client } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { GCS_BUCKET, RE2OB_GCS_BASE_PATH } from '../../src/scenarios/constants';
+
+const WINDOW_BEFORE_S = 600;
+const WINDOW_AFTER_S = 600;
+const TARGET_INJECT_OFFSET_S = 600;
+const BATCH_SIZE = 2000;
+
+interface CaseMeta {
+  service: string;
+  faultType: string;
+  snapshotName: string;
+  logsDataStream: string;
+  tracesDataStream: string;
+}
+
+function parseCaseMeta(caseDir: string): CaseMeta {
+  const faultDirName = basename(dirname(caseDir));
+  const lastUnderscore = faultDirName.lastIndexOf('_');
+  const service = faultDirName.slice(0, lastUnderscore);
+  const faultType = faultDirName.slice(lastUnderscore + 1);
+  const snapshotName = `${service}-${faultType}`;
+  return {
+    service,
+    faultType,
+    snapshotName,
+    logsDataStream: `logs-rca-bench-re2ob-${snapshotName}`,
+    tracesDataStream: `traces-rca-bench-re2ob-${snapshotName}`,
+  };
+}
+
+async function assertFileExists(filePath: string): Promise<void> {
+  try {
+    await access(filePath);
+  } catch {
+    throw new Error(`Required file not found: ${filePath}`);
+  }
+}
+
+async function bulkIndex(
+  esClient: Client,
+  dataStream: string,
+  docs: Record<string, unknown>[]
+): Promise<{ indexed: number; failed: number }> {
+  const ndjson =
+    docs
+      .flatMap((doc) => [JSON.stringify({ create: { _index: dataStream } }), JSON.stringify(doc)])
+      .join('\n') + '\n';
+
+  const result = await esClient.bulk({ body: ndjson, refresh: false });
+  const failed = result.errors ? (result.items ?? []).filter((i) => i.create?.error).length : 0;
+  return { indexed: docs.length - failed, failed };
+}
+
+type RowToDoc = (
+  row: Record<string, string>,
+  shiftSeconds: number,
+  injectTime: number
+) => Record<string, unknown> | null;
+
+async function indexCsv(
+  esClient: Client,
+  log: ToolingLog,
+  csvPath: string,
+  dataStream: string,
+  rowToDoc: RowToDoc,
+  shiftSeconds: number,
+  injectTime: number
+): Promise<{ indexed: number; skipped: number }> {
+  const rl = createInterface({ input: createReadStream(csvPath), crlfDelay: Infinity });
+
+  let header: string[] | null = null;
+  let batch: Record<string, unknown>[] = [];
+  let totalIndexed = 0;
+  let totalSkipped = 0;
+
+  const flush = async () => {
+    if (batch.length === 0) return;
+    const { indexed } = await bulkIndex(esClient, dataStream, batch);
+    totalIndexed += indexed;
+    batch = [];
+  };
+
+  for await (const line of rl) {
+    if (!header) {
+      header = line.split(',');
+      continue;
+    }
+    if (!line.trim()) continue;
+
+    const values = line.split(',');
+    const row = Object.fromEntries(header.map((k, i) => [k.trim(), (values[i] ?? '').trim()]));
+
+    const doc = rowToDoc(row, shiftSeconds, injectTime);
+    if (!doc) {
+      totalSkipped++;
+      continue;
+    }
+
+    batch.push(doc);
+    if (batch.length >= BATCH_SIZE) await flush();
+  }
+  await flush();
+
+  log.info(`  ${dataStream}: ${totalIndexed} indexed, ${totalSkipped} out-of-window`);
+  return { indexed: totalIndexed, skipped: totalSkipped };
+}
+
+function logRowToDoc(
+  row: Record<string, string>,
+  shiftSeconds: number,
+  injectTime: number
+): Record<string, unknown> | null {
+  const tsNs = parseInt(row.timestamp, 10);
+  if (isNaN(tsNs)) return null;
+  const tsSeconds = tsNs / 1_000_000_000;
+
+  if (tsSeconds < injectTime - WINDOW_BEFORE_S || tsSeconds >= injectTime + WINDOW_AFTER_S) {
+    return null;
+  }
+
+  const shiftedNs = BigInt(Math.round(tsNs)) + BigInt(Math.round(shiftSeconds * 1_000_000_000));
+  const shiftedMs = Number(shiftedNs / 1_000_000n);
+
+  const doc: Record<string, unknown> = {
+    '@timestamp': new Date(shiftedMs).toISOString(),
+    'service.name': row.container_name || undefined,
+    message: row.message || undefined,
+    'log.level': row.level || undefined,
+  };
+  if (row.req_path) doc['http.url.path'] = row.req_path;
+  if (row.error) doc['error.message'] = row.error;
+  if (row.log_template) doc['rcaeval.log_template'] = row.log_template;
+  return doc;
+}
+
+function traceRowToDoc(
+  row: Record<string, string>,
+  shiftSeconds: number,
+  injectTime: number
+): Record<string, unknown> | null {
+  const startMs = parseInt(row.startTimeMillis, 10);
+  if (isNaN(startMs)) return null;
+  const startSeconds = startMs / 1000;
+
+  if (startSeconds < injectTime - WINDOW_BEFORE_S || startSeconds >= injectTime + WINDOW_AFTER_S) {
+    return null;
+  }
+
+  const shiftedMs = startMs + shiftSeconds * 1000;
+  const durationNs = parseFloat(row.duration) || 0;
+
+  const doc: Record<string, unknown> = {
+    '@timestamp': new Date(shiftedMs).toISOString(),
+    'service.name': row.serviceName || undefined,
+    'trace.id': row.traceID || undefined,
+    'span.id': row.spanID || undefined,
+    'span.name': row.operationName || undefined,
+    'event.duration': Math.round(durationNs * 1000),
+  };
+  if (row.methodName) doc['span.action'] = row.methodName;
+  if (row.parentSpanID) doc['parent.id'] = row.parentSpanID;
+  const status = parseFloat(row.statusCode);
+  if (!isNaN(status) && status > 0) doc['http.response.status_code'] = Math.round(status);
+  return doc;
+}
+
+async function deleteDataStreams(
+  esClient: Client,
+  log: ToolingLog,
+  ...dataStreams: string[]
+): Promise<void> {
+  for (const ds of dataStreams) {
+    try {
+      await esClient.indices.deleteDataStream({ name: ds });
+    } catch {
+      log.debug(`Could not delete ${ds} (may not exist)`);
+    }
+  }
+}
+
+run(
+  async ({ log, flags }) => {
+    const caseDir = String(flags['case-dir'] || '');
+    if (!caseDir) {
+      throw new Error(
+        'Required: --case-dir <path>\n' +
+          'Point at a RCAEval case instance directory, e.g.:\n' +
+          '  --case-dir /data/RE2-OB/currencyservice_loss/1'
+      );
+    }
+
+    const esUrl = String(flags['es-url'] || 'http://localhost:9200');
+    const esUsername = String(flags['es-username'] || 'elastic');
+    const esPassword = String(flags['es-password'] || 'changeme');
+    const gcsBucket = String(flags['gcs-bucket'] || GCS_BUCKET);
+    const gcsBasePath = String(flags['gcs-base-path'] || RE2OB_GCS_BASE_PATH);
+    const skipCleanup = Boolean(flags['skip-cleanup']);
+
+    const meta = parseCaseMeta(caseDir);
+    log.info(`Service:        ${meta.service}`);
+    log.info(`Fault type:     ${meta.faultType}`);
+    log.info(`Snapshot name:  ${meta.snapshotName}`);
+    log.info(`GCS target:     gs://${gcsBucket}/${gcsBasePath}/${meta.snapshotName}`);
+    log.info(`ES:             ${esUrl}`);
+    log.info('');
+
+    const logsPath = join(caseDir, 'logs.csv');
+    const tracesPath = join(caseDir, 'traces.csv');
+    const injectTimePath = join(caseDir, 'inject_time.txt');
+
+    await assertFileExists(logsPath);
+    await assertFileExists(tracesPath);
+    await assertFileExists(injectTimePath);
+
+    const injectTime = parseInt(await readFile(injectTimePath, 'utf-8'), 10);
+    if (isNaN(injectTime)) throw new Error(`Invalid inject_time.txt in ${caseDir}`);
+
+    const nowSeconds = Date.now() / 1000;
+    const shiftSeconds = nowSeconds - TARGET_INJECT_OFFSET_S - injectTime;
+    log.info(
+      `Time shift: +${Math.round(shiftSeconds / 3600 / 24)}d ` +
+        `${Math.round((shiftSeconds % 86400) / 3600)}h`
+    );
+    log.info('');
+
+    const esClient = new Client({
+      node: esUrl,
+      auth: { username: esUsername, password: esPassword },
+    });
+
+    log.info('[1/3] Indexing data into Elasticsearch...');
+    await deleteDataStreams(esClient, log, meta.logsDataStream, meta.tracesDataStream);
+
+    await indexCsv(
+      esClient,
+      log,
+      logsPath,
+      meta.logsDataStream,
+      logRowToDoc,
+      shiftSeconds,
+      injectTime
+    );
+    await indexCsv(
+      esClient,
+      log,
+      tracesPath,
+      meta.tracesDataStream,
+      traceRowToDoc,
+      shiftSeconds,
+      injectTime
+    );
+
+    await esClient.indices.refresh({
+      index: `${meta.logsDataStream},${meta.tracesDataStream}`,
+    });
+
+    log.info('');
+    log.info('[2/3] Creating GCS snapshot...');
+
+    const repoName = `rca-bench-capture-${Date.now()}`;
+    await esClient.snapshot.createRepository({
+      name: repoName,
+      repository: {
+        type: 'gcs',
+        settings: { bucket: gcsBucket, base_path: gcsBasePath },
+      },
+    });
+
+    try {
+      await esClient.snapshot.create({
+        repository: repoName,
+        snapshot: meta.snapshotName,
+        wait_for_completion: true,
+        indices: `${meta.logsDataStream},${meta.tracesDataStream}`,
+        include_global_state: false,
+      });
+      log.info(
+        `Snapshot "${meta.snapshotName}" created at gs://${gcsBucket}/${gcsBasePath}/${meta.snapshotName}`
+      );
+    } finally {
+      await esClient.snapshot.deleteRepository({ name: repoName }).catch(() => {});
+    }
+
+    if (!skipCleanup) {
+      log.info('');
+      log.info('[3/3] Cleaning up indexed data...');
+      await deleteDataStreams(esClient, log, meta.logsDataStream, meta.tracesDataStream);
+    }
+
+    log.info('');
+    log.info('Done. Add this scenario to src/scenarios/re2ob_scenarios.ts if not already present:');
+    log.info(`  scenario('${meta.service}', '${meta.faultType}'),`);
+  },
+  {
+    description: `
+      Captures a GCS snapshot from a local RCAEval case directory.
+
+      Reads logs.csv + traces.csv, indexes them into Elasticsearch with timestamps
+      shifted to "now-10min", snapshots to GCS, then cleans up.
+
+      Prerequisites:
+        - ES running with GCS credentials in keystore:
+            yarn es snapshot --license trial \\
+              --secure-files gcs.client.default.credentials_file=/path/to/creds.json
+        - GCS bucket "${GCS_BUCKET}" exists with write access
+
+      Example:
+        node scripts/capture_rcabench_re2ob_snapshot.js \\
+          --case-dir /data/RE2-OB/currencyservice_loss/1
+    `,
+    flags: {
+      string: ['case-dir', 'es-url', 'es-username', 'es-password', 'gcs-bucket', 'gcs-base-path'],
+      boolean: ['skip-cleanup'],
+      help: `
+        --case-dir      (required) Path to RCAEval case instance directory
+        --es-url        Elasticsearch URL (default: http://localhost:9200)
+        --es-username   ES username (default: elastic)
+        --es-password   ES password (default: changeme)
+        --gcs-bucket    GCS bucket name (default: ${GCS_BUCKET})
+        --gcs-base-path GCS base path (default: ${RE2OB_GCS_BASE_PATH})
+        --skip-cleanup  Leave indexed data in ES after snapshot
+      `,
+    },
+  }
+);

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/agent_builder_client.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/agent_builder_client.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { HttpHandler } from '@kbn/core/public';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import pRetry from 'p-retry';
+
+export interface ConverseAttachment {
+  id?: string;
+  type: string;
+  data?: Record<string, unknown>;
+  hidden?: boolean;
+}
+
+export interface ConverseUsage {
+  input_tokens: number;
+  output_tokens: number;
+  llm_calls: number;
+}
+
+export interface ConverseResponse {
+  conversationId?: string;
+  traceId?: string;
+  messages: Array<{ content: string }>;
+  steps?: any[];
+  errors: unknown[];
+  usage?: ConverseUsage;
+}
+
+export class AgentBuilderClient {
+  constructor(
+    private readonly fetch: HttpHandler,
+    private readonly log: ToolingLog,
+    private readonly connectorId: string,
+    private readonly agentId: string | undefined
+  ) {}
+
+  async converse(params: {
+    messages: string;
+    conversationId?: string;
+    attachments?: ConverseAttachment[];
+  }): Promise<ConverseResponse> {
+    const { messages, conversationId, attachments } = params;
+    this.log.info('Calling Agent Builder converse API');
+
+    const call = async () => {
+      const response = (await this.fetch('/api/agent_builder/converse', {
+        method: 'POST',
+        version: '2023-10-31',
+        body: JSON.stringify({
+          agent_id: this.agentId ?? agentBuilderDefaultAgentId,
+          connector_id: this.connectorId,
+          conversation_id: conversationId,
+          input: messages,
+          ...(attachments?.length ? { attachments } : {}),
+        }),
+      })) as {
+        conversation_id: string;
+        trace_id?: string;
+        steps: any[];
+        response: { message: string };
+      };
+
+      return {
+        conversationId: response.conversation_id,
+        traceId: response.trace_id,
+        messages: [{ content: messages }, { content: response.response.message }],
+        steps: response.steps,
+        errors: [],
+      };
+    };
+
+    try {
+      return await pRetry(call, {
+        retries: 4,
+        minTimeout: 10_000,
+        factor: 1.5,
+        onFailedAttempt: (err) => {
+          this.log.warning(
+            `Converse API attempt ${err.attemptNumber} failed (${err.retriesLeft} left); retrying…`
+          );
+        },
+      });
+    } catch (err) {
+      this.log.error('Converse API failed after retries');
+      return {
+        conversationId,
+        messages: [
+          { content: messages },
+          { content: 'Internal error — could not complete investigation.' },
+        ],
+        steps: [],
+        errors: [err],
+      };
+    }
+  }
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/criteria_evaluator.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/criteria_evaluator.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DefaultEvaluators } from '@kbn/evals';
+
+export function createCriteriaEvaluator({ evaluators }: { evaluators: DefaultEvaluators }) {
+  return {
+    name: 'Criteria',
+    kind: 'LLM' as const,
+    evaluate: async ({ input, output, expected, metadata }: any) => {
+      const criteria: string[] = expected?.criteria ?? [];
+      return evaluators.criteria(criteria).evaluate({ input, expected, output, metadata });
+    },
+  };
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/data_generators/local_replay.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/data_generators/local_replay.ts
@@ -1,0 +1,411 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Local CSV-based eval data loader — no GCS or snapshot infrastructure required.
+ *
+ * Used by evals/re2ob_local.spec.ts for local development and CI runs that have
+ * access to extracted RCAEval CSV files (RCAEVAL_DATA_DIR env var).
+ *
+ * Production evals use evals/re2ob.spec.ts (GCS snapshots via replaySnapshot).
+ */
+
+import { createReadStream, existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { createInterface } from 'readline';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import type { Client } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { RcaScenario } from '../scenarios/types';
+
+const WINDOW_BEFORE_S = 600;
+const WINDOW_AFTER_S = 600;
+const TARGET_INJECT_OFFSET_S = 600;
+const BATCH_SIZE = 2000;
+
+export interface LocalReplayHandle {
+  scenario: RcaScenario;
+  logsIndex: string;
+  tracesIndex: string;
+  metricsIndex: string;
+}
+
+function generateOpaqueDataStreamNames(): {
+  logsIndex: string;
+  tracesIndex: string;
+  metricsIndex: string;
+} {
+  const runId = randomUUID().slice(0, 8);
+  return {
+    logsIndex: `logs-rcabench-${runId}`,
+    tracesIndex: `traces-rcabench-${runId}`,
+    metricsIndex: `metrics-rcabench-${runId}`,
+  };
+}
+
+// Known services in the RE2-OB simple_metrics.csv, longest-prefix-first to avoid
+// matching "frontend" before "frontend-external".
+const METRICS_SERVICES = [
+  'frontend-external',
+  'adservice',
+  'cartservice',
+  'checkoutservice',
+  'currencyservice',
+  'emailservice',
+  'frontend',
+  'paymentservice',
+  'productcatalogservice',
+  'recommendationservice',
+  'redis',
+  'shippingservice',
+];
+
+// Maps simple_metrics column suffix → ES field name
+const METRIC_SUFFIX_TO_FIELD: Record<string, string> = {
+  cpu: 'system.cpu.pct',
+  mem: 'system.memory.bytes',
+  diskio: 'system.diskio.bytes',
+  socket: 'system.socket.count',
+  workload: 'service.request_rate',
+  'latency-50': 'service.latency.p50_ms',
+  'latency-90': 'service.latency.p90_ms',
+  error: 'service.error_rate',
+};
+
+interface MetricsColSpec {
+  colIndex: number;
+  service: string;
+  field: string;
+}
+
+function parseMetricsHeader(headers: string[]): MetricsColSpec[] {
+  const specs: MetricsColSpec[] = [];
+  for (let i = 0; i < headers.length; i++) {
+    const col = headers[i].trim();
+    if (col === 'time') continue;
+    for (const svc of METRICS_SERVICES) {
+      if (col.startsWith(svc + '_')) {
+        const suffix = col.slice(svc.length + 1);
+        const field = METRIC_SUFFIX_TO_FIELD[suffix];
+        if (field) specs.push({ colIndex: i, service: svc, field });
+        break;
+      }
+    }
+  }
+  return specs;
+}
+
+async function indexMetricsCsv(
+  esClient: Client,
+  csvPath: string,
+  index: string,
+  shiftS: number,
+  injectTime: number
+): Promise<number> {
+  const rl = createInterface({ input: createReadStream(csvPath), crlfDelay: Infinity });
+
+  let specs: MetricsColSpec[] | null = null;
+  let timeColIndex = -1;
+  let batch: Record<string, unknown>[] = [];
+  let total = 0;
+
+  const flush = async () => {
+    if (batch.length === 0) return;
+    total += await bulkIndex(esClient, index, batch);
+    batch = [];
+  };
+
+  for await (const line of rl) {
+    if (!specs) {
+      const headers = parseCsvRow(line);
+      timeColIndex = headers.findIndex((h) => h.trim() === 'time');
+      specs = parseMetricsHeader(headers);
+      continue;
+    }
+    if (!line.trim()) continue;
+
+    const values = parseCsvRow(line);
+    const timeS = parseInt(values[timeColIndex] ?? '', 10);
+    if (isNaN(timeS)) continue;
+    if (timeS < injectTime - WINDOW_BEFORE_S || timeS >= injectTime + WINDOW_AFTER_S) continue;
+
+    const shiftedMs = (timeS + shiftS) * 1000;
+    const timestamp = new Date(shiftedMs).toISOString();
+
+    // Group columns by service, emit one doc per service per timestamp
+    const byService = new Map<string, Record<string, unknown>>();
+    for (const spec of specs) {
+      const raw = values[spec.colIndex];
+      const val = raw !== undefined && raw !== '' ? parseFloat(raw) : NaN;
+      if (isNaN(val)) continue;
+      let doc = byService.get(spec.service);
+      if (!doc) {
+        doc = { '@timestamp': timestamp, 'service.name': spec.service };
+        byService.set(spec.service, doc);
+      }
+      doc[spec.field] = val;
+    }
+
+    for (const doc of byService.values()) {
+      batch.push(doc);
+    }
+    if (batch.length >= BATCH_SIZE) await flush();
+  }
+  await flush();
+  return total;
+}
+
+export function resolveLocalCaseDir(rcaevalDataDir: string, scenario: RcaScenario): string | null {
+  // Standard RE2-OB layout: {dataDir}/RE2-OB/{service}_{faultType}/1
+  const standard = join(rcaevalDataDir, 'RE2-OB', `${scenario.service}_${scenario.faultType}`, '1');
+  if (existsSync(join(standard, 'logs.csv'))) return standard;
+
+  // Fallback: flat layout used for currencyservice_loss in our local cache
+  const flat = join(rcaevalDataDir, `re2ob-${scenario.service}-${scenario.faultType}-1`);
+  if (existsSync(join(flat, 'logs.csv'))) return flat;
+
+  return null;
+}
+
+async function bulkIndex(
+  esClient: Client,
+  index: string,
+  docs: Record<string, unknown>[]
+): Promise<number> {
+  const body = docs.flatMap((doc) => [
+    JSON.stringify({ create: { _index: index } }),
+    JSON.stringify(doc),
+  ]);
+  const result = await esClient.bulk({ body: body.join('\n') + '\n', refresh: false });
+  const failed = result.errors
+    ? (result.items ?? []).filter((i: any) => i.create?.error).length
+    : 0;
+  return docs.length - failed;
+}
+
+type RowMapper = (
+  row: Record<string, string>,
+  shiftS: number,
+  injectTime: number
+) => Record<string, unknown> | null;
+
+function parseCsvRow(line: string): string[] {
+  const fields: string[] = [];
+  let i = 0;
+
+  while (true) {
+    if (i < line.length && line[i] === '"') {
+      let field = '';
+      i++; // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            field += '"';
+            i += 2;
+          } else {
+            i++; // skip closing quote
+            break;
+          }
+        } else {
+          field += line[i++];
+        }
+      }
+      fields.push(field);
+    } else {
+      const start = i;
+      while (i < line.length && line[i] !== ',') i++;
+      fields.push(line.slice(start, i).trim());
+    }
+
+    if (i >= line.length) break;
+    i++; // skip comma separator
+    if (i === line.length) {
+      fields.push('');
+      break;
+    }
+  }
+
+  return fields;
+}
+
+async function indexCsv(
+  esClient: Client,
+  csvPath: string,
+  index: string,
+  rowMapper: RowMapper,
+  shiftS: number,
+  injectTime: number
+): Promise<number> {
+  const rl = createInterface({ input: createReadStream(csvPath), crlfDelay: Infinity });
+
+  let header: string[] | null = null;
+  let batch: Record<string, unknown>[] = [];
+  let total = 0;
+
+  const flush = async () => {
+    if (batch.length === 0) return;
+    total += await bulkIndex(esClient, index, batch);
+    batch = [];
+  };
+
+  for await (const line of rl) {
+    if (!header) {
+      header = parseCsvRow(line);
+      continue;
+    }
+    if (!line.trim()) continue;
+    const values = parseCsvRow(line);
+    const row = Object.fromEntries(header.map((k, i) => [k.trim(), values[i] ?? '']));
+    const doc = rowMapper(row, shiftS, injectTime);
+    if (!doc) continue;
+    batch.push(doc);
+    if (batch.length >= BATCH_SIZE) await flush();
+  }
+  await flush();
+  return total;
+}
+
+function mapLogRow(
+  row: Record<string, string>,
+  shiftS: number,
+  injectTime: number
+): Record<string, unknown> | null {
+  const tsNs = parseInt(row.timestamp, 10);
+  if (isNaN(tsNs)) return null;
+  const tsS = tsNs / 1_000_000_000;
+  if (tsS < injectTime - WINDOW_BEFORE_S || tsS >= injectTime + WINDOW_AFTER_S) return null;
+
+  const shiftedNs = BigInt(Math.round(tsNs)) + BigInt(Math.round(shiftS * 1_000_000_000));
+  const shiftedMs = Number(shiftedNs / 1_000_000n);
+
+  const doc: Record<string, unknown> = {
+    '@timestamp': new Date(shiftedMs).toISOString(),
+    'service.name': row.container_name || undefined,
+    message: row.message || undefined,
+    'log.level': row.level || undefined,
+  };
+  if (row.req_path) doc['http.url.path'] = row.req_path;
+  if (row.error) doc['error.message'] = row.error;
+  if (row.log_template) doc['rcaeval.log_template'] = row.log_template;
+  return doc;
+}
+
+function mapTraceRow(
+  row: Record<string, string>,
+  shiftS: number,
+  injectTime: number
+): Record<string, unknown> | null {
+  const startMs = parseInt(row.startTimeMillis, 10);
+  if (isNaN(startMs)) return null;
+  const startS = startMs / 1000;
+  if (startS < injectTime - WINDOW_BEFORE_S || startS >= injectTime + WINDOW_AFTER_S) return null;
+
+  const shiftedMs = startMs + shiftS * 1000;
+  const durationNs = parseFloat(row.duration) || 0;
+
+  const doc: Record<string, unknown> = {
+    '@timestamp': new Date(shiftedMs).toISOString(),
+    'service.name': row.serviceName || undefined,
+    'trace.id': row.traceID || undefined,
+    'span.id': row.spanID || undefined,
+    'span.name': row.operationName || undefined,
+    'event.duration': Math.round(durationNs * 1000),
+  };
+  if (row.methodName) doc['span.action'] = row.methodName;
+  if (row.parentSpanID) doc['parent.id'] = row.parentSpanID;
+  const status = parseFloat(row.statusCode);
+  if (!isNaN(status) && status > 0) doc['http.response.status_code'] = Math.round(status);
+  return doc;
+}
+
+async function createMetricsDataStream(esClient: Client, name: string): Promise<void> {
+  await esClient.indices.createDataStream({ name });
+}
+
+async function createTracesIndex(esClient: Client, index: string): Promise<void> {
+  await esClient.indices.create({
+    index,
+    mappings: {
+      dynamic: true,
+      properties: {
+        '@timestamp': { type: 'date' },
+        service: { properties: { name: { type: 'keyword' } } },
+        trace: { properties: { id: { type: 'keyword' } } },
+        span: {
+          properties: {
+            id: { type: 'keyword' },
+            name: { type: 'keyword' },
+            action: { type: 'keyword' },
+          },
+        },
+        parent: { properties: { id: { type: 'keyword' } } },
+        event: { properties: { duration: { type: 'long' } } },
+        http: {
+          properties: {
+            response: { properties: { status_code: { type: 'long' } } },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function indexLocalScenario(
+  esClient: Client,
+  log: ToolingLog,
+  scenario: RcaScenario,
+  caseDir: string
+): Promise<LocalReplayHandle> {
+  const injectTime = parseInt(await readFile(join(caseDir, 'inject_time.txt'), 'utf-8'), 10);
+  const shiftS = Date.now() / 1000 - TARGET_INJECT_OFFSET_S - injectTime;
+
+  const { logsIndex, tracesIndex, metricsIndex } = generateOpaqueDataStreamNames();
+
+  log.info(
+    `[${scenario.snapshotName}] Indexing — shift +${Math.round(shiftS / 3600)}h, ` +
+      `inject → ${new Date((injectTime + shiftS) * 1000).toISOString()}`
+  );
+
+  await Promise.all([
+    createTracesIndex(esClient, tracesIndex),
+    createMetricsDataStream(esClient, metricsIndex),
+  ]);
+
+  const [logsIndexed, tracesIndexed, metricsIndexed] = await Promise.all([
+    indexCsv(esClient, join(caseDir, 'logs.csv'), logsIndex, mapLogRow, shiftS, injectTime),
+    indexCsv(esClient, join(caseDir, 'traces.csv'), tracesIndex, mapTraceRow, shiftS, injectTime),
+    indexMetricsCsv(esClient, join(caseDir, 'simple_metrics.csv'), metricsIndex, shiftS, injectTime),
+  ]);
+
+  await esClient.indices.refresh({ index: `${logsIndex},${tracesIndex},${metricsIndex}` });
+
+  log.info(
+    `[${scenario.snapshotName}] Indexed ${logsIndexed} logs + ${tracesIndexed} traces + ${metricsIndexed} metric docs`
+  );
+
+  return { scenario, logsIndex, tracesIndex, metricsIndex };
+}
+
+export async function cleanLocalScenario(
+  esClient: Client,
+  handle: LocalReplayHandle,
+  log: ToolingLog
+): Promise<void> {
+  for (const index of [handle.logsIndex, handle.tracesIndex]) {
+    try {
+      await esClient.indices.delete({ index, ignore_unavailable: true });
+    } catch (err) {
+      log.warning(`Cleanup failed for ${index}: ${(err as Error).message}`);
+    }
+  }
+  try {
+    await esClient.indices.deleteDataStream({ name: handle.metricsIndex });
+  } catch (err) {
+    log.warning(`Cleanup failed for data stream ${handle.metricsIndex}: ${(err as Error).message}`);
+  }
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/data_generators/replay.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/data_generators/replay.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import {
+  createGcsRepository,
+  replaySnapshot,
+  TEMP_INDEX_PREFIX,
+  type LoadResult,
+} from '@kbn/es-snapshot-loader';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { RcaScenario } from '../scenarios/types';
+
+async function deleteStaleTemporaryIndices(esClient: Client, log: ToolingLog): Promise<void> {
+  let staleIndices: string[];
+  try {
+    const resolved = await esClient.indices.resolveIndex({ name: `${TEMP_INDEX_PREFIX}*` });
+    staleIndices = resolved.indices.map((entry) => entry.name);
+  } catch (error) {
+    log.error(`Failed to resolve stale temporary indices: ${(error as Error).message}`);
+    return;
+  }
+
+  if (staleIndices.length === 0) {
+    return;
+  }
+
+  log.warning(`Found ${staleIndices.length} stale temporary indices from a previous run; deleting`);
+  try {
+    await esClient.indices.delete({ index: staleIndices.join(','), ignore_unavailable: true });
+    log.info(`Deleted ${staleIndices.length} stale temporary indices`);
+  } catch (error) {
+    log.error(`Failed to delete stale temporary indices: ${(error as Error).message}`);
+  }
+}
+
+export async function replayRcaBenchSnapshot(
+  esClient: Client,
+  log: ToolingLog,
+  scenario: RcaScenario
+): Promise<LoadResult> {
+  log.debug(
+    `Replaying snapshot "${scenario.snapshotName}" from ${scenario.gcs.bucket}/${scenario.gcs.basePath}`
+  );
+
+  await deleteStaleTemporaryIndices(esClient, log);
+
+  return replaySnapshot({
+    esClient,
+    log,
+    repository: createGcsRepository({
+      bucket: scenario.gcs.bucket,
+      basePath: scenario.gcs.basePath,
+    }),
+    snapshotName: scenario.snapshotName,
+    patterns: ['logs-*', 'traces-*'],
+  });
+}
+
+export async function cleanRcaBenchDataStreams(
+  esClient: Client,
+  replayResult: LoadResult,
+  log?: ToolingLog
+): Promise<void> {
+  const indices = [...new Set(replayResult?.reindexedIndices ?? [])];
+  if (indices.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    indices.map(async (index) => {
+      try {
+        await esClient.deleteByQuery({ index, query: { match_all: {} }, refresh: true });
+      } catch (error) {
+        log?.warning(`deleteByQuery cleanup failed for [${index}]; documents may remain.`);
+      }
+    })
+  );
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/evaluate.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/evaluate.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  evaluate as base,
+  createToolCallsEvaluator,
+  createSpanLatencyEvaluator,
+  type EvaluationDataset,
+  type Example,
+} from '@kbn/evals';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { AgentBuilderClient } from './agent_builder_client';
+import type { ConverseAttachment } from './agent_builder_client';
+import { createCriteriaEvaluator } from './criteria_evaluator';
+
+export interface RcaEvalExample extends Example {
+  input: {
+    question: string;
+    attachments?: ConverseAttachment[];
+  };
+  output: {
+    criteria: string[];
+  };
+  metadata?: Record<string, string>;
+}
+
+export type EvaluateRcaDataset = (params: {
+  dataset: {
+    name: string;
+    description: string;
+    examples: RcaEvalExample[];
+  };
+}) => Promise<void>;
+
+export const evaluate = base.extend<
+  {},
+  {
+    chatClient: AgentBuilderClient;
+    evaluateDataset: EvaluateRcaDataset;
+  }
+>({
+  chatClient: [
+    async ({ fetch, log, connector }, use) => {
+      const client = new AgentBuilderClient(fetch, log, connector.id, agentBuilderDefaultAgentId);
+      await use(client);
+    },
+    { scope: 'worker' },
+  ],
+
+  evaluateDataset: [
+    ({ chatClient, evaluators, executorClient, traceEsClient, log }, use) => {
+      use(async ({ dataset: { name, description, examples } }) => {
+        await executorClient.runExperiment(
+          {
+            datasets: [{ name, description, examples } satisfies EvaluationDataset],
+            concurrency: 1,
+            task: async ({ input }) => {
+              const { question, attachments } = input as RcaEvalExample['input'];
+
+              const response = await chatClient.converse({ messages: question, attachments });
+
+              return {
+                errors: response.errors,
+                messages: response.messages,
+                steps: response.steps,
+                traceId: response.traceId,
+              };
+            },
+          },
+          [
+            createCriteriaEvaluator({ evaluators }),
+            createToolCallsEvaluator({ traceEsClient, log }),
+            evaluators.traceBasedEvaluators.inputTokens,
+            evaluators.traceBasedEvaluators.outputTokens,
+            evaluators.traceBasedEvaluators.cachedTokens,
+            createSpanLatencyEvaluator({ traceEsClient, log, spanName: 'ChatComplete' }),
+          ]
+        );
+      });
+    },
+    { scope: 'worker' },
+  ],
+});

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/scenarios/constants.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/scenarios/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const GCS_BUCKET = 'rca-bench-datasets';
+
+export const RE2OB_GCS_BASE_PATH = 're2ob';
+export const RE2TT_GCS_BASE_PATH = 're2tt';

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/scenarios/re2ob_scenarios.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/scenarios/re2ob_scenarios.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GCS_BUCKET, RE2OB_GCS_BASE_PATH } from './constants';
+import type { RcaScenario } from './types';
+
+const FAULT_DESCRIPTIONS: Record<string, string> = {
+  cpu: 'CPU stress injection — high CPU load on the target service',
+  mem: 'Memory pressure injection — memory exhaustion on the target service',
+  disk: 'Disk I/O saturation — heavy disk read/write load on the target service',
+  delay: 'Network delay injection — artificial latency added to service traffic',
+  loss: 'Packet loss injection — intermittent network packet drops on the target service',
+  socket: 'Socket exhaustion — connection/socket resource limits reached on the target service',
+};
+
+function scenario(service: string, faultType: string): RcaScenario {
+  return {
+    snapshotName: `${service}-${faultType}`,
+    service,
+    faultType,
+    faultDescription: FAULT_DESCRIPTIONS[faultType] ?? `fault type: ${faultType}`,
+    gcs: { bucket: GCS_BUCKET, basePath: RE2OB_GCS_BASE_PATH },
+  };
+}
+
+/**
+ * Scenarios with local CSV data extracted from the RCAEval RE2-OB Zenodo dataset.
+ * Add a row here + capture a GCS snapshot (scripts/capture_re2ob_snapshot) to
+ * include a scenario in CI. Local runs only need RCAEVAL_DATA_DIR to point at the
+ * extracted RE2-OB directory.
+ */
+
+// Original 6-scenario set used for the first round of evals (kept for reference /
+// reproducibility of earlier score tables).
+export const RE2OB_SCENARIOS_V1: RcaScenario[] = [
+  scenario('currencyservice', 'loss'),
+  scenario('checkoutservice', 'delay'),
+  scenario('checkoutservice', 'mem'),
+  scenario('emailservice', 'cpu'),
+  scenario('productcatalogservice', 'cpu'),
+  scenario('recommendationservice', 'socket'),
+];
+
+// Expanded 20-scenario set (distinct service×fault combos, none overlapping V1),
+// balanced ~4 per service and covering all 6 fault types — including `disk`, which
+// V1 never exercised. Instance "1" of each combo is extracted under RCAEVAL_DATA_DIR.
+export const RE2OB_SCENARIOS_V2: RcaScenario[] = [
+  scenario('checkoutservice', 'cpu'),
+  scenario('checkoutservice', 'disk'),
+  scenario('checkoutservice', 'loss'),
+  scenario('checkoutservice', 'socket'),
+  scenario('currencyservice', 'cpu'),
+  scenario('currencyservice', 'delay'),
+  scenario('currencyservice', 'disk'),
+  scenario('currencyservice', 'socket'),
+  scenario('emailservice', 'delay'),
+  scenario('emailservice', 'disk'),
+  scenario('emailservice', 'loss'),
+  scenario('emailservice', 'mem'),
+  scenario('productcatalogservice', 'delay'),
+  scenario('productcatalogservice', 'disk'),
+  scenario('productcatalogservice', 'mem'),
+  scenario('productcatalogservice', 'socket'),
+  scenario('recommendationservice', 'cpu'),
+  scenario('recommendationservice', 'delay'),
+  scenario('recommendationservice', 'disk'),
+  scenario('recommendationservice', 'mem'),
+];
+
+// 10-scenario subset for prompt-iteration runs: 2 per service (1 resource fault +
+// 1 network fault), chosen for fault-type coverage, not based on observed scores.
+//   checkoutservice:       cpu (resource),   loss (network)
+//   currencyservice:       disk (resource),  delay (network)
+//   emailservice:          mem (resource),   loss (network)
+//   productcatalogservice: socket (resource),delay (network)
+//   recommendationservice: mem (resource),   delay (network)
+export const RE2OB_SCENARIOS_V2_SUBSET: RcaScenario[] = [
+  scenario('checkoutservice', 'cpu'),
+  scenario('checkoutservice', 'loss'),
+  scenario('currencyservice', 'disk'),
+  scenario('currencyservice', 'delay'),
+  scenario('emailservice', 'mem'),
+  scenario('emailservice', 'loss'),
+  scenario('productcatalogservice', 'socket'),
+  scenario('productcatalogservice', 'delay'),
+  scenario('recommendationservice', 'mem'),
+  scenario('recommendationservice', 'delay'),
+];
+
+// Active set for the current eval run.
+export const RE2OB_SCENARIOS: RcaScenario[] = RE2OB_SCENARIOS_V2;

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/scenarios/types.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/scenarios/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface GcsConfig {
+  bucket: string;
+  basePath: string;
+}
+
+export interface RcaScenario {
+  snapshotName: string;
+  service: string;
+  faultType: string;
+  faultDescription: string;
+  gcs: GcsConfig;
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/simple_workflow_client.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/src/simple_workflow_client.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { HttpHandler } from '@kbn/core/public';
+import type { ConverseResponse, ConverseUsage } from './agent_builder_client';
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'timed_out', 'skipped']);
+const POLL_INTERVAL_MS = 15_000;
+const MAX_WAIT_MS = 60 * 60_000;
+
+interface SingleAgentOutput {
+  contributing_factors: string;
+  confidence: number;
+  evidence_summary: string;
+  mechanism?: string;
+  gaps_found?: string[];
+}
+
+interface AdversarialOutput {
+  contributing_factors: string;
+  confidence: number;
+  evidence_summary: string;
+  mechanism?: string;
+  final_reasoning?: string;
+  how_critique_was_addressed?: string;
+  gaps_found?: string[];
+}
+
+interface StepUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  llm_calls?: number;
+}
+
+interface StepExecution {
+  stepId?: string;
+  status: string;
+  output?: { usage?: StepUsage; structured_output?: unknown; [key: string]: unknown } | null;
+}
+
+interface WorkflowExecution {
+  status: string;
+  traceId?: string;
+  error?: { message?: string } | null;
+  stepExecutions?: StepExecution[];
+}
+
+export interface SimpleWorkflowInput {
+  streamNames: string[];
+  scenarioId: string;
+  scenarioTitle: string;
+  service: string;
+  faultType: string;
+  connectorId?: string;
+}
+
+function formatSingleAgentResult(output: SingleAgentOutput): string {
+  const lines: string[] = [];
+  lines.push(`Contributing factors: ${output.contributing_factors}`);
+  lines.push(`Confidence: ${(output.confidence * 100).toFixed(0)}%`);
+  lines.push(`Mechanism: ${output.mechanism ?? 'unspecified'}`);
+  lines.push(`Evidence: ${output.evidence_summary}`);
+  if ((output.gaps_found ?? []).length > 0) {
+    lines.push(`Gaps: ${(output.gaps_found ?? []).join('; ')}`);
+  }
+  return lines.join('\n');
+}
+
+function formatAdversarialResult(output: AdversarialOutput, roundsUsed: number): string {
+  const lines: string[] = [];
+  lines.push(`Contributing factors: ${output.contributing_factors}`);
+  lines.push(`Confidence: ${(output.confidence * 100).toFixed(0)}%`);
+  lines.push(`Mechanism: ${output.mechanism ?? 'unspecified'}`);
+  lines.push(`Rounds used: ${roundsUsed}`);
+  lines.push(`Evidence: ${output.evidence_summary}`);
+  if (output.final_reasoning) {
+    lines.push(`Final reasoning: ${output.final_reasoning}`);
+  }
+  if (output.how_critique_was_addressed) {
+    lines.push(`Critique addressed: ${output.how_critique_was_addressed}`);
+  }
+  return lines.join('\n');
+}
+
+export class SimpleWorkflowClient {
+  constructor(
+    private readonly fetch: HttpHandler,
+    private readonly log: ToolingLog,
+    private readonly workflowId: string
+  ) {}
+
+  async run(input: SimpleWorkflowInput): Promise<ConverseResponse> {
+    const { streamNames, scenarioId, service, faultType, connectorId } = input;
+    const opaqueId = randomUUID();
+    const discoveryId = `eval-simple-${opaqueId}`;
+
+    this.log.info(`[simple-workflow] Triggering workflow ${this.workflowId} for: ${scenarioId}`);
+
+    const { workflowExecutionId } = (await this.fetch(
+      `/api/workflows/workflow/${this.workflowId}/run`,
+      {
+        method: 'POST',
+        version: '2023-10-31',
+        body: JSON.stringify({
+          inputs: {
+            event_id: `eval-event-${opaqueId}`,
+            discovery_id: discoveryId,
+            discovery_slug: opaqueId,
+            title: `Microservice system degradation or outage`,
+            summary: `A microservice system is experiencing degradation or an outage.`,
+            question:
+              `A microservice system is experiencing degradation or an outage. ` +
+              `Investigate the root cause and identify the responsible service. ` +
+              `Telemetry is in stream_names (logs, traces, and infrastructure metrics): ${streamNames.join(', ')}. ` +
+              `Use available tools to inspect these data streams. ` +
+              `Identify: (1) the root cause component, (2) the failure mode, and (3) supporting evidence.`,
+            contributing_factors: '',
+            impact: '',
+            stream_names: streamNames,
+            cause_kis: [],
+            evidences: [],
+            ...(connectorId ? { connector_id: connectorId } : {}),
+          },
+        }),
+      }
+    )) as { workflowExecutionId: string };
+
+    this.log.info(`[simple-workflow] Execution started: ${workflowExecutionId} for ${scenarioId}`);
+
+    const execution = await this.pollUntilTerminal(workflowExecutionId, scenarioId);
+    return this.buildConverseResponse(execution, workflowExecutionId, scenarioId, service, faultType);
+  }
+
+  private async pollUntilTerminal(executionId: string, scenarioId: string): Promise<WorkflowExecution> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < MAX_WAIT_MS) {
+      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      this.log.info(`[simple-workflow] Polling ${executionId} (${elapsed}s) for ${scenarioId}`);
+
+      const execution = (await this.fetch(`/api/workflows/executions/${executionId}`, {
+        version: '2023-10-31',
+        query: { includeOutput: true },
+      })) as WorkflowExecution;
+
+      if (TERMINAL_STATUSES.has(execution.status)) {
+        this.log.info(`[simple-workflow] ${executionId} terminal: ${execution.status}`);
+        return execution;
+      }
+    }
+
+    throw new Error(`Simple workflow ${executionId} timed out after ${MAX_WAIT_MS / 60_000} minutes`);
+  }
+
+  private buildConverseResponse(
+    execution: WorkflowExecution,
+    executionId: string,
+    scenarioId: string,
+    service: string,
+    faultType: string
+  ): ConverseResponse {
+    const errors: unknown[] = [];
+
+    if (execution.status !== 'completed') {
+      const errMsg = execution.error?.message ?? `Workflow ended with status: ${execution.status}`;
+      this.log.warning(`[simple-workflow] Non-completed execution ${executionId}: ${errMsg}`);
+      errors.push(new Error(errMsg));
+    }
+
+    // For single-agent workflow, look for the 'investigate' step
+    // For adversarial workflow, look for emit_result or investigate_r3/r2/r1
+    const investigateStep = execution.stepExecutions?.find(
+      (s) => (s.stepId === 'investigate' || s.stepId === 'emit_result') && s.output != null
+    );
+
+    const r3Step = execution.stepExecutions?.find((s) => s.stepId === 'investigate_r3' && s.output != null);
+    const r2Step = execution.stepExecutions?.find((s) => s.stepId === 'investigate_r2' && s.output != null);
+    const r1Step = execution.stepExecutions?.find((s) => s.stepId === 'investigate_r1' && s.output != null);
+    const roundsUsed = r3Step ? 3 : r2Step ? 2 : 1;
+
+    let messageContent: string;
+
+    const finalStep = investigateStep ?? r3Step ?? r2Step ?? r1Step;
+    if (finalStep?.output) {
+      const rawOutput = finalStep.output as { structured_output?: unknown } | unknown;
+      const structured = ('structured_output' in (rawOutput as object)
+        ? (rawOutput as { structured_output: unknown }).structured_output
+        : rawOutput) as SingleAgentOutput | AdversarialOutput;
+
+      if (roundsUsed > 1) {
+        messageContent = formatAdversarialResult(structured as AdversarialOutput, roundsUsed);
+      } else {
+        messageContent = formatSingleAgentResult(structured as SingleAgentOutput);
+      }
+
+      this.log.info(
+        `[simple-workflow] ${scenarioId} contributing_factors: ${(structured as SingleAgentOutput).contributing_factors} (${roundsUsed} round${roundsUsed > 1 ? 's' : ''})`
+      );
+    } else {
+      this.log.warning(`[simple-workflow] No output found for ${scenarioId}`);
+      messageContent = 'Workflow did not produce a result.';
+    }
+
+    const usage: ConverseUsage = { input_tokens: 0, output_tokens: 0, llm_calls: 0 };
+    for (const step of execution.stepExecutions ?? []) {
+      const stepUsage = step.output?.usage;
+      if (stepUsage) {
+        usage.input_tokens += stepUsage.input_tokens ?? 0;
+        usage.output_tokens += stepUsage.output_tokens ?? 0;
+        usage.llm_calls += stepUsage.llm_calls ?? 0;
+      }
+    }
+    this.log.info(
+      `[simple-workflow] ${scenarioId} usage: ${usage.input_tokens} in / ${usage.output_tokens} out / ${usage.llm_calls} calls`
+    );
+
+    const promptMessage =
+      `A microservice system in Online Boutique is experiencing a fault. ` +
+      `Fault details — service: ${service}, type: ${faultType}. ` +
+      `Investigate root cause and identify the responsible service.`;
+
+    return {
+      conversationId: executionId,
+      traceId: execution.traceId,
+      messages: [{ content: promptMessage }, { content: messageContent }],
+      steps: [],
+      errors,
+      usage,
+    };
+  }
+}

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/evals",
+    "@kbn/tooling-log",
+    "@kbn/core",
+    "@kbn/agent-builder-common",
+    "@kbn/es-snapshot-loader",
+    "@kbn/scout",
+    "@kbn/dev-cli-runner"
+  ]
+}


### PR DESCRIPTION
## Summary

Single eval spec tracking the `system-streams-sigevents-investigation` workflow
on the RE2-OB fault-injection benchmark (Online Boutique, 20 scenarios).

This PR replaces four previous eval PRs (#273574, #273575, #273573, #273571)
which were closed after an extensive multi-agent architecture evaluation concluded
that the single-agent workflow is the best approach.

## What's here

- **`re2ob_investigation_workflow.spec.ts`** — one spec, one workflow, 20 scenarios.
  Uses `SimpleWorkflowClient` against `system-streams-sigevents-investigation`
  (the unified investigation workflow defined in PR #273237).
- **20-scenario RE2-OB dataset** (5 services × 4 fault types, instance 1 each).
  Covers cpu, mem, disk, socket, delay, loss faults on checkoutservice,
  currencyservice, emailservice, productcatalogservice, recommendationservice.
- **4 evaluators per scenario**: Criteria (LLM judge, 4 sub-criteria), Input Tokens,
  Output Tokens, LLM Calls.

## Why single-agent

See the closing comments on #273574 for the full benchmarking journey. Short version:

| Variant | Score (10-scenario subset) |
|---|---|
| Haiku single-agent | **0.675** |
| Haiku multi-agent (best, v21) | 0.525 |
| Sonnet single-agent | 0.650 |
| Sonnet multi-agent | 0.575 |

The fan-out architecture introduced failure modes (premature contributing factor filtering,
context loss between parallel sub-workflows, hub over-attribution) that consistently
outweighed its gains. Single-agent's holistic view across all tool calls is an
advantage for this task.

## Running locally

```bash
RCAEVAL_DATA_DIR=/path/to/re2ob \
EVALUATION_CONNECTOR_ID=anthropic-claude-4-5-haiku \
node scripts/evals run --suite rca-benchmark \
  --config x-pack/solutions/observability/packages/kbn-evals-suite-rca-benchmark/playwright.workflow.config.ts
```

Override agent model:
```bash
WORKFLOW_AGENT_CONNECTOR_ID=.anthropic-claude-4.6-sonnet-chat_completion
```

## Test plan

- [ ] `RCAEVAL_MAX_SCENARIOS=1` gate run completes and scores a single scenario
- [ ] Full 20-scenario run produces scores matching the baseline (0.65–0.68 range with Haiku)
- [ ] `WORKFLOW_AGENT_CONNECTOR_ID` override routes to Sonnet correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Implements elastic/nightshift-program#203 — RCA benchmark evaluation pipeline.