### PR TITLE
[Fleet] Extract shared toNewAgentlessPolicy() mapper

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -51,7 +51,10 @@ export {
   MINIMUM_PRIVILEGE_LEVEL_CHANGE_AGENT_VERSION,
   isAgentEligibleForPrivilegeLevelChange,
 } from './agent_privilege_level_change_helpers';
-export { syncDataStreamTypeFromVar } from './simplified_package_policy_helper';
+export {
+  syncDataStreamTypeFromVar,
+  toNewAgentlessPolicy,
+} from './simplified_package_policy_helper';
 export {
   addUseAPMVarIfNotPresent,
   DATA_STREAM_USE_APM_VAR,

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -14,7 +14,13 @@ import {
   simplifiedPackagePolicytoNewPackagePolicy,
   packagePolicyToSimplifiedPackagePolicy,
   generateInputId,
+  toNewAgentlessPolicy,
 } from './simplified_package_policy_helper';
+
+jest.mock('./cloud_connectors', () => ({
+  ...jest.requireActual('./cloud_connectors'),
+  detectTargetCsp: jest.fn(() => undefined),
+}));
 
 /**
  * Minimal multi-template package fixture covering both shapes of the
@@ -582,6 +588,168 @@ describe('toPackagePolicy', () => {
         'nginx-logfile': ['nginx.access', 'nginx.error'],
         'nginx-nginx/metrics': ['nginx.stubstatus'],
       });
+    });
+  });
+});
+
+describe('toNewAgentlessPolicy', () => {
+  const { detectTargetCsp } = jest.requireMock('./cloud_connectors');
+
+  type AgentlessPolicyInput = NewPackagePolicy & {
+    force?: boolean;
+    create_dataset_templates?: boolean;
+  };
+
+  const createPackagePolicy = (
+    overrides: Partial<AgentlessPolicyInput> = {}
+  ): AgentlessPolicyInput => ({
+    name: 'my-agentless-policy',
+    namespace: 'default',
+    description: 'a description',
+    enabled: true,
+    policy_ids: ['agent-policy-1'],
+    package: { name: 'cspm', title: 'CSPM', version: '1.0.0' },
+    inputs: [],
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    detectTargetCsp.mockReturnValue(undefined);
+  });
+
+  it('maps the allowlisted fields and strips the disallowed ones', () => {
+    const result = toNewAgentlessPolicy(
+      createPackagePolicy({
+        global_data_tags: [{ name: 'team', value: 'fleet' }],
+        additional_datastreams_permissions: ['logs-*'],
+        force: true,
+        create_dataset_templates: false,
+      })
+    );
+
+    expect(result).toEqual({
+      name: 'my-agentless-policy',
+      namespace: 'default',
+      description: 'a description',
+      global_data_tags: [{ name: 'team', value: 'fleet' }],
+      additional_datastreams_permissions: ['logs-*'],
+      force: true,
+      create_dataset_templates: false,
+      package: { name: 'cspm', version: '1.0.0' },
+      id: undefined,
+      inputs: {},
+      vars: undefined,
+    });
+  });
+
+  it('disables inputs that are blocked in agentless mode', () => {
+    // 'logfile' is in AGENTLESS_DISABLED_INPUTS — should be forced to enabled=false
+    const result = toNewAgentlessPolicy(
+      createPackagePolicy({
+        inputs: [{ type: 'logfile', enabled: true, streams: [], vars: undefined }],
+      })
+    );
+
+    expect(result.inputs).toMatchObject({ logfile: { enabled: false } });
+  });
+
+  it('strips package.title', () => {
+    const result = toNewAgentlessPolicy(createPackagePolicy());
+
+    expect(result.package).toEqual({ name: 'cspm', version: '1.0.0' });
+    expect(result.package).not.toHaveProperty('title');
+  });
+
+  it('stringifies the id when present', () => {
+    const result = toNewAgentlessPolicy(createPackagePolicy({ id: 123 as unknown as string }));
+
+    expect(result.id).toBe('123');
+  });
+
+  it('does not forward fields that are not part of the agentless contract', () => {
+    const result = toNewAgentlessPolicy(
+      createPackagePolicy({
+        policy_id: 'agent-policy-1',
+        policy_ids: ['agent-policy-1'],
+        supports_agentless: true,
+        output_id: 'output-1',
+        condition: 'true',
+        supports_cloud_connector: false,
+        cloud_connector_id: 'cc-1',
+        cloud_connector_name: 'cc-name',
+      })
+    );
+
+    expect(result).not.toHaveProperty('policy_id');
+    expect(result).not.toHaveProperty('policy_ids');
+    expect(result).not.toHaveProperty('supports_agentless');
+    expect(result).not.toHaveProperty('output_id');
+    expect(result).not.toHaveProperty('condition');
+    expect(result).not.toHaveProperty('enabled');
+    expect(result).not.toHaveProperty('supports_cloud_connector');
+    expect(result).not.toHaveProperty('cloud_connector_id');
+    expect(result).not.toHaveProperty('cloud_connector_name');
+    // supports_cloud_connector is false → no nested cloud_connector
+    expect(result).not.toHaveProperty('cloud_connector');
+  });
+
+  describe('cloud_connector', () => {
+    it('reuses an existing connector when cloud_connector_id is set', () => {
+      const result = toNewAgentlessPolicy(
+        createPackagePolicy({
+          supports_cloud_connector: true,
+          cloud_connector_id: 'cc-123',
+          cloud_connector_name: 'ignored-when-id-present',
+        })
+      );
+
+      expect(result.cloud_connector).toEqual({
+        enabled: true,
+        cloud_connector_id: 'cc-123',
+      });
+    });
+
+    it('creates a new connector with name when no cloud_connector_id', () => {
+      const result = toNewAgentlessPolicy(
+        createPackagePolicy({
+          supports_cloud_connector: true,
+          cloud_connector_name: 'new-connector',
+        })
+      );
+
+      expect(result.cloud_connector).toEqual({
+        enabled: true,
+        name: 'new-connector',
+      });
+    });
+
+    it('injects target_csp when detected', () => {
+      detectTargetCsp.mockReturnValue('aws');
+
+      const result = toNewAgentlessPolicy(
+        createPackagePolicy({
+          supports_cloud_connector: true,
+          cloud_connector_id: 'cc-123',
+        })
+      );
+
+      expect(result.cloud_connector).toEqual({
+        enabled: true,
+        target_csp: 'aws',
+        cloud_connector_id: 'cc-123',
+      });
+    });
+
+    it('passes the policy and varGroups to detectTargetCsp', () => {
+      const policy = createPackagePolicy();
+      const varGroups = [
+        { name: 'auth', title: 'Auth', selector_title: 'Select auth', options: [] },
+      ];
+
+      toNewAgentlessPolicy(policy, varGroups);
+
+      expect(detectTargetCsp).toHaveBeenCalledWith(policy, varGroups);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -694,6 +694,25 @@ describe('toNewAgentlessPolicy', () => {
     expect(result).not.toHaveProperty('cloud_connector');
   });
 
+  it('drops unknown/new fields not in the allowlist (leak-proof contract)', () => {
+    // These fields exist on NewPackagePolicy (or could be added in the future) and
+    // are NOT part of the agentless contract. A blocklist would silently forward
+    // them; the pick allowlist must drop them.
+    const result = toNewAgentlessPolicy(
+      createPackagePolicy({
+        is_managed: true,
+        overrides: { inputs: { 'some-input': { enabled: false } } },
+        elasticsearch: { privileges: { cluster: ['monitor'] } },
+        var_group_selections: { group: 'selection' },
+      })
+    );
+
+    expect(result).not.toHaveProperty('is_managed');
+    expect(result).not.toHaveProperty('overrides');
+    expect(result).not.toHaveProperty('elasticsearch');
+    expect(result).not.toHaveProperty('var_group_selections');
+  });
+
   describe('cloud_connector', () => {
     it('reuses an existing connector when cloud_connector_id is set', () => {
       const result = toNewAgentlessPolicy(

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -710,7 +710,6 @@ describe('toNewAgentlessPolicy', () => {
     expect(result).not.toHaveProperty('is_managed');
     expect(result).not.toHaveProperty('overrides');
     expect(result).not.toHaveProperty('elasticsearch');
-    expect(result).not.toHaveProperty('var_group_selections');
   });
 
   describe('cloud_connector', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty, omit } from 'lodash';
 
 import type {
   AgentConditionExpression,
@@ -17,11 +17,14 @@ import type {
   ExperimentalDataStreamFeature,
 } from '../types';
 import { DATASET_VAR_NAME, DATA_STREAM_TYPE_VAR_NAME } from '../constants';
+import type { RegistryVarGroup } from '../types/models/package_spec';
+import type { NewAgentlessPolicy } from '../types/rest_spec/agentless_policy';
 
 import { PackagePolicyValidationError } from '../errors';
 
 import { packageToPackagePolicy, getInputEffectiveName } from '.';
 import { isInputAllowedForDeploymentMode } from './agentless_policy_helper';
+import { detectTargetCsp } from './cloud_connectors';
 
 export type SimplifiedVars = Record<
   string,
@@ -329,3 +332,51 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
 
   return packagePolicy;
 }
+
+type AgentlessPolicyInput = NewPackagePolicy & {
+  force?: boolean;
+  create_dataset_templates?: boolean;
+};
+
+export const toNewAgentlessPolicy = (
+  packagePolicy: AgentlessPolicyInput,
+  varGroups?: RegistryVarGroup[]
+): NewAgentlessPolicy => {
+  const targetCsp = detectTargetCsp(packagePolicy, varGroups);
+
+  return {
+    ...omit(
+      packagePolicy,
+      'policy_ids',
+      'policy_id',
+      'output_id',
+      'package',
+      'enabled',
+      'inputs',
+      'vars',
+      'id',
+      'condition',
+      'supports_agentless',
+      'supports_cloud_connector',
+      'cloud_connector_id',
+      'cloud_connector_name'
+    ),
+    package: omit(packagePolicy.package, 'title'),
+    id: packagePolicy.id ? String(packagePolicy.id) : undefined,
+    inputs: formatInputs(packagePolicy.inputs, true),
+    vars: formatVars(packagePolicy.vars),
+    ...(packagePolicy.supports_cloud_connector && {
+      cloud_connector: {
+        enabled: true,
+        ...(targetCsp && { target_csp: targetCsp }),
+        ...(packagePolicy.cloud_connector_id && {
+          cloud_connector_id: packagePolicy.cloud_connector_id,
+        }),
+        ...(!packagePolicy.cloud_connector_id &&
+          packagePolicy.cloud_connector_name && {
+            name: packagePolicy.cloud_connector_name,
+          }),
+      },
+    }),
+  };
+};

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isEmpty, omit } from 'lodash';
+import { isEmpty, omit, pick } from 'lodash';
 
 import type {
   AgentConditionExpression,
@@ -338,6 +338,18 @@ type AgentlessPolicyInput = NewPackagePolicy & {
   create_dataset_templates?: boolean;
 };
 
+/**
+ * Build the agentless create request body ({@link NewAgentlessPolicy}) from a
+ * package policy. Single source of truth shared by the UI create submit
+ * (`form.tsx`) and the Dev Tools request preview (`devtools_request.tsx`) so the
+ * two can never drift.
+ *
+ * Uses an explicit `pick` allowlist (not an `omit` blocklist): only fields that
+ * are part of the agentless contract are ever forwarded. This keeps the UI→API
+ * payload leak-proof as `NewPackagePolicy` evolves — any new/unknown property
+ * (e.g. `overrides`, `elasticsearch`, `is_managed`) is dropped instead of being
+ * silently sent and potentially rejected by the server.
+ */
 export const toNewAgentlessPolicy = (
   packagePolicy: AgentlessPolicyInput,
   varGroups?: RegistryVarGroup[]
@@ -345,22 +357,15 @@ export const toNewAgentlessPolicy = (
   const targetCsp = detectTargetCsp(packagePolicy, varGroups);
 
   return {
-    ...omit(
-      packagePolicy,
-      'policy_ids',
-      'policy_id',
-      'output_id',
-      'package',
-      'enabled',
-      'inputs',
-      'vars',
-      'id',
-      'condition',
-      'supports_agentless',
-      'supports_cloud_connector',
-      'cloud_connector_id',
-      'cloud_connector_name'
-    ),
+    ...pick(packagePolicy, [
+      'name',
+      'description',
+      'namespace',
+      'additional_datastreams_permissions',
+      'force',
+      'create_dataset_templates',
+      'global_data_tags',
+    ]),
     package: omit(packagePolicy.package, 'title'),
     id: packagePolicy.id ? String(packagePolicy.id) : undefined,
     inputs: formatInputs(packagePolicy.inputs, true),

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -22,7 +22,7 @@ import type { NewAgentlessPolicy } from '../types/rest_spec/agentless_policy';
 
 import { PackagePolicyValidationError } from '../errors';
 
-import { packageToPackagePolicy, getInputEffectiveName } from '.';
+import { packageToPackagePolicy, getInputEffectiveName } from './package_to_package_policy';
 import { isInputAllowedForDeploymentMode } from './agentless_policy_helper';
 import { detectTargetCsp } from './cloud_connectors';
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -365,6 +365,7 @@ export const toNewAgentlessPolicy = (
       'force',
       'create_dataset_templates',
       'global_data_tags',
+      'var_group_selections',
     ]),
     package: omit(packagePolicy.package, 'title'),
     id: packagePolicy.id ? String(packagePolicy.id) : undefined,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -8,17 +8,14 @@
 import React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { isEqual, omit, pick } from 'lodash';
+import { isEqual, pick } from 'lodash';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiLink } from '@elastic/eui';
 
 import { validateAgentConditionExpression } from '@kbn/elastic-agent-condition-language';
 
-import {
-  formatInputs,
-  formatVars,
-} from '../../../../../../../../common/services/simplified_package_policy_helper';
+import { toNewAgentlessPolicy } from '../../../../../../../../common/services';
 
 import { sendCreateAgentlessPolicy } from '../../../../../../../hooks/use_request/agentless_policy';
 
@@ -159,53 +156,7 @@ async function savePackagePolicy(
 
   // If agentless use agentless policies API
   if (policy.supports_agentless) {
-    function formatPackage(pkg: NewPackagePolicy['package']) {
-      return omit(pkg, 'title');
-    }
-
-    // Detect target cloud provider from var_groups or inputs
-    const targetCsp = detectTargetCsp(pkgPolicy as NewPackagePolicy, varGroups);
-
-    // TODO: Replace this omit-based approach with a pick-based toNewAgentlessPolicy()
-    // mapper that produces a NewAgentlessPolicy directly.
-    const agentlessRequestBody = {
-      package: formatPackage(pkgPolicy.package),
-      ...omit(
-        pkgPolicy,
-        'policy_ids',
-        'policy_id',
-        'package',
-        'enabled',
-        'inputs',
-        'vars',
-        'id',
-        'condition',
-        'supports_agentless',
-        'supports_cloud_connector',
-        'cloud_connector_id',
-        'cloud_connector_name'
-      ),
-      id: pkgPolicy.id ? String(pkgPolicy.id) : undefined,
-      inputs: formatInputs(pkgPolicy.inputs),
-      vars: formatVars(pkgPolicy.vars),
-      // Build cloud_connector object if cloud connectors are supported
-      ...(pkgPolicy.supports_cloud_connector && {
-        cloud_connector: {
-          enabled: true,
-          // Include target_csp if detected (required for var_groups packages)
-          ...(targetCsp && { target_csp: targetCsp }),
-          ...(pkgPolicy.cloud_connector_id && {
-            cloud_connector_id: pkgPolicy.cloud_connector_id,
-          }),
-          // Only pass the name if creating a new connector (no cloud_connector_id)
-          ...(!pkgPolicy.cloud_connector_id &&
-            pkgPolicy.cloud_connector_name && {
-              name: pkgPolicy.cloud_connector_name,
-            }),
-        },
-      }),
-    };
-
+    const agentlessRequestBody = toNewAgentlessPolicy(pkgPolicy as NewPackagePolicy, varGroups);
     const { item } = await sendCreateAgentlessPolicy(agentlessRequestBody);
     return { type: 'agentless', policy: item };
   }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
@@ -12,7 +12,6 @@ import {
   formatInputs,
   formatVars,
 } from '../../../../../../common/services/simplified_package_policy_helper';
-import { detectTargetCsp } from '../../../../../../common/services/cloud_connectors';
 import type {
   NewAgentPolicy,
   NewPackagePolicy,
@@ -21,7 +20,10 @@ import type {
   RegistryVarGroup,
 } from '../../../types';
 import { canUseMultipleAgentPolicies } from '../../../hooks';
-import { agentlessPolicyRouteService } from '../../../../../../common/services';
+import {
+  agentlessPolicyRouteService,
+  toNewAgentlessPolicy,
+} from '../../../../../../common/services';
 
 function generateKibanaDevToolsRequest(method: string, path: string, body: any) {
   return `${method} kbn:${path}\n${JSON.stringify(body, null, 2)}\n`;
@@ -67,51 +69,15 @@ export function generateCreatePackagePolicyDevToolsRequest(
   });
 }
 
-// TODO: Replace this omit-based approach with a pick-based toNewAgentlessPolicy()
-// mapper shared with form.tsx.
 export function generateCreateAgentlessPolicyDevToolsRequest(
   packagePolicy: NewPackagePolicy & { force?: boolean; create_dataset_templates?: boolean },
   varGroups?: RegistryVarGroup[]
 ) {
-  // Mirror the form submission path: detect the target cloud provider from
-  // var_groups or inputs so the generated request matches the actual UI request
-  // (target_csp is required for var_groups-based cloud connector creation).
-  const targetCsp = detectTargetCsp(packagePolicy, varGroups);
-
-  return generateKibanaDevToolsRequest('POST', agentlessPolicyRouteService.getCreatePath(), {
-    package: formatPackage(packagePolicy.package),
-    ...omit(
-      packagePolicy,
-      'policy_ids',
-      'policy_id',
-      'package',
-      'enabled',
-      'inputs',
-      'vars',
-      'id',
-      'condition',
-      'supports_agentless',
-      'supports_cloud_connector',
-      'cloud_connector_id',
-      'cloud_connector_name'
-    ),
-    id: packagePolicy.id ? String(packagePolicy.id) : undefined,
-    inputs: formatInputs(packagePolicy.inputs, true),
-    vars: formatVars(packagePolicy.vars),
-    ...(packagePolicy.supports_cloud_connector && {
-      cloud_connector: {
-        enabled: true,
-        ...(targetCsp && { target_csp: targetCsp }),
-        ...(packagePolicy.cloud_connector_id && {
-          cloud_connector_id: packagePolicy.cloud_connector_id,
-        }),
-        ...(!packagePolicy.cloud_connector_id &&
-          packagePolicy.cloud_connector_name && {
-            name: packagePolicy.cloud_connector_name,
-          }),
-      },
-    }),
-  });
+  return generateKibanaDevToolsRequest(
+    'POST',
+    agentlessPolicyRouteService.getCreatePath(),
+    toNewAgentlessPolicy(packagePolicy, varGroups)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR adds a mapper `toNewAgentlessPolicy` that converts a package policy into an AgentlessPolicy. This mapper then is shared between the UI form and the API request preview ensuring they do not drift.

### Behavior change (intentional)
Previously `form.tsx` called `formatInputs(inputs)` without the second parameter (`supportsAgentless`) while in the API request preview it was send as true. This PR unifies them sending alwasy true in the case of agentless

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




