### PR TITLE
[Agent Builder] Add per-connector sub-action restrictions to agent configuration

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/definition.ts
@@ -131,6 +131,18 @@ export interface AgentConfiguration {
   connector_ids?: string[];
 
   /**
+   * Optional per-connector sub-action restrictions for this agent.
+   * When set, the `execute_connector_sub_action` tool enforces these restrictions at call time:
+   * - A connector not listed here cannot be called at all.
+   * - For a listed connector, only the sub-actions in `allowed_sub_actions` may be called.
+   *   If `allowed_sub_actions` is absent for an entry, all sub-actions that are marked
+   *   `isTool: true` in the connector spec remain accessible.
+   * When the field itself is absent, no extra restrictions apply beyond the connector spec's
+   * own `isTool` flag.
+   */
+  connector_restrictions?: ConnectorRestriction[];
+
+  /**
    * Custom configuration for the research step of the agent.
    */
   research?: AgentResearchStepConfiguration;
@@ -139,6 +151,21 @@ export interface AgentConfiguration {
    * Custom configuration for the answer step of the agent.
    */
   answer?: AgentAnswerStepConfiguration;
+}
+
+/**
+ * Per-connector restriction entry used in {@link AgentConfiguration.connector_restrictions}.
+ */
+export interface ConnectorRestriction {
+  /**
+   * The saved connector ID to restrict.
+   */
+  connector_id: string;
+  /**
+   * Subset of sub-actions the agent may call on this connector.
+   * When absent, all sub-actions marked `isTool: true` in the connector spec are allowed.
+   */
+  allowed_sub_actions?: string[];
 }
 
 export interface AgentResearchStepConfiguration {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/index.ts
@@ -14,6 +14,7 @@ export {
   type RuntimeAgentConfigurationOverrides,
   type AgentResearchStepConfiguration,
   type AgentAnswerStepConfiguration,
+  type ConnectorRestriction,
 } from './definition';
 export { VISIBILITY_ICON, VISIBILITY_BADGE_COLOR, AgentVisibility } from './visibility';
 export {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
@@ -138,6 +138,7 @@ export {
   type ResolvedAgentCapabilities,
   type AgentAnswerStepConfiguration,
   type AgentResearchStepConfiguration,
+  type ConnectorRestriction,
   agentIdRegexp,
   AgentExecutionMode,
   SubagentExecutionMode,

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/agents.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/agents.ts
@@ -71,6 +71,42 @@ const CONNECTORS_SCHEMA = schema.arrayOf(
   }
 );
 
+const CONNECTOR_RESTRICTIONS_SCHEMA = schema.arrayOf(
+  schema.object(
+    {
+      connector_id: schema.string({
+        meta: { description: 'The saved connector ID to restrict.' },
+      }),
+      allowed_sub_actions: schema.maybe(
+        schema.arrayOf(
+          schema.string({
+            meta: { description: 'Sub-action name the agent is allowed to call.' },
+          }),
+          {
+            meta: {
+              description:
+                'Subset of sub-actions the agent may call on this connector. When absent, all sub-actions marked as tools in the connector spec are allowed.',
+            },
+          }
+        )
+      ),
+    },
+    {
+      meta: {
+        description:
+          'Per-connector restriction entry. Connectors not listed here cannot be called via execute_connector_sub_action.',
+      },
+    }
+  ),
+  {
+    maxSize: 100,
+    meta: {
+      description:
+        'Optional per-connector sub-action restrictions. When set, the agent may only call connectors listed here, and only the specified sub-actions.',
+    },
+  }
+);
+
 export function registerAgentRoutes({
   router,
   getInternalServices,
@@ -252,6 +288,7 @@ export function registerAgentRoutes({
                   ),
                   plugin_ids: schema.maybe(PLUGINS_SCHEMA),
                   connector_ids: schema.maybe(CONNECTORS_SCHEMA),
+                  connector_restrictions: schema.maybe(CONNECTOR_RESTRICTIONS_SCHEMA),
                 },
                 {
                   meta: { description: 'Configuration settings for the agent.' },
@@ -396,6 +433,7 @@ export function registerAgentRoutes({
                     ),
                     plugin_ids: schema.maybe(PLUGINS_SCHEMA),
                     connector_ids: schema.maybe(CONNECTORS_SCHEMA),
+                    connector_restrictions: schema.maybe(CONNECTOR_RESTRICTIONS_SCHEMA),
                   },
                   {
                     meta: { description: 'Updated configuration settings for the agent.' },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
@@ -59,6 +59,7 @@ export const fromEs = (document: Document): PersistedAgentDefinition => {
       workflow_ids: configuration.workflow_ids,
       plugin_ids: configuration.plugin_ids,
       connector_ids: configuration.connector_ids,
+      connector_restrictions: configuration.connector_restrictions,
     },
   };
 };
@@ -95,6 +96,7 @@ export const createRequestToEs = ({
       workflow_ids: profile.configuration.workflow_ids,
       plugin_ids: profile.configuration.plugin_ids,
       connector_ids: profile.configuration.connector_ids,
+      connector_restrictions: profile.configuration.connector_restrictions,
     },
     created_at: creationDate.toISOString(),
     updated_at: creationDate.toISOString(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/storage.ts
@@ -12,6 +12,7 @@ import type {
   AgentAcl,
   AgentType,
   AgentVisibility,
+  ConnectorRestriction,
   ToolSelection,
 } from '@kbn/agent-builder-common';
 import { chatSystemIndex } from '@kbn/agent-builder-server';
@@ -51,6 +52,12 @@ const storageSettings = {
           plugin_ids: types.keyword({}),
           skill_ids: types.keyword({}),
           connector_ids: types.keyword({}),
+          connector_restrictions: types.nested({
+            properties: {
+              connector_id: types.keyword({}),
+              allowed_sub_actions: types.keyword({}),
+            },
+          }),
         },
         dynamic: false,
       }),
@@ -88,6 +95,7 @@ export interface AgentConfigurationProperties {
   workflow_ids?: string[];
   plugin_ids?: string[];
   connector_ids?: string[];
+  connector_restrictions?: ConnectorRestriction[];
 }
 
 export type AgentProfileStorageSettings = typeof storageSettings;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts
@@ -347,6 +347,87 @@ describe('createExecuteConnectorSubActionTool', () => {
     });
   });
 
+  describe('connector_restrictions enforcement', () => {
+    const buildContext = (restrictions: Array<{ connector_id: string; allowed_sub_actions?: string[] }>) =>
+      ({
+        ...mockContext,
+        agentConfiguration: {
+          tools: [],
+          connector_restrictions: restrictions,
+        },
+      } as unknown as ToolHandlerContext);
+
+    it('blocks a connector not listed in restrictions', async () => {
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        buildContext([{ connector_id: 'other-connector' }])
+      );
+
+      expect((result as ToolHandlerStandardReturn).results).toHaveLength(1);
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
+      expect(
+        ((result as ToolHandlerStandardReturn).results[0] as ErrorResult).data.message
+      ).toContain("'conn-123' is not permitted");
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('blocks a sub-action not in allowed_sub_actions', async () => {
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'sendMessage', params: {} },
+        buildContext([{ connector_id: 'conn-123', allowed_sub_actions: ['searchMessages', 'listChannels'] }])
+      );
+
+      expect((result as ToolHandlerStandardReturn).results).toHaveLength(1);
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.error);
+      const msg = ((result as ToolHandlerStandardReturn).results[0] as ErrorResult).data.message;
+      expect(msg).toContain("'sendMessage' is not permitted");
+      expect(msg).toContain('searchMessages');
+      expect(msg).toContain('listChannels');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('allows a sub-action present in allowed_sub_actions', async () => {
+      mockExecute.mockResolvedValue({ status: 'ok', data: { ok: true } });
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'searchMessages', params: {} },
+        buildContext([{ connector_id: 'conn-123', allowed_sub_actions: ['searchMessages'] }])
+      );
+
+      expect(mockExecute).toHaveBeenCalled();
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.other);
+    });
+
+    it('allows all isTool sub-actions when allowed_sub_actions is absent', async () => {
+      mockExecute.mockResolvedValue({ status: 'ok', data: { ok: true } });
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'sendMessage', params: {} },
+        buildContext([{ connector_id: 'conn-123' }])
+      );
+
+      expect(mockExecute).toHaveBeenCalled();
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.other);
+    });
+
+    it('applies no restrictions when connector_restrictions is absent', async () => {
+      mockExecute.mockResolvedValue({ status: 'ok', data: { ok: true } });
+
+      const tool = createExecuteConnectorSubActionTool({ getActions });
+      const result = await tool.handler(
+        { connectorId: 'conn-123', subAction: 'sendMessage', params: {} },
+        mockContext
+      );
+
+      expect(mockExecute).toHaveBeenCalled();
+      expect((result as ToolHandlerStandardReturn).results[0].type).toBe(ToolResultType.other);
+    });
+  });
+
   describe('connector authorization (HITL prompt)', () => {
     const expectedPromptId = `tools.${platformCoreTools.executeConnectorSubAction}.authorization.conn-123`;
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.ts
@@ -129,6 +129,37 @@ export const createExecuteConnectorSubActionTool = ({
       };
     }
 
+    // Enforce per-connector sub-action restrictions from the agent configuration
+    const restrictions = context.agentConfiguration?.connector_restrictions;
+    if (restrictions !== undefined) {
+      const entry = restrictions.find((r) => r.connector_id === connectorId);
+      if (!entry) {
+        return {
+          results: [
+            createErrorResult({
+              message: `Connector '${connectorId}' is not permitted for this agent.`,
+              metadata: { connectorId, subAction },
+            }),
+          ],
+        };
+      }
+      if (
+        entry.allowed_sub_actions !== undefined &&
+        !entry.allowed_sub_actions.includes(subAction)
+      ) {
+        return {
+          results: [
+            createErrorResult({
+              message:
+                `Sub-action '${subAction}' is not permitted on connector '${connectorId}' for this agent. ` +
+                `Allowed sub-actions: ${entry.allowed_sub_actions.join(', ')}.`,
+              metadata: { connectorId, subAction, allowedSubActions: entry.allowed_sub_actions },
+            }),
+          ],
+        };
+      }
+    }
+
     const resolveAuthorizationResult = ({
       authMethod,
       connectorName,


### PR DESCRIPTION
## Summary

When an agent uses the `execute_connector_sub_action` tool (currently behind the experimental features flag), the only gate on which sub-actions it can call is the `isTool: true` flag hardcoded in each connector's spec. That flag is intentionally coarse-grained — it exposes a sub-action to _all_ agents.

This PR adds a second, agent-level restriction layer: `connector_restrictions` on `AgentConfiguration`. It lets an agent author:

- Restrict which connectors the agent is allowed to call at all (any connector not listed is blocked).
- For each listed connector, optionally restrict it to a subset of its tool-flagged sub-actions (when `allowed_sub_actions` is absent, all `isTool: true` sub-actions remain accessible).

This is intentionally separate from the existing `connector_ids` field, which only scopes SML connector search/discovery and carries different semantics.

### Example agent configuration

```json
{
  "connector_restrictions": [
    {
      "connector_id": "github-prod",
      "allowed_sub_actions": ["searchIssues", "getIssue", "createIssue"]
    },
    {
      "connector_id": "slack-alerts"
    }
  ]
}
```

In this example the agent can call three specific sub-actions on the GitHub connector and any tool-flagged sub-action on the Slack connector, but nothing else — even if other connectors are visible in SML search.

## Changes

| File | Change |
|---|---|
| `agent-builder-common/.../agents/definition.ts` | Add `ConnectorRestriction` interface and `connector_restrictions` field to `AgentConfiguration` |
| `agent-builder-common/.../agents/index.ts` | Re-export `ConnectorRestriction` |
| `agent_builder/.../routes/agents.ts` | Add `CONNECTOR_RESTRICTIONS_SCHEMA` to create and update request body schemas |
| `agent_builder/.../persisted/client/storage.ts` | Add field to `AgentConfigurationProperties` interface and ES index mapping |
| `agent_builder/.../persisted/client/converters.ts` | Pass field through ES ↔ domain converters |
| `agent_builder/.../connectors/execute_connector_sub_action.ts` | Enforce restrictions at call time (after the existing `isToolAction` check) |
| `agent_builder/.../connectors/execute_connector_sub_action.test.ts` | 5 new tests covering block/allow/absent-restrictions scenarios |

## Test plan

- [ ] Run `node scripts/jest x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/connectors/execute_connector_sub_action.test.ts` — 24 tests pass, including 5 new `connector_restrictions enforcement` cases
- [ ] Create an agent via API with `connector_restrictions` and verify the field is stored and returned
- [ ] Verify that calling a blocked connector returns an error result (not a thrown exception)
- [ ] Verify that omitting `connector_restrictions` entirely preserves current behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)