### PR TITLE
[9.3] chore(deps): upgrade dompurify from 3.4.1 to 3.4.11 (#273787)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1296,7 +1296,7 @@
     "del": "6.1.1",
     "diff": "8.0.4",
     "dom-to-image-more": "3.6.0",
-    "dompurify": "3.4.1",
+    "dompurify": "3.4.11",
     "dotenv": "17.2.4",
     "elastic-apm-node": "4.15.0",
     "email-addresses": "5.0.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -85,7 +85,7 @@ export const PER_PACKAGE_ALLOWED_LICENSES = {
   'openpgp@5.11.3': ['LGPL-3.0+'],
   '@img/sharp-libvips-linuxmusl-x64@1.2.3': ['LGPL-3.0-or-later'],
   '@img/sharp-libvips-linux-x64@1.2.3': ['LGPL-3.0-or-later'],
-  'dompurify@3.4.1': ['(MPL-2.0 OR Apache-2.0)'],
+  'dompurify@3.4.11': ['(MPL-2.0 OR Apache-2.0)'],
 };
 // Globally overrides a license for a given package@version
 export const LICENSE_OVERRIDES = {

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
@@ -54,7 +54,7 @@ css-loader@7.1.2
 css-tree@1.1.3
 cssesc@3.0.0
 csstype@3.1.2
-dompurify@3.4.1
+dompurify@3.4.11
 electron-to-chromium@1.5.321
 enhanced-resolve@5.20.0
 error-stack-parser@2.0.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -19770,10 +19770,10 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@3.4.1, dompurify@^3.2.4:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.1.tgz#521d04483ac12631b2aedf434a5f5390933b8789"
-  integrity sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==
+dompurify@3.4.11, dompurify@^3.2.4:
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
+  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [chore(deps): upgrade dompurify from 3.4.1 to 3.4.11 (#273787)](https://github.com/elastic/kibana/pull/273787)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-06-18T06:18:47Z","message":"chore(deps): upgrade dompurify from 3.4.1 to 3.4.11 (#273787)\n\n## Summary\n\nUpgrades the `dompurify` dependency from `3.4.1` to `3.4.11` (latest).\n\n## Changes\n\n- Bumped `dompurify` in `package.json` from `3.4.1` → `3.4.11`\n- Updated `yarn.lock` with the new resolved version\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` succeeds\n- [ ] No type errors introduced (`yarn tsc --noEmit`)\n- [ ] Existing unit tests pass for any code that uses `dompurify`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"52cdb065c0f041d02b969c04509e2fc683828263","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0","v9.4.3"],"title":"chore(deps): upgrade dompurify from 3.4.1 to 3.4.11","number":273787,"url":"https://github.com/elastic/kibana/pull/273787","mergeCommit":{"message":"chore(deps): upgrade dompurify from 3.4.1 to 3.4.11 (#273787)\n\n## Summary\n\nUpgrades the `dompurify` dependency from `3.4.1` to `3.4.11` (latest).\n\n## Changes\n\n- Bumped `dompurify` in `package.json` from `3.4.1` → `3.4.11`\n- Updated `yarn.lock` with the new resolved version\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` succeeds\n- [ ] No type errors introduced (`yarn tsc --noEmit`)\n- [ ] Existing unit tests pass for any code that uses `dompurify`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"52cdb065c0f041d02b969c04509e2fc683828263"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273787","number":273787,"mergeCommit":{"message":"chore(deps): upgrade dompurify from 3.4.1 to 3.4.11 (#273787)\n\n## Summary\n\nUpgrades the `dompurify` dependency from `3.4.1` to `3.4.11` (latest).\n\n## Changes\n\n- Bumped `dompurify` in `package.json` from `3.4.1` → `3.4.11`\n- Updated `yarn.lock` with the new resolved version\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` succeeds\n- [ ] No type errors introduced (`yarn tsc --noEmit`)\n- [ ] Existing unit tests pass for any code that uses `dompurify`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"52cdb065c0f041d02b969c04509e2fc683828263"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/273870","number":273870,"state":"MERGED","mergeCommit":{"sha":"06882539dcecb68c4078855e6c523a17c2bfb68e","message":"[9.4] chore(deps): upgrade dompurify from 3.4.1 to 3.4.11 (#273787) (#273870)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [chore(deps): upgrade dompurify from 3.4.1 to 3.4.11\n(#273787)](https://github.com/elastic/kibana/pull/273787)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"}}]}] BACKPORT-->