### PR TITLE
[Alerting v2] Fix rule sidebar header layout and restrict query preview tab to Agent Builder

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.tsx
@@ -122,7 +122,7 @@ export const RuleCanvasContent = ({
       <EuiPanel paddingSize="l" hasShadow={false}>
         <RuleHeaderDescription />
         <EuiSpacer size="m" />
-        <RuleSidebar />
+        <RuleSidebar showQueryPreview />
       </EuiPanel>
     </RuleProvider>
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_sidebar.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_sidebar.test.tsx
@@ -38,19 +38,28 @@ const baseRule: RuleApiResponse = {
   updatedAt: '2026-03-04T12:00:00.000Z',
 };
 
-const renderSidebar = () =>
+import type { RuleSidebarProps } from './rule_sidebar';
+
+const renderSidebar = (props: RuleSidebarProps = {}) =>
   render(
     <I18nProvider>
       <RuleProvider rule={baseRule}>
-        <RuleSidebar />
+        <RuleSidebar {...props} />
       </RuleProvider>
     </I18nProvider>
   );
 
 describe('RuleSidebar', () => {
-  it('renders the tab group with three tabs', () => {
+  it('renders two tabs by default (no query preview)', () => {
     renderSidebar();
     expect(screen.getByTestId('sidebarTabGroup')).toBeInTheDocument();
+    expect(screen.getByText('Conditions')).toBeInTheDocument();
+    expect(screen.queryByText('Query preview')).not.toBeInTheDocument();
+    expect(screen.getByText('Runbook')).toBeInTheDocument();
+  });
+
+  it('renders three tabs when showQueryPreview is true', () => {
+    renderSidebar({ showQueryPreview: true });
     expect(screen.getByText('Conditions')).toBeInTheDocument();
     expect(screen.getByText('Query preview')).toBeInTheDocument();
     expect(screen.getByText('Runbook')).toBeInTheDocument();
@@ -63,8 +72,8 @@ describe('RuleSidebar', () => {
     expect(screen.queryByTestId('mockRunbookTab')).not.toBeInTheDocument();
   });
 
-  it('switches to query preview tab when clicked', () => {
-    renderSidebar();
+  it('switches to query preview tab when clicked (showQueryPreview)', () => {
+    renderSidebar({ showQueryPreview: true });
     fireEvent.click(screen.getByText('Query preview'));
     expect(screen.getByTestId('mockPreviewTab')).toBeInTheDocument();
     expect(screen.queryByTestId('mockConditionsTab')).not.toBeInTheDocument();
@@ -80,7 +89,7 @@ describe('RuleSidebar', () => {
   });
 
   it('switches back to conditions from query preview', () => {
-    renderSidebar();
+    renderSidebar({ showQueryPreview: true });
     fireEvent.click(screen.getByText('Query preview'));
     expect(screen.getByTestId('mockPreviewTab')).toBeInTheDocument();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_sidebar.tsx
@@ -18,36 +18,44 @@ import { RuleSidebarConditionsTab } from './rule_sidebar_conditions_tab';
 import { RuleSidebarPreviewTab } from './rule_sidebar_preview_tab';
 import { RuleSidebarRunbookTab } from './rule_sidebar_runbook_tab';
 
-const SIDEBAR_TAB_OPTIONS = [
-  {
-    id: 'conditions',
-    label: i18n.translate('xpack.alertingV2.sidebar.conditionsTab', {
-      defaultMessage: 'Conditions',
-    }),
-    'data-test-subj': 'sidebarConditionsTab',
-  },
-  {
-    id: 'queryPreview',
-    label: i18n.translate('xpack.alertingV2.sidebar.queryPreviewTab', {
-      defaultMessage: 'Query preview',
-    }),
-    'data-test-subj': 'sidebarQueryPreviewTab',
-  },
-  {
-    id: 'runbook',
-    label: i18n.translate('xpack.alertingV2.sidebar.runbookTab', {
-      defaultMessage: 'Runbook',
-    }),
-    'data-test-subj': 'sidebarRunbookTab',
-  },
-];
+const CONDITIONS_TAB = {
+  id: 'conditions',
+  label: i18n.translate('xpack.alertingV2.sidebar.conditionsTab', {
+    defaultMessage: 'Conditions',
+  }),
+  'data-test-subj': 'sidebarConditionsTab',
+};
 
-export const RuleSidebar: React.FC = () => {
+const QUERY_PREVIEW_TAB = {
+  id: 'queryPreview',
+  label: i18n.translate('xpack.alertingV2.sidebar.queryPreviewTab', {
+    defaultMessage: 'Query preview',
+  }),
+  'data-test-subj': 'sidebarQueryPreviewTab',
+};
+
+const RUNBOOK_TAB = {
+  id: 'runbook',
+  label: i18n.translate('xpack.alertingV2.sidebar.runbookTab', {
+    defaultMessage: 'Runbook',
+  }),
+  'data-test-subj': 'sidebarRunbookTab',
+};
+
+export interface RuleSidebarProps {
+  showQueryPreview?: boolean;
+}
+
+export const RuleSidebar: React.FC<RuleSidebarProps> = ({ showQueryPreview = false }) => {
   const [selectedTab, setSelectedTab] = useState('conditions');
+
+  const tabOptions = showQueryPreview
+    ? [CONDITIONS_TAB, QUERY_PREVIEW_TAB, RUNBOOK_TAB]
+    : [CONDITIONS_TAB, RUNBOOK_TAB];
 
   return (
     <div>
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" wrap>
         <EuiFlexItem grow={false}>
           <EuiTitle size="s">
             <h2>
@@ -62,7 +70,7 @@ export const RuleSidebar: React.FC = () => {
             legend={i18n.translate('xpack.alertingV2.sidebar.tabSelection', {
               defaultMessage: 'Rule conditions view selection',
             })}
-            options={SIDEBAR_TAB_OPTIONS}
+            options={tabOptions}
             idSelected={selectedTab}
             onChange={(id) => setSelectedTab(id)}
             buttonSize="compressed"


### PR DESCRIPTION
## Summary

Closes elastic/rna-program#589

Fixes two bugs on the Rule Details sidebar:

- **Visually broken header** — The "Rule conditions" title and tab button group were forced onto a single row with `responsive={false}`, causing the title to break character-by-character in narrow containers (especially the Agent Builder canvas). Changed to `wrap` so the button group drops below the title when space is limited.
- **Query preview tab leaking** — The "Query preview" tab (introduced in #270484) was rendering on all Rule Details pages instead of only in the Agent Builder interface. Added a `showQueryPreview` prop to `RuleSidebar` (defaults to `false`), which is only set in the Agent Builder canvas content.

In Rule Details
<img width="1458" height="620" alt="Screenshot 2026-06-17 at 9 18 09 PM" src="https://github.com/user-attachments/assets/ec583096-d4c5-47cc-b319-fd7ae210f304" />

In Agent Builder
<img width="1421" height="637" alt="Screenshot 2026-06-17 at 9 22 01 PM" src="https://github.com/user-attachments/assets/e165ce1d-f8f6-49bd-b231-7e96203de48b" />


### Changes

| File | Change |
|------|--------|
| `rule_sidebar.tsx` | Added `showQueryPreview` prop, conditional tab options, flex wrap layout |
| `rule_canvas_content.tsx` | Pass `showQueryPreview` to `RuleSidebar` |
| `rule_sidebar.test.tsx` | Updated tests for 2-tab default, added test for 3-tab `showQueryPreview` mode |

## Test plan

- [ ] Navigate to Rule Details page for any alertingV2 rule
- [ ] Verify only **Conditions** and **Runbook** tabs appear (no "Query preview")
- [ ] Verify the header title and tabs render correctly without visual breakage
- [ ] Navigate to Agent Builder → open a rule attachment canvas
- [ ] Verify all three tabs appear: **Conditions**, **Query preview**, **Runbook**
- [ ] Resize the sidebar/canvas to confirm the header wraps gracefully at narrow widths

### Run unit tests

```bash
node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/
node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/
```

Made with [Cursor](https://cursor.com)