### PR TITLE
[Security Solution] Add Rule and Endpoint exception actions to Take action button

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
@@ -533,6 +533,7 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
 
   return (
     <EuiFlyout
+      session="never"
       size="l"
       onClose={handleCloseFlyout}
       data-test-subj="addExceptionFlyout"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { render, waitFor, fireEvent } from '@testing-library/react';
-import { AlertContextMenu } from './alert_context_menu';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { AddExceptionFlyoutWrapper, AlertContextMenu } from './alert_context_menu';
 import { TestProviders } from '../../../../common/mock';
 import React from 'react';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import { mockTimelines } from '../../../../common/mock/mock_timelines_plugin';
 import { mockCasesContract } from '@kbn/cases-plugin/public/mocks';
 import { initialUserPrivilegesState as mockInitialUserPrivilegesState } from '../../../../common/components/user_privileges/user_privileges_context';
@@ -17,6 +18,7 @@ import { useUserPrivileges } from '../../../../common/components/user_privileges
 import { TableId } from '@kbn/securitysolution-data-table';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { ALERTS_FEATURE_ID, SECURITY_FEATURE_ID } from '../../../../../common/constants';
+import type { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 
 jest.mock('../../../../common/components/user_privileges');
 
@@ -156,7 +158,22 @@ jest.mock(
 );
 jest.mock('../../osquery/osquery_flyout', () => ({ OsqueryFlyout: () => null }));
 jest.mock('../../../../detection_engine/rule_exceptions/components/add_exception_flyout', () => ({
-  AddExceptionFlyout: () => null,
+  AddExceptionFlyout: jest.fn().mockReturnValue(null),
+}));
+
+const mockUseRuleWithFallback = jest.fn();
+jest.mock('../../../../detection_engine/rule_management/logic/use_rule_with_fallback', () => ({
+  useRuleWithFallback: (...args: unknown[]) => mockUseRuleWithFallback(...args),
+}));
+
+const mockUseSignalIndex = jest.fn();
+jest.mock('../../../containers/detection_engine/alerts/use_signal_index', () => ({
+  useSignalIndex: () => mockUseSignalIndex(),
+}));
+
+const mockUseQueryAlerts = jest.fn();
+jest.mock('../../../containers/detection_engine/alerts/use_query', () => ({
+  useQueryAlerts: (...args: unknown[]) => mockUseQueryAlerts(...args),
 }));
 jest.mock(
   '../../../../management/pages/event_filters/view/components/event_filters_flyout',
@@ -573,6 +590,151 @@ describe('Alert table context menu', () => {
 
     afterEach(() => {
       mockUseAddToChatAction.mockReturnValue({ addToChatActionItems: [] });
+    });
+  });
+});
+
+// ─── AddExceptionFlyoutWrapper ───────────────────────────────────────────────
+
+const createMockHit = (fields: Record<string, unknown> = {}): DataTableRecord => ({
+  id: 'test-id',
+  raw: { _id: 'test-id', _index: 'test-index' },
+  flattened: fields,
+  isAnchor: false,
+});
+
+// An enrichedAlert whose source has no index info, so the fallback values
+// derived from `hit` are what memoRuleIndices / memoDataViewId fall back to.
+const enrichedAlertWithoutIndex = {
+  loading: false,
+  data: { hits: { hits: [{ _id: 'test-id', _index: 'test-index', _source: {} }] } },
+};
+
+const mockAddExceptionFlyout = jest.requireMock(
+  '../../../../detection_engine/rule_exceptions/components/add_exception_flyout'
+).AddExceptionFlyout as jest.Mock;
+
+const wrapperDefaults = {
+  exceptionListType: null as ExceptionListTypeEnum | null,
+  eventId: 'test-id',
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+  alertStatus: 'open' as const,
+};
+
+describe('AddExceptionFlyoutWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRuleWithFallback.mockReturnValue({ rule: null, loading: false });
+    mockUseSignalIndex.mockReturnValue({ loading: false, signalIndexName: '.siem-signals' });
+    mockUseQueryAlerts.mockReturnValue(enrichedAlertWithoutIndex);
+    mockAddExceptionFlyout.mockReturnValue(<div data-test-subj="mock-add-exception-flyout" />);
+  });
+
+  describe('ruleId derivation', () => {
+    it('reads ruleId from kibana.alert.rule.uuid', () => {
+      render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'kibana.alert.rule.uuid': 'rule-abc',
+            'kibana.alert.rule.parameters.index': ['test-index'],
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(mockUseRuleWithFallback).toHaveBeenCalledWith('rule-abc');
+    });
+
+    it('falls back to signal.rule.id when ALERT_RULE_UUID is absent', () => {
+      render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'signal.rule.id': 'legacy-rule-id',
+            'signal.rule.index': ['legacy-index'],
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(mockUseRuleWithFallback).toHaveBeenCalledWith('legacy-rule-id');
+    });
+  });
+
+  describe('ruleIndices derivation', () => {
+    it('renders when index array is available from hit', () => {
+      const { getByTestId } = render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'kibana.alert.rule.uuid': 'rule-abc',
+            'kibana.alert.rule.parameters.index': ['index-1', 'index-2'],
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(getByTestId('mock-add-exception-flyout')).toBeInTheDocument();
+    });
+
+    it('wraps a single string index into an array so the component renders', () => {
+      const { getByTestId } = render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'kibana.alert.rule.uuid': 'rule-abc',
+            'kibana.alert.rule.parameters.index': 'single-index',
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(getByTestId('mock-add-exception-flyout')).toBeInTheDocument();
+    });
+
+    it('falls back to signal.rule.index', () => {
+      const { getByTestId } = render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'kibana.alert.rule.uuid': 'rule-abc',
+            'signal.rule.index': ['legacy-index'],
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(getByTestId('mock-add-exception-flyout')).toBeInTheDocument();
+    });
+
+    it('stays in loading state (renders nothing) when no index or data_view_id', () => {
+      const { queryByTestId } = render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({ 'kibana.alert.rule.uuid': 'rule-abc' })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(queryByTestId('mock-add-exception-flyout')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ruleDataViewId derivation', () => {
+    it('renders when kibana.alert.rule.parameters.data_view_id is present', () => {
+      const { getByTestId } = render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'kibana.alert.rule.uuid': 'rule-abc',
+            'kibana.alert.rule.parameters.data_view_id': 'my-data-view',
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(getByTestId('mock-add-exception-flyout')).toBeInTheDocument();
+    });
+
+    it('falls back to signal.rule.data_view_id', () => {
+      const { getByTestId } = render(
+        <AddExceptionFlyoutWrapper
+          hit={createMockHit({
+            'kibana.alert.rule.uuid': 'rule-abc',
+            'signal.rule.data_view_id': 'legacy-data-view',
+          })}
+          {...wrapperDefaults}
+        />
+      );
+      expect(getByTestId('mock-add-exception-flyout')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -15,6 +15,9 @@ import { get, getOr } from 'lodash/fp';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { flattenObject } from '@kbn/object-utils';
+import { buildDataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
+import { ALERT_RULE_UUID, ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { useRunAlertWorkflowPanel } from './use_run_alert_workflow_panel';
 import { useRunDocumentWorkflowPanel } from './use_run_document_workflow_panel';
 import { EndpointExceptionsFlyout } from '../../../../management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout';
@@ -42,18 +45,11 @@ import { useExceptionFlyout } from './use_add_exception_flyout';
 import { useAlertExceptionActions } from './use_add_exception_actions';
 import { useEventFilterModal } from './use_event_filter_modal';
 import { TimelineId } from '../../../../../common/types/timeline';
-import type {
-  DataViewId,
-  IndexPatternArray,
-  RuleObjectId,
-  RuleSignatureId,
-  Status,
-} from '../../../../../common/api/detection_engine';
+import type { Status } from '../../../../../common/api/detection_engine';
 import { ATTACH_ALERT_TO_CASE_FOR_ROW } from '../../../../timelines/components/timeline/body/translations';
 import { selectTimelineById } from '../../../../timelines/store/selectors';
 import { useEventFilterAction } from './use_event_filter_action';
 import { useAddToCaseActions } from './use_add_to_case_actions';
-import type { Rule } from '../../../../detection_engine/rule_management/logic/types';
 import type { AlertTableContextMenuItem } from '../types';
 import { useAlertTagsActions } from './use_alert_tags_actions';
 import { useAlertAssigneesActions } from './use_alert_assignees_actions';
@@ -99,8 +95,6 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
   const getAlertId = () => (ecsRowData?.kibana?.alert ? ecsRowData?._id : null);
   const alertId = getAlertId();
   const ruleId = get(0, ecsRowData?.kibana?.alert?.rule?.uuid);
-  const ruleRuleId = get(0, ecsRowData?.kibana?.alert?.rule?.rule_id);
-  const ruleName = get(0, ecsRowData?.kibana?.alert?.rule?.name);
 
   const flattenedEcsData = useMemo(() => {
     const flattened = flattenObject(ecsRowData);
@@ -163,11 +157,15 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
     if (refetch) refetch();
   }, [scopeId, globalQuery, timelineQuery, refetch]);
 
-  const ruleIndex =
-    ecsRowData['kibana.alert.rule.parameters']?.index ?? ecsRowData?.signal?.rule?.index;
-  const ruleDataViewId =
-    ecsRowData['kibana.alert.rule.parameters']?.data_view_id ??
-    ecsRowData?.signal?.rule?.data_view_id;
+  const hit = useMemo(
+    () =>
+      buildDataTableRecord({
+        _id: ecsRowData._id,
+        _index: ecsRowData._index,
+        _source: ecsRowData as unknown as EsHitRecord['_source'],
+      }),
+    [ecsRowData]
+  );
 
   const {
     exceptionFlyoutType,
@@ -376,24 +374,14 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
           </EuiPopover>
         </EventsTdContent>
       </div>
-      {openAddExceptionFlyout &&
-        ruleId &&
-        ruleRuleId &&
-        ruleName != null &&
-        ecsRowData?._id != null && (
-          <AddExceptionFlyoutWrapper
-            ruleId={ruleId}
-            ruleRuleId={ruleRuleId}
-            ruleIndices={ruleIndex}
-            ruleDataViewId={ruleDataViewId}
-            ruleName={ruleName}
-            exceptionListType={exceptionFlyoutType}
-            eventId={ecsRowData?._id}
-            onCancel={onAddExceptionCancel}
-            onConfirm={onAddExceptionConfirm}
-            alertStatus={alertStatus}
-          />
-        )}
+      {openAddExceptionFlyout && ruleId && ecsRowData._id && (
+        <AddExceptionFlyoutWrapper
+          hit={hit}
+          exceptionListType={exceptionFlyoutType}
+          onCancel={onAddExceptionCancel}
+          onConfirm={onAddExceptionConfirm}
+        />
+      )}
       {isAddEventFilterModalOpen && ecsRowData != null && (
         <EventFiltersFlyout data={ecsRowData} onCancel={closeAddEventFilterModal} />
       )}
@@ -412,13 +400,9 @@ type AddExceptionFlyoutWrapperProps = Omit<
   | 'rules'
   | 'isBulkAction'
   | 'showAlertCloseOptions'
+  | 'alertStatus'
 > & {
-  eventId?: string;
-  ruleId: RuleObjectId;
-  ruleRuleId: RuleSignatureId;
-  ruleIndices: IndexPatternArray | undefined;
-  ruleDataViewId: DataViewId | undefined;
-  ruleName: Rule['name'];
+  hit: DataTableRecord;
   exceptionListType: ExceptionListTypeEnum | null;
 };
 
@@ -428,17 +412,23 @@ type AddExceptionFlyoutWrapperProps = Omit<
  * we cannot use the fetch hook within the flyout component itself
  */
 export const AddExceptionFlyoutWrapper: React.FC<AddExceptionFlyoutWrapperProps> = ({
-  ruleId,
-  ruleRuleId,
-  ruleIndices,
-  ruleDataViewId,
-  ruleName,
+  hit,
   exceptionListType,
-  eventId,
   onCancel,
   onConfirm,
-  alertStatus,
 }) => {
+  const eventId = hit.raw._id;
+  const alertStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS) as Status | undefined;
+  const ruleId = (getFieldValue(hit, ALERT_RULE_UUID) ??
+    getFieldValue(hit, 'signal.rule.id') ??
+    '') as string;
+  const rawIndices =
+    hit.flattened['kibana.alert.rule.parameters.index'] ?? hit.flattened['signal.rule.index'];
+  const ruleIndices =
+    rawIndices != null ? ([] as string[]).concat(rawIndices as string | string[]) : undefined;
+  const ruleDataViewId = (getFieldValue(hit, 'kibana.alert.rule.parameters.data_view_id') ??
+    getFieldValue(hit, 'signal.rule.data_view_id')) as string | undefined;
+
   const isEndpointExceptionsMovedUnderManagement = useIsExperimentalFeatureEnabled(
     'endpointExceptionsMovedUnderManagement'
   );
@@ -454,11 +444,11 @@ export const AddExceptionFlyoutWrapper: React.FC<AddExceptionFlyoutWrapperProps>
 
   const enrichedAlert: AlertData | undefined = useMemo(() => {
     if (isLoadingAlertData === false) {
-      const hit = data?.hits.hits[0];
-      if (!hit) {
+      const esHit = data?.hits.hits[0];
+      if (!esHit) {
         return undefined;
       }
-      const { _id, _index, _source } = hit;
+      const { _id, _index, _source } = esHit;
       return { ..._source, _id, _index };
     }
   }, [data?.hits.hits, isLoadingAlertData]);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_exception_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_exception_actions.test.tsx
@@ -8,12 +8,9 @@
 import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { useAlertExceptionActions } from './use_add_exception_actions';
-import { useUserData } from '../../user_info';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useEndpointExceptionsCapability } from '../../../../exceptions/hooks/use_endpoint_exceptions_capability';
-
-jest.mock('../../user_info');
-const mockUseUserData = useUserData as jest.Mock;
+import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 
 jest.mock('../../../../common/components/user_privileges');
 const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
@@ -21,13 +18,19 @@ const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
 jest.mock('../../../../exceptions/hooks/use_endpoint_exceptions_capability');
 const mockUseEndpointExceptionsCapability = useEndpointExceptionsCapability as jest.Mock;
 
+jest.mock('../../../containers/detection_engine/alerts/use_alerts_privileges');
+const mockUseAlertsPrivileges = useAlertsPrivileges as jest.Mock;
+
 describe('useAlertExceptionActions', () => {
+  beforeEach(() => {
+    mockUseAlertsPrivileges.mockReturnValue({ hasIndexWrite: true });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('should return both add rule exception and add endpoint exception menu items with all privileges', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: true }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: true } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(true);
 
@@ -46,7 +49,6 @@ describe('useAlertExceptionActions', () => {
   });
 
   it('should disable adding endpoint exceptions when user has no endpoint exceptions ALL privilege', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: true }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: true } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(false);
 
@@ -65,7 +67,6 @@ describe('useAlertExceptionActions', () => {
   });
 
   it('should disable adding endpoint exceptions when alert is not an endpoint alert', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: true }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: true } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(true);
 
@@ -85,7 +86,6 @@ describe('useAlertExceptionActions', () => {
   });
 
   it('should disable adding rule exceptions when user has no security:ALL privilege', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: true }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: false } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(true);
 
@@ -104,9 +104,9 @@ describe('useAlertExceptionActions', () => {
   });
 
   it('should disable adding rule exceptions when user has no index write privilege', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: false }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: true } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(true);
+    mockUseAlertsPrivileges.mockReturnValue({ hasIndexWrite: false });
 
     const { result } = renderHook(
       () => useAlertExceptionActions({ isEndpointAlert: true, onAddExceptionTypeClick: jest.fn() }),
@@ -123,7 +123,6 @@ describe('useAlertExceptionActions', () => {
   });
 
   it('should not return menu items when user has neither security:ALL nor endpoint exceptions ALL privilege', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: true }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: false } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(false);
 
@@ -136,9 +135,9 @@ describe('useAlertExceptionActions', () => {
   });
 
   it('should not return menu items when user has neither index write and it is not an endpoint alert', () => {
-    mockUseUserData.mockReturnValue([{ hasIndexWrite: false }]);
     mockUseUserPrivileges.mockReturnValue({ rulesPrivileges: { exceptions: { edit: true } } });
     mockUseEndpointExceptionsCapability.mockReturnValue(true);
+    mockUseAlertsPrivileges.mockReturnValue({ hasIndexWrite: false });
 
     const { result } = renderHook(
       () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_exception_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_exception_actions.tsx
@@ -9,10 +9,10 @@ import { useCallback, useMemo } from 'react';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 
 import { useEndpointExceptionsCapability } from '../../../../exceptions/hooks/use_endpoint_exceptions_capability';
-import { useUserData } from '../../user_info';
 import { ACTION_ADD_ENDPOINT_EXCEPTION, ACTION_ADD_EXCEPTION } from '../translations';
 import type { AlertTableContextMenuItem } from '../types';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 
 export interface UseExceptionActionProps {
   isEndpointAlert: boolean;
@@ -24,7 +24,7 @@ export const useAlertExceptionActions = ({
   onAddExceptionTypeClick,
 }: UseExceptionActionProps) => {
   const canEditExceptions = useUserPrivileges().rulesPrivileges.exceptions.edit;
-  const [{ hasIndexWrite }] = useUserData();
+  const { hasIndexWrite } = useAlertsPrivileges();
   const canWriteEndpointExceptions = useEndpointExceptionsCapability('crudEndpointExceptions');
 
   const handleDetectionExceptionModal = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/preview/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/preview/footer.test.tsx
@@ -17,7 +17,6 @@ import { PREVIEW_FOOTER_TEST_ID, PREVIEW_FOOTER_LINK_TEST_ID } from './test_ids'
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from '../shared/components/test_ids';
 import { createTelemetryServiceMock } from '../../../common/lib/telemetry/telemetry_service.mock';
 import { useKibana } from '../../../common/lib/kibana';
-import { useAlertExceptionActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions';
 import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 
@@ -31,11 +30,15 @@ jest.mock('react-router-dom', () => {
 });
 
 jest.mock('../../../common/lib/kibana');
-jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions');
 jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
 jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions');
+jest.mock('../shared/components/take_action_button', () => ({
+  TakeActionButton: () => (
+    <button data-test-subj="securitySolutionFlyoutFooterDropdownButton" type="button" />
+  ),
+}));
 
 const mockedTelemetry = createTelemetryServiceMock();
 
@@ -49,7 +52,6 @@ describe('<PreviewPanelFooter />', () => {
         cases: { hooks: { useIsAddToCaseOpen: jest.fn().mockReturnValue(false) } },
       },
     });
-    (useAlertExceptionActions as jest.Mock).mockReturnValue({ exceptionActionItems: [] });
     (useInvestigateInTimeline as jest.Mock).mockReturnValue({
       investigateInTimelineActionItems: [],
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/footer.test.tsx
@@ -13,7 +13,6 @@ import { DocumentDetailsContext } from '../shared/context';
 import { FLYOUT_FOOTER_TEST_ID } from './test_ids';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from '../shared/components/test_ids';
 import { useKibana } from '../../../common/lib/kibana';
-import { useAlertExceptionActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions';
 import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 import { FooterAiActions } from '../../../flyout_v2/document/main/components/footer_ai_actions';
@@ -29,11 +28,15 @@ jest.mock('react-router-dom', () => {
     useLocation: jest.fn().mockReturnValue({ search: '' }),
   };
 });
-jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions');
 jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
 jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions');
+jest.mock('../shared/components/take_action_button', () => ({
+  TakeActionButton: () => (
+    <button data-test-subj="securitySolutionFlyoutFooterDropdownButton" type="button" />
+  ),
+}));
 
 const renderPanelFooter = (isPreview: boolean) =>
   render(
@@ -62,7 +65,6 @@ describe('PanelFooter', () => {
         cases: { hooks: { useIsAddToCaseOpen: jest.fn().mockReturnValue(false) } },
       },
     });
-    (useAlertExceptionActions as jest.Mock).mockReturnValue({ exceptionActionItems: [] });
     (useInvestigateInTimeline as jest.Mock).mockReturnValue({
       investigateInTimelineActionItems: [{ name: 'test', onClick: jest.fn() }],
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_button.tsx
@@ -8,7 +8,6 @@
 import type { FC } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { find } from 'lodash/fp';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils';
 import type { Status } from '../../../../../common/api/detection_engine';
@@ -38,14 +37,6 @@ interface AlertSummaryData {
    * Id of the rule
    */
   ruleId: string;
-  /**
-   * Property ruleId on the rule
-   */
-  ruleRuleId: string;
-  /**
-   * Name of the rule
-   */
-  ruleName: string;
 }
 
 /**
@@ -71,40 +62,10 @@ export const TakeActionButton: FC = () => {
   const { refetch: refetchAll } = useRefetchByScope({ scopeId });
 
   // exception interaction
-  const ruleIndexRaw = useMemo(
-    () =>
-      find({ category: 'signal', field: 'signal.rule.index' }, dataFormattedForFieldBrowser)
-        ?.values ??
-      find(
-        { category: 'kibana', field: 'kibana.alert.rule.parameters.index' },
-        dataFormattedForFieldBrowser
-      )?.values,
-    [dataFormattedForFieldBrowser]
-  );
-  const ruleIndex = useMemo(
-    (): string[] | undefined => (Array.isArray(ruleIndexRaw) ? ruleIndexRaw : undefined),
-    [ruleIndexRaw]
-  );
-  const ruleDataViewIdRaw = useMemo(
-    () =>
-      find({ category: 'signal', field: 'signal.rule.data_view_id' }, dataFormattedForFieldBrowser)
-        ?.values ??
-      find(
-        { category: 'kibana', field: 'kibana.alert.rule.parameters.data_view_id' },
-        dataFormattedForFieldBrowser
-      )?.values,
-    [dataFormattedForFieldBrowser]
-  );
-  const ruleDataViewId = useMemo(
-    (): string | undefined => (Array.isArray(ruleDataViewIdRaw) ? ruleDataViewIdRaw[0] : undefined),
-    [ruleDataViewIdRaw]
-  );
   const alertSummaryData = useMemo(
     () =>
       [
         { category: 'signal', field: 'signal.rule.id', name: 'ruleId' },
-        { category: 'signal', field: 'signal.rule.rule_id', name: 'ruleRuleId' },
-        { category: 'signal', field: 'signal.rule.name', name: 'ruleName' },
         { category: 'signal', field: 'kibana.alert.workflow_status', name: 'alertStatus' },
         { category: '_id', field: '_id', name: 'eventId' },
       ].reduce<AlertSummaryData>(
@@ -174,13 +135,11 @@ export const TakeActionButton: FC = () => {
       )}
 
       {openAddExceptionFlyout &&
+        hit != null &&
         alertSummaryData.ruleId != null &&
-        alertSummaryData.ruleRuleId != null &&
         alertSummaryData.eventId != null && (
           <AddExceptionFlyoutWrapper
-            {...alertSummaryData}
-            ruleIndices={ruleIndex}
-            ruleDataViewId={ruleDataViewId}
+            hit={hit}
             exceptionListType={exceptionFlyoutType}
             onCancel={onAddExceptionCancel}
             onConfirm={onAddExceptionConfirm}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.test.tsx
@@ -69,7 +69,7 @@ jest.mock('../../../../common/lib/kibana');
 jest.mock(
   '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges',
   () => ({
-    useAlertsPrivileges: jest.fn().mockReturnValue({ hasAlertsUpdate: true }),
+    useAlertsPrivileges: jest.fn().mockReturnValue({ hasAlertsUpdate: true, hasIndexWrite: true }),
   })
 );
 jest.mock('../../../../cases/components/use_insert_timeline');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.test.tsx
@@ -13,6 +13,7 @@ import { useAddToCaseActions } from '../../../../detections/components/alerts_ta
 import { useAlertsActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
 import { useAlertTagsActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
+import { useAlertExceptionActions } from '../../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions';
 import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { useHostIsolationAction } from '../../../../common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action';
@@ -29,6 +30,9 @@ jest.mock(
 jest.mock('../../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions');
 jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
+);
+jest.mock(
+  '../../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions'
 );
 jest.mock('../../../../common/hooks/is_in_security_app');
 jest.mock(
@@ -64,6 +68,13 @@ jest.mock('../hooks/use_explore_actions', () => ({
   useExploreActions: (...args: unknown[]) => mockUseExploreActions(...args),
 }));
 
+jest.mock(
+  '../../../../detections/components/alerts_table/timeline_actions/alert_context_menu',
+  () => ({
+    AddExceptionFlyoutWrapper: () => <div data-test-subj="addExceptionFlyoutWrapper" />,
+  })
+);
+
 const mockUseRunAlertWorkflowPanel = jest.fn().mockReturnValue({
   runWorkflowMenuItem: [],
   runAlertWorkflowPanel: [],
@@ -90,6 +101,7 @@ const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
 const mockUseAlertsActions = useAlertsActions as jest.Mock;
 const mockUseAlertAssigneesActions = useAlertAssigneesActions as jest.Mock;
 const mockUseAlertTagsActions = useAlertTagsActions as jest.Mock;
+const mockUseAlertExceptionActions = useAlertExceptionActions as jest.Mock;
 
 const createMockHit = (
   flattened: Record<string, unknown> = {},
@@ -146,6 +158,7 @@ describe('<TakeActionButton />', () => {
       alertAssigneesPanels: [],
     });
     mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [], alertTagsPanels: [] });
+    mockUseAlertExceptionActions.mockReturnValue({ exceptionActionItems: [] });
     mockUseInvestigateInTimeline.mockReturnValue({ investigateInTimelineActionItems: [] });
     mockUseIsInSecurityApp.mockReturnValue(true);
     mockUseRunAlertWorkflowPanel.mockReturnValue({
@@ -302,6 +315,49 @@ describe('<TakeActionButton />', () => {
         refetch: mockOnAlertUpdated,
       })
     );
+  });
+
+  describe('isEndpointAlert detection', () => {
+    it('should be true when module=endpoint and kind=alert', () => {
+      const alertHit = createMockHit({
+        'event.kind': 'signal',
+        'kibana.alert.original_event.module': 'endpoint',
+        'kibana.alert.original_event.kind': ['alert'],
+      });
+
+      renderTakeActionButton({ ...defaultProps, hit: alertHit });
+
+      expect(mockUseAlertExceptionActions).toHaveBeenCalledWith(
+        expect.objectContaining({ isEndpointAlert: true })
+      );
+    });
+
+    it('should be false when module=endpoint but kind is not alert', () => {
+      const alertHit = createMockHit({
+        'event.kind': 'signal',
+        'kibana.alert.original_event.module': 'endpoint',
+        'kibana.alert.original_event.kind': ['metric'],
+      });
+
+      renderTakeActionButton({ ...defaultProps, hit: alertHit });
+
+      expect(mockUseAlertExceptionActions).toHaveBeenCalledWith(
+        expect.objectContaining({ isEndpointAlert: false })
+      );
+    });
+
+    it('should be false when module is missing', () => {
+      const alertHit = createMockHit({
+        'event.kind': 'signal',
+        'kibana.alert.original_event.kind': ['alert'],
+      });
+
+      renderTakeActionButton({ ...defaultProps, hit: alertHit });
+
+      expect(mockUseAlertExceptionActions).toHaveBeenCalledWith(
+        expect.objectContaining({ isEndpointAlert: false })
+      );
+    });
   });
 
   it('should call useRunAlertWorkflowPanel with ecsData and closePopover', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/take_action_button.tsx
@@ -12,6 +12,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALERT_WORKFLOW_STATUS, EVENT_KIND } from '@kbn/rule-data-utils';
+import type { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { EventKind } from '../constants/event_kinds';
 import type { Status } from '../../../../../common/api/detection_engine';
@@ -19,6 +20,7 @@ import { useAddToCaseActions } from '../../../../detections/components/alerts_ta
 import { useAlertsActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
 import { useAlertTagsActions } from '../../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
+import { useAlertExceptionActions } from '../../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions';
 import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { useRunAlertWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel';
@@ -28,6 +30,7 @@ import { useHostIsolationAction } from '../../../../common/components/endpoint/h
 import { HostIsolationFlyout } from '../../../../common/components/endpoint/host_isolation/from_alerts/host_isolation_flyout';
 import { useResponderActionItem } from '../../../../common/components/endpoint/responder';
 import { useExploreActions } from '../hooks/use_explore_actions';
+import { AddExceptionFlyoutWrapper } from '../../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
 import { getTimelineEventsDetailsFromRecord } from '../utils/get_timeline_events_details_from_record';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
@@ -91,10 +94,13 @@ export const TakeActionButton = memo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
     );
-    const alertStatus = useMemo(() => {
-      const rawStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
-      return (Array.isArray(rawStatus) ? rawStatus[0] : rawStatus) as Status;
-    }, [hit]);
+    const alertStatus = useMemo(() => getFieldValue(hit, ALERT_WORKFLOW_STATUS) as Status, [hit]);
+    const isEndpointAlert = useMemo(
+      () =>
+        getFieldValue(hit, 'kibana.alert.original_event.module') === 'endpoint' &&
+        getFieldValue(hit, 'kibana.alert.original_event.kind') === 'alert',
+      [hit]
+    );
 
     const dataFormattedForFieldBrowser = useMemo(
       () => getTimelineEventsDetailsFromRecord(hit),
@@ -191,12 +197,42 @@ export const TakeActionButton = memo(
       closePopoverHandler
     );
 
+    const [isExceptionFlyoutOpen, setIsExceptionFlyoutOpen] = useState(false);
+    const [exceptionFlyoutType, setExceptionFlyoutType] = useState<ExceptionListTypeEnum | null>(
+      null
+    );
+    const handleOpenAddRuleException = useCallback(
+      (type?: ExceptionListTypeEnum) => {
+        closePopoverHandler();
+        setExceptionFlyoutType(type ?? null);
+        setIsExceptionFlyoutOpen(true);
+      },
+      [closePopoverHandler]
+    );
+    const handleExceptionCancel = useCallback((_didRuleChange: boolean) => {
+      setIsExceptionFlyoutOpen(false);
+    }, []);
+    const handleExceptionConfirm = useCallback(
+      (_didRuleChange: boolean, didCloseAlert: boolean, didBulkCloseAlert: boolean) => {
+        if (didCloseAlert || didBulkCloseAlert) {
+          onAlertUpdated();
+        }
+        setIsExceptionFlyoutOpen(false);
+      },
+      [onAlertUpdated]
+    );
+    const { exceptionActionItems } = useAlertExceptionActions({
+      isEndpointAlert,
+      onAddExceptionTypeClick: handleOpenAddRuleException,
+    });
+
     const items = useMemo(
       () => [
         ...(!isRemoteDocument ? addToCaseActionItems : []),
         ...(!isRemoteDocument && isAlert ? statusActionItems : []),
         ...(!isRemoteDocument && isAlert ? alertTagsItems : []),
         ...(!isRemoteDocument && isAlert ? alertAssigneesItems : []),
+        ...(!isRemoteDocument && isAlert ? exceptionActionItems : []),
         ...(!isRemoteDocument && isAlert ? hostIsolationActionItems : []),
         ...(!isRemoteDocument ? (isAlert ? runWorkflowMenuItem : documentWorkflowMenuItem) : []),
         ...(!isRemoteDocument ? endpointResponseActionsConsoleItems : []),
@@ -210,6 +246,7 @@ export const TakeActionButton = memo(
         alertTagsItems,
         documentWorkflowMenuItem,
         endpointResponseActionsConsoleItems,
+        exceptionActionItems,
         exploreActionItems,
         hostIsolationActionItems,
         investigateInTimelineActionItems,
@@ -277,6 +314,14 @@ export const TakeActionButton = memo(
         >
           <EuiContextMenu initialPanelId={0} panels={panels} data-test-subj="takeActionPanelMenu" />
         </EuiPopover>
+        {isExceptionFlyoutOpen && (
+          <AddExceptionFlyoutWrapper
+            hit={hit}
+            exceptionListType={exceptionFlyoutType}
+            onCancel={handleExceptionCancel}
+            onConfirm={handleExceptionConfirm}
+          />
+        )}
       </>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
@@ -107,9 +107,7 @@ export const flyoutProviders = ({
                     <CaseProvider>
                       <EntityStoreEuidApiProvider>
                         <MlCapabilitiesProvider>
-                          <AssistantProvider>
-                            <TimeRangeSync>{flyoutContent}</TimeRangeSync>
-                          </AssistantProvider>
+                          <TimeRangeSync>{flyoutContent}</TimeRangeSync>
                         </MlCapabilitiesProvider>
                       </EntityStoreEuidApiProvider>
                     </CaseProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.tsx
@@ -181,8 +181,80 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
     }
   }, [confirmModalLabels, submitException]);
 
+  const bodyContent = (
+    <>
+      {exception && (
+        <EndpointExceptionsForm
+          allowSelectOs={!alertData}
+          error={undefined}
+          disabled={false}
+          item={exception}
+          additionalEntries={additionalEntries}
+          mode="create"
+          onChange={handleOnChange}
+        />
+      )}
+
+      {hasAlertsUpdate && (
+        <>
+          <EuiHorizontalRule />
+
+          <ExceptionItemsFlyoutAlertsActions
+            exceptionListType="endpoint"
+            shouldCloseSingleAlert={closeSingleAlert}
+            onSingleAlertCloseCheckboxChange={setCloseSingleAlert}
+            shouldBulkCloseAlert={bulkCloseAlerts}
+            onBulkCloseCheckboxChange={setBulkCloseAlerts}
+            disableBulkClose={disableBulkClose}
+            onDisableBulkClose={setDisableBulkCloseAlerts}
+            exceptionListItems={exceptionArrayWrapper}
+            onUpdateBulkCloseIndex={setBulkCloseIndex}
+            alertData={alertData}
+            isAlertDataLoading={isAlertDataLoading ?? false}
+            alertStatus={alertStatus}
+          />
+        </>
+      )}
+    </>
+  );
+
+  const footerContent = (
+    <EuiFlexGroup
+      justifyContent="spaceBetween"
+      css={css`
+        padding: ${euiTheme.size.s};
+      `}
+    >
+      <EuiButtonEmpty
+        data-test-subj="add-endpoint-exception-cancel-button"
+        onClick={handleCloseFlyout}
+      >
+        {ARTIFACT_FLYOUT_LABELS.flyoutCancelButtonLabel}
+      </EuiButtonEmpty>
+
+      <EuiButton
+        data-test-subj="add-endpoint-exception-confirm-button"
+        fill
+        disabled={isAlertDataLoading || !isFormValid || isSubmittingData || isClosingAlerts}
+        onClick={handleOnSubmit}
+      >
+        {ENDPOINT_EXCEPTIONS_PAGE_LABELS.flyoutCreateSubmitButtonLabel}
+      </EuiButton>
+    </EuiFlexGroup>
+  );
+
+  const confirmModal = showConfirmModal && confirmModalLabels && (
+    <ArtifactConfirmModal
+      labels={confirmModalLabels}
+      onSuccess={submitException}
+      onCancel={() => setShowConfirmModal(false)}
+      data-test-subj="endpointExceptionConfirmModal"
+    />
+  );
+
   return (
     <EuiFlyout
+      session="never"
       size="l"
       onClose={handleCloseFlyout}
       aria-labelledby={endpointExceptionsFlyoutTitleId}
@@ -197,74 +269,11 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
         </EuiTitle>
       </EuiFlyoutHeader>
 
-      <EuiFlyoutBody>
-        {exception && (
-          <EndpointExceptionsForm
-            allowSelectOs={!alertData}
-            error={undefined}
-            disabled={false}
-            item={exception}
-            additionalEntries={additionalEntries}
-            mode="create"
-            onChange={handleOnChange}
-          />
-        )}
+      <EuiFlyoutBody>{bodyContent}</EuiFlyoutBody>
 
-        {hasAlertsUpdate && (
-          <>
-            <EuiHorizontalRule />
+      <EuiFlyoutFooter>{footerContent}</EuiFlyoutFooter>
 
-            <ExceptionItemsFlyoutAlertsActions
-              exceptionListType="endpoint"
-              shouldCloseSingleAlert={closeSingleAlert}
-              onSingleAlertCloseCheckboxChange={setCloseSingleAlert}
-              shouldBulkCloseAlert={bulkCloseAlerts}
-              onBulkCloseCheckboxChange={setBulkCloseAlerts}
-              disableBulkClose={disableBulkClose}
-              onDisableBulkClose={setDisableBulkCloseAlerts}
-              exceptionListItems={exceptionArrayWrapper}
-              onUpdateBulkCloseIndex={setBulkCloseIndex}
-              alertData={alertData}
-              isAlertDataLoading={isAlertDataLoading ?? false}
-              alertStatus={alertStatus}
-            />
-          </>
-        )}
-      </EuiFlyoutBody>
-
-      <EuiFlyoutFooter>
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
-          css={css`
-            padding: ${euiTheme.size.s};
-          `}
-        >
-          <EuiButtonEmpty
-            data-test-subj="add-endpoint-exception-cancel-button"
-            onClick={handleCloseFlyout}
-          >
-            {ARTIFACT_FLYOUT_LABELS.flyoutCancelButtonLabel}
-          </EuiButtonEmpty>
-
-          <EuiButton
-            data-test-subj="add-endpoint-exception-confirm-button"
-            fill
-            disabled={isAlertDataLoading || !isFormValid || isSubmittingData || isClosingAlerts}
-            onClick={handleOnSubmit}
-          >
-            {ENDPOINT_EXCEPTIONS_PAGE_LABELS.flyoutCreateSubmitButtonLabel}
-          </EuiButton>
-        </EuiFlexGroup>
-      </EuiFlyoutFooter>
-
-      {showConfirmModal && confirmModalLabels && (
-        <ArtifactConfirmModal
-          labels={confirmModalLabels}
-          onSuccess={submitException}
-          onCancel={() => setShowConfirmModal(false)}
-          data-test-subj="endpointExceptionConfirmModal"
-        />
-      )}
+      {confirmModal}
     </EuiFlyout>
   );
 };


### PR DESCRIPTION
## Summary

This PR is starting over from [this prior work](https://github.com/elastic/kibana/pull/268676). It got split into 2 PRs:
- [this one](https://github.com/elastic/kibana/pull/273772) that converts all the `styled-components` to `@emotion`
- this current one which actually adds the `Add rule exception` and `Add Endpoint exception` actions to the new flyout system

The actions are now available in Discover

https://github.com/user-attachments/assets/b8157000-23ac-4c5b-9536-37cb24b2086e

The legacy expandable flyout experience remains unchanged (`newFlyoutSystemEnabled` feature flag is `false`)

https://github.com/user-attachments/assets/7f4fecf6-d0cb-4664-be8b-be1674476984

And the new flyout also now has the new actions in Security Solution (`newFlyoutSystemEnabled` feature flag is set to `true`)

https://github.com/user-attachments/assets/52ca785a-b95c-4025-8325-175711753c95

## How to test

1. Start Kibana and navigate to **Discover** with a security alerts data view (`.alerts-security.alerts-*`).
2. Open an alert document and use **Take action → Add rule exception** — the form should open with conditions pre-populated from the alert fields.
3. Submit and verify the exception is created; if "Close this alert" is checked the alert closes.
4. Cancel and verify the document flyout remains open.
5. Repeat for an endpoint alert and **Add Endpoint exception**.
6. Confirm the same works from the **Security → Alerts** view via the Take action menu in the document flyout.
7. On the legacy alerts page (Flyout v2 feature flag off), confirm Add rule exception still works and that disabled states (insufficient privileges) behave the same as before.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/251791