### PR TITLE
[UII] Fix data stream ES endpoint in `AutoInstallContentPackagesTask`

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/data_streams.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/data_streams.test.ts
@@ -22,7 +22,7 @@ describe('DataStreamService', () => {
       expect(result).toEqual(['logs-system.cpu-default', 'logs-system.cpu-production']);
     });
 
-    it('calls the data streams API with filter_path=data_streams.name', async () => {
+    it('calls the _data_stream API with filter_path=data_streams.name', async () => {
       const esClient = elasticsearchServiceMock.createElasticsearchClient();
       esClient.transport.request.mockResolvedValue({ data_streams: [] });
 
@@ -31,6 +31,7 @@ describe('DataStreamService', () => {
       expect(esClient.transport.request).toHaveBeenCalledWith(
         expect.objectContaining({
           method: 'GET',
+          path: '/_data_stream/logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*,profiling-*',
           querystring: { filter_path: 'data_streams.name' },
         })
       );

--- a/x-pack/platform/plugins/shared/fleet/server/services/data_streams.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/data_streams.ts
@@ -48,7 +48,7 @@ class DataStreamService {
 
   public async getAllFleetDataStreamNames(esClient: ElasticsearchClient): Promise<string[]> {
     const res = await esClient.transport.request<DataStreamNamesResponse>({
-      path: `/_data_streams/${DATA_STREAM_INDEX_PATTERN}`,
+      path: `/_data_stream/${DATA_STREAM_INDEX_PATTERN}`,
       method: 'GET',
       querystring: { filter_path: 'data_streams.name' },
     });


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #273362.

`/_data_streams` is not the correct ES endpoint. It should be `/_data_stream`.

This caused all lookups to fail for `AutoInstallContentPackagesTask`, Kibana logs show error `no handler found for uri
[/_data_streams/...]`.

Backporting this to all branches from the above PR.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->