### PR TITLE
[content list][framework] Decouple custom filter registration from toolbar rendering

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
@@ -261,6 +261,8 @@ const TypeFilter = createFilterControl(typeFilter, {
 </ContentListClientProvider>;
 ```
 
+Omit `options` to derive the option list from the values present in the current list (faceted), exactly like the built-in tag and created-by filters — the control then shows only the values that actually occur, each with its live count, instead of a fixed universe with zero-count noise. Provide `options` only when you want a fixed set (including values not currently present).
+
 For full control over the popover, drop `createFilterControl` and use `CustomFilterRenderer` (or `SelectableFilterPopover` from `@kbn/content-list-toolbar`) inside your own `filter.createComponent`.
 
 ### Rendering `<Action.ContentEditor />`

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import { CustomFilterRenderer } from './custom_filter_renderer';
+import { defineContentListFilter } from './filters';
+import { useClientFilterCounts } from './use_client_filter_counts';
+
+jest.mock('./use_client_filter_counts');
+
+const mockUseClientFilterCounts = useClientFilterCounts as jest.Mock;
+
+type TypedItem = UserContentCommonSchema & { typeTitle?: string };
+
+describe('CustomFilterRenderer', () => {
+  const openPopover = () => fireEvent.click(screen.getByTestId('testFilter'));
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('derives options from live facet counts when the dimension has no static options', () => {
+    const dimension = defineContentListFilter<TypedItem>({
+      id: 'visualizationType',
+      queryField: 'typeTitle',
+      title: 'Type',
+      getItemValue: (item) => item.typeTitle,
+    });
+    mockUseClientFilterCounts.mockReturnValue(
+      new Map([
+        ['Pie', 1],
+        ['Area', 3],
+      ])
+    );
+
+    render(<CustomFilterRenderer filterDefinition={dimension} data-test-subj="testFilter" />);
+    openPopover();
+
+    const list = screen.getByTestId('testFilter-list');
+    const labels = Array.from(list.querySelectorAll('li')).map((li) => li.textContent ?? '');
+    // Only the values present in the current list, sorted by label.
+    expect(labels.some((text) => text.includes('Area'))).toBe(true);
+    expect(labels.some((text) => text.includes('Pie'))).toBe(true);
+    expect(labels.findIndex((t) => t.includes('Area'))).toBeLessThan(
+      labels.findIndex((t) => t.includes('Pie'))
+    );
+  });
+
+  it('uses the static option universe when the dimension declares one', () => {
+    const dimension = defineContentListFilter<TypedItem>({
+      id: 'visualizationType',
+      queryField: 'typeTitle',
+      title: 'Type',
+      getItemValue: (item) => item.typeTitle,
+      options: [
+        { value: 'Area', label: 'Area chart' },
+        { value: 'Pie', label: 'Pie chart' },
+      ],
+    });
+    mockUseClientFilterCounts.mockReturnValue(new Map([['Area', 3]]));
+
+    render(<CustomFilterRenderer filterDefinition={dimension} data-test-subj="testFilter" />);
+    openPopover();
+
+    expect(screen.getByText('Area chart')).toBeInTheDocument();
+    // Declared options render even with a zero count.
+    expect(screen.getByText('Pie chart')).toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
@@ -54,16 +54,25 @@ export const CustomFilterRenderer = ({
   const idTail = filterDefinition.id.slice(1);
   const fallbackDataTestSubj = `contentList${idHead}${idTail}Filter`;
 
-  const options = useMemo(
-    (): Array<SelectableFilterOption> =>
-      filterDefinition.getOptions().map((option) => ({
-        key: option.value,
-        label: option.label,
-        value: option.label,
-        count: countByKey.get(option.value) ?? 0,
-      })),
-    [countByKey, filterDefinition]
-  );
+  const options = useMemo((): Array<SelectableFilterOption> => {
+    const toOption = (value: string, label: string): SelectableFilterOption => ({
+      key: value,
+      label,
+      value: label,
+      count: countByKey.get(value) ?? 0,
+    });
+
+    const known = filterDefinition.getOptions();
+    if (known.length > 0) {
+      return known.map((option) => toOption(option.value, option.label));
+    }
+
+    // No static option universe: derive options from the values present in the
+    // current list (faceted), mirroring the built-in tag and created-by facets.
+    return [...countByKey.keys()]
+      .sort((a, b) => a.localeCompare(b))
+      .map((value) => toOption(value, filterDefinition.getLabelForValue(value) ?? value));
+  }, [countByKey, filterDefinition]);
 
   const renderOption = useCallback(
     (option: SelectableFilterOption, state: { isActive: boolean }) => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/filters.ts
@@ -46,7 +46,11 @@ export interface ContentListFilterDefinition<
   queryField?: string;
   /** Extracts the filterable value(s) from a single item. */
   getItemValue: (item: TItem) => MaybeArray<TValue>;
-  /** Static option list or a descriptor for deriving options from a data array. */
+  /**
+   * Static option list or a descriptor for deriving options from a data array.
+   * Omit to let the toolbar control derive options from the values present in
+   * the current list (faceted), like the built-in tag and created-by filters.
+   */
   options?: ContentListFilterOptions<TOption, TValue>;
   /** Shown when the option list is empty. */
   emptyMessage?: string;


### PR DESCRIPTION
## Summary

In the Content List framework, registering a custom filter dimension did two things at once: it wired up KQL search + facet counts (correct), **and** it auto-appended a filter control to the toolbar in a fixed position (a hidden side effect). There was no way to register a dimension without rendering a control, nor to choose where the control goes.

This was inconsistent with every other toolbar affordance. Built-in presets (`<Filters.Tags />`, `<Filters.Sort />`) and the recently-accessed filter (`<recents.RecentsFilter />`) are all placed **explicitly** by the consumer inside `<Filters>`. Custom filters were the lone exception, and the only escape hatches were hacky (register-then-hide, or a throwaway preset).

The deviation surfaced while exploring a proposed consumer-defined "type" filter, but the fix is purely a framework concern.

### Change

Registration and placement are now two separate, composable steps:

- **Register** a dimension via `features.filters` — this is all KQL search and client-side facet counts need. A registered dimension filters correctly through the search bar on its own, with no toolbar control.
- **Place** a control explicitly with the new `createFilterControl(filterDefinition, opts?)` helper, which returns a declarative component for the `<Filters>` slot — exactly mirroring `<recents.RecentsFilter />`.

Details:

- The client provider no longer emits `toolbarFilters`; it only registers the KQL `fields` definitions.
- The toolbar's `useFilters` resolves declarative `<Filters>` children only — no provider-supplied append step.
- `toolbarFilters` is removed from `ContentListFeatures` (it was internal to the content_list packages — no external consumers).
- `CustomFilterRenderer` is now exported and gains an optional `renderOptionContent`, so a control can render icons / avatars / colors instead of plain text (the same extension point the tag and created-by filters already use).
- A registered dimension that declares no static `options` now derives its toolbar options from the values present in the current list (faceted, with live counts), matching the built-in tag/created-by facets instead of a fixed universe with zero-count noise. Declaring `options` keeps the fixed-universe behaviour.

### Demo / docs

The dashboard storybook (`Content List/Dashboard Listing` → `ClientProviderExtensions`) now places its `timeRestore` filter explicitly via `createFilterControl`, and the provider-client README documents the register-vs-place split.

## Test plan

- [ ] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client` (includes `custom_filter_renderer.test.tsx` covering static vs. faceted options)
- [ ] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.test.tsx`
- [ ] Storybook: `Content List/Dashboard Listing` → `ClientProviderExtensions` — the "Time behavior" filter renders in the toolbar and filters the list.

## Stack

Middle of a stack; review bottom-to-top. Based on #273978, so this PR's diff is only the framework changes.

1. #273978 — Migrate the visualize library listing to Content List.
2. #273979 — **Decouple custom filter registration from toolbar rendering** (this PR).
3. #273980 — Add a Type filter to the visualize listing.
