### PR TITLE
[UII] Add callout when deleting Fleet Server integration from a policy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
@@ -11,7 +11,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 
 import { EuiContextMenuItem } from '@elastic/eui';
 
-import type { AgentPolicy, PackagePolicy } from '../types';
+import type { AgentPolicy, PackagePolicy, PackagePolicyPackage } from '../types';
 import { createIntegrationsTestRendererMock } from '../mock';
 
 import { sendGetAgents, useMultipleAgentPolicies } from '../hooks';
@@ -46,14 +46,19 @@ const sendGetAgentsMock = sendGetAgents as jest.MockedFunction<typeof sendGetAge
 function renderMenu({
   agentPolicies,
   packagePolicyIds,
+  packagePolicyPackage,
 }: {
   agentPolicies: AgentPolicy[];
   packagePolicyIds: string[];
+  packagePolicyPackage?: PackagePolicyPackage;
 }) {
   const renderer = createIntegrationsTestRendererMock();
 
   const utils = renderer.render(
-    <PackagePolicyDeleteProvider agentPolicies={agentPolicies}>
+    <PackagePolicyDeleteProvider
+      agentPolicies={agentPolicies}
+      packagePolicyPackage={packagePolicyPackage}
+    >
       {(deletePackagePoliciesPrompt) => {
         return (
           <EuiContextMenuItem
@@ -266,5 +271,66 @@ describe('PackagePolicyDeleteProvider', () => {
         'about to delete an integration'
       );
     });
+  });
+
+  it('When deleting the Fleet Server integration show a specific warning', async () => {
+    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: false });
+    sendGetAgentsMock.mockResolvedValue({
+      data: { statusSummary: {}, items: [], total: 0 },
+    } as any);
+    const agentPolicies = createMockAgentPolicies();
+    const { utils } = renderMenu({
+      agentPolicies,
+      packagePolicyIds: ['integration-0001'],
+      packagePolicyPackage: { name: 'fleet_server' } as PackagePolicyPackage,
+    });
+    const button = utils.getByTestId('deleteIntegrationBtn');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(utils.getByTestId('fleetServerDeleteCallOut').textContent).toContain(
+        'will lose their connection to Fleet'
+      );
+    });
+  });
+
+  it('Shows the Fleet Server warning even when multiple agent policies are present', async () => {
+    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: true });
+    sendGetAgentsMock.mockResolvedValue({
+      data: { statusSummary: {}, items: [], total: 0 },
+    } as any);
+    const agentPolicies = createMockAgentPolicies(undefined, true);
+    const { utils } = renderMenu({
+      agentPolicies,
+      packagePolicyIds: ['integration-0001'],
+      packagePolicyPackage: { name: 'fleet_server' } as PackagePolicyPackage,
+    });
+    const button = utils.getByTestId('deleteIntegrationBtn');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(utils.getByTestId('fleetServerDeleteCallOut')).toBeInTheDocument();
+      expect(utils.getByTestId('sharedAgentPolicyCallOut')).toBeInTheDocument();
+    });
+  });
+
+  it('Does not show the Fleet Server warning when deleting a non-Fleet Server integration', async () => {
+    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: false });
+    sendGetAgentsMock.mockResolvedValue({
+      data: { statusSummary: {}, items: [], total: 0 },
+    } as any);
+    const agentPolicies = createMockAgentPolicies();
+    const { utils } = renderMenu({
+      agentPolicies,
+      packagePolicyIds: ['integration-0001'],
+      packagePolicyPackage: { name: 'nginx' } as PackagePolicyPackage,
+    });
+    const button = utils.getByTestId('deleteIntegrationBtn');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(utils.getByTestId('confirmModalBodyText')).toBeInTheDocument();
+    });
+    expect(utils.queryByTestId('fleetServerDeleteCallOut')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
@@ -286,7 +286,7 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
             >
               <FormattedMessage
                 id="xpack.fleet.deletePackagePolicy.confirmModal.fleetServerWarningMessage"
-                defaultMessage="If any Fleet Servers are running this policy, removing the Fleet Server integration will stop them. Agents that rely on those Fleet Servers will lose their connection to Fleet and can no longer be managed or receive policy updates. Reconnecting them requires re-enrolling each agent."
+                defaultMessage="If this policy is assigned to any Fleet Servers, deleting the Fleet Server integration will stop them from running. Agents that depend on those Fleet Servers will lose their connection to Fleet — you won't be able to manage them or send policy updates until you re-enroll each agent individually."
               />
             </EuiCallOut>
             <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
@@ -286,7 +286,7 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
             >
               <FormattedMessage
                 id="xpack.fleet.deletePackagePolicy.confirmModal.fleetServerWarningMessage"
-                defaultMessage="If any Fleet Servers are running this policy, removing the Fleet Server integration will stop them. Agents that rely on those Fleet Servers will lose their connection to Fleet and can no longer be managed or receive policy updates. This cannot be undone without re-enrolling your agents."
+                defaultMessage="If any Fleet Servers are running this policy, removing the Fleet Server integration will stop them. Agents that rely on those Fleet Servers will lose their connection to Fleet and can no longer be managed or receive policy updates. Reconnecting them requires re-enrolling each agent."
               />
             </EuiCallOut>
             <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
@@ -24,7 +24,7 @@ import {
   useDeletePackagePolicyMutation,
   sendDeletePackageDatastreamAssets,
 } from '../hooks';
-import { AGENTS_PREFIX } from '../../common/constants';
+import { AGENTS_PREFIX, FLEET_SERVER_PACKAGE } from '../../common/constants';
 import type { AgentPolicy, PackagePolicyPackage } from '../types';
 import { sendDeleteAgentlessPolicy } from '../hooks/use_request/agentless_policy';
 
@@ -75,6 +75,8 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
 
   const hasMultipleAgentPolicies =
     canUseMultipleAgentPolicies && agentPolicies && agentPolicies.length > 1;
+
+  const isDeletingFleetServer = packagePolicyPackage?.name === FLEET_SERVER_PACKAGE;
 
   const fetchAgentsCount = useMemo(
     () => async () => {
@@ -268,6 +270,28 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
         buttonColor="danger"
         confirmButtonDisabled={isLoading || isLoadingAgentsCount}
       >
+        {isDeletingFleetServer && (
+          <>
+            <EuiCallOut
+              announceOnMount={false}
+              color="danger"
+              iconType="warning"
+              title={
+                <FormattedMessage
+                  id="xpack.fleet.deletePackagePolicy.confirmModal.fleetServerWarningTitle"
+                  defaultMessage="This may disconnect agents from Fleet"
+                />
+              }
+              data-test-subj="fleetServerDeleteCallOut"
+            >
+              <FormattedMessage
+                id="xpack.fleet.deletePackagePolicy.confirmModal.fleetServerWarningMessage"
+                defaultMessage="If any Fleet Servers are running this policy, removing the Fleet Server integration will stop them. Agents that rely on those Fleet Servers will lose their connection to Fleet and can no longer be managed or receive policy updates. This cannot be undone without re-enrolling your agents."
+              />
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
         {packagePolicyPackage?.type === 'input' && (
           <>
             <EuiCallOut


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/ingest-dev/issues/7825.

Add a callout to the confirmation modal for removing Fleet Server integration:

<img width="1254" height="746" alt="image" src="https://github.com/user-attachments/assets/853b340c-e470-4202-88be-cd080afb762a" />


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->