### PR TITLE
[Security Solution][Workflow Steps] Set Alert Status step (#17814)

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/step_definition_types.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/step_definition_types.ts
@@ -17,6 +17,7 @@ export enum StepCategory {
   Ai = 'ai',
   Kibana = 'kibana',
   KibanaCases = 'kibana.cases',
+  KibanaSecurity = 'kibana.security',
   Data = 'data',
   FlowControl = 'flowControl',
 }

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -198,6 +198,6 @@ export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; definitionHash: stri
   },
   {
     id: 'security.setAlertStatus',
-    definitionHash: '8404b8a70cc79308b0b8a1eb41408abd2647eb2d6dff24323c9b254a82315ef3',
+    definitionHash: 'cb1720032b9f90a53888a08fe7d7a75e0ca274d572e3effad7760cea7e5bc5d8',
   },
 ];

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -196,4 +196,8 @@ export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; definitionHash: stri
     id: 'search.rerank',
     definitionHash: 'c989f0b20019b12079d797d11b122285552e3b863ef96aaddad81640f0c2a951',
   },
+  {
+    id: 'security.setAlertStatus',
+    definitionHash: '0007017ee2a537b28b7f466e1ffeea935bd9d7f5bf3691218383e55ebc5e7024',
+  },
 ];

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -198,6 +198,6 @@ export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; definitionHash: stri
   },
   {
     id: 'security.setAlertStatus',
-    definitionHash: '0007017ee2a537b28b7f466e1ffeea935bd9d7f5bf3691218383e55ebc5e7024',
+    definitionHash: '8404b8a70cc79308b0b8a1eb41408abd2647eb2d6dff24323c9b254a82315ef3',
   },
 ];

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.ts
@@ -92,6 +92,18 @@ export function getActionOptions(
     options: [],
   };
 
+  const kibanaSecurityGroup: ActionGroup = {
+    iconType: 'securityApp',
+    id: 'kibana.security',
+    label: i18n.translate('workflows.actionsMenu.kibanaSecurity', {
+      defaultMessage: 'Security',
+    }),
+    description: i18n.translate('workflows.actionsMenu.kibanaSecurityDescription', {
+      defaultMessage: 'Work with Security data and features directly from your workflow',
+    }),
+    options: [],
+  };
+
   const kibanaGroup: ActionGroup = {
     iconType: 'logoKibana',
     id: 'kibana',
@@ -102,7 +114,7 @@ export function getActionOptions(
       defaultMessage: 'Work with Kibana data and features directly from your workflow',
     }),
     options: [],
-    nestedGroups: [kibanaCasesGroup],
+    nestedGroups: [kibanaCasesGroup, kibanaSecurityGroup],
   };
   const externalGroup: ActionOptionData = {
     iconType: 'plugs',
@@ -258,6 +270,7 @@ export function getActionOptions(
     [StepCategory.Ai]: aiGroup,
     [StepCategory.Kibana]: kibanaGroup,
     [StepCategory.KibanaCases]: kibanaCasesGroup,
+    [StepCategory.KibanaSecurity]: kibanaSecurityGroup,
     [StepCategory.Data]: dataTransformationGroup,
     [StepCategory.FlowControl]: flowControlGroup,
   };

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/common/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const MAX_ALERT_ID_LENGTH = 256;
+export const MAX_WORKFLOW_MESSAGE_LENGTH = 1000;

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setAlertStatusInputSchema } from './set_alert_status_step_common';
+
+describe('setAlertStatusInputSchema', () => {
+  it('should validate valid input for closing an alert', () => {
+    const input = { alert_ids: 'alert-1', status: 'closed', close_reason: 'false_positive' };
+    expect(setAlertStatusInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('should validate valid input for closing multiple alerts', () => {
+    const input = {
+      alert_ids: ['alert-1', 'alert-2'],
+      status: 'closed',
+      close_reason: 'duplicate',
+    };
+    expect(setAlertStatusInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('should validate valid input for closing an alert without reason', () => {
+    const input = { alert_ids: 'alert-1', status: 'closed' };
+    expect(setAlertStatusInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('should validate valid input for acknowledging an alert', () => {
+    const input = { alert_ids: 'alert-1', status: 'acknowledged' };
+    expect(setAlertStatusInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('should validate valid input for opening multiple alerts', () => {
+    const input = { alert_ids: ['alert-1', 'alert-2'], status: 'open' };
+    expect(setAlertStatusInputSchema.parse(input)).toEqual(input);
+  });
+
+  it('should strip close_reason if provided for non-closed status', () => {
+    const input = { alert_ids: 'alert-1', status: 'open', close_reason: 'false_positive' };
+    const parsed = setAlertStatusInputSchema.parse(input);
+    expect(parsed).not.toHaveProperty('close_reason');
+  });
+
+  it('should fail for invalid status', () => {
+    const input = { alert_ids: 'alert-1', status: 'invalid_status' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+
+  it('should fail if alert_ids is missing', () => {
+    const input = { status: 'closed' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+
+  it('should fail if alert_ids is an empty string', () => {
+    const input = { alert_ids: '', status: 'closed' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+
+  it('should fail if alert_ids is an empty array', () => {
+    const input = { alert_ids: [], status: 'closed' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+
+  it('should fail if alert_ids array contains an empty string', () => {
+    const input = { alert_ids: ['alert-1', ''], status: 'closed' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { setAlertStatusInputSchema } from './set_alert_status_step_common';
+import { MAX_ALERT_ID_LENGTH } from '../common/constants';
 
 describe('setAlertStatusInputSchema', () => {
   it('should validate valid input for closing an alert', () => {
@@ -65,6 +66,16 @@ describe('setAlertStatusInputSchema', () => {
 
   it('should fail if alert_ids array contains an empty string', () => {
     const input = { alert_ids: ['alert-1', ''], status: 'closed' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+
+  it('should fail if alert_ids string is too long', () => {
+    const input = { alert_ids: 'a'.repeat(MAX_ALERT_ID_LENGTH + 1), status: 'closed' };
+    expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
+  });
+
+  it('should fail if alert_ids array contains a string that is too long', () => {
+    const input = { alert_ids: ['alert-1', 'a'.repeat(MAX_ALERT_ID_LENGTH + 1)], status: 'closed' };
     expect(() => setAlertStatusInputSchema.parse(input)).toThrow();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.ts
@@ -10,12 +10,16 @@ import { StepCategory } from '@kbn/workflows';
 import type { BaseStepDefinition } from '@kbn/workflows';
 import { i18n } from '@kbn/i18n';
 import { Reason } from '../../../api/detection_engine/signals/set_signal_status/set_signals_status_route.gen';
+import { MAX_ALERT_ID_LENGTH, MAX_WORKFLOW_MESSAGE_LENGTH } from '../common/constants';
 
 export const SetAlertStatusStepId = 'security.setAlertStatus' as const;
 
 const alertIdsBase = z.object({
   alert_ids: z
-    .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+    .union([
+      z.string().min(1).max(MAX_ALERT_ID_LENGTH),
+      z.array(z.string().min(1).max(MAX_ALERT_ID_LENGTH)).min(1),
+    ])
     .describe('A single alert ID or a list of IDs to support bulk updates'),
 });
 
@@ -33,7 +37,7 @@ export const setAlertStatusInputSchema = z.discriminatedUnion('status', [
 
 export const setAlertStatusOutputSchema = z.object({
   success: z.boolean(),
-  message: z.string().optional(),
+  message: z.string().max(MAX_WORKFLOW_MESSAGE_LENGTH).optional(),
 });
 
 export const setAlertStatusStepCommonDefinition: BaseStepDefinition<

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { StepCategory } from '@kbn/workflows';
+import type { BaseStepDefinition } from '@kbn/workflows';
+import { i18n } from '@kbn/i18n';
+import { Reason } from '../../../api/detection_engine/signals/set_signal_status/set_signals_status_route.gen';
+
+export const SetAlertStatusStepId = 'security.setAlertStatus' as const;
+
+const alertIdsBase = z.object({
+  alert_ids: z
+    .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+    .describe('A single alert ID or a list of IDs to support bulk updates'),
+});
+
+export const setAlertStatusInputSchema = z.discriminatedUnion('status', [
+  alertIdsBase.extend({
+    status: z.literal('closed').describe('The new status for the alerts'),
+    close_reason: Reason.optional().describe(
+      'Optional reason when closing the alert (e.g. duplicate, false_positive)'
+    ),
+  }),
+  alertIdsBase.extend({
+    status: z.enum(['open', 'acknowledged']).describe('The new status for the alerts'),
+  }),
+]);
+
+export const setAlertStatusOutputSchema = z.object({
+  success: z.boolean(),
+  message: z.string().optional(),
+});
+
+export const setAlertStatusStepCommonDefinition: BaseStepDefinition<
+  typeof setAlertStatusInputSchema,
+  typeof setAlertStatusOutputSchema
+> = {
+  id: SetAlertStatusStepId,
+  label: i18n.translate('xpack.securitySolution.workflows.steps.setAlertStatus.label', {
+    defaultMessage: 'Set Alert Status',
+  }),
+  description: i18n.translate('xpack.securitySolution.workflows.steps.setAlertStatus.description', {
+    defaultMessage: 'Change the status of one or multiple alerts to open, acknowledged, or closed.',
+  }),
+  category: StepCategory.KibanaSecurity,
+  inputSchema: setAlertStatusInputSchema,
+  outputSchema: setAlertStatusOutputSchema,
+  documentation: {
+    details: i18n.translate(
+      'xpack.securitySolution.workflows.steps.setAlertStatus.documentation.details',
+      {
+        defaultMessage:
+          'Updates the status of specified alerts. When setting the status to closed, an optional close reason can be provided.',
+      }
+    ),
+    examples: [
+      `## Set alert status to acknowledged
+\`\`\`yaml
+- name: set_alert_status
+  type: security.setAlertStatus
+  with:
+    alert_ids: "{{ variables.alert_id }}"
+    status: "acknowledged"
+\`\`\``,
+      `## Close multiple alerts with a reason
+\`\`\`yaml
+- name: close_alerts
+  type: security.setAlertStatus
+  with:
+    alert_ids: 
+      - "alert-1"
+      - "alert-2"
+    status: "closed"
+    close_reason: "false_positive"
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/set_alert_status_step/set_alert_status_step_common.ts
@@ -72,7 +72,7 @@ export const setAlertStatusStepCommonDefinition: BaseStepDefinition<
 - name: close_alerts
   type: security.setAlertStatus
   with:
-    alert_ids: 
+    alert_ids:
       - "alert-1"
       - "alert-2"
     status: "closed"

--- a/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
@@ -67,6 +67,7 @@
       "telemetry",
       "elasticAssistantSharedState",
       "share",
+      "workflowsExtensions"
     ],
     "optionalPlugins": [
       "encryptedSavedObjects",
@@ -86,7 +87,6 @@
       "serverless",
       "agentBuilder",
       "llmTasks",
-      "workflowsExtensions",
       "cps",
       "searchInferenceEndpoints"
     ],
@@ -100,7 +100,8 @@
       "ml",
       "unifiedSearch",
       "esql",
-      "agentBuilder"
+      "agentBuilder",
+      "workflowsExtensions"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
@@ -11,6 +11,7 @@ import { workflowsExtensionsMock } from '@kbn/workflows-extensions/public/mocks'
 import { registerWorkflowSteps } from './register_workflow_steps';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import { setAlertStatusStepDefinition } from './set_alert_status_step/set_alert_status_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -29,13 +30,13 @@ describe('registerWorkflowSteps (public)', () => {
     return { core, coreStart };
   };
 
-  it('calls registerStepDefinition synchronously for both steps', () => {
+  it('calls registerStepDefinition synchronously for all steps', () => {
     const { core } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
+    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(3);
     // getStartServices is called once eagerly to create the shared memoized promise
     expect(core.getStartServices).toHaveBeenCalledTimes(1);
   });
@@ -46,12 +47,13 @@ describe('registerWorkflowSteps (public)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
 
     await expect(loader1()).resolves.toBe(renderAlertNarrativeStepDefinition);
     await expect(loader2()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+    await expect(loader3()).resolves.toBe(setAlertStatusStepDefinition);
   });
 
   it('async loader returns undefined when feature flag is disabled', async () => {
@@ -60,12 +62,13 @@ describe('registerWorkflowSteps (public)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
 
     await expect(loader1()).resolves.toBeUndefined();
     await expect(loader2()).resolves.toBeUndefined();
+    await expect(loader3()).resolves.toBe(setAlertStatusStepDefinition);
   });
 
   it('checks the feature flag exactly once even when both loaders resolve', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
@@ -43,4 +43,10 @@ export const registerWorkflowSteps = (
       (m) => m.buildAlertEntityGraphStepDefinition
     );
   });
+
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./set_alert_status_step/set_alert_status_step').then(
+      (m) => m.setAlertStatusStepDefinition
+    )
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/set_alert_status_step/set_alert_status_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/set_alert_status_step/set_alert_status_step.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { setAlertStatusStepCommonDefinition } from '../../../../common/workflows/step_types/set_alert_status_step/set_alert_status_step_common';
+
+export const setAlertStatusStepDefinition = createPublicStepDefinition({
+  ...setAlertStatusStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/app_security').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
@@ -11,6 +11,7 @@ import { workflowsExtensionsMock } from '@kbn/workflows-extensions/server/mocks'
 import { registerWorkflowSteps } from './register_workflow_steps';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import { setAlertStatusStepDefinition } from './set_alert_status_step/set_alert_status_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -29,13 +30,13 @@ describe('registerWorkflowSteps (server)', () => {
     return { core, coreStart };
   };
 
-  it('calls registerStepDefinition synchronously for both steps', () => {
+  it('calls registerStepDefinition synchronously for all steps', () => {
     const { core } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
+    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(3);
     // getStartServices is called once eagerly to create the shared memoized promise
     expect(core.getStartServices).toHaveBeenCalledTimes(1);
   });
@@ -46,12 +47,13 @@ describe('registerWorkflowSteps (server)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
-      ([arg]) => arg as StepLoader
+    const [loader1, loader2, step3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg
     );
 
-    await expect(loader1()).resolves.toBe(renderAlertNarrativeStepDefinition);
-    await expect(loader2()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+    await expect((loader1 as StepLoader)()).resolves.toBe(renderAlertNarrativeStepDefinition);
+    await expect((loader2 as StepLoader)()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+    expect(step3).toBe(setAlertStatusStepDefinition);
   });
 
   it('async loader returns undefined when feature flag is disabled', async () => {
@@ -60,12 +62,13 @@ describe('registerWorkflowSteps (server)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
-      ([arg]) => arg as StepLoader
+    const [loader1, loader2, step3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg
     );
 
-    await expect(loader1()).resolves.toBeUndefined();
-    await expect(loader2()).resolves.toBeUndefined();
+    await expect((loader1 as StepLoader)()).resolves.toBeUndefined();
+    await expect((loader2 as StepLoader)()).resolves.toBeUndefined();
+    expect(step3).toBe(setAlertStatusStepDefinition);
   });
 
   it('checks the feature flag exactly once even when both loaders resolve', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
@@ -9,6 +9,7 @@ import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extens
 import type { CoreSetup } from '@kbn/core/server';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import { setAlertStatusStepDefinition } from './set_alert_status_step/set_alert_status_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -41,4 +42,6 @@ export const registerWorkflowSteps = (
     if (!(await isEnabled)) return undefined;
     return buildAlertEntityGraphStepDefinition;
   });
+
+  workflowsExtensions.registerStepDefinition(setAlertStatusStepDefinition);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_alert_status_step/set_alert_status_step.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_alert_status_step/set_alert_status_step.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setAlertStatusStepDefinition } from './set_alert_status_step';
+import { ExecutionError } from '@kbn/workflows/server';
+import { DETECTION_ENGINE_SIGNALS_STATUS_URL } from '../../../../common/constants';
+import type { StepHandlerContext } from '@kbn/workflows-extensions/server';
+
+const createMockContext = (input: Record<string, unknown>) => {
+  return {
+    input,
+    config: {},
+    rawInput: input,
+    contextManager: {
+      getContext: jest.fn(),
+      getScopedEsClient: jest.fn(),
+      renderInputTemplate: jest.fn(),
+      getFakeRequest: jest.fn(),
+      callKibanaApi: jest.fn(),
+    },
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    abortSignal: new AbortController().signal,
+    stepId: 'test-step',
+    stepType: 'security.setAlertStatus',
+  } as unknown as StepHandlerContext<unknown, unknown>;
+};
+
+describe('setAlertStatusStepDefinition', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handler', () => {
+    it('should call Kibana API successfully with single alert ID and close_reason', async () => {
+      const mockContext = createMockContext({
+        alert_ids: 'alert-1',
+        status: 'closed',
+        close_reason: 'false_positive',
+      });
+      (mockContext.contextManager.callKibanaApi as jest.Mock).mockResolvedValue({
+        status: 200,
+        body: {},
+      });
+
+      const result = await setAlertStatusStepDefinition.handler(mockContext);
+
+      expect(mockContext.contextManager.callKibanaApi).toHaveBeenCalledWith({
+        method: 'POST',
+        path: DETECTION_ENGINE_SIGNALS_STATUS_URL,
+        body: {
+          signal_ids: ['alert-1'],
+          status: 'closed',
+          reason: 'false_positive',
+        },
+      });
+      expect(result).toEqual({
+        output: {
+          success: true,
+          message: 'Successfully updated status to closed for 1 alert(s)',
+        },
+      });
+    });
+
+    it('should call Kibana API successfully with multiple alert IDs', async () => {
+      const mockContext = createMockContext({
+        alert_ids: ['alert-1', 'alert-2'],
+        status: 'acknowledged',
+      });
+      (mockContext.contextManager.callKibanaApi as jest.Mock).mockResolvedValue({
+        status: 200,
+        body: {},
+      });
+
+      const result = await setAlertStatusStepDefinition.handler(mockContext);
+
+      expect(mockContext.contextManager.callKibanaApi).toHaveBeenCalledWith({
+        method: 'POST',
+        path: DETECTION_ENGINE_SIGNALS_STATUS_URL,
+        body: {
+          signal_ids: ['alert-1', 'alert-2'],
+          status: 'acknowledged',
+        },
+      });
+      expect(result).toEqual({
+        output: {
+          success: true,
+          message: 'Successfully updated status to acknowledged for 2 alert(s)',
+        },
+      });
+    });
+
+    it('should throw ExecutionError if API returns >= 400', async () => {
+      const mockContext = createMockContext({ alert_ids: 'alert-1', status: 'open' });
+      (mockContext.contextManager.callKibanaApi as jest.Mock).mockResolvedValue({
+        status: 404,
+        body: { error: 'Not found' },
+      });
+
+      await expect(setAlertStatusStepDefinition.handler(mockContext)).rejects.toThrow(
+        ExecutionError
+      );
+    });
+
+    it('should throw ExecutionError if API call throws an error', async () => {
+      const mockContext = createMockContext({ alert_ids: 'alert-1', status: 'open' });
+      (mockContext.contextManager.callKibanaApi as jest.Mock).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      await expect(setAlertStatusStepDefinition.handler(mockContext)).rejects.toThrow(
+        ExecutionError
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_alert_status_step/set_alert_status_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/set_alert_status_step/set_alert_status_step.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { ExecutionError } from '@kbn/workflows/server';
+import { DETECTION_ENGINE_SIGNALS_STATUS_URL } from '../../../../common/constants';
+import { setAlertStatusStepCommonDefinition } from '../../../../common/workflows/step_types/set_alert_status_step/set_alert_status_step_common';
+
+export const setAlertStatusStepDefinition = createServerStepDefinition({
+  ...setAlertStatusStepCommonDefinition,
+  handler: async (context) => {
+    const { alert_ids: alertIds, status } = context.input;
+    const closeReason = 'close_reason' in context.input ? context.input.close_reason : undefined;
+
+    const signalIds = Array.isArray(alertIds) ? alertIds : [alertIds];
+
+    try {
+      const { status: responseStatus, body } = await context.contextManager.callKibanaApi<{
+        took?: number;
+        errors?: boolean;
+        items?: unknown[];
+      }>({
+        method: 'POST',
+        path: DETECTION_ENGINE_SIGNALS_STATUS_URL,
+        body: {
+          signal_ids: signalIds,
+          status,
+          ...(closeReason ? { reason: closeReason } : {}),
+        },
+      });
+
+      if (responseStatus >= 400) {
+        throw new ExecutionError({
+          type: 'ApiError',
+          message: `Failed to set alert status: HTTP ${responseStatus}`,
+          details: { body },
+        });
+      }
+
+      return {
+        output: {
+          success: true,
+          message: `Successfully updated status to ${status} for ${signalIds.length} alert(s)`,
+        },
+      };
+    } catch (error) {
+      if (error instanceof ExecutionError) {
+        throw error;
+      }
+      throw new ExecutionError({
+        type: 'ApiError',
+        message: error instanceof Error ? error.message : 'Unknown error occurred',
+        details: { error },
+      });
+    }
+  },
+});


### PR DESCRIPTION
## Summary

This PR introduces a new custom workflow step `security.setAlertStatus` to allow updating the status of Security alerts directly from workflows.

Closes https://github.com/elastic/security-team/issues/17814

### Key Features:

- **Status Updates**: Supports changing alert status to `open`, `acknowledged`, or `closed`.
- **Bulk Updates**: Accepts a single `alert_ids` string or an array of strings for bulk operations (enforces minimum length of 1).
- **Close Reason**: Supports an optional `close_reason` that automatically stays in sync with the API's predefined reasons (e.g., `false_positive`, `duplicate`) when the status is set to `closed`.
- **API Integration**: Internally utilizes `callKibanaApi` to communicate with the existing `DETECTION_ENGINE_SIGNALS_STATUS_URL` endpoint.
- **Testing**: Added comprehensive unit tests for input schema validation (including empty array/string edge cases) and server-side handler logic.
- **Approval Gate**: Updated `APPROVED_STEP_DEFINITIONS` with the new handler hash.
- **Dependency Management**: Added `workflowsExtensions` to the `requiredPlugins` list in `kibana.jsonc` to ensure reliable step registration.

## Verification steps

1. Start Kibana and Elasticsearch with the Security Solution enabled (`yarn start`).
2. Generate or find an existing Security alert and note its ID.
3. Create or edit a workflow that includes the `security.setAlertStatus` step. Example YAML:
   ```yaml
   - name: close_alert
     type: security.setAlertStatus
     with:
       alert_ids: '<your-alert-id>'
       status: closed
       close_reason: false_positive
   ```
4. Run the workflow.
5. Verify that the workflow step executes successfully in the execution logs.
6. Navigate to the Security Alerts page and verify that the specified alert's status has been updated to "Closed" with the correct reason.

## Screenshots

<img width="1840" height="1196" alt="Screenshot 2026-06-18 at 12 10 50" src="https://github.com/user-attachments/assets/12eb7fb9-80a4-46e5-a447-33157b4cac6d" />

---

_PR developed with Cursor + Gemini 3.1 Pro_
