### PR TITLE
[9.4] [ES|QL] Fixes KQL suggestions in autocomplete (#273931)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.test.ts
@@ -55,7 +55,17 @@ describe('getKqlSuggestionsIfApplicable', () => {
   });
 
   it('should return suggestions if applicable', async () => {
-    const mockSuggestions = [{ text: 'value1', kind: 'Value', detail: 'A value' }];
+    const mockSuggestions = [
+      {
+        text: 'value1',
+        kind: 'Value',
+        detail: 'A value',
+        rangeToReplace: {
+          end: 12,
+          start: 7,
+        },
+      },
+    ];
     const mockGetKqlSuggestions = jest.fn().mockResolvedValue(mockSuggestions);
     const ctx = createContext('KQL("""query', mockGetKqlSuggestions);
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
@@ -208,14 +208,22 @@ export async function getKqlSuggestionsIfApplicable(
   const cursorPositionInKql = kqlQuery.length;
 
   try {
-    // Get KQL suggestions from the autocomplete service
     const suggestions = await getKqlSuggestions(kqlQuery, cursorPositionInKql);
 
     if (!suggestions || suggestions.length === 0) {
       return null;
     }
 
-    return suggestions;
+    const kqlWordBoundary = /[\s:()"'=<>]/;
+    let kqlWordStart = kqlQuery.length;
+    while (kqlWordStart > 0 && !kqlWordBoundary.test(kqlQuery[kqlWordStart - 1])) {
+      kqlWordStart--;
+    }
+    const kqlStartInText = innerText.length - kqlQuery.length;
+    const wordStartInText = kqlStartInText + kqlWordStart;
+    const rangeToReplace = { start: wordStartInText, end: innerText.length };
+
+    return suggestions.map((s) => ({ ...s, rangeToReplace }));
   } catch (error) {
     return null;
   }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/where/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/where/autocomplete.test.ts
@@ -16,6 +16,7 @@ import {
   getFunctionSignaturesByReturnType,
   mockFieldsWithTypes,
   getOperatorSuggestions,
+  suggest,
 } from '../../../__tests__/commands/autocomplete';
 import {
   logicalOperators,
@@ -77,7 +78,7 @@ describe('WHERE Autocomplete', () => {
   });
 
   describe('within the expression', () => {
-    const suggest = async (query: string) => {
+    const whereSuggest = async (query: string) => {
       const correctedQuery = correctQuerySyntax(query);
       const { root } = Parser.parse(correctedQuery, { withFormatting: true });
 
@@ -348,7 +349,7 @@ describe('WHERE Autocomplete', () => {
     });
 
     test('pipe suggestion after complete expression', async () => {
-      expect(await suggest('from index | WHERE doubleField != doubleField ')).toContainEqual(
+      expect(await whereSuggest('from index | WHERE doubleField != doubleField ')).toContainEqual(
         expect.objectContaining({
           label: '|',
         })
@@ -363,6 +364,62 @@ describe('WHERE Autocomplete', () => {
         DATE_DIFF_TIME_UNITS,
         mockCallbacks
       );
+    });
+  });
+
+  describe('KQL function autocomplete', () => {
+    const kqlSuggestions = [
+      { text: 'field_name', label: 'field_name', kind: 'Field' as const },
+      { text: 'other_field', label: 'other_field', kind: 'Field' as const },
+    ];
+
+    beforeEach(() => {
+      mockCallbacks = {
+        ...getMockCallbacks(),
+        getKqlSuggestions: jest.fn().mockResolvedValue(kqlSuggestions),
+      };
+    });
+
+    it('returns KQL suggestions when cursor is inside KQL("""...)', async () => {
+      await whereExpectSuggestions(
+        'from index | WHERE KQL("""field_na',
+        ['field_name', 'other_field'],
+        mockCallbacks
+      );
+    });
+
+    it('returns KQL suggestions for an empty KQL query (cursor right after """)', async () => {
+      await whereExpectSuggestions(
+        'from index | WHERE KQL("""',
+        ['field_name', 'other_field'],
+        mockCallbacks
+      );
+    });
+
+    it('rangeToReplace starts at the typed word, not at the """ delimiter', async () => {
+      const query = 'from index | WHERE KQL("""field_na';
+      const kqlStartOffset = 'from index | WHERE KQL("""'.length;
+      const results = await suggest(query, mockContext, 'where', mockCallbacks, autocomplete);
+
+      const suggestion = results.find((s) => s.text === 'field_name');
+      expect(suggestion).toBeDefined();
+      expect(suggestion!.rangeToReplace).toEqual({
+        start: kqlStartOffset,
+        end: query.length,
+      });
+    });
+
+    it('rangeToReplace covers only the current word in multi-token KQL queries', async () => {
+      const query = 'from index | WHERE KQL("""fieldA AND field_na';
+      const wordStart = query.lastIndexOf('field_na');
+      const results = await suggest(query, mockContext, 'where', mockCallbacks, autocomplete);
+
+      const suggestion = results.find((s) => s.text === 'field_name');
+      expect(suggestion).toBeDefined();
+      expect(suggestion!.rangeToReplace).toEqual({
+        start: wordStart,
+        end: query.length,
+      });
     });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ES|QL] Fixes KQL suggestions in autocomplete (#273931)](https://github.com/elastic/kibana/pull/273931)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratou","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2026-06-18T12:35:13Z","message":"[ES|QL] Fixes KQL suggestions in autocomplete (#273931)\n\n## Summary\n\nImportant regression created by\nhttp://github.com/elastic/kibana/pull/258082\n\nThe KQL autocomplete suggestions have broken. This PR is fixing it\n\n\n<img width=\"1176\" height=\"521\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7a565cdb-4ba5-4b49-a240-7074f9f3a8fe\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"ba4cfb37ac30ce6c7bbb1a3d70aca73a8c864d29","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["regression","release_note:fix","Feature:ES|QL","Team:ESQL","backport:version","v9.5.0","v9.4.3"],"title":"[ES|QL] Fixes KQL suggestions in autocomplete","number":273931,"url":"https://github.com/elastic/kibana/pull/273931","mergeCommit":{"message":"[ES|QL] Fixes KQL suggestions in autocomplete (#273931)\n\n## Summary\n\nImportant regression created by\nhttp://github.com/elastic/kibana/pull/258082\n\nThe KQL autocomplete suggestions have broken. This PR is fixing it\n\n\n<img width=\"1176\" height=\"521\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7a565cdb-4ba5-4b49-a240-7074f9f3a8fe\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"ba4cfb37ac30ce6c7bbb1a3d70aca73a8c864d29"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273931","number":273931,"mergeCommit":{"message":"[ES|QL] Fixes KQL suggestions in autocomplete (#273931)\n\n## Summary\n\nImportant regression created by\nhttp://github.com/elastic/kibana/pull/258082\n\nThe KQL autocomplete suggestions have broken. This PR is fixing it\n\n\n<img width=\"1176\" height=\"521\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7a565cdb-4ba5-4b49-a240-7074f9f3a8fe\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"ba4cfb37ac30ce6c7bbb1a3d70aca73a8c864d29"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->