### PR TITLE
[content list][visualizations] Add a Type filter to the visualize listing

### DIFF
--- a/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_content_list.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_content_list.tsx
@@ -19,6 +19,7 @@ import {
 import { useContentListConfig } from '@kbn/content-list-provider';
 import { getNoItemsMessage } from '@kbn/visualization-listing-components';
 import { DashboardFlowCallout } from './dashboard_flow_callout';
+import { VisualizeTypeFilter } from './visualize_type_filter';
 import { VisualizeTypeColumn } from './visualize_type_column';
 
 const { Column, Action } = ContentListTable;
@@ -70,6 +71,7 @@ export const VisualizeContentList = ({
         <ContentListToolbar>
           <Filters>
             <Filters.Tags />
+            <VisualizeTypeFilter />
             <Filters.Sort />
           </Filters>
         </ContentListToolbar>

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_listing_provider.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_listing_provider.tsx
@@ -32,6 +32,7 @@ import { getTypes } from '../../services';
 import type { VisualizeServices } from '../types';
 import { getVisualizeListItemLinkFn } from '../utils/get_visualize_list_item_link';
 import { navigateToVisualizeEditor, type VisualizeEditor } from './navigate_to_visualize_editor';
+import { visualizeTypeFilter } from './visualize_type_filter';
 
 /**
  * Shape returned by {@link ContentListClientProvider}'s strategy after it
@@ -264,6 +265,9 @@ export const VisualizeListingProvider = ({ children }: { children: ReactNode }) 
         initialSort: { field: 'updatedAt', direction: 'desc' as const },
         fields: sortFields,
       },
+      // Registers the `typeTitle` filter dimension (KQL search + facet counts).
+      // The toolbar control is placed explicitly via `<VisualizeTypeFilter />`.
+      filters: { visualizationType: visualizeTypeFilter },
       selection: canSave,
       contentEditor: {
         isReadonly: !canSave,

--- a/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_type_filter.tsx
+++ b/src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_type_filter.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useEffect, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, type IconType } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import { createFilterControl, defineContentListFilter } from '@kbn/content-list-provider-client';
+import { getTypes } from '../../services';
+
+/**
+ * KQL field for the type filter. Matches the `typeTitle` the Type column
+ * renders and the `typeTitle` sort field, so search, sort, and filter all key
+ * off the same value.
+ */
+const TYPE_FIELD = 'typeTitle';
+
+const typeFilterTitle = i18n.translate('visualizations.listing.typeFilter.title', {
+  defaultMessage: 'Type',
+});
+
+/**
+ * The filter dimension registered on the provider via `features.filters`.
+ * No static `options`, so the control lists only the types present in the
+ * current page (faceted) — the toolbar control is placed by
+ * {@link VisualizeTypeFilter}.
+ */
+export const visualizeTypeFilter = defineContentListFilter<
+  UserContentCommonSchema & { typeTitle?: string }
+>({
+  id: 'visualizationType',
+  queryField: TYPE_FIELD,
+  title: typeFilterTitle,
+  getItemValue: (item) => item.typeTitle,
+});
+
+interface TypeIconMeta {
+  icon?: IconType;
+  image?: string;
+}
+
+/**
+ * Lazily builds a `typeTitle -> { icon, image }` map from the visualization
+ * type registry — the same source the Type column icon resolves from. Shared
+ * across option rows via a single in-flight promise.
+ */
+let iconMetaPromise: Promise<Map<string, TypeIconMeta>> | undefined;
+const loadTypeIconMeta = (): Promise<Map<string, TypeIconMeta>> => {
+  if (!iconMetaPromise) {
+    iconMetaPromise = (async () => {
+      const map = new Map<string, TypeIconMeta>();
+      const add = (title?: string, icon?: IconType, image?: string) => {
+        if (title && !map.has(title)) {
+          map.set(title, { icon, image });
+        }
+      };
+      const types = getTypes();
+      for (const visType of await types.all()) {
+        add(visType.title, visType.icon, visType.image);
+      }
+      for (const alias of types.getAliases()) {
+        add(alias.title, alias.icon);
+      }
+      return map;
+    })();
+  }
+  return iconMetaPromise;
+};
+
+/** Type label with its registry icon, mirroring the Type column cell. */
+const VisualizeTypeOption = ({ value, label }: { value: string; label: string }) => {
+  const [meta, setMeta] = useState<TypeIconMeta>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    loadTypeIconMeta().then((map) => {
+      if (!cancelled) {
+        setMeta(map.get(value) ?? {});
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [value]);
+
+  const { icon, image } = meta;
+
+  return (
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        {image ? (
+          <img src={image} alt="" aria-hidden width={16} height={16} />
+        ) : (
+          <EuiIcon type={icon || 'empty'} size="m" aria-hidden />
+        )}
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="s" data-test-subj={`visualizeListingTypeOption-${value}`}>
+          {label}
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+/**
+ * Declarative control for the toolbar's `<Filters>` slot. Pair with
+ * {@link visualizeTypeFilter} registered on the provider.
+ */
+export const VisualizeTypeFilter = createFilterControl(visualizeTypeFilter, {
+  'data-test-subj': 'visualizeListingTypeFilter',
+  renderOptionContent: ({ value, label }) => <VisualizeTypeOption {...{ value, label }} />,
+});


### PR DESCRIPTION
## Summary

Adds a **Type** filter to the Visualize library listing — a control that isn't present today. It's offered as a proposal for Visualize's designers/PMs to weigh, and independently of that it's a tidy demonstration of how a consumer composes a custom, icon-rich filter on top of the Content List framework.

The whole control is:

```tsx
export const visualizeTypeFilter = defineContentListFilter({
  id: 'visualizationType',
  queryField: 'typeTitle',
  title: 'Type',
  getItemValue: (item) => item.typeTitle,
});

export const VisualizeTypeFilter = createFilterControl(visualizeTypeFilter, {
  renderOptionContent: ({ value, label }) => <VisualizeTypeOption {...{ value, label }} />,
});
```

- **Register** the dimension on the provider via `features.filters` (powers KQL search + facet counts).
- **Place** the control explicitly in the toolbar's `<Filters>` slot with `createFilterControl` — between Tags and Sort.
- The dimension declares no static `options`, so the popover lists **only the visualization types present on the current page** (faceted, with live counts), rather than the entire type registry.
- Each option renders its **registry icon** via `renderOptionContent`, resolved from the same `getTypes()` source the Type column uses — `EuiIcon` for icon types, `<img>` for image-based ones.

## Stack

Top of a stack; review bottom-to-top. This PR's diff is only the three files that add the filter.

1. #274674 — Creator for custom columns, bug and test fixes.
2. #275464 — Decouple custom filter registration from toolbar rendering (+ derive custom filter options from facet counts).
3. #273978 — Migrate the visualize library listing to Content List.
4. #273980 — **Add a Type filter to the visualize listing** (this PR).

## Test plan

- [ ] `node scripts/jest src/platform/plugins/shared/visualizations/public/visualize_app/components/visualize_listing.test.tsx`
- [ ] Manual: load Visualize library at `/app/visualize`; open the **Type** filter — confirm it lists only the types present, each with its icon, and that selecting one narrows the list and the KQL bar.

## Screenshots

| Before | After |
| --- | --- |
| _no Type filter in the toolbar_ | _to follow in a comment_ |

