### PR TITLE
[sigevents][ki] use internaluser instead of currentuser for KI access

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -255,7 +255,7 @@ export class StreamsPlugin
             rulesClientOptions
           );
           return knowledgeIndicatorService.getClient({
-            esClient: scopedClusterClient.asCurrentUser,
+            esClient: scopedClusterClient.asInternalUser,
             soClient,
             alertingRulesClient: rulesClient,
             alertingV2RulesClient,


### PR DESCRIPTION
## Summary

Use internalUser instead of currentUser for KI access.
This is a temporary change to workaround privilege issues.


