### PR TITLE
[Alerting v2][POC] Unified ES|QL query sandbox — Compose Discover

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md
@@ -1,0 +1,100 @@
+# Design issue: Unified ES|QL query sandbox (Rules v2 — Compose Discover)
+
+_Use this document when filing a design issue on `elastic/platform-ux-team` (label: `Needs design`). Template source: [design-elastic-old `context/issue-templates.md`](https://github.com/elastic/design-elastic-old/blob/main/context/issue-templates.md) — **Design Issue (General)**._
+
+**Related:** [POC spec & decisions](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md) · Kibana POC branch `poc/query-sandbox-unified-editor`
+
+---
+
+## Problem to solve
+
+Rules v2 alert rules are stored as a **base ES|QL query** plus an **alert condition** (appendable segment). Users naturally author **one continuous pipeline** in Discover style — they do not think in “base” vs “condition” until they need to tune recovery or reuse a shared base.
+
+Today, exposing split editors upfront adds cognitive load and breaks the mental model of “write a query, run it, create a rule.” We need a **query sandbox** in the Compose Discover flyout that:
+
+- Feels like Discover (editor, time range, Search, results grid)
+- Defers split until the user is ready (after **Apply**)
+- Offers **escape hatches** (manual base/alert tabs, YAML split tabs) without forcing them
+- Keeps form/YAML mode switches safe while the sandbox is open
+
+This work supports Rules v2 authoring (RnA program) and aligns ES|QL-first alert creation with how users already explore data.
+
+---
+
+## Goals
+
+1. **Reduce time-to-first-valid query** — users can paste or write one pipeline and Apply without choosing split mode first.
+2. **Make the base/alert model legible after commit** — form summary shows base + alert blocks when split succeeds; clear copy when it does not.
+3. **Support power users** — manual split and YAML editing without blocking the default path.
+4. **Meet SharedUX / EUI bar** — flyout chrome, callouts, helpers, keyboard/a11y patterns consistent with Kibana Borealis.
+
+---
+
+## Deliverables
+
+| Artifact | Description |
+|----------|-------------|
+| **Figma** | Compose Discover flyout + query sandbox (unified, manual split, recovery, YAML); form step 1 summary states |
+| **Interaction spec** | States, transitions, mode gating, copy (can extend [POC spec](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md)) |
+| **UX guidelines** (if pattern is reusable) | “Unified editor → auto-split on Apply” for ES|QL rule authoring |
+| **Design critique sign-off** | EUI compliance, a11y, copy review before GA |
+
+---
+
+## Acceptance criteria
+
+Key user journeys that must be designed and specified end-to-end:
+
+1. **Create alert — happy path** — Open flyout → unified sandbox → Search → Apply → form shows base + alert → continue wizard.
+2. **Create alert — split failed** — Heuristic cannot assign base → info callout + **Separate base and alert** → manual split sandbox.
+3. **Create alert — no alert condition** — e.g. `STATS` without trailing `WHERE` → `no_where` → form shows base + *Not defined* + **No alert condition** callout ([POC spec §2](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#2-after-apply--form-summary-step-1)); user can proceed (OQ4).
+4. **Re-edit query** — After Apply, **Edit query** reopens unified editor; edits do not corrupt split (no duplicated pipeline lines).
+5. **Manual split ↔ unified** — Helper links *Separate base and alert* / *Use single editor* with confirm when merged text changed.
+6. **YAML mode** — Split tabs in sandbox; toggle back to form **preserves** YAML split (not re-heuristicized).
+7. **Recovery** — Custom recovery: locked base + editable recovery block in sandbox.
+8. **Signal rules** — Single editor; no split helpers.
+9. **Mode gating** — Alert/Signal and Form/YAML toggles disabled appropriately while sandbox is open in form mode; Next disabled until query is defined.
+
+---
+
+## Supporting documents and insights
+
+- **POC implementation & decisions:** [UNIFIED_QUERY_SANDBOX_POC_SPEC.md](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md) (includes flows, copy, open questions)
+- **Rules v2 query model:** composed `base` + `breach.segment` vs standalone `breach.query` (`@kbn/alerting-v2-schemas`)
+- **RnA architecture:** executor treats every row returned by breach query as breached
+- **Heuristic split:** `use_heuristic_split.ts` (`split_succeeded`, `no_where`, `where_without_stats`, …)
+
+_Evidence gaps for GA: FullStory / telemetry on rule create drop-off at query step; support themes on ES|QL rule authoring._
+
+---
+
+## Initial starting points
+
+- **POC branch:** `poc/query-sandbox-unified-editor` in `elastic/kibana` — `@kbn/alerting-v2-rule-form` → `flyout/compose_discover/`
+- **Principles already validated in POC:** one editor first; Apply as commit boundary; helper links (not title-row icons) for split/merge
+- **Competitive reference:** Discover ES|QL editor + time picker; Grafana/Splunk alert query UIs (single editor default)
+
+_Add screenshots or Loom from POC in the POC spec doc._
+
+---
+
+## Resources and links
+
+| Resource | Link |
+|----------|------|
+| POC spec & media | [UNIFIED_QUERY_SANDBOX_POC_SPEC.md](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md) |
+| Kibana package | `x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/` |
+| EUI patterns | [Error messages](https://eui.elastic.co/docs/patterns/error-messages/), [Help content](https://eui.elastic.co/docs/patterns/help-content/) |
+| Figma (Elastic UI — Borealis) | _Add node URLs_ |
+| PRD / problem brief | _Add link_ |
+| RnA open question (recovery YAML) | [rna-program#268984](https://github.com/elastic/rna-program/issues/268984) |
+
+---
+
+## Suggested GitHub issue title
+
+`[Rules v2] Design: Unified ES|QL query sandbox — Compose Discover flyout`
+
+## Suggested labels
+
+`Needs design`

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md
@@ -1,0 +1,341 @@
+# Unified ES|QL query sandbox — proposed dev scope (clean implementation)
+
+Proposal for engineering breakdown before filing GitHub issues.
+
+| | |
+|---|---|
+| **Surface** | Compose Discover flyout — create / edit ES|QL rules (Rules v2) |
+| **Package** | `@kbn/alerting-v2-rule-form` → `flyout/compose_discover/` |
+| **Program** | Rules v2 / RnA |
+
+**POC branch `poc/query-sandbox-unified-editor` is exploration only** — it validated UX and informed the spec. **Do not merge or extend the POC.** Implement against main using [POC spec](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md) and [design issue](./UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md) as the source of truth.
+
+---
+
+## What we're building
+
+Users write **one ES|QL pipeline** in a Discover-style **query sandbox** (child flyout). **Apply** is the commit boundary: sandbox draft → wizard form state → heuristic split into **base + alert condition** where applicable.
+
+| Principle | Implication for implementation |
+|-----------|-------------------------------|
+| One editor first | Default sandbox = single pipeline, not base/alert tabs |
+| Apply commits | Sandbox edits are draft until Apply; wizard Next/gating uses committed query |
+| Split after Apply | Auto-split runs on Apply; form shows base + alert summary |
+| Escape hatches | Manual split tabs + YAML split tabs; opt-in via helper links |
+| Safe mode switches | Disable Form/YAML and Alert/Signal toggles while sandbox open (form mode) |
+
+---
+
+## POC learnings (reference only)
+
+Exploration surfaced behaviors to **design in from the start**, not copy-paste from the branch:
+
+| Topic | Takeaway |
+|-------|----------|
+| Unified editor while typing | Store **standalone** `breach.query` in sandbox while user edits one pipeline — avoids duplicating lines on Enter/re-Apply when form is logically `composed` |
+| `no_where` ≠ split failed | Empty **alert segment** with non-empty **base** is valid (`no_where`); split failed = empty **base** |
+| No alert condition | Info callout + distinct section copy; do not use success copy (*alert condition identified*) |
+| YAML → Form | Preserve composed split + manual-split flag; do not re-run heuristic on toggle |
+| Save (OQ4) | UI allows base-only; API/schema must be resolved in mapper or schema work — don't ship UI-only |
+| Edit mode (OQ1) | Decide up front how API `Query` maps to sandbox on open |
+
+---
+
+## Proposed work packages
+
+Sized for **clean implementation** on existing Compose Discover code. Adjust with tech lead.
+
+### WP0 — Design & product gates (parallel)
+
+| Input | Owner |
+|-------|--------|
+| Design issue on `platform-ux-team` | Design |
+| Figma: unified, manual split, form states, YAML, recovery | Design |
+| **OQ4:** base-only rules allowed on save? | Product + backend |
+| **OQ1:** edit-mode sandbox entry | Product + eng |
+| **OQ2 / OQ3** | Product (can defer post-v1) |
+
+**Blocks GA-quality UI (WP8), not necessarily WP1–3.**
+
+---
+
+### WP1 — Query state model & Apply contract
+
+**Goal:** Shared foundation for sandbox ↔ wizard without UI beyond minimal wiring.
+
+**Build**
+
+- Sandbox draft vs **committed** query (`queryCommitted`, `isQueryDefined`)
+- In-memory rule query shape: `composed` (`base`, `breach.segment`, optional `recovery`) vs `standalone` (`breach.query`)
+- **Apply** handler: unified path runs heuristic split → writes committed query to form state → closes sandbox
+- Flags: `manualSplitEnabled`, child flyout open/which step
+- Pure utilities: join/split pipeline, snapshot for Apply, unified-editor change handler (standalone while typing)
+- Reuse or reimplement heuristic split (`STATS` + trailing `WHERE` logic) with explicit result types: `split_succeeded`, `no_where`, `split_failed`, etc.
+
+**Tests:** unit tests for utilities and state transitions (no full flyout yet).
+
+**Acceptance**
+
+- Given a pipeline string, Apply produces expected `base` / `breach.segment` (or standalone draft while editing)
+- Gating rules documented and testable: Next requires committed + defined query
+
+**Estimate:** M
+
+---
+
+### WP2 — Query sandbox flyout (unified + signal)
+
+**Goal:** Discover-like child flyout for step 1 (alert) and signal rules.
+
+**Build**
+
+- Nested flyout: title, helper text, time field + date range, **Search**, ES|QL editor, chart + grid, **Apply**
+- **Alert — unified:** single editor; helper with link to manual split (WP3)
+- **Signal:** single editor; no split helpers ([spec](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#query-sandbox))
+- Create flow: sandbox opens automatically on new alert rule
+- Footer: Apply; disable parent Back/Next while open
+- Integrate existing query execution / autocomplete hooks in package
+
+**Acceptance**
+
+- User can Search, edit, Apply → returns to form with committed query (split deferred to WP4 summary if same PR, or stub summary)
+- Signal path: Apply → committed standalone query
+
+**Depends on:** WP1
+
+**Estimate:** L
+
+---
+
+### WP3 — Manual split mode
+
+**Goal:** Power-user escape hatch without changing default path.
+
+**Build**
+
+- Base / Alert tabs in sandbox when `manualSplitEnabled`
+- Helpers: *Separate base and alert* / *Use single editor* ([copy in spec](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#query-sandbox))
+- Confirm when merging manual edits back to unified (if text changed)
+- Apply in manual mode: persist split as `composed` without re-heuristic
+
+**Acceptance**
+
+- Round-trip unified → manual → unified without data loss
+- Manual Apply → form shows correct base and alert blocks
+
+**Depends on:** WP1, WP2
+
+**Estimate:** M
+
+---
+
+### WP4 — Alert condition form step (summary + callouts)
+
+**Goal:** Step 1 form reflects committed query and split outcome.
+
+**Build**
+
+- `EsqlQuerySummarySection`: read-only base + alert blocks; **Not defined** for empty segments
+- Section descriptions per state ([table](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#alert-condition-step-form))
+- Callouts:
+  - **No query defined** (empty after Apply) → Next disabled
+  - **No alert condition** (`no_where`) → [POC spec §2](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#2-after-apply--form-summary-step-1)
+  - **Split failed** → CTA **Separate base and alert** → opens manual split (WP3)
+- **Edit query** reopens sandbox (unified unless manual split was enabled)
+- Fix success copy: only when `breach.segment` is non-empty
+
+**Acceptance**
+
+- [QA scenarios 1–4, 5](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#qa-scenarios) pass manually
+- Unit tests per callout trigger conditions
+
+**Depends on:** WP1; best delivered with WP2/WP3
+
+**Estimate:** M
+
+---
+
+### WP5 — YAML mode integration
+
+**Goal:** YAML authors get split sandbox; Form ↔ YAML does not destroy split.
+
+**Build**
+
+- YAML mode: sandbox uses Base / Alert / Recovery tabs; Apply updates YAML text; sandbox **stays open**
+- Form/YAML toggle **enabled** in YAML; **disabled** while sandbox open in form mode
+- YAML → Form: preserve composed split + `manualSplitEnabled`; set recovery type when recovery segment present ([D5](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#decisions))
+- Do not re-run heuristic when leaving YAML ([OQ2](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#open-questions) — default: no)
+
+**Acceptance**
+
+- QA scenarios 7–8
+- YAML debounce → sandbox stays in sync
+
+**Depends on:** WP1, WP2, WP3
+
+**Estimate:** M
+
+---
+
+### WP6 — Recovery query sandbox
+
+**Goal:** Custom recovery editing with locked base.
+
+**Build**
+
+- Recovery step: open sandbox with read-only base + editable recovery block
+- Apply commits recovery segment only
+- Helper copy per spec
+
+**Acceptance**
+
+- QA scenario 9
+- Recovery segment round-trips in composed query
+
+**Depends on:** WP1, WP2
+
+**Estimate:** S–M
+
+---
+
+### WP7 — API mapping, save & edit load
+
+**Goal:** Create/update/load rules correctly for all query shapes.
+
+**Build**
+
+- `composeFormToCreateRequest` / update / `mapRuleToComposeFormValues`
+- **OQ4:** when alert has base-only effective query, persist via chosen strategy:
+  - **A.** Emit `standalone` `breach.query` on save, or
+  - **B.** Relax composed schema for empty `breach.segment`
+- **OQ1:** load existing rule → form summary + sandbox snapshot (unified vs manual split)
+- Validation aligned with `@kbn/alerting-v2-schemas`
+
+**Acceptance**
+
+- Create with `STATS` only → save succeeds → reload shows no-alert-condition state
+- Composed + standalone rules edit without corrupting query
+- Mapper unit tests
+
+**Depends on:** WP1, WP4; product decision OQ4
+
+**Estimate:** M (S if option A only in kibana)
+
+---
+
+### WP8 — Wizard chrome, gating & polish
+
+**Goal:** Spec-compliant flyout shell ([D10, D11](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md#decisions)).
+
+**Build**
+
+- Stepper / YAML badge; Alert ↔ Signal toggle rules
+- Details step: name auto-focus, description always visible, optional labels
+- Back/Next `color="text"`; Create/Save primary
+- No Cancel in footer (existing confirm-on-close pattern)
+- a11y: focus management between parent/child flyouts
+
+**Depends on:** WP2+; design sign-off for GA
+
+**Estimate:** S–M
+
+---
+
+### WP9 — Automated tests
+
+**Goal:** Regression safety for clean implementation.
+
+| Layer | Scope |
+|-------|--------|
+| **Unit** | Heuristic split, Apply/snapshot utils, mapper, callout conditions, state reducer |
+| **Scout** | Create alert happy path; `no_where` callout; split failed → manual; YAML → Form |
+
+**Depends on:** WP4, WP7 for meaningful E2E save tests
+
+**Estimate:** M
+
+---
+
+### WP10 — Follow-ups (post-v1 unless required)
+
+| Item | Notes |
+|------|--------|
+| Telemetry | Apply, split outcome, manual split usage |
+| OQ2 | Re-split policy for YAML-only edits |
+| OQ3 | `recoveryType` UI vs infer |
+| Heuristic improvements | New ES\|QL patterns beyond STATS/WHERE |
+
+---
+
+## Suggested GitHub issues
+
+| # | Title | WP |
+|---|--------|-----|
+| 0 | [Rules v2] Design: Unified ES\|QL query sandbox | WP0 (platform-ux) |
+| 1 | [Rules v2] Query sandbox — state model & Apply contract | WP1 |
+| 2 | [Rules v2] Query sandbox flyout — unified editor & signal | WP2 |
+| 3 | [Rules v2] Query sandbox — manual base/alert split | WP3 |
+| 4 | [Rules v2] Alert condition step — query summary & callouts | WP4 |
+| 5 | [Rules v2] Query sandbox — YAML mode integration | WP5 |
+| 6 | [Rules v2] Query sandbox — recovery editor | WP6 |
+| 7 | [Rules v2] ES\|QL rule query — API map, save & edit load | WP7 |
+| 8 | [Rules v2] Compose flyout — wizard chrome & gating | WP8 |
+| 9 | [Rules v2] Tests: query sandbox unit + Scout | WP9 |
+
+**Epic (optional):** link 1–9 under Rules v2 compose / RnA milestone.
+
+**PR strategy (for tech lead):** WP1 first; then WP2+WP4 as vertical slice (create alert happy path); WP3, WP5, WP6 incremental; WP7 before calling save flows done; WP9 ongoing.
+
+---
+
+## Sequencing
+
+```mermaid
+flowchart TD
+  WP0[WP0 Design + OQ4/OQ1] --> WP8
+  WP1[WP1 State & Apply] --> WP2[WP2 Sandbox UI]
+  WP1 --> WP4[WP4 Form summary]
+  WP2 --> WP3[WP3 Manual split]
+  WP2 --> WP6[WP6 Recovery]
+  WP3 --> WP5[WP5 YAML]
+  WP4 --> WP7[WP7 API save/load]
+  OQ4[Product OQ4] --> WP7
+  WP7 --> WP9[WP9 Scout]
+  WP4 --> WP9
+```
+
+**Minimum vertical slice (demo):** WP1 + WP2 + WP4 — create alert, Apply, see summary (save may stub until WP7).
+
+**Minimum shippable:** above + WP7 (save/load) + WP3 (split failed path) + unit tests.
+
+**Recommended v1:** WP1–WP8 + WP9; WP10 later.
+
+---
+
+## Out of scope
+
+- Merging or maintaining POC branch code
+- Heuristic split algorithm owned by another team (unless shared package extracted)
+- Executor / notification pipeline changes
+- Rule builder threshold UI (`rule_builder/threshold/`)
+- Non–Compose Discover authoring surfaces
+
+---
+
+## References
+
+- [POC spec & decisions](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md) — behavior & copy (not code)
+- [Design issue](./UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md)
+- `@kbn/alerting-v2-schemas` — `rule_data_schema.ts`
+- Existing package entry: `compose_discover_flyout.tsx`, `query_sandbox_flyout.tsx` (baseline on main — refactor/replace as needed)
+
+---
+
+## Questions for tech lead
+
+1. **WP7 / OQ4:** Standalone mapper on save (A) vs composed schema change (B)?
+2. **WP1:** New state module vs extend `use_compose_discover_state`?
+3. **WP2:** Reuse existing `query_sandbox.tsx` / flyout or replace?
+4. **WP7 / OQ1:** Edit always opens unified editor, or respect saved `format` + `manualSplitEnabled`?
+5. **Vertical slice:** Single team owns WP1–4, or parallel tracks (UI vs mappers)?
+6. **Feature flag:** Ship behind Rules v2 flag or new sub-flag?

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_POC_SPEC.md
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_POC_SPEC.md
@@ -1,0 +1,197 @@
+# Unified ES|QL query sandbox — POC spec
+
+**Surface:** Compose Discover flyout (Rules v2 create/edit) · **Package:** `flyout/compose_discover/`  
+**POC branch:** `poc/query-sandbox-unified-editor` (exploration only — informs this spec)  
+**Design issue:** [UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md](./UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md) · **Dev scope:** [UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md](./UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md)
+
+Users write **one ES|QL pipeline** in a Discover-style sandbox. **Apply** commits to the wizard and auto-splits into **base + alert condition**. Manual split and YAML are opt-in escape hatches.
+
+---
+
+## Flows
+
+### Create alert rule
+
+```mermaid
+flowchart LR
+  A[Open flyout] --> B[Unified sandbox]
+  B --> C[Search + Apply]
+  C --> D{Auto-split}
+  D -->|OK| E[Base + alert on form]
+  D -->|no_where| N[Base only + callout]
+  D -->|Fail| F[Manual split CTA]
+  E --> G[Recovery → Details → Notifications]
+  N --> G
+  F --> B
+```
+
+### Editor modes
+
+```mermaid
+flowchart TD
+  U[Unified] -->|Separate base and alert| M[Manual split tabs]
+  M -->|Use single editor| U
+  U -->|Apply| F[Form summary]
+  M -->|Apply| F
+  F -->|Edit query| U
+  F -->|Edit query manual| M
+```
+
+### Form ↔ YAML
+
+```mermaid
+flowchart LR
+  A[Form] --> B[YAML]
+  B --> C[Split tabs + Apply → YAML text]
+  B -->|Toggle back| A2[Form keeps split + manualSplit]
+  A2 --> A
+```
+
+---
+
+## 1. Query sandbox (default path)
+
+**What:** Child flyout where users Search, preview results, and **Apply**. Alert rules start here with a **single editor** — not base/alert tabs.
+
+**Layout:** helper → (tabs if split) → time field + range → **Search** → editor → chart + grid → **Apply**
+
+| Mode | Editor | On Apply |
+|------|--------|----------|
+| Unified (default) | One pipeline | Auto-split → close sandbox |
+| Manual split | Base / Alert tabs | Keep split → close |
+| YAML | Base / Alert / Recovery tabs | Update YAML · sandbox **stays open** |
+| Recovery step | Locked base + recovery block | Close |
+| Signal | One pipeline | Close |
+
+**Unified helper:** *We'll automatically identify the base query and alert condition when you apply changes.* → link **Separate base and alert**
+
+**Implementation note:** While typing in the unified editor, store **standalone** `breach.query` (full pipeline) — avoids duplicated lines on Enter/re-Apply.
+
+> **Media**  
+> ![Unified editor](media/01-unified-editor.png)  
+> _[Video: re-edit unified — Enter does not duplicate lines](media/06-re-edit-unified.mp4)_
+
+---
+
+## 2. After Apply — form summary (step 1)
+
+**What:** Wizard step **Alert condition** shows read-only **base** and **alert** blocks. Copy and callouts depend on how auto-split resolved.
+
+| Outcome | Section description | Callout | Next |
+|---------|---------------------|---------|------|
+| **Before Apply** | *Open the editor to write your ES\|QL query* | — · CTA **Open query editor** | Off |
+| **Success** | *Search query and alert condition identified* | — | On |
+| **No alert condition** (`no_where`) | *Base query defined — no separate alert condition* | **No alert condition** — *Without an alert condition, every row returned by the base query is treated as a breach.* | On¹ |
+| **Empty query** | *Define an ES\|QL query in the editor* | **No query defined** | Off |
+| **Split failed** | *Review your query or separate it manually* | Info callout + **Separate base and alert** | On |
+
+Empty summary blocks → **Not defined**. Primary action: **Edit query**.
+
+**`no_where` vs split failed**
+
+| | `no_where` | Split failed |
+|---|------------|--------------|
+| **Base** | Non-empty (full pipeline) | Empty |
+| **Alert segment** | Empty | Any |
+| **Meaning** | Every result row = breach | Heuristic could not split — user fixes manually |
+| **Example** | `FROM flights \| STATS COUNT(*) BY city` | Unsplittable / invalid pipeline |
+
+¹ Save API may reject empty `breach.segment` today — product decision [OQ4](#open-questions).
+
+> **Media**  
+> ![After Apply — base + alert](media/02-after-apply-split.png)  
+> ![No alert condition callout](media/03-no-alert-condition.png)  
+> ![Split failed + manual CTA](media/04-split-failed.png)
+
+---
+
+## 3. Escape hatches — manual split & YAML
+
+**What:** Power users edit base and alert separately, or work in YAML, without changing the default unified path.
+
+**Manual split**
+
+- Open via helper **Separate base and alert** or split-failed CTA
+- Tabs: Base · Alert · helper **Use single editor** (confirm if merge would lose edits)
+- Apply keeps `composed` shape; set `manualSplitEnabled`
+
+**YAML**
+
+- Alert rules: sandbox always uses split tabs
+- Form ↔ YAML toggle **off** while sandbox open in **form** mode; **on** in YAML mode
+- **YAML → Form:** preserve split + `manualSplitEnabled` — **do not** re-run heuristic
+- YAML debounces to form; sandbox follows live state
+
+> **Media**  
+> ![Manual split tabs](media/05-manual-split.png)  
+> ![YAML sandbox tabs](media/07-yaml-sandbox.png)  
+> ![YAML → Form split preserved](media/08-yaml-to-form.png)
+
+---
+
+## 4. Wizard chrome, recovery & signal
+
+**What:** Parent flyout behavior around the sandbox — steps, gating, recovery editing, signal rules.
+
+**Steps:** Alert condition → Recovery → Details & artifacts → Notifications  
+**Chrome:** Stepper hidden in YAML (**YAML MODE** badge) · Footer Back + Next/Create · no Cancel · Details: name auto-focus, description always visible
+
+**Gating**
+
+| Control | Disabled when |
+|---------|---------------|
+| Alert ↔ Signal | Sandbox open, query not committed/defined, or edit mode |
+| Form ↔ YAML | Sandbox open in form mode |
+| Back / Next | Sandbox open |
+| Next (step 1) | Query not committed or not defined |
+
+**Recovery:** Custom recovery opens sandbox with **locked base** + editable recovery block. Helper: *Define when the alert should recover…*
+
+**Signal:** Single editor only — no split helpers.
+
+> **Media**  
+> ![Recovery — locked base](media/09-recovery.png)  
+> ![Details step — name focus](media/10-details.png)
+
+---
+
+## Decisions (POC)
+
+| # | Decision |
+|---|----------|
+| D1 | Unified editor first; split on form after Apply |
+| D2 | Apply = commit boundary (sandbox draft ≠ wizard until Apply) |
+| D3 | Split/merge via **helper links**, not title icons |
+| D4 | Form/YAML toggle off while sandbox open (form mode) |
+| D5 | YAML → Form keeps split; no re-heuristic |
+| D6 | Unified typing uses standalone `breach.query` |
+| D7 | `no_where` → **No alert condition** callout (not success copy) |
+| D8 | Empty query → callout; Next off |
+| D9 | Split failed = empty **base** only |
+| D10–D11 | Details polish; Back/Next text, Create/Save fill |
+
+---
+
+## Open questions
+
+| ID | Question | POC stance |
+|----|----------|------------|
+| OQ1 | Edit existing rule — unified or composed sandbox? | TBD |
+| OQ2 | Re-split on YAML-only edits? | TBD |
+| OQ3 | `recoveryType` UI vs infer from query? | TBD |
+| OQ4 | Base-only rules (empty alert segment)? | Yes in UI + callout; save needs API/mapper |
+
+---
+
+## Quick QA
+
+1. `STATS … \| WHERE c > 100` → base + alert  
+2. `STATS …` (no WHERE) → no alert condition callout  
+3. Empty Apply → no query callout; Next off  
+4. Split failed → manual split  
+5. Re-edit + Enter → no duplication  
+6. YAML ↔ Form → split preserved  
+
+```bash
+node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/
+```

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_UX_SPEC.md
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_UX_SPEC.md
@@ -1,0 +1,12 @@
+# Unified ES|QL query sandbox — documentation index
+
+This POC is documented in **two GitHub-ready markdown files**:
+
+| Document | Purpose |
+|----------|---------|
+| [**UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md**](./UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md) | **Design issue** — problem, goals, deliverables, acceptance criteria ([design-elastic-old](https://github.com/elastic/design-elastic-old) Design Issue template). File on `elastic/platform-ux-team` with label `Needs design`. |
+| [**UNIFIED_QUERY_SANDBOX_POC_SPEC.md**](./UNIFIED_QUERY_SANDBOX_POC_SPEC.md) | **POC spec** — flows, section-by-section behavior with **media per section**, decisions, open questions. |
+| [**UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md**](./UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md) | **Dev scope proposal** — work packages, suggested GitHub issues, sequencing (for tech lead review). |
+
+**Branch:** `poc/query-sandbox-unified-editor`  
+**Package:** `@kbn/alerting-v2-rule-form` → `flyout/compose_discover/`

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -163,12 +163,20 @@ describe('ComposeDiscoverFlyout', () => {
     });
 
     it('does not render the stepper in YAML mode', () => {
-      renderFlyout();
+      renderFlyout({ mode: 'edit' });
 
       clickEditMode('yaml');
 
       expect(screen.queryByRole('group', { name: /Step \d+ of \d+/ })).not.toBeInTheDocument();
       expect(screen.getByTestId('composeDiscoverYamlBadge')).toBeInTheDocument();
+    });
+
+    it('disables the form/YAML toggle while the query sandbox is open in form mode', () => {
+      renderFlyout();
+
+      const toggleGroup = screen.getByTestId('composeDiscoverEditModeToggle');
+      expect(toggleGroup.querySelector('button[data-test-subj="yaml"]')).toBeDisabled();
+      expect(toggleGroup.querySelector('button[data-test-subj="form"]')).toBeDisabled();
     });
   });
 
@@ -227,6 +235,10 @@ describe('ComposeDiscoverFlyout', () => {
       renderFlyout();
       expect(screen.getByTestId('composeDiscoverNext')).toBeDisabled();
     });
+    it('does not show Cancel button in the footer', () => {
+      renderFlyout();
+      expect(screen.queryByTestId('composeDiscoverCancel')).not.toBeInTheDocument();
+    });
   });
 
   describe('unsaved-changes confirmation', () => {
@@ -240,33 +252,12 @@ describe('ComposeDiscoverFlyout', () => {
       expect(screen.queryByTestId('alertingV2ConfirmRuleCloseModal')).not.toBeInTheDocument();
     });
 
-    it('closes immediately when the form is pristine and Cancel is clicked', () => {
-      const onClose = jest.fn();
-      renderFlyout({ onClose });
-
-      fireEvent.click(screen.getByTestId('composeDiscoverCancel'));
-
-      expect(onClose).toHaveBeenCalledTimes(1);
-      expect(screen.queryByTestId('alertingV2ConfirmRuleCloseModal')).not.toBeInTheDocument();
-    });
-
     it('shows the confirmation modal when the form is dirty and the X button is clicked', () => {
       const onClose = jest.fn();
       renderFlyout({ onClose });
 
       fireEvent.click(screen.getByTestId('mockMakeDirty'));
       fireEvent.click(screen.getByTestId('euiFlyoutCloseButton'));
-
-      expect(onClose).not.toHaveBeenCalled();
-      expect(screen.getByTestId('alertingV2ConfirmRuleCloseModal')).toBeInTheDocument();
-    });
-
-    it('shows the confirmation modal when the form is dirty and Cancel is clicked', () => {
-      const onClose = jest.fn();
-      renderFlyout({ onClose });
-
-      fireEvent.click(screen.getByTestId('mockMakeDirty'));
-      fireEvent.click(screen.getByTestId('composeDiscoverCancel'));
 
       expect(onClose).not.toHaveBeenCalled();
       expect(screen.getByTestId('alertingV2ConfirmRuleCloseModal')).toBeInTheDocument();
@@ -298,7 +289,7 @@ describe('ComposeDiscoverFlyout', () => {
 
     it('shows confirmation in YAML mode when text differs from baseline', () => {
       const onClose = jest.fn();
-      renderFlyout({ onClose });
+      renderFlyout({ onClose, mode: 'edit' });
 
       clickEditMode('yaml');
 
@@ -311,7 +302,7 @@ describe('ComposeDiscoverFlyout', () => {
 
     it('closes immediately in YAML mode when text matches baseline', () => {
       const onClose = jest.fn();
-      renderFlyout({ onClose });
+      renderFlyout({ onClose, mode: 'edit' });
 
       clickEditMode('yaml');
 
@@ -336,7 +327,7 @@ describe('ComposeDiscoverFlyout', () => {
 
     it('"Continue editing" reopens sandbox in YAML mode', () => {
       const onClose = jest.fn();
-      renderFlyout({ onClose });
+      renderFlyout({ onClose, mode: 'edit' });
 
       clickEditMode('yaml');
 
@@ -351,7 +342,7 @@ describe('ComposeDiscoverFlyout', () => {
 
     it('shows confirmation after editing in YAML mode and switching back to form mode', () => {
       const onClose = jest.fn();
-      renderFlyout({ onClose });
+      renderFlyout({ onClose, mode: 'edit' });
 
       clickEditMode('yaml');
       fireEvent.click(screen.getByTestId('mockMakeYamlDirty'));

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -8,9 +8,9 @@
 import {
   EuiBadge,
   EuiButton,
-  EuiButtonEmpty,
   EuiButtonGroup,
   EuiCallOut,
+  EuiConfirmModal,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -36,7 +36,7 @@ import { mergeArtifactsByType, splitArtifactsByType } from '../../form/utils/art
 import { parseYamlToFormValues, serializeFormToYaml } from '../../form/utils/yaml_form_utils';
 import { ComposeDiscoverForm, getSteps } from './compose_discover_form';
 import type { ComposeFormValues, RuleQuery } from './compose_form_types';
-import { getBreachQuery, getRecoverQuery } from './compose_form_types';
+import { getBreachQuery, getRecoverQuery, isQueryDefined } from './compose_form_types';
 import {
   composeFormToCreateRequest,
   composeFormToUpdateRequest,
@@ -48,8 +48,22 @@ import { RULE_BUILDER_REGISTRY, BuilderStateProvider, type BuilderState } from '
 import type { ComposeDiscoverMode, QueryTab, RecoveryType } from './types';
 import { getSandboxTabs, useComposeDiscoverState } from './use_compose_discover_state';
 import { useEsqlAutocomplete } from './use_esql_providers';
-import { guessRecoveryBlock, discoverQueryToComposed, splitQuery } from './use_heuristic_split';
+import { guessRecoveryBlock, discoverQueryToComposed } from './use_heuristic_split';
 import { useSplitQueryCompletion } from './use_split_query_completion';
+import {
+  ensureComposedQuery,
+  getYamlSandboxTabs,
+  queryFromYamlToForm,
+  resolveSandboxQueryOnApply,
+  shouldPreserveYamlSplitOnFormExit,
+  shouldShowManualSplitToggle,
+  shouldShowRecoverySandboxHeader,
+  shouldShowSignalQueryHeader,
+  shouldUseUnifiedSandboxEditor,
+  toManualSplitQuery,
+  toUnifiedSandboxQuery,
+  type AlertQuerySnapshot,
+} from './sandbox_query_utils';
 
 const LazyYamlRuleForm = React.lazy(() =>
   import('../../form/yaml_rule_form').then((m) => ({ default: m.YamlRuleForm }))
@@ -93,11 +107,6 @@ const CREATE_RULE_BUTTON_LABEL = i18n.translate(
 const SAVE_RULE_BUTTON_LABEL = i18n.translate(
   'xpack.alertingV2.composeDiscover.flyout.saveButtonLabel',
   { defaultMessage: 'Save rule' }
-);
-
-const CANCEL_BUTTON_LABEL = i18n.translate(
-  'xpack.alertingV2.composeDiscover.flyout.cancelButtonLabel',
-  { defaultMessage: 'Cancel' }
 );
 
 const BACK_BUTTON_LABEL = i18n.translate(
@@ -217,7 +226,7 @@ const EMPTY_FORM_VALUES: ComposeFormValues = {
   metadata: { name: '', enabled: true, description: '', tags: [] },
   timeField: '@timestamp',
   schedule: { every: '1m', lookback: '5m' },
-  query: { format: 'composed', base: '', breach: { segment: '' } },
+  query: { format: 'standalone', breach: { query: '' } },
   grouping: undefined,
   stateTransition: undefined,
   stateTransitionAlertDelayMode: 'immediate',
@@ -325,8 +334,7 @@ export function ComposeDiscoverFlyout({
   // our onClose callback for EUI-managed close paths (X, ESC, outside click).
   // By the time handleRequestClose runs, the flyout is already unregistered
   // from the manager. Incrementing the key forces React to re-mount the
-  // EuiFlyout, re-registering it with the manager. The Cancel button doesn't
-  // go through closeAllFlyouts(), so no remount is needed for that path.
+  // EuiFlyout, re-registering it with the manager.
   // Form state is preserved because FormProvider sits above the flyout.
   const [flyoutKey, setFlyoutKey] = useState(0);
   const isDirtyRef = useRef(false);
@@ -346,11 +354,10 @@ export function ComposeDiscoverFlyout({
   // the form dirty. Track the initial value to detect user changes.
   const initialRecoveryTypeRef = useRef(hasInitialCustomRecovery ? 'custom' : 'default');
 
-  // Tracks whether the close was triggered by the Cancel button ('button')
-  // or by EUI's managed paths — X, ESC, outside click ('eui'). Only the
-  // EUI path calls closeAllFlyouts() which unregisters the flyout and
-  // requires a flyoutKey remount.
-  const closeSourceRef = useRef<'button' | 'eui'>('eui');
+  // Tracks whether the close was triggered by EUI's managed paths — X, ESC,
+  // outside click. Used when "Continue editing" remounts the flyout after
+  // dismissing the unsaved-changes confirmation.
+  const closeSourceRef = useRef<'eui'>('eui');
 
   // After "Continue editing" on the EUI-managed path, the flyoutKey remount
   // cascade-closes the sandbox. This ref tells the subsequent effect whether
@@ -380,21 +387,26 @@ export function ComposeDiscoverFlyout({
 
   const handleCancelDiscard = useCallback(() => {
     setIsConfirmCloseVisible(false);
-    if (closeSourceRef.current === 'eui') {
-      // EUI-managed close already called closeAllFlyouts() — remount to
-      // re-register the flyout with the manager, and reopen the sandbox
-      // if it was cascade-closed.
-      reopenChildRef.current = uiState.yamlMode || uiState.childOpen;
-      setFlyoutKey((k) => k + 1);
-    }
+    // EUI-managed close already called closeAllFlyouts() — remount to
+    // re-register the flyout with the manager, and reopen the sandbox
+    // if it was cascade-closed.
+    reopenChildRef.current = uiState.yamlMode || uiState.childOpen;
+    setFlyoutKey((k) => k + 1);
     closeSourceRef.current = 'eui';
   }, [uiState.yamlMode, uiState.childOpen]);
 
-  const [sandboxQuery, setSandboxQuery] = useState<RuleQuery>(() => methods.getValues('query'));
+  const [sandboxQuery, setSandboxQuery] = useState<RuleQuery>(() => {
+    const formQuery = methods.getValues('query');
+    const kind = methods.getValues('kind');
+    return kind === 'alert' ? toUnifiedSandboxQuery(formQuery) : formQuery;
+  });
   const [sandboxTimeField, setSandboxTimeField] = useState<string>(() =>
     methods.getValues('timeField')
   );
   const [dateRange, setDateRange] = useState({ dateStart: 'now-15m', dateEnd: 'now' });
+  const [isConfirmUnifiedVisible, setIsConfirmUnifiedVisible] = useState(false);
+  const alertSnapshotRef = useRef<AlertQuerySnapshot | null>(null);
+  const unifiedBufferBeforeManualRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (rule || initialQuery === undefined) {
@@ -422,9 +434,28 @@ export function ComposeDiscoverFlyout({
   }, [initialQuery, esqlVariables, inlineResult.query, rule, methods, dispatch]);
 
   const syncSandbox = useCallback(() => {
-    setSandboxQuery(methods.getValues('query'));
+    const formQuery = methods.getValues('query');
+    const kind = methods.getValues('kind');
+    const isAlertKind = kind === 'alert';
+
+    if (uiState.yamlMode && isAlertKind && !isBuilderMode) {
+      setSandboxQuery(ensureComposedQuery(formQuery));
+    } else {
+      const useUnified = shouldUseUnifiedSandboxEditor(
+        isAlertKind,
+        uiState.step,
+        uiState.yamlMode,
+        isBuilderMode,
+        uiState.manualSplitEnabled
+      );
+      setSandboxQuery(useUnified ? toUnifiedSandboxQuery(formQuery) : formQuery);
+    }
     setSandboxTimeField(methods.getValues('timeField'));
-  }, [methods]);
+  }, [methods, uiState.step, uiState.yamlMode, uiState.manualSplitEnabled, isBuilderMode]);
+
+  const handleSandboxQueryChange = useCallback((query: RuleQuery) => {
+    setSandboxQuery(query);
+  }, []);
 
   /*
    * Split-query completion for alert and recovery block editors. Registered at
@@ -442,6 +473,8 @@ export function ComposeDiscoverFlyout({
   });
 
   const isAlert = useWatch({ control: methods.control, name: 'kind' }) === 'alert';
+  const committedQuery = useWatch({ control: methods.control, name: 'query' });
+  const hasDefinedQuery = uiState.queryCommitted && isQueryDefined(committedQuery);
   const isAlertRef = useRef(isAlert);
   isAlertRef.current = isAlert;
 
@@ -458,31 +491,113 @@ export function ComposeDiscoverFlyout({
 
   const handleKindChange = useCallback(
     (kind: 'signal' | 'alert') => {
-      if (kind === 'alert') {
-        const full = getBreachQuery(methods.getValues('query'));
-        const { base, alertBlock } = splitQuery(full);
-        const composed: RuleQuery = {
-          format: 'composed',
-          base,
-          breach: { segment: alertBlock },
-        };
-        setSandboxQuery(composed);
-        methods.setValue('query', composed, { shouldDirty: true });
-      } else {
-        // Assemble from committed query — discards any unapplied sandbox edits cleanly.
-        const assembled = getBreachQuery(methods.getValues('query'));
+      if (uiState.childOpen) {
+        return;
+      }
+
+      const currentKind = methods.getValues('kind');
+      if (currentKind === kind) {
+        return;
+      }
+
+      if (kind === 'signal') {
+        const currentQuery = methods.getValues('query');
+        const fullQuery = getBreachQuery(currentQuery).trim();
+        if (currentQuery.format === 'composed') {
+          alertSnapshotRef.current = {
+            query: currentQuery,
+            manualSplitEnabled: uiState.manualSplitEnabled,
+            fullQuery,
+          };
+        } else {
+          alertSnapshotRef.current = null;
+        }
         const standalone: RuleQuery = {
           format: 'standalone',
-          breach: { query: assembled },
+          breach: { query: fullQuery },
         };
         setSandboxQuery(standalone);
         methods.setValue('query', standalone, { shouldDirty: true });
+      } else {
+        const currentQuery = methods.getValues('query');
+        const fullQuery = getBreachQuery(currentQuery).trim();
+        const snapshot = alertSnapshotRef.current;
+        let composed: RuleQuery;
+        let restoreManualSplit = false;
+
+        if (snapshot && snapshot.fullQuery === fullQuery) {
+          composed = snapshot.query;
+          restoreManualSplit = snapshot.manualSplitEnabled;
+        } else {
+          composed = toManualSplitQuery(fullQuery);
+          restoreManualSplit = false;
+        }
+
+        setSandboxQuery(
+          restoreManualSplit ? composed : toUnifiedSandboxQuery(composed)
+        );
+        methods.setValue('query', composed, { shouldDirty: true });
+        dispatch({ type: 'KIND_CHANGE', kind: 'alert' });
+        if (restoreManualSplit) {
+          dispatch({ type: 'ENABLE_MANUAL_SPLIT' });
+        }
+        methods.setValue('kind', kind, { shouldDirty: true });
+        return;
       }
+
       methods.setValue('kind', kind, { shouldDirty: true });
       dispatch({ type: 'KIND_CHANGE', kind });
     },
-    [methods, dispatch]
+    [methods, dispatch, uiState.childOpen, uiState.manualSplitEnabled]
   );
+
+  const handleEnableManualSplit = useCallback(() => {
+    const fullQuery =
+      sandboxQuery.format === 'standalone'
+        ? sandboxQuery.breach.query
+        : getBreachQuery(sandboxQuery);
+    unifiedBufferBeforeManualRef.current = fullQuery.trim();
+    setSandboxQuery(toManualSplitQuery(fullQuery));
+    dispatch({ type: 'ENABLE_MANUAL_SPLIT' });
+  }, [sandboxQuery, dispatch]);
+
+  const handleOpenSeparateBaseAndAlert = useCallback(() => {
+    if (uiState.childOpen) {
+      return;
+    }
+
+    const formQuery = methods.getValues('query');
+    const fullQuery = getBreachQuery(formQuery).trim();
+    unifiedBufferBeforeManualRef.current = fullQuery;
+
+    if (formQuery.format === 'composed') {
+      setSandboxQuery(formQuery);
+    } else {
+      setSandboxQuery(toManualSplitQuery(fullQuery));
+    }
+
+    dispatch({ type: 'ENABLE_MANUAL_SPLIT' });
+    dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: uiState.step, isAlert: true });
+  }, [uiState.childOpen, uiState.step, methods, dispatch]);
+
+  const handleDisableManualSplit = useCallback(() => {
+    const currentJoined = getBreachQuery(sandboxQuery).trim();
+    const priorJoined = unifiedBufferBeforeManualRef.current?.trim() ?? '';
+    if (priorJoined && currentJoined !== priorJoined) {
+      setIsConfirmUnifiedVisible(true);
+      return;
+    }
+    setSandboxQuery(toUnifiedSandboxQuery(sandboxQuery));
+    unifiedBufferBeforeManualRef.current = null;
+    dispatch({ type: 'DISABLE_MANUAL_SPLIT' });
+  }, [sandboxQuery, dispatch]);
+
+  const handleConfirmUseSingleEditor = useCallback(() => {
+    setSandboxQuery(toUnifiedSandboxQuery(sandboxQuery));
+    unifiedBufferBeforeManualRef.current = null;
+    dispatch({ type: 'DISABLE_MANUAL_SPLIT' });
+    setIsConfirmUnifiedVisible(false);
+  }, [sandboxQuery, dispatch]);
 
   useEffect(() => {
     if (!isBuilderMode) return;
@@ -496,22 +611,25 @@ export function ComposeDiscoverFlyout({
   const handleRecoveryTypeChange = useCallback(
     (type: RecoveryType) => {
       if (type === 'custom') {
-        setSandboxQuery((q) => {
-          if (q.format !== 'composed') return q;
-          const current = q.recovery?.segment ?? '';
-          if (current.trim()) return q;
+        const formQuery = methods.getValues('query');
+        const composedQuery = ensureComposedQuery(formQuery);
+
+        setSandboxQuery(() => {
+          const current = composedQuery.recovery?.segment ?? '';
+          if (current.trim()) {
+            return composedQuery;
+          }
           if (isBuilderMode) {
-            const formQuery = methods.getValues('query');
             const builderRecover =
               formQuery.format === 'composed' ? formQuery.recovery?.segment ?? '' : '';
             if (builderRecover.trim()) {
-              return { ...q, recovery: { segment: builderRecover } };
+              return { ...composedQuery, recovery: { segment: builderRecover } };
             }
           }
           return {
-            ...q,
+            ...composedQuery,
             recovery: {
-              segment: guessRecoveryBlock(q.breach.segment),
+              segment: guessRecoveryBlock(composedQuery.breach.segment),
             },
           };
         });
@@ -606,12 +724,18 @@ export function ComposeDiscoverFlyout({
 
   const handleToggleYamlMode = useCallback(
     (enabled: boolean) => {
+      if (enabled && uiState.childOpen && !uiState.yamlMode) {
+        return;
+      }
       if (enabled) {
         const serialized = serializeFormToYaml(
           composeFormValuesForYamlSerialize(methods.getValues())
         );
         setYamlText(serialized);
         yamlBaselineRef.current = serialized;
+        if (methods.getValues('kind') === 'alert' && !isBuilderMode) {
+          setSandboxQuery(ensureComposedQuery(methods.getValues('query')));
+        }
       } else {
         const yamlWasDirty =
           yamlBaselineRef.current !== null && yamlTextRef.current !== yamlBaselineRef.current;
@@ -619,12 +743,35 @@ export function ComposeDiscoverFlyout({
         cancelYamlParse();
         const result = parseYamlToFormValues(yamlText);
         if (result.values) {
+          const parsedForm = formValuesFromYamlToCompose(result.values);
+          const preserveYamlSplit = shouldPreserveYamlSplitOnFormExit(
+            parsedForm.kind === 'alert',
+            isBuilderMode,
+            sandboxQuery
+          );
           const composed = {
-            ...formValuesFromYamlToCompose(result.values),
+            ...parsedForm,
+            query: queryFromYamlToForm({
+              parsedQuery: parsedForm.query,
+              yamlSandboxQuery: sandboxQuery,
+              isAlertKind: parsedForm.kind === 'alert',
+              isBuilderMode,
+            }),
             notifications: methods.getValues('notifications'),
           };
           methods.reset(composed);
-          syncSandbox();
+          if (preserveYamlSplit) {
+            setSandboxQuery(sandboxQuery);
+            dispatch({ type: 'ENABLE_MANUAL_SPLIT' });
+            if (
+              sandboxQuery.format === 'composed' &&
+              Boolean(sandboxQuery.recovery?.segment?.trim())
+            ) {
+              dispatch({ type: 'SET_RECOVERY_TYPE', recoveryType: 'custom', isBuilderMode });
+            }
+          } else {
+            syncSandbox();
+          }
           if (getBreachQuery(composed.query).trim()) {
             dispatch({ type: 'COMMIT_QUERY' });
           }
@@ -638,21 +785,78 @@ export function ComposeDiscoverFlyout({
       }
       dispatch({ type: 'SET_YAML_MODE', enabled });
     },
-    [cancelYamlParse, methods, yamlText, syncSandbox, dispatch]
+    [
+      cancelYamlParse,
+      methods,
+      yamlText,
+      sandboxQuery,
+      syncSandbox,
+      dispatch,
+      isBuilderMode,
+      uiState.childOpen,
+      uiState.yamlMode,
+    ]
   );
 
   const handleSandboxApply = useCallback(() => {
-    methods.setValue('query', sandboxQuery, { shouldDirty: true });
+    const useUnified = shouldUseUnifiedSandboxEditor(
+      isAlert,
+      uiState.step,
+      uiState.yamlMode,
+      isBuilderMode,
+      uiState.manualSplitEnabled
+    );
+
+    const queryToCommit = resolveSandboxQueryOnApply({
+      sandboxQuery,
+      committedQuery: methods.getValues('query'),
+      useUnified,
+    });
+
+    methods.setValue('query', queryToCommit, { shouldDirty: true });
     methods.setValue('timeField', sandboxTimeField, { shouldDirty: true });
+    setSandboxQuery(queryToCommit);
     if (uiState.yamlMode) {
-      const current = { ...methods.getValues(), query: sandboxQuery, timeField: sandboxTimeField };
+      const current = { ...methods.getValues(), query: queryToCommit, timeField: sandboxTimeField };
       setYamlText(serializeFormToYaml(composeFormValuesForYamlSerialize(current)));
     }
     dispatch({ type: 'COMMIT_QUERY' });
     if (!uiState.yamlMode) {
       dispatch({ type: 'CLOSE_CHILD' });
     }
-  }, [sandboxQuery, sandboxTimeField, uiState.yamlMode, methods, dispatch]);
+  }, [
+    sandboxQuery,
+    sandboxTimeField,
+    uiState.yamlMode,
+    uiState.step,
+    uiState.manualSplitEnabled,
+    isAlert,
+    isBuilderMode,
+    methods,
+    dispatch,
+  ]);
+
+  const showManualSplitToggle = shouldShowManualSplitToggle(
+    isAlert,
+    uiState.step,
+    uiState.yamlMode,
+    isBuilderMode,
+    uiState.manualSplitEnabled,
+    uiState.queryCommitted
+  );
+
+  const showUnifiedQueryHeader =
+    !isBuilderMode &&
+    shouldUseUnifiedSandboxEditor(
+      isAlert,
+      uiState.step,
+      uiState.yamlMode,
+      isBuilderMode,
+      uiState.manualSplitEnabled
+    );
+
+  const showSignalQueryHeader =
+    !isBuilderMode && shouldShowSignalQueryHeader(isAlert, uiState.step, isBuilderMode);
 
   const handleSubmit = methods.handleSubmit((values) => {
     if (hasValidationErrors) {
@@ -754,15 +958,20 @@ export function ComposeDiscoverFlyout({
     </>
   ) : null;
 
-  // TODO: recoveryType drives whether the recovery tab appears in YAML mode.
-  // Follow schema decisions in #268984 — if recoveryType is superseded by a
-  // field on RuleQuery itself, gate this on query shape instead.
   const sandboxTabs: QueryTab[] | undefined =
-    uiState.yamlMode && sandboxQuery.format === 'composed'
-      ? uiState.recoveryType === 'custom'
-        ? ['base', 'alert', 'recovery']
-        : ['base', 'alert']
+    uiState.yamlMode && isAlert && !isBuilderMode
+      ? getYamlSandboxTabs(sandboxQuery, uiState.recoveryType)
       : getSandboxTabs(isAlert, uiState);
+
+  const showYamlQueryHeader = uiState.yamlMode && isAlert && !isBuilderMode;
+
+  const showRecoveryQueryHeader = shouldShowRecoverySandboxHeader(
+    isAlert,
+    uiState.step,
+    uiState.yamlMode,
+    isBuilderMode,
+    uiState.recoveryType
+  );
 
   return (
     <RuleFormProvider services={services} meta={{ layout: 'flyout' }}>
@@ -812,6 +1021,7 @@ export function ComposeDiscoverFlyout({
                     options={EDIT_MODE_OPTIONS}
                     idSelected={uiState.yamlMode ? 'yaml' : 'form'}
                     onChange={(id) => handleToggleYamlMode(id === 'yaml')}
+                    isDisabled={uiState.childOpen && !uiState.yamlMode}
                     isIconOnly
                     buttonSize="compressed"
                     data-test-subj="composeDiscoverEditModeToggle"
@@ -841,6 +1051,9 @@ export function ComposeDiscoverFlyout({
                   services={baseServices}
                   onRecoveryTypeChange={handleRecoveryTypeChange}
                   onKindChange={handleKindChange}
+                  onSeparateBaseAndAlert={
+                    !isBuilderMode ? handleOpenSeparateBaseAndAlert : undefined
+                  }
                   isEditing={isEditing}
                   ruleId={ruleId}
                   builderType={builderType}
@@ -865,75 +1078,61 @@ export function ComposeDiscoverFlyout({
                 </EuiFlexItem>
               </EuiFlexGroup>
             ) : (
-              <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty
-                    onClick={() => {
-                      closeSourceRef.current = 'button';
-                      handleRequestClose();
-                    }}
-                    data-test-subj="composeDiscoverCancel"
-                  >
-                    {CANCEL_BUTTON_LABEL}
-                  </EuiButtonEmpty>
+                  {uiState.step > 0 && (
+                    <EuiButton
+                      color="text"
+                      iconType="arrowLeft"
+                      isDisabled={uiState.childOpen}
+                      onClick={() => dispatch({ type: 'GO_BACK' })}
+                      data-test-subj="composeDiscoverBack"
+                    >
+                      {BACK_BUTTON_LABEL}
+                    </EuiButton>
+                  )}
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiFlexGroup gutterSize="s" responsive={false}>
-                    {uiState.step > 0 && (
-                      <EuiFlexItem grow={false}>
-                        <EuiButtonEmpty
-                          iconType="arrowLeft"
-                          isDisabled={uiState.childOpen}
-                          onClick={() => dispatch({ type: 'GO_BACK' })}
-                          data-test-subj="composeDiscoverBack"
-                        >
-                          {BACK_BUTTON_LABEL}
-                        </EuiButtonEmpty>
-                      </EuiFlexItem>
-                    )}
-                    <EuiFlexItem grow={false}>
-                      {isLastStep ? (
-                        <EuiButton
-                          fill
-                          isLoading={isSaving}
-                          isDisabled={hasValidationErrors}
-                          onClick={handleFinalSubmit}
-                          data-test-subj="composeDiscoverSubmit"
-                        >
-                          {isCreate ? CREATE_RULE_BUTTON_LABEL : SAVE_RULE_BUTTON_LABEL}
-                        </EuiButton>
-                      ) : (
-                        <EuiToolTip
-                          content={
-                            hasValidationErrors
-                              ? VALIDATION_ERRORS_NEXT_TOOLTIP
-                              : (currentStep?.id === 'alertCondition' ||
-                                  currentStep?.id === 'builderCondition') &&
-                                !uiState.queryCommitted
-                              ? NEXT_DISABLED_TOOLTIP
-                              : undefined
-                          }
-                        >
-                          <EuiButton
-                            fill
-                            iconType="arrowRight"
-                            iconSide="right"
-                            isDisabled={
-                              uiState.childOpen ||
-                              hasValidationErrors ||
-                              ((currentStep?.id === 'alertCondition' ||
-                                currentStep?.id === 'builderCondition') &&
-                                !uiState.queryCommitted)
-                            }
-                            onClick={handleNext}
-                            data-test-subj="composeDiscoverNext"
-                          >
-                            {NEXT_BUTTON_LABEL}
-                          </EuiButton>
-                        </EuiToolTip>
-                      )}
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
+                  {isLastStep ? (
+                    <EuiButton
+                      fill
+                      isLoading={isSaving}
+                      isDisabled={hasValidationErrors}
+                      onClick={handleFinalSubmit}
+                      data-test-subj="composeDiscoverSubmit"
+                    >
+                      {isCreate ? CREATE_RULE_BUTTON_LABEL : SAVE_RULE_BUTTON_LABEL}
+                    </EuiButton>
+                  ) : (
+                    <EuiToolTip
+                      content={
+                        hasValidationErrors
+                          ? VALIDATION_ERRORS_NEXT_TOOLTIP
+                          : (currentStep?.id === 'alertCondition' ||
+                              currentStep?.id === 'builderCondition') &&
+                            !hasDefinedQuery
+                          ? NEXT_DISABLED_TOOLTIP
+                          : undefined
+                      }
+                    >
+                      <EuiButton
+                        color="text"
+                        iconType="arrowRight"
+                        iconSide="right"
+                        isDisabled={
+                          uiState.childOpen ||
+                          hasValidationErrors ||
+                          ((currentStep?.id === 'alertCondition' ||
+                            currentStep?.id === 'builderCondition') &&
+                            !hasDefinedQuery)
+                        }
+                        onClick={handleNext}
+                        data-test-subj="composeDiscoverNext"
+                      >
+                        {NEXT_BUTTON_LABEL}
+                      </EuiButton>
+                    </EuiToolTip>
+                  )}
                 </EuiFlexItem>
               </EuiFlexGroup>
             )}
@@ -942,7 +1141,7 @@ export function ComposeDiscoverFlyout({
           {uiState.childOpen && (
             <QuerySandboxFlyout
               query={sandboxQuery}
-              onQueryChange={isBuilderMode ? undefined : setSandboxQuery}
+              onQueryChange={isBuilderMode ? undefined : handleSandboxQueryChange}
               tabs={sandboxTabs}
               timeField={sandboxTimeField}
               onTimeFieldChange={isBuilderMode ? undefined : setSandboxTimeField}
@@ -952,6 +1151,16 @@ export function ComposeDiscoverFlyout({
               onTabChange={(tab) => dispatch({ type: 'SET_TAB', tab })}
               onAlertEditorMount={onAlertEditorMount}
               onRecoveryEditorMount={onRecoveryEditorMount}
+              onEditManually={
+                showManualSplitToggle && !isBuilderMode ? handleEnableManualSplit : undefined
+              }
+              onUseSingleEditor={
+                uiState.manualSplitEnabled && !isBuilderMode ? handleDisableManualSplit : undefined
+              }
+              showUnifiedQueryHeader={showUnifiedQueryHeader}
+              showYamlQueryHeader={showYamlQueryHeader}
+              showRecoveryQueryHeader={showRecoveryQueryHeader}
+              showSignalQueryHeader={showSignalQueryHeader}
               onClose={() => {
                 syncSandbox();
                 dispatch({ type: 'CLOSE_CHILD' });
@@ -960,6 +1169,45 @@ export function ComposeDiscoverFlyout({
             />
           )}
         </EuiFlyout>
+        {isConfirmUnifiedVisible && (
+          <EuiConfirmModal
+            title={i18n.translate(
+              'xpack.alertingV2.composeDiscover.querySandbox.confirmUnifiedTitle',
+              { defaultMessage: 'Switch to single editor?' }
+            )}
+            onCancel={() => setIsConfirmUnifiedVisible(false)}
+            onConfirm={handleConfirmUseSingleEditor}
+            cancelButtonText={i18n.translate(
+              'xpack.alertingV2.composeDiscover.querySandbox.confirmUnifiedCancel',
+              { defaultMessage: 'Keep split editor' }
+            )}
+            confirmButtonText={i18n.translate(
+              'xpack.alertingV2.composeDiscover.querySandbox.confirmUnifiedConfirm',
+              { defaultMessage: 'Use single editor' }
+            )}
+            buttonColor="primary"
+            data-test-subj="querySandboxConfirmUnified"
+          >
+            <p>
+              {i18n.translate(
+                'xpack.alertingV2.composeDiscover.querySandbox.confirmUnifiedBodyMerge',
+                {
+                  defaultMessage:
+                    'Your base and alert edits will be merged into one query in the editor.',
+                }
+              )}
+            </p>
+            <p>
+              {i18n.translate(
+                'xpack.alertingV2.composeDiscover.querySandbox.confirmUnifiedBodyApply',
+                {
+                  defaultMessage:
+                    'When you apply, we automatically separate the base query and alert condition again. You can adjust the split later if needed.',
+                }
+              )}
+            </p>
+          </EuiConfirmModal>
+        )}
         {isConfirmCloseVisible && (
           <ConfirmRuleClose onCancel={handleCancelDiscard} onConfirm={handleConfirmDiscard} />
         )}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
@@ -105,6 +105,7 @@ const renderStep = (
   });
   const dispatch = jest.fn();
   const onKindChange = jest.fn();
+  const onSeparateBaseAndAlert = jest.fn();
   const services = createMockServices();
 
   render(
@@ -115,13 +116,14 @@ const renderStep = (
         dispatch={dispatch}
         services={services}
         onKindChange={onKindChange}
+        onSeparateBaseAndAlert={onSeparateBaseAndAlert}
         isEditing={isEditing}
       />
     </>,
     { wrapper: createComposeFormWrapper(formValueOverrides, services) }
   );
 
-  return { dispatch, state, onKindChange };
+  return { dispatch, state, onKindChange, onSeparateBaseAndAlert };
 };
 
 const STANDALONE_QUERY: RuleQuery = {
@@ -141,13 +143,28 @@ const COMPOSED_QUERY_EMPTY_BASE: RuleQuery = {
   breach: { segment: '| WHERE count > 100' },
 };
 
+const COMPOSED_QUERY_EMPTY: RuleQuery = {
+  format: 'composed',
+  base: '',
+  breach: { segment: '' },
+};
+
+const COMPOSED_QUERY_NO_ALERT_CONDITION: RuleQuery = {
+  format: 'composed',
+  base: 'FROM logs-* | STATS count = COUNT(*) BY host.name',
+  breach: { segment: '' },
+};
+
 describe('AlertConditionStep', () => {
   describe('query display', () => {
-    it('shows "No query defined yet" when query is not committed', () => {
+    it('shows "Open the editor to write your ES|QL query" when query is not committed', () => {
       renderStep({ queryCommitted: false });
 
-      expect(screen.getByText('No query defined yet')).toBeInTheDocument();
+      expect(screen.getByTestId('composeDiscoverEsqlQuerySectionDescription')).toHaveTextContent(
+        'Open the editor to write your ES|QL query'
+      );
       expect(screen.getByTestId('composeDiscoverOpenEditor')).toBeInTheDocument();
+      expect(screen.queryByText('No query defined yet')).not.toBeInTheDocument();
     });
 
     it('shows standalone query summary for signal kind', () => {
@@ -159,26 +176,80 @@ describe('AlertConditionStep', () => {
       expect(screen.getByTestId('composeDiscoverEditQuery')).toBeInTheDocument();
     });
 
-    it('shows base and alert condition summaries for alert kind', () => {
+    it('shows base and alert block summaries for alert kind', () => {
       renderStep(
         { queryCommitted: true },
         { formValueOverrides: { kind: 'alert', query: COMPOSED_QUERY } }
       );
 
+      expect(screen.getByTestId('composeDiscoverEsqlQuerySection')).toBeInTheDocument();
       expect(screen.getByText('Base query')).toBeInTheDocument();
       expect(screen.getByText('Alert condition')).toBeInTheDocument();
-      expect(screen.getByTestId('composeDiscoverEditQueries')).toBeInTheDocument();
+      expect(screen.getByText('Search query and alert condition identified')).toBeInTheDocument();
+      expect(screen.getByTestId('composeDiscoverEditQuery')).toBeInTheDocument();
     });
 
-    it('shows split-failed callout when base query is empty', () => {
+    it('shows empty-query callout when Apply committed no query content', () => {
       renderStep(
-        { queryCommitted: true },
+        { queryCommitted: true, childOpen: false },
+        { formValueOverrides: { kind: 'alert', query: COMPOSED_QUERY_EMPTY } }
+      );
+
+      const querySection = screen.getByTestId('composeDiscoverEsqlQuerySection');
+      expect(
+        within(querySection).getByText('No query defined')
+      ).toBeInTheDocument();
+      expect(
+        within(querySection).getByText('Enter an ES|QL query in the editor before continuing.')
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('composeDiscoverEsqlQuerySectionDescription')).toHaveTextContent(
+        'Define an ES|QL query in the editor'
+      );
+      expect(
+        within(querySection).queryByText(/Couldn't automatically separate base query/)
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('composeDiscoverSeparateBaseAndAlert')).not.toBeInTheDocument();
+    });
+
+    it('shows split-failed callout inside the query section with separate action when base query is empty', async () => {
+      const user = userEvent.setup();
+      const { onSeparateBaseAndAlert } = renderStep(
+        { queryCommitted: true, childOpen: false },
         { formValueOverrides: { kind: 'alert', query: COMPOSED_QUERY_EMPTY_BASE } }
       );
 
+      const querySection = screen.getByTestId('composeDiscoverEsqlQuerySection');
       expect(
-        screen.getByText(/Couldn't automatically separate base query from alert condition/)
+        within(querySection).getByText(/Couldn't automatically separate base query from alert condition/)
       ).toBeInTheDocument();
+      expect(screen.getByTestId('composeDiscoverEsqlQuerySectionDescription')).toHaveTextContent(
+        'Review your query or separate it manually'
+      );
+      const separateButton = screen.getByTestId('composeDiscoverSeparateBaseAndAlert');
+      expect(separateButton).not.toBeDisabled();
+      await user.click(separateButton);
+      expect(onSeparateBaseAndAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows no-alert-condition callout when base query is defined without an alert segment', () => {
+      renderStep(
+        { queryCommitted: true, childOpen: false },
+        { formValueOverrides: { kind: 'alert', query: COMPOSED_QUERY_NO_ALERT_CONDITION } }
+      );
+
+      const querySection = screen.getByTestId('composeDiscoverEsqlQuerySection');
+      expect(within(querySection).getByText('No alert condition')).toBeInTheDocument();
+      expect(
+        within(querySection).getByText(
+          'Without an alert condition, every row returned by the base query is treated as a breach.'
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('composeDiscoverEsqlQuerySectionDescription')).toHaveTextContent(
+        'Base query defined — no separate alert condition'
+      );
+      expect(
+        screen.queryByText('Search query and alert condition identified')
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -198,13 +269,13 @@ describe('AlertConditionStep', () => {
       expect(screen.getByTestId('composeDiscoverEditQuery')).toBeDisabled();
     });
 
-    it('disables "Edit queries" when child flyout is open', () => {
+    it('disables "Edit query" when child flyout is open', () => {
       renderStep(
         { queryCommitted: true, childOpen: true },
         { formValueOverrides: { kind: 'alert', query: COMPOSED_QUERY } }
       );
 
-      expect(screen.getByTestId('composeDiscoverEditQueries')).toBeDisabled();
+      expect(screen.getByTestId('composeDiscoverEditQuery')).toBeDisabled();
     });
 
     it('dispatches OPEN_CHILD_FOR_STEP on "Open query editor" click', () => {
@@ -243,8 +314,8 @@ describe('AlertConditionStep', () => {
   });
 
   describe('mode select', () => {
-    it('is enabled when queryCommitted is true and not editing', () => {
-      renderStep({ queryCommitted: true }, { isEditing: false });
+    it('is enabled when queryCommitted is true, sandbox is closed, and not editing', () => {
+      renderStep({ queryCommitted: true, childOpen: false }, { isEditing: false });
 
       expect(screen.getByTestId('composeDiscoverModeSelect')).not.toBeDisabled();
     });
@@ -257,6 +328,12 @@ describe('AlertConditionStep', () => {
 
     it('is disabled when query is not committed', () => {
       renderStep({ queryCommitted: false }, { isEditing: false });
+
+      expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
+    });
+
+    it('is disabled while the query sandbox is open', () => {
+      renderStep({ queryCommitted: true, childOpen: true }, { isEditing: false });
 
       expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
     });
@@ -279,7 +356,7 @@ describe('AlertConditionStep', () => {
     it('calls onKindChange when Signal is selected', async () => {
       const user = userEvent.setup({ pointerEventsCheck: 0 });
       const { onKindChange } = renderStep(
-        { queryCommitted: true },
+        { queryCommitted: true, childOpen: false },
         { formValueOverrides: { kind: 'alert' } }
       );
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
@@ -10,22 +10,22 @@ import { useFormContext } from 'react-hook-form';
 import { Parser, isColumn } from '@elastic/esql';
 import { useQuery } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { getEsqlColumns } from '@kbn/esql-utils';
 import {
   EuiButton,
   EuiCallOut,
   EuiComboBox,
   EuiFormRow,
-  EuiPanel,
+  EuiHorizontalRule,
   EuiSelect,
   EuiSpacer,
-  EuiText,
   EuiTitle,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { ComposeDiscoverAction, ComposeDiscoverState } from '../types';
 import type { ComposeFormValues } from '../compose_form_types';
-import { QuerySummary } from '../query_summary';
+import { isQueryDefined } from '../compose_form_types';
+import { EsqlQuerySummarySection } from './esql_query_summary_section';
 import type { RuleFormServices } from '../../../form/contexts/rule_form_context';
 import { useDataFields } from '../../../form/hooks/use_data_fields';
 import { ScheduleField } from '../../../form/fields/schedule_field';
@@ -38,6 +38,7 @@ interface AlertConditionStepProps {
   dispatch: React.Dispatch<ComposeDiscoverAction>;
   services: RuleFormServices;
   onKindChange: (kind: 'signal' | 'alert') => void;
+  onSeparateBaseAndAlert?: () => void;
   isEditing: boolean;
 }
 
@@ -46,6 +47,7 @@ export function AlertConditionStep({
   dispatch,
   services,
   onKindChange,
+  onSeparateBaseAndAlert,
   isEditing,
 }: AlertConditionStepProps) {
   const { setValue, watch } = useFormContext<ComposeFormValues>();
@@ -125,145 +127,196 @@ export function AlertConditionStep({
     }
   }, [state.queryCommitted, committedQuery, setValue]);
 
+  // Callout when Apply was used but no query content was committed.
+  const queryEmpty = isAlert && state.queryCommitted && !isQueryDefined(query);
+
   // Callout when the heuristic split couldn't find a clear split point.
-  // Only relevant after Apply (when the committed query is in composed format).
   const splitFailed =
-    isAlert && state.queryCommitted && query.format === 'composed' && !query.base.trim();
+    isAlert &&
+    state.queryCommitted &&
+    isQueryDefined(query) &&
+    query.format === 'composed' &&
+    !query.base.trim();
+
+  // Base query without a separate alert condition (e.g. STATS with no trailing WHERE).
+  const noAlertCondition =
+    isAlert &&
+    state.queryCommitted &&
+    isQueryDefined(query) &&
+    query.format === 'composed' &&
+    Boolean(query.base.trim()) &&
+    !query.breach.segment.trim();
+
+  const openQueryEditor = () =>
+    dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert });
+
+  const editQueryLabel = i18n.translate(
+    'xpack.alertingV2.composeDiscover.alertCondition.editQueryButtonLabel',
+    { defaultMessage: 'Edit query' }
+  );
+
+  const openEditorLabel = i18n.translate(
+    'xpack.alertingV2.composeDiscover.alertCondition.openEditorButtonLabel',
+    { defaultMessage: 'Open query editor' }
+  );
+
+  const notDefinedLabel = i18n.translate(
+    'xpack.alertingV2.composeDiscover.alertCondition.notDefined',
+    { defaultMessage: 'Not defined' }
+  );
+
+  const querySectionDescription = !state.queryCommitted
+    ? i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.startQueryDescription', {
+        defaultMessage: 'Open the editor to write your ES|QL query',
+      })
+    : queryEmpty
+      ? i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.queryEmptyDescription', {
+          defaultMessage: 'Define an ES|QL query in the editor',
+        })
+      : splitFailed
+        ? i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.splitFailedDescription', {
+            defaultMessage: 'Review your query or separate it manually',
+          })
+        : noAlertCondition
+          ? i18n.translate(
+              'xpack.alertingV2.composeDiscover.alertCondition.noAlertConditionDescription',
+              {
+                defaultMessage: 'Base query defined — no separate alert condition',
+              }
+            )
+          : isAlert
+            ? i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.baseAndAlertDetected', {
+                defaultMessage: 'Search query and alert condition identified',
+              })
+            : i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.queryDefined', {
+                defaultMessage: 'Query defined',
+              });
+
+  const queryEmptyCallout = queryEmpty ? (
+    <EuiCallOut
+      announceOnMount={false}
+      size="s"
+      color="primary"
+      iconType="info"
+      title={i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.queryEmptyTitle', {
+        defaultMessage: 'No query defined',
+      })}
+    >
+      {i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.queryEmptyBody', {
+        defaultMessage: 'Enter an ES|QL query in the editor before continuing.',
+      })}
+    </EuiCallOut>
+  ) : undefined;
+
+  const splitFailedCallout = splitFailed ? (
+    <EuiCallOut
+      announceOnMount={false}
+      size="s"
+      color="primary"
+      iconType="info"
+      title={i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.splitFailedTitle', {
+        defaultMessage: "Couldn't automatically separate base query from alert condition.",
+      })}
+    >
+      {onSeparateBaseAndAlert && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiButton
+            size="s"
+            isDisabled={state.childOpen}
+            onClick={onSeparateBaseAndAlert}
+            data-test-subj="composeDiscoverSeparateBaseAndAlert"
+          >
+            {i18n.translate(
+              'xpack.alertingV2.composeDiscover.alertCondition.separateBaseAndAlertButton',
+              { defaultMessage: 'Separate base and alert' }
+            )}
+          </EuiButton>
+        </>
+      )}
+    </EuiCallOut>
+  ) : undefined;
+
+  const noAlertConditionCallout = noAlertCondition ? (
+    <EuiCallOut
+      announceOnMount={false}
+      size="s"
+      color="primary"
+      iconType="info"
+      title={i18n.translate(
+        'xpack.alertingV2.composeDiscover.alertCondition.noAlertConditionTitle',
+        {
+          defaultMessage: 'No alert condition',
+        }
+      )}
+    >
+      {i18n.translate('xpack.alertingV2.composeDiscover.alertCondition.noAlertConditionBody', {
+        defaultMessage:
+          'Without an alert condition, every row returned by the base query is treated as a breach.',
+      })}
+    </EuiCallOut>
+  ) : undefined;
 
   return (
     <>
       <ModeSelect
         value={isAlert ? 'alert' : 'signal'}
         onChange={onKindChange}
-        disabled={!state.queryCommitted || isEditing}
+        disabled={!state.queryCommitted || !isQueryDefined(query) || isEditing || state.childOpen}
         compressed
         data-test-subj="composeDiscoverModeSelect"
       />
       <EuiSpacer size="m" />
-      <EuiTitle size="xs">
-        <h3>
-          <FormattedMessage
-            id="xpack.alertingV2.composeDiscover.alertCondition.esqlQueryTitle"
-            defaultMessage="ES|QL query"
-          />
-        </h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
 
-      {!state.queryCommitted ? (
-        <>
-          <EuiPanel color="subdued" paddingSize="m">
-            <EuiText size="s" color="subdued">
-              <FormattedMessage
-                id="xpack.alertingV2.composeDiscover.alertCondition.noQueryDescription"
-                defaultMessage="No query defined yet"
-              />
-            </EuiText>
-          </EuiPanel>
-          <EuiSpacer size="s" />
-          <EuiButton
-            iconType="editorCodeBlock"
-            isDisabled={state.childOpen}
-            onClick={() => dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert })}
-            data-test-subj="composeDiscoverOpenEditor"
-          >
-            <FormattedMessage
-              id="xpack.alertingV2.composeDiscover.alertCondition.openEditorButtonLabel"
-              defaultMessage="Open query editor"
-            />
-          </EuiButton>
-        </>
-      ) : !isAlert ? (
-        <>
-          <QuerySummary
-            query={fullQuery}
-            emptyMessage={i18n.translate(
-              'xpack.alertingV2.composeDiscover.alertCondition.noQueryDefined',
-              { defaultMessage: 'No query defined' }
-            )}
-          />
-          <EuiSpacer size="s" />
-          <EuiButton
-            size="s"
-            iconType="editorCodeBlock"
-            isDisabled={state.childOpen}
-            onClick={() => dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert })}
-            data-test-subj="composeDiscoverEditQuery"
-          >
-            <FormattedMessage
-              id="xpack.alertingV2.composeDiscover.alertCondition.editQueryButtonLabel"
-              defaultMessage="Edit query"
-            />
-          </EuiButton>
-        </>
-      ) : (
-        <>
-          {splitFailed && (
-            <>
-              <EuiCallOut
-                announceOnMount={false}
-                size="s"
-                color="primary"
-                iconType="iInCircle"
-                title={i18n.translate(
-                  'xpack.alertingV2.composeDiscover.alertCondition.splitFailedTitle',
-                  {
-                    defaultMessage:
-                      "Couldn't automatically separate base query from alert condition. Adjust the split in the query editor.",
-                  }
-                )}
-              />
-              <EuiSpacer size="s" />
-            </>
-          )}
-          <EuiText size="xs" color="subdued">
-            <strong>
-              <FormattedMessage
-                id="xpack.alertingV2.composeDiscover.alertCondition.baseQueryLabel"
-                defaultMessage="Base query"
-              />
-            </strong>
-          </EuiText>
-          <EuiSpacer size="xs" />
-          <QuerySummary
-            query={baseQuery}
-            emptyMessage={i18n.translate(
-              'xpack.alertingV2.composeDiscover.alertCondition.noBaseQueryDefined',
-              { defaultMessage: 'No base query defined' }
-            )}
-          />
-          <EuiSpacer size="m" />
-          <EuiText size="xs" color="subdued">
-            <strong>
-              <FormattedMessage
-                id="xpack.alertingV2.composeDiscover.alertCondition.alertConditionLabel"
-                defaultMessage="Alert condition"
-              />
-            </strong>
-          </EuiText>
-          <EuiSpacer size="xs" />
-          <QuerySummary
-            query={alertBlock}
-            emptyMessage={i18n.translate(
-              'xpack.alertingV2.composeDiscover.alertCondition.noAlertConditionDefined',
-              { defaultMessage: 'No alert condition defined' }
-            )}
-          />
-          <EuiSpacer size="s" />
-          <EuiButton
-            size="s"
-            iconType="editorCodeBlock"
-            isDisabled={state.childOpen}
-            onClick={() => dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert })}
-            data-test-subj="composeDiscoverEditQueries"
-          >
-            <FormattedMessage
-              id="xpack.alertingV2.composeDiscover.alertCondition.editQueriesButtonLabel"
-              defaultMessage="Edit queries"
-            />
-          </EuiButton>
-        </>
-      )}
+      <EsqlQuerySummarySection
+        description={querySectionDescription}
+        callout={queryEmptyCallout ?? splitFailedCallout ?? noAlertConditionCallout}
+        isEmpty={!state.queryCommitted}
+        emptyAction={{
+          label: openEditorLabel,
+          onClick: openQueryEditor,
+          testSubj: 'composeDiscoverOpenEditor',
+          disabled: state.childOpen,
+        }}
+        blocks={
+          isAlert
+            ? [
+                {
+                  id: 'base',
+                  label: i18n.translate(
+                    'xpack.alertingV2.composeDiscover.alertCondition.baseQueryLabel',
+                    { defaultMessage: 'Base query' }
+                  ),
+                  query: baseQuery,
+                  emptyMessage: notDefinedLabel,
+                },
+                {
+                  id: 'alert',
+                  label: i18n.translate(
+                    'xpack.alertingV2.composeDiscover.alertCondition.alertBlockLabel',
+                    { defaultMessage: 'Alert condition' }
+                  ),
+                  query: alertBlock,
+                  emptyMessage: notDefinedLabel,
+                },
+              ]
+            : [
+                {
+                  id: 'query',
+                  label: i18n.translate(
+                    'xpack.alertingV2.composeDiscover.alertCondition.queryLabel',
+                    { defaultMessage: 'Query' }
+                  ),
+                  query: fullQuery,
+                  emptyMessage: notDefinedLabel,
+                },
+              ]
+        }
+        editButtonLabel={editQueryLabel}
+        onEdit={openQueryEditor}
+        editDisabled={state.childOpen}
+        editTestSubj="composeDiscoverEditQuery"
+      />
 
       <EuiSpacer size="m" />
       <EuiFormRow
@@ -274,6 +327,7 @@ export function AlertConditionStep({
       >
         <EuiSelect
           fullWidth
+          compressed
           options={timeFieldOptions}
           value={timeField}
           onChange={(e) => setValue('timeField', e.target.value, { shouldDirty: true })}
@@ -290,6 +344,7 @@ export function AlertConditionStep({
       >
         <EuiComboBox
           fullWidth
+          compressed
           options={outputColumns.map((name) => ({ label: name }))}
           selectedOptions={groupFields.map((f) => ({ label: f }))}
           onChange={(opts) =>
@@ -308,15 +363,33 @@ export function AlertConditionStep({
         />
       </EuiFormRow>
 
+      <EuiHorizontalRule margin="m" />
+
       {isAlert && (
         <>
-          <EuiSpacer size="m" />
+          <EuiTitle size="xs" data-test-subj="composeDiscoverAlertConditionsSectionTitle">
+            <h3>
+              <FormattedMessage
+                id="xpack.alertingV2.composeDiscover.alertCondition.alertConditionsSectionTitle"
+                defaultMessage="Alert conditions"
+              />
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
           <AlertDelayField />
+          <EuiHorizontalRule margin="m" />
         </>
       )}
 
-      {/* Schedule and lookback -- connected to RHF via useFormContext() internally */}
-      <EuiSpacer size="m" />
+      <EuiTitle size="xs" data-test-subj="composeDiscoverRuleExecutionSectionTitle">
+        <h3>
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.alertCondition.ruleExecutionSectionTitle"
+            defaultMessage="Rule execution"
+          />
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
       <ScheduleField />
       <EuiSpacer size="m" />
       <LookbackWindowField />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -104,43 +104,56 @@ describe('step validation', () => {
   describe('alertCondition.validate', () => {
     const alertStep = getSteps(false).steps.find((s) => s.id === 'alertCondition')!;
 
-    it('returns true when queryCommitted and composed alert query is complete', async () => {
+    it('returns true when queryCommitted is true and query is defined', async () => {
+      const state = createState({ queryCommitted: true });
+      const definedQuery = {
+        format: 'composed' as const,
+        base: 'FROM logs-*',
+        breach: { segment: '| WHERE count > 100' },
+      };
+      const methods = {
+        getValues: jest.fn().mockReturnValue(definedQuery),
+      } as unknown as UseFormReturn<ComposeFormValues>;
+
+      expect(await alertStep.validate!(methods, state)).toBe(true);
+      expect(methods.getValues).toHaveBeenCalledWith('query');
+    });
+
+    it('returns true when queryCommitted with base only (no alert segment)', async () => {
       const state = createState({ queryCommitted: true });
       const methods = {
-        getValues: (field?: keyof ComposeFormValues) => {
-          if (field === 'kind') return 'alert';
-          if (field === 'query') {
-            return {
-              format: 'composed',
-              base: 'FROM logs-*',
-              breach: { segment: '| WHERE status == "error"' },
-            };
-          }
-          return undefined;
-        },
+        getValues: jest.fn().mockReturnValue({
+          format: 'composed',
+          base: 'FROM logs-*',
+          breach: { segment: '' },
+        }),
       } as unknown as UseFormReturn<ComposeFormValues>;
 
       expect(await alertStep.validate!(methods, state)).toBe(true);
     });
 
-    it('returns false when queryCommitted but breach segment is empty', async () => {
-      const state = createState({ queryCommitted: true });
+    it('returns false when queryCommitted is false', async () => {
+      const state = createState({ queryCommitted: false });
       const methods = {
-        getValues: (field?: keyof ComposeFormValues) => {
-          if (field === 'kind') return 'alert';
-          if (field === 'query') {
-            return { format: 'composed', base: 'FROM logs-*', breach: { segment: '' } };
-          }
-          return undefined;
-        },
+        getValues: jest.fn().mockReturnValue({
+          format: 'composed',
+          base: 'FROM logs-*',
+          breach: { segment: '| WHERE count > 100' },
+        }),
       } as unknown as UseFormReturn<ComposeFormValues>;
 
       expect(await alertStep.validate!(methods, state)).toBe(false);
     });
 
-    it('returns false when queryCommitted is false', async () => {
-      const state = createState({ queryCommitted: false });
-      const methods = {} as UseFormReturn<ComposeFormValues>;
+    it('returns false when queryCommitted is true but query is empty', async () => {
+      const state = createState({ queryCommitted: true });
+      const methods = {
+        getValues: jest.fn().mockReturnValue({
+          format: 'composed',
+          base: '',
+          breach: { segment: '' },
+        }),
+      } as unknown as UseFormReturn<ComposeFormValues>;
 
       expect(await alertStep.validate!(methods, state)).toBe(false);
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -18,7 +18,7 @@ import type {
 } from '../types';
 import { getStepIds, getBuilderStepIds } from '../use_compose_discover_state';
 import type { ComposeFormValues } from '../compose_form_types';
-import { getBreachQuery } from '../compose_form_types';
+import { isQueryDefined } from '../compose_form_types';
 import type { RuleFormServices } from '../../../form/contexts/rule_form_context';
 import { RULE_BUILDER_REGISTRY } from '../rule_builder';
 import { isActionValid } from '../../../actions_form';
@@ -35,6 +35,7 @@ interface Props {
   services: RuleFormServices;
   onRecoveryTypeChange: (type: RecoveryType) => void;
   onKindChange: (kind: 'signal' | 'alert') => void;
+  onSeparateBaseAndAlert?: () => void;
   isEditing: boolean;
   ruleId?: string;
   builderType?: string;
@@ -52,20 +53,11 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
         dispatch={props.dispatch}
         services={props.services}
         onKindChange={props.onKindChange}
+        onSeparateBaseAndAlert={props.onSeparateBaseAndAlert}
         isEditing={props.isEditing}
       />
     ),
-    validate: (methods, s) => {
-      if (!s.queryCommitted) {
-        return false;
-      }
-      const kind = methods.getValues('kind');
-      const query = methods.getValues('query');
-      if (kind === 'alert' && query.format === 'composed') {
-        return query.base.trim().length > 0 && query.breach.segment.trim().length > 0;
-      }
-      return getBreachQuery(query).trim().length > 0;
-    },
+    validate: (methods, s) => s.queryCommitted && isQueryDefined(methods.getValues('query')),
   },
   builderCondition: {
     id: 'builderCondition',
@@ -73,7 +65,7 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
       defaultMessage: 'Alert Condition',
     }),
     render: () => null,
-    validate: (_methods, s) => s.queryCommitted,
+    validate: (methods, s) => s.queryCommitted && isQueryDefined(methods.getValues('query')),
   },
   recoveryCondition: {
     id: 'recoveryCondition',
@@ -162,6 +154,7 @@ export const ComposeDiscoverForm = ({
   services,
   onRecoveryTypeChange,
   onKindChange,
+  onSeparateBaseAndAlert,
   isEditing,
   ruleId,
   builderType,
@@ -175,6 +168,7 @@ export const ComposeDiscoverForm = ({
     services,
     onRecoveryTypeChange,
     onKindChange,
+    onSeparateBaseAndAlert,
     isEditing,
     ruleId,
     renderBuilderRecovery,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/details_and_artifacts_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/details_and_artifacts_step.tsx
@@ -15,7 +15,7 @@ export function DetailsAndArtifactsStep() {
   return (
     <>
       {/* Name, description, tags -- connected to RHF via useFormContext() internally */}
-      <RuleDetailsFieldGroup />
+      <RuleDetailsFieldGroup autoFocusName />
 
       <EuiHorizontalRule margin="m" />
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EsqlQuerySummarySection } from './esql_query_summary_section';
+
+const defaultBlocks = [
+  {
+    id: 'base',
+    label: 'Base query',
+    query: 'FROM logs-*\n| STATS count = COUNT(*) BY host.name',
+    emptyMessage: 'No base query defined',
+  },
+  {
+    id: 'alert',
+    label: 'Alert condition',
+    query: '| WHERE count > 100',
+    emptyMessage: 'No alert condition defined',
+  },
+];
+
+const renderSection = (overrides: Partial<React.ComponentProps<typeof EsqlQuerySummarySection>> = {}) =>
+  render(
+    <I18nProvider>
+      <EsqlQuerySummarySection
+        description="Search query and alert condition identified"
+        blocks={defaultBlocks}
+        editButtonLabel="Edit query"
+        onEdit={jest.fn()}
+        editTestSubj="composeDiscoverEditQuery"
+        {...overrides}
+      />
+    </I18nProvider>
+  );
+
+describe('EsqlQuerySummarySection', () => {
+  it('renders the split panel with title, description, and query blocks', () => {
+    renderSection();
+
+    expect(screen.getByTestId('composeDiscoverEsqlQuerySection')).toBeInTheDocument();
+    expect(screen.getByText('ES|QL query')).toBeInTheDocument();
+    expect(screen.getByText('Search query and alert condition identified')).toBeInTheDocument();
+    expect(screen.getByText('Base query')).toBeInTheDocument();
+    expect(screen.getByText('Alert condition')).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-base')).toHaveTextContent('FROM logs-*');
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-alert')).toHaveTextContent(
+      '| WHERE count > 100'
+    );
+    expect(screen.getByTestId('composeDiscoverEditQuery')).toBeInTheDocument();
+  });
+
+  it('renders the empty state with open editor action', () => {
+    renderSection({
+      description: 'Open the editor to write your ES|QL query',
+      isEmpty: true,
+      emptyAction: {
+        label: 'Open query editor',
+        onClick: jest.fn(),
+        testSubj: 'composeDiscoverOpenEditor',
+      },
+      blocks: [],
+    });
+
+    expect(screen.getByText('Open the editor to write your ES|QL query')).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverOpenEditor')).toBeInTheDocument();
+    expect(screen.queryByTestId('composeDiscoverEsqlQuerySectionToggle')).not.toBeInTheDocument();
+  });
+
+  it('renders a callout inside the section body', () => {
+    renderSection({
+      callout: <div data-test-subj="composeDiscoverTestCallout">Split failed</div>,
+    });
+
+    expect(screen.getByTestId('composeDiscoverTestCallout')).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverEsqlQuerySection')).toContainElement(
+      screen.getByTestId('composeDiscoverTestCallout')
+    );
+  });
+
+  it('keeps long query blocks visible with scroll overflow instead of a collapse control', () => {
+    const longQuery = Array.from({ length: 10 }, (_, i) => `| WHERE field${i} == ${i}`).join('\n');
+    renderSection({
+      blocks: [
+        {
+          id: 'base',
+          label: 'Base query',
+          query: longQuery,
+          emptyMessage: 'No base query defined',
+        },
+      ],
+    });
+
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-base')).toBeInTheDocument();
+    expect(screen.queryByTestId('composeDiscoverEsqlQuerySectionToggle')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_query_summary_section.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiCodeBlock,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiSplitPanel,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import type { ReactNode } from 'react';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+
+const LONG_QUERY_LINE_THRESHOLD = 8;
+const CODE_BLOCK_OVERFLOW_HEIGHT = 120;
+
+const queryBodyPanelStyles = css`
+  padding-top: 0;
+`;
+
+export interface EsqlQuerySummaryBlock {
+  id: string;
+  label: string;
+  query: string;
+  emptyMessage: string;
+}
+
+export interface EsqlQuerySummarySectionProps {
+  /** Section heading. Defaults to "ES|QL query". */
+  title?: string;
+  description: string;
+  blocks: EsqlQuerySummaryBlock[];
+  editButtonLabel: string;
+  onEdit: () => void;
+  editDisabled?: boolean;
+  editTestSubj: string;
+  isEmpty?: boolean;
+  callout?: ReactNode;
+  emptyMessage?: string;
+  emptyAction?: {
+    label: string;
+    onClick: () => void;
+    testSubj: string;
+    disabled?: boolean;
+  };
+}
+
+const countLines = (query: string): number => (query.trim() ? query.split('\n').length : 0);
+
+export const EsqlQuerySummarySection: React.FC<EsqlQuerySummarySectionProps> = ({
+  title = i18n.translate('xpack.alertingV2.composeDiscover.esqlQuerySummary.title', {
+    defaultMessage: 'ES|QL query',
+  }),
+  description,
+  blocks,
+  editButtonLabel,
+  onEdit,
+  editDisabled = false,
+  editTestSubj,
+  isEmpty = false,
+  callout,
+  emptyMessage,
+  emptyAction,
+}) => {
+  return (
+    <EuiSplitPanel.Outer hasBorder data-test-subj="composeDiscoverEsqlQuerySection">
+      <EuiSplitPanel.Inner grow={false} paddingSize="m">
+        <EuiTitle size="xs" data-test-subj="composeDiscoverEsqlQuerySectionTitle">
+          <h3>{title}</h3>
+        </EuiTitle>
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued" data-test-subj="composeDiscoverEsqlQuerySectionDescription">
+          {description}
+        </EuiText>
+      </EuiSplitPanel.Inner>
+
+      <EuiSplitPanel.Inner css={queryBodyPanelStyles}>
+        {callout && (
+          <>
+            {callout}
+            <EuiSpacer size="m" />
+          </>
+        )}
+        {isEmpty ? (
+          <>
+            {emptyMessage && (
+              <>
+                <EuiPanel color="subdued" paddingSize="m">
+                  <EuiText size="s" color="subdued">
+                    {emptyMessage}
+                  </EuiText>
+                </EuiPanel>
+                {emptyAction && <EuiSpacer size="s" />}
+              </>
+            )}
+            {emptyAction && (
+              <>
+                <EuiButton
+                  iconType="editorCodeBlock"
+                  isDisabled={emptyAction.disabled}
+                  onClick={emptyAction.onClick}
+                  data-test-subj={emptyAction.testSubj}
+                >
+                  {emptyAction.label}
+                </EuiButton>
+              </>
+            )}
+          </>
+        ) : (
+          <>
+            {blocks.map((block, index) => (
+              <React.Fragment key={block.id}>
+                {index > 0 && <EuiSpacer size="m" />}
+                <EuiFormRow label={block.label} fullWidth>
+                  {block.query.trim() ? (
+                    <EuiCodeBlock
+                      language="esql"
+                      fontSize="s"
+                      paddingSize="m"
+                      isCopyable
+                      overflowHeight={
+                        countLines(block.query) > LONG_QUERY_LINE_THRESHOLD
+                          ? CODE_BLOCK_OVERFLOW_HEIGHT
+                          : undefined
+                      }
+                      data-test-subj={`composeDiscoverEsqlQueryBlock-${block.id}`}
+                    >
+                      {block.query}
+                    </EuiCodeBlock>
+                  ) : (
+                    <EuiPanel color="subdued" paddingSize="s">
+                      <EuiText size="s" color="subdued">
+                        {block.emptyMessage}
+                      </EuiText>
+                    </EuiPanel>
+                  )}
+                </EuiFormRow>
+              </React.Fragment>
+            ))}
+            <EuiSpacer size="m" />
+            <EuiButton
+              size="s"
+              color="text"
+              iconType="editorCodeBlock"
+              isDisabled={editDisabled}
+              onClick={onEdit}
+              data-test-subj={editTestSubj}
+            >
+              {editButtonLabel}
+            </EuiButton>
+          </>
+        )}
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
@@ -17,11 +17,6 @@ import type { ComposeDiscoverState } from '../types';
 import type { ComposeFormValues, RuleQuery } from '../compose_form_types';
 import { RecoveryConditionStep } from './recovery_condition_step';
 
-jest.mock('@kbn/code-editor', () => ({
-  ...jest.requireActual('@kbn/code-editor'),
-  CodeEditor: ({ value }: { value: string }) => <pre data-test-subj="codeEditorMock">{value}</pre>,
-}));
-
 const BASE_QUERY = 'FROM logs-*\n| STATS count = COUNT(*) BY host.name';
 const ALERT_SEGMENT = 'WHERE count > 100';
 const RECOVERY_SEGMENT = 'WHERE count < 100';
@@ -116,29 +111,52 @@ describe('RecoveryConditionStep', () => {
   it('does not render query summaries or edit button in default mode', () => {
     renderRecoveryStep({ recoveryType: 'default' });
 
-    expect(screen.queryByText('Base query')).not.toBeInTheDocument();
-    expect(screen.queryByText('Recovery condition')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('composeDiscoverEsqlQuerySection')).not.toBeInTheDocument();
     expect(screen.queryByTestId('composeDiscoverEditRecovery')).not.toBeInTheDocument();
   });
 
-  it('renders query summaries and edit button in custom mode', () => {
+  it('renders the ES|QL summary section with code blocks and edit button in custom mode', () => {
     renderRecoveryStep({ recoveryType: 'custom' }, CUSTOM_RECOVERY_QUERY);
 
+    expect(screen.getByTestId('composeDiscoverEsqlQuerySection')).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverEsqlQuerySectionTitle')).toHaveTextContent(
+      'Recovery condition'
+    );
+    expect(screen.getByText('Custom recovery condition defined')).toBeInTheDocument();
     expect(screen.getByText('Base query')).toBeInTheDocument();
-    expect(screen.getByText('Recovery condition')).toBeInTheDocument();
+    expect(screen.getByText('Recovery condition', { selector: 'label' })).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-base')).toHaveTextContent('FROM logs-*');
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-base')).toHaveTextContent(
+      'STATS count = COUNT(*) BY host.name'
+    );
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-recovery')).toHaveTextContent(
+      RECOVERY_SEGMENT
+    );
     expect(screen.getByTestId('composeDiscoverEditRecovery')).toBeInTheDocument();
   });
 
-  it('shows "Custom condition set" badge when recovery block is populated', () => {
-    renderRecoveryStep({ recoveryType: 'custom' }, CUSTOM_RECOVERY_QUERY);
+  it('derives the base query display from standalone committed queries', () => {
+    renderRecoveryStep(
+      { recoveryType: 'custom' },
+      {
+        format: 'standalone',
+        breach: {
+          query: `${BASE_QUERY}\n| ${ALERT_SEGMENT}`,
+        },
+      }
+    );
 
-    expect(screen.getByText('Custom condition set')).toBeInTheDocument();
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-base')).toHaveTextContent('FROM logs-*');
+    expect(screen.getByTestId('composeDiscoverEsqlQueryBlock-base')).toHaveTextContent(
+      'STATS count = COUNT(*) BY host.name'
+    );
   });
 
-  it('does not show badge when recovery block is empty', () => {
+  it('shows start description when recovery block is empty', () => {
     renderRecoveryStep({ recoveryType: 'custom' }, CUSTOM_NO_RECOVERY_QUERY);
 
-    expect(screen.queryByText('Custom condition set')).not.toBeInTheDocument();
+    expect(screen.getByText('Open the editor to define your recovery condition')).toBeInTheDocument();
+    expect(screen.getByText('Not defined')).toBeInTheDocument();
   });
 
   it('disables the edit button when the child flyout is open', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.tsx
@@ -8,22 +8,17 @@
 import React from 'react';
 import { useWatch } from 'react-hook-form';
 import {
-  EuiBadge,
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFormRow,
-  EuiHorizontalRule,
   EuiSpacer,
   EuiSuperSelect,
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 import type { ComposeDiscoverAction, ComposeDiscoverState, RecoveryType } from '../types';
 import type { RuleBuilderRecoveryProps } from '../rule_builder/types';
 import type { ComposeFormValues } from '../compose_form_types';
-import { QuerySummary } from '../query_summary';
+import { ensureComposedQuery } from '../sandbox_query_utils';
+import { EsqlQuerySummarySection } from './esql_query_summary_section';
 import { RecoveryDelayField } from '../../../form/fields/recovery_delay_field';
 
 const defaultRecoveryLabel = i18n.translate(
@@ -117,11 +112,40 @@ export function RecoveryConditionStep({
   renderBuilderRecovery,
 }: RecoveryConditionStepProps) {
   const query = useWatch<ComposeFormValues, 'query'>({ name: 'query' });
-  const baseQuery = query?.format === 'composed' ? query.base : '';
-  const recoveryBlock = query?.format === 'composed' ? query.recovery?.segment ?? '' : '';
+  const composedQuery = query ? ensureComposedQuery(query) : undefined;
+  const baseQuery = composedQuery?.base ?? '';
+  const recoveryBlock = composedQuery?.recovery?.segment ?? '';
 
   const isBuilderMode = Boolean(renderBuilderRecovery);
   const hasValidRecoveryBlock = Boolean(recoveryBlock.trim());
+
+  const notDefinedLabel = i18n.translate(
+    'xpack.alertingV2.composeDiscover.recoveryCondition.notDefined',
+    { defaultMessage: 'Not defined' }
+  );
+
+  const openRecoveryEditor = () =>
+    dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert: true });
+
+  const editRecoveryLabel = i18n.translate(
+    'xpack.alertingV2.composeDiscover.recoveryCondition.editRecoveryButtonLabel',
+    { defaultMessage: 'Edit recovery query' }
+  );
+
+  const recoverySectionTitle = i18n.translate(
+    'xpack.alertingV2.composeDiscover.recoveryCondition.recoveryQuerySectionTitle',
+    { defaultMessage: 'Recovery condition' }
+  );
+
+  const recoverySectionDescription = hasValidRecoveryBlock
+    ? i18n.translate(
+        'xpack.alertingV2.composeDiscover.recoveryCondition.recoveryConditionDefined',
+        { defaultMessage: 'Custom recovery condition defined' }
+      )
+    : i18n.translate(
+        'xpack.alertingV2.composeDiscover.recoveryCondition.startRecoveryDescription',
+        { defaultMessage: 'Open the editor to define your recovery condition' }
+      );
 
   return (
     <>
@@ -132,8 +156,6 @@ export function RecoveryConditionStep({
 
       {state.recoveryType === 'custom' && (
         <>
-          <EuiSpacer size="l" />
-          <EuiHorizontalRule margin="none" />
           <EuiSpacer size="m" />
 
           {isBuilderMode ? (
@@ -142,70 +164,41 @@ export function RecoveryConditionStep({
               dispatch,
             })
           ) : (
-            <>
-              <EuiText size="xs" color="subdued">
-                <strong>
-                  <FormattedMessage
-                    id="xpack.alertingV2.composeDiscover.recoveryCondition.baseQueryLabel"
-                    defaultMessage="Base query"
-                  />
-                </strong>
-              </EuiText>
-              <EuiSpacer size="xs" />
-              <QuerySummary
-                query={baseQuery}
-                emptyMessage={i18n.translate(
-                  'xpack.alertingV2.composeDiscover.recoveryCondition.noBaseQueryDefined',
-                  { defaultMessage: 'No base query defined' }
-                )}
-              />
-              <EuiSpacer size="m" />
-              <EuiText size="xs" color="subdued">
-                <strong>
-                  <FormattedMessage
-                    id="xpack.alertingV2.composeDiscover.recoveryCondition.recoveryConditionLabel"
-                    defaultMessage="Recovery condition"
-                  />
-                </strong>
-              </EuiText>
-              <EuiSpacer size="xs" />
-              <QuerySummary
-                query={recoveryBlock}
-                emptyMessage={i18n.translate(
-                  'xpack.alertingV2.composeDiscover.recoveryCondition.noRecoveryConditionDefined',
-                  { defaultMessage: 'No recovery condition defined' }
-                )}
-              />
-              <EuiSpacer size="s" />
-              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    size="s"
-                    iconType="editorCodeBlock"
-                    isDisabled={state.childOpen}
-                    onClick={() =>
-                      dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert: true })
-                    }
-                    data-test-subj="composeDiscoverEditRecovery"
-                  >
-                    <FormattedMessage
-                      id="xpack.alertingV2.composeDiscover.recoveryCondition.editRecoveryButtonLabel"
-                      defaultMessage="Edit recovery query"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
-                {hasValidRecoveryBlock && (
-                  <EuiFlexItem grow={false}>
-                    <EuiBadge color="success">
-                      <FormattedMessage
-                        id="xpack.alertingV2.composeDiscover.recoveryCondition.customConditionSetBadgeLabel"
-                        defaultMessage="Custom condition set"
-                      />
-                    </EuiBadge>
-                  </EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            </>
+            <EsqlQuerySummarySection
+              title={recoverySectionTitle}
+              description={recoverySectionDescription}
+              isEmpty={!hasValidRecoveryBlock && !baseQuery.trim()}
+              emptyAction={{
+                label: editRecoveryLabel,
+                onClick: openRecoveryEditor,
+                testSubj: 'composeDiscoverEditRecovery',
+                disabled: state.childOpen,
+              }}
+              blocks={[
+                {
+                  id: 'base',
+                  label: i18n.translate(
+                    'xpack.alertingV2.composeDiscover.recoveryCondition.baseQueryLabel',
+                    { defaultMessage: 'Base query' }
+                  ),
+                  query: baseQuery,
+                  emptyMessage: notDefinedLabel,
+                },
+                {
+                  id: 'recovery',
+                  label: i18n.translate(
+                    'xpack.alertingV2.composeDiscover.recoveryCondition.recoveryConditionLabel',
+                    { defaultMessage: 'Recovery condition' }
+                  ),
+                  query: recoveryBlock,
+                  emptyMessage: notDefinedLabel,
+                },
+              ]}
+              editButtonLabel={editRecoveryLabel}
+              onEdit={openRecoveryEditor}
+              editDisabled={state.childOpen}
+              editTestSubj="composeDiscoverEditRecovery"
+            />
           )}
         </>
       )}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_tabs.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_tabs.test.tsx
@@ -74,6 +74,23 @@ describe('ComposeDiscoverTabs', () => {
     expect(onAlertEditorMount).not.toHaveBeenCalled();
   });
 
+  it('renders the locked base query above the recovery block editor', () => {
+    render(
+      <ComposeDiscoverTabs
+        {...defaultProps}
+        activeTab="recovery"
+        tabs={['recovery']}
+        hideTabBar
+        onRecoveryEditorMount={jest.fn()}
+      />
+    );
+
+    const editors = screen.getAllByTestId('codeEditorMock');
+    expect(editors).toHaveLength(2);
+    expect(editors[0]).toHaveTextContent('FROM logs-*');
+    expect(editors[1]).toHaveTextContent(recoveryBlock);
+  });
+
   it('uses the ES|QL language for base and split block editors', () => {
     render(
       <ComposeDiscoverTabs

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_form_types.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_form_types.test.ts
@@ -39,6 +39,25 @@ describe('getBreachQuery', () => {
     expect(getBreachQuery(query)).toBe(`${BASE}\n| ${ALERT_SEGMENT}`);
   });
 
+  it('joins base and breach segment when breach segment already has a leading pipe', () => {
+    const query: ComposedQuery = {
+      format: 'composed',
+      base: BASE,
+      breach: { segment: `| ${ALERT_SEGMENT}` },
+    };
+    expect(getBreachQuery(query)).toBe(`${BASE}\n| ${ALERT_SEGMENT}`);
+  });
+
+  it('joins multi-line base and piped breach segment without duplicating pipes', () => {
+    const multiLineBase = 'FROM flights | STATS c = COUNT(*) BY price\n| WHERE price IS NOT NULL';
+    const query: ComposedQuery = {
+      format: 'composed',
+      base: multiLineBase,
+      breach: { segment: '| WHERE price > 100' },
+    };
+    expect(getBreachQuery(query)).toBe(`${multiLineBase}\n| WHERE price > 100`);
+  });
+
   it('returns just breach segment when composed base is empty', () => {
     const query: ComposedQuery = {
       format: 'composed',
@@ -83,6 +102,16 @@ describe('getRecoverQuery', () => {
       base: BASE,
       breach: { segment: ALERT_SEGMENT },
       recovery: { segment: RECOVERY_SEGMENT },
+    };
+    expect(getRecoverQuery(query)).toBe(`${BASE}\n| ${RECOVERY_SEGMENT}`);
+  });
+
+  it('joins base and recovery segment when recovery segment already has a leading pipe', () => {
+    const query: ComposedQuery = {
+      format: 'composed',
+      base: BASE,
+      breach: { segment: ALERT_SEGMENT },
+      recovery: { segment: `| ${RECOVERY_SEGMENT}` },
     };
     expect(getRecoverQuery(query)).toBe(`${BASE}\n| ${RECOVERY_SEGMENT}`);
   });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_form_types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_form_types.ts
@@ -31,17 +31,40 @@ export interface StandaloneQuery {
 
 export type RuleQuery = ComposedQuery | StandaloneQuery;
 
+/** Strip leading pipes so composed segments can be joined with a single `| `. */
+function normalizeComposedSegment(segment: string): string {
+  return segment.trim().replace(/^\|+\s*/, '');
+}
+
+function joinComposedQuery(base: string, segment: string): string {
+  const trimmedBase = base.trim();
+  const normalizedSegment = normalizeComposedSegment(segment);
+
+  if (!trimmedBase) {
+    return normalizedSegment;
+  }
+  if (!normalizedSegment) {
+    return trimmedBase;
+  }
+  return `${trimmedBase}\n| ${normalizedSegment}`;
+}
+
 export function getBreachQuery(query: RuleQuery | undefined): string {
   if (!query) return '';
   if (query.format === 'standalone') return query.breach.query;
-  return [query.base, query.breach.segment].filter(Boolean).join('\n| ');
+  return joinComposedQuery(query.base, query.breach.segment);
+}
+
+/** True when the rule has any ES|QL content in the breach (alert) pipeline. */
+export function isQueryDefined(query: RuleQuery | undefined): boolean {
+  return Boolean(getBreachQuery(query).trim());
 }
 
 export function getRecoverQuery(query: RuleQuery | undefined): string {
   if (!query) return '';
   if (query.format === 'standalone') return query.recovery?.query ?? '';
   if (!query.recovery?.segment) return '';
-  return [query.base, query.recovery.segment].filter(Boolean).join('\n| ');
+  return joinComposedQuery(query.base, query.recovery.segment);
 }
 
 // ---------------------------------------------------------------------------

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
@@ -144,6 +144,125 @@ describe('QuerySandbox', () => {
     expect(screen.getByText('Alert')).toBeInTheDocument();
   });
 
+  it('renders ES|QL query title and helper on first create without the separate link', () => {
+    renderSandbox({ showUnifiedQueryHeader: true });
+
+    expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
+    expect(screen.getByText('ES|QL query')).toBeInTheDocument();
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      "We'll automatically identify the base query and alert condition when you apply changes."
+    );
+    expect(screen.queryByTestId('querySandboxSeparateBaseAndAlert')).not.toBeInTheDocument();
+  });
+
+  it('renders separate link in helper when onEditManually is provided', () => {
+    renderSandbox({ onEditManually: jest.fn() });
+    expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
+    expect(screen.getByText('ES|QL query')).toBeInTheDocument();
+    expect(screen.getByTestId('querySandboxSeparateBaseAndAlert')).toHaveTextContent(
+      'Separate base and alert'
+    );
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      "We'll automatically identify the base query and alert condition when you apply changes."
+    );
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      'Prefer to edit them separately?'
+    );
+    expect(screen.queryByText('Base')).not.toBeInTheDocument();
+  });
+
+  it('renders ES|QL query title and base/alert sub-tabs when manual split', () => {
+    renderSandbox({
+      onUseSingleEditor: jest.fn(),
+      tabProps: {
+        tabs: ['base', 'alert'],
+        activeTab: 'alert',
+        onTabChange: jest.fn(),
+        baseQuery: 'FROM logs-*',
+        alertBlock: '| WHERE count > 100',
+        recoveryBlock: '',
+        onBaseQueryChange: jest.fn(),
+        onAlertBlockChange: jest.fn(),
+        onRecoveryBlockChange: jest.fn(),
+      },
+    });
+    expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
+    expect(screen.getByTestId('querySandboxUseSingleEditor')).toHaveTextContent('Use single editor');
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      'Define the base query and alert condition separately. Automatic query splitting is disabled in this mode.'
+    );
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      'Prefer one editor?'
+    );
+    expect(screen.getByText('Base')).toBeInTheDocument();
+    expect(screen.getByText('Alert')).toBeInTheDocument();
+  });
+
+  it('renders ES|QL title, YAML helper, and tabs in YAML mode without mode-switch links', () => {
+    renderSandbox({
+      showYamlQueryHeader: true,
+      tabProps: {
+        tabs: ['base', 'alert', 'recovery'],
+        activeTab: 'alert',
+        onTabChange: jest.fn(),
+        baseQuery: 'FROM logs-*',
+        alertBlock: '| WHERE count > 100',
+        recoveryBlock: '| WHERE count < 50',
+        onBaseQueryChange: jest.fn(),
+        onAlertBlockChange: jest.fn(),
+        onRecoveryBlockChange: jest.fn(),
+      },
+    });
+    expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      'Edit in YAML view or in this query sandbox. Apply changes to update the YAML. Each query block is on its own tab.'
+    );
+    expect(screen.queryByTestId('querySandboxSeparateBaseAndAlert')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('querySandboxUseSingleEditor')).not.toBeInTheDocument();
+    expect(screen.getByText('Base')).toBeInTheDocument();
+    expect(screen.getByText('Alert')).toBeInTheDocument();
+    expect(screen.getByText('Recovery')).toBeInTheDocument();
+  });
+
+  it('renders signal title and helper without split-query copy', () => {
+    renderSandbox({ showSignalQueryHeader: true });
+
+    expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toHaveTextContent('ES|QL query');
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      'Define what to detect with ES|QL. Each match is recorded as a signal for querying and investigation, without alert lifecycle or notifications.'
+    );
+    expect(screen.queryByTestId('querySandboxSeparateBaseAndAlert')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('querySandboxUseSingleEditor')).not.toBeInTheDocument();
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).not.toHaveTextContent(
+      'base query and alert condition'
+    );
+  });
+
+  it('renders recovery title, helper, and split editor without a tab bar in recovery-only sandbox', () => {
+    renderSandbox({
+      showRecoveryQueryHeader: true,
+      tabProps: {
+        tabs: ['recovery'],
+        activeTab: 'recovery',
+        onTabChange: jest.fn(),
+        baseQuery: 'FROM logs-* | STATS c = COUNT(*) BY host',
+        alertBlock: '| WHERE c > 100',
+        recoveryBlock: '| WHERE c < 50',
+        onBaseQueryChange: jest.fn(),
+        onAlertBlockChange: jest.fn(),
+        onRecoveryBlockChange: jest.fn(),
+      },
+    });
+    expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toHaveTextContent(
+      'Recovery condition'
+    );
+    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
+      'Define when the alert should recover. This ES|QL block is evaluated against the base query.'
+    );
+    expect(screen.getByTestId('mockComposeDiscoverTabs')).toBeInTheDocument();
+    expect(screen.queryByTestId('querySandboxTab-recovery')).not.toBeInTheDocument();
+  });
+
   it('shows "Run your query" prompt when hasRun is false', () => {
     renderSandbox();
     expect(screen.getByText('Run your query to see results')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
@@ -184,9 +184,7 @@ describe('QuerySandbox', () => {
       },
     });
     expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
-    expect(screen.getByTestId('querySandboxUseSingleEditor')).toHaveTextContent(
-      'Merge to single editor'
-    );
+    expect(screen.getByTestId('querySandboxUseSingleEditor')).toHaveTextContent('Use single editor');
     expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
       'Define the base query and alert condition separately. Automatic query splitting is disabled in this mode.'
     );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
@@ -155,18 +155,15 @@ describe('QuerySandbox', () => {
     expect(screen.queryByTestId('querySandboxSeparateBaseAndAlert')).not.toBeInTheDocument();
   });
 
-  it('renders separate link in helper when onEditManually is provided', () => {
+  it('renders split button in header when onEditManually is provided', () => {
     renderSandbox({ onEditManually: jest.fn() });
     expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
     expect(screen.getByText('ES|QL query')).toBeInTheDocument();
     expect(screen.getByTestId('querySandboxSeparateBaseAndAlert')).toHaveTextContent(
-      'Separate base and alert'
+      'Split base and alert'
     );
     expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
       "We'll automatically identify the base query and alert condition when you apply changes."
-    );
-    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
-      'Prefer to edit them separately?'
     );
     expect(screen.queryByText('Base')).not.toBeInTheDocument();
   });
@@ -187,12 +184,11 @@ describe('QuerySandbox', () => {
       },
     });
     expect(screen.getByTestId('querySandboxEsqlQueryTitle')).toBeInTheDocument();
-    expect(screen.getByTestId('querySandboxUseSingleEditor')).toHaveTextContent('Use single editor');
-    expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
-      'Define the base query and alert condition separately. Automatic query splitting is disabled in this mode.'
+    expect(screen.getByTestId('querySandboxUseSingleEditor')).toHaveTextContent(
+      'Merge to single editor'
     );
     expect(screen.getByTestId('querySandboxSeparateQueryHelper')).toHaveTextContent(
-      'Prefer one editor?'
+      'Define the base query and alert condition separately. Automatic query splitting is disabled in this mode.'
     );
     expect(screen.getByText('Base')).toBeInTheDocument();
     expect(screen.getByText('Alert')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -239,6 +239,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
       return (
         <EuiButton
           size="s"
+          color="text"
           iconType="branch"
           onClick={onEditManually}
           data-test-subj="querySandboxSeparateBaseAndAlert"
@@ -252,6 +253,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
       return (
         <EuiButton
           size="s"
+          color="text"
           iconType="merge"
           onClick={onUseSingleEditor}
           data-test-subj="querySandboxUseSingleEditor"
@@ -389,7 +391,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
         <>
           {showEsqlQueryHeader && (
             <>
-              <EuiFlexGroup alignItems="flexStart" gutterSize="m" responsive={false}>
+              <EuiFlexGroup alignItems="flexEnd" gutterSize="m" responsive={false}>
                 <EuiFlexItem>
                   <EuiTitle size="xs" data-test-subj="querySandboxEsqlQueryTitle">
                     <h3>{querySectionTitle}</h3>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -111,6 +111,14 @@ const SPLIT_BASE_AND_ALERT_LABEL = i18n.translate(
   { defaultMessage: 'Split base and alert' }
 );
 
+const SPLIT_BASE_AND_ALERT_TOOLTIP = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.splitBaseAndAlertTooltip',
+  {
+    defaultMessage:
+      'Open separate editors for the base query and alert condition. Automatic splitting is disabled in this mode.',
+  }
+);
+
 const MERGE_TO_SINGLE_EDITOR_LABEL = i18n.translate(
   'xpack.alertingV2.composeDiscover.querySandbox.mergeToSingleEditorButton',
   { defaultMessage: 'Merge to single editor' }
@@ -237,15 +245,17 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
   const modeSwitchButton = useMemo(() => {
     if (onEditManually) {
       return (
-        <EuiButton
-          size="s"
-          color="text"
-          iconType="branch"
-          onClick={onEditManually}
-          data-test-subj="querySandboxSeparateBaseAndAlert"
-        >
-          {SPLIT_BASE_AND_ALERT_LABEL}
-        </EuiButton>
+        <EuiToolTip content={SPLIT_BASE_AND_ALERT_TOOLTIP}>
+          <EuiButton
+            size="s"
+            color="text"
+            iconType="branch"
+            onClick={onEditManually}
+            data-test-subj="querySandboxSeparateBaseAndAlert"
+          >
+            {SPLIT_BASE_AND_ALERT_LABEL}
+          </EuiButton>
+        </EuiToolTip>
       );
     }
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -273,7 +273,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
           <EuiButton
             size="s"
             color="text"
-            iconType="merge"
+            iconType="querySelector"
             onClick={onUseSingleEditor}
             data-test-subj="querySandboxUseSingleEditor"
           >

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -257,7 +257,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
           <EuiButton
             size="s"
             color="text"
-            iconType="branch"
+            iconType="inputOutput"
             onClick={onEditManually}
             data-test-subj="querySandboxSeparateBaseAndAlert"
           >

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -119,9 +119,17 @@ const SPLIT_BASE_AND_ALERT_TOOLTIP = i18n.translate(
   }
 );
 
-const MERGE_TO_SINGLE_EDITOR_LABEL = i18n.translate(
-  'xpack.alertingV2.composeDiscover.querySandbox.mergeToSingleEditorButton',
-  { defaultMessage: 'Merge to single editor' }
+const USE_SINGLE_EDITOR_LABEL = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.useSingleEditorButton',
+  { defaultMessage: 'Use single editor' }
+);
+
+const USE_SINGLE_EDITOR_TOOLTIP = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.useSingleEditorTooltip',
+  {
+    defaultMessage:
+      'Combine the base query and alert condition in one editor. When you apply, we automatically split them again.',
+  }
 );
 
 const UNIFIED_QUERY_HELPER_TEXT = i18n.translate(
@@ -261,15 +269,17 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
 
     if (onUseSingleEditor) {
       return (
-        <EuiButton
-          size="s"
-          color="text"
-          iconType="merge"
-          onClick={onUseSingleEditor}
-          data-test-subj="querySandboxUseSingleEditor"
-        >
-          {MERGE_TO_SINGLE_EDITOR_LABEL}
-        </EuiButton>
+        <EuiToolTip content={USE_SINGLE_EDITOR_TOOLTIP}>
+          <EuiButton
+            size="s"
+            color="text"
+            iconType="merge"
+            onClick={onUseSingleEditor}
+            data-test-subj="querySandboxUseSingleEditor"
+          >
+            {USE_SINGLE_EDITOR_LABEL}
+          </EuiButton>
+        </EuiToolTip>
       );
     }
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -13,7 +13,6 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
   EuiLoadingSpinner,
   EuiPanel,
   EuiSelect,
@@ -107,14 +106,14 @@ const ESQL_QUERY_TITLE = i18n.translate(
   { defaultMessage: 'ES|QL query' }
 );
 
-const SEPARATE_BASE_AND_ALERT_LABEL = i18n.translate(
-  'xpack.alertingV2.composeDiscover.querySandbox.separateBaseAndAlertButton',
-  { defaultMessage: 'Separate base and alert' }
+const SPLIT_BASE_AND_ALERT_LABEL = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.splitBaseAndAlertButton',
+  { defaultMessage: 'Split base and alert' }
 );
 
-const USE_SINGLE_EDITOR_LABEL = i18n.translate(
-  'xpack.alertingV2.composeDiscover.querySandbox.useSingleEditorButton',
-  { defaultMessage: 'Use single editor' }
+const MERGE_TO_SINGLE_EDITOR_LABEL = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.mergeToSingleEditorButton',
+  { defaultMessage: 'Merge to single editor' }
 );
 
 const UNIFIED_QUERY_HELPER_TEXT = i18n.translate(
@@ -225,54 +224,45 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
     }
 
     if (onUseSingleEditor) {
-      return (
-        <>
-          {MANUAL_SPLIT_QUERY_HELPER_TEXT}{' '}
-          <FormattedMessage
-            id="xpack.alertingV2.composeDiscover.querySandbox.useSingleEditorHelperLink"
-            defaultMessage="Prefer one editor? {link}"
-            values={{
-              link: (
-                <EuiLink onClick={onUseSingleEditor} data-test-subj="querySandboxUseSingleEditor">
-                  {USE_SINGLE_EDITOR_LABEL}
-                </EuiLink>
-              ),
-            }}
-          />
-        </>
-      );
+      return MANUAL_SPLIT_QUERY_HELPER_TEXT;
     }
 
     if (onEditManually) {
-      return (
-        <>
-          {UNIFIED_QUERY_HELPER_TEXT}{' '}
-          <FormattedMessage
-            id="xpack.alertingV2.composeDiscover.querySandbox.separateBaseAndAlertHelperLink"
-            defaultMessage="Prefer to edit them separately? {link}"
-            values={{
-              link: (
-                <EuiLink
-                  onClick={onEditManually}
-                  data-test-subj="querySandboxSeparateBaseAndAlert"
-                >
-                  {SEPARATE_BASE_AND_ALERT_LABEL}
-                </EuiLink>
-              ),
-            }}
-          />
-        </>
-      );
+      return UNIFIED_QUERY_HELPER_TEXT;
     }
 
     return UNIFIED_QUERY_HELPER_TEXT;
-  }, [
-    showRecoveryQueryHeader,
-    showSignalQueryHeader,
-    showYamlQueryHeader,
-    onUseSingleEditor,
-    onEditManually,
-  ]);
+  }, [showRecoveryQueryHeader, showSignalQueryHeader, showYamlQueryHeader, onUseSingleEditor, onEditManually]);
+
+  const modeSwitchButton = useMemo(() => {
+    if (onEditManually) {
+      return (
+        <EuiButton
+          size="s"
+          iconType="branch"
+          onClick={onEditManually}
+          data-test-subj="querySandboxSeparateBaseAndAlert"
+        >
+          {SPLIT_BASE_AND_ALERT_LABEL}
+        </EuiButton>
+      );
+    }
+
+    if (onUseSingleEditor) {
+      return (
+        <EuiButton
+          size="s"
+          iconType="merge"
+          onClick={onUseSingleEditor}
+          data-test-subj="querySandboxUseSingleEditor"
+        >
+          {MERGE_TO_SINGLE_EDITOR_LABEL}
+        </EuiButton>
+      );
+    }
+
+    return null;
+  }, [onEditManually, onUseSingleEditor]);
 
   const executionQuery = previewQuery ?? query;
 
@@ -399,13 +389,20 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
         <>
           {showEsqlQueryHeader && (
             <>
-              <EuiTitle size="xs" data-test-subj="querySandboxEsqlQueryTitle">
-                <h3>{querySectionTitle}</h3>
-              </EuiTitle>
-              <EuiSpacer size="xs" />
-              <EuiText size="xs" color="subdued" data-test-subj="querySandboxSeparateQueryHelper">
-                {queryHelperContent}
-              </EuiText>
+              <EuiFlexGroup alignItems="flexStart" gutterSize="m" responsive={false}>
+                <EuiFlexItem>
+                  <EuiTitle size="xs" data-test-subj="querySandboxEsqlQueryTitle">
+                    <h3>{querySectionTitle}</h3>
+                  </EuiTitle>
+                  <EuiSpacer size="xs" />
+                  <EuiText size="xs" color="subdued" data-test-subj="querySandboxSeparateQueryHelper">
+                    {queryHelperContent}
+                  </EuiText>
+                </EuiFlexItem>
+                {modeSwitchButton && (
+                  <EuiFlexItem grow={false}>{modeSwitchButton}</EuiFlexItem>
+                )}
+              </EuiFlexGroup>
               <EuiSpacer size="s" />
             </>
           )}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -13,6 +13,7 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiLoadingSpinner,
   EuiPanel,
   EuiSelect,
@@ -21,6 +22,7 @@ import {
   EuiTab,
   EuiTabs,
   EuiText,
+  EuiTitle,
   EuiToolTip,
   type EuiDataGridColumn,
   type EuiDataGridCellValueElementProps,
@@ -78,12 +80,87 @@ export interface QuerySandboxProps {
     onRecoveryEditorMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
     readOnly?: boolean;
   };
+  /** Unified mode — opt into base/alert split editors via helper link. */
+  onEditManually?: () => void;
+  /** Split mode — return to a single editor via helper link. */
+  onUseSingleEditor?: () => void;
+  /** Show ES|QL title and helper text in unified alert mode (before first apply). */
+  showUnifiedQueryHeader?: boolean;
+  /** YAML mode — title, manual-split helper, and tabs (no unified/split toggle icons). */
+  showYamlQueryHeader?: boolean;
+  /** Recovery step — title and helper; single editor for the recovery block (no tab bar). */
+  showRecoveryQueryHeader?: boolean;
+  /** Signal rules — title and helper on the condition step (single editor, no split copy). */
+  showSignalQueryHeader?: boolean;
+  /** Query executed for Search/preview when it differs from the editor value (recovery step). */
+  previewQuery?: string;
+  onEditorMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
 }
 
 const VISIBLE_ROWS = 10;
 const INITIAL_EDITOR_HEIGHT = 200;
 const MIN_EDITOR_HEIGHT = 80;
 const MAX_EDITOR_HEIGHT = 600;
+
+const ESQL_QUERY_TITLE = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.esqlQueryTitle',
+  { defaultMessage: 'ES|QL query' }
+);
+
+const SEPARATE_BASE_AND_ALERT_LABEL = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.separateBaseAndAlertButton',
+  { defaultMessage: 'Separate base and alert' }
+);
+
+const USE_SINGLE_EDITOR_LABEL = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.useSingleEditorButton',
+  { defaultMessage: 'Use single editor' }
+);
+
+const UNIFIED_QUERY_HELPER_TEXT = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.unifiedQueryHelperText',
+  {
+    defaultMessage:
+      "We'll automatically identify the base query and alert condition when you apply changes.",
+  }
+);
+
+const MANUAL_SPLIT_QUERY_HELPER_TEXT = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.manualSplitQueryHelperText',
+  {
+    defaultMessage:
+      'Define the base query and alert condition separately. Automatic query splitting is disabled in this mode.',
+  }
+);
+
+const YAML_QUERY_HELPER_TEXT = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.yamlQueryHelperText',
+  {
+    defaultMessage:
+      'Edit in YAML view or in this query sandbox. Apply changes to update the YAML. Each query block is on its own tab.',
+  }
+);
+
+const RECOVERY_QUERY_TITLE = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.recoveryQueryTitle',
+  { defaultMessage: 'Recovery condition' }
+);
+
+const RECOVERY_QUERY_HELPER_TEXT = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.recoveryQueryHelperText',
+  {
+    defaultMessage:
+      'Define when the alert should recover. This ES|QL block is evaluated against the base query.',
+  }
+);
+
+const SIGNAL_QUERY_HELPER_TEXT = i18n.translate(
+  'xpack.alertingV2.composeDiscover.querySandbox.signalQueryHelperText',
+  {
+    defaultMessage:
+      'Define what to detect with ES|QL. Each match is recorded as a signal for querying and investigation, without alert lifecycle or notifications.',
+  }
+);
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
 const RUN_SHORTCUT_LABEL = isMac ? '⌘⏎' : 'Ctrl+Enter';
@@ -97,6 +174,14 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
   onDateRangeChange,
   autoRun = false,
   tabProps,
+  onEditManually,
+  onUseSingleEditor,
+  showUnifiedQueryHeader = false,
+  showYamlQueryHeader = false,
+  showRecoveryQueryHeader = false,
+  showSignalQueryHeader = false,
+  previewQuery,
+  onEditorMount,
 }) => {
   const services = useRuleFormServices();
   const isReadOnly = !onQueryChange;
@@ -107,12 +192,96 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
     return TAB_DEFINITIONS.filter((t) => tabProps.tabs.includes(t.id));
   }, [tabProps?.tabs]);
 
+  const showEsqlQueryHeader = Boolean(
+    showUnifiedQueryHeader ||
+      showYamlQueryHeader ||
+      showRecoveryQueryHeader ||
+      showSignalQueryHeader ||
+      onEditManually ||
+      onUseSingleEditor
+  );
+  const showTabsBelowHeader =
+    splitTabs.length > 0 &&
+    Boolean(tabProps) &&
+    showEsqlQueryHeader &&
+    !showRecoveryQueryHeader;
+  const showTabsWithoutHeader =
+    splitTabs.length > 0 && Boolean(tabProps) && !showEsqlQueryHeader && !showRecoveryQueryHeader;
+  const showEditorChrome =
+    showEsqlQueryHeader || showTabsBelowHeader || showTabsWithoutHeader;
+  const querySectionTitle = showRecoveryQueryHeader ? RECOVERY_QUERY_TITLE : ESQL_QUERY_TITLE;
+
+  const queryHelperContent = useMemo(() => {
+    if (showRecoveryQueryHeader) {
+      return RECOVERY_QUERY_HELPER_TEXT;
+    }
+
+    if (showSignalQueryHeader) {
+      return SIGNAL_QUERY_HELPER_TEXT;
+    }
+
+    if (showYamlQueryHeader) {
+      return YAML_QUERY_HELPER_TEXT;
+    }
+
+    if (onUseSingleEditor) {
+      return (
+        <>
+          {MANUAL_SPLIT_QUERY_HELPER_TEXT}{' '}
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.querySandbox.useSingleEditorHelperLink"
+            defaultMessage="Prefer one editor? {link}"
+            values={{
+              link: (
+                <EuiLink onClick={onUseSingleEditor} data-test-subj="querySandboxUseSingleEditor">
+                  {USE_SINGLE_EDITOR_LABEL}
+                </EuiLink>
+              ),
+            }}
+          />
+        </>
+      );
+    }
+
+    if (onEditManually) {
+      return (
+        <>
+          {UNIFIED_QUERY_HELPER_TEXT}{' '}
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.querySandbox.separateBaseAndAlertHelperLink"
+            defaultMessage="Prefer to edit them separately? {link}"
+            values={{
+              link: (
+                <EuiLink
+                  onClick={onEditManually}
+                  data-test-subj="querySandboxSeparateBaseAndAlert"
+                >
+                  {SEPARATE_BASE_AND_ALERT_LABEL}
+                </EuiLink>
+              ),
+            }}
+          />
+        </>
+      );
+    }
+
+    return UNIFIED_QUERY_HELPER_TEXT;
+  }, [
+    showRecoveryQueryHeader,
+    showSignalQueryHeader,
+    showYamlQueryHeader,
+    onUseSingleEditor,
+    onEditManually,
+  ]);
+
+  const executionQuery = previewQuery ?? query;
+
   const timeRange = useMemo(
     () => ({ from: dateRange.dateStart, to: dateRange.dateEnd }),
     [dateRange.dateStart, dateRange.dateEnd]
   );
 
-  const queryForFields = /^\s*FROM\s+[a-zA-Z0-9_.*-]/i.test(query) ? query : '';
+  const queryForFields = /^\s*FROM\s+[a-zA-Z0-9_.*-]/i.test(executionQuery) ? executionQuery : '';
   const { data: fieldMap } = useDataFields({
     query: queryForFields,
     http: services.http,
@@ -155,7 +324,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
     hasRun,
     lastExecutedQuery,
   } = useQueryExecution({
-    query,
+    query: executionQuery,
     timeField,
     timeRange,
     data: services.data,
@@ -226,6 +395,40 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
 
   return (
     <div data-test-subj="querySandbox">
+      {showEditorChrome && (
+        <>
+          {showEsqlQueryHeader && (
+            <>
+              <EuiTitle size="xs" data-test-subj="querySandboxEsqlQueryTitle">
+                <h3>{querySectionTitle}</h3>
+              </EuiTitle>
+              <EuiSpacer size="xs" />
+              <EuiText size="xs" color="subdued" data-test-subj="querySandboxSeparateQueryHelper">
+                {queryHelperContent}
+              </EuiText>
+              <EuiSpacer size="s" />
+            </>
+          )}
+          {(showTabsBelowHeader || showTabsWithoutHeader) && tabProps && (
+            <>
+              <EuiTabs>
+                {splitTabs.map((tab) => (
+                  <EuiTab
+                    key={tab.id}
+                    isSelected={tabProps.activeTab === tab.id}
+                    onClick={() => tabProps.onTabChange(tab.id)}
+                    data-test-subj={`querySandboxTab-${tab.id}`}
+                  >
+                    {tab.label}
+                  </EuiTab>
+                ))}
+              </EuiTabs>
+              <EuiSpacer size="s" />
+            </>
+          )}
+        </>
+      )}
+
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
         <CpsPicker />
         <EuiFlexItem grow={false} style={{ width: 200, minWidth: 0 }}>
@@ -280,24 +483,6 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
       </EuiFlexGroup>
       <EuiSpacer size="s" />
 
-      {splitTabs.length > 0 && tabProps && (
-        <>
-          <EuiTabs>
-            {splitTabs.map((tab) => (
-              <EuiTab
-                key={tab.id}
-                isSelected={tabProps.activeTab === tab.id}
-                onClick={() => tabProps.onTabChange(tab.id)}
-                data-test-subj={`querySandboxTab-${tab.id}`}
-              >
-                {tab.label}
-              </EuiTab>
-            ))}
-          </EuiTabs>
-          <EuiSpacer size="s" />
-        </>
-      )}
-
       <EuiPanel hasBorder paddingSize="s" style={{ ...editorPanelStyles }}>
         {tabProps && hasTabs ? (
           <ComposeDiscoverTabs
@@ -321,6 +506,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
             value={query}
             onChange={(v) => onQueryChange?.(v)}
             height="100%"
+            editorDidMount={onEditorMount}
             options={{
               minimap: { enabled: false },
               automaticLayout: true,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox_flyout.tsx
@@ -19,6 +19,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { monaco } from '@kbn/code-editor';
 import type { RuleQuery } from './compose_form_types';
+import { getBreachQuery, getRecoverQuery } from './compose_form_types';
+import { ensureComposedQuery, ruleQueryFromUnifiedEditorChange } from './sandbox_query_utils';
 import type { QueryTab } from './types';
 import { QuerySandbox } from './query_sandbox';
 import type { QuerySandboxProps } from './query_sandbox';
@@ -52,7 +54,7 @@ export interface QuerySandboxFlyoutProps {
   onQueryChange?: (q: RuleQuery) => void;
   /**
    * Which tabs to show. Absent or [] → single editor, no tab bar.
-   * ['base', 'alert'] → base-alert split; ['recovery'] → recovery tab only.
+   * ['base', 'alert'] → base-alert split. Recovery step uses locked base + recovery editor (no tab bar).
    */
   tabs?: QueryTab[];
   /** Active tab — ignored when tabs is absent/[]. */
@@ -68,6 +70,18 @@ export interface QuerySandboxFlyoutProps {
   onDateRangeChange: (r: { dateStart: string; dateEnd: string }) => void;
   /** When provided an Apply button is shown. No-args: caller already holds current state. */
   onApply?: () => void;
+  /** When provided, shows a separate-base-and-alert icon above the preview toolbar (unified mode). */
+  onEditManually?: () => void;
+  /** When provided, shows "Use single editor" on the tab row (split mode). */
+  onUseSingleEditor?: () => void;
+  /** Show ES|QL title and helper text in unified alert mode (before first apply). */
+  showUnifiedQueryHeader?: boolean;
+  /** YAML mode — title, manual-split helper, and tabs (no unified/split toggle icons). */
+  showYamlQueryHeader?: boolean;
+  /** Recovery step — title and helper when editing the recovery tab only. */
+  showRecoveryQueryHeader?: boolean;
+  /** Signal rules — title and helper on the condition step. */
+  showSignalQueryHeader?: boolean;
   onClose: () => void;
   title?: string;
   onAlertEditorMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
@@ -88,6 +102,12 @@ export const QuerySandboxFlyout: React.FC<QuerySandboxFlyoutProps> = ({
   onDateRangeChange,
   onApply,
   onClose,
+  onEditManually,
+  onUseSingleEditor,
+  showUnifiedQueryHeader,
+  showYamlQueryHeader,
+  showRecoveryQueryHeader,
+  showSignalQueryHeader,
   onAlertEditorMount,
   onRecoveryEditorMount,
   title = i18n.translate('xpack.alertingV2.composeDiscover.querySandbox.defaultTitle', {
@@ -96,21 +116,14 @@ export const QuerySandboxFlyout: React.FC<QuerySandboxFlyoutProps> = ({
 }) => {
   const isReadOnly = !onQueryChange;
 
-  const queryFields = useMemo(
-    () =>
-      query.format === 'composed'
-        ? {
-            base: query.base,
-            breach: query.breach.segment,
-            recover: query.recovery?.segment ?? '',
-          }
-        : {
-            base: query.no_data?.query ?? '',
-            breach: query.breach.query,
-            recover: query.recovery?.query ?? '',
-          },
-    [query]
-  );
+  const queryFields = useMemo(() => {
+    const composed = ensureComposedQuery(query);
+    return {
+      base: composed.base,
+      breach: composed.breach.segment,
+      recover: composed.recovery?.segment ?? '',
+    };
+  }, [query]);
 
   const updateQuery = useCallback(
     (patch: { base?: string; breach?: string; recover?: string }) => {
@@ -135,14 +148,39 @@ export const QuerySandboxFlyout: React.FC<QuerySandboxFlyoutProps> = ({
     [query, queryFields, onQueryChange]
   );
 
-  const activeQuery =
-    query.format === 'composed'
-      ? [query.base, query.breach.segment].filter(Boolean).join('\n')
-      : query.breach.query;
+  const handleUnifiedEditorChange = useCallback(
+    (value: string) => {
+      if (!onQueryChange) return;
+      onQueryChange(ruleQueryFromUnifiedEditorChange(query, value));
+    },
+    [onQueryChange, query]
+  );
 
-  const handleQueryChange = useCallback((v: string) => updateQuery({ breach: v }), [updateQuery]);
+  const isRecoveryEditor = Boolean(showRecoveryQueryHeader);
+
+  const previewQuery = isRecoveryEditor ? getRecoverQuery(query) : undefined;
+
+  const editorQuery =
+    previewQuery ??
+    (query.format === 'composed' ? getBreachQuery(query) : query.breach.query);
 
   const tabProps: QuerySandboxProps['tabProps'] = useMemo(() => {
+    if (showRecoveryQueryHeader) {
+      return {
+        tabs: ['recovery'],
+        activeTab: 'recovery',
+        onTabChange: onTabChange ?? (() => {}),
+        baseQuery: queryFields.base,
+        alertBlock: queryFields.breach,
+        recoveryBlock: queryFields.recover,
+        onBaseQueryChange: (v: string) => updateQuery({ base: v }),
+        onAlertBlockChange: (v: string) => updateQuery({ breach: v }),
+        onRecoveryBlockChange: (v: string) => updateQuery({ recover: v }),
+        onAlertEditorMount,
+        onRecoveryEditorMount,
+        readOnly: isReadOnly,
+      };
+    }
     if (!tabs?.length) return undefined;
     return {
       tabs,
@@ -159,6 +197,7 @@ export const QuerySandboxFlyout: React.FC<QuerySandboxFlyoutProps> = ({
       readOnly: isReadOnly,
     };
   }, [
+    showRecoveryQueryHeader,
     tabs,
     activeTab,
     onTabChange,
@@ -185,14 +224,21 @@ export const QuerySandboxFlyout: React.FC<QuerySandboxFlyoutProps> = ({
 
       <EuiFlyoutBody>
         <QuerySandbox
-          query={activeQuery}
-          onQueryChange={isReadOnly ? undefined : handleQueryChange}
+          query={editorQuery}
+          previewQuery={previewQuery}
+          onQueryChange={isReadOnly ? undefined : handleUnifiedEditorChange}
           timeField={timeField}
           onTimeFieldChange={onTimeFieldChange}
           dateRange={dateRange}
           onDateRangeChange={onDateRangeChange}
           autoRun
           tabProps={tabProps}
+          onEditManually={onEditManually}
+          onUseSingleEditor={onUseSingleEditor}
+          showUnifiedQueryHeader={showUnifiedQueryHeader}
+          showYamlQueryHeader={showYamlQueryHeader}
+          showRecoveryQueryHeader={showRecoveryQueryHeader}
+          showSignalQueryHeader={showSignalQueryHeader}
         />
       </EuiFlyoutBody>
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/sandbox_query_utils.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/sandbox_query_utils.test.ts
@@ -1,0 +1,331 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ensureComposedQuery,
+  getYamlSandboxTabs,
+  queryFromYamlToForm,
+  resolveSandboxQueryOnApply,
+  ruleQueryFromUnifiedEditorChange,
+  shouldPreserveYamlSplitOnFormExit,
+  shouldShowManualSplitToggle,
+  shouldShowRecoverySandboxHeader,
+  shouldShowSignalQueryHeader,
+  shouldUseUnifiedSandboxEditor,
+  toManualSplitQuery,
+  toUnifiedSandboxQuery,
+} from './sandbox_query_utils';
+
+describe('toUnifiedSandboxQuery', () => {
+  it('joins composed base and alert segment into a standalone breach query', () => {
+    const result = toUnifiedSandboxQuery({
+      format: 'composed',
+      base: 'FROM logs-* | STATS c = COUNT(*) BY host',
+      breach: { segment: '| WHERE c > 100' },
+    });
+
+    expect(result.format).toBe('standalone');
+    expect(result).toMatchObject({
+      breach: {
+        query: 'FROM logs-* | STATS c = COUNT(*) BY host\n| WHERE c > 100',
+      },
+    });
+  });
+});
+
+describe('toManualSplitQuery', () => {
+  it('splits a threshold query into composed form', () => {
+    const result = toManualSplitQuery(
+      'FROM logs-* | STATS c = COUNT(*) BY host | WHERE c > 100'
+    );
+
+    expect(result.format).toBe('composed');
+    expect(result.base).toContain('STATS');
+    expect(result.breach.segment).toContain('WHERE c > 100');
+  });
+
+  it('allows apply without a WHERE clause (entire query becomes base)', () => {
+    const result = toManualSplitQuery('FROM logs-* | STATS c = COUNT(*) BY host');
+
+    expect(result.base).toContain('STATS');
+    expect(result.breach.segment).toBe('');
+  });
+});
+
+describe('shouldUseUnifiedSandboxEditor', () => {
+  it('returns true on alert condition step for alert kind', () => {
+    expect(shouldUseUnifiedSandboxEditor(true, 0, false, false, false)).toBe(true);
+  });
+
+  it('returns false when manual split is enabled', () => {
+    expect(shouldUseUnifiedSandboxEditor(true, 0, false, false, true)).toBe(false);
+  });
+
+  it('returns false on recovery step', () => {
+    expect(shouldUseUnifiedSandboxEditor(true, 1, false, false, false)).toBe(false);
+  });
+
+  it('returns false in yaml or builder mode', () => {
+    expect(shouldUseUnifiedSandboxEditor(true, 0, true, false, false)).toBe(false);
+    expect(shouldUseUnifiedSandboxEditor(true, 0, false, true, false)).toBe(false);
+  });
+});
+
+describe('shouldShowSignalQueryHeader', () => {
+  it('returns true on alert condition step for signal kind', () => {
+    expect(shouldShowSignalQueryHeader(false, 0, false)).toBe(true);
+  });
+
+  it('returns false for alert kind', () => {
+    expect(shouldShowSignalQueryHeader(true, 0, false)).toBe(false);
+  });
+
+  it('returns false on details step', () => {
+    expect(shouldShowSignalQueryHeader(false, 1, false)).toBe(false);
+  });
+
+  it('returns false in builder mode', () => {
+    expect(shouldShowSignalQueryHeader(false, 0, true)).toBe(false);
+  });
+});
+
+describe('shouldShowManualSplitToggle', () => {
+  it('returns true on alert condition step when query is committed and not in manual split', () => {
+    expect(shouldShowManualSplitToggle(true, 0, false, false, false, true)).toBe(true);
+  });
+
+  it('returns false before the query is committed', () => {
+    expect(shouldShowManualSplitToggle(true, 0, false, false, false, false)).toBe(false);
+  });
+
+  it('returns false when manual split is already enabled', () => {
+    expect(shouldShowManualSplitToggle(true, 0, false, false, true, true)).toBe(false);
+  });
+});
+
+describe('shouldShowRecoverySandboxHeader', () => {
+  it('returns true on recovery step with custom recovery in form view', () => {
+    expect(shouldShowRecoverySandboxHeader(true, 1, false, false, 'custom')).toBe(true);
+  });
+
+  it('returns false on alert condition step', () => {
+    expect(shouldShowRecoverySandboxHeader(true, 0, false, false, 'custom')).toBe(false);
+  });
+
+  it('returns false with default recovery type', () => {
+    expect(shouldShowRecoverySandboxHeader(true, 1, false, false, 'default')).toBe(false);
+  });
+
+  it('returns false in yaml mode', () => {
+    expect(shouldShowRecoverySandboxHeader(true, 1, true, false, 'custom')).toBe(false);
+  });
+});
+
+describe('ensureComposedQuery', () => {
+  it('returns composed queries unchanged', () => {
+    const query = {
+      format: 'composed' as const,
+      base: 'FROM logs-*',
+      breach: { segment: '| WHERE c > 1' },
+    };
+
+    expect(ensureComposedQuery(query)).toBe(query);
+  });
+
+  it('splits standalone breach queries into composed form', () => {
+    const result = ensureComposedQuery({
+      format: 'standalone',
+      breach: { query: 'FROM logs-* | STATS c = COUNT(*) BY host | WHERE c > 1' },
+    });
+
+    expect(result.base).toContain('STATS');
+    expect(result.breach.segment).toContain('WHERE c > 1');
+  });
+
+  it('preserves recovery segment from standalone queries', () => {
+    const result = ensureComposedQuery({
+      format: 'standalone',
+      breach: { query: 'FROM logs-* | STATS c = COUNT(*) BY host | WHERE c > 1' },
+      recovery: { query: '| WHERE c < 50' },
+    });
+
+    expect(result.recovery?.segment).toBe('| WHERE c < 50');
+  });
+});
+
+describe('getYamlSandboxTabs', () => {
+  it('returns base and alert tabs by default', () => {
+    expect(
+      getYamlSandboxTabs({ format: 'standalone', breach: { query: 'FROM logs-*' } }, 'default')
+    ).toEqual(['base', 'alert']);
+  });
+
+  it('includes recovery when recoveryType is custom', () => {
+    expect(
+      getYamlSandboxTabs({ format: 'standalone', breach: { query: 'FROM logs-*' } }, 'custom')
+    ).toEqual(['base', 'alert', 'recovery']);
+  });
+
+  it('includes recovery when the query defines a recovery segment', () => {
+    expect(
+      getYamlSandboxTabs(
+        {
+          format: 'standalone',
+          breach: { query: 'FROM logs-* | WHERE c > 1' },
+          recovery: { query: '| WHERE c < 50' },
+        },
+        'default'
+      )
+    ).toEqual(['base', 'alert', 'recovery']);
+  });
+});
+
+describe('resolveSandboxQueryOnApply', () => {
+  const committedComposed = {
+    format: 'composed' as const,
+    base: 'FROM logs-* | STATS c = COUNT(*) BY host',
+    breach: { segment: '| WHERE c > 100' },
+  };
+
+  it('splits unified standalone sandbox queries on alert apply', () => {
+    const result = resolveSandboxQueryOnApply({
+      sandboxQuery: {
+        format: 'standalone',
+        breach: { query: 'FROM logs-* | STATS c = COUNT(*) BY host | WHERE c > 100' },
+      },
+      committedQuery: { format: 'standalone', breach: { query: '' } },
+      useUnified: true,
+    });
+
+    expect(result).toEqual(committedComposed);
+  });
+
+  it('preserves composed base and breach when recovery apply uses stale standalone sandbox state', () => {
+    const result = resolveSandboxQueryOnApply({
+      sandboxQuery: {
+        format: 'standalone',
+        breach: {
+          query: 'FROM logs-* | STATS c = COUNT(*) BY host | WHERE c > 100',
+        },
+        recovery: { query: '| WHERE c < 50' },
+      },
+      committedQuery: committedComposed,
+      useUnified: false,
+    });
+
+    expect(result).toEqual({
+      ...committedComposed,
+      recovery: { segment: '| WHERE c < 50' },
+    });
+  });
+});
+
+describe('shouldPreserveYamlSplitOnFormExit', () => {
+  const yamlSplit = {
+    format: 'composed' as const,
+    base: 'FROM logs',
+    breach: { segment: '| WHERE c > 1' },
+  };
+
+  it('returns true for alert rules with a composed YAML sandbox query', () => {
+    expect(shouldPreserveYamlSplitOnFormExit(true, false, yamlSplit)).toBe(true);
+  });
+
+  it('returns false for signal rules or builder mode', () => {
+    expect(shouldPreserveYamlSplitOnFormExit(false, false, yamlSplit)).toBe(false);
+    expect(shouldPreserveYamlSplitOnFormExit(true, true, yamlSplit)).toBe(false);
+  });
+
+  it('returns false when the YAML sandbox query is standalone', () => {
+    expect(
+      shouldPreserveYamlSplitOnFormExit(true, false, {
+        format: 'standalone',
+        breach: { query: 'FROM logs' },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('queryFromYamlToForm', () => {
+  const yamlSplit = {
+    format: 'composed' as const,
+    base: 'FROM logs | STATS c = COUNT(*)',
+    breach: { segment: '| WHERE c > 100' },
+  };
+
+  it('keeps the YAML sandbox split instead of the parsed standalone query', () => {
+    const parsedStandalone = {
+      format: 'standalone' as const,
+      breach: {
+        query: 'FROM logs | STATS c = COUNT(*) | WHERE c > 100',
+      },
+    };
+
+    expect(
+      queryFromYamlToForm({
+        parsedQuery: parsedStandalone,
+        yamlSandboxQuery: yamlSplit,
+        isAlertKind: true,
+        isBuilderMode: false,
+      })
+    ).toEqual(yamlSplit);
+  });
+
+  it('returns the parsed query for signal rules', () => {
+    const parsedStandalone = {
+      format: 'standalone' as const,
+      breach: { query: 'FROM logs' },
+    };
+
+    expect(
+      queryFromYamlToForm({
+        parsedQuery: parsedStandalone,
+        yamlSandboxQuery: yamlSplit,
+        isAlertKind: false,
+        isBuilderMode: false,
+      })
+    ).toEqual(parsedStandalone);
+  });
+});
+
+describe('ruleQueryFromUnifiedEditorChange', () => {
+  it('stores the full editor text as standalone breach query', () => {
+    const result = ruleQueryFromUnifiedEditorChange(
+      {
+        format: 'composed',
+        base: 'FROM logs-* | STATS count = COUNT(*) BY host.name',
+        breach: { segment: '| WHERE count > 100' },
+      },
+      'FROM logs-* | STATS count = COUNT(*) BY host.name\n| WHERE count > 200'
+    );
+
+    expect(result).toEqual({
+      format: 'standalone',
+      breach: {
+        query: 'FROM logs-* | STATS count = COUNT(*) BY host.name\n| WHERE count > 200',
+      },
+    });
+  });
+
+  it('preserves recovery when converting composed sandbox state to standalone', () => {
+    const result = ruleQueryFromUnifiedEditorChange(
+      {
+        format: 'composed',
+        base: 'FROM logs-*',
+        breach: { segment: '| WHERE count > 100' },
+        recovery: { segment: '| WHERE count < 50' },
+      },
+      'FROM logs-* | WHERE count > 100'
+    );
+
+    expect(result).toEqual({
+      format: 'standalone',
+      breach: { query: 'FROM logs-* | WHERE count > 100' },
+      recovery: { query: 'FROM logs-*\n| WHERE count < 50' },
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/sandbox_query_utils.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/sandbox_query_utils.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposedQuery, RuleQuery } from './compose_form_types';
+import { getBreachQuery, getRecoverQuery } from './compose_form_types';
+import type { QueryTab, RecoveryType } from './types';
+import { splitQuery } from './use_heuristic_split';
+import { getStepIds } from './use_compose_discover_state';
+
+export interface AlertQuerySnapshot {
+  query: ComposedQuery;
+  manualSplitEnabled: boolean;
+  fullQuery: string;
+}
+
+export function toUnifiedSandboxQuery(query: RuleQuery): RuleQuery {
+  return {
+    format: 'standalone',
+    breach: { query: getBreachQuery(query) },
+  };
+}
+
+export function toManualSplitQuery(fullQuery: string): ComposedQuery {
+  const { base, alertBlock } = splitQuery(fullQuery.trim());
+  return {
+    format: 'composed',
+    base,
+    breach: { segment: alertBlock },
+  };
+}
+
+export function ensureComposedQuery(query: RuleQuery): ComposedQuery {
+  if (query.format === 'composed') {
+    return query;
+  }
+  const composed = toManualSplitQuery(getBreachQuery(query));
+  if (query.recovery?.query?.trim()) {
+    return {
+      ...composed,
+      recovery: { segment: query.recovery.query },
+    };
+  }
+  return composed;
+}
+
+/** YAML mode always edits base/alert in separate tabs; recovery tab appears when present. */
+export function getYamlSandboxTabs(
+  query: RuleQuery,
+  recoveryType: RecoveryType
+): QueryTab[] {
+  const composed = ensureComposedQuery(query);
+  const hasRecovery =
+    recoveryType === 'custom' || Boolean(composed.recovery?.segment?.trim());
+  return hasRecovery ? ['base', 'alert', 'recovery'] : ['base', 'alert'];
+}
+
+export function resolveSandboxQueryOnApply({
+  sandboxQuery,
+  committedQuery,
+  useUnified,
+}: {
+  sandboxQuery: RuleQuery;
+  committedQuery: RuleQuery;
+  useUnified: boolean;
+}): RuleQuery {
+  if (useUnified && sandboxQuery.format === 'standalone') {
+    return toManualSplitQuery(sandboxQuery.breach.query);
+  }
+
+  if (sandboxQuery.format === 'standalone' && committedQuery.format === 'composed') {
+    return {
+      ...committedQuery,
+      ...(sandboxQuery.recovery?.query.trim()
+        ? { recovery: { segment: sandboxQuery.recovery.query } }
+        : {}),
+    };
+  }
+
+  return sandboxQuery;
+}
+
+export function shouldUseUnifiedSandboxEditor(
+  isAlert: boolean,
+  step: number,
+  yamlMode: boolean,
+  isBuilderMode: boolean,
+  manualSplitEnabled: boolean
+): boolean {
+  if (isBuilderMode || !isAlert || yamlMode || manualSplitEnabled) {
+    return false;
+  }
+  return getStepIds(true)[step] === 'alertCondition';
+}
+
+export function shouldShowSignalQueryHeader(
+  isAlert: boolean,
+  step: number,
+  isBuilderMode: boolean
+): boolean {
+  if (isBuilderMode || isAlert) {
+    return false;
+  }
+  return getStepIds(false)[step] === 'alertCondition';
+}
+
+export function shouldShowManualSplitToggle(
+  isAlert: boolean,
+  step: number,
+  yamlMode: boolean,
+  isBuilderMode: boolean,
+  manualSplitEnabled: boolean,
+  queryCommitted: boolean
+): boolean {
+  if (isBuilderMode || !isAlert || yamlMode || !queryCommitted) {
+    return false;
+  }
+  return getStepIds(true)[step] === 'alertCondition' && !manualSplitEnabled;
+}
+
+export function shouldShowRecoverySandboxHeader(
+  isAlert: boolean,
+  step: number,
+  yamlMode: boolean,
+  isBuilderMode: boolean,
+  recoveryType: RecoveryType
+): boolean {
+  if (isBuilderMode || !isAlert || yamlMode) {
+    return false;
+  }
+  return (
+    getStepIds(true)[step] === 'recoveryCondition' && recoveryType === 'custom'
+  );
+}
+
+/** YAML sandbox always edits explicit base/alert/recovery tabs for alert rules. */
+export function shouldPreserveYamlSplitOnFormExit(
+  isAlertKind: boolean,
+  isBuilderMode: boolean,
+  yamlSandboxQuery: RuleQuery
+): boolean {
+  return isAlertKind && !isBuilderMode && yamlSandboxQuery.format === 'composed';
+}
+
+/**
+ * When leaving YAML mode, keep the sandbox's composed split instead of flattening
+ * to standalone via YAML parse (which only stores the joined breach query).
+ */
+export function queryFromYamlToForm({
+  parsedQuery,
+  yamlSandboxQuery,
+  isAlertKind,
+  isBuilderMode,
+}: {
+  parsedQuery: RuleQuery;
+  yamlSandboxQuery: RuleQuery;
+  isAlertKind: boolean;
+  isBuilderMode: boolean;
+}): RuleQuery {
+  if (shouldPreserveYamlSplitOnFormExit(isAlertKind, isBuilderMode, yamlSandboxQuery)) {
+    return yamlSandboxQuery;
+  }
+  return parsedQuery;
+}
+
+/**
+ * The unified (single) editor always edits the full breach pipeline. When the
+ * sandbox still holds a composed query (e.g. after Apply), writing that full
+ * text into `breach.segment` duplicates the base on the next join.
+ */
+export function ruleQueryFromUnifiedEditorChange(
+  currentQuery: RuleQuery,
+  fullQuery: string
+): RuleQuery {
+  const recovery =
+    currentQuery.format === 'composed' && currentQuery.recovery?.segment?.trim()
+      ? { query: getRecoverQuery(currentQuery) }
+      : currentQuery.format === 'standalone' && currentQuery.recovery?.query?.trim()
+        ? currentQuery.recovery
+        : undefined;
+
+  return {
+    format: 'standalone',
+    breach: { query: fullQuery },
+    ...(recovery ? { recovery } : {}),
+  };
+}
+

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
@@ -30,6 +30,8 @@ export interface StepRenderProps {
   services: RuleFormServices;
   onRecoveryTypeChange: (type: RecoveryType) => void;
   onKindChange: (kind: 'signal' | 'alert') => void;
+  /** Opens the sandbox in base/alert split mode. */
+  onSeparateBaseAndAlert?: () => void;
   isEditing: boolean;
   ruleId?: string;
   renderBuilderRecovery?: (props: RuleBuilderRecoveryProps) => React.ReactNode;
@@ -67,11 +69,15 @@ export interface ComposeDiscoverState {
   queryCommitted: boolean;
   /** When true the stepped form is replaced by a full YAML editor. */
   yamlMode: boolean;
+  /** Session flag: user opted into base/alert tab split in the query sandbox. */
+  manualSplitEnabled: boolean;
 }
 
 export type ComposeDiscoverAction =
   | { type: 'SET_RECOVERY_TYPE'; recoveryType: RecoveryType; isBuilderMode?: boolean }
   | { type: 'KIND_CHANGE'; kind: 'signal' | 'alert' }
+  | { type: 'ENABLE_MANUAL_SPLIT' }
+  | { type: 'DISABLE_MANUAL_SPLIT' }
   | { type: 'SET_TAB'; tab: QueryTab }
   | { type: 'SET_STEP'; step: number }
   | { type: 'GO_NEXT'; isAlert: boolean }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
@@ -22,8 +22,8 @@ describe('createInitialState', () => {
     expect(state.mode).toBe('create');
     expect(state.childOpen).toBe(true);
     expect(state.queryCommitted).toBe(false);
-    // Split editor opens on the base query, not the alert query.
-    expect(state.activeTab).toBe('base');
+    // Unified editor — no split tabs on alert condition step.
+    expect(state.activeTab).toBe('alert');
   });
 
   it('starts on the alert tab for signal create (single editor)', () => {
@@ -94,22 +94,42 @@ describe('createInitialState', () => {
 
 describe('reducer', () => {
   describe('KIND_CHANGE', () => {
-    it('kind=alert opens child on the base tab and resets to step 0', () => {
+    it('kind=alert resets to step 0 without opening child', () => {
       const state = createState({ step: 2, childOpen: false, activeTab: 'alert' });
       const next = reducer(state, { type: 'KIND_CHANGE', kind: 'alert' });
 
-      expect(next.childOpen).toBe(true);
+      expect(next.childOpen).toBe(false);
       expect(next.step).toBe(0);
-      expect(next.activeTab).toBe('base');
+      expect(next.activeTab).toBe('alert');
+      expect(next.manualSplitEnabled).toBe(false);
     });
 
-    it('kind=signal keeps child open, resets step and recoveryType', () => {
-      const state = createState({ step: 1, childOpen: true, recoveryType: 'custom' });
+    it('kind=signal resets step and recoveryType without opening child', () => {
+      const state = createState({ step: 1, childOpen: false, recoveryType: 'custom' });
       const next = reducer(state, { type: 'KIND_CHANGE', kind: 'signal' });
 
-      expect(next.childOpen).toBe(true);
+      expect(next.childOpen).toBe(false);
       expect(next.step).toBe(0);
       expect(next.recoveryType).toBe('default');
+      expect(next.manualSplitEnabled).toBe(false);
+    });
+  });
+
+  describe('manual split', () => {
+    it('ENABLE_MANUAL_SPLIT sets manualSplitEnabled and alert tab', () => {
+      const state = createState();
+      const next = reducer(state, { type: 'ENABLE_MANUAL_SPLIT' });
+
+      expect(next.manualSplitEnabled).toBe(true);
+      expect(next.activeTab).toBe('alert');
+    });
+
+    it('DISABLE_MANUAL_SPLIT clears manualSplitEnabled', () => {
+      const state = createState({ manualSplitEnabled: true });
+      const next = reducer(state, { type: 'DISABLE_MANUAL_SPLIT' });
+
+      expect(next.manualSplitEnabled).toBe(false);
+      expect(next.activeTab).toBe('alert');
     });
   });
 
@@ -199,14 +219,19 @@ describe('getSandboxTabs', () => {
     expect(getSandboxTabs(false, state)).toBeUndefined();
   });
 
-  it('returns [base, alert] on alertCondition step with isAlert true', () => {
-    const state = createState({ step: 0 });
+  it('returns [base, alert] on alertCondition step when manual split is enabled', () => {
+    const state = createState({ step: 0, manualSplitEnabled: true });
     expect(getSandboxTabs(true, state)).toEqual(['base', 'alert']);
   });
 
-  it('returns [recovery] on recoveryCondition step with custom recovery', () => {
+  it('returns undefined on alertCondition step with isAlert true (unified editor)', () => {
+    const state = createState({ step: 0 });
+    expect(getSandboxTabs(true, state)).toBeUndefined();
+  });
+
+  it('returns undefined on recoveryCondition step with custom recovery (single editor + header)', () => {
     const state = createState({ step: 1, recoveryType: 'custom' });
-    expect(getSandboxTabs(true, state)).toEqual(['recovery']);
+    expect(getSandboxTabs(true, state)).toBeUndefined();
   });
 
   it('returns undefined on recoveryCondition step with default recovery', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
@@ -53,34 +53,32 @@ export const createInitialState = ({
     childOpen: mode === 'create',
     queryCommitted: mode === 'edit' || isQueryPrePopulated,
     yamlMode: false,
+    manualSplitEnabled: false,
   };
 };
 
 /**
  * Returns the tabs to show in the Sandbox for the current step.
  *
- * isAlert + alertCondition     → ['base', 'alert']
- * isAlert + recoveryCondition  + custom → ['recovery']
+ * isAlert + alertCondition     → undefined (unified single editor; split on Apply)
+ * isAlert + alertCondition     + manualSplit → ['base', 'alert']
+ * isAlert + recoveryCondition  + custom → undefined (single editor + recovery header)
  * everything else              → undefined (single editor)
  */
 export function getSandboxTabs(
   isAlert: boolean,
-  state: Pick<ComposeDiscoverState, 'step' | 'recoveryType'>
+  state: Pick<ComposeDiscoverState, 'step' | 'recoveryType' | 'manualSplitEnabled'>
 ): QueryTab[] | undefined {
   if (!isAlert) return undefined;
 
   const stepId = getStepIds(isAlert)[state.step];
 
-  if (stepId === 'alertCondition') return ['base', 'alert'];
-  if (stepId === 'recoveryCondition' && state.recoveryType === 'custom') return ['recovery'];
+  if (stepId === 'alertCondition' && state.manualSplitEnabled) return ['base', 'alert'];
   return undefined;
 }
 
 function defaultTabForTabs(tabs: QueryTab[] | undefined): QueryTab {
   if (tabs?.includes('recovery')) return 'recovery';
-  // When the split editor is open (base + alert), start on the base query —
-  // users build the base query first, then layer the alert condition on top.
-  if (tabs?.includes('base')) return 'base';
   return 'alert';
 }
 
@@ -99,8 +97,18 @@ export function reducer(
       };
     case 'KIND_CHANGE':
       return action.kind === 'alert'
-        ? { ...state, step: 0, childOpen: true, activeTab: 'base' }
-        : { ...state, recoveryType: 'default', step: 0, activeTab: 'alert' };
+        ? { ...state, step: 0, activeTab: 'alert', manualSplitEnabled: false }
+        : {
+            ...state,
+            recoveryType: 'default',
+            step: 0,
+            activeTab: 'alert',
+            manualSplitEnabled: false,
+          };
+    case 'ENABLE_MANUAL_SPLIT':
+      return { ...state, manualSplitEnabled: true, activeTab: 'alert' };
+    case 'DISABLE_MANUAL_SPLIT':
+      return { ...state, manualSplitEnabled: false, activeTab: 'alert' };
     case 'SET_TAB':
       return { ...state, activeTab: action.tab };
     case 'SET_STEP':

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/related_dashboard_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/related_dashboard_selector.tsx
@@ -29,6 +29,7 @@ import { useDebounceFn } from '@kbn/react-hooks';
 import { useController, useFormContext } from 'react-hook-form';
 import { useRuleFormServices } from '../contexts';
 import type { FormValues } from '../types';
+import { OptionalFieldLabelAppend } from '../optional_field_label_append';
 import {
   resolveDashboardsByIds,
   searchRelatedDashboard,
@@ -153,6 +154,7 @@ const RelatedDashboardsComboBox = ({
   return (
     <EuiComboBox
       async
+      compressed
       fullWidth
       isLoading={isLoading}
       options={dashboardOptions}
@@ -331,14 +333,7 @@ export const RelatedDashboardSelector: React.FC = () => {
           </span>
         }
         fullWidth
-        labelAppend={
-          <EuiText size="xs">
-            <FormattedMessage
-              id="xpack.alertingV2.ruleForm.artifactFieldOptional"
-              defaultMessage="optional"
-            />
-          </EuiText>
-        }
+        labelAppend={<OptionalFieldLabelAppend />}
       >
         <RelatedDashboardsComboBox
           dashboard={dashboard}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.tsx
@@ -10,10 +10,14 @@ import { NameField } from '../fields/name_field';
 import { TagsField } from '../fields/tags_field';
 import { DescriptionField } from '../fields/description_field';
 
-export const RuleDetailsFieldGroup = () => {
+interface RuleDetailsFieldGroupProps {
+  autoFocusName?: boolean;
+}
+
+export const RuleDetailsFieldGroup = ({ autoFocusName = false }: RuleDetailsFieldGroupProps) => {
   return (
     <>
-      <NameField />
+      <NameField autoFocus={autoFocusName} />
       <TagsField />
       <DescriptionField />
     </>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
@@ -33,6 +33,7 @@ describe('DescriptionField', () => {
 
     expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
     expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('optional')).toBeInTheDocument();
   });
 
   it('displays textarea directly when initial description value exists', () => {
@@ -57,9 +58,7 @@ describe('DescriptionField', () => {
 
     await user.click(screen.getByTestId('addDescriptionButton'));
 
-    expect(
-      screen.getByPlaceholderText('Add an optional description for this rule...')
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Add a description for this rule')).toBeInTheDocument();
   });
 
   it('updates value when user types in textarea', async () => {
@@ -73,15 +72,15 @@ describe('DescriptionField', () => {
     expect(textarea).toHaveValue('My new description');
   });
 
-  it('renders correctly in flyout layout', async () => {
-    const user = userEvent.setup();
+  it('renders the description field with optional label in flyout layout', () => {
     render(<DescriptionField />, {
       wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
     });
 
-    await user.click(screen.getByTestId('addDescriptionButton'));
-
     expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
+    expect(screen.getByText('optional')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Add a description for this rule')).toBeInTheDocument();
+    expect(screen.queryByTestId('addDescriptionButton')).not.toBeInTheDocument();
   });
 
   it('keeps textarea visible after clearing the value', async () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -11,6 +11,7 @@ import { EuiFormRow, EuiTextArea, EuiButtonEmpty, EuiSpacer } from '@elastic/eui
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
+import { OptionalFieldLabelAppend } from '../optional_field_label_append';
 
 const DESCRIPTION_ROW_ID = 'ruleV2FormDescriptionField';
 
@@ -18,9 +19,12 @@ export const DescriptionField = () => {
   const { control, watch } = useFormContext<FormValues>();
   const { layout } = useRuleFormMeta();
   const descriptionValue = watch('metadata.description');
+  const isFlyoutLayout = layout === 'flyout';
 
-  // Show the input if there's already a description value
-  const [isInputVisible, setIsInputVisible] = useState(() => Boolean(descriptionValue));
+  // Flyout wizards show the field up front; page layout keeps progressive disclosure.
+  const [isInputVisible, setIsInputVisible] = useState(
+    () => isFlyoutLayout || Boolean(descriptionValue)
+  );
 
   // Update visibility if description value changes externally (e.g., form reset)
   useEffect(() => {
@@ -63,6 +67,7 @@ export const DescriptionField = () => {
           label={i18n.translate('xpack.alertingV2.ruleForm.descriptionLabel', {
             defaultMessage: 'Description',
           })}
+          labelAppend={<OptionalFieldLabelAppend />}
           fullWidth
           isInvalid={!!error}
           error={error?.message}
@@ -75,7 +80,7 @@ export const DescriptionField = () => {
             isInvalid={!!error}
             compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.descriptionPlaceholder', {
-              defaultMessage: 'Add an optional description for this rule...',
+              defaultMessage: 'Add a description for this rule',
             })}
             data-test-subj="ruleDescriptionInput"
           />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.test.tsx
@@ -48,6 +48,12 @@ describe('NameField', () => {
     expect(screen.getByTestId('ruleNameInput')).toHaveValue('My Test Rule');
   });
 
+  it('focuses the name input when autoFocus is enabled', () => {
+    render(<NameField autoFocus />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('ruleNameInput')).toHaveFocus();
+  });
+
   it('shows required error when submitted with empty value', async () => {
     const queryClient = createTestQueryClient();
     const services = createMockServices();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.tsx
@@ -15,7 +15,11 @@ import { useRuleFormMeta } from '../contexts';
 
 const NAME_ROW_ID = 'ruleV2FormNameField';
 
-export const NameField = () => {
+interface NameFieldProps {
+  autoFocus?: boolean;
+}
+
+export const NameField = ({ autoFocus = false }: NameFieldProps) => {
   const { control } = useFormContext<FormValues>();
   const { layout } = useRuleFormMeta();
 
@@ -52,6 +56,7 @@ export const NameField = () => {
             {...field}
             value={field.value ?? ''}
             inputRef={ref}
+            autoFocus={autoFocus}
             fullWidth
             isInvalid={!!error}
             compressed={layout === 'flyout'}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
@@ -12,6 +12,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { MAX_TAG_LENGTH } from '@kbn/alerting-v2-constants';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
+import { OptionalFieldLabelAppend } from '../optional_field_label_append';
 
 export const TagsField = () => {
   const { control } = useFormContext<FormValues>();
@@ -41,9 +42,7 @@ export const TagsField = () => {
             label={i18n.translate('xpack.alertingV2.ruleForm.tagsLabel', {
               defaultMessage: 'Tags',
             })}
-            labelAppend={i18n.translate('xpack.alertingV2.ruleForm.tagsOptional', {
-              defaultMessage: 'optional',
-            })}
+            labelAppend={<OptionalFieldLabelAppend />}
             isInvalid={!!error}
             error={error?.message}
             fullWidth

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/optional_field_label_append.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/optional_field_label_append.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const OptionalFieldLabelAppend = () => (
+  <EuiText size="xs">
+    <FormattedMessage
+      id="xpack.alertingV2.ruleForm.optionalFieldLabel"
+      defaultMessage="optional"
+    />
+  </EuiText>
+);


### PR DESCRIPTION
> **⚠️ UX POC — not production ready**
>
> This pull request is an **exploration / proof of concept** for unified ES|QL query authoring in the Compose Discover flyout. It is **not intended to be merged as-is**. Use it for design review, demos, and scoping discussions only.

## Summary

- Adds a **unified ES|QL query sandbox** (single editor by default) with **Apply** as the commit boundary and heuristic auto-split into base + alert condition
- Form step 1 shows read-only summary with callouts for success, empty query, split failed, and **no alert condition** (`no_where`)
- Escape hatches: **manual base/alert split**, YAML split tabs, recovery editor with locked base
- Wizard polish: gating while sandbox is open, details step UX, optional field labels
- Includes POC spec, design issue template, and dev scope docs under `flyout/compose_discover/`

## Spec & docs

- [POC spec](./x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_POC_SPEC.md)
- [Dev scope proposal](./x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_DEV_SCOPE.md)
- [Design issue template](./x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/UNIFIED_QUERY_SANDBOX_DESIGN_ISSUE.md)

## Known limitations (POC)

- Base-only rules (`no_where`) may fail on save — composed API requires non-empty `breach.segment` (see OQ4 in spec)
- Built on top of merged Compose Discover flow; not a clean-room implementation
- No Scout/FTR coverage in this PR

## Test plan

- [ ] Create alert rule → unified sandbox opens → Search → Apply → form shows base + alert (or callouts for edge cases)
- [ ] `STATS` without trailing `WHERE` → **No alert condition** callout; Next enabled
- [ ] Split failed → **Separate base and alert** → manual split Apply
- [ ] YAML → Form preserves split
- [ ] `node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/`


Made with [Cursor](https://cursor.com)