### PR TITLE
[Workflows] Preserve comments when cloning a workflow

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
@@ -206,6 +206,56 @@ steps:
       expect(mockWorkflowsService.createWorkflow).toHaveBeenCalled();
     });
 
+    it('should preserve comments and commented-out steps in cloned YAML', async () => {
+      const originalWorkflow = createMockWorkflow({
+        yaml: `name: Original Workflow
+enabled: true
+steps:
+  - name: first_step
+    type: console
+    with:
+      message: hello
+  # This is a commented out step that should survive cloning
+  # - name: commented_step
+  #   type: console
+  #   with:
+  #     message: i am commented out
+  - name: second_step
+    type: console
+    with:
+      message: world`,
+      });
+
+      const mockZodSchema = z.object({
+        name: z.string(),
+        enabled: z.boolean().optional(),
+        steps: z.array(z.any()).optional(),
+      });
+
+      mockWorkflowsService.getWorkflowZodSchema.mockResolvedValue(mockZodSchema);
+
+      mockWorkflowsService.createWorkflow.mockImplementation((command) =>
+        Promise.resolve({
+          ...originalWorkflow,
+          id: 'workflow-clone-456',
+          name: 'Original Workflow Copy',
+          yaml: command.yaml,
+        })
+      );
+
+      await api.cloneWorkflow(originalWorkflow, 'default', mockRequest);
+
+      expect(mockWorkflowsService.createWorkflow).toHaveBeenCalled();
+      const yamlString = mockWorkflowsService.createWorkflow.mock.calls[0][0].yaml;
+
+      // The name is updated...
+      expect(yamlString).toContain('name: Original Workflow Copy');
+      // ...but the comments and commented-out step are preserved.
+      expect(yamlString).toContain('# This is a commented out step that should survive cloning');
+      expect(yamlString).toContain('# - name: commented_step');
+      expect(yamlString).toContain('#     message: i am commented out');
+    });
+
     it('should handle YAML parsing errors gracefully', async () => {
       const originalWorkflow = createMockWorkflow({
         yaml: 'invalid: yaml: content: with: multiple: colons',

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -36,7 +36,6 @@ import type {
   WorkflowExecutionEventDispatchMetadata,
   WorkflowExecutionListDto,
   WorkflowListDto,
-  WorkflowYaml,
 } from '@kbn/workflows';
 import { WORKFLOW_SML_TYPE } from '@kbn/workflows/common/constants';
 import { WorkflowNotFoundError } from '@kbn/workflows/common/errors';
@@ -54,7 +53,7 @@ import type {
 import type { ServerTriggerDefinition } from '@kbn/workflows-extensions/server';
 import {
   parseWorkflowYamlToJSON,
-  stringifyWorkflowDefinition,
+  updateYamlField,
   WorkflowValidationError,
 } from '@kbn/workflows-yaml';
 import type { z } from '@kbn/zod/v4';
@@ -345,15 +344,12 @@ export class WorkflowsManagementApi {
       throw parsedYaml.error;
     }
 
-    const updatedYaml = {
-      ...parsedYaml.data,
-      name: `${workflow.name} ${i18n.translate('workflowsManagement.cloneSuffix', {
-        defaultMessage: 'Copy',
-      })}`,
-    };
-
-    // Convert back to YAML string using proper YAML stringification
-    const clonedYaml = stringifyWorkflowDefinition(updatedYaml as unknown as WorkflowYaml);
+    // Update only the `name` field in place so the rest of the YAML
+    // (comments, commented-out steps, blank lines, formatting) is preserved.
+    const clonedName = `${workflow.name} ${i18n.translate('workflowsManagement.cloneSuffix', {
+      defaultMessage: 'Copy',
+    })}`;
+    const clonedYaml = updateYamlField(workflow.yaml, 'name', clonedName);
     const result = await this.workflowsService.createWorkflow(
       { yaml: clonedYaml },
       spaceId,


### PR DESCRIPTION
## Summary

Cloning a workflow previously re-serialized its YAML from the parsed object (`parseWorkflowYamlToJSON` → `stringifyWorkflowDefinition`), which discarded comments, commented-out steps, blank lines, and other original formatting (and injected fields like `version: "1"` that weren't in the source).

This change updates only the `name` field in place using `updateYamlField` (from `@kbn/workflows-yaml`, backed by `yaml`'s `parseDocument`/`setIn`), so the rest of the original YAML is preserved verbatim. The YAML is still parsed for validation before cloning.

- Fix `WorkflowsManagementApi.cloneWorkflow` to preserve YAML comments/formatting.
- Add a regression test asserting commented-out steps survive cloning.

### Before
```yaml
# comment block + commented-out steps are dropped on clone
version: "1"
name: my-workflow Copy
...
```

### After
```yaml
name: my-workflow Copy
...
  # This is a commented out step that should survive cloning
  # - name: commented_step
  ...
```

## Testing

`node scripts/jest src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts` — 49 passed. The new test fails on the previous implementation (comments stripped) and passes with the fix.

## References

Closes elastic/security-team#17846

Made with [Cursor](https://cursor.com)