### PR TITLE
[ES|QL] Fixes KQL suggestions in autocomplete

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.test.ts
@@ -55,7 +55,17 @@ describe('getKqlSuggestionsIfApplicable', () => {
   });
 
   it('should return suggestions if applicable', async () => {
-    const mockSuggestions = [{ text: 'value1', kind: 'Value', detail: 'A value' }];
+    const mockSuggestions = [
+      {
+        text: 'value1',
+        kind: 'Value',
+        detail: 'A value',
+        rangeToReplace: {
+          end: 12,
+          start: 7,
+        },
+      },
+    ];
     const mockGetKqlSuggestions = jest.fn().mockResolvedValue(mockSuggestions);
     const ctx = createContext('KQL("""query', mockGetKqlSuggestions);
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
@@ -207,14 +207,22 @@ export async function getKqlSuggestionsIfApplicable(
   const cursorPositionInKql = kqlQuery.length;
 
   try {
-    // Get KQL suggestions from the autocomplete service
     const suggestions = await getKqlSuggestions(kqlQuery, cursorPositionInKql);
 
     if (!suggestions || suggestions.length === 0) {
       return null;
     }
 
-    return suggestions;
+    const kqlWordBoundary = /[\s:()"'=<>]/;
+    let kqlWordStart = kqlQuery.length;
+    while (kqlWordStart > 0 && !kqlWordBoundary.test(kqlQuery[kqlWordStart - 1])) {
+      kqlWordStart--;
+    }
+    const kqlStartInText = innerText.length - kqlQuery.length;
+    const wordStartInText = kqlStartInText + kqlWordStart;
+    const rangeToReplace = { start: wordStartInText, end: innerText.length };
+
+    return suggestions.map((s) => ({ ...s, rangeToReplace }));
   } catch (error) {
     return null;
   }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/where/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/where/autocomplete.test.ts
@@ -16,6 +16,7 @@ import {
   getFunctionSignaturesByReturnType,
   mockFieldsWithTypes,
   getOperatorSuggestions,
+  suggest,
 } from '../../../__tests__/commands/autocomplete';
 import {
   logicalOperators,
@@ -388,6 +389,62 @@ describe('WHERE Autocomplete', () => {
         DATE_DIFF_TIME_UNITS,
         mockCallbacks
       );
+    });
+  });
+
+  describe('KQL function autocomplete', () => {
+    const kqlSuggestions = [
+      { text: 'field_name', label: 'field_name', kind: 'Field' as const },
+      { text: 'other_field', label: 'other_field', kind: 'Field' as const },
+    ];
+
+    beforeEach(() => {
+      mockCallbacks = {
+        ...getMockCallbacks(),
+        getKqlSuggestions: jest.fn().mockResolvedValue(kqlSuggestions),
+      };
+    });
+
+    it('returns KQL suggestions when cursor is inside KQL("""...)', async () => {
+      await whereExpectSuggestions(
+        'from index | WHERE KQL("""field_na',
+        ['field_name', 'other_field'],
+        mockCallbacks
+      );
+    });
+
+    it('returns KQL suggestions for an empty KQL query (cursor right after """)', async () => {
+      await whereExpectSuggestions(
+        'from index | WHERE KQL("""',
+        ['field_name', 'other_field'],
+        mockCallbacks
+      );
+    });
+
+    it('rangeToReplace starts at the typed word, not at the """ delimiter', async () => {
+      const query = 'from index | WHERE KQL("""field_na';
+      const kqlStartOffset = 'from index | WHERE KQL("""'.length;
+      const results = await suggest(query, whereContext, 'where', mockCallbacks, autocomplete);
+
+      const suggestion = results.find((s) => s.text === 'field_name');
+      expect(suggestion).toBeDefined();
+      expect(suggestion!.rangeToReplace).toEqual({
+        start: kqlStartOffset,
+        end: query.length,
+      });
+    });
+
+    it('rangeToReplace covers only the current word in multi-token KQL queries', async () => {
+      const query = 'from index | WHERE KQL("""fieldA AND field_na';
+      const wordStart = query.lastIndexOf('field_na');
+      const results = await suggest(query, whereContext, 'where', mockCallbacks, autocomplete);
+
+      const suggestion = results.find((s) => s.text === 'field_name');
+      expect(suggestion).toBeDefined();
+      expect(suggestion!.rangeToReplace).toEqual({
+        start: wordStart,
+        end: query.length,
+      });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/where/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/where/autocomplete.test.ts
@@ -82,7 +82,7 @@ describe('WHERE Autocomplete', () => {
   });
 
   describe('within the expression', () => {
-    const suggest = async (query: string) => {
+    const whereSuggest = async (query: string) => {
       const cursorPosition = query.length;
       const { command } = findAutocompleteAstPosition(query, cursorPosition);
       if (!command) {
@@ -374,7 +374,7 @@ describe('WHERE Autocomplete', () => {
     });
 
     test('pipe suggestion after complete expression', async () => {
-      expect(await suggest('from index | WHERE doubleField != doubleField ')).toContainEqual(
+      expect(await whereSuggest('from index | WHERE doubleField != doubleField ')).toContainEqual(
         expect.objectContaining({
           label: '|',
         })


### PR DESCRIPTION
## Summary

Important regression created by http://github.com/elastic/kibana/pull/258082

The KQL autocomplete suggestions have broken. This PR is fixing it


<img width="1176" height="521" alt="image" src="https://github.com/user-attachments/assets/7a565cdb-4ba5-4b49-a240-7074f9f3a8fe" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->