### PR TITLE
[Security Solution] [Graph] Suppress selection visuals in non-interactive mode

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.test.tsx
@@ -756,6 +756,44 @@ describe('<Graph />', () => {
       });
     });
 
+    it('should disable selection and focus on nodes when interactive is false', async () => {
+      const { container } = renderGraphPreview({
+        nodes: testNodes,
+        edges: [],
+        interactive: false,
+      });
+
+      await waitFor(() => {
+        const nodes = container.querySelectorAll('.react-flow__node');
+        expect(nodes.length).toBeGreaterThan(0);
+
+        nodes.forEach((node) => {
+          // React Flow only adds the `selectable` class when `elementsSelectable` is enabled
+          expect(node).not.toHaveClass('selectable');
+          // and only makes nodes focusable (tabbable) when `nodesFocusable` is enabled
+          expect(node).not.toHaveAttribute('tabindex');
+        });
+      });
+    });
+
+    it('should enable selection and focus on nodes when interactive is true', async () => {
+      const { container } = renderGraphPreview({
+        nodes: testNodes,
+        edges: [],
+        interactive: true,
+      });
+
+      await waitFor(() => {
+        const nodes = container.querySelectorAll('.react-flow__node');
+        expect(nodes.length).toBeGreaterThan(0);
+
+        nodes.forEach((node) => {
+          expect(node).toHaveClass('selectable');
+          expect(node).toHaveAttribute('tabindex', '0');
+        });
+      });
+    });
+
     it('should add non-interactive class to relationship nodes when interactive is false', async () => {
       const nodesWithRelationship: NodeViewModel[] = [
         ...testNodes,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph.tsx
@@ -294,6 +294,11 @@ export const Graph = memo<GraphProps>(
           edges={edgesState}
           nodesConnectable={false}
           edgesFocusable={false}
+          // Disable React Flow's built-in selection/focus in non-interactive mode (e.g. flyout
+          // preview) so nodes never receive a selected/focused state through keyboard focus or
+          // programmatic selection, which would otherwise show selection visuals.
+          nodesFocusable={interactive}
+          elementsSelectable={interactive}
           onlyRenderVisibleElements={ONLY_RENDER_VISIBLE_ELEMENTS}
           snapToGrid={true} // Snap to grid is enabled to avoid sub-pixel positioning
           snapGrid={[GRID_SIZE, GRID_SIZE]} // Snap nodes to a 10px grid


### PR DESCRIPTION
## Summary

Closes elastic/security-team#17269.

Disable React Flow's built-in node selection and focus (nodesFocusable, elementsSelectable) when the graph is rendered non-interactively, e.g. the flyout "Graph preview". Previously nodes could still acquire a selected/ focused state through keyboard focus or programmatic centering, which showed selection visuals even though the preview doesn't support interaction.

### Video

Difference between interactive (left) and non-interactive (right) modes.

https://github.com/user-attachments/assets/298ad740-24f9-45cd-b43e-c811d14acd0e

### How to test

1. In Kibana, enable Entity Store.
2. Optionally, add mock data with `security-documents-generator` using `yarn start entity-resolution-demo`.
3. Go to Entity Analytics page and open the flyout for any entity within the Entities list.
4. Check Graph Visualization preview shows no selection visuals when hovering and can't focus on the previewed nodes

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.