### PR TITLE
[content list][framework] Decouple custom filter registration from toolbar rendering

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/dashboard_listing.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/dashboard_listing.stories.tsx
@@ -20,6 +20,7 @@ import {
 } from '@kbn/content-list';
 import {
   ContentListClientProvider,
+  createFilterControl,
   defineContentListFilter,
   defineContentListSortField,
   type ContentListClientProviderProps,
@@ -74,6 +75,12 @@ const timeRestoreFilter = defineContentListFilter<DashboardMockItem, TimeRestore
     { value: 'restoresTime', label: 'Restores time range' },
     { value: 'usesGlobalTime', label: 'Uses global time' },
   ],
+});
+
+// Registering the dimension above powers KQL search + facet counts; the toolbar
+// control is placed explicitly below.
+const TimeRestoreFilter = createFilterControl(timeRestoreFilter, {
+  'data-test-subj': 'contentListTimeRestoreFilter',
 });
 
 const timeRestoreSort = defineContentListSortField<DashboardMockItem>({
@@ -334,7 +341,14 @@ const ClientProviderExtensionsStory = () => {
         />
         <Section>
           <ContentList emptyState={<DashboardListingEmptyPromptMock />}>
-            <ContentListToolbar />
+            <ContentListToolbar>
+              <Filters>
+                <Filters.Tags />
+                <Filters.CreatedBy />
+                <TimeRestoreFilter />
+                <Filters.Sort />
+              </Filters>
+            </ContentListToolbar>
             <ContentListTable title="Dashboards">
               <Column.Name showDescription showTags />
               <Column

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
@@ -213,6 +213,56 @@ return (
 );
 ```
 
+### Custom filters
+
+Registering a filter dimension and rendering its toolbar control are two separate steps:
+
+- **Register** with `features.filters` (a `ResolvedContentListFilter` from `defineContentListFilter`). This is all that KQL search and facet counts need — a registered dimension filters correctly through the search bar on its own, with no toolbar control.
+- **Place** a control explicitly with `createFilterControl(filterDefinition, opts?)`, which returns a declarative component for the `<Filters>` slot. This mirrors `<recents.RecentsFilter />`: registration never auto-renders a control, so you decide whether and where one appears.
+
+```tsx
+import {
+  ContentListClientProvider,
+  defineContentListFilter,
+  createFilterControl,
+} from '@kbn/content-list-provider-client';
+
+const typeFilter = defineContentListFilter({
+  id: 'contentType',
+  title: 'Type',
+  getItemValue: (item) => item.type,
+  options: [
+    { value: 'dashboard', label: 'Dashboard' },
+    { value: 'visualization', label: 'Visualization' },
+  ],
+});
+
+// Stable identity — define at module scope or memoize.
+const TypeFilter = createFilterControl(typeFilter, {
+  // Optional: render an icon/avatar/color instead of plain text.
+  renderOptionContent: ({ label, value }) => (
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiIcon type={iconByValue.get(value) ?? 'empty'} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>{label}</EuiFlexItem>
+    </EuiFlexGroup>
+  ),
+});
+
+<ContentListClientProvider features={{ filters: { contentType: typeFilter } }} /* … */>
+  <ContentListToolbar>
+    <Filters>
+      <Filters.Tags />
+      <TypeFilter />
+      <Filters.Sort />
+    </Filters>
+  </ContentListToolbar>
+</ContentListClientProvider>;
+```
+
+For full control over the popover, drop `createFilterControl` and use `CustomFilterRenderer` (or `SelectableFilterPopover` from `@kbn/content-list-toolbar`) inside your own `filter.createComponent`.
+
 ### Rendering `<Action.ContentEditor />`
 
 `<Action.ContentEditor />` reads `open` from `features.contentEditor` on the active provider. When the consumer supplies a `contentEditor` config here, the client provider rebuilds it into a base `{ open }` callback so the action can wire itself; if no config is supplied, `open` is `undefined` and the action self-skips, dropping the row icon. Consumers therefore render the action unconditionally — there's no flag to gate on.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
@@ -261,6 +261,8 @@ const TypeFilter = createFilterControl(typeFilter, {
 </ContentListClientProvider>;
 ```
 
+Omit `options` to derive the option list from the values present in the current list (faceted), exactly like the built-in tag and created-by filters — the control then shows only the values that actually occur, each with its live count, instead of a fixed universe with zero-count noise. Provide `options` only when you want a fixed set (including values not currently present).
+
 For full control over the popover, drop `createFilterControl` and use `CustomFilterRenderer` (or `SelectableFilterPopover` from `@kbn/content-list-toolbar`) inside your own `filter.createComponent`.
 
 ### Rendering `<Action.ContentEditor />`

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
@@ -24,6 +24,10 @@ export type {
   ResolvedContentListFilter,
 } from './src/filters';
 export { useClientFilterCounts } from './src/use_client_filter_counts';
+export { CustomFilterRenderer } from './src/custom_filter_renderer';
+export type { CustomFilterRendererProps, CustomFilterOption } from './src/custom_filter_renderer';
+export { createFilterControl } from './src/create_filter_control';
+export type { CreateFilterControlOptions } from './src/create_filter_control';
 export { defineContentListSortField } from './src/sorting';
 export type {
   ContentListSortField,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/create_filter_control.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/create_filter_control.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import { filter, type FilterContext } from '@kbn/content-list-toolbar';
+import { createFilterControl } from './create_filter_control';
+import { defineContentListFilter } from './filters';
+
+const context: FilterContext = {
+  hasSorting: true,
+  hasTags: true,
+  hasStarred: true,
+  hasCreatedBy: true,
+};
+
+const contentTypeFilter = defineContentListFilter({
+  id: 'contentType',
+  title: 'Content type',
+  getItemValue: (item: UserContentCommonSchema) => item.type,
+});
+
+describe('createFilterControl', () => {
+  it('produces a declarative control that resolves to a placeable custom_component', () => {
+    const Control = createFilterControl(contentTypeFilter, {
+      'data-test-subj': 'contentListContentTypeFilter',
+    });
+
+    const parts = filter.parseChildren(<Control />);
+    expect(parts).toHaveLength(1);
+
+    const config = filter.resolve(parts[0], context);
+    expect(config).toMatchObject({ type: 'custom_component' });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/create_filter_control.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/create_filter_control.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { type ComponentType } from 'react';
+import { filter } from '@kbn/content-list-toolbar';
+import { CustomFilterRenderer, type CustomFilterRendererProps } from './custom_filter_renderer';
+import type { ResolvedContentListFilter } from './filters';
+
+/** Options for {@link createFilterControl}. */
+export interface CreateFilterControlOptions {
+  /** Custom option renderer — see {@link CustomFilterRendererProps.renderOptionContent}. */
+  renderOptionContent?: CustomFilterRendererProps['renderOptionContent'];
+  /** `data-test-subj` for the filter popover button. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Builds a declarative toolbar control for a registered filter dimension.
+ *
+ * Registering a filter via `features.filters` powers KQL search and facet
+ * counts; it does **not** render a toolbar control. Call this to obtain a
+ * component for the `<Filters>` slot, placing it wherever it belongs:
+ *
+ * @example
+ * ```tsx
+ * const TypeFilter = createFilterControl(typeFilter, {
+ *   renderOptionContent: ({ label, value }) => (
+ *     <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+ *       <EuiIcon type={iconByValue.get(value) ?? 'empty'} />
+ *       <span>{label}</span>
+ *     </EuiFlexGroup>
+ *   ),
+ * });
+ *
+ * <Filters>
+ *   <Filters.Tags />
+ *   <TypeFilter />
+ *   <Filters.Sort />
+ * </Filters>
+ * ```
+ *
+ * Returns a fresh component each call, so memoize (or define at module scope)
+ * for a stable identity — mirrors `useRecentlyAccessedDecoration`.
+ */
+export const createFilterControl = (
+  filterDefinition: ResolvedContentListFilter,
+  { renderOptionContent, 'data-test-subj': dataTestSubj }: CreateFilterControlOptions = {}
+): ComponentType<Record<never, never>> =>
+  filter.createComponent<Record<never, never>>({
+    resolve: () => ({
+      type: 'custom_component',
+      component: (props) => (
+        <CustomFilterRenderer
+          {...props}
+          filterDefinition={filterDefinition}
+          renderOptionContent={renderOptionContent}
+          data-test-subj={dataTestSubj}
+        />
+      ),
+    }),
+  });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import { CustomFilterRenderer } from './custom_filter_renderer';
+import { defineContentListFilter } from './filters';
+import { useClientFilterCounts } from './use_client_filter_counts';
+
+jest.mock('./use_client_filter_counts');
+
+const mockUseClientFilterCounts = useClientFilterCounts as jest.Mock;
+
+type TypedItem = UserContentCommonSchema & { typeTitle?: string };
+
+describe('CustomFilterRenderer', () => {
+  const openPopover = () => fireEvent.click(screen.getByTestId('testFilter'));
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('derives options from live facet counts when the dimension has no static options', () => {
+    const dimension = defineContentListFilter<TypedItem>({
+      id: 'visualizationType',
+      queryField: 'typeTitle',
+      title: 'Type',
+      getItemValue: (item) => item.typeTitle,
+    });
+    mockUseClientFilterCounts.mockReturnValue(
+      new Map([
+        ['Pie', 1],
+        ['Area', 3],
+      ])
+    );
+
+    render(<CustomFilterRenderer filterDefinition={dimension} data-test-subj="testFilter" />);
+    openPopover();
+
+    const list = screen.getByTestId('testFilter-list');
+    const labels = Array.from(list.querySelectorAll('li')).map((li) => li.textContent ?? '');
+    // Only the values present in the current list, sorted by label.
+    expect(labels.some((text) => text.includes('Area'))).toBe(true);
+    expect(labels.some((text) => text.includes('Pie'))).toBe(true);
+    expect(labels.findIndex((t) => t.includes('Area'))).toBeLessThan(
+      labels.findIndex((t) => t.includes('Pie'))
+    );
+  });
+
+  it('uses the static option universe when the dimension declares one', () => {
+    const dimension = defineContentListFilter<TypedItem>({
+      id: 'visualizationType',
+      queryField: 'typeTitle',
+      title: 'Type',
+      getItemValue: (item) => item.typeTitle,
+      options: [
+        { value: 'Area', label: 'Area chart' },
+        { value: 'Pie', label: 'Pie chart' },
+      ],
+    });
+    mockUseClientFilterCounts.mockReturnValue(new Map([['Area', 3]]));
+
+    render(<CustomFilterRenderer filterDefinition={dimension} data-test-subj="testFilter" />);
+    openPopover();
+
+    expect(screen.getByText('Area chart')).toBeInTheDocument();
+    // Declared options render even with a zero count.
+    expect(screen.getByText('Pie chart')).toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
@@ -54,16 +54,25 @@ export const CustomFilterRenderer = ({
   const idTail = filterDefinition.id.slice(1);
   const fallbackDataTestSubj = `contentList${idHead}${idTail}Filter`;
 
-  const options = useMemo(
-    (): Array<SelectableFilterOption> =>
-      filterDefinition.getOptions().map((option) => ({
-        key: option.value,
-        label: option.label,
-        value: option.label,
-        count: countByKey.get(option.value) ?? 0,
-      })),
-    [countByKey, filterDefinition]
-  );
+  const options = useMemo((): Array<SelectableFilterOption> => {
+    const toOption = (value: string, label: string): SelectableFilterOption => ({
+      key: value,
+      label,
+      value: label,
+      count: countByKey.get(value) ?? 0,
+    });
+
+    const known = filterDefinition.getOptions();
+    if (known.length > 0) {
+      return known.map((option) => toOption(option.value, option.label));
+    }
+
+    // No static option universe: derive options from the values present in the
+    // current list (faceted), mirroring the built-in tag and created-by facets.
+    return [...countByKey.keys()]
+      .sort((a, b) => a.localeCompare(b))
+      .map((value) => toOption(value, filterDefinition.getLabelForValue(value) ?? value));
+  }, [countByKey, filterDefinition]);
 
   const renderOption = useCallback(
     (option: SelectableFilterOption, state: { isActive: boolean }) => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, type ReactNode } from 'react';
 import { EuiText, type Query } from '@elastic/eui';
 import {
   SelectableFilterPopover,
@@ -17,10 +17,27 @@ import {
 import type { ResolvedContentListFilter } from './filters';
 import { useClientFilterCounts } from './use_client_filter_counts';
 
-interface CustomFilterRendererProps {
+/** A single option surfaced to {@link CustomFilterRendererProps.renderOptionContent}. */
+export interface CustomFilterOption {
+  /** Stored filter value (the KQL value, also the facet-count key). */
+  value: string;
+  /** Display label. */
+  label: string;
+  /** Item count for this value. */
+  count: number;
+}
+
+export interface CustomFilterRendererProps {
   query?: Query;
   onChange?: (query: Query) => void;
   filterDefinition: ResolvedContentListFilter;
+  /**
+   * Renders the content of a single option, inside the standard count-badge
+   * row. Defaults to the option label as plain text. Supply this to add an
+   * icon, color, avatar, etc. — the same extension point the built-in tag and
+   * created-by filters use.
+   */
+  renderOptionContent?: (option: CustomFilterOption, state: { isActive: boolean }) => ReactNode;
   'data-test-subj'?: string;
 }
 
@@ -28,6 +45,7 @@ export const CustomFilterRenderer = ({
   query,
   onChange,
   filterDefinition,
+  renderOptionContent,
   'data-test-subj': dataTestSubj,
 }: CustomFilterRendererProps) => {
   const countByKey = useClientFilterCounts(filterDefinition.fieldName);
@@ -48,17 +66,28 @@ export const CustomFilterRenderer = ({
   );
 
   const renderOption = useCallback(
-    (option: SelectableFilterOption, state: { isActive: boolean }) => (
-      <StandardFilterOption count={option.count} isActive={state.isActive}>
-        <EuiText
-          size="s"
-          data-test-subj={`${filterDefinition.fieldName}-searchbar-option-${option.key}`}
-        >
-          {option.label}
-        </EuiText>
-      </StandardFilterOption>
-    ),
-    [filterDefinition.fieldName]
+    (option: SelectableFilterOption, state: { isActive: boolean }) => {
+      const customOption: CustomFilterOption = {
+        value: option.key,
+        label: option.label,
+        count: option.count ?? 0,
+      };
+      return (
+        <StandardFilterOption count={customOption.count} isActive={state.isActive}>
+          {renderOptionContent ? (
+            renderOptionContent(customOption, { isActive: state.isActive })
+          ) : (
+            <EuiText
+              size="s"
+              data-test-subj={`${filterDefinition.fieldName}-searchbar-option-${customOption.value}`}
+            >
+              {customOption.label}
+            </EuiText>
+          )}
+        </StandardFilterOption>
+      );
+    },
+    [filterDefinition.fieldName, renderOptionContent]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/filters.ts
@@ -46,7 +46,11 @@ export interface ContentListFilterDefinition<
   queryField?: string;
   /** Extracts the filterable value(s) from a single item. */
   getItemValue: (item: TItem) => MaybeArray<TValue>;
-  /** Static option list or a descriptor for deriving options from a data array. */
+  /**
+   * Static option list or a descriptor for deriving options from a data array.
+   * Omit to let the toolbar control derive options from the values present in
+   * the current list (faceted), like the built-in tag and created-by filters.
+   */
   options?: ContentListFilterOptions<TOption, TValue>;
   /** Shown when the option list is empty. */
   emptyMessage?: string;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.test.tsx
@@ -242,12 +242,12 @@ describe('ContentListClientProvider', () => {
         }),
       });
 
+      // Registration wires the KQL field + client-side filtering, but does not
+      // auto-render a toolbar control (placement is explicit via
+      // `createFilterControl`).
       expect(result.current.features.fields).toEqual([
         expect.objectContaining({ fieldName: 'contentType' }),
       ]);
-      expect(result.current.features.toolbarFilters?.contentType).toMatchObject({
-        type: 'custom_component',
-      });
       await expect(
         findIds(result.current.dataSource, {
           filters: { contentType: { include: ['visualization'] } },

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
@@ -8,7 +8,6 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import type { SearchFilterConfig } from '@elastic/eui';
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
 import type {
   ContentEditorFeatureConfig,
@@ -56,7 +55,6 @@ import { ClientStrategyContext } from './client_strategy_context';
 import type { ClientStrategyContextValue } from './client_strategy_context';
 import { defineContentListFilter, type ContentListFilterMap } from './filters';
 import type { ResolvedContentListFilter } from './filters';
-import { CustomFilterRenderer } from './custom_filter_renderer';
 import type { ContentListSortFieldMap } from './sorting';
 import { resolveSortFieldMap, toSortField } from './sorting';
 
@@ -513,18 +511,14 @@ const ContentListClientProviderInner = ({
 
   // Rewrite the client-flavored `contentEditor` config into the base
   // `{ open }` shape (or drop it). Every other field passes through unchanged.
+  // Custom filters are *registered* here (KQL field definitions + client-side
+  // filtering/facet counts via `filterDimensions`), but never auto-rendered in
+  // the toolbar. Consumers place a control explicitly with
+  // `createFilterControl` / `CustomFilterRenderer`, so registration and
+  // placement stay decoupled — see `RecentsFilterRenderer` for the same shape.
   const features: ContentListFeatures = useMemo(() => {
     const baseContentEditor: ContentEditorFeatureConfig | undefined = open ? { open } : undefined;
     const { filters: _filters, sorting: _sorting, ...baseFeatures } = featuresProp;
-    const toolbarFilters: Record<string, SearchFilterConfig> = Object.fromEntries(
-      Object.values(customFilters).map((filter) => [
-        filter.id,
-        {
-          type: 'custom_component' as const,
-          component: (props) => <CustomFilterRenderer {...props} filterDefinition={filter} />,
-        },
-      ])
-    );
     return {
       ...baseFeatures,
       sorting: sortingFeature,
@@ -532,7 +526,6 @@ const ContentListClientProviderInner = ({
         ...(featuresProp.fields ?? []),
         ...Object.values(customFilters).map((filter) => filter.toFieldDefinition()),
       ],
-      toolbarFilters,
       tags: tagsFeature,
       userProfiles: userProfilesFeature,
       contentEditor: baseContentEditor,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/types.ts
@@ -58,7 +58,7 @@ export interface ContentListClientSortingConfig extends Omit<SortingConfig, 'fie
 }
 
 export interface ContentListClientFeatures
-  extends Omit<ContentListFeatures, 'contentEditor' | 'sorting' | 'toolbarFilters'> {
+  extends Omit<ContentListFeatures, 'contentEditor' | 'sorting'> {
   /**
    * Content editor (metadata editing flyout) feature configuration.
    */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
@@ -163,15 +163,6 @@ export interface ContentListFeatures {
   flags?: FlagDefinition[];
 
   /**
-   * Toolbar filter configs compiled by a provider variant.
-   *
-   * Internal pass-through from a provider to {@link `@kbn/content-list-toolbar`};
-   * the toolbar narrows each value to `SearchFilterConfig` at the consumption
-   * site, keeping the EUI dependency out of this base package's public types.
-   */
-  toolbarFilters?: Record<string, unknown>;
-
-  /**
    * Content editor configuration. See {@link ContentEditorFeatureConfig}.
    * Populated automatically by the client provider.
    */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
@@ -76,16 +76,20 @@ const parseFilterParts = (children: ReactNode): ParsedPart[] => {
  * 1. Extract `<Filters>` children from the toolbar's children.
  * 2. Parse declarative `Filter` presets via `filter.parseChildren`.
  * 3. Resolve `SearchFilterConfig` objects via `filter.resolve`.
- * 4. Fall back to default filters (tags + sort) if none are found.
+ * 4. Fall back to default filters (starred + tags + created by + sort) if none are found.
+ *
+ * Custom (consumer-registered) filters are *not* rendered automatically; a
+ * registered filter dimension powers KQL search and facet counts on its own,
+ * and its toolbar control is placed explicitly via `filter.createComponent`
+ * (see `createFilterControl` in `@kbn/content-list-provider-client`).
  *
  * @param children - React children from the toolbar component.
  * @returns Array of EUI search filter configs ready for `EuiSearchBar`.
  */
 export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
   const { isSupported: hasSorting } = useContentListSort();
-  const { features, supports } = useContentListConfig();
+  const { supports } = useContentListConfig();
   const { tags: hasTags, starred: hasStarred, userProfiles: hasCreatedBy } = supports;
-  const toolbarFilters = features.toolbarFilters;
 
   // Note: `children` is used as a memo dependency. React children are often
   // unstable references (new JSX objects each render), so this memo may
@@ -95,27 +99,8 @@ export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
     const parts = parseFilterParts(children);
     const context: FilterContext = { hasSorting, hasTags, hasStarred, hasCreatedBy };
 
-    const resolvedParts = parts
-      .map((part) => ({ part, filterConfig: filter.resolve(part, context) }))
-      .filter(
-        (entry): entry is { part: ParsedPart; filterConfig: SearchFilterConfig } =>
-          entry.filterConfig !== undefined
-      );
-    // `toolbarFilters` is typed `Record<string, unknown>` in the base provider
-    // package to keep `@elastic/eui` out of its public types; the client
-    // provider always populates entries as {@link SearchFilterConfig}, so we
-    // narrow them at the consumption site.
-    const customFilters = Object.values(toolbarFilters ?? {}) as SearchFilterConfig[];
-    if (parts === DEFAULT_PARTS) {
-      const sortIndex = resolvedParts.findIndex((entry) => entry.part.preset === 'sort');
-      if (sortIndex >= 0) {
-        return [
-          ...resolvedParts.slice(0, sortIndex).map(({ filterConfig }) => filterConfig),
-          ...customFilters,
-          ...resolvedParts.slice(sortIndex).map(({ filterConfig }) => filterConfig),
-        ];
-      }
-    }
-    return [...resolvedParts.map(({ filterConfig }) => filterConfig), ...customFilters];
-  }, [children, hasSorting, hasTags, hasStarred, hasCreatedBy, toolbarFilters]);
+    return parts
+      .map((part) => filter.resolve(part, context))
+      .filter((filterConfig): filterConfig is SearchFilterConfig => filterConfig !== undefined);
+  }, [children, hasSorting, hasTags, hasStarred, hasCreatedBy]);
 };


### PR DESCRIPTION
## Summary

In the Content List framework, registering a custom filter dimension did two things at once: it wired up KQL search + facet counts (correct), **and** it auto-appended a filter control to the toolbar in a fixed position (a hidden side effect). There was no way to register a dimension without rendering a control, nor to choose where the control goes.

This was inconsistent with every other toolbar affordance. Built-in presets (`<Filters.Tags />`, `<Filters.Sort />`) and the recently-accessed filter (`<recents.RecentsFilter />`) are all placed **explicitly** by the consumer inside `<Filters>`. Custom filters were the lone exception, and the only escape hatches were hacky (register-then-hide, or a throwaway preset).

The deviation surfaced while exploring a proposed consumer-defined "type" filter, but the fix is purely a framework concern.

### Change

Registration and placement are now two separate, composable steps:

- **Register** a dimension via `features.filters` — this is all KQL search and client-side facet counts need. A registered dimension filters correctly through the search bar on its own, with no toolbar control.
- **Place** a control explicitly with the new `createFilterControl(filterDefinition, opts?)` helper, which returns a declarative component for the `<Filters>` slot — exactly mirroring `<recents.RecentsFilter />`.

Details:

- The client provider no longer emits `toolbarFilters`; it only registers the KQL `fields` definitions.
- The toolbar's `useFilters` resolves declarative `<Filters>` children only — no provider-supplied append step.
- `toolbarFilters` is removed from `ContentListFeatures` (it was internal to the content_list packages — no external consumers).
- `CustomFilterRenderer` is now exported and gains an optional `renderOptionContent`, so a control can render icons / avatars / colors instead of plain text (the same extension point the tag and created-by filters already use).
- A registered dimension that declares no static `options` now derives its toolbar options from the values present in the current list (faceted, with live counts), matching the built-in tag/created-by facets instead of a fixed universe with zero-count noise. Declaring `options` keeps the fixed-universe behaviour.

### Demo / docs

The dashboard storybook (`Content List/Dashboard Listing` → `ClientProviderExtensions`) now places its `timeRestore` filter explicitly via `createFilterControl`, and the provider-client README documents the register-vs-place split.

## Test plan

- [ ] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client` (includes `custom_filter_renderer.test.tsx` covering static vs. faceted options)
- [ ] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.test.tsx`
- [ ] Storybook: `Content List/Dashboard Listing` → `ClientProviderExtensions` — the "Time behavior" filter renders in the toolbar and filters the list.
