### PR TITLE
[Alerting V2] Audit rule management skill for post-schema alignment

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`schema_to_skill_docs generateActionPolicySchemaDoc matches the snapshot 1`] = `
+"# Action Policy API Schema Reference
+
+Auto-generated from \`@kbn/alerting-v2-schemas\`. This is the source of truth for field names, types, and constraints.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`name\` | string | required | The name of the action policy. (min length: 1, max length: 256) |
+| \`description\` | string | required | A description of the action policy. (max length: 1024) |
+| \`destinations\` | { type: \\"workflow\\", ... }[] | required | The list of destinations. At least one is required. (min items: 1, max items: 10) |
+| \`matcher\` | string | optional | A KQL query string to match alerts. (max length: 4096) |
+| \`groupBy\` | string[] | optional | The fields used to group alerts. (max items: 16) |
+| \`tags\` | string[] | optional | Tags for categorizing the action policy. (max items: 20) |
+| \`groupingMode\` | \\"per_episode\\" | \\"all\\" | \\"per_field\\" | optional | The grouping mode for alert notifications. (enum: per_episode | all | per_field) |
+| \`throttle\` | object | optional | The throttle configuration for notifications. |"
+`;
+
+exports[`schema_to_skill_docs generateRuleOperationsDoc matches the snapshot 1`] = `
+"# Rule Operations Schema Reference
+
+Auto-generated from the \`manage_rule\` tool Zod schemas.
+
+#### \`operation: \\"set_metadata\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`name\` | string | optional | Rule name (must be unique within the space). (min length: 1, max length: 256) |
+| \`description\` | string | optional | Human-readable description of the rule. (max length: 1024) |
+| \`tags\` | string[] | optional | Tags for categorization, e.g. [\\"production\\", \\"infra\\"]. (min items: 1, max items: 20) |
+| \`builder_type\` | string | optional | Identifies the rule builder that authored this rule (e.g. \\"threshold\\"). Absent for rules authored directly in ES|QL. (max length: 64) |
+| \`operation\` | string | required |  |
+
+#### \`operation: \\"set_kind\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`operation\` | string | required |  |
+| \`kind\` | \\"alert\\" | \\"signal\\" | required | Rule kind: \\"alert\\" for stateful alerting with transitions, \\"signal\\" for stateless detection. (enum: alert | signal) |
+
+#### \`operation: \\"set_schedule\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`every\` | string | optional | Execution interval, e.g. 1m, 5m, 1h. |
+| \`lookback\` | string | optional | Lookback window for the query, e.g. 5m, 1h. Can also be expressed in ES|QL. |
+| \`operation\` | string | required |  |
+
+#### \`operation: \\"set_query\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`operation\` | string | required |  |
+| \`query\` | { format: \\"composed\\", ... } | { format: \\"standalone\\", ... } | required | Detection query configuration. |
+| \`recovery_strategy\` | \\"no_breach\\" | \\"query\\" | \\"none\\" | optional |  (enum: no_breach | query | none) |
+| \`no_data_strategy\` | \\"last_known_status\\" | \\"emit\\" | \\"recover\\" | \\"none\\" | optional |  (enum: last_known_status | emit | recover | none) |
+
+#### \`operation: \\"set_grouping\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`fields\` | string[] | required | Fields to group alerts by, e.g. [\\"host.name\\", \\"service.name\\"]. Should match ES|QL GROUP BY fields. (max items: 16) |
+| \`operation\` | string | required |  |
+
+#### \`operation: \\"set_state_transition\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`pending_count\` | integer | optional | Consecutive breaches before transitioning to active. (min: 0, max: 1000) |
+| \`pending_timeframe\` | string | optional | Time window for pending evaluation, e.g. 5m, 15m. |
+| \`recovering_count\` | integer | optional | Consecutive recoveries before transitioning to inactive. (min: 0, max: 1000) |
+| \`recovering_timeframe\` | string | optional | Time window for recovering evaluation, e.g. 5m, 15m. |
+| \`operation\` | string | required |  |
+
+#### \`operation: \\"validate\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`operation\` | string | required |  |"
+`;
+
+exports[`schema_to_skill_docs generateRuleSchemaDoc matches the snapshot 1`] = `
+"# Rule API Schema Reference
+
+Auto-generated from \`@kbn/alerting-v2-schemas\`. This is the source of truth for field names, types, and constraints.
+
+## Top-Level Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`kind\` | \\"alert\\" | \\"signal\\" | required | Rule kind: \\"alert\\" for stateful alerting with transitions, \\"signal\\" for stateless detection. (enum: alert | signal) |
+| \`metadata\` | object | required | Rule metadata. |
+| \`time_field\` | string | required | Time field used for the lookback window range filter. (min length: 1, max length: 128, default: \\"@timestamp\\") |
+| \`schedule\` | object | required | Execution schedule configuration. |
+| \`query\` | { format: \\"composed\\", ... } | { format: \\"standalone\\", ... } | required | Detection query configuration. |
+| \`recovery_strategy\` | \\"no_breach\\" | \\"query\\" | \\"none\\" | optional | How recovery is detected. \\"no_breach\\" recovers groups that stop breaching; \\"query\\" uses a custom recovery query; \\"none\\" disables recovery. (enum: no_breach | query | none) |
+| \`no_data_strategy\` | \\"last_known_status\\" | \\"emit\\" | \\"recover\\" | \\"none\\" | optional | How to handle no-data situations. \\"emit\\" emits a no-data event; \\"last_known_status\\" holds the last known status; \\"recover\\" forces recovery; \\"none\\" disables no-data detection. (enum: last_known_status | emit | recover | none) |
+| \`state_transition\` | object | null | optional |  |
+| \`grouping\` | object | optional | Grouping configuration. |
+| \`artifacts\` | object[] | optional |  (max items: 100) |
+
+## Query Formats
+
+#### \`format: \\"composed\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`format\` | string | required |  |
+| \`base\` | string | required | Base ES|QL query. Time filters are applied automatically via the lookback window. (min length: 1, max length: 10000) |
+| \`breach\` | object | required | Breach detection configuration (required). |
+| \`recovery\` | object | optional | Recovery query segment. Required when recovery_strategy is \\"query\\". |
+
+#### \`format: \\"standalone\\"\`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| \`format\` | string | required |  |
+| \`breach\` | object | required | Breach detection configuration (required). |
+| \`recovery\` | object | optional | Recovery query. Required when recovery_strategy is \\"query\\". |
+| \`no_data\` | object | optional | No-data detection query. Required when no_data_strategy is not \\"none\\". |"
+`;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -10,6 +10,11 @@ import { manageRuleTool } from '../tools/manage_rule';
 import { manageActionPolicyTool } from '../tools/manage_action_policy';
 import type { ManageActionPolicyToolDeps } from '../tools/manage_action_policy';
 import { alertingTools } from '../common/constants';
+import {
+  generateRuleSchemaDoc,
+  generateRuleOperationsDoc,
+  generateActionPolicySchemaDoc,
+} from './schema_to_skill_docs';
 
 export const createRuleManagementSkill = (deps: ManageActionPolicyToolDeps) =>
   defineSkillType({
@@ -30,7 +35,7 @@ Rules declare a \`kind\` of \`alert\` or \`signal\`. This is the most important 
 
 ### Alert (\`kind: alert\`)
 - **Stateful alerting** with full episode lifecycle: pending, active, recovering, inactive.
-- Supports state transitions (\`consecutive_breaches\`), recovery detection, and notification dispatch.
+- Supports state transitions (\`pending_count\` / \`recovering_count\`), recovery detection, and notification dispatch.
 - Produces \`type: 'alert'\` events that participate in the dispatcher pipeline.
 - UI label: **"Alert"**.
 - Use when the user wants to be **notified**, needs **lifecycle tracking**, or wants **recovery detection**.
@@ -133,6 +138,21 @@ The end-to-end notification path:
 
 Signal rules (\`kind: signal\`) are excluded at step 2 — the dispatcher query only selects \`type == 'alert'\` events.`,
       },
+      {
+        name: 'rule-schema',
+        relativePath: './references',
+        content: generateRuleSchemaDoc(),
+      },
+      {
+        name: 'rule-operations-schema',
+        relativePath: './references',
+        content: generateRuleOperationsDoc(),
+      },
+      {
+        name: 'action-policy-schema',
+        relativePath: './references',
+        content: generateActionPolicySchemaDoc(),
+      },
     ],
     content: `## Domain Knowledge
 
@@ -178,6 +198,11 @@ For an existing rule, pass the \`ruleAttachmentId\` and only include the operati
 
 ## ES|QL Query Guidance
 
+- Every \`set_query\` call **must** include \`format: "composed"\` or \`format: "standalone"\`. Omitting \`format\` will fail validation.
+  - **Composed** shares a \`base\` query with appendable \`breach.segment\` and optional \`recovery.segment\`:
+    \`{ format: "composed", base: "FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name", breach: { segment: "WHERE avg_cpu > 0.9" } }\`
+  - **Standalone** uses independent full queries:
+    \`{ format: "standalone", breach: { query: "FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name | WHERE avg_cpu > 0.9" } }\`
 - The base query must be a valid ES|QL statement.
 - Do **not** include time range filters in the query — the lookback window is applied automatically.
 - The query must return rows for an alert to fire. Use \`| WHERE ...\` to filter for breach conditions.
@@ -192,39 +217,34 @@ For an existing rule, pass the \`ruleAttachmentId\` and only include the operati
 
 ## State Transition
 
-- \`set_state_transition\` with \`consecutive_breaches: N\` means the rule fires only after N consecutive evaluation cycles breach the threshold. Use this when the user wants to reduce noise.
+Use \`set_state_transition\` to delay alert firing until the threshold is breached N times in a row. This reduces noise from transient spikes.
+
+- \`pending_count: N\` — breaches required before transitioning from pending to active (e.g. \`pending_count: 3\` means 3 consecutive breach cycles).
+- \`pending_timeframe\` — optional time window for the pending evaluation (e.g. \`"15m"\`).
+- \`recovering_count: N\` — non-breach cycles required before transitioning from recovering to inactive.
+- \`recovering_timeframe\` — optional time window for the recovering evaluation.
+
+State transition is only allowed on \`kind: alert\` rules. Refer to the [rule-operations-schema reference](./references/rule-operations-schema.md) for the full field schema.
 
 ## Recovery Strategy
 
-\`recovery_strategy\` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive.
-
-| Value | Behaviour |
-|---|---|
-| \`'no_breach'\` | Recovers episodes automatically when a breaching group stops appearing in breach query results. **Default for most alert rules.** |
-| \`'query'\` | Runs a separate recovery query each cycle. Requires a \`recovery\` block inside \`set_query\` (\`{ segment }\` for composed, \`{ query }\` for standalone). Use when recovery needs different criteria than "not breaching". |
-| \`'none'\` | Disables recovery entirely — episodes never transition to recovering/inactive. Use only when lifecycle tracking is not needed. |
-
-Signal rules (\`kind: signal\`) cannot set \`recovery_strategy\`.
+\`recovery_strategy\` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive. Signal rules (\`kind: signal\`) cannot set \`recovery_strategy\`.
 
 When using \`recovery_strategy: 'query'\`, add a \`set_query\` operation that includes a \`recovery\` block alongside \`breach\`:
 - **Composed**: \`recovery: { segment: 'WHERE cpu < 0.5' }\`
 - **Standalone**: \`recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' }\`
 
+Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints.
+
 ## No-Data Strategy
 
 \`no_data_strategy\` is a **top-level rule field** that controls behaviour when no data is present. Only meaningful for standalone queries with a \`no_data\` block.
-
-| Value | Behaviour |
-|---|---|
-| \`'none'\` | No-data situations are ignored (default). |
-| \`'emit'\` | Emits a \`no_data\` alert event when \`no_data\` query returns no rows. |
-| \`'last_known_status'\` | Holds the last known episode status when no data is present. |
-| \`'recover'\` | Forces recovery when no data is present. |
 
 When setting \`no_data_strategy\` to anything other than \`'none'\`, add a \`no_data\` block to the standalone query:
 \`no_data: { query: 'FROM heartbeat-* | STATS count = COUNT(*) BY host.name | WHERE count >= 1' }\`
 
 Signal rules cannot set \`no_data_strategy\`. Composed queries do not support \`no_data\`.
+Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints.
 
 ## Final Validation
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -274,6 +274,26 @@ After composing or modifying a rule, always render it inline for user review:
 \`<render_attachment id="{attachmentId}" version="{version}"/>\`
 where \`attachmentId\` is \`ruleAttachment.id\` and \`version\` is \`version\` from the ${alertingTools.manageRule} tool result.
 
+## Save Order
+
+When a conversation creates a full alerting setup (rule + workflow + action policy), the artifacts must be saved in a specific order because of cross-references:
+
+1. **Rule** — save first. The action policy's matcher references \`rule.id\`, which must exist.
+2. **Workflow** — save second. The action policy destination references the workflow ID, which must exist.
+3. **Action Policy** — save last. It depends on both the persisted rule and the persisted workflow.
+
+After composing all three artifacts, guide the user through saving in order:
+> "To activate notifications, please save in this order:
+> 1. Click **Create rule** on the rule card
+> 2. Click **Save workflow** on the workflow card
+> 3. Click **Create policy** on the action policy card
+>
+> The action policy references both the rule and the workflow, so they need to exist first."
+
+If the user tries to save out of order, the action policy will fail because its referenced rule or workflow hasn't been persisted yet. The action policy card automatically detects unsaved dependencies and disables the Create button until they are saved.
+
+---
+
 ## Notifications Require Alert Kind
 
 Action policies only process alert episodes. Signal rules (\`kind: signal\`) do not participate in episode lifecycle or notification dispatch.
@@ -461,6 +481,12 @@ Use ${alertingTools.manageActionPolicy} with these operations in order:
 Render the action policy inline for user review:
 \`<render_attachment id="{attachmentId}" version="{version}"/>\`
 where \`attachmentId\` is \`actionPolicyAttachment.id\` and \`version\` is \`version\` from the ${alertingTools.manageActionPolicy} tool result.
+
+## Save Order Reminder
+
+After rendering all three attachments (rule, workflow, action policy), remind the user of the required save order:
+
+> "To activate this alerting setup, please save in order: **Rule → Workflow → Action Policy**. The action policy depends on both the rule and the workflow being saved first."
 
 ## Customization Hints
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  generateRuleSchemaDoc,
+  generateRuleOperationsDoc,
+  generateActionPolicySchemaDoc,
+} from './schema_to_skill_docs';
+
+describe('schema_to_skill_docs', () => {
+  describe('generateRuleSchemaDoc', () => {
+    it('matches the snapshot', () => {
+      expect(generateRuleSchemaDoc()).toMatchSnapshot();
+    });
+
+    it('includes key field names from the schema', () => {
+      const doc = generateRuleSchemaDoc();
+      expect(doc).toContain('`kind`');
+      expect(doc).toContain('`metadata`');
+      expect(doc).toContain('`schedule`');
+      expect(doc).toContain('`query`');
+      expect(doc).toContain('`recovery_strategy`');
+      expect(doc).toContain('`no_data_strategy`');
+      expect(doc).toContain('`state_transition`');
+    });
+
+    it('does not contain stale field names', () => {
+      const doc = generateRuleSchemaDoc();
+      expect(doc).not.toContain('consecutive_breaches');
+      expect(doc).not.toContain('evaluation');
+      expect(doc).not.toContain('recovery_policy');
+    });
+  });
+
+  describe('generateRuleOperationsDoc', () => {
+    it('matches the snapshot', () => {
+      expect(generateRuleOperationsDoc()).toMatchSnapshot();
+    });
+
+    it('includes all operation types', () => {
+      const doc = generateRuleOperationsDoc();
+      expect(doc).toContain('set_metadata');
+      expect(doc).toContain('set_kind');
+      expect(doc).toContain('set_schedule');
+      expect(doc).toContain('set_query');
+      expect(doc).toContain('set_grouping');
+      expect(doc).toContain('set_state_transition');
+      expect(doc).toContain('validate');
+    });
+
+    it('includes pending_count and recovering_count fields', () => {
+      const doc = generateRuleOperationsDoc();
+      expect(doc).toContain('pending_count');
+      expect(doc).toContain('recovering_count');
+    });
+  });
+
+  describe('generateActionPolicySchemaDoc', () => {
+    it('matches the snapshot', () => {
+      expect(generateActionPolicySchemaDoc()).toMatchSnapshot();
+    });
+
+    it('includes key field names', () => {
+      const doc = generateActionPolicySchemaDoc();
+      expect(doc).toContain('`name`');
+      expect(doc).toContain('`destinations`');
+      expect(doc).toContain('`matcher`');
+      expect(doc).toContain('`groupingMode`');
+      expect(doc).toContain('`throttle`');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -46,12 +46,23 @@ function compactLargeEnums(node: unknown): unknown {
   return result;
 }
 
-function zodToJsonSchemaSafe(schema: z.ZodType): unknown {
+export class SchemaTranslationError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'SchemaTranslationError';
+  }
+}
+
+function zodToJsonSchema(schema: z.ZodType): unknown {
   try {
     const jsonSchema = z.toJSONSchema(schema, { target: 'draft-7', unrepresentable: 'any' });
     return compactLargeEnums(jsonSchema);
-  } catch {
-    return undefined;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new SchemaTranslationError(
+      `Failed to convert Zod schema to JSON Schema: ${message}`,
+      e
+    );
   }
 }
 
@@ -178,11 +189,10 @@ function formatVariantSchemas(jsonSchema: unknown): string {
  * Intended for embedding in the skill's `referencedContent`.
  */
 export const generateRuleSchemaDoc = (): string => {
-  const jsonSchema = zodToJsonSchemaSafe(createRuleDataBaseSchema);
+  const jsonSchema = zodToJsonSchema(createRuleDataBaseSchema);
   const fields = jsonSchemaToFieldTable(jsonSchema);
   const fieldTable = formatFieldTable(fields);
 
-  const queryField = fields.find((f) => f.name === 'query');
   let queryVariants = '';
   if (jsonSchema && typeof jsonSchema === 'object') {
     const schema = jsonSchema as JsonSchemaNode;
@@ -213,7 +223,7 @@ export const generateRuleSchemaDoc = (): string => {
  * Generates concise markdown documentation for the manage_rule tool operations.
  */
 export const generateRuleOperationsDoc = (): string => {
-  const jsonSchema = zodToJsonSchemaSafe(ruleOperationSchema);
+  const jsonSchema = zodToJsonSchema(ruleOperationSchema);
   const variants = formatVariantSchemas(jsonSchema);
 
   return [
@@ -229,7 +239,7 @@ export const generateRuleOperationsDoc = (): string => {
  * Generates concise markdown documentation from the create-action-policy Zod schema.
  */
 export const generateActionPolicySchemaDoc = (): string => {
-  const jsonSchema = zodToJsonSchemaSafe(createActionPolicyDataSchema);
+  const jsonSchema = zodToJsonSchema(createActionPolicyDataSchema);
   const fields = jsonSchemaToFieldTable(jsonSchema);
   const fieldTable = formatFieldTable(fields);
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import {
+  createRuleDataBaseSchema,
+  createActionPolicyDataSchema,
+} from '@kbn/alerting-v2-schemas';
+import { ruleOperationSchema } from '../tools/manage_rule/operations';
+
+const LARGE_ENUM_THRESHOLD = 20;
+
+type JsonSchemaNode = Record<string, unknown>;
+
+/**
+ * Replaces large enum arrays with a compact description to keep token counts
+ * manageable. Reuses the pattern from the workflows plugin
+ * (`build_trigger_definitions_for_agent.ts`).
+ */
+function compactLargeEnums(node: unknown): unknown {
+  if (node === null || typeof node !== 'object') return node;
+  if (Array.isArray(node)) return node.map(compactLargeEnums);
+
+  const obj = node as JsonSchemaNode;
+  const result: JsonSchemaNode = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'enum' && Array.isArray(value) && value.length > LARGE_ENUM_THRESHOLD) {
+      const examples = value.slice(0, 5) as string[];
+      result.type = 'string';
+      result.description = [
+        obj.description ?? '',
+        `One of ${value.length} allowed values, e.g.: ${examples.join(', ')}`,
+      ]
+        .filter(Boolean)
+        .join('. ');
+    } else {
+      result[key] = compactLargeEnums(value);
+    }
+  }
+
+  return result;
+}
+
+function zodToJsonSchemaSafe(schema: z.ZodType): unknown {
+  try {
+    const jsonSchema = z.toJSONSchema(schema, { target: 'draft-7', unrepresentable: 'any' });
+    return compactLargeEnums(jsonSchema);
+  } catch {
+    return undefined;
+  }
+}
+
+interface FieldInfo {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+  constraints: string;
+}
+
+function extractConstraints(prop: JsonSchemaNode): string {
+  const parts: string[] = [];
+  if (prop.minLength !== undefined) parts.push(`min length: ${prop.minLength}`);
+  if (prop.maxLength !== undefined) parts.push(`max length: ${prop.maxLength}`);
+  if (prop.minimum !== undefined) parts.push(`min: ${prop.minimum}`);
+  if (prop.maximum !== undefined) parts.push(`max: ${prop.maximum}`);
+  if (prop.pattern !== undefined) parts.push(`pattern: ${prop.pattern}`);
+  if (prop.enum !== undefined && Array.isArray(prop.enum)) {
+    parts.push(`enum: ${(prop.enum as string[]).join(' | ')}`);
+  }
+  if (prop.minItems !== undefined) parts.push(`min items: ${prop.minItems}`);
+  if (prop.maxItems !== undefined) parts.push(`max items: ${prop.maxItems}`);
+  if (prop.default !== undefined) parts.push(`default: ${JSON.stringify(prop.default)}`);
+  return parts.join(', ');
+}
+
+function resolveType(prop: JsonSchemaNode): string {
+  if (prop.enum !== undefined && Array.isArray(prop.enum)) {
+    return (prop.enum as string[]).map((v) => `"${v}"`).join(' | ');
+  }
+  if (prop.anyOf !== undefined && Array.isArray(prop.anyOf)) {
+    return (prop.anyOf as JsonSchemaNode[])
+      .map((variant) => {
+        if (variant.enum) return (variant.enum as string[]).map((v) => `"${v}"`).join(' | ');
+        if (variant.const !== undefined) return `"${variant.const}"`;
+        return (variant.type as string) ?? 'unknown';
+      })
+      .join(' | ');
+  }
+  if (prop.oneOf !== undefined && Array.isArray(prop.oneOf)) {
+    return (prop.oneOf as JsonSchemaNode[])
+      .map((variant) => {
+        const disc = variant.properties as JsonSchemaNode | undefined;
+        if (disc) {
+          const firstKey = Object.keys(disc)[0];
+          const firstProp = disc[firstKey] as JsonSchemaNode | undefined;
+          if (firstProp?.const) return `{ ${firstKey}: "${firstProp.const}", ... }`;
+        }
+        return (variant.type as string) ?? 'variant';
+      })
+      .join(' | ');
+  }
+  if (prop.type === 'array') {
+    const items = prop.items as JsonSchemaNode | undefined;
+    const itemType = items ? resolveType(items) : 'unknown';
+    return `${itemType}[]`;
+  }
+  return (prop.type as string) ?? 'unknown';
+}
+
+function jsonSchemaToFieldTable(jsonSchema: unknown): FieldInfo[] {
+  if (!jsonSchema || typeof jsonSchema !== 'object') return [];
+  const schema = jsonSchema as JsonSchemaNode;
+  const properties = schema.properties as JsonSchemaNode | undefined;
+  if (!properties) return [];
+  const required = new Set((schema.required as string[]) ?? []);
+
+  return Object.entries(properties).map(([name, rawProp]) => {
+    const prop = rawProp as JsonSchemaNode;
+    return {
+      name,
+      type: resolveType(prop),
+      required: required.has(name),
+      description: (prop.description as string) ?? '',
+      constraints: extractConstraints(prop),
+    };
+  });
+}
+
+function formatFieldTable(fields: FieldInfo[]): string {
+  if (fields.length === 0) return '';
+  const rows = fields.map(
+    (f) =>
+      `| \`${f.name}\` | ${f.type} | ${f.required ? 'required' : 'optional'} | ${f.description}${f.constraints ? ` (${f.constraints})` : ''} |`
+  );
+  return ['| Field | Type | Required | Description |', '|---|---|---|---|', ...rows].join('\n');
+}
+
+function formatVariantSchemas(jsonSchema: unknown): string {
+  if (!jsonSchema || typeof jsonSchema !== 'object') return '';
+  const schema = jsonSchema as JsonSchemaNode;
+  const variants = (schema.oneOf ?? schema.anyOf) as JsonSchemaNode[] | undefined;
+  if (!variants) return '';
+
+  const sections: string[] = [];
+  for (const variant of variants) {
+    const props = variant.properties as JsonSchemaNode | undefined;
+    if (!props) continue;
+
+    const discriminatorKey = Object.keys(props).find((k) => {
+      const p = props[k] as JsonSchemaNode;
+      return p.const !== undefined || (p.enum && (p.enum as string[]).length === 1);
+    });
+    const discriminatorValue = discriminatorKey
+      ? ((props[discriminatorKey] as JsonSchemaNode).const as string) ??
+        ((props[discriminatorKey] as JsonSchemaNode).enum as string[])?.[0]
+      : undefined;
+
+    const label = discriminatorKey && discriminatorValue
+      ? `\`${discriminatorKey}: "${discriminatorValue}"\``
+      : variant.description ?? 'Variant';
+
+    const fields = jsonSchemaToFieldTable(variant);
+    if (fields.length > 0) {
+      sections.push(`#### ${label}\n\n${formatFieldTable(fields)}`);
+    }
+  }
+  return sections.join('\n\n');
+}
+
+/**
+ * Generates concise markdown documentation from the create-rule Zod schema.
+ * Intended for embedding in the skill's `referencedContent`.
+ */
+export const generateRuleSchemaDoc = (): string => {
+  const jsonSchema = zodToJsonSchemaSafe(createRuleDataBaseSchema);
+  const fields = jsonSchemaToFieldTable(jsonSchema);
+  const fieldTable = formatFieldTable(fields);
+
+  const queryField = fields.find((f) => f.name === 'query');
+  let queryVariants = '';
+  if (jsonSchema && typeof jsonSchema === 'object') {
+    const schema = jsonSchema as JsonSchemaNode;
+    const props = schema.properties as JsonSchemaNode | undefined;
+    if (props?.query) {
+      queryVariants = formatVariantSchemas(props.query as JsonSchemaNode);
+    }
+  }
+
+  const sections = [
+    '# Rule API Schema Reference',
+    '',
+    'Auto-generated from `@kbn/alerting-v2-schemas`. This is the source of truth for field names, types, and constraints.',
+    '',
+    '## Top-Level Fields',
+    '',
+    fieldTable,
+  ];
+
+  if (queryVariants) {
+    sections.push('', '## Query Formats', '', queryVariants);
+  }
+
+  return sections.join('\n');
+};
+
+/**
+ * Generates concise markdown documentation for the manage_rule tool operations.
+ */
+export const generateRuleOperationsDoc = (): string => {
+  const jsonSchema = zodToJsonSchemaSafe(ruleOperationSchema);
+  const variants = formatVariantSchemas(jsonSchema);
+
+  return [
+    '# Rule Operations Schema Reference',
+    '',
+    'Auto-generated from the `manage_rule` tool Zod schemas.',
+    '',
+    variants,
+  ].join('\n');
+};
+
+/**
+ * Generates concise markdown documentation from the create-action-policy Zod schema.
+ */
+export const generateActionPolicySchemaDoc = (): string => {
+  const jsonSchema = zodToJsonSchemaSafe(createActionPolicyDataSchema);
+  const fields = jsonSchemaToFieldTable(jsonSchema);
+  const fieldTable = formatFieldTable(fields);
+
+  return [
+    '# Action Policy API Schema Reference',
+    '',
+    'Auto-generated from `@kbn/alerting-v2-schemas`. This is the source of truth for field names, types, and constraints.',
+    '',
+    fieldTable,
+  ].join('\n');
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -56,10 +56,7 @@ function zodToJsonSchema(schema: z.ZodType): unknown {
     return compactLargeEnums(jsonSchema);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    throw new SchemaTranslationError(
-      `Failed to convert Zod schema to JSON Schema: ${message}`,
-      e
-    );
+    throw new SchemaTranslationError(`Failed to convert Zod schema to JSON Schema: ${message}`, e);
   }
 }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -6,10 +6,7 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import {
-  createRuleDataBaseSchema,
-  createActionPolicyDataSchema,
-} from '@kbn/alerting-v2-schemas';
+import { createRuleDataBaseSchema, createActionPolicyDataSchema } from '@kbn/alerting-v2-schemas';
 import { ruleOperationSchema } from '../tools/manage_rule/operations';
 
 const LARGE_ENUM_THRESHOLD = 20;
@@ -136,7 +133,9 @@ function formatFieldTable(fields: FieldInfo[]): string {
   if (fields.length === 0) return '';
   const rows = fields.map(
     (f) =>
-      `| \`${f.name}\` | ${f.type} | ${f.required ? 'required' : 'optional'} | ${f.description}${f.constraints ? ` (${f.constraints})` : ''} |`
+      `| \`${f.name}\` | ${f.type} | ${f.required ? 'required' : 'optional'} | ${f.description}${
+        f.constraints ? ` (${f.constraints})` : ''
+      } |`
   );
   return ['| Field | Type | Required | Description |', '|---|---|---|---|', ...rows].join('\n');
 }
@@ -161,9 +160,10 @@ function formatVariantSchemas(jsonSchema: unknown): string {
         ((props[discriminatorKey] as JsonSchemaNode).enum as string[])?.[0]
       : undefined;
 
-    const label = discriminatorKey && discriminatorValue
-      ? `\`${discriminatorKey}: "${discriminatorValue}"\``
-      : variant.description ?? 'Variant';
+    const label =
+      discriminatorKey && discriminatorValue
+        ? `\`${discriminatorKey}: "${discriminatorValue}"\``
+        : variant.description ?? 'Variant';
 
     const fields = jsonSchemaToFieldTable(variant);
     if (fields.length > 0) {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
@@ -235,9 +235,9 @@ describe('executeRuleOperations', () => {
       const result = await executeRuleOperations({}, ops);
 
       expect(result.data.recovery_strategy).toBe('query');
-      expect(
-        (result.data.query as { recovery?: { segment: string } }).recovery
-      ).toEqual({ segment: 'WHERE avg_cpu < 0.5' });
+      expect((result.data.query as { recovery?: { segment: string } }).recovery).toEqual({
+        segment: 'WHERE avg_cpu < 0.5',
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
@@ -291,9 +291,7 @@ describe('executeRuleOperations', () => {
       ];
 
       const promise = executeRuleOperations({}, ops);
-      await expect(promise).rejects.toThrow(
-        'recovery_strategy "query" requires a recovery block'
-      );
+      await expect(promise).rejects.toThrow('recovery_strategy "query" requires a recovery block');
       await expect(executeRuleOperations({}, ops)).rejects.toBeInstanceOf(
         RuleOperationValidationError
       );
@@ -315,7 +313,6 @@ describe('executeRuleOperations', () => {
       const result = await executeRuleOperations({}, ops);
       expect(result.data.recovery_strategy).toBe('query');
     });
-
   });
 
   describe('set_grouping with column validation', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
@@ -290,8 +290,12 @@ describe('executeRuleOperations', () => {
         },
       ];
 
-      await expect(executeRuleOperations({}, ops)).rejects.toThrow(
+      const promise = executeRuleOperations({}, ops);
+      await expect(promise).rejects.toThrow(
         'recovery_strategy "query" requires a recovery block'
+      );
+      await expect(executeRuleOperations({}, ops)).rejects.toBeInstanceOf(
+        RuleOperationValidationError
       );
     });
 
@@ -312,22 +316,6 @@ describe('executeRuleOperations', () => {
       expect(result.data.recovery_strategy).toBe('query');
     });
 
-    it('wraps recovery cross-field errors as RuleOperationValidationError', async () => {
-      const ops: RuleOperation[] = [
-        {
-          operation: 'set_query',
-          query: {
-            format: 'standalone',
-            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
-          },
-          recovery_strategy: 'query',
-        },
-      ];
-
-      await expect(executeRuleOperations({}, ops)).rejects.toBeInstanceOf(
-        RuleOperationValidationError
-      );
-    });
   });
 
   describe('set_grouping with column validation', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
@@ -179,6 +179,157 @@ describe('executeRuleOperations', () => {
     });
   });
 
+  describe('set_query with composed format', () => {
+    it('validates composed query using base for the LIMIT 0 call', async () => {
+      const esClient = createMockEsClient();
+      esClient.asCurrentUser.esql.query.mockResolvedValueOnce({
+        columns: [
+          { name: 'host.name', type: 'keyword' },
+          { name: 'avg_cpu', type: 'double' },
+        ],
+        values: [],
+      } as never);
+
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'composed',
+            base: 'FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name',
+            breach: { segment: 'WHERE avg_cpu > 0.9' },
+          },
+        },
+      ];
+
+      const result = await executeRuleOperations({}, ops, esClient);
+
+      expect(esClient.asCurrentUser.esql.query).toHaveBeenCalledWith({
+        query: 'FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name | LIMIT 0',
+        format: 'json',
+      });
+      expect(result.data.query).toEqual({
+        format: 'composed',
+        base: 'FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name',
+        breach: { segment: 'WHERE avg_cpu > 0.9' },
+      });
+      expect(result.queryColumns).toEqual([
+        { name: 'host.name', type: 'keyword' },
+        { name: 'avg_cpu', type: 'double' },
+      ]);
+    });
+
+    it('stores composed query with recovery segment and recovery_strategy', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'composed',
+            base: 'FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name',
+            breach: { segment: 'WHERE avg_cpu > 0.9' },
+            recovery: { segment: 'WHERE avg_cpu < 0.5' },
+          },
+          recovery_strategy: 'query',
+        },
+      ];
+
+      const result = await executeRuleOperations({}, ops);
+
+      expect(result.data.recovery_strategy).toBe('query');
+      expect(
+        (result.data.query as { recovery?: { segment: string } }).recovery
+      ).toEqual({ segment: 'WHERE avg_cpu < 0.5' });
+    });
+  });
+
+  describe('set_query recovery cross-field validation', () => {
+    it('throws when recovery block is present but recovery_strategy is not "query"', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+            recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' },
+          },
+          recovery_strategy: 'no_breach',
+        },
+      ];
+
+      await expect(executeRuleOperations({}, ops)).rejects.toThrow(
+        'query.recovery is only allowed when recovery_strategy is "query"'
+      );
+    });
+
+    it('throws when recovery block is present with no recovery_strategy on existing rule', async () => {
+      const existing: Partial<RuleAttachmentData> = { recovery_strategy: 'no_breach' };
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+            recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' },
+          },
+        },
+      ];
+
+      await expect(executeRuleOperations(existing, ops)).rejects.toThrow(
+        'query.recovery is only allowed when recovery_strategy is "query"'
+      );
+    });
+
+    it('throws when recovery_strategy is "query" but no recovery block is provided', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+          },
+          recovery_strategy: 'query',
+        },
+      ];
+
+      await expect(executeRuleOperations({}, ops)).rejects.toThrow(
+        'recovery_strategy "query" requires a recovery block'
+      );
+    });
+
+    it('passes when recovery_strategy is "query" and recovery block is provided', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+            recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' },
+          },
+          recovery_strategy: 'query',
+        },
+      ];
+
+      const result = await executeRuleOperations({}, ops);
+      expect(result.data.recovery_strategy).toBe('query');
+    });
+
+    it('wraps recovery cross-field errors as RuleOperationValidationError', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+          },
+          recovery_strategy: 'query',
+        },
+      ];
+
+      await expect(executeRuleOperations({}, ops)).rejects.toBeInstanceOf(
+        RuleOperationValidationError
+      );
+    });
+  });
+
   describe('set_grouping with column validation', () => {
     it('accepts grouping fields that exist in query columns', async () => {
       const esClient = createMockEsClient();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.ts
@@ -22,6 +22,8 @@ import {
   isStateTransitionAllowed,
   isSignalUsingStandaloneFormat,
   isSignalQueryBreachOnly,
+  isRecoveryQueryConsistentWithStrategy,
+  isRecoveryQueryProvidedForStrategy,
 } from '@kbn/alerting-v2-schemas';
 import { buildRulePayload } from '../../../../common/agent_builder/rule_mappers';
 
@@ -171,10 +173,8 @@ export const executeRuleOperations = async (
         break;
       }
 
-      case 'set_query':
+      case 'set_query': {
         if (esClient) {
-          // Validate the root query (the one with the FROM clause) so column
-          // metadata is available for downstream set_grouping validation.
           lastQueryColumns = await validateEsqlQuery(esClient, getRootEsqlQuery(op.query));
         }
         next = {
@@ -185,7 +185,20 @@ export const executeRuleOperations = async (
             : {}),
           ...(op.no_data_strategy !== undefined ? { no_data_strategy: op.no_data_strategy } : {}),
         };
+
+        if (!isRecoveryQueryConsistentWithStrategy(next)) {
+          throw new RuleOperationValidationError(
+            'query.recovery is only allowed when recovery_strategy is "query".'
+          );
+        }
+        if (!isRecoveryQueryProvidedForStrategy(next)) {
+          throw new RuleOperationValidationError(
+            'recovery_strategy "query" requires a recovery block in the query ' +
+              '(recovery: { segment } for composed, recovery: { query } for standalone).'
+          );
+        }
         break;
+      }
 
       case 'set_grouping': {
         if (lastQueryColumns && lastQueryColumns.length > 0) {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -131,9 +131,7 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
           .get(Logger)
           .warn(`Rule management skill registered with empty schema docs: ${message}`);
       } else {
-        container
-          .get(Logger)
-          .warn(`Failed to register rule management skill: ${message}`);
+        container.get(Logger).warn(`Failed to register rule management skill: ${message}`);
       }
     }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -13,6 +13,7 @@ import { createActionPolicyAttachmentType } from '../agent_builder/attachments/a
 import { createRuleAttachmentType } from '../agent_builder/attachments/rule_attachment_type';
 import { resolveRequestScoped } from '../agent_builder/resolve_request_scoped';
 import { registerSkills } from '../agent_builder/skills/register_skills';
+import { SchemaTranslationError } from '../agent_builder/skills/schema_to_skill_docs';
 import { createActionPolicySmlType } from '../agent_builder/sml/action_policy_sml_type';
 import { createRuleSmlType } from '../agent_builder/sml/rule_sml_type';
 import { AttachmentTypeToken } from '../agent_builder/tokens';
@@ -117,10 +118,24 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
     }
 
     const workflowsManagementApi = container.get(WorkflowsManagementApiToken);
-    registerSkills(agentBuilder, {
-      getWorkflow: (id, sid) => workflowsManagementApi.getWorkflow(id, sid),
-      getAvailableConnectors: (sid, req) => workflowsManagementApi.getAvailableConnectors(sid, req),
-    });
+    try {
+      registerSkills(agentBuilder, {
+        getWorkflow: (id, sid) => workflowsManagementApi.getWorkflow(id, sid),
+        getAvailableConnectors: (sid, req) =>
+          workflowsManagementApi.getAvailableConnectors(sid, req),
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (e instanceof SchemaTranslationError) {
+        container
+          .get(Logger)
+          .warn(`Rule management skill registered with empty schema docs: ${message}`);
+      } else {
+        container
+          .get(Logger)
+          .warn(`Failed to register rule management skill: ${message}`);
+      }
+    }
 
     container.get(Logger).debug('Rule management skill and attachments registered');
   });


### PR DESCRIPTION
## Summary

Audits and fixes the alerting V2 rule management agent builder skill after the query schema overhaul in #271758.

### Changes

**Auto-generated schema docs** (`schema_to_skill_docs.ts`)
- New utility that converts `createRuleDataBaseSchema`, `ruleOperationSchema`, and `createActionPolicyDataSchema` to concise markdown field tables via `z.toJSONSchema()`, following the proven pattern from workflows' `build_trigger_definitions_for_agent.ts`
- Replaces hand-written type/field/enum documentation in the skill with generated output, eliminating the class of drift problems that caused `consecutive_breaches` vs `pending_count` mismatches
- Snapshot tests ensure schema changes surface in CI instead of silently diverging

**Skill prompt fixes** (`rule_management_skill.ts`)
- Fixed `consecutive_breaches` → `pending_count` / `recovering_count` in concepts reference and state transition section
- Added explicit `format` discriminator guidance with inline composed/standalone examples
- Replaced hand-written Recovery Strategy, No-Data Strategy, and State Transition field tables with references to auto-generated schema docs
- Added 3 new `referencedContent` entries generated from Zod at registration time

**Save-order instructions** (`rule_management_skill.ts`)
- Added "Save Order" section explaining the Rule → Workflow → Action Policy dependency chain
- Added save-order reminder in Part 3 (Default Notification Setup) so the agent guides users through saving in the correct sequence

**Early cross-field validation** (`operations.ts`)
- Added `isRecoveryQueryConsistentWithStrategy` and `isRecoveryQueryProvidedForStrategy` checks in the `set_query` case for immediate, actionable errors instead of deferring to the `validate` step

**Test coverage** (`operations.test.ts`, `schema_to_skill_docs.test.ts`)
- Added composed-format tests (validates `getRootEsqlQuery` extracts `base` for LIMIT 0 call)
- Added recovery cross-field validation tests (5 cases covering all error/success paths)
- Added snapshot tests for all 3 generated schema docs

Addresses #272605 (agent builder stragglers checklist item)
Addresses #273148 (save-order instructions for rules, workflows, and action policies)
Addresses elastic/rna-program#514 (eliminate hand-written type drift)

## Test plan

- [x] `operations.test.ts` — 41 tests passing (7 new)
- [x] `schema_to_skill_docs.test.ts` — 8 tests passing (all new, 3 snapshots)
- [x] `manage_rule.test.ts` — 10 tests passing (no regressions)