### PR TITLE
[DI] Wire Dependency Injection into the Plugin System

### DIFF
--- a/packages/kbn-kibana-manifest-schema/src/kibana_json_v1_schema.ts
+++ b/packages/kbn-kibana-manifest-schema/src/kibana_json_v1_schema.ts
@@ -142,5 +142,71 @@ export const MANIFEST_V1: JSONSchema = {
       `,
       type: 'boolean',
     },
+    globals: {
+      description: desc`
+        Cross-plugin contract declarations. The platform uses these for visibility, startup
+        health checks, and future bundle-loading optimisation.
+      `,
+      type: 'object',
+      properties: {
+        services: {
+          type: 'object',
+          properties: {
+            provides: {
+              description: desc`
+                Service token names (in \`<pluginId>.<ServiceName>\` format) that this plugin
+                provides for cross-plugin consumption. Auto-maintained by \`node scripts/lint_packages --fix\`.
+              `,
+              type: 'array',
+              items: {
+                type: 'string',
+                pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+              },
+            },
+            consumes: {
+              description: desc`
+                Service token names (in \`<pluginId>.<ServiceName>\` format) that this plugin
+                consumes from other plugins. Auto-maintained by \`node scripts/lint_packages --fix\`.
+              `,
+              type: 'array',
+              items: {
+                type: 'string',
+                pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+              },
+            },
+          },
+          additionalProperties: false,
+        },
+        extensionPoints: {
+          type: 'object',
+          properties: {
+            hosts: {
+              description: desc`
+                Extension point token names (in \`<pluginId>.<ServiceName>\` format) hosted by this
+                plugin. Auto-maintained by \`node scripts/lint_packages --fix\`.
+              `,
+              type: 'array',
+              items: {
+                type: 'string',
+                pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+              },
+            },
+            contributes: {
+              description: desc`
+                Extension point token names (in \`<pluginId>.<ServiceName>\` format) this plugin
+                contributes to. Auto-maintained by \`node scripts/lint_packages --fix\`.
+              `,
+              type: 'array',
+              items: {
+                type: 'string',
+                pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+              },
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    },
   },
 };

--- a/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
+++ b/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
@@ -204,6 +204,72 @@ export const MANIFEST_V2: JSONSchema = {
                 to be imported by the server and the plugin started by core.
               `,
             },
+            globals: {
+              type: 'object',
+              description: desc`
+                Cross-plugin contract declarations. The platform uses these for visibility, startup
+                health checks, and future bundle-loading optimisation.
+              `,
+              properties: {
+                services: {
+                  type: 'object',
+                  properties: {
+                    provides: {
+                      type: 'array',
+                      description: desc`
+                        Service token names (in \`<pluginId>.<ServiceName>\` format) that this plugin
+                        provides for cross-plugin consumption. Auto-maintained by \`node scripts/lint_packages --fix\`.
+                      `,
+                      items: {
+                        type: 'string',
+                        pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+                      },
+                    },
+                    consumes: {
+                      type: 'array',
+                      description: desc`
+                        Service token names (in \`<pluginId>.<ServiceName>\` format) that this plugin
+                        consumes from other plugins. Auto-maintained by \`node scripts/lint_packages --fix\`.
+                      `,
+                      items: {
+                        type: 'string',
+                        pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+                      },
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                extensionPoints: {
+                  type: 'object',
+                  properties: {
+                    hosts: {
+                      type: 'array',
+                      description: desc`
+                        Extension point token names (in \`<pluginId>.<ServiceName>\` format) hosted by
+                        this plugin. Auto-maintained by \`node scripts/lint_packages --fix\`.
+                      `,
+                      items: {
+                        type: 'string',
+                        pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+                      },
+                    },
+                    contributes: {
+                      type: 'array',
+                      description: desc`
+                        Extension point token names (in \`<pluginId>.<ServiceName>\` format) this plugin
+                        contributes to. Auto-maintained by \`node scripts/lint_packages --fix\`.
+                      `,
+                      items: {
+                        type: 'string',
+                        pattern: '^[a-z][a-zA-Z0-9]*\\.[A-Z][a-zA-Z0-9]*$',
+                      },
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
+              additionalProperties: false,
+            },
           },
         },
       },

--- a/src/core/packages/apps/server-internal/src/core_app.test.ts
+++ b/src/core/packages/apps/server-internal/src/core_app.test.ts
@@ -191,6 +191,10 @@ describe('CoreApp', () => {
         requiredBundles: [],
         requiredPlugins: [],
         runtimePluginDependencies: [],
+        globals: {
+          services: { provides: [], consumes: [] },
+          extensionPoints: { hosts: [], contributes: [] },
+        },
       });
     });
     it('calls `registerBundleRoutes` with the correct options', async () => {
@@ -302,6 +306,10 @@ describe('CoreApp', () => {
         requiredBundles: [],
         requiredPlugins: [],
         runtimePluginDependencies: [],
+        globals: {
+          services: { provides: [], consumes: [] },
+          extensionPoints: { hosts: [], contributes: [] },
+        },
       });
       prebootUIPlugins.internal.set('some-plugin-2', {
         publicAssetsDir: '/foo',
@@ -433,6 +441,10 @@ describe('CoreApp', () => {
       requiredBundles: [],
       requiredPlugins: [],
       runtimePluginDependencies: [],
+      globals: {
+        services: { provides: [], consumes: [] },
+        extensionPoints: { hosts: [], contributes: [] },
+      },
     });
     uiPlugins.internal.set('some-plugin', {
       publicAssetsDir: '/foo',
@@ -448,6 +460,10 @@ describe('CoreApp', () => {
       requiredBundles: [],
       requiredPlugins: [],
       runtimePluginDependencies: [],
+      globals: {
+        services: { provides: [], consumes: [] },
+        extensionPoints: { hosts: [], contributes: [] },
+      },
     });
     uiPlugins.internal.set('some-plugin-2', {
       publicAssetsDir: '/foo',

--- a/src/core/packages/base/common/src/plugins.ts
+++ b/src/core/packages/base/common/src/plugins.ts
@@ -85,6 +85,21 @@ export interface DiscoveredPlugin {
   readonly runtimePluginDependencies: readonly PluginName[];
 
   /**
+   * Global DI token declarations for this plugin.  Used for documentation, startup health checks,
+   * and future bundle-loading optimisation.
+   */
+  readonly globals: {
+    readonly services: {
+      readonly provides: readonly string[];
+      readonly consumes: readonly string[];
+    };
+    readonly extensionPoints: {
+      readonly hosts: readonly string[];
+      readonly contributes: readonly string[];
+    };
+  };
+
+  /**
    * Specifies whether this plugin - and its required dependencies - will be enabled for anonymous pages (login page, status page when
    * configured, etc.) Default is false.
    */

--- a/src/core/packages/di/common/README.md
+++ b/src/core/packages/di/common/README.md
@@ -82,13 +82,13 @@ services bound in the request scope can still inject request-scope dependencies.
 ## Usage
 ### Get Started
 To get started, create an empty plugin and declare a named export called
-`module` in your `index.ts`. The plugin-author guide for the PoC lives in
+`services` in your `index.ts`. The plugin-author guide for the PoC lives in
 [`@kbn/plugin-di/GETTING_STARTED.md`](../plugin/GETTING_STARTED.md).
 
 The short version is:
 
 - define cross-plugin tokens with `createTokenFactory('myPlugin')`
-- author your plugin's `module` export with `declare(({ bind, provide, host, contribute }) => ...)`
+- author a plugin `services` module with `declare(({ bind, provide, host, contribute }) => ...)`
 
 ```ts
 import { declare } from '@kbn/plugin-di';
@@ -101,7 +101,7 @@ export class Greeting {
   }
 }
 
-export const module = declare(({ bind }) => {
+export const services = declare(({ bind }) => {
   bind(Greeting).toSelf();
 });
 ```
@@ -122,16 +122,12 @@ class HelloWorld {
   }
 }
 
-export const module = declare(({ bind }) => {
+export const services = declare(({ bind }) => {
   bind(HelloWorld).toSelf();
 });
 ```
 
-> **Note:** The `module` export can be either a plain Inversify `ContainerModule`
-> (`export const module = new ContainerModule(...)`) or the `declare(...)` form
-> from `@kbn/plugin-di`. `declare(...)` is the blessed authoring path in this
-> PoC; it returns a `ContainerModule`, so both are interchangeable from the
-> platform's perspective.
+> **Note:** Plugins may also export a `module` named export (`export const module = new ContainerModule(...)`) when they want to author bindings directly with plain Inversify. The `services = declare(...)` form is the blessed `@kbn/plugin-di` authoring path in this PoC; if both are present, `services` wins.
 
 ### Exposing Contracts
 In order to expose services to already existing plugins, they should be returned as part of the contract via the `Setup` or `Start` services.
@@ -499,10 +495,11 @@ Cross-plugin DI introduces two explicit runtime patterns:
 - **Extension points** for one-host, many-contributor contracts resolved with
   `getExtensions(...)`, `useExtensions(...)`, and `injectExtensions(...)`
 
-Those patterns are part of the runtime subsystem documented here. The
-plugin-author workflow for defining tokens and declaring providers, hosts, and
-contributions lives in
-[`@kbn/plugin-di/GETTING_STARTED.md`](../plugin/GETTING_STARTED.md).
+Those patterns are part of the runtime subsystem documented here. Plugins record
+the contracts they provide, host, contribute, and consume in `plugin.globals`,
+and the platform validates those declarations at startup. The plugin-author
+workflow for defining tokens and declaring providers, hosts, and contributions
+lives in [`@kbn/plugin-di/GETTING_STARTED.md`](../plugin/GETTING_STARTED.md).
 
 ## Testing
 

--- a/src/core/packages/di/plugin/GETTING_STARTED.md
+++ b/src/core/packages/di/plugin/GETTING_STARTED.md
@@ -22,31 +22,27 @@ task.
 
 ## I expose a service
 
-In the plugin that owns the service, inside its `module`, provide the token from
-a concrete implementation:
+In the plugin that owns the service, inside its `services` module:
 
 ```ts
-import { declare, implementedBy } from '@kbn/plugin-di';
+import { declare } from '@kbn/plugin-di';
+import type { MyPluginStart } from './types';
 import { MyServiceToken } from '@kbn/my-plugin-types';
-import { MyServiceImpl } from './my_service';
 
-export const module = declare(({ provide }) => {
-  provide(MyServiceToken, implementedBy(MyServiceImpl));
+export const services = declare<MyPluginStart>(({ provide }) => {
+  provide(MyServiceToken, (start) => start.myService);
 });
 ```
 
-`provide(...)` accepts several sources for the value:
+The selector projects a piece of your plugin's own `start()` contract, which the
+platform auto-bridges into DI. Pass your start contract as `declare<MyPluginStart>`
+so `start` is typed.
+
+If the service is not sourced from `start`:
 
 - class-backed: `provide(MyServiceToken, implementedBy(MyServiceImpl))`
 - constant value: `provide(MyServiceToken, withValue(value))`
 - derived from another binding: `provide(MyServiceToken, fromToken(SourceToken, (source) => derived))`
-
-It also accepts a `start` selector
-(`declare<MyPluginStart>(({ provide }) => provide(MyServiceToken, (start) => start.myService))`),
-which projects a piece of your plugin's own classic `start()` contract into DI.
-This effort introduces the plugin-system bridge that makes that selector resolve
-a plugin's classic contract, so it becomes the natural path for plugins
-migrating gradually from `setup()`/`start()`.
 
 ## I consume a service
 
@@ -69,7 +65,7 @@ In the plugin that owns the collection point:
 import { declare } from '@kbn/plugin-di';
 import { MyMenuItemsToken } from '@kbn/my-plugin-types';
 
-export const module = declare(({ host }) => {
+export const services = declare(({ host }) => {
   host(MyMenuItemsToken);
 });
 ```
@@ -90,7 +86,7 @@ In any plugin that wants to add to the collection:
 import { declare } from '@kbn/plugin-di';
 import { MyMenuItemsToken } from '@kbn/my-plugin-types';
 
-export const module = declare(({ contribute }) => {
+export const services = declare(({ contribute }) => {
   contribute(MyMenuItemsToken, { id: 'reports', label: 'Reports' });
 });
 ```
@@ -111,7 +107,7 @@ export const MyMenuItemsToken = tokens.extensionPoint<MenuItem>('MyMenuItems');
 import { declare } from '@kbn/plugin-di';
 import { MyServiceToken, MyMenuItemsToken } from '@kbn/my-plugin-types';
 
-export const module = declare<MyPluginStart>(({ provide, host }) => {
+export const services = declare<MyPluginStart>(({ provide, host }) => {
   provide(MyServiceToken, (start) => start.myService);
   host(MyMenuItemsToken);
 });
@@ -122,7 +118,7 @@ const items = useExtensions(MyMenuItemsToken); // MenuItem[], read wherever the 
 import { declare } from '@kbn/plugin-di';
 import { MyServiceToken, MyMenuItemsToken } from '@kbn/my-plugin-types';
 
-export const module = declare(({ contribute }) => {
+export const services = declare(({ contribute }) => {
   contribute(MyMenuItemsToken, { id: 'reports', label: 'Reports' });
 });
 
@@ -141,11 +137,11 @@ A few things make this work:
   is typed via `declare<MyPluginStart>`.
 - **Registration and consumption happen at different times.** `provide`/`host`/
   `contribute` run when the module loads; `useService`/`useExtensions` run in the
-  UI. A missing provider or host is not a type error; resolving such a token
-  fails at resolution time. This effort adds startup validation that surfaces
-  those mismatches before the runtime path is hit.
-- **The export name is the contract.** Core loads the module by its `module`
-  export name.
+  UI. A missing provider or host is not a type error; it is caught at startup by
+  the platform's contract validation.
+- **The export name is the contract.** Core loads plugin-owned DI declarations
+  from the `services` export. The older `module` export (a raw Inversify
+  `ContainerModule`) is still accepted; if both are present, `services` wins.
 
 The runtime resolution helpers come from `@kbn/core-di`
 ([getService/getExtensions](../common/src/resolve_tokens.ts)) and
@@ -168,7 +164,7 @@ is the single expert escape to the raw InversifyJS builder:
 ```ts
 import { declare, using } from '@kbn/plugin-di';
 
-export const module = declare(({ provide }) => {
+export const services = declare(({ provide }) => {
   provide(MyServiceToken, using((bindTo) => bindTo.to(MyServiceImpl).inRequestScope()));
 });
 ```
@@ -183,7 +179,7 @@ import { OnStart, getExtensions, type Container } from '@kbn/core-di';
 import { declare } from '@kbn/plugin-di';
 import { MyRegistrationToken } from '@kbn/my-plugin-types';
 
-export const module = declare(({ bind, host }) => {
+export const services = declare(({ bind, host }) => {
   host(MyRegistrationToken);
 
   bind(OnStart).toConstantValue((container: Container) => {
@@ -193,6 +189,49 @@ export const module = declare(({ bind, host }) => {
   });
 });
 ```
+
+## Server entry and lazy loading
+
+On the server, the platform reads your `services` export from the plugin's
+`server` entry, which is loaded with a synchronous `require(...)`. Top-level
+imports in that entry are therefore evaluated eagerly when the plugin is loaded —
+the same sensitivity that `@kbn/eslint/no_sync_import_from_plugin` guards for
+`server/index.ts`. A `services` export that statically pulls in your
+implementation reintroduces eager parsing of plugin code.
+
+Keep the `services`-declaring entry cheap to import:
+
+- Source services from the bridged `start()` contract (`provide(token, (start) => ...)`) so the implementation loads with the plugin, not with the entry.
+- For non-`start` bindings, prefer lazy construction: bind `OnSetup`/`OnStart` callbacks that `await import('./impl')`, rather than importing implementation classes at module top level.
+- Do not `import './plugin'` (or re-export runtime values from implementation modules) in the same entry that declares `services`.
+
+## `plugin.globals` records your contracts
+
+Cross-plugin contracts are recorded in `plugin.globals` in your plugin's
+`kibana.jsonc`, and the platform validates them at startup:
+
+- `services.provides` / `extensionPoints.hosts` / `extensionPoints.contributes`
+  mirror your `provide(...)` / `host(...)` / `contribute(...)` calls.
+- `services.consumes` records the services you resolve with `getService(...)` /
+  `useService(...)` / `injectService(...)`. There is intentionally no `consume()`
+  verb, so seeing `consumes` without a matching call is expected.
+
+Token ownership is inferred from the `<pluginId>` prefix rather than declared as
+a separate field. The prefix already names the owner, it is the same key used by
+`Symbol.for('<pluginId>.<name>')`, and keeping one source avoids a second
+ownership declaration drifting from the token name.
+
+Startup validation runs before any plugin's `start()`. It flags missing or
+duplicate service providers and missing or duplicate extension-point hosts, so a
+contract mismatch surfaces — and, in `error` mode, aborts startup — ahead of
+plugin start rather than after. On the server, validation severity is
+configurable via the `plugins.globalTokenValidation` setting
+(`warn` | `error` | `off`, default `warn`). In the browser, validation currently
+always logs warnings to the console with no opt-out — a known limitation of this
+PoC.
+
+At this layer these fields are declared and maintained by hand; the platform
+reads and validates them but does not yet generate them.
 
 ## Common mistakes
 

--- a/src/core/packages/plugins/browser-internal/src/plugin.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin.test.ts
@@ -9,10 +9,10 @@
 
 import { mockInitializer, mockPlugin, mockPluginReader } from './plugin.test.mocks';
 
-import { ContainerModule } from 'inversify';
+import { Container, ContainerModule } from 'inversify';
 import type { DiscoveredPlugin } from '@kbn/core-base-common';
 import { PluginType } from '@kbn/core-base-common';
-import { PluginSetup, PluginStart, Setup, Start } from '@kbn/core-di';
+import { OnStart, PluginSetup, PluginStart, Setup, Start } from '@kbn/core-di';
 import { injectionServiceMock } from '@kbn/core-di-mocks';
 import { CoreSetup, CoreStart, PluginInitializer } from '@kbn/core-di-browser';
 import { createPluginInitializerContextMock } from './test_helpers';
@@ -31,6 +31,10 @@ function createManifest(
     optionalPlugins: optional,
     requiredBundles: [],
     runtimePluginDependencies: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     owner: {
       name: 'foo',
     },
@@ -157,6 +161,56 @@ describe('PluginWrapper', () => {
     const container = injection.getContainer();
     expect(container.get(CoreStart('injection'))).toBeDefined();
     expect(container.get(PluginStart('otherDep'))).toBe('value');
+  });
+
+  test('`start` bridges the classic start contract into DI before OnStart hooks resolve Start', () => {
+    // Mimic PluginModule: a default Start binding plus a container-module
+    // activation that fires OnStart hooks. The wrapper operates on a child
+    // scope, matching production, so the rebound Start is observed by the hooks.
+    const root = new Container({ defaultScope: 'Singleton' });
+    const activated = new WeakSet<Container>();
+    root.loadSync(
+      new ContainerModule(({ bind, onActivation }) => {
+        bind(Setup)
+          .toResolvedValue(() => undefined)
+          .inRequestScope();
+        bind(Start)
+          .toResolvedValue(() => undefined)
+          .inRequestScope();
+        onActivation(Start, ({ get }, contract) => {
+          const container = get(Container);
+          if (!activated.has(container)) {
+            activated.add(container);
+            container.getAll(OnStart, { chained: true }).forEach((callback) => callback(container));
+          }
+          return contract;
+        });
+      })
+    );
+    const child = new Container({ defaultScope: 'Singleton', parent: root });
+    child.bind(Container).toConstantValue(child);
+    const injection = { getContainer: () => child, fork: () => child };
+
+    const classicStartContract = { value: 'classic-start' };
+    mockPluginReader.mockReturnValueOnce({ plugin: mockInitializer, module: pluginModule } as any);
+    mockInitializer.mockReturnValueOnce({
+      setup: jest.fn(),
+      start: jest.fn().mockReturnValue(classicStartContract),
+      stop: jest.fn(),
+    });
+
+    let observedStart: unknown;
+    mockContainerModuleCallback.mockImplementationOnce(({ bind }) => {
+      bind(OnStart).toConstantValue((container: Container) => {
+        observedStart = container.get(Start);
+      });
+    });
+
+    plugin.setup({ injection } as any, {});
+    const startContract = plugin.start({ injection } as any, {});
+
+    expect(startContract).toBe(classicStartContract);
+    expect(observedStart).toBe(classicStartContract);
   });
 
   test('`stop` fails if plugin is not setup up', async () => {

--- a/src/core/packages/plugins/browser-internal/src/plugin.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin.test.ts
@@ -103,6 +103,24 @@ describe('PluginWrapper', () => {
     expect(container.get(PluginSetup('otherDep'))).toBe('value');
   });
 
+  test('`setup` prefers `services` over `module` when both are exported', () => {
+    const servicesCallback = jest.fn(({ bind }) => {
+      bind(Setup).toConstantValue({ from: 'services' });
+    });
+    const legacyCallback = jest.fn(({ bind }) => {
+      bind(Setup).toConstantValue({ from: 'module' });
+    });
+    mockPluginReader.mockReturnValueOnce({
+      services: new ContainerModule(servicesCallback),
+      module: new ContainerModule(legacyCallback),
+    } as any);
+    const injection = injectionServiceMock.createInternalSetupContract();
+
+    expect(plugin.setup({ injection } as any, {})).toEqual({ from: 'services' });
+    expect(servicesCallback).toHaveBeenCalledTimes(1);
+    expect(legacyCallback).not.toHaveBeenCalled();
+  });
+
   test('`start` fails if setup is not called first', () => {
     expect(() => plugin.start({} as any, {} as any)).toThrowErrorMatchingInlineSnapshot(
       `"Plugin \\"plugin-a\\" can't be started since it isn't set up."`

--- a/src/core/packages/plugins/browser-internal/src/plugin.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin.ts
@@ -67,9 +67,10 @@ export class PluginWrapper<
     this.definition = read(this.name);
     this.instance = this.createPluginInstance();
 
-    if (this.definition.module) {
+    const diModule = this.definition.services ?? this.definition.module;
+    if (diModule) {
       this.container = setupContext.injection.getContainer();
-      this.container.loadSync(this.definition.module);
+      this.container.loadSync(diModule);
       this.container.loadSync(createSetupModule(this.initializerContext, setupContext, plugins));
     }
 

--- a/src/core/packages/plugins/browser-internal/src/plugin.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin.ts
@@ -91,10 +91,36 @@ export class PluginWrapper<
     }
 
     this.container?.loadSync(createStartModule(startContext, plugins));
-    const contract = [
-      this.instance?.start(startContext, plugins),
-      this.container?.get<TStart>(Start),
-    ].find(Boolean)!;
+
+    const instanceContract = this.instance?.start(startContext, plugins);
+    return this.bridgeStartContract(startContext, plugins, instanceContract);
+  }
+
+  /**
+   * Bridges the classic plugin `start()` contract into DI as {@link Start}
+   * before resolving it, so `OnStart` hooks and `provide(token, (start) => ...)`
+   * selectors observe the plugin's contract rather than the default. A pure-DI
+   * plugin (no classic instance) falls back to the contract bound by its module.
+   */
+  private bridgeStartContract(
+    startContext: CoreStart,
+    plugins: TPluginsStart,
+    instanceContract: TStart | undefined
+  ): TStart {
+    if (!this.container) {
+      this.startDependencies$.next([startContext, plugins, instanceContract!]);
+      return instanceContract!;
+    }
+
+    let contract: TStart;
+    if (instanceContract) {
+      this.container.rebindSync(Start).toConstantValue(instanceContract);
+      this.container.get(Start);
+      contract = instanceContract;
+    } else {
+      contract = this.container.get<TStart>(Start);
+      this.container.rebindSync(Start).toConstantValue(contract);
+    }
 
     this.startDependencies$.next([startContext, plugins, contract]);
 

--- a/src/core/packages/plugins/browser-internal/src/plugin_context.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin_context.test.ts
@@ -23,6 +23,10 @@ const createPluginManifest = (pluginName: string): DiscoveredPlugin => {
     optionalPlugins: [],
     requiredBundles: [],
     runtimePluginDependencies: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
   };
 };
 

--- a/src/core/packages/plugins/browser-internal/src/plugin_reader.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin_reader.test.ts
@@ -42,7 +42,7 @@ it('handles plugin exports with a "plugin" export that is not a function', () =>
 
   expect(() => {
     read('foo');
-  }).toThrowError(`Definition of plugin "foo" should either be a function or a module.`);
+  }).toThrowError(`Definition of plugin "foo" should export "plugin", "services", or "module".`);
 });
 
 it('returns the plugin definition when the "plugin" named export is a function', () => {

--- a/src/core/packages/plugins/browser-internal/src/plugin_reader.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugin_reader.ts
@@ -21,6 +21,7 @@ export type UnknownPluginInitializer = PluginInitializer<unknown, unknown>;
  */
 export interface PluginDefinition {
   module?: ContainerModule;
+  services?: ContainerModule;
   plugin?: UnknownPluginInitializer;
 }
 
@@ -47,8 +48,14 @@ export function read(name: string): PluginDefinition {
   }
 
   const pluginExport = coreWindow.__kbnBundles__.get(exportId);
-  if (!pluginExport?.module && typeof pluginExport?.plugin !== 'function') {
-    throw new Error(`Definition of plugin "${name}" should either be a function or a module.`);
+  if (
+    !pluginExport?.services &&
+    !pluginExport?.module &&
+    typeof pluginExport?.plugin !== 'function'
+  ) {
+    throw new Error(
+      `Definition of plugin "${name}" should export "plugin", "services", or "module".`
+    );
   }
 
   return pluginExport;

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.test.ts
@@ -69,6 +69,10 @@ function createManifest(
     optionalPlugins: optional,
     requiredBundles: [],
     runtimePluginDependencies: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
   };
 }
 

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -18,6 +18,7 @@ import {
   createPluginStartContext,
 } from './plugin_context';
 import { RuntimePluginContractResolver } from './plugin_contract_resolver';
+import { validateGlobalTokens } from './validate_global_tokens';
 
 /** @internal */
 export type PluginsServiceSetupDeps = InternalCoreSetup;
@@ -50,7 +51,11 @@ export class PluginsService
 
   private readonly satupPlugins: PluginName[] = [];
 
-  constructor(private readonly coreContext: CoreContext, plugins: InjectedMetadataPlugin[]) {
+  constructor(
+    private readonly coreContext: CoreContext,
+    private readonly injectedPlugins: InjectedMetadataPlugin[]
+  ) {
+    const plugins = injectedPlugins;
     // Generate opaque ids
     const opaqueIds = new Map<PluginName, PluginOpaqueId>(plugins.map((p) => [p.id, Symbol(p.id)]));
 
@@ -154,7 +159,8 @@ export class PluginsService
 
     this.runtimeResolver.resolveStartRequests(contracts);
 
-    // Expose start contracts
+    validateGlobalTokens(this.injectedPlugins);
+
     return { contracts };
   }
 

--- a/src/core/packages/plugins/browser-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/browser-internal/src/plugins_service.ts
@@ -129,6 +129,10 @@ export class PluginsService
   }
 
   public async start(deps: PluginsServiceStartDeps): Promise<InternalPluginsServiceStart> {
+    // Validate cross-plugin DI contracts from the manifests before any plugin
+    // starts, mirroring the server ordering.
+    validateGlobalTokens(this.injectedPlugins);
+
     // Setup each plugin with required and optional plugin contracts
     const contracts = new Map<string, unknown>();
     for (const [pluginName, plugin] of this.plugins.entries()) {
@@ -158,8 +162,6 @@ export class PluginsService
     }
 
     this.runtimeResolver.resolveStartRequests(contracts);
-
-    validateGlobalTokens(this.injectedPlugins);
 
     return { contracts };
   }

--- a/src/core/packages/plugins/browser-internal/src/validate_global_tokens.test.ts
+++ b/src/core/packages/plugins/browser-internal/src/validate_global_tokens.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { InjectedMetadataPlugin } from '@kbn/core-injected-metadata-common-internal';
+import type { DiscoveredPlugin } from '@kbn/core-base-common';
+import { PluginType } from '@kbn/core-base-common';
+import { validateGlobalTokens } from './validate_global_tokens';
+
+const createPlugin = (
+  id: string,
+  {
+    provides = [],
+    consumes = [],
+    hosts = [],
+    contributes = [],
+  }: {
+    provides?: string[];
+    consumes?: string[];
+    hosts?: string[];
+    contributes?: string[];
+  } = {}
+): InjectedMetadataPlugin => ({
+  id,
+  plugin: {
+    id,
+    type: PluginType.standard,
+    configPath: id,
+    requiredPlugins: [],
+    optionalPlugins: [],
+    requiredBundles: [],
+    runtimePluginDependencies: [],
+    globals: {
+      services: { provides, consumes },
+      extensionPoints: { hosts, contributes },
+    },
+  } as DiscoveredPlugin,
+});
+
+describe('validateGlobalTokens (browser)', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('does nothing when all consumed tokens have publishers', () => {
+    const plugins = [
+      createPlugin('slo', { provides: ['slo.CreateFlyout'] }),
+      createPlugin('apm', { consumes: ['slo.CreateFlyout'] }),
+    ];
+
+    validateGlobalTokens(plugins);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there are no globals declared', () => {
+    const plugins = [createPlugin('slo'), createPlugin('apm')];
+
+    validateGlobalTokens(plugins);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs a console.warn for each consumed token with no publisher', () => {
+    const plugins = [
+      createPlugin('apm', { consumes: ['slo.CreateFlyout', 'slo.DetailsFlyout'] }),
+      createPlugin('slo', { provides: ['slo.CreateFlyout'] }),
+    ];
+
+    validateGlobalTokens(plugins);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"slo.DetailsFlyout"'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"slo" plugin may be disabled'));
+  });
+
+  it('never throws, only warns', () => {
+    const plugins = [
+      createPlugin('apm', { consumes: ['slo.CreateFlyout', 'ml.AnomalyDetection'] }),
+    ];
+
+    expect(() => validateGlobalTokens(plugins)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns when an extension point contribution has no host', () => {
+    const plugins = [createPlugin('lens', { contributes: ['embeddable.FactoryRegistration'] })];
+
+    validateGlobalTokens(plugins);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('contributes to extension point "embeddable.FactoryRegistration"')
+    );
+  });
+
+  it('warns when a token has multiple hosts', () => {
+    const plugins = [
+      createPlugin('embeddable', { hosts: ['embeddable.FactoryRegistration'] }),
+      createPlugin('dashboard', { hosts: ['embeddable.FactoryRegistration'] }),
+    ];
+
+    validateGlobalTokens(plugins);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('multiple hosts'));
+  });
+});

--- a/src/core/packages/plugins/browser-internal/src/validate_global_tokens.ts
+++ b/src/core/packages/plugins/browser-internal/src/validate_global_tokens.ts
@@ -10,7 +10,8 @@
 import type { InjectedMetadataPlugin } from '@kbn/core-injected-metadata-common-internal';
 
 /**
- * Validates cross-plugin DI services and extension points in the browser.
+ * Validates cross-plugin DI services and extension points in the browser,
+ * before any plugin is started.
  *
  * Logs warnings to the browser console; never throws.
  */

--- a/src/core/packages/plugins/browser-internal/src/validate_global_tokens.ts
+++ b/src/core/packages/plugins/browser-internal/src/validate_global_tokens.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { InjectedMetadataPlugin } from '@kbn/core-injected-metadata-common-internal';
+
+/**
+ * Validates cross-plugin DI services and extension points in the browser.
+ *
+ * Logs warnings to the browser console; never throws.
+ */
+export const validateGlobalTokens = (plugins: readonly InjectedMetadataPlugin[]): void => {
+  const serviceProviders = new Map<string, string[]>();
+  const extensionHosts = new Map<string, string[]>();
+
+  for (const { plugin } of plugins) {
+    for (const token of plugin.globals.services.provides) {
+      serviceProviders.set(token, [...(serviceProviders.get(token) ?? []), plugin.id]);
+    }
+    for (const token of plugin.globals.extensionPoints.hosts) {
+      extensionHosts.set(token, [...(extensionHosts.get(token) ?? []), plugin.id]);
+    }
+  }
+
+  for (const { id, plugin } of plugins) {
+    for (const token of plugin.globals.services.consumes) {
+      const providers = serviceProviders.get(token) ?? [];
+      if (providers.length === 0) {
+        const expectedProvider = token.split('.')[0] ?? 'unknown';
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[DI] Plugin "${id}" consumes service token "${token}" but no enabled plugin provides it. ` +
+            `The "${expectedProvider}" plugin may be disabled or not loaded.`
+        );
+      } else if (providers.length > 1) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[DI] Plugin "${id}" consumes service token "${token}" but it has multiple providers: ${providers.join(
+            ', '
+          )}.`
+        );
+      }
+    }
+
+    for (const token of plugin.globals.extensionPoints.contributes) {
+      const hosts = extensionHosts.get(token) ?? [];
+      if (hosts.length === 0) {
+        const expectedHost = token.split('.')[0] ?? 'unknown';
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[DI] Plugin "${id}" contributes to extension point "${token}" but no enabled plugin hosts it. ` +
+            `The "${expectedHost}" plugin may be disabled or not loaded.`
+        );
+      } else if (hosts.length > 1) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[DI] Plugin "${id}" contributes to extension point "${token}" but it has multiple hosts: ${hosts.join(
+            ', '
+          )}.`
+        );
+      }
+    }
+  }
+
+  for (const [token, providers] of serviceProviders) {
+    if (providers.length > 1) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[DI] Service token "${token}" has multiple providers: ${providers.join(', ')}.`
+      );
+    }
+  }
+
+  for (const [token, hosts] of extensionHosts) {
+    if (hosts.length > 1) {
+      // eslint-disable-next-line no-console
+      console.warn(`[DI] Extension point "${token}" has multiple hosts: ${hosts.join(', ')}.`);
+    }
+  }
+};

--- a/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_from_plugin_package.test.ts
+++ b/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_from_plugin_package.test.ts
@@ -47,6 +47,16 @@ describe('pluginManifestFromPluginPackage()', () => {
           "legacy",
         ],
         "enabledOnAnonymousPages": false,
+        "globals": Object {
+          "extensionPoints": Object {
+            "contributes": Array [],
+            "hosts": Array [],
+          },
+          "services": Object {
+            "consumes": Array [],
+            "provides": Array [],
+          },
+        },
         "id": "someLegacyPluginId",
         "kibanaVersion": "static",
         "optionalPlugins": Array [

--- a/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_from_plugin_package.ts
+++ b/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_from_plugin_package.ts
@@ -24,6 +24,16 @@ export function pluginManifestFromPluginPackage(
     serviceFolders: manifest.serviceFolders,
     kibanaVersion,
     optionalPlugins: manifest.plugin.optionalPlugins ?? [],
+    globals: {
+      services: {
+        provides: manifest.plugin.globals?.services?.provides ?? [],
+        consumes: manifest.plugin.globals?.services?.consumes ?? [],
+      },
+      extensionPoints: {
+        hosts: manifest.plugin.globals?.extensionPoints?.hosts ?? [],
+        contributes: manifest.plugin.globals?.extensionPoints?.contributes ?? [],
+      },
+    },
     requiredBundles: manifest.plugin.requiredBundles ?? [],
     requiredPlugins: manifest.plugin.requiredPlugins ?? [],
     runtimePluginDependencies: manifest.plugin.runtimePluginDependencies ?? [],

--- a/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_parser.test.ts
+++ b/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_parser.test.ts
@@ -388,6 +388,10 @@ test('set defaults for all missing optional fields', async () => {
     kibanaVersion: '7.0.0',
     type: 'standard',
     optionalPlugins: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     requiredPlugins: [],
     requiredBundles: [],
     runtimePluginDependencies: [],
@@ -426,6 +430,10 @@ test('return all set optional fields as they are in manifest', async () => {
     kibanaVersion: '7.0.0',
     type: 'preboot',
     optionalPlugins: ['some-optional-plugin'],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     requiredBundles: [],
     requiredPlugins: ['some-required-plugin', 'some-required-plugin-2'],
     runtimePluginDependencies: ['runtime-plugin-dependency'],
@@ -461,6 +469,10 @@ test('return manifest when plugin expected Kibana version matches actual version
     kibanaVersion: '7.0.0-alpha2',
     type: 'standard',
     optionalPlugins: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     requiredPlugins: ['some-required-plugin'],
     requiredBundles: [],
     runtimePluginDependencies: [],
@@ -495,6 +507,10 @@ test('return manifest when plugin expected Kibana version is `kibana`', async ()
     kibanaVersion: 'kibana',
     type: 'standard',
     optionalPlugins: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     requiredPlugins: ['some-required-plugin'],
     requiredBundles: [],
     runtimePluginDependencies: [],

--- a/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_parser.ts
+++ b/src/core/packages/plugins/server-internal/src/discovery/plugin_manifest_parser.ts
@@ -45,6 +45,7 @@ const KNOWN_MANIFEST_FIELDS = (() => {
     configPath: true,
     requiredPlugins: true,
     optionalPlugins: true,
+    globals: true,
     runtimePluginDependencies: true,
     ui: true,
     server: true,
@@ -209,6 +210,24 @@ export async function parseManifest(
     configPath: manifest.configPath || snakeCase(manifest.id),
     requiredPlugins: Array.isArray(manifest.requiredPlugins) ? manifest.requiredPlugins : [],
     optionalPlugins: Array.isArray(manifest.optionalPlugins) ? manifest.optionalPlugins : [],
+    globals: {
+      services: {
+        provides: Array.isArray(manifest.globals?.services?.provides)
+          ? [...manifest.globals.services.provides]
+          : [],
+        consumes: Array.isArray(manifest.globals?.services?.consumes)
+          ? [...manifest.globals.services.consumes]
+          : [],
+      },
+      extensionPoints: {
+        hosts: Array.isArray(manifest.globals?.extensionPoints?.hosts)
+          ? [...manifest.globals.extensionPoints.hosts]
+          : [],
+        contributes: Array.isArray(manifest.globals?.extensionPoints?.contributes)
+          ? [...manifest.globals.extensionPoints.contributes]
+          : [],
+      },
+    },
     requiredBundles: Array.isArray(manifest.requiredBundles) ? manifest.requiredBundles : [],
     runtimePluginDependencies: Array.isArray(manifest.runtimePluginDependencies)
       ? manifest.runtimePluginDependencies

--- a/src/core/packages/plugins/server-internal/src/plugin.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin.test.ts
@@ -39,6 +39,14 @@ const mockContainerModuleCallback: jest.MockedFunction<
   ConstructorParameters<typeof ContainerModule>[0]
 > = jest.fn();
 const pluginModule = new ContainerModule(mockContainerModuleCallback);
+const mockServicesModuleCallback: jest.MockedFunction<
+  ConstructorParameters<typeof ContainerModule>[0]
+> = jest.fn();
+const servicesModule = new ContainerModule(mockServicesModuleCallback);
+const mockLegacyModuleCallback: jest.MockedFunction<
+  ConstructorParameters<typeof ContainerModule>[0]
+> = jest.fn();
+const legacyModule = new ContainerModule(mockLegacyModuleCallback);
 const logger = loggingSystemMock.create();
 jest.doMock(
   join('plugin-with-initializer-path', 'server'),
@@ -57,6 +65,11 @@ jest.doMock(join('plugin-with-module', 'server'), () => ({ module: pluginModule 
 jest.doMock(
   join('plugin-with-instance-and-module', 'server'),
   () => ({ plugin: mockPluginInitializer, module: pluginModule }),
+  { virtual: true }
+);
+jest.doMock(
+  join('plugin-with-services-and-module', 'server'),
+  () => ({ services: servicesModule, module: legacyModule }),
   { virtual: true }
 );
 
@@ -359,6 +372,41 @@ test('`setup` initializes the plugin container module', async () => {
   expect(container.get(PluginInitializer('opaqueId'))).toBe(opaqueId);
   expect(container.get(CoreSetup('injection'))).toBeDefined();
   expect(container.get(PluginSetup('some-required-dep'))).toEqual({ contract: 'no' });
+});
+
+test('`setup` prefers `services` over `module` when both are exported', async () => {
+  const manifest = createPluginManifest();
+  const opaqueId = Symbol();
+  const plugin = new PluginWrapper({
+    path: 'plugin-with-services-and-module',
+    manifest,
+    opaqueId,
+    initializerContext: createPluginInitializerContext({
+      coreContext,
+      opaqueId,
+      manifest,
+      instanceInfo,
+      nodeInfo,
+    }),
+  });
+  const setupContext = createPluginSetupContext({
+    deps: coreInternalLifecycleMock.createInternalSetup(),
+    plugin,
+    runtimeResolver,
+  });
+
+  mockServicesModuleCallback.mockImplementationOnce(({ bind }) => {
+    bind(Setup).toConstantValue({ from: 'services' });
+  });
+  mockLegacyModuleCallback.mockImplementationOnce(({ bind }) => {
+    bind(Setup).toConstantValue({ from: 'module' });
+  });
+
+  await plugin.init();
+
+  expect(plugin.setup(setupContext, {} as any)).toEqual({ from: 'services' });
+  expect(mockServicesModuleCallback).toHaveBeenCalledTimes(1);
+  expect(mockLegacyModuleCallback).not.toHaveBeenCalled();
 });
 
 test('`start` fails if setup is not called first', () => {

--- a/src/core/packages/plugins/server-internal/src/plugin.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ContainerModule } from 'inversify';
+import { Container, ContainerModule } from 'inversify';
 import { join } from 'path';
 import { BehaviorSubject } from 'rxjs';
 import { REPO_ROOT } from '@kbn/repo-info';
@@ -22,7 +22,7 @@ import { nodeServiceMock } from '@kbn/core-node-server-mocks';
 import type { PluginManifest } from '@kbn/core-plugins-server';
 import { PluginType } from '@kbn/core-base-common';
 import { coreInternalLifecycleMock } from '@kbn/core-lifecycle-server-mocks';
-import { PluginSetup, PluginStart, Setup, Start } from '@kbn/core-di';
+import { OnStart, PluginSetup, PluginStart, Setup, Start } from '@kbn/core-di';
 import { CoreSetup, CoreStart, PluginInitializer } from '@kbn/core-di-server';
 import { createRuntimePluginContractResolverMock } from './test_helpers';
 import { PluginWrapper } from './plugin';
@@ -54,6 +54,11 @@ jest.doMock(join('plugin-with-wrong-initializer-path', 'server'), () => ({ plugi
 jest.doMock(join('plugin-with-module', 'server'), () => ({ module: pluginModule }), {
   virtual: true,
 });
+jest.doMock(
+  join('plugin-with-instance-and-module', 'server'),
+  () => ({ plugin: mockPluginInitializer, module: pluginModule }),
+  { virtual: true }
+);
 
 const OSS_PLUGIN_PATH_POSIX = '/kibana/src/plugins/ossPlugin';
 const OSS_PLUGIN_PATH_WINDOWS = 'C:\\kibana\\src\\plugins\\ossPlugin';
@@ -71,6 +76,10 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     optionalPlugins: ['some-optional-dep'],
     requiredBundles: [],
     runtimePluginDependencies: ['some-runtime-dep'],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     server: true,
     ui: true,
     owner: { name: 'Core' },
@@ -210,7 +219,7 @@ test('`init` fails if no `plugin` initializer nor `module` is exported', async (
   });
 
   await expect(() => plugin.init()).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"Plugin \\"some-plugin-id\\" does not export the \\"plugin\\" definition or \\"module\\" (plugin-without-initializer-path)."`
+    `"Plugin \\"some-plugin-id\\" does not export \\"plugin\\", \\"services\\", or \\"module\\" (plugin-without-initializer-path)."`
   );
 });
 
@@ -523,6 +532,85 @@ test('`start` loads start dependencies into the plugin container', async () => {
   const container = setupContext.injection.getContainer();
   expect(container.get(CoreStart('injection'))).toBeDefined();
   expect(container.get(PluginStart('someDep'))).toBe('value');
+});
+
+test('`start` bridges the classic start contract into DI before OnStart hooks resolve Start', async () => {
+  // Mimic PluginModule: a default Start binding plus a container-module
+  // activation that fires OnStart hooks. The wrapper operates on a child scope,
+  // matching production, so the rebound Start is observed by the hooks.
+  const root = new Container({ defaultScope: 'Singleton' });
+  const activated = new WeakSet<Container>();
+  root.loadSync(
+    new ContainerModule(({ bind, onActivation }) => {
+      bind(Setup)
+        .toResolvedValue(() => undefined)
+        .inRequestScope();
+      bind(Start)
+        .toResolvedValue(() => undefined)
+        .inRequestScope();
+      onActivation(Start, ({ get }, contract) => {
+        const container = get(Container);
+        if (!activated.has(container)) {
+          activated.add(container);
+          container.getAll(OnStart, { chained: true }).forEach((callback) => callback(container));
+        }
+        return contract;
+      });
+    })
+  );
+  const child = new Container({ defaultScope: 'Singleton', parent: root });
+  child.bind(Container).toConstantValue(child);
+
+  const manifest = createPluginManifest();
+  const opaqueId = Symbol();
+  const plugin = new PluginWrapper({
+    path: 'plugin-with-instance-and-module',
+    manifest,
+    opaqueId,
+    initializerContext: createPluginInitializerContext({
+      coreContext,
+      opaqueId,
+      manifest,
+      instanceInfo,
+      nodeInfo,
+    }),
+  });
+
+  const internalSetupDeps = coreInternalLifecycleMock.createInternalSetup();
+  internalSetupDeps.injection.getContainer.mockReturnValue(child);
+  const internalStartDeps = coreInternalLifecycleMock.createInternalStart();
+  internalStartDeps.injection.getContainer.mockReturnValue(child);
+
+  const setupContext = createPluginSetupContext({
+    deps: internalSetupDeps,
+    plugin,
+    runtimeResolver,
+  });
+  const startContext = createPluginStartContext({
+    deps: internalStartDeps,
+    plugin,
+    runtimeResolver,
+  });
+
+  const classicStartContract = { value: 'classic-start' };
+  mockPluginInitializer.mockResolvedValue({
+    setup: jest.fn(),
+    start: jest.fn().mockReturnValue(classicStartContract),
+  });
+
+  let observedStart: unknown;
+  mockContainerModuleCallback.mockImplementationOnce(({ bind }) => {
+    bind(OnStart).toConstantValue((container: Container) => {
+      observedStart = container.get(Start);
+    });
+  });
+
+  await plugin.init();
+  await plugin.setup(setupContext, {} as any);
+  const startContract = await plugin.start(startContext, {} as any);
+
+  expect(startContract).toBe(classicStartContract);
+  expect(observedStart).toBe(classicStartContract);
 });
 
 test('`stop` fails if plugin is not set up', async () => {

--- a/src/core/packages/plugins/server-internal/src/plugin.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin.ts
@@ -38,6 +38,7 @@ interface PluginDefinition<
 > {
   readonly config?: PluginConfigDescriptor;
   readonly module?: ContainerModule;
+  readonly services?: ContainerModule;
   readonly plugin?: PluginInitializer<TSetup, TStart, TPluginsSetup, TPluginsStart>;
 }
 
@@ -110,9 +111,11 @@ export class PluginWrapper<
     this.definition = await this.getPluginDefinition();
     this.instance = await this.createPluginInstance();
 
-    if (!('plugin' in this.definition || 'module' in this.definition)) {
+    if (
+      !('plugin' in this.definition || 'module' in this.definition || 'services' in this.definition)
+    ) {
       throw new Error(
-        `Plugin "${this.name}" does not export the "plugin" definition or "module" (${this.path}).`
+        `Plugin "${this.name}" does not export "plugin", "services", or "module" (${this.path}).`
       );
     }
   }
@@ -136,9 +139,10 @@ export class PluginWrapper<
       return this.instance.setup(setupContext as CorePreboot, plugins);
     }
 
-    if (this.definition.module) {
+    const diModule = this.definition.services ?? this.definition.module;
+    if (diModule) {
       this.container = (setupContext as CoreSetup).injection.getContainer();
-      this.container.loadSync(this.definition.module);
+      this.container.loadSync(diModule);
       this.container.loadSync(createSetupModule(this.initializerContext, setupContext, plugins));
     }
 

--- a/src/core/packages/plugins/server-internal/src/plugin.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin.ts
@@ -165,16 +165,41 @@ export class PluginWrapper<
     }
 
     this.container?.loadSync(createStartModule(startContext, plugins));
-    const contract = [
-      this.instance?.start(startContext, plugins),
-      this.container?.get<TStart>(Start),
-    ].find(Boolean)!;
 
-    if (isPromise(contract)) {
-      return contract.then((resolvedContract) => {
-        this.startDependencies$.next([startContext, plugins, resolvedContract]);
-        return resolvedContract!;
-      });
+    const instanceContract = this.instance?.start(startContext, plugins);
+    if (isPromise(instanceContract)) {
+      return instanceContract.then((contract) =>
+        this.bridgeStartContract(startContext, plugins, contract)
+      );
+    }
+
+    return this.bridgeStartContract(startContext, plugins, instanceContract);
+  }
+
+  /**
+   * Bridges the classic plugin `start()` contract into DI as {@link Start}
+   * before resolving it, so `OnStart` hooks and `provide(token, (start) => ...)`
+   * selectors observe the plugin's contract rather than the default. A pure-DI
+   * plugin (no classic instance) falls back to the contract bound by its module.
+   */
+  private bridgeStartContract(
+    startContext: CoreStart,
+    plugins: TPluginsStart,
+    instanceContract: TStart | undefined
+  ): TStart {
+    if (!this.container) {
+      this.startDependencies$.next([startContext, plugins, instanceContract!]);
+      return instanceContract!;
+    }
+
+    let contract: TStart;
+    if (instanceContract) {
+      this.container.rebindSync(Start).toConstantValue(instanceContract);
+      this.container.get(Start);
+      contract = instanceContract;
+    } else {
+      contract = this.container.get<TStart>(Start);
+      this.container.rebindSync(Start).toConstantValue(contract);
     }
 
     this.startDependencies$.next([startContext, plugins, contract]);
@@ -213,10 +238,13 @@ export class PluginWrapper<
     return config;
   }
 
-  protected async getPluginDefinition(): Promise<
-    PluginDefinition<TSetup, TStart, TPluginsSetup, TPluginsStart>
-  > {
-    return (await import(join(this.path, 'server'))) ?? {};
+  // Synchronous `require()` is intentional: server-side plugins are CommonJS
+  // modules, and synchronous loading allows `getConfigDescriptor()` and
+  // `init()` to avoid unnecessary async overhead.  The DI `module` export is
+  // available immediately after require, which simplifies container loading
+  // during `setup()`.
+  protected getPluginDefinition(): PluginDefinition<TSetup, TStart, TPluginsSetup, TPluginsStart> {
+    return require(join(this.path, 'server')) ?? {};
   }
 
   protected async createPluginInstance() {

--- a/src/core/packages/plugins/server-internal/src/plugin_context.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_context.test.ts
@@ -39,6 +39,10 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     requiredBundles: [],
     optionalPlugins: ['some-optional-dep'],
     runtimePluginDependencies: [],
+    globals: {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     server: true,
     ui: true,
     owner: {

--- a/src/core/packages/plugins/server-internal/src/plugins_config.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_config.test.ts
@@ -18,6 +18,7 @@ describe('PluginsConfig', () => {
     const env = Env.createDefault(REPO_ROOT, getEnvOptions({ cliArgs: { dev: false } }));
     const rawConfig: PluginsConfigType = {
       initialize: true,
+      globalTokenValidation: 'warn',
       paths: ['some-path', 'another-path'],
     };
     const config = new PluginsConfig(rawConfig, env);
@@ -28,6 +29,7 @@ describe('PluginsConfig', () => {
     const env = Env.createDefault(REPO_ROOT, getEnvOptions({ cliArgs: { dev: true } }));
     const rawConfig: PluginsConfigType = {
       initialize: true,
+      globalTokenValidation: 'warn',
       paths: ['some-path', 'another-path'],
     };
     const config = new PluginsConfig(rawConfig, env);
@@ -38,6 +40,7 @@ describe('PluginsConfig', () => {
     const env = Env.createDefault(REPO_ROOT, getEnvOptions({ cliArgs: { dev: true } }));
     const rawConfig: PluginsConfigType = {
       initialize: true,
+      globalTokenValidation: 'warn',
       paths: ['some-path', 'another-path'],
       forceEnableAllPlugins: true,
     };
@@ -49,6 +52,7 @@ describe('PluginsConfig', () => {
     const env = Env.createDefault(REPO_ROOT, getEnvOptions({ cliArgs: { dev: true } }));
     const rawConfig: PluginsConfigType = {
       initialize: true,
+      globalTokenValidation: 'warn',
       paths: ['some-path', 'another-path'],
       forceEnableAllPlugins: true,
       allowlistPluginGroups: ['search'],

--- a/src/core/packages/plugins/server-internal/src/plugins_config.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_config.ts
@@ -38,6 +38,16 @@ const configSchema = schema.object({
     )
   ),
   /**
+   * Controls startup validation of cross-plugin DI services and extension points.
+   * - `'warn'` (default): log a warning for each invalid declaration.
+   * - `'error'`: throw and prevent startup if any invalid declaration exists.
+   * - `'off'`: skip validation entirely.
+   */
+  globalTokenValidation: schema.oneOf(
+    [schema.literal('warn'), schema.literal('error'), schema.literal('off')],
+    { defaultValue: 'warn' }
+  ),
+  /**
    * Internal config, not intended to be used by end users. Only for specific
    * internal purposes.
    */
@@ -84,11 +94,17 @@ export class PluginsConfig {
    */
   public readonly allowlistPluginGroups?: readonly KibanaGroup[];
 
+  /**
+   * Controls startup validation of cross-plugin DI declarations.
+   */
+  public readonly globalTokenValidation: 'warn' | 'error' | 'off';
+
   constructor(rawConfig: PluginsConfigType, env: Env) {
     this.initialize = rawConfig.initialize;
     this.pluginSearchPaths = env.pluginSearchPaths;
     this.additionalPluginPaths = rawConfig.paths;
     this.allowlistPluginGroups = get(rawConfig, INCLUDED_PLUGIN_GROUPS);
     this.shouldEnableAllPlugins = get(rawConfig, ENABLE_ALL_PLUGINS_CONFIG_PATH, false);
+    this.globalTokenValidation = rawConfig.globalTokenValidation;
   }
 }

--- a/src/core/packages/plugins/server-internal/src/plugins_service.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_service.test.ts
@@ -81,6 +81,10 @@ const createPlugin = (
     requiredBundles = [],
     optionalPlugins = [],
     runtimePluginDependencies = [],
+    globals = {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
     kibanaVersion = '7.0.0',
     configPath = [path],
     server = true,
@@ -94,6 +98,10 @@ const createPlugin = (
     requiredBundles?: string[];
     optionalPlugins?: string[];
     runtimePluginDependencies?: string[];
+    globals?: {
+      services: { provides: string[]; consumes: string[] };
+      extensionPoints: { hosts: string[]; contributes: string[] };
+    };
     kibanaVersion?: string;
     configPath?: ConfigPath;
     server?: boolean;
@@ -112,6 +120,7 @@ const createPlugin = (
       requiredBundles,
       optionalPlugins,
       runtimePluginDependencies,
+      globals,
       server,
       owner: {
         name: 'Core',
@@ -142,6 +151,7 @@ async function testSetup() {
     initialize: true,
     paths: [],
     allowlistPluginGroups: ['observability'],
+    globalTokenValidation: 'warn',
   };
   config$ = new BehaviorSubject<Record<string, any>>({ plugins: pluginsConfig });
   const rawConfigService = rawConfigServiceMock.create({ rawConfig$: config$ });
@@ -747,16 +757,17 @@ describe('PluginsService', () => {
 
       expect(mockDiscover).toHaveBeenCalledTimes(1);
       expect(mockDiscover).toHaveBeenCalledWith({
-        config: {
+        config: expect.objectContaining({
           additionalPluginPaths: [],
           allowlistPluginGroups: ['observability'],
+          globalTokenValidation: 'warn',
           initialize: true,
           pluginSearchPaths: [
             resolve(REPO_ROOT, '..', 'kibana-extra'),
             resolve(REPO_ROOT, 'plugins'),
           ],
           shouldEnableAllPlugins: false,
-        },
+        }),
         coreContext: { coreId, env, logger, configService },
         instanceInfo: { uuid: 'uuid', airgapped: false },
         nodeInfo: { roles: { backgroundTasks: true, ui: true, migrator: false } },
@@ -1001,6 +1012,10 @@ describe('PluginsService', () => {
         requiredBundles: [],
         optionalPlugins: [],
         runtimePluginDependencies: [],
+        globals: {
+          services: { provides: [], consumes: [] },
+          extensionPoints: { hosts: [], contributes: [] },
+        },
       },
     ];
 

--- a/src/core/packages/plugins/server-internal/src/plugins_service.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_service.ts
@@ -200,6 +200,7 @@ export class PluginsService
     await this.prebootPluginsSystem.stopPlugins();
     this.arePrebootPluginsStopped = true;
 
+    this.standardPluginsSystem.setGlobalTokenValidation(config.globalTokenValidation);
     const contracts = await this.standardPluginsSystem.startPlugins(deps);
     return { contracts };
   }

--- a/src/core/packages/plugins/server-internal/src/plugins_system.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.test.ts
@@ -57,6 +57,10 @@ function createPlugin(
       requiredPlugins: required,
       optionalPlugins: optional,
       runtimePluginDependencies: runtime,
+      globals: {
+        services: { provides: [], consumes: [] },
+        extensionPoints: { hosts: [], contributes: [] },
+      },
       requiredBundles: [],
       server,
       ui,

--- a/src/core/packages/plugins/server-internal/src/plugins_system.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.test.ts
@@ -37,6 +37,10 @@ function createPlugin(
     server = true,
     ui = true,
     type = PluginType.standard,
+    globals = {
+      services: { provides: [], consumes: [] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
   }: {
     required?: string[];
     optional?: string[];
@@ -44,6 +48,10 @@ function createPlugin(
     server?: boolean;
     ui?: boolean;
     type?: PluginType;
+    globals?: {
+      services: { provides: string[]; consumes: string[] };
+      extensionPoints: { hosts: string[]; contributes: string[] };
+    };
   } = {}
 ): PluginWrapper<any, any> {
   const plugin = new PluginWrapper<any, any>({
@@ -57,10 +65,7 @@ function createPlugin(
       requiredPlugins: required,
       optionalPlugins: optional,
       runtimePluginDependencies: runtime,
-      globals: {
-        services: { provides: [], consumes: [] },
-        extensionPoints: { hosts: [], contributes: [] },
-      },
+      globals,
       requiredBundles: [],
       server,
       ui,
@@ -627,6 +632,26 @@ test('`startPlugins` only starts plugins that were setup', async () => {
       ],
     ]
   `);
+});
+
+test('`startPlugins` validates global tokens before starting plugins and aborts in `error` mode', async () => {
+  const consumer = createPlugin('consumer', {
+    globals: {
+      services: { provides: [], consumes: ['provider.MyService'] },
+      extensionPoints: { hosts: [], contributes: [] },
+    },
+  });
+  jest.spyOn(consumer, 'setup').mockResolvedValue('setup');
+  const startSpy = jest.spyOn(consumer, 'start').mockResolvedValue('started');
+
+  pluginsSystem.addPlugin(consumer);
+  pluginsSystem.setGlobalTokenValidation('error');
+  await pluginsSystem.setupPlugins(setupDeps);
+
+  await expect(pluginsSystem.startPlugins(startDeps)).rejects.toThrow(
+    /Cross-plugin DI validation failed/
+  );
+  expect(startSpy).not.toHaveBeenCalled();
 });
 
 describe('setup', () => {

--- a/src/core/packages/plugins/server-internal/src/plugins_system.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.ts
@@ -25,6 +25,7 @@ import type {
   PluginsServiceStartDeps,
 } from './plugins_service';
 import { RuntimePluginContractResolver } from './plugin_contract_resolver';
+import { validateGlobalTokens } from './validate_global_tokens';
 
 const Sec = 1000;
 
@@ -36,9 +37,14 @@ export class PluginsSystem<T extends PluginType> {
   // `satup`, the past-tense version of the noun `setup`.
   private readonly satupPlugins: PluginName[] = [];
   private sortedPluginNames?: Set<string>;
+  private globalTokenValidation: 'warn' | 'error' | 'off' = 'warn';
 
   constructor(private readonly coreContext: CoreContext, public readonly type: T) {
     this.log = coreContext.logger.get('plugins-system', this.type);
+  }
+
+  public setGlobalTokenValidation(mode: 'warn' | 'error' | 'off') {
+    this.globalTokenValidation = mode;
   }
 
   public addPlugin(plugin: PluginWrapper) {
@@ -227,6 +233,10 @@ export class PluginsSystem<T extends PluginType> {
 
     this.runtimeResolver.resolveStartRequests(contracts);
 
+    if (this.globalTokenValidation !== 'off') {
+      validateGlobalTokens(this.plugins, this.globalTokenValidation, this.log);
+    }
+
     return contracts;
   }
 
@@ -292,8 +302,6 @@ export class PluginsSystem<T extends PluginType> {
             optionalPlugins: plugin.manifest.optionalPlugins.filter(filterUiPlugins),
             runtimePluginDependencies: plugin.manifest.runtimePluginDependencies,
             requiredBundles: plugin.manifest.requiredBundles,
-            // TODO: use `globals` at runtime to log warnings for
-            // unresolved tokens at startup and to drive browser bundle loading.
             globals: plugin.manifest.globals,
             enabledOnAnonymousPages: plugin.manifest.enabledOnAnonymousPages,
           },

--- a/src/core/packages/plugins/server-internal/src/plugins_system.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.ts
@@ -187,6 +187,13 @@ export class PluginsSystem<T extends PluginType> {
 
     this.log.info(`Starting [${this.satupPlugins.length}] plugins: [${[...this.satupPlugins]}]`);
 
+    // Validate cross-plugin DI contracts from the manifests before any plugin
+    // starts, so mismatches surface (and, in `error` mode, abort startup) ahead
+    // of `start()` rather than after.
+    if (this.globalTokenValidation !== 'off') {
+      validateGlobalTokens(this.plugins, this.globalTokenValidation, this.log);
+    }
+
     for (const pluginName of this.satupPlugins) {
       this.log.debug(`Starting plugin "${pluginName}"...`);
       const plugin = this.plugins.get(pluginName)!;
@@ -232,10 +239,6 @@ export class PluginsSystem<T extends PluginType> {
     }
 
     this.runtimeResolver.resolveStartRequests(contracts);
-
-    if (this.globalTokenValidation !== 'off') {
-      validateGlobalTokens(this.plugins, this.globalTokenValidation, this.log);
-    }
 
     return contracts;
   }

--- a/src/core/packages/plugins/server-internal/src/plugins_system.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_system.ts
@@ -292,6 +292,9 @@ export class PluginsSystem<T extends PluginType> {
             optionalPlugins: plugin.manifest.optionalPlugins.filter(filterUiPlugins),
             runtimePluginDependencies: plugin.manifest.runtimePluginDependencies,
             requiredBundles: plugin.manifest.requiredBundles,
+            // TODO: use `globals` at runtime to log warnings for
+            // unresolved tokens at startup and to drive browser bundle loading.
+            globals: plugin.manifest.globals,
             enabledOnAnonymousPages: plugin.manifest.enabledOnAnonymousPages,
           },
         ];
@@ -487,7 +490,9 @@ export const findCircularDependencies = (
  * This helps identify duplicate cycles regardless of where we start traversing
  */
 export const normalizeCycle = (cycle: PluginName[]): PluginName[] => {
-  if (cycle.length <= 1) return cycle;
+  if (cycle.length <= 1) {
+    return cycle;
+  }
   if (new Set(cycle).size !== cycle.length) {
     throw new Error(`Cycle contains duplicate plugins: ${cycle}`);
   }

--- a/src/core/packages/plugins/server-internal/src/validate_global_tokens.test.ts
+++ b/src/core/packages/plugins/server-internal/src/validate_global_tokens.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { validateGlobalTokens } from './validate_global_tokens';
+import type { PluginWrapper } from './plugin';
+
+const createPlugin = (
+  name: string,
+  {
+    provides = [],
+    consumes = [],
+    hosts = [],
+    contributes = [],
+  }: {
+    provides?: string[];
+    consumes?: string[];
+    hosts?: string[];
+    contributes?: string[];
+  } = {}
+): [string, PluginWrapper] => [
+  name,
+  {
+    name,
+    manifest: {
+      globals: {
+        services: { provides, consumes },
+        extensionPoints: { hosts, contributes },
+      },
+    },
+  } as unknown as PluginWrapper,
+];
+
+describe('validateGlobalTokens', () => {
+  let log: jest.Mocked<Logger>;
+
+  beforeEach(() => {
+    log = loggingSystemMock.createLogger();
+  });
+
+  it('does nothing when all consumed tokens have publishers', () => {
+    const plugins = new Map([
+      createPlugin('slo', { provides: ['slo.CreateFlyout'] }),
+      createPlugin('apm', { consumes: ['slo.CreateFlyout'] }),
+    ]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there are no globals declared', () => {
+    const plugins = new Map([createPlugin('slo'), createPlugin('apm')]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning for each consumed token with no publisher in warn mode', () => {
+    const plugins = new Map([
+      createPlugin('apm', { consumes: ['slo.CreateFlyout', 'slo.DetailsFlyout'] }),
+      createPlugin('slo', { provides: ['slo.CreateFlyout'] }),
+    ]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('"slo.DetailsFlyout"'));
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('"slo" plugin may be disabled'));
+  });
+
+  it('throws after logging in error mode', () => {
+    const plugins = new Map([
+      createPlugin('apm', { consumes: ['slo.CreateFlyout'] }),
+      createPlugin('infra', { consumes: ['ml.AnomalyDetection'] }),
+    ]);
+
+    expect(() => validateGlobalTokens(plugins, 'error', log)).toThrow(
+      /Cross-plugin DI validation failed\. 2 issue\(s\) found/
+    );
+    expect(log.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throw in warn mode even with violations', () => {
+    const plugins = new Map([createPlugin('apm', { consumes: ['slo.CreateFlyout'] })]);
+
+    expect(() => validateGlobalTokens(plugins, 'warn', log)).not.toThrow();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes the expected publisher name from the token prefix', () => {
+    const plugins = new Map([createPlugin('dashboard', { consumes: ['lens.EmbeddableFactory'] })]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('"lens" plugin may be disabled'));
+  });
+
+  it('allows hosted extension points with no contributions', () => {
+    const plugins = new Map([
+      createPlugin('embeddable', { hosts: ['embeddable.FactoryRegistration'] }),
+    ]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when an extension point contribution has no host', () => {
+    const plugins = new Map([
+      createPlugin('lens', { contributes: ['embeddable.FactoryRegistration'] }),
+    ]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('contributes to extension point "embeddable.FactoryRegistration"')
+    );
+  });
+
+  it('warns when a service has multiple providers', () => {
+    const plugins = new Map([
+      createPlugin('slo', { provides: ['slo.CreateFlyout'] }),
+      createPlugin('sloAlt', { provides: ['slo.CreateFlyout'] }),
+    ]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('multiple providers'));
+  });
+
+  it('warns when an extension point has multiple hosts', () => {
+    const plugins = new Map([
+      createPlugin('embeddable', { hosts: ['embeddable.FactoryRegistration'] }),
+      createPlugin('dashboard', { hosts: ['embeddable.FactoryRegistration'] }),
+    ]);
+
+    validateGlobalTokens(plugins, 'warn', log);
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('multiple hosts'));
+  });
+});

--- a/src/core/packages/plugins/server-internal/src/validate_global_tokens.ts
+++ b/src/core/packages/plugins/server-internal/src/validate_global_tokens.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PluginName } from '@kbn/core-base-common';
+import type { Logger } from '@kbn/logging';
+import type { PluginWrapper } from './plugin';
+
+/**
+ * Validates cross-plugin DI services and extension points after all plugins
+ * have completed `start()`.
+ *
+ * Services must have exactly one provider when consumed. Extension points must
+ * have exactly one host when contributions exist. Zero contributions to a
+ * hosted extension point are allowed.
+ */
+export const validateGlobalTokens = (
+  plugins: ReadonlyMap<PluginName, PluginWrapper>,
+  mode: 'warn' | 'error',
+  log: Logger
+): void => {
+  const serviceProviders = new Map<string, string[]>();
+  const extensionHosts = new Map<string, string[]>();
+
+  for (const plugin of plugins.values()) {
+    for (const token of plugin.manifest.globals.services.provides) {
+      serviceProviders.set(token, [...(serviceProviders.get(token) ?? []), plugin.name]);
+    }
+    for (const token of plugin.manifest.globals.extensionPoints.hosts) {
+      extensionHosts.set(token, [...(extensionHosts.get(token) ?? []), plugin.name]);
+    }
+  }
+
+  const violations: string[] = [];
+
+  for (const [pluginName, plugin] of plugins) {
+    for (const token of plugin.manifest.globals.services.consumes) {
+      const providers = serviceProviders.get(token) ?? [];
+      if (providers.length === 0) {
+        const expectedProvider = token.split('.')[0] ?? 'unknown';
+        violations.push(
+          `Plugin "${pluginName}" consumes service token "${token}" but no enabled plugin provides it. ` +
+            `The "${expectedProvider}" plugin may be disabled or not installed.`
+        );
+      } else if (providers.length > 1) {
+        violations.push(
+          `Plugin "${pluginName}" consumes service token "${token}" but it has multiple providers: ${providers.join(
+            ', '
+          )}.`
+        );
+      }
+    }
+
+    for (const token of plugin.manifest.globals.extensionPoints.contributes) {
+      const hosts = extensionHosts.get(token) ?? [];
+      if (hosts.length === 0) {
+        const expectedHost = token.split('.')[0] ?? 'unknown';
+        violations.push(
+          `Plugin "${pluginName}" contributes to extension point "${token}" but no enabled plugin hosts it. ` +
+            `The "${expectedHost}" plugin may be disabled or not installed.`
+        );
+      } else if (hosts.length > 1) {
+        violations.push(
+          `Plugin "${pluginName}" contributes to extension point "${token}" but it has multiple hosts: ${hosts.join(
+            ', '
+          )}.`
+        );
+      }
+    }
+  }
+
+  for (const [token, providers] of serviceProviders) {
+    if (providers.length > 1) {
+      violations.push(`Service token "${token}" has multiple providers: ${providers.join(', ')}.`);
+    }
+  }
+
+  for (const [token, hosts] of extensionHosts) {
+    if (hosts.length > 1) {
+      violations.push(`Extension point "${token}" has multiple hosts: ${hosts.join(', ')}.`);
+    }
+  }
+
+  if (violations.length === 0) {
+    return;
+  }
+
+  for (const message of violations) {
+    log.warn(message);
+  }
+
+  if (mode === 'error') {
+    throw new Error(
+      `Cross-plugin DI validation failed. ${violations.length} issue(s) found:\n${violations
+        .map((message) => `  ${message}`)
+        .join('\n')}`
+    );
+  }
+};

--- a/src/core/packages/plugins/server-internal/src/validate_global_tokens.ts
+++ b/src/core/packages/plugins/server-internal/src/validate_global_tokens.ts
@@ -12,12 +12,13 @@ import type { Logger } from '@kbn/logging';
 import type { PluginWrapper } from './plugin';
 
 /**
- * Validates cross-plugin DI services and extension points after all plugins
- * have completed `start()`.
+ * Validates cross-plugin DI services and extension points from the plugin
+ * manifests, before any plugin is started.
  *
  * Services must have exactly one provider when consumed. Extension points must
  * have exactly one host when contributions exist. Zero contributions to a
- * hosted extension point are allowed.
+ * hosted extension point are allowed. In `error` mode this throws, aborting
+ * startup before `start()` runs.
  */
 export const validateGlobalTokens = (
   plugins: ReadonlyMap<PluginName, PluginWrapper>,

--- a/src/core/packages/plugins/server/src/types.ts
+++ b/src/core/packages/plugins/server/src/types.ts
@@ -223,6 +223,21 @@ export interface PluginManifest {
   readonly runtimePluginDependencies: readonly string[];
 
   /**
+   * Global DI token declarations for this plugin.  Used for documentation, startup health checks,
+   * and future bundle-loading optimisation.
+   */
+  readonly globals: {
+    readonly services: {
+      readonly provides: readonly string[];
+      readonly consumes: readonly string[];
+    };
+    readonly extensionPoints: {
+      readonly hosts: readonly string[];
+      readonly contributes: readonly string[];
+    };
+  };
+
+  /**
    * Specifies whether plugin includes some client/browser specific functionality
    * that should be included into client bundle via `public/ui_plugin.js` file.
    */

--- a/src/core/packages/rendering/server-internal/src/bootstrap/get_plugin_bundle_paths.test.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/get_plugin_bundle_paths.test.ts
@@ -32,6 +32,10 @@ const createUiPlugins = (pluginDeps: Record<string, string[]>) => {
       optionalPlugins: [],
       requiredPlugins: [],
       runtimePluginDependencies: [],
+      globals: {
+        services: { provides: [], consumes: [] },
+        extensionPoints: { hosts: [], contributes: [] },
+      },
       requiredBundles: deps,
     });
 

--- a/src/platform/packages/private/kbn-repo-packages/legacy/types.ts
+++ b/src/platform/packages/private/kbn-repo-packages/legacy/types.ts
@@ -33,6 +33,16 @@ export interface LegacyKibanaPlatformPluginManifest {
   requiredPlugins: readonly string[];
   optionalPlugins: readonly string[];
   runtimePluginDependencies?: readonly string[];
+  globals?: {
+    services?: {
+      provides?: readonly string[];
+      consumes?: readonly string[];
+    };
+    extensionPoints?: {
+      hosts?: readonly string[];
+      contributes?: readonly string[];
+    };
+  };
   requiredBundles: readonly string[];
   extraPublicDirs: readonly string[];
 }

--- a/src/platform/packages/private/kbn-repo-packages/modern/parse_helpers.js
+++ b/src/platform/packages/private/kbn-repo-packages/modern/parse_helpers.js
@@ -24,6 +24,7 @@ const PACKAGE_TYPES = /** @type {Array<import('./types').KibanaPackageType>} */ 
 );
 
 const PLUGIN_ID_PATTERN = /^[a-z][a-zA-Z_]*$/;
+const GLOBAL_TOKEN_ID_PATTERN = /^[a-z][a-zA-Z0-9]*\.[A-Z][a-zA-Z0-9]*$/;
 
 /**
  * @param {unknown} v
@@ -67,10 +68,26 @@ function isArrOfStrings(v) {
 
 /**
  * @param {unknown} v
+ * @returns {v is string}
+ */
+function isValidGlobalTokenId(v) {
+  return typeof v === 'string' && GLOBAL_TOKEN_ID_PATTERN.test(v);
+}
+
+/**
+ * @param {unknown} v
  * @returns {v is string[]}
  */
 function isArrOfIds(v) {
   return Array.isArray(v) && v.every(isValidPluginId);
+}
+
+/**
+ * @param {unknown} v
+ * @returns {v is string[]}
+ */
+function isArrOfGlobalTokenIds(v) {
+  return Array.isArray(v) && v.every(isValidGlobalTokenId);
 }
 
 module.exports = {
@@ -78,7 +95,9 @@ module.exports = {
   isSomeString,
   isObj,
   isValidPluginId,
+  isValidGlobalTokenId,
   isValidPkgType,
   isArrOfIds,
+  isArrOfGlobalTokenIds,
   isArrOfStrings,
 };

--- a/src/platform/packages/private/kbn-repo-packages/modern/parse_package_manifest.js
+++ b/src/platform/packages/private/kbn-repo-packages/modern/parse_package_manifest.js
@@ -17,6 +17,7 @@ const {
   isValidPluginId,
   isValidPkgType,
   isArrOfIds,
+  isArrOfGlobalTokenIds,
   isArrOfStrings,
   PACKAGE_TYPES,
 } = require('./parse_helpers');
@@ -62,6 +63,7 @@ function validatePackageManifestPlugin(plugin, repoRoot, path) {
     configPath,
     requiredPlugins,
     optionalPlugins,
+    globals,
     requiredBundles,
     runtimePluginDependencies,
     enabledOnAnonymousPages,
@@ -99,10 +101,72 @@ function validatePackageManifestPlugin(plugin, repoRoot, path) {
 
   if (optionalPlugins !== undefined && !isArrOfIds(optionalPlugins)) {
     throw err(
-      `plugin.requiredPlugins`,
+      `plugin.optionalPlugins`,
       optionalPlugins,
       `must be an array of strings in camel or snake case`
     );
+  }
+
+  if (globals !== undefined) {
+    if (!isObj(globals)) {
+      throw err(`plugin.globals`, globals, `must be an object when defined`);
+    }
+
+    if (globals.services !== undefined) {
+      if (!isObj(globals.services)) {
+        throw err(`plugin.globals.services`, globals.services, `must be an object when defined`);
+      }
+      if (
+        globals.services.provides !== undefined &&
+        !isArrOfGlobalTokenIds(globals.services.provides)
+      ) {
+        throw err(
+          `plugin.globals.services.provides`,
+          globals.services.provides,
+          `must be an array of strings in <pluginId>.<ServiceName> format`
+        );
+      }
+      if (
+        globals.services.consumes !== undefined &&
+        !isArrOfGlobalTokenIds(globals.services.consumes)
+      ) {
+        throw err(
+          `plugin.globals.services.consumes`,
+          globals.services.consumes,
+          `must be an array of strings in <pluginId>.<ServiceName> format`
+        );
+      }
+    }
+
+    if (globals.extensionPoints !== undefined) {
+      if (!isObj(globals.extensionPoints)) {
+        throw err(
+          `plugin.globals.extensionPoints`,
+          globals.extensionPoints,
+          `must be an object when defined`
+        );
+      }
+      if (
+        globals.extensionPoints.hosts !== undefined &&
+        !isArrOfGlobalTokenIds(globals.extensionPoints.hosts)
+      ) {
+        throw err(
+          `plugin.globals.extensionPoints.hosts`,
+          globals.extensionPoints.hosts,
+          `must be an array of strings in <pluginId>.<ServiceName> format`
+        );
+      }
+      if (
+        globals.extensionPoints.contributes !== undefined &&
+        !isArrOfGlobalTokenIds(globals.extensionPoints.contributes)
+      ) {
+        throw err(
+          `plugin.globals.extensionPoints.contributes`,
+          globals.extensionPoints.contributes,
+          `must be an array of strings in <pluginId>.<ServiceName> format`
+        );
+      }
+    }
   }
 
   if (runtimePluginDependencies !== undefined && !isArrOfIds(runtimePluginDependencies)) {
@@ -163,6 +227,7 @@ function validatePackageManifestPlugin(plugin, repoRoot, path) {
     configPath,
     requiredPlugins,
     optionalPlugins,
+    globals,
     requiredBundles,
     runtimePluginDependencies,
     enabledOnAnonymousPages,

--- a/src/platform/packages/private/kbn-repo-packages/modern/types.ts
+++ b/src/platform/packages/private/kbn-repo-packages/modern/types.ts
@@ -126,6 +126,16 @@ export interface PluginPackageManifest extends PackageManifestBaseFields {
     requiredBundles?: string[];
     runtimePluginDependencies?: string[];
     enabledOnAnonymousPages?: boolean;
+    globals?: {
+      services?: {
+        provides?: string[];
+        consumes?: string[];
+      };
+      extensionPoints?: {
+        hosts?: string[];
+        contributes?: string[];
+      };
+    };
     type?: 'preboot';
     extraPublicDirs?: string[];
     [PLUGIN_CATEGORY]?: PluginCategoryInfo;


### PR DESCRIPTION
## Summary

Wires the cross-plugin dependency injection process into Kibana's plugin loading system.

> [!NOTE]
> This PR was derived from https://github.com/elastic/kibana/pull/254091 as a proposed production-ready implementation.
>
> It is part of a stack of PRs which culminates in working examples using real-world use cases, like embeddables and flyouts.

This PR teaches the plugin platform to:

- load plugin-owned DI declarations from a new `services` export, 
- bridge classic plugin lifecycle contracts into DI, 
- propagate cross-plugin contract metadata through plugin discovery, and 
- validate declared service/extension-point relationships before plugins start.

It builds on the foundational DI packages by making the new model usable by real Kibana plugins without requiring an all-at-once migration away from classic `setup()` / `start()` plugins.

## New Constructs

This PR introduces `plugin.globals` as the manifest-level declaration of cross-plugin DI contracts.

```ts
globals: {
  services: {
    provides: ['slo.CreateFlyout'],
    consumes: ['embeddable.FactoryRegistry'],
  },
  extensionPoints: {
    hosts: ['embeddable.FactoryRegistration'],
    contributes: ['embeddable.FactoryRegistration'],
  },
}
```

The fields map directly to the DI contract model:

- **`services.provides`**: service tokens this plugin owns and exposes.
- **`services.consumes`**: service tokens this plugin resolves from other plugins.
- **`extensionPoints.hosts`**: extension-point tokens this plugin owns as collection points.
- **`extensionPoints.contributes`**: extension-point tokens this plugin contributes values to.

Token names use the `<pluginId>.<Name>` shape, for example `slo.CreateFlyout` or `embeddable.FactoryRegistration`.

## Plugin Loading Flow

```mermaid
flowchart TD
  Manifest["kibana.jsonc / package manifest"] -->|"plugin.globals"| Discovery["Plugin discovery"]
  Discovery --> ServerManifest["Server PluginManifest"]
  Discovery --> InjectedMetadata["Browser injected metadata"]

  ServerManifest --> ServerValidation["Server startup validation"]
  InjectedMetadata --> BrowserValidation["Browser startup validation"]

  ServerValidation -->|"warn / error / off"| StartPlugins["Start plugins"]
  BrowserValidation -->|"console warnings"| BrowserStart["Start browser plugins"]
```

## DI Lifecycle Bridge

```mermaid
flowchart LR
  ClassicPlugin["Classic plugin"] -->|"setup()"| SetupContract["Setup contract"]
  ClassicPlugin -->|"start()"| StartContract["Start contract"]

  ServicesExport["services export"] --> Container["Plugin DI container"]
  SetupContract -->|"createSetupModule"| Container
  StartContract -->|"rebinds Start token"| Container

  Container -->|"Setup token"| ReturnedSetup["DI setup contract"]
  Container -->|"Start token / OnStart hooks"| ReturnedStart["DI start contract"]
```

## `services` Export

Plugins can now export DI declarations as `services`:

```ts
export const services = declare<MyPluginStart>(({ provide, host, contribute }) => {
  provide(MyServiceToken, (start) => start.myService);
  host(MyExtensionPointToken);
  contribute(MyExtensionPointToken, myContribution);
});
```

`services` is the preferred authoring path for the new `@kbn/plugin-di` model. The older `module` export remains supported for raw Inversify `ContainerModule` usage, but `services` wins when both are present.

## Classic Plugin Interop

This PR makes gradual migration possible:

```mermaid
flowchart TD
  PluginInitializer["plugin(initializerContext)"] --> Instance["Classic plugin instance"]
  Instance -->|"setup(core, deps)"| ClassicSetup["Classic setup contract"]
  Instance -->|"start(core, deps)"| ClassicStart["Classic start contract"]

  Services["services DI module"] --> PluginContainer["Plugin container"]
  ClassicSetup --> PluginContainer
  ClassicStart -->|"bound as Start"| PluginContainer

  PluginContainer -->|"provide(token, start => ...)"| CrossPluginService["Cross-plugin service"]
```

A plugin can keep its classic `plugin` initializer while adding a `services` export. During `start()`, the wrapper bridges the classic start contract into DI as the `Start` token before resolving DI `Start` and `OnStart` hooks, so `provide(token, (start) => ...)` observes the real plugin start contract.

## Startup Validation

The platform now validates cross-plugin DI declarations before plugin `start()` runs.

```mermaid
flowchart TD
  Provides["services.provides"] --> ServiceIndex["Service provider index"]
  Consumes["services.consumes"] --> ServiceCheck["Each consumed service has exactly one provider"]

  Hosts["extensionPoints.hosts"] --> ExtensionIndex["Extension host index"]
  Contributes["extensionPoints.contributes"] --> ExtensionCheck["Each contributed extension point has exactly one host"]

  ServiceCheck --> Result["Warnings or startup error"]
  ExtensionCheck --> Result
```

Validation catches:

- consumed service tokens with no enabled provider
- service tokens with multiple providers
- extension-point contributions with no enabled host
- extension points with multiple hosts

On the server, validation is controlled by `plugins.globalTokenValidation`:

- `warn` default: log warnings and continue
- `error`: throw before plugin start
- `off`: skip validation

In the browser, validation logs console warnings and never throws.

## Details

- Adds `plugin.globals` to v1/v2 Kibana manifest schemas.
- Adds `globals` to `DiscoveredPlugin` and server `PluginManifest` types.
- Parses and normalizes `plugin.globals` from legacy and modern package manifests.
- Includes `globals` in injected browser plugin metadata.
- Updates server and browser plugin wrappers to load `definition.services ?? definition.module`.
- Updates plugin readers/errors to accept `plugin`, `services`, or `module`.
- Bridges classic setup/start contracts into plugin DI containers with `createSetupModule(...)` and `createStartModule(...)`.
- Rebinds the DI `Start` token to the classic start contract when a classic plugin instance returns one.
- Adds server and browser `validateGlobalTokens(...)` implementations.
- Adds `plugins.globalTokenValidation` server config.

## Validation

Adds coverage for:

- manifest parsing and default `globals` normalization
- manifest/package validation for `<pluginId>.<Name>` token IDs
- `services` export precedence over `module`
- classic start contract bridging into DI
- server startup validation in warn/error modes
- browser validation warnings
- propagation of `globals` into UI plugin metadata