### PR TITLE
[Security Solution] fix assignees only showing first in the list in alert flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/assignees.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/assignees.test.tsx
@@ -153,6 +153,13 @@ describe('<Assignees />', () => {
     expect(getByTestId(USER_AVATAR_ITEM_TEST_ID('user1'))).toBeInTheDocument();
   });
 
+  it('renders all assignee avatars when multiple users are assigned', () => {
+    const { getByTestId } = renderAssignees({}, ['user-id-1', 'user-id-2']);
+
+    expect(getByTestId(USER_AVATAR_ITEM_TEST_ID('user1'))).toBeInTheDocument();
+    expect(getByTestId(USER_AVATAR_ITEM_TEST_ID('user2'))).toBeInTheDocument();
+  });
+
   it('applies updated assignees and calls the success callback', async () => {
     const onAlertUpdated = jest.fn();
     const { getByTestId, queryByTestId } = renderAssignees({ onAlertUpdated });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/assignees.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/assignees.tsx
@@ -82,7 +82,7 @@ export const Assignees = memo(({ hit, onAlertUpdated, showAssignees = true }: As
     [hit]
   );
   const initialAssignedUserIds = useMemo(() => {
-    const value = getFieldValue(hit, ALERT_WORKFLOW_ASSIGNEE_IDS) as string[] | string | null;
+    const value = hit.flattened[ALERT_WORKFLOW_ASSIGNEE_IDS] as string[] | string | null;
 
     if (Array.isArray(value)) {
       return value;


### PR DESCRIPTION
## Summary

This PR a small issue introduced in this previous [PR](https://github.com/elastic/kibana/pull/260449) that changed the way we retrieve the assignees from the `hit`. We were using `getFieldValue` from the discover package, but that function only returns the first value of an array.

### Before

https://github.com/user-attachments/assets/8138c1c7-390d-4c8e-b35a-6d8b6b0c331b

### After

https://github.com/user-attachments/assets/8bad5f32-9f94-4a8d-9b78-bf573bdb3591

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/273119



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->