### PR TITLE
[9.3] [Observability] Fix Custom threshold rule: editing a saved query filter is a no-op

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/custom_threshold_rule_expression.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/custom_threshold_rule_expression.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import type { RuleTypeParams } from '@kbn/alerting-plugin/common';
 import type { Query } from '@kbn/data-plugin/common';
+import { FilterStateStore } from '@kbn/es-query';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { mountWithIntl, nextTick } from '@kbn/test-jest-helpers';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
@@ -268,6 +269,35 @@ describe('Expression', () => {
     ).toBe(
       'The selected data view does not have a timestamp field, please select another data view.'
     );
+  });
+
+  it('should re-add $state to saved filters before passing them to the SearchBar', async () => {
+    const kibanaMock = kibanaStartMock.startContract();
+    const searchBarMock = kibanaMock.services.unifiedSearch.ui.SearchBar as jest.Mock;
+    searchBarMock.mockClear();
+    useKibanaMock.mockReturnValue(kibanaMock);
+
+    const savedFilter = {
+      meta: { index: 'mockedIndex', key: 'host.name', type: 'phrase' },
+      query: { match_phrase: { 'host.name': 'host-1' } },
+    };
+
+    await setup(undefined, {
+      searchConfiguration: {
+        index: 'mockedIndex',
+        query: { query: '', language: 'kuery' },
+        filter: [savedFilter],
+      },
+    });
+
+    expect(searchBarMock).toHaveBeenCalled();
+    const { filters } = searchBarMock.mock.calls[searchBarMock.mock.calls.length - 1][0];
+    expect(filters).toEqual([
+      {
+        ...savedFilter,
+        $state: { store: FilterStateStore.APP_STATE },
+      },
+    ]);
   });
 
   it('should use output of getSerializedFields() as searchConfiguration', async () => {

--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/custom_threshold_rule_expression.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/custom_threshold_rule_expression.tsx
@@ -27,7 +27,7 @@ import type { ISearchSource, Query } from '@kbn/data-plugin/common';
 import { type SavedQuery } from '@kbn/data-plugin/common';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DataViewBase } from '@kbn/es-query';
-import { type Filter } from '@kbn/es-query';
+import { type Filter, FilterStateStore } from '@kbn/es-query';
 import { DataViewSelectPopover } from '@kbn/stack-alerts-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -80,6 +80,18 @@ export const defaultExpression: MetricExpression = {
 
 const FILTER_TYPING_DEBOUNCE_MS = 500;
 const EMPTY_FILTERS: Filter[] = [];
+
+/**
+ * Saved filters are persisted without `$state` (only `meta` and `query` are stored). The unified
+ * search filter editor's `onSubmit` returns early when `$state.store` is missing, so editing a
+ * saved filter would be a no-op. Re-add `$state` before handing filters back to the `SearchBar`.
+ */
+const ensureFiltersHaveState = (filters: Filter[]): Filter[] =>
+  filters.map((filter) =>
+    filter.$state?.store != null
+      ? filter
+      : { ...filter, $state: { store: FilterStateStore.APP_STATE } }
+  );
 
 const getNoDataBehaviorOptions = (hasGroupBy: boolean) => [
   {
@@ -398,6 +410,11 @@ export default function Expressions(props: Props) {
     [setRuleParams, ruleParams.searchConfiguration]
   );
 
+  const searchBarFilters = useMemo(
+    () => ensureFiltersHaveState(ruleParams.searchConfiguration?.filter ?? EMPTY_FILTERS),
+    [ruleParams.searchConfiguration?.filter]
+  );
+
   const onQuerySubmit = useCallback(
     ({ query: newQuery }: { query?: Query }) => {
       setParamsWarning(undefined);
@@ -627,7 +644,7 @@ export default function Expressions(props: Props) {
         onSaved={onSavedQueryUpdated}
         dataTestSubj="thresholdRuleUnifiedSearchBar"
         query={ruleParams.searchConfiguration?.query}
-        filters={ruleParams.searchConfiguration?.filter ?? EMPTY_FILTERS}
+        filters={searchBarFilters}
         savedQuery={savedQuery}
         onFiltersUpdated={onFilterUpdated}
         hiddenFilterPanelOptions={HIDDEN_FILTER_PANEL_OPTIONS}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[Observability] Fix Custom threshold rule: editing a saved query filter is a no-op #273141](https://github.com/elastic/kibana/pull/273141)

<!--- Backport version: 9.6.6 -->

### Questions ?

Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

Co-authored-by: Kevin Delemme <kevin.delemme@elastic.co>