### PR TITLE
Fix ML enrichment test timeout when risk-score maintainer is not registered

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/entity_store_v2_enrichment_setup.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/entity_store_v2_enrichment_setup.ts
@@ -99,7 +99,13 @@ export const EntityStoreV2EnrichmentSetup = (getService: FtrProviderContext['get
         const maintainer = res.body?.maintainers?.[0];
         if (!maintainer) return false;
         if (maintainer.lastErrorTimestamp && !maintainer.lastSuccessTimestamp) {
-          throw new Error(`risk-score maintainer first run failed: ${JSON.stringify(res.body)}`);
+          // Every run so far has failed. The maintainer will not retry until its next
+          // scheduled interval, so it cannot overwrite CRUD-seeded entities in the
+          // test window. Log and proceed rather than failing the test setup.
+          log.debug(
+            `risk-score maintainer first run failed, proceeding: ${JSON.stringify(res.body)}`
+          );
+          return true;
         }
         return maintainer.runs > 0 && maintainer.lastSuccessTimestamp !== null;
       }


### PR DESCRIPTION
## Summary

The two ML rule enrichment tests were consistently failing on MKI CI:

- `Machine learning type rules > alerts should be enriched > should be enriched with host risk score`
- `Machine learning type rules > with asset criticality > should be enriched alert with criticality_level`

**Root cause:** The `EntityStoreV2EnrichmentSetup.setup()` helper polls for the risk-score entity maintainer to complete its first successful run before seeding test entities. On MKI CI the maintainer's first run fails (no risk score data or ML infrastructure available in that environment). When the first run fails, `lastErrorTimestamp` is set and `lastSuccessTimestamp` stays null. The original code threw an error in that case, which caused the `before` hook to fail and both enrichment tests to report as failed.

**Fix:** When the maintainer's first run has failed, proceed rather than throwing. A failed maintainer will not retry until its next scheduled interval, so it cannot overwrite CRUD-seeded test entities within the test window. The test entities are seeded via the CRUD API with explicit risk score fields and do not rely on the maintainer to compute them.

## Manual testing steps

1. Run the ML rule integration tests against a serverless environment where the risk-score maintainer fails its first run (e.g. MKI CI):
   ```
   node scripts/jest_integration x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/machine_learning/trial_license_complete_tier/machine_learning.ts
   ```
2. Confirm both `alerts should be enriched` tests pass without the before hook throwing.
3. In an environment where the maintainer succeeds on its first run, confirm that setup still waits for the first successful run before proceeding.

## Related

- PR that introduced the failing tests: https://github.com/elastic/kibana/pull/271093