### PR TITLE
[Flaky] Fix test (fixes #272791)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
@@ -10,6 +10,7 @@ import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { closeFlyout } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
@@ -19,6 +20,7 @@ describe('Expandable flyout state sync', { tags: ['@ess', '@serverless'] }, () =
   const rule = getNewRule();
 
   beforeEach(() => {
+    deleteAlertsAndRules();
     login();
     createRule(rule);
     visit(ALERTS_URL);


### PR DESCRIPTION
Fixes #272791
## Approach and Hypothesis

The test `Expandable flyout state sync "should test flyout url sync"` was failing in its `beforeEach` hook because `waitForAlerts()` timed out at 150 seconds waiting for `cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist')`. The global loading indicator remains visible while any Kibana HTTP requests are pending. Every other test in the same `expandable_flyout/` directory calls `deleteAlertsAndRules()` at the top of `beforeEach` to ensure a clean cluster state, but `alert_details_url_sync.cy.ts` was the only file in that directory that omitted this cleanup. Without it, leftover detection rules from prior CI runs (or test retries) can continue running rule evaluations in the background, keeping Kibana's HTTP loading count above zero and preventing the global loading indicator from disappearing within the allowed window. The fix adds `deleteAlertsAndRules()` as the first call in `beforeEach`, matching the established pattern across all peer tests in the directory, ensuring the cluster starts clean and no background rule-execution requests interfere with the `waitForAlerts` checks.