### PR TITLE
[Chrome Next] Add disabled and toolTipContent to AppHeaderTab

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -45,6 +45,13 @@ const tabs: AppHeaderTab[] = [
   { id: 'overview', label: 'Overview', isSelected: true, onClick: action('tab-overview') },
   { id: 'alerts', label: 'Alerts', badge: 3, onClick: action('tab-alerts') },
   { id: 'settings', label: 'Settings', onClick: action('tab-settings') },
+  {
+    id: 'logs',
+    label: 'Logs',
+    onClick: action('tab-logs'),
+    disabled: true,
+    toolTipContent: 'Logs are disabled for this app',
+  },
 ];
 
 const metadata: AppHeaderMetadataItems = [

--- a/src/core/packages/chrome/app-header/src/app_header/app_tabs.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_tabs.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { EuiNotificationBadge, EuiTab, EuiTabs } from '@elastic/eui';
+import { EuiNotificationBadge, EuiTab, EuiTabs, EuiToolTip } from '@elastic/eui';
 import type { AppHeaderTab } from '../types';
 
 export interface AppTabsProps {
@@ -27,6 +27,7 @@ export const AppTabs = React.memo<AppTabsProps>(({ tabs }) => {
           onClick={tab.onClick}
           href={tab.href}
           data-test-subj={tab['data-test-subj']}
+          disabled={tab.disabled}
           append={
             tab.badge !== undefined ? (
               <EuiNotificationBadge color="subdued" size="m">
@@ -35,7 +36,13 @@ export const AppTabs = React.memo<AppTabsProps>(({ tabs }) => {
             ) : undefined
           }
         >
-          {tab.label}
+          {tab.toolTipContent !== undefined ? (
+            <EuiToolTip content={tab.toolTipContent} position="bottom">
+              <span tabIndex={0}>{tab.label}</span>
+            </EuiToolTip>
+          ) : (
+            tab.label
+          )}
         </EuiTab>
       ))}
     </EuiTabs>

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -63,6 +63,8 @@ export interface AppHeaderTab {
   href?: string;
   badge?: number;
   'data-test-subj'?: string;
+  disabled?: boolean;
+  toolTipContent?: string;
 }
 
 /** @public */


### PR DESCRIPTION
## Summary

This PR adds `disabled` and `toolTipContent` props to `AppHeaderTab`


