### PR TITLE
[ResponseOps] Add per-rule-type CODEOWNERS for @kbn/response-ops-rule-params

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1107,41 +1107,6 @@ x-pack/platform/packages/shared/response-ops/recurring-schedule-form @elastic/re
 x-pack/platform/packages/shared/response-ops/retry-service @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/rule_form @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/rule_params @elastic/response-ops
-x-pack/platform/packages/shared/response-ops/rule_params/anomaly_detection @elastic/ml-ui
-x-pack/platform/packages/shared/response-ops/rule_params/anomaly_detection_jobs_health @elastic/ml-ui
-x-pack/platform/packages/shared/response-ops/rule_params/apm_anomaly @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/ccr_read_exceptions @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/cluster_health @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/cpu_usage @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/custom_threshold @elastic/actionable-obs-team
-x-pack/platform/packages/shared/response-ops/rule_params/degraded_docs @elastic/kibana-management
-x-pack/platform/packages/shared/response-ops/rule_params/disk_usage @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/error_count @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/es_query @elastic/response-ops
-x-pack/platform/packages/shared/response-ops/rule_params/es_version_mismatch @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/geo_containment @elastic/kibana-presentation
-x-pack/platform/packages/shared/response-ops/rule_params/index_threshold @elastic/response-ops
-x-pack/platform/packages/shared/response-ops/rule_params/kibana_version_mismatch @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/large_shard_size @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/license_expiration @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/log_threshold @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/logstash_version_mismatch @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/memory_usage @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/metric_inventory_threshold @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/metric_threshold @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/missing_monitoring_data @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/nodes_changed @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/slo_burn_rate @elastic/actionable-obs-team
-x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status @elastic/actionable-obs-team
-x-pack/platform/packages/shared/response-ops/rule_params/synthetics_tls @elastic/actionable-obs-team
-x-pack/platform/packages/shared/response-ops/rule_params/thread_pool_search_rejections @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/thread_pool_write_rejections @elastic/stack-monitoring
-x-pack/platform/packages/shared/response-ops/rule_params/transaction_duration @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/transaction_error_rate @elastic/obs-presentation-team @elastic/obs-exploration-team
-x-pack/platform/packages/shared/response-ops/rule_params/transform_health @elastic/kibana-management
-x-pack/platform/packages/shared/response-ops/rule_params/uptime_duration_anomaly @elastic/actionable-obs-team
-x-pack/platform/packages/shared/response-ops/rule_params/uptime_monitor_status @elastic/actionable-obs-team
-x-pack/platform/packages/shared/response-ops/rule_params/uptime_tls @elastic/actionable-obs-team
 x-pack/platform/packages/shared/response-ops/rules-apis @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/scheduling-types @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/yaml-rule-editor @elastic/response-ops
@@ -1435,6 +1400,45 @@ x-pack/solutions/workplaceai/test @elastic/workchat-eng
 ## Items lower in the file have higher precedence:
 ##  https://help.github.com/articles/about-codeowners/
 ####
+
+# Per-rule-type ownership inside @kbn/response-ops-rule-params.
+# The package-level entry (@elastic/response-ops) is auto-generated above;
+# these overrides narrow ownership to the team responsible for each rule type.
+x-pack/platform/packages/shared/response-ops/rule_params/anomaly_detection @elastic/ml-ui
+x-pack/platform/packages/shared/response-ops/rule_params/anomaly_detection_jobs_health @elastic/ml-ui
+x-pack/platform/packages/shared/response-ops/rule_params/apm_anomaly @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/ccr_read_exceptions @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/cluster_health @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/cpu_usage @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/custom_threshold @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/degraded_docs @elastic/kibana-management
+x-pack/platform/packages/shared/response-ops/rule_params/disk_usage @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/error_count @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/es_query @elastic/response-ops
+x-pack/platform/packages/shared/response-ops/rule_params/es_version_mismatch @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/geo_containment @elastic/kibana-presentation
+x-pack/platform/packages/shared/response-ops/rule_params/index_threshold @elastic/response-ops
+x-pack/platform/packages/shared/response-ops/rule_params/kibana_version_mismatch @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/large_shard_size @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/license_expiration @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/log_threshold @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/logstash_version_mismatch @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/memory_usage @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/metric_inventory_threshold @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/metric_threshold @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/missing_monitoring_data @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/nodes_changed @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/slo_burn_rate @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/synthetics_tls @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/thread_pool_search_rejections @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/thread_pool_write_rejections @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/transaction_duration @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/transaction_error_rate @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/transform_health @elastic/kibana-management
+x-pack/platform/packages/shared/response-ops/rule_params/uptime_duration_anomaly @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/uptime_monitor_status @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/uptime_tls @elastic/actionable-obs-team
 
 # limits.yml changes frequently as bundle sizes shift; no owner means the ops
 # team isn't auto-requested as reviewer on every bump. A GitHub Actions workflow

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1107,6 +1107,41 @@ x-pack/platform/packages/shared/response-ops/recurring-schedule-form @elastic/re
 x-pack/platform/packages/shared/response-ops/retry-service @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/rule_form @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/rule_params @elastic/response-ops
+x-pack/platform/packages/shared/response-ops/rule_params/anomaly_detection @elastic/ml-ui
+x-pack/platform/packages/shared/response-ops/rule_params/anomaly_detection_jobs_health @elastic/ml-ui
+x-pack/platform/packages/shared/response-ops/rule_params/apm_anomaly @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/ccr_read_exceptions @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/cluster_health @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/cpu_usage @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/custom_threshold @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/degraded_docs @elastic/kibana-management
+x-pack/platform/packages/shared/response-ops/rule_params/disk_usage @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/error_count @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/es_query @elastic/response-ops
+x-pack/platform/packages/shared/response-ops/rule_params/es_version_mismatch @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/geo_containment @elastic/kibana-presentation
+x-pack/platform/packages/shared/response-ops/rule_params/index_threshold @elastic/response-ops
+x-pack/platform/packages/shared/response-ops/rule_params/kibana_version_mismatch @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/large_shard_size @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/license_expiration @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/log_threshold @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/logstash_version_mismatch @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/memory_usage @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/metric_inventory_threshold @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/metric_threshold @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/missing_monitoring_data @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/nodes_changed @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/slo_burn_rate @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/synthetics_tls @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/thread_pool_search_rejections @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/thread_pool_write_rejections @elastic/stack-monitoring
+x-pack/platform/packages/shared/response-ops/rule_params/transaction_duration @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/transaction_error_rate @elastic/obs-presentation-team @elastic/obs-exploration-team
+x-pack/platform/packages/shared/response-ops/rule_params/transform_health @elastic/kibana-management
+x-pack/platform/packages/shared/response-ops/rule_params/uptime_duration_anomaly @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/uptime_monitor_status @elastic/actionable-obs-team
+x-pack/platform/packages/shared/response-ops/rule_params/uptime_tls @elastic/actionable-obs-team
 x-pack/platform/packages/shared/response-ops/rules-apis @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/scheduling-types @elastic/response-ops
 x-pack/platform/packages/shared/response-ops/yaml-rule-editor @elastic/response-ops


### PR DESCRIPTION
## Summary

The `@kbn/response-ops-rule-params` package centralises params schemas for all rule types, but previously had a single `@elastic/response-ops` owner for the entire package. This PR adds per-subdirectory CODEOWNERS entries so that each rule-type schema directory gets reviewed by the team that owns that rule type.

### Ownership added

| Team | Subdirectories |
|---|---|
| `@elastic/ml-ui` | `anomaly_detection`, `anomaly_detection_jobs_health` |
| `@elastic/obs-presentation-team` + `@elastic/obs-exploration-team` | `apm_anomaly`, `error_count`, `metric_inventory_threshold`, `metric_threshold`, `transaction_duration`, `transaction_error_rate` |
| `@elastic/stack-monitoring` | `ccr_read_exceptions`, `cluster_health`, `cpu_usage`, `disk_usage`, `es_version_mismatch`, `kibana_version_mismatch`, `large_shard_size`, `license_expiration`, `logstash_version_mismatch`, `memory_usage`, `missing_monitoring_data`, `nodes_changed`, `thread_pool_search_rejections`, `thread_pool_write_rejections` |
| `@elastic/actionable-obs-team` | `custom_threshold`, `slo_burn_rate`, `synthetics_monitor_status`, `synthetics_tls`, `uptime_duration_anomaly`, `uptime_monitor_status`, `uptime_tls` |
| `@elastic/kibana-management` | `degraded_docs`, `transform_health` |
| `@elastic/obs-exploration-team` | `log_threshold` |
| `@elastic/kibana-presentation` | `geo_containment` |
| `@elastic/response-ops` (inherited) | `es_query`, `index_threshold`, `common` |

The package-level `@elastic/response-ops` entry is kept so that package-wide files (`index.ts`, `v1.ts`, `README.md`, etc.) remain owned by response-ops.
