### PR TITLE
[Security Solution] [Graph] Wrap filter chips when value is too long

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/styles.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/styles.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EuiProvider } from '@elastic/eui';
+import { AnimatedSearchBarContainer } from './styles';
+
+const renderContainer = (className?: string) =>
+  render(
+    <EuiProvider>
+      <AnimatedSearchBarContainer className={className} data-test-subj="container">
+        <div />
+      </AnimatedSearchBarContainer>
+    </EuiProvider>
+  );
+
+describe('AnimatedSearchBarContainer', () => {
+  it('constrains the implicit grid column so long filter chips cannot overflow the parent', () => {
+    // Regression guard for the graph search bar layout breaking when a long filter chip is
+    // applied. Grid items default to `min-width: auto`, so without `minmax(0, 1fr)` a single
+    // long chip would push the date pickers, time-range selector and refresh button out of
+    // the viewport instead of wrapping inside the chip (see security-team#17288).
+    const { getByTestId } = renderContainer();
+
+    expect(getByTestId('container')).toHaveStyleRule('grid-template-columns', 'minmax(0, 1fr)');
+  });
+
+  it('keeps a single grid row so the toggle-search collapse/expand animation is preserved', () => {
+    // The `grid-template-rows: 1fr ↔ 0fr` trick drives the collapse/expand height transition;
+    // the column constraint above must not regress it.
+    const { getByTestId } = renderContainer();
+
+    expect(getByTestId('container')).toHaveStyleRule('grid-template-rows', '1fr');
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/styles.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/styles.tsx
@@ -16,6 +16,15 @@ export const useBorder = () => {
 export const AnimatedSearchBarContainer = styled.div`
   display: grid;
   grid-template-rows: 1fr;
+  /**
+   * Constrain the implicit grid column to the parent width. Grid items default to
+   * \`min-width: auto\` (min-content), so a single long filter chip would otherwise force
+   * the cell — and the SearchBar inside it — to grow past the panel, pushing the date
+   * pickers, time-range selector and refresh button out of the viewport. \`minmax(0, 1fr)\`
+   * gives the column a finite width so EUI's \`whiteSpace: normal\` on \`.globalFilterItem\`
+   * can wrap long chip values onto multiple lines (matching Timeline's behavior).
+   */
+  grid-template-columns: minmax(0, 1fr);
   border-top: ${() => useBorder()};
   padding: 16px 8px;
 


### PR DESCRIPTION
## Summary

Closes elastic/security-team#17288.

In the graph investigation view, applying a filter whose value is longer than the available filter bar width broke the row layout: the chip extended past the panel edge and pushed the date pickers, time-range selector and refresh button out of the viewport.

Root cause: `AnimatedSearchBarContainer` declares `display: grid` with only `grid-template-rows` defined. Grid items default to `min-width: auto` (min-content), so a single long chip forces the implicit column — and the SearchBar inside it — to grow past the parent width. EUI already applies `whiteSpace: normal` to `.globalFilterItem`, but it cannot wrap until the parent has a finite width.

### Solution

Constrain the implicit column with `grid-template-columns: minmax(0, 1fr)`. This is the minimal change that fixes the overflow while preserving the grid layout that powers the toggle-search collapse/expand animation (`grid-template-rows: 1fr ↔ 0fr`). Long chip values now wrap onto multiple lines inside the chip, matching Timeline's behavior.

### Screenshots

<img width="807" height="621" alt="Screenshot 2026-06-17 at 20 45 44" src="https://github.com/user-attachments/assets/b3d01d92-fbe3-45e1-98e7-c5b5c5d5f30b" />

<img width="819" height="624" alt="Screenshot 2026-06-17 at 20 46 45" src="https://github.com/user-attachments/assets/3834d5da-12ea-4ed4-aa68-33a61eddc2ee" />

### How to test

1. In Kibana, enable Entity Store.
2. Optionally, add mock data with `security-documents-generator` using `yarn start entity-resolution-demo`.
3. Go to Entity Analytics page and open the flyout for any entity within the Entities list.
4. Expand Graph Visualization and play with the filter chips

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.