### PR TITLE
[Security Solution] Prevent Esc on Timeline modal from closing the flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.test.tsx
@@ -9,10 +9,30 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '../../common/mock/react_beautiful_dnd';
-import { TestProviders } from '../../common/mock';
+import { TestProviders, createMockStore, mockGlobalState } from '../../common/mock';
 import { TimelineId } from '../../../common/types/timeline';
 import * as timelineActions from '../store/actions';
 import { TimelineWrapper } from '.';
+
+/**
+ * Builds a store where the timeline modal is shown (`show: true`), mirroring the
+ * graph "Investigate in Timeline" scenario where the modal is rendered on top of
+ * the expandable flyout.
+ */
+const createVisibleTimelineStore = () =>
+  createMockStore({
+    ...mockGlobalState,
+    timeline: {
+      ...mockGlobalState.timeline,
+      timelineById: {
+        ...mockGlobalState.timeline.timelineById,
+        [TimelineId.test]: {
+          ...mockGlobalState.timeline.timelineById[TimelineId.test],
+          show: true,
+        },
+      },
+    },
+  });
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -84,5 +104,54 @@ describe('TimelineWrapper', () => {
     expect(mockDispatch).toBeCalledWith(
       timelineActions.showTimeline({ id: TimelineId.test, show: false })
     );
+  });
+
+  it('should not bubble the esc keydown to the underlying flyout when the timeline modal is visible', async () => {
+    // The expandable flyout (e.g. the graph investigation view) registers a window-level
+    // keydown listener too. The timeline wrapper mounts first (persistent app shell), so its
+    // listener runs first and must stop the event before the flyout's listener fires.
+    const underlyingFlyoutHandler = jest.fn();
+
+    render(
+      <TestProviders store={createVisibleTimelineStore()}>
+        <TimelineWrapper {...props} />
+      </TestProviders>
+    );
+
+    window.addEventListener('keydown', underlyingFlyoutHandler);
+
+    try {
+      await userEvent.keyboard('{Escape}');
+
+      // The timeline modal still closes...
+      expect(mockDispatch).toBeCalledWith(
+        timelineActions.showTimeline({ id: TimelineId.test, show: false })
+      );
+      // ...but the underlying flyout's window-level handler is never reached.
+      expect(underlyingFlyoutHandler).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', underlyingFlyoutHandler);
+    }
+  });
+
+  it('should let the esc keydown reach the underlying flyout when the timeline modal is not visible', async () => {
+    const underlyingFlyoutHandler = jest.fn();
+
+    render(
+      <TestProviders>
+        <TimelineWrapper {...props} />
+      </TestProviders>
+    );
+
+    window.addEventListener('keydown', underlyingFlyoutHandler);
+
+    try {
+      await userEvent.keyboard('{Escape}');
+
+      // When the timeline is collapsed, Esc must keep working on other pages/flyouts.
+      expect(underlyingFlyoutHandler).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', underlyingFlyoutHandler);
+    }
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/wrapper/index.tsx
@@ -49,18 +49,31 @@ export const TimelineWrapper: React.FC<TimelineWrapperProps> = React.memo(
     // pressing the ESC key closes the timeline portal unless a flyout is opened on top of it
     const onKeyDown = useCallback(
       (ev: KeyboardEvent) => {
-        if (ev.key === keys.ESCAPE) {
-          const query = new URLSearchParams(window.location.search);
-          const timelineFlyoutOpen = isTimelineFlyoutOpen(query);
-
-          if (timelineFlyoutOpen) {
-            closeFlyout();
-            return;
-          }
-          handleClose();
+        if (ev.key !== keys.ESCAPE) {
+          return;
         }
+
+        const query = new URLSearchParams(window.location.search);
+        const timelineFlyoutOpen = isTimelineFlyoutOpen(query);
+
+        // While the Timeline modal is visible, keep this Esc keydown from reaching the
+        // window-level handler of the underlying expandable flyout (e.g. the graph
+        // investigation view), which would otherwise also close it. Both listeners are
+        // registered on `window`, so `stopImmediatePropagation` (not `stopPropagation`)
+        // is required to suppress the sibling listener. We skip this when the Timeline is
+        // not visible so Esc still closes flyouts on other pages.
+        if (show) {
+          ev.stopImmediatePropagation();
+          ev.preventDefault();
+        }
+
+        if (timelineFlyoutOpen) {
+          closeFlyout();
+          return;
+        }
+        handleClose();
       },
-      [closeFlyout, handleClose]
+      [show, closeFlyout, handleClose]
     );
 
     useTimelineSavePrompt(timelineId, onAppLeave);


### PR DESCRIPTION
## Summary

Closes elastic/security-team#17309.

When the Timeline modal is opened on top of the expandable flyout (e.g. from the graph "Investigate in Timeline" action), pressing Esc closed both the modal and the underlying flyout, dropping the analyst out of the investigation context.

### Solution

The Timeline wrapper and the expandable flyout (EuiFlyoutResizable) both register window-level keydown listeners via `EuiWindowEvent`. Because they share the same `window` target, `stopPropagation` does not prevent the sibling listener from firing; `stopImmediatePropagation` is required. The Timeline wrapper mounts first (persistent app shell), so its listener runs first and can suppress the flyout's.

Now, while the Timeline modal is visible (`show === true`), the Esc handler calls `stopImmediatePropagation` + `preventDefault` before dispatching its close action. When the Timeline is not visible, propagation is left untouched so Esc keeps closing flyouts on other pages.

### Video

First Esc closes the Timeline modal, second Esc closes the flyout

https://github.com/user-attachments/assets/68ce14e0-a50e-4c47-8f6e-5d237a37578d

### How to test

1. In Kibana, enable Entity Store.
2. Optionally, add mock data with `security-documents-generator` using `yarn start entity-resolution-demo`.
3. Go to Entity Analytics page and open the flyout for any entity within the Entities list.
4. Expand Graph Visualization Click on "Investigate in Timeline".

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks.