### PR TITLE
[ResponseOps][PerAlertSnooze] remove action privilege gate from snooze, unsnooze alert

### DIFF
--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.test.ts
@@ -347,6 +347,8 @@ describe(`feature_privilege_builder`, () => {
           Array [
             "alerting:alert-type/my-consumer/rule/muteAlert",
             "alerting:alert-type/my-consumer/rule/unmuteAlert",
+            "alerting:alert-type/my-consumer/rule/snoozeAlert",
+            "alerting:alert-type/my-consumer/rule/unsnoozeAlert",
           ]
         `);
       });

--- a/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
+++ b/x-pack/platform/packages/private/security/authorization_core/src/privileges/feature_privilege_builder/alerting.ts
@@ -63,7 +63,7 @@ const manageRuleSettingsOperations: Record<AlertingEntity, string[]> = {
 
 // Covers both per-alert snooze/unsnooze and muteAlert/unmuteAlert
 const muteAlertsOperations: Record<AlertingEntity, string[]> = {
-  rule: ['muteAlert', 'unmuteAlert'],
+  rule: ['muteAlert', 'unmuteAlert', 'snoozeAlert', 'unsnoozeAlert'],
   alert: [],
 };
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze_alert_instance/snooze_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze_alert_instance/snooze_instance.test.ts
@@ -112,6 +112,7 @@ describe('snooze alert instance', () => {
     });
     expect(alertsServiceMock.isExistingAlert).not.toHaveBeenCalled();
     expect(alertsServiceMock.muteAlertInstance).not.toHaveBeenCalled();
+    expect(actionsAuthorizationMock.ensureAuthorized).not.toHaveBeenCalled();
     expect(unsecuredSavedObjectsClient.update).toHaveBeenCalledWith(
       'alert',
       '1',
@@ -166,6 +167,43 @@ describe('snooze alert instance', () => {
     });
 
     expect(alertsServiceMock.isExistingAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not check actionsAuthorization.execute even when the rule has actions', async () => {
+    unsecuredSavedObjectsClient.get.mockResolvedValueOnce({
+      id: '1',
+      type: 'test-rule-type',
+      attributes: {
+        name: 'connector rule',
+        alertTypeId: '123',
+        consumer: 'test-consumer',
+        schedule: { interval: '10s' },
+        params: { bar: true },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        actions: [
+          {
+            group: 'default',
+            actionRef: 'action_0',
+            params: { foo: true },
+          },
+        ],
+        notifyWhen: 'onActiveAlert',
+        mutedInstanceIds: [],
+        snoozedInstances: [],
+      },
+      references: [{ name: 'action_0', type: 'action', id: '1' }],
+      version: 'v1',
+    });
+
+    await snoozeAlertInstance(context, {
+      params: { alertId: '1', alertInstanceId: 'instance1' },
+      query: { validateAlertsExistence: false },
+      body: { expiresAt: '2099-12-31T23:59:59.000Z' },
+    });
+
+    expect(actionsAuthorizationMock.ensureAuthorized).not.toHaveBeenCalled();
+    expect(unsecuredSavedObjectsClient.update).toHaveBeenCalled();
   });
 
   it('rejects conditionOperator when conditions are absent', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze_alert_instance/snooze_instance.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/snooze_alert_instance/snooze_instance.ts
@@ -86,10 +86,6 @@ async function snoozeAlertInstanceWithOCC(
       operation: WriteOperations.snoozeAlert,
       entity: AlertingAuthorizationEntity.Rule,
     });
-
-    if (attributes.actions.length) {
-      await context.actionsAuthorization.ensureAuthorized({ operation: 'execute' });
-    }
   } catch (error) {
     context.auditLogger?.log(
       alertAuditEvent({

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze_alert/unsnooze_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze_alert/unsnooze_instance.test.ts
@@ -114,6 +114,44 @@ describe('unsnooze alert instance', () => {
     expect(savedObjectsMock.update).not.toHaveBeenCalled();
   });
 
+  it('does not check actionsAuthorization.execute even when the rule has actions', async () => {
+    savedObjectsMock.get.mockResolvedValueOnce({
+      id: '1',
+      type: 'test-rule-type',
+      attributes: {
+        name: 'connector rule',
+        alertTypeId: '123',
+        consumer: 'alerts',
+        schedule: { interval: '10s' },
+        params: { bar: true },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        actions: [
+          {
+            group: 'default',
+            actionRef: 'action_0',
+            params: { foo: true },
+          },
+        ],
+        notifyWhen: 'onActiveAlert',
+        snoozedInstances: [
+          {
+            instanceId: 'instance1',
+            snoozedAt: '2026-04-14T10:00:00.000Z',
+            snoozedBy: 'elastic',
+          },
+        ],
+      },
+      references: [{ name: 'action_0', type: 'action', id: '1' }],
+      version: 'v1',
+    });
+
+    await unsnoozeAlertInstance(context, { alertId: '1', alertInstanceId: 'instance1' });
+
+    expect(actionsAuthorizationMock.ensureAuthorized).not.toHaveBeenCalled();
+    expect(savedObjectsMock.update).toHaveBeenCalled();
+  });
+
   it('logs an alert_unsnooze audit event before the SO update', async () => {
     savedObjectsMock.get.mockResolvedValueOnce({
       id: '1',

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze_alert/unsnooze_instance.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/unsnooze_alert/unsnooze_instance.ts
@@ -52,10 +52,6 @@ async function unsnoozeInstanceWithOCC(
       operation: WriteOperations.unsnoozeAlert,
       entity: AlertingAuthorizationEntity.Rule,
     });
-
-    if (attributes.actions.length) {
-      await context.actionsAuthorization.ensureAuthorized({ operation: 'execute' });
-    }
   } catch (error) {
     context.auditLogger?.log(
       alertAuditEvent({

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/snooze_instance.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/snooze_instance.test.ts
@@ -247,7 +247,7 @@ describe('snoozeAlertInstance()', () => {
         body: { expiresAt: '2099-12-31T23:59:59.000Z' },
       });
 
-      expect(actionsAuthorization.ensureAuthorized).toHaveBeenCalledWith({ operation: 'execute' });
+      expect(actionsAuthorization.ensureAuthorized).not.toHaveBeenCalled();
       expect(authorization.ensureAuthorized).toHaveBeenCalledWith({
         entity: 'rule',
         consumer: 'myApp',

--- a/x-pack/platform/plugins/shared/alerting/test/scout/api/tests/alert_actions_authorization.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting/test/scout/api/tests/alert_actions_authorization.spec.ts
@@ -345,5 +345,68 @@ apiTest.describe(
         expect(after.apiKeyOwner).toBe(before.apiKeyOwner);
       }
     );
+
+    apiTest(
+      'restricted user (alerting all, no actions) can snooze an alert instance',
+      async ({ apiClient }) => {
+        const response = await apiClient.post(
+          `api/alerting/rule/${ruleId}/alert/${ENCODED_ALERT_INSTANCE_ID}/_snooze`,
+          {
+            headers: { ...COMMON_HEADERS, ...restrictedCreds.apiKeyHeader },
+            body: { expires_at: '2099-12-31T23:59:59.000Z' },
+            responseType: 'json',
+          }
+        );
+        expect(response).toHaveStatusCode(204);
+      }
+    );
+
+    apiTest(
+      'restricted user (alerting all, no actions) can unsnooze an alert instance',
+      async ({ apiClient }) => {
+        const response = await apiClient.post(
+          `api/alerting/rule/${ruleId}/alert/${ENCODED_ALERT_INSTANCE_ID}/_unsnooze`,
+          { headers: { ...COMMON_HEADERS, ...restrictedCreds.apiKeyHeader } }
+        );
+        expect(response).toHaveStatusCode(204);
+      }
+    );
+
+    apiTest(
+      'per-alert snooze/unsnooze by restricted user does not rotate the rule API key',
+      async ({ apiClient, esClient }) => {
+        const getAlertAttrs = async () => {
+          const result = await esClient.search({
+            index: '.kibana_alerting_cases*',
+            query: { term: { _id: `alert:${ruleId}` } },
+            size: 1,
+          });
+          const hit = result.hits.hits[0];
+          expect(hit).toBeDefined();
+          return (hit._source as Record<string, unknown>)?.alert as Record<string, unknown>;
+        };
+
+        const before = await getAlertAttrs();
+        expect(before.apiKey).toBeDefined();
+        expect(before.apiKeyOwner).toBeDefined();
+
+        await apiClient.post(
+          `api/alerting/rule/${ruleId}/alert/${ENCODED_ALERT_INSTANCE_ID}/_snooze`,
+          {
+            headers: { ...COMMON_HEADERS, ...restrictedCreds.apiKeyHeader },
+            body: { expires_at: '2099-12-31T23:59:59.000Z' },
+            responseType: 'json',
+          }
+        );
+        await apiClient.post(
+          `api/alerting/rule/${ruleId}/alert/${ENCODED_ALERT_INSTANCE_ID}/_unsnooze`,
+          { headers: { ...COMMON_HEADERS, ...restrictedCreds.apiKeyHeader } }
+        );
+
+        const after = await getAlertAttrs();
+        expect(after.apiKey).toBe(before.apiKey);
+        expect(after.apiKeyOwner).toBe(before.apiKeyOwner);
+      }
+    );
   }
 );

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/snooze_instance.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/snooze_instance.ts
@@ -81,16 +81,9 @@ export default function createSnoozeAlertInstanceTests({ getService }: FtrProvid
                 statusCode: 403,
               });
               break;
-            case 'space_1_all_alerts_none_actions at space1':
-              expect(response.statusCode).to.eql(403);
-              expect(response.body).to.eql({
-                error: 'Forbidden',
-                message: `Unauthorized to execute actions`,
-                statusCode: 403,
-              });
-              break;
             case 'superuser at space1':
             case 'space_1_all at space1':
+            case 'space_1_all_alerts_none_actions at space1':
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.statusCode).to.eql(204);
               expect(response.body).to.eql('');

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unsnooze_instance.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unsnooze_instance.ts
@@ -87,16 +87,9 @@ export default function createUnsnoozeAlertInstanceTests({ getService }: FtrProv
                 statusCode: 403,
               });
               break;
-            case 'space_1_all_alerts_none_actions at space1':
-              expect(response.statusCode).to.eql(403);
-              expect(response.body).to.eql({
-                error: 'Forbidden',
-                message: `Unauthorized to execute actions`,
-                statusCode: 403,
-              });
-              break;
             case 'superuser at space1':
             case 'space_1_all at space1':
+            case 'space_1_all_alerts_none_actions at space1':
             case 'space_1_all_with_restricted_fixture at space1':
               expect(response.statusCode).to.eql(204);
               expect(response.body).to.eql('');


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/273412

Removes the `actionsAuthorization.ensureAuthorized({ operation: 'execute' })` check from per-alert snooze and unsnooze operations. This gate required connector execution privileges for snoozing individual alert instances — an operation that suppresses notifications rather than triggering connector execution.

With this change, a user who has alerting rule privileges (e.g., logs: all) but no actions (connectors) feature privilege can now (similar to https://github.com/elastic/kibana/issues/273246):

- Snooze and unsnooze individual alert instances on connector-backed rules
- The rule's API key is not rotated by per-alert snooze/unsnooze, confirming these are purely notification-suppression operations. Rule-level operations that can trigger connector execution (enable, run_soon, update_api_key) still require connector privileges.

This PR also adds snoozeAlert and unsnoozeAlert to muteAlertsOperations introduced in 
### Changes

- **snooze_instance.ts / unsnooze_instance.ts** — removed the actionsAuthorization.execute gate from per-alert snooze and unsnooze
- **muteAlertsOperations (feature_privilege_builder/alerting.ts)** — added `snoozeAlert` and `unsnoozeAlert` to the `mute_alerts` operation group (introduced in https://github.com/elastic/kibana/pull/273342)  so features granting mute_alerts also cover per-alert snooze 
- **Unit tests** (snooze_instance.test.ts, unsnooze_instance.test.ts, rules_client/tests/snooze_instance.test.ts) — updated assertions to confirm actionsAuthorization.ensureAuthorized is never called for these operations, even for rules with actions configured
- **FTR integration tests** (group2/tests/alerting/snooze_instance.ts, unsnooze_instance.ts) — updated expected status codes from 403 → 204 for the space_1_all_alerts_none_actions user scenario
- **Scout API tests** (alert_actions_authorization.spec.ts) — added tests that verify:
  - A restricted user (alerting all, no actions privilege) can snooze an individual alert instance (204)
  - A restricted user can unsnooze an individual alert instance (204)
  - Per-alert snooze/unsnooze by a restricted user does not rotate the rule's API key
  
###   How to test
1. Create a restricted role (no connector privilege)
```
curl -X PUT "http://localhost:5601/api/security/role/alerting_no_actions" \
  -H "kbn-xsrf: true" \
  -H "Content-Type: application/json" \
  -u elastic:changeme \
  -d '{
    "kibana": [{ "base": [], "feature": { "logs": ["all"] }, "spaces": ["*"] }],
    "elasticsearch": { "cluster": [], "indices": [{ "names": [".alerts-*"], "privileges": ["read"] }] }
  }'
```

2. Create a user with that role
```
curl -X POST "http://localhost:9200/_security/user/restricted_alerting" \
  -H "Content-Type: application/json" \
  -u elastic:changeme \
  -d '{ "password": "changeme", "roles": ["alerting_no_actions"] }'
```

3. Verify the user cannot access connectors (Expected: 403)
```
curl -s -o /dev/null -w "%{http_code}" \
  "http://localhost:5601/api/actions/connectors" \
  -H "kbn-xsrf: true" \
  -u restricted_alerting:changeme
```
4. Create a connector-backed rule as admin, wait for it to fire, then test as the restricted user
```
# Per-alert snooze — Expected: 204
curl -X POST "http://localhost:5601/api/alerting/rule/{RULE_ID}/alert/{ALERT_INSTANCE_ID}/_snooze" \
  -H "kbn-xsrf: true" \
  -H "Content-Type: application/json" \
  -u restricted_alerting:changeme \
  -d '{"expires_at": "2099-12-31T23:59:59.000Z"}'
# Per-alert unsnooze — Expected: 204
curl -X POST "http://localhost:5601/api/alerting/rule/{RULE_ID}/alert/{ALERT_INSTANCE_ID}/_unsnooze" \
  -H "kbn-xsrf: true" \
  -u restricted_alerting:changeme

```
5. Verify rule-level operations that require connector privilege still return 403
```
# Enable — Expected: 403
curl -X POST "http://localhost:5601/api/alerting/rule/{RULE_ID}/_enable" \
  -H "kbn-xsrf: true" \
  -u restricted_alerting:changeme
# Run soon — Expected: 403
curl -X POST "http://localhost:5601/internal/alerting/rule/{RULE_ID}/_run_soon" \
  -H "kbn-xsrf: true" \
  -u restricted_alerting:changeme
```

6. Run the Scout API tests
```
node scripts/scout.js run-tests --arch stateful --domain classic \
  --testFiles x-pack/platform/plugins/shared/alerting/test/scout/api/tests/alert_actions_authorization.spec.ts
```

### Checklist

Check the PR satisfies following conditions. 

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
