### PR TITLE
[9.3] chore: bump defend-workflows disk space to 125gb (#273896)

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -260,8 +260,8 @@ steps:
     label: 'Defend Workflows Cypress Tests'
     agents:
       enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 120
+      machineType: n2-highmem-4
+      diskSizeGb: 125
     depends_on:
       - build
     timeout_in_minutes: 75

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -280,8 +280,8 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
-          machineType: n2-standard-4
-          diskSizeGb: 120
+          machineType: n2-highmem-4
+          diskSizeGb: 125
         depends_on: build
         timeout_in_minutes: 75
         parallelism: 12

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -74,8 +74,8 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 120
+      machineType: n2-highmem-4
+      diskSizeGb: 125
     timeout_in_minutes: 75
     parallelism: 20
     key: defend-workflows-stateful
@@ -92,8 +92,8 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 120
+      machineType: n2-highmem-4
+      diskSizeGb: 125
     timeout_in_minutes: 75
     parallelism: 14
     key: defend-workflows-serverless

--- a/.buildkite/pipelines/node_glibc_217.yml
+++ b/.buildkite/pipelines/node_glibc_217.yml
@@ -1,5 +1,5 @@
 env:
-  CI_FORCE_NODE_POINTER_COMPRESSION: true
+  CI_FORCE_NODE_GLIBC_217: true
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
@@ -25,8 +25,6 @@ steps:
       preemptible: true
     key: build
     timeout_in_minutes: 60
-    env:
-      CI_FORCE_NODE_POINTER_COMPRESSION: false
     retry:
       automatic:
         - exit_status: '*'
@@ -41,7 +39,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
@@ -67,6 +65,144 @@ steps:
     retry:
       automatic:
         - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
+    label: 'Serverless Entity Analytics - Security Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
+    label: 'Serverless Explore - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
+    label: 'Serverless Investigations - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      diskSizeGb: 110
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 11
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
+    label: 'Serverless Rule Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      diskSizeGb: 120
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 6
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
@@ -154,6 +290,40 @@ steps:
         - exit_status: '-1'
           limit: 1
 
+  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
+    label: 'Serverless Detection Engine - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 7
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
+    label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 4
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
@@ -188,6 +358,22 @@ steps:
         - exit_status: '-1'
           limit: 1
 
+  - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
+    label: 'Serverless AI Assistant - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
@@ -234,7 +420,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 3
+    parallelism: 5
     retry:
       automatic:
         - exit_status: '-1'
@@ -264,7 +450,25 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
+      machineType: n2-highmem-4
+      diskSizeGb: 120
+      preemptible: true
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
+    label: 'Osquery Cypress Tests on Serverless'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-highmem-4
       diskSizeGb: 120
       preemptible: true
     depends_on:
@@ -283,7 +487,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
-      machineType: n2-standard-4
+      machineType: n2-highmem-4
       diskSizeGb: 125
     depends_on:
       - build
@@ -302,7 +506,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-highmem-4
-      diskSizeGb: 120
+      diskSizeGb: 125
     depends_on:
       - build
     timeout_in_minutes: 75

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -239,13 +239,35 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 120
+      machineType: n2-highmem-4
+      diskSizeGb: 125
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
     depends_on: *on_merge_gates
     parallelism: 24
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
+    label: 'Defend Workflows Cypress Tests on Serverless'
+    branches: main
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      enableNestedVirtualization: true
+      machineType: n2-highmem-4
+      diskSizeGb: 120
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 16
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -5,6 +5,24 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 125
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    soft_fail: true
+    parallelism: 1
+    retry:
+      automatic: false
+
+  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless_burn.sh
+    label: '[Soft fail] Defend Workflows Cypress Tests on Serverless, burning changed specs'
+    key: defend-workflows-serverless-burn
+    if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
+    agents:
+      enableNestedVirtualization: true
+      machineType: n2-standard-4
       diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,14 +4,35 @@ steps:
     key: defend-workflows
     agents:
       enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 120
+      machineType: n2-highmem-4
+      diskSizeGb: 125
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
     timeout_in_minutes: 60
     parallelism: 24
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
+    label: 'Defend Workflows Cypress Tests on Serverless'
+    key: defend-workflows-serverless
+    if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
+    agents:
+      enableNestedVirtualization: true
+      machineType: n2-highmem-4
+      diskSizeGb: 120
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 16
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [chore: bump defend-workflows disk space to 125gb (#273896)](https://github.com/elastic/kibana/pull/273896)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tamerlan","email":"37669316+TamerlanG@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-18T09:07:23Z","message":"chore: bump defend-workflows disk space to 125gb (#273896)\n\n## Summary\n\nThese tests seem to be failing due to lack of disk space. \n\nExample:\n• [Defend Workflows Cypress Tests\n#11](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9be-d4f2-4b49-a4b9-1690c67d5658)\n• [Defend Workflows Cypress Tests\n#16](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9bf-5af1-41e6-a408-10d3d4fe92be)\n• [Defend Workflows Cypress Tests\n#18](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9b6-ffc7-4e85-83f2-780a3707c8dc)\n• [Defend Workflows Cypress Tests\n#22](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9b4-3ce2-46a8-b318-cae6232fe6c2)","sha":"c0532038bc764cd3027cc471ea07f2f554ecc666","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v9.5.0"],"title":"chore: bump defend-workflows disk space to 125gb","number":273896,"url":"https://github.com/elastic/kibana/pull/273896","mergeCommit":{"message":"chore: bump defend-workflows disk space to 125gb (#273896)\n\n## Summary\n\nThese tests seem to be failing due to lack of disk space. \n\nExample:\n• [Defend Workflows Cypress Tests\n#11](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9be-d4f2-4b49-a4b9-1690c67d5658)\n• [Defend Workflows Cypress Tests\n#16](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9bf-5af1-41e6-a408-10d3d4fe92be)\n• [Defend Workflows Cypress Tests\n#18](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9b6-ffc7-4e85-83f2-780a3707c8dc)\n• [Defend Workflows Cypress Tests\n#22](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9b4-3ce2-46a8-b318-cae6232fe6c2)","sha":"c0532038bc764cd3027cc471ea07f2f554ecc666"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273896","number":273896,"mergeCommit":{"message":"chore: bump defend-workflows disk space to 125gb (#273896)\n\n## Summary\n\nThese tests seem to be failing due to lack of disk space. \n\nExample:\n• [Defend Workflows Cypress Tests\n#11](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9be-d4f2-4b49-a4b9-1690c67d5658)\n• [Defend Workflows Cypress Tests\n#16](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9bf-5af1-41e6-a408-10d3d4fe92be)\n• [Defend Workflows Cypress Tests\n#18](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9b6-ffc7-4e85-83f2-780a3707c8dc)\n• [Defend Workflows Cypress Tests\n#22](https://buildkite.com/elastic/kibana-on-merge/builds/99864#019ed9b4-3ce2-46a8-b318-cae6232fe6c2)","sha":"c0532038bc764cd3027cc471ea07f2f554ecc666"}}]}] BACKPORT-->