### PR TITLE
[9.4] feat(kibana-presentation): replace title props and wrap EuiButtonIcon with EuiToolTip (#271486)

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_section/grid_section_header.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_section/grid_section_header.tsx
@@ -11,7 +11,7 @@ import { cloneDeep } from 'lodash';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { distinctUntilChanged, filter, map, pairwise } from 'rxjs';
 
-import { type UseEuiTheme, transparentize } from '@elastic/eui';
+import { EuiToolTip, transparentize, type UseEuiTheme } from '@elastic/eui';
 import {
   EuiButtonIcon,
   EuiIcon,
@@ -307,16 +307,23 @@ export const GridSectionHeader = React.memo(({ sectionId }: GridSectionHeaderPro
                 <>
                   {!isActive && (
                     <EuiFlexItem grow={false} css={[styles.floatToRight]}>
-                      <EuiButtonIcon
-                        data-no-drag
-                        iconType="trash"
-                        color="danger"
-                        className="kbnGridLayout--deleteSectionIcon"
-                        onClick={confirmDeleteSection}
-                        aria-label={i18n.translate('kbnGridLayout.section.deleteSection', {
+                      <EuiToolTip
+                        content={i18n.translate('kbnGridLayout.section.deleteSection', {
                           defaultMessage: 'Delete section',
                         })}
-                      />
+                        disableScreenReaderOutput
+                      >
+                        <EuiButtonIcon
+                          data-no-drag
+                          iconType="trash"
+                          color="danger"
+                          className="kbnGridLayout--deleteSectionIcon"
+                          onClick={confirmDeleteSection}
+                          aria-label={i18n.translate('kbnGridLayout.section.deleteSection', {
+                            defaultMessage: 'Delete section',
+                          })}
+                        />
+                      </EuiToolTip>
                     </EuiFlexItem>
                   )}
                   <EuiFlexItem

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_section/grid_section_title.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_section/grid_section_title.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexItem,
   EuiInlineEditTitle,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -160,16 +161,23 @@ export const GridSectionTitle = React.memo(
           <>
             {!readOnly && (
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  data-no-drag
-                  iconType="pencil"
-                  onClick={() => setEditTitleOpen(true)}
-                  color="text"
-                  aria-label={i18n.translate('kbnGridLayout.section.editTitleAriaLabel', {
+                <EuiToolTip
+                  content={i18n.translate('kbnGridLayout.section.editTitleAriaLabel', {
                     defaultMessage: 'Edit section title',
                   })}
-                  data-test-subj={`kbnGridSectionTitle-${sectionId}--edit`}
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    data-no-drag
+                    iconType="pencil"
+                    onClick={() => setEditTitleOpen(true)}
+                    color="text"
+                    aria-label={i18n.translate('kbnGridLayout.section.editTitleAriaLabel', {
+                      defaultMessage: 'Edit section title',
+                    })}
+                    data-test-subj={`kbnGridSectionTitle-${sectionId}--edit`}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             )}
           </>

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_settings.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_settings.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButtonIcon, EuiPopover, EuiContextMenu } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { strings } from './strings';
 
@@ -52,14 +52,16 @@ export const ProjectPickerSettings = ({ onResetToDefaults }: ProjectPickerSettin
   return (
     <EuiPopover
       button={
-        <EuiButtonIcon
-          display="empty"
-          iconType="ellipsis"
-          aria-label={strings.getManageCrossProjectSearchLabel()}
-          onClick={() => setIsOpen(!isOpen)}
-          size="s"
-          color="text"
-        />
+        <EuiToolTip content={strings.getManageCrossProjectSearchLabel()} disableScreenReaderOutput>
+          <EuiButtonIcon
+            display="empty"
+            iconType="ellipsis"
+            aria-label={strings.getManageCrossProjectSearchLabel()}
+            onClick={() => setIsOpen(!isOpen)}
+            size="s"
+            color="text"
+          />
+        </EuiToolTip>
       }
       isOpen={isOpen}
       closePopover={closePopover}

--- a/src/platform/plugins/private/input_control_vis/public/components/editor/control_editor.tsx
+++ b/src/platform/plugins/private/input_control_vis/public/components/editor/control_editor.tsx
@@ -22,6 +22,7 @@ import {
   EuiFormRow,
   EuiPanel,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import type { DataView } from '@kbn/data-views-plugin/public';
@@ -136,36 +137,60 @@ class ControlEditorUi extends PureComponent<ControlEditorUiProps & WrappedCompon
   renderEditorButtons() {
     return (
       <div>
-        <EuiButtonIcon
-          aria-label={this.props.intl.formatMessage({
+        <EuiToolTip
+          content={this.props.intl.formatMessage({
             id: 'inputControl.editor.controlEditor.moveControlUpAriaLabel',
             defaultMessage: 'Move control up',
           })}
-          color="primary"
-          onClick={this.moveUpControl}
-          iconType="sortUp"
-          data-test-subj={`inputControlEditorMoveUpControl${this.props.controlIndex}`}
-        />
-        <EuiButtonIcon
-          aria-label={this.props.intl.formatMessage({
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            aria-label={this.props.intl.formatMessage({
+              id: 'inputControl.editor.controlEditor.moveControlUpAriaLabel',
+              defaultMessage: 'Move control up',
+            })}
+            color="primary"
+            onClick={this.moveUpControl}
+            iconType="sortUp"
+            data-test-subj={`inputControlEditorMoveUpControl${this.props.controlIndex}`}
+          />
+        </EuiToolTip>
+        <EuiToolTip
+          content={this.props.intl.formatMessage({
             id: 'inputControl.editor.controlEditor.moveControlDownAriaLabel',
             defaultMessage: 'Move control down',
           })}
-          color="primary"
-          onClick={this.moveDownControl}
-          iconType="sortDown"
-          data-test-subj={`inputControlEditorMoveDownControl${this.props.controlIndex}`}
-        />
-        <EuiButtonIcon
-          aria-label={this.props.intl.formatMessage({
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            aria-label={this.props.intl.formatMessage({
+              id: 'inputControl.editor.controlEditor.moveControlDownAriaLabel',
+              defaultMessage: 'Move control down',
+            })}
+            color="primary"
+            onClick={this.moveDownControl}
+            iconType="sortDown"
+            data-test-subj={`inputControlEditorMoveDownControl${this.props.controlIndex}`}
+          />
+        </EuiToolTip>
+        <EuiToolTip
+          content={this.props.intl.formatMessage({
             id: 'inputControl.editor.controlEditor.removeControlAriaLabel',
             defaultMessage: 'Remove control',
           })}
-          color="danger"
-          onClick={this.removeControl}
-          iconType="cross"
-          data-test-subj={`inputControlEditorRemoveControl${this.props.controlIndex}`}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            aria-label={this.props.intl.formatMessage({
+              id: 'inputControl.editor.controlEditor.removeControlAriaLabel',
+              defaultMessage: 'Remove control',
+            })}
+            color="danger"
+            onClick={this.removeControl}
+            iconType="cross"
+            data-test-subj={`inputControlEditorRemoveControl${this.props.controlIndex}`}
+          />
+        </EuiToolTip>
       </div>
     );
   }

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_sorting_button.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_sorting_button.tsx
@@ -105,33 +105,31 @@ export const OptionsListPopoverSortingButton = ({
   );
 
   const SortButton = () => (
-    <EuiButtonIcon
-      size="xs"
-      display="empty"
-      color="text"
-      iconType={sort?.direction === 'asc' ? 'sortAscending' : 'sortDescending'}
-      isDisabled={showOnlySelected}
-      className="optionsList__sortButton"
-      data-test-subj="optionsListControl__sortingOptionsButton"
-      onClick={() => setIsSortingPopoverOpen(!isSortingPopoverOpen)}
-      aria-label={OptionsListStrings.popover.getSortPopoverDescription()}
-    />
+    <EuiToolTip
+      position="top"
+      content={
+        showOnlySelected
+          ? OptionsListStrings.popover.getSortDisabledTooltip()
+          : OptionsListStrings.popover.getSortPopoverTitle()
+      }
+    >
+      <EuiButtonIcon
+        size="xs"
+        display="empty"
+        color="text"
+        iconType={sort?.direction === 'asc' ? 'sortAscending' : 'sortDescending'}
+        isDisabled={showOnlySelected}
+        className="optionsList__sortButton"
+        data-test-subj="optionsListControl__sortingOptionsButton"
+        onClick={() => setIsSortingPopoverOpen(!isSortingPopoverOpen)}
+        aria-label={OptionsListStrings.popover.getSortPopoverDescription()}
+      />
+    </EuiToolTip>
   );
 
   return (
     <EuiPopover
-      button={
-        <EuiToolTip
-          position="top"
-          content={
-            showOnlySelected
-              ? OptionsListStrings.popover.getSortDisabledTooltip()
-              : OptionsListStrings.popover.getSortPopoverTitle()
-          }
-        >
-          <SortButton />
-        </EuiToolTip>
-      }
+      button={<SortButton />}
       panelPaddingSize="none"
       isOpen={isSortingPopoverOpen}
       aria-labelledby="optionsList_sortingOptions"

--- a/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/play_button.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/play_button.tsx
@@ -33,15 +33,20 @@ export function PlayButton(props: Props) {
   }
 
   const Button = (
-    <EuiButtonIcon
-      onClick={props.isPaused ? props.onPlay : props.onPause}
-      disabled={props.disablePlayButton}
-      iconType={props.isPaused ? 'play' : 'pause'}
-      size="s"
-      display="fill"
-      aria-label={TimeSliderStrings.control.getPlayButtonAriaLabel(props.isPaused)}
-      css={styles.icon}
-    />
+    <EuiToolTip
+      content={TimeSliderStrings.control.getPlayButtonAriaLabel(props.isPaused)}
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        onClick={props.isPaused ? props.onPlay : props.onPause}
+        disabled={props.disablePlayButton}
+        iconType={props.isPaused ? 'play' : 'pause'}
+        size="s"
+        display="fill"
+        aria-label={TimeSliderStrings.control.getPlayButtonAriaLabel(props.isPaused)}
+        css={styles.icon}
+      />
+    </EuiToolTip>
   );
   return props.disablePlayButton ? (
     <EuiToolTip display="block" content={TimeSliderStrings.control.getPlayButtonDisabledTooltip()}>

--- a/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/time_slider_prepend.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/time_slider_prepend.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiButtonIcon, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import type { ViewMode } from '@kbn/presentation-publishing';
 import type { FC } from 'react';
 import React, { useCallback, useState } from 'react';
@@ -70,16 +70,21 @@ export const TimeSliderPrepend: FC<Props> = (props: Props) => {
   return (
     <>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          onClick={() => {
-            onPause();
-            props.onPrevious();
-          }}
-          iconType="chevronLimitLeft"
-          color="text"
-          aria-label={TimeSliderStrings.control.getPreviousButtonAriaLabel()}
-          data-test-subj="timeSlider-previousTimeWindow"
-        />
+        <EuiToolTip
+          content={TimeSliderStrings.control.getPreviousButtonAriaLabel()}
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            onClick={() => {
+              onPause();
+              props.onPrevious();
+            }}
+            iconType="chevronLimitLeft"
+            color="text"
+            aria-label={TimeSliderStrings.control.getPreviousButtonAriaLabel()}
+            data-test-subj="timeSlider-previousTimeWindow"
+          />
+        </EuiToolTip>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <PlayButton
@@ -92,16 +97,21 @@ export const TimeSliderPrepend: FC<Props> = (props: Props) => {
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          onClick={() => {
-            onPause();
-            props.onNext();
-          }}
-          iconType="chevronLimitRight"
-          color="text"
-          aria-label={TimeSliderStrings.control.getNextButtonAriaLabel()}
-          data-test-subj="timeSlider-nextTimeWindow"
-        />
+        <EuiToolTip
+          content={TimeSliderStrings.control.getNextButtonAriaLabel()}
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            onClick={() => {
+              onPause();
+              props.onNext();
+            }}
+            iconType="chevronLimitRight"
+            color="text"
+            aria-label={TimeSliderStrings.control.getNextButtonAriaLabel()}
+            data-test-subj="timeSlider-nextTimeWindow"
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     </>
   );

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.tsx
@@ -19,6 +19,7 @@ import {
   EuiFormRow,
   EuiPopover,
   EuiPopoverFooter,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { css } from '@emotion/react';
@@ -89,18 +90,20 @@ export function FiltersNotificationPopover({ api }: { api: FiltersNotificationAc
   return (
     <EuiPopover
       button={
-        <EuiButtonIcon
-          color="text"
-          iconType={'filter'}
-          onClick={() => {
-            setIsPopoverOpen(!isPopoverOpen);
-            if (apiCanLockHoverActions(api)) {
-              api?.lockHoverActions(!api.hasLockedHoverActions$.value);
-            }
-          }}
-          data-test-subj={`embeddablePanelNotification-${api.uuid}`}
-          aria-label={displayName}
-        />
+        <EuiToolTip content={displayName} disableScreenReaderOutput>
+          <EuiButtonIcon
+            color="text"
+            iconType={'filter'}
+            onClick={() => {
+              setIsPopoverOpen(!isPopoverOpen);
+              if (apiCanLockHoverActions(api)) {
+                api?.lockHoverActions(!api.hasLockedHoverActions$.value);
+              }
+            }}
+            data-test-subj={`embeddablePanelNotification-${api.uuid}`}
+            aria-label={displayName}
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={() => {

--- a/src/platform/plugins/shared/embeddable/public/drilldowns/drilldown_manager_ui/components/flyout_frame/flyout_frame.tsx
+++ b/src/platform/plugins/shared/embeddable/public/drilldowns/drilldown_manager_ui/components/flyout_frame/flyout_frame.tsx
@@ -10,14 +10,15 @@
 import type { FC, PropsWithChildren } from 'react';
 import React from 'react';
 import {
-  EuiFlyoutHeader,
-  EuiTitle,
-  EuiFlyoutBody,
-  EuiFlyoutFooter,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiButtonEmpty,
   EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { txtClose, txtBack } from './i18n';
 
@@ -47,12 +48,14 @@ export const FlyoutFrame: FC<PropsWithChildren<FlyoutFrameProps>> = ({
           {onBack && (
             <EuiFlexItem grow={false}>
               <div css={{ marginLeft: '-8px', marginTop: '-4px' }}>
-                <EuiButtonIcon
-                  color="text"
-                  onClick={onBack}
-                  iconType="chevronSingleLeft"
-                  aria-label={txtBack}
-                />
+                <EuiToolTip content={txtBack} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    color="text"
+                    onClick={onBack}
+                    iconType="chevronSingleLeft"
+                    aria-label={txtBack}
+                  />
+                </EuiToolTip>
               </div>
             </EuiFlexItem>
           )}

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/clusters_table.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/clusters_table.tsx
@@ -15,9 +15,10 @@ import type { Criteria } from '@elastic/eui';
 import {
   Comparators,
   EuiBasicTable,
-  type EuiBasicTableColumn,
   EuiButtonIcon,
   EuiText,
+  EuiToolTip,
+  type EuiBasicTableColumn,
 } from '@elastic/eui';
 import { ClusterView } from './cluster_view';
 import { ClusterHealth } from '../clusters_health';
@@ -74,22 +75,24 @@ export function ClustersTable({ clusters }: Props) {
         defaultMessage: 'Name',
       }),
       render: (name: string) => {
+        const label =
+          name in expandedRows
+            ? i18n.translate('inspector.requests.clusters.table.collapseRow', {
+                defaultMessage: 'Collapse table row to hide cluster details',
+              })
+            : i18n.translate('inspector.requests.clusters.table.expandRow', {
+                defaultMessage: 'Expand table row to view cluster details',
+              });
         return (
           <>
-            <EuiButtonIcon
-              data-test-subj={`inspectorRequestToggleClusterDetails${name}`}
-              onClick={() => toggleDetails(name)}
-              aria-label={
-                name in expandedRows
-                  ? i18n.translate('inspector.requests.clusters.table.collapseRow', {
-                      defaultMessage: 'Collapse table row to hide cluster details',
-                    })
-                  : i18n.translate('inspector.requests.clusters.table.expandRow', {
-                      defaultMessage: 'Expand table row to view cluster details',
-                    })
-              }
-              iconType={name in expandedRows ? 'chevronSingleDown' : 'chevronSingleRight'}
-            />
+            <EuiToolTip content={label} disableScreenReaderOutput>
+              <EuiButtonIcon
+                data-test-subj={`inspectorRequestToggleClusterDetails${name}`}
+                onClick={() => toggleDetails(name)}
+                aria-label={label}
+                iconType={name in expandedRows ? 'chevronSingleDown' : 'chevronSingleRight'}
+              />
+            </EuiToolTip>
             <EuiText size="xs" color="subdued">
               {name === LOCAL_CLUSTER_KEY
                 ? i18n.translate('inspector.requests.clusters.table.localClusterDisplayName', {

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_flyout.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_flyout.tsx
@@ -11,13 +11,14 @@ import React from 'react';
 import type { estypes } from '@elastic/elasticsearch';
 import { i18n } from '@kbn/i18n';
 import {
-  EuiButtonIcon,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiTitle,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { ShardFailureTable } from './shard_failure_table';
@@ -43,7 +44,9 @@ export function ShardFailureFlyout({ failures, onClose }: Props) {
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="s">
           <h1 id={flyoutTitleId}>
-            <EuiButtonIcon iconType="sortLeft" onClick={onClose} aria-label={backButtonLabel} />
+            <EuiToolTip content={backButtonLabel} disableScreenReaderOutput>
+              <EuiButtonIcon iconType="sortLeft" onClick={onClose} aria-label={backButtonLabel} />
+            </EuiToolTip>
             {i18n.translate('inspector.requests.clusters.shards.flyoutTitle', {
               defaultMessage:
                 '{failedShardCount} failed {failedShardCount, plural, one {shard} other {shards}}',

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_table.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_table.tsx
@@ -11,7 +11,13 @@ import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { estypes } from '@elastic/elasticsearch';
 import { i18n } from '@kbn/i18n';
-import { EuiBasicTable, type EuiBasicTableColumn, EuiButtonIcon, EuiText } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiButtonIcon,
+  EuiText,
+  EuiToolTip,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
 import { ShardFailureDetails } from './shard_failure_details';
 
 function getRowId(failure: estypes.ShardFailure) {
@@ -52,21 +58,23 @@ export function ShardFailureTable({ failures }: Props) {
         defaultMessage: 'Shard',
       }),
       render: (shard: number, item: ShardRow) => {
+        const label =
+          item.rowId in expandedRows
+            ? i18n.translate('inspector.requests.clusters.shards.table.collapseRow', {
+                defaultMessage: 'Collapse table row to hide shard details',
+              })
+            : i18n.translate('inspector.requests.clusters.shards.table.expandRow', {
+                defaultMessage: 'Expand table row to view shard details',
+              });
         return (
           <>
-            <EuiButtonIcon
-              onClick={() => toggleDetails(item.rowId)}
-              aria-label={
-                item.rowId in expandedRows
-                  ? i18n.translate('inspector.requests.clusters.shards.table.collapseRow', {
-                      defaultMessage: 'Collapse table row to hide shard details',
-                    })
-                  : i18n.translate('inspector.requests.clusters.shards.table.expandRow', {
-                      defaultMessage: 'Expand table row to view shard details',
-                    })
-              }
-              iconType={item.rowId in expandedRows ? 'chevronSingleDown' : 'chevronSingleRight'}
-            />
+            <EuiToolTip content={label} disableScreenReaderOutput>
+              <EuiButtonIcon
+                onClick={() => toggleDetails(item.rowId)}
+                aria-label={label}
+                iconType={item.rowId in expandedRows ? 'chevronSingleDown' : 'chevronSingleRight'}
+              />
+            </EuiToolTip>
             <EuiText size="xs" color="subdued">
               {shard}
             </EuiText>

--- a/src/platform/plugins/shared/kql/public/components/query_string_input/language_switcher.tsx
+++ b/src/platform/plugins/shared/kql/public/components/query_string_input/language_switcher.tsx
@@ -9,13 +9,14 @@
 
 import type { PopoverAnchorPosition } from '@elastic/eui';
 import {
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiHorizontalRule,
   EuiPopover,
   EuiPopoverTitle,
-  EuiContextMenuItem,
-  toSentenceCase,
-  EuiHorizontalRule,
-  EuiButtonIcon,
   EuiSelectable,
+  EuiToolTip,
+  toSentenceCase,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState } from 'react';
@@ -62,15 +63,17 @@ export const QueryLanguageSwitcher = React.memo(function QueryLanguageSwitcher({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const button = (
-    <EuiButtonIcon
-      size="s"
-      iconType="filter"
-      onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-      className="kqlQueryBar__languageSwitcherButton"
-      data-test-subj={'switchQueryLanguageButton'}
-      aria-label={strings.getSwitchLanguageButtonText()}
-      disabled={isDisabled}
-    />
+    <EuiToolTip content={strings.getSwitchLanguageButtonText()} disableScreenReaderOutput>
+      <EuiButtonIcon
+        size="s"
+        iconType="filter"
+        onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+        className="kqlQueryBar__languageSwitcherButton"
+        data-test-subj={'switchQueryLanguageButton'}
+        aria-label={strings.getSwitchLanguageButtonText()}
+        disabled={isDisabled}
+      />
+    </EuiToolTip>
   );
 
   const isKqlSelected = language === 'kuery';

--- a/src/platform/plugins/shared/unified_search/public/filters_builder/filter_item/actions/actions.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filters_builder/filter_item/actions/actions.tsx
@@ -14,9 +14,9 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
-import { Tooltip } from '../tooltip';
 import { strings } from './action_strings';
 import type { FilterItemActionsProps } from './types';
 import { actionButtonCss } from '../filter_item.styles';
@@ -39,7 +39,14 @@ export const FilterItemActions: FC<FilterItemActionsProps & { minimizePaddings?:
   return (
     <EuiFlexGroup justifyContent="flexEnd" alignItems="flexEnd" gutterSize="xs" responsive={false}>
       <EuiFlexItem grow={false}>
-        <Tooltip content={strings.getDeleteButtonDisabled()} show={disableRemove || disabled}>
+        <EuiToolTip
+          content={
+            disableRemove || disabled
+              ? strings.getDeleteButtonDisabled()
+              : strings.getDeleteFilterGroupButtonIconLabel()
+          }
+          disableScreenReaderOutput
+        >
           <EuiButtonIcon
             onClick={onRemoveFilter}
             iconType="trash"
@@ -49,7 +56,7 @@ export const FilterItemActions: FC<FilterItemActionsProps & { minimizePaddings?:
             aria-label={strings.getDeleteFilterGroupButtonIconLabel()}
             // EuiButtonIcon has no padding to minimize
           />
-        </Tooltip>
+        </EuiToolTip>
       </EuiFlexItem>
       {!hideOr && (
         <EuiFlexItem grow={false}>

--- a/src/platform/plugins/shared/unified_search/public/filters_builder/filter_item/actions/minimised_actions.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filters_builder/filter_item/actions/minimised_actions.tsx
@@ -9,7 +9,7 @@
 
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import { EuiButtonIcon, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { strings } from './action_strings';
 import type { FilterItemActionsProps } from './types';
 import { FilterItemActions } from './actions';
@@ -24,12 +24,14 @@ export const MinimisedFilterItemActions: FC<FilterItemActionsProps> = (props) =>
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButtonIcon
-      iconType="boxesVertical"
-      color="text"
-      aria-label={strings.getMoreActionsLabel()}
-      onClick={onMoreActionsButtonClick}
-    />
+    <EuiToolTip content={strings.getMoreActionsLabel()} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="boxesVertical"
+        color="text"
+        aria-label={strings.getMoreActionsLabel()}
+        onClick={onMoreActionsButtonClick}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/error/components/error/error.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/error/components/error/error.tsx
@@ -7,7 +7,7 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import { EuiButtonIcon, EuiCallOut } from '@elastic/eui';
+import { EuiButtonIcon, EuiCallOut, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Markdown } from '@kbn/shared-ux-markdown';
 import { ShowDebugging } from './show_debugging';
@@ -34,14 +34,21 @@ export const Error: FC<Props> = ({ payload, onClose }) => {
   const message = payload.error?.message;
 
   const CloseIconButton = () => (
-    <EuiButtonIcon
-      color="danger"
-      iconType="cross"
-      onClick={onClose}
-      aria-label={i18n.translate('xpack.canvas.errorComponent.dismissErrorAriaLabel', {
+    <EuiToolTip
+      content={i18n.translate('xpack.canvas.errorComponent.dismissErrorAriaLabel', {
         defaultMessage: 'Dismiss error',
       })}
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        color="danger"
+        iconType="cross"
+        onClick={onClose}
+        aria-label={i18n.translate('xpack.canvas.errorComponent.dismissErrorAriaLabel', {
+          defaultMessage: 'Dismiss error',
+        })}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.tsx
@@ -7,7 +7,7 @@
 
 import type { MouseEventHandler, FC } from 'react';
 import React from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Popover } from '../popover';
 import { ArgAdd } from '../arg_add';
@@ -32,12 +32,14 @@ interface Props {
 
 export const ArgAddPopover: FC<Props> = ({ options }) => {
   const button = (handleClick: MouseEventHandler<HTMLButtonElement>) => (
-    <EuiButtonIcon
-      iconType="plusCircle"
-      aria-label={strings.getAddAriaLabel()}
-      onClick={handleClick}
-      className="canvasArg__addArg"
-    />
+    <EuiToolTip content={strings.getAddAriaLabel()} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="plusCircle"
+        aria-label={strings.getAddAriaLabel()}
+        onClick={handleClick}
+        className="canvasArg__addArg"
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/platform/plugins/private/canvas/public/components/color_manager/color_manager.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_manager/color_manager.tsx
@@ -7,7 +7,7 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import { EuiButtonIcon, EuiFieldText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import chroma from 'chroma-js';
 import { i18n } from '@kbn/i18n';
 
@@ -61,18 +61,22 @@ export const ColorManager: FC<Props> = ({
   if (hasButtons) {
     buttons = (
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          aria-label={strings.getAddAriaLabel()}
-          iconType="plusCircle"
-          isDisabled={!validColor || !onAddColor}
-          onClick={() => onAddColor && onAddColor(value)}
-        />
-        <EuiButtonIcon
-          aria-label={strings.getRemoveAriaLabel()}
-          iconType="minusCircle"
-          isDisabled={!validColor || !onRemoveColor}
-          onClick={() => onRemoveColor && onRemoveColor(value)}
-        />
+        <EuiToolTip content={strings.getAddAriaLabel()} disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label={strings.getAddAriaLabel()}
+            iconType="plusCircle"
+            isDisabled={!validColor || !onAddColor}
+            onClick={() => onAddColor && onAddColor(value)}
+          />
+        </EuiToolTip>
+        <EuiToolTip content={strings.getRemoveAriaLabel()} disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label={strings.getRemoveAriaLabel()}
+            iconType="minusCircle"
+            isDisabled={!validColor || !onRemoveColor}
+            onClick={() => onRemoveColor && onRemoveColor(value)}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     );
   }

--- a/x-pack/platform/plugins/private/canvas/public/components/palette_picker/stops_palette_picker/stop_color_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/palette_picker/stops_palette_picker/stop_color_picker.tsx
@@ -11,6 +11,7 @@ import {
   EuiFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { FC } from 'react';
@@ -120,14 +121,15 @@ export const StopColorPicker: FC<Props> = (props) => {
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          iconType="trash"
-          color="danger"
-          title={strings.getDeleteStopColorLabel()}
-          onClick={onDelete}
-          isDisabled={!removable}
-          aria-label={strings.getDeleteStopColorLabel()}
-        />
+        <EuiToolTip content={strings.getDeleteStopColorLabel()} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="trash"
+            color="danger"
+            onClick={onDelete}
+            isDisabled={!removable}
+            aria-label={strings.getDeleteStopColorLabel()}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.tsx
@@ -7,7 +7,7 @@
 
 import type { ReactNode, MouseEventHandler } from 'react';
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 const strings = {
@@ -27,12 +27,14 @@ export const Tray = ({ children, done }: Props) => {
     <>
       <EuiFlexGroup className="canvasTray__toggle" justifyContent="spaceAround">
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            size="s"
-            onClick={done}
-            aria-label={strings.getCloseTrayAriaLabel()}
-            iconType="chevronSingleDown"
-          />
+          <EuiToolTip content={strings.getCloseTrayAriaLabel()} disableScreenReaderOutput>
+            <EuiButtonIcon
+              size="s"
+              onClick={done}
+              aria-label={strings.getCloseTrayAriaLabel()}
+              iconType="chevronSingleDown"
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
       <div className="canvasTray">{children}</div>

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/simple_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/simple_template.tsx
@@ -7,7 +7,14 @@
 
 import type { FunctionComponent } from 'react';
 import React, { Fragment } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiButtonIcon, EuiText } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
 import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
 import type { ResolvedArgProps, ResolvedLabels } from '../../arg';
@@ -86,12 +93,14 @@ export const SimpleTemplate: FunctionComponent<Props> = (props) => {
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButtonIcon
-              iconType="cross"
-              color="danger"
-              onClick={() => handleChange('color', '')}
-              aria-label={strings.getRemoveAriaLabel()}
-            />
+            <EuiToolTip content={strings.getRemoveAriaLabel()} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                color="danger"
+                onClick={() => handleChange('color', '')}
+                aria-label={strings.getRemoveAriaLabel()}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </Fragment>
       )}

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/scaling_documenation_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/scaling_documenation_popover.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButtonIcon, EuiLink, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiLink,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getDocLinks } from '../../../../kibana_services';
@@ -26,13 +33,15 @@ export function ScalingDocumenationPopover(props: Props) {
       id="scalingHelpPopover"
       anchorPosition="leftCenter"
       button={
-        <EuiButtonIcon
-          onClick={() => {
-            setIsPopoverOpen(!isPopoverOpen);
-          }}
-          iconType="documentation"
-          aria-label="Scaling documentation"
-        />
+        <EuiToolTip content="Scaling documentation" disableScreenReaderOutput>
+          <EuiButtonIcon
+            onClick={() => {
+              setIsPopoverOpen(!isPopoverOpen);
+            }}
+            iconType="documentation"
+            aria-label="Scaling documentation"
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={() => {

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/mvt_single_layer_vector_source/__snapshots__/mvt_field_config_editor.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/mvt_single_layer_vector_source/__snapshots__/mvt_field_config_editor.test.tsx.snap
@@ -73,13 +73,17 @@ exports[`should render error for dupes 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <EuiButtonIcon
-        aria-label="Remove field"
-        color="danger"
-        iconType="trash"
-        onClick={[Function]}
-        title="Remove field"
-      />
+      <EuiToolTip
+        content="Remove field"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Remove field"
+          color="danger"
+          iconType="trash"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer
@@ -156,13 +160,17 @@ exports[`should render error for dupes 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <EuiButtonIcon
-        aria-label="Remove field"
-        color="danger"
-        iconType="trash"
-        onClick={[Function]}
-        title="Remove field"
-      />
+      <EuiToolTip
+        content="Remove field"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Remove field"
+          color="danger"
+          iconType="trash"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer
@@ -264,13 +272,17 @@ exports[`should render error for empty name 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <EuiButtonIcon
-        aria-label="Remove field"
-        color="danger"
-        iconType="trash"
-        onClick={[Function]}
-        title="Remove field"
-      />
+      <EuiToolTip
+        content="Remove field"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Remove field"
+          color="danger"
+          iconType="trash"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer
@@ -372,13 +384,17 @@ exports[`should render field editor 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <EuiButtonIcon
-        aria-label="Remove field"
-        color="danger"
-        iconType="trash"
-        onClick={[Function]}
-        title="Remove field"
-      />
+      <EuiToolTip
+        content="Remove field"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Remove field"
+          color="danger"
+          iconType="trash"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer
@@ -455,13 +471,17 @@ exports[`should render field editor 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <EuiButtonIcon
-        aria-label="Remove field"
-        color="danger"
-        iconType="trash"
-        onClick={[Function]}
-        title="Remove field"
-      />
+      <EuiToolTip
+        content="Remove field"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Remove field"
+          color="danger"
+          iconType="trash"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/mvt_single_layer_vector_source/mvt_field_config_editor.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/mvt_single_layer_vector_source/mvt_field_config_editor.tsx
@@ -8,13 +8,14 @@
 import type { ChangeEvent } from 'react';
 import React, { Component, Fragment } from 'react';
 import {
+  EuiButtonEmpty,
   EuiButtonIcon,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonEmpty,
-  EuiSuperSelect,
-  EuiFieldText,
   EuiSpacer,
+  EuiSuperSelect,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FieldIcon } from '@kbn/react-field';
@@ -134,19 +135,23 @@ export class MVTFieldConfigEditor extends Component<Props, State> {
 
   _renderFieldButtonDelete(index: number) {
     return (
-      <EuiButtonIcon
-        iconType="trash"
-        color="danger"
-        onClick={() => {
-          this._removeField(index);
-        }}
-        title={i18n.translate('xpack.maps.mvtSource.trashButtonTitle', {
+      <EuiToolTip
+        content={i18n.translate('xpack.maps.mvtSource.trashButtonTitle', {
           defaultMessage: 'Remove field',
         })}
-        aria-label={i18n.translate('xpack.maps.mvtSource.trashButtonAriaLabel', {
-          defaultMessage: 'Remove field',
-        })}
-      />
+        disableScreenReaderOutput
+      >
+        <EuiButtonIcon
+          iconType="trash"
+          color="danger"
+          onClick={() => {
+            this._removeField(index);
+          }}
+          aria-label={i18n.translate('xpack.maps.mvtSource.trashButtonAriaLabel', {
+            defaultMessage: 'Remove field',
+          })}
+        />
+      </EuiToolTip>
     );
   }
 

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/row_action_buttons.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/row_action_buttons.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
 const ADD_BUTTON_TITLE = i18n.translate('xpack.maps.addBtnTitle', {
   defaultMessage: 'Add',
@@ -29,21 +29,23 @@ export const RowActionButtons = ({
   return (
     <div>
       {showDeleteButton ? (
-        <EuiButtonIcon
-          iconType="trash"
-          color="danger"
-          aria-label={DELETE_BUTTON_TITLE}
-          title={DELETE_BUTTON_TITLE}
-          onClick={onRemove}
-        />
+        <EuiToolTip content={DELETE_BUTTON_TITLE} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="trash"
+            color="danger"
+            aria-label={DELETE_BUTTON_TITLE}
+            onClick={onRemove}
+          />
+        </EuiToolTip>
       ) : null}
-      <EuiButtonIcon
-        iconType="plusCircle"
-        color="primary"
-        aria-label={ADD_BUTTON_TITLE}
-        title={ADD_BUTTON_TITLE}
-        onClick={onAdd}
-      />
+      <EuiToolTip content={ADD_BUTTON_TITLE} disableScreenReaderOutput>
+        <EuiButtonIcon
+          iconType="plusCircle"
+          color="primary"
+          aria-label={ADD_BUTTON_TITLE}
+          onClick={onAdd}
+        />
+      </EuiToolTip>
     </div>
   );
 };

--- a/x-pack/platform/plugins/shared/maps/public/components/tooltip_selector/tooltip_selector.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/components/tooltip_selector/tooltip_selector.tsx
@@ -13,10 +13,11 @@ import {
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
+  EuiSpacer,
   EuiText,
   EuiTextAlign,
   EuiTextColor,
-  EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -199,35 +200,43 @@ export class TooltipSelector extends Component<Props, State> {
                         {this._getPropertyLabel(field.name)}
                       </EuiText>
                       <div className="mapTooltipSelector__propertyIcons">
-                        <EuiButtonIcon
-                          iconType="trash"
-                          color="danger"
-                          onClick={this._removeProperty.bind(null, idx)}
-                          title={i18n.translate('xpack.maps.tooltipSelector.trashButtonTitle', {
+                        <EuiToolTip
+                          content={i18n.translate('xpack.maps.tooltipSelector.trashButtonTitle', {
                             defaultMessage: 'Remove property',
                           })}
-                          aria-label={i18n.translate(
-                            'xpack.maps.tooltipSelector.trashButtonAriaLabel',
-                            {
-                              defaultMessage: 'Remove property',
-                            }
-                          )}
-                        />
-                        <EuiButtonIcon
-                          className="mapTooltipSelector__grab"
-                          iconType="dragVertical"
-                          color="text"
-                          title={i18n.translate('xpack.maps.tooltipSelector.grabButtonTitle', {
+                          disableScreenReaderOutput
+                        >
+                          <EuiButtonIcon
+                            iconType="trash"
+                            color="danger"
+                            onClick={this._removeProperty.bind(null, idx)}
+                            aria-label={i18n.translate(
+                              'xpack.maps.tooltipSelector.trashButtonAriaLabel',
+                              {
+                                defaultMessage: 'Remove property',
+                              }
+                            )}
+                          />
+                        </EuiToolTip>
+                        <EuiToolTip
+                          content={i18n.translate('xpack.maps.tooltipSelector.grabButtonTitle', {
                             defaultMessage: 'Reorder property',
                           })}
-                          aria-label={i18n.translate(
-                            'xpack.maps.tooltipSelector.grabButtonAriaLabel',
-                            {
-                              defaultMessage: 'Reorder property',
-                            }
-                          )}
-                          {...provided.dragHandleProps}
-                        />
+                          disableScreenReaderOutput
+                        >
+                          <EuiButtonIcon
+                            className="mapTooltipSelector__grab"
+                            iconType="dragVertical"
+                            color="text"
+                            aria-label={i18n.translate(
+                              'xpack.maps.tooltipSelector.grabButtonAriaLabel',
+                              {
+                                defaultMessage: 'Reorder property',
+                              }
+                            )}
+                            {...provided.dragHandleProps}
+                          />
+                        </EuiToolTip>
                       </div>
                     </div>
                   )}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/join.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/join.tsx
@@ -7,7 +7,14 @@
 
 import _ from 'lodash';
 import React, { Component } from 'react';
-import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon, EuiText, EuiTextColor } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTextColor,
+  EuiToolTip,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DataViewField, DataView, Query } from '@kbn/data-plugin/common';
 import { isNestedField } from '@kbn/data-views-plugin/common';
@@ -279,18 +286,22 @@ export class Join extends Component<Props, State> {
 
         {globalTimeCheckbox}
 
-        <EuiButtonIcon
-          className="mapJoinItem__delete"
-          iconType="trash"
-          color="danger"
-          aria-label={i18n.translate('xpack.maps.layerPanel.join.deleteJoinAriaLabel', {
+        <EuiToolTip
+          content={i18n.translate('xpack.maps.layerPanel.join.deleteJoinTitle', {
             defaultMessage: 'Delete join',
           })}
-          title={i18n.translate('xpack.maps.layerPanel.join.deleteJoinTitle', {
-            defaultMessage: 'Delete join',
-          })}
-          onClick={onRemove}
-        />
+          anchorClassName="mapJoinItem__delete"
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="trash"
+            color="danger"
+            aria-label={i18n.translate('xpack.maps.layerPanel.join.deleteJoinAriaLabel', {
+              defaultMessage: 'Delete join',
+            })}
+            onClick={onRemove}
+          />
+        </EuiToolTip>
       </div>
     );
   }

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_documentation_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_documentation_popover.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButtonIcon, EuiLink, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiLink,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getDocLinks } from '../../../../kibana_services';
@@ -19,13 +26,15 @@ export function JoinDocumentationPopover() {
       id="joinHelpPopover"
       anchorPosition="leftCenter"
       button={
-        <EuiButtonIcon
-          onClick={() => {
-            setIsPopoverOpen(!isPopoverOpen);
-          }}
-          iconType="documentation"
-          aria-label="Join documentation"
-        />
+        <EuiToolTip content="Join documentation" disableScreenReaderOutput>
+          <EuiButtonIcon
+            onClick={() => {
+              setIsPopoverOpen(!isPopoverOpen);
+            }}
+            iconType="documentation"
+            aria-label="Join documentation"
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={() => {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/header.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/header.test.tsx.snap
@@ -24,12 +24,17 @@ exports[`isLocked 1`] = `
       grow={false}
       key="closeButton"
     >
-      <EuiButtonIcon
-        aria-label="Close tooltip"
-        data-test-subj="mapTooltipCloseButton"
-        iconType="cross"
-        onClick={[Function]}
-      />
+      <EuiToolTip
+        content="Close tooltip"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Close tooltip"
+          data-test-subj="mapTooltipCloseButton"
+          iconType="cross"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiHorizontalRule
@@ -78,12 +83,17 @@ exports[`should only show close button when layer name is not yet loaded 1`] = `
       grow={false}
       key="closeButton"
     >
-      <EuiButtonIcon
-        aria-label="Close tooltip"
-        data-test-subj="mapTooltipCloseButton"
-        iconType="cross"
-        onClick={[Function]}
-      />
+      <EuiToolTip
+        content="Close tooltip"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Close tooltip"
+          data-test-subj="mapTooltipCloseButton"
+          iconType="cross"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiHorizontalRule

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/header.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/header.tsx
@@ -10,10 +10,11 @@ import React, { Component, Fragment } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiButtonIcon,
-  EuiHorizontalRule,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
   EuiTextColor,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { IVectorLayer } from '../../../../classes/layers/vector_layer';
 
@@ -77,14 +78,21 @@ export class Header extends Component<Props, State> {
 
       items.push(
         <EuiFlexItem grow={false} key="closeButton">
-          <EuiButtonIcon
-            onClick={this.props.onClose}
-            iconType="cross"
-            aria-label={i18n.translate('xpack.maps.tooltip.closeAriaLabel', {
+          <EuiToolTip
+            content={i18n.translate('xpack.maps.tooltip.closeAriaLabel', {
               defaultMessage: 'Close tooltip',
             })}
-            data-test-subj="mapTooltipCloseButton"
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              onClick={this.props.onClose}
+              iconType="cross"
+              aria-label={i18n.translate('xpack.maps.tooltip.closeAriaLabel', {
+                defaultMessage: 'Close tooltip',
+              })}
+              data-test-subj="mapTooltipCloseButton"
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       );
     }

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/__snapshots__/toc_entry.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/__snapshots__/toc_entry.test.tsx.snap
@@ -33,35 +33,51 @@ exports[`TOCEntry is rendered 1`] = `
     <div
       className="mapTocEntry__layerIcons"
     >
-      <EuiButtonIcon
-        aria-label="Hide layer"
-        iconType="eyeSlash"
-        key="toggleVisiblity"
-        onClick={[Function]}
-        title="Hide layer"
-      />
-      <EuiButtonIcon
-        aria-label="Fit to data"
-        iconType="maximize"
-        key="fitToBounds"
-        onClick={[Function]}
-        title="Fit to data"
-      />
-      <EuiButtonIcon
-        aria-label="Edit layer settings"
-        iconType="pencil"
-        isDisabled={false}
-        key="settings"
-        onClick={[Function]}
-        title="Edit layer settings"
-      />
-      <EuiButtonIcon
-        aria-label="Reorder layer"
-        className="mapTocEntry__grab"
-        iconType="dragVertical"
-        key="reorder"
-        title="Reorder layer"
-      />
+      <EuiToolTip
+        content="Hide layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Hide layer"
+          iconType="eyeSlash"
+          key="toggleVisiblity"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Fit to data"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Fit to data"
+          iconType="maximize"
+          key="fitToBounds"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Edit layer settings"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Edit layer settings"
+          iconType="pencil"
+          isDisabled={false}
+          key="settings"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Reorder layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Reorder layer"
+          className="mapTocEntry__grab"
+          iconType="dragVertical"
+          key="reorder"
+        />
+      </EuiToolTip>
     </div>
   </div>
   <span
@@ -121,35 +137,51 @@ exports[`TOCEntry props Should indent child layer 1`] = `
     <div
       className="mapTocEntry__layerIcons"
     >
-      <EuiButtonIcon
-        aria-label="Hide layer"
-        iconType="eyeSlash"
-        key="toggleVisiblity"
-        onClick={[Function]}
-        title="Hide layer"
-      />
-      <EuiButtonIcon
-        aria-label="Fit to data"
-        iconType="maximize"
-        key="fitToBounds"
-        onClick={[Function]}
-        title="Fit to data"
-      />
-      <EuiButtonIcon
-        aria-label="Edit layer settings"
-        iconType="pencil"
-        isDisabled={false}
-        key="settings"
-        onClick={[Function]}
-        title="Edit layer settings"
-      />
-      <EuiButtonIcon
-        aria-label="Reorder layer"
-        className="mapTocEntry__grab"
-        iconType="dragVertical"
-        key="reorder"
-        title="Reorder layer"
-      />
+      <EuiToolTip
+        content="Hide layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Hide layer"
+          iconType="eyeSlash"
+          key="toggleVisiblity"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Fit to data"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Fit to data"
+          iconType="maximize"
+          key="fitToBounds"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Edit layer settings"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Edit layer settings"
+          iconType="pencil"
+          isDisabled={false}
+          key="settings"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Reorder layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Reorder layer"
+          className="mapTocEntry__grab"
+          iconType="dragVertical"
+          key="reorder"
+        />
+      </EuiToolTip>
     </div>
   </div>
   <span
@@ -205,35 +237,51 @@ exports[`TOCEntry props Should shade background when not selected layer 1`] = `
     <div
       className="mapTocEntry__layerIcons"
     >
-      <EuiButtonIcon
-        aria-label="Hide layer"
-        iconType="eyeSlash"
-        key="toggleVisiblity"
-        onClick={[Function]}
-        title="Hide layer"
-      />
-      <EuiButtonIcon
-        aria-label="Fit to data"
-        iconType="maximize"
-        key="fitToBounds"
-        onClick={[Function]}
-        title="Fit to data"
-      />
-      <EuiButtonIcon
-        aria-label="Edit layer settings"
-        iconType="pencil"
-        isDisabled={false}
-        key="settings"
-        onClick={[Function]}
-        title="Edit layer settings"
-      />
-      <EuiButtonIcon
-        aria-label="Reorder layer"
-        className="mapTocEntry__grab"
-        iconType="dragVertical"
-        key="reorder"
-        title="Reorder layer"
-      />
+      <EuiToolTip
+        content="Hide layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Hide layer"
+          iconType="eyeSlash"
+          key="toggleVisiblity"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Fit to data"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Fit to data"
+          iconType="maximize"
+          key="fitToBounds"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Edit layer settings"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Edit layer settings"
+          iconType="pencil"
+          isDisabled={false}
+          key="settings"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Reorder layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Reorder layer"
+          className="mapTocEntry__grab"
+          iconType="dragVertical"
+          key="reorder"
+        />
+      </EuiToolTip>
     </div>
   </div>
   <span
@@ -289,35 +337,51 @@ exports[`TOCEntry props Should shade background when selected layer 1`] = `
     <div
       className="mapTocEntry__layerIcons"
     >
-      <EuiButtonIcon
-        aria-label="Hide layer"
-        iconType="eyeSlash"
-        key="toggleVisiblity"
-        onClick={[Function]}
-        title="Hide layer"
-      />
-      <EuiButtonIcon
-        aria-label="Fit to data"
-        iconType="maximize"
-        key="fitToBounds"
-        onClick={[Function]}
-        title="Fit to data"
-      />
-      <EuiButtonIcon
-        aria-label="Edit layer settings"
-        iconType="pencil"
-        isDisabled={false}
-        key="settings"
-        onClick={[Function]}
-        title="Edit layer settings"
-      />
-      <EuiButtonIcon
-        aria-label="Reorder layer"
-        className="mapTocEntry__grab"
-        iconType="dragVertical"
-        key="reorder"
-        title="Reorder layer"
-      />
+      <EuiToolTip
+        content="Hide layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Hide layer"
+          iconType="eyeSlash"
+          key="toggleVisiblity"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Fit to data"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Fit to data"
+          iconType="maximize"
+          key="fitToBounds"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Edit layer settings"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Edit layer settings"
+          iconType="pencil"
+          isDisabled={false}
+          key="settings"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Reorder layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Reorder layer"
+          className="mapTocEntry__grab"
+          iconType="dragVertical"
+          key="reorder"
+        />
+      </EuiToolTip>
     </div>
   </div>
   <span
@@ -373,20 +437,28 @@ exports[`TOCEntry props isReadOnly 1`] = `
     <div
       className="mapTocEntry__layerIcons"
     >
-      <EuiButtonIcon
-        aria-label="Hide layer"
-        iconType="eyeSlash"
-        key="toggleVisiblity"
-        onClick={[Function]}
-        title="Hide layer"
-      />
-      <EuiButtonIcon
-        aria-label="Fit to data"
-        iconType="maximize"
-        key="fitToBounds"
-        onClick={[Function]}
-        title="Fit to data"
-      />
+      <EuiToolTip
+        content="Hide layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Hide layer"
+          iconType="eyeSlash"
+          key="toggleVisiblity"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Fit to data"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Fit to data"
+          iconType="maximize"
+          key="fitToBounds"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     </div>
   </div>
   <span
@@ -442,35 +514,51 @@ exports[`TOCEntry props should display layer details when isLegendDetailsOpen is
     <div
       className="mapTocEntry__layerIcons"
     >
-      <EuiButtonIcon
-        aria-label="Hide layer"
-        iconType="eyeSlash"
-        key="toggleVisiblity"
-        onClick={[Function]}
-        title="Hide layer"
-      />
-      <EuiButtonIcon
-        aria-label="Fit to data"
-        iconType="maximize"
-        key="fitToBounds"
-        onClick={[Function]}
-        title="Fit to data"
-      />
-      <EuiButtonIcon
-        aria-label="Edit layer settings"
-        iconType="pencil"
-        isDisabled={false}
-        key="settings"
-        onClick={[Function]}
-        title="Edit layer settings"
-      />
-      <EuiButtonIcon
-        aria-label="Reorder layer"
-        className="mapTocEntry__grab"
-        iconType="dragVertical"
-        key="reorder"
-        title="Reorder layer"
-      />
+      <EuiToolTip
+        content="Hide layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Hide layer"
+          iconType="eyeSlash"
+          key="toggleVisiblity"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Fit to data"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Fit to data"
+          iconType="maximize"
+          key="fitToBounds"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Edit layer settings"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Edit layer settings"
+          iconType="pencil"
+          isDisabled={false}
+          key="settings"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
+      <EuiToolTip
+        content="Reorder layer"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Reorder layer"
+          className="mapTocEntry__grab"
+          iconType="dragVertical"
+          key="reorder"
+        />
+      </EuiToolTip>
     </div>
   </div>
   <div

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.tsx
@@ -11,10 +11,11 @@ import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import type { Adapters } from '@kbn/inspector-plugin/common/adapters';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
-  EuiIcon,
+  EuiButtonEmpty,
   EuiButtonIcon,
   EuiConfirmModal,
-  EuiButtonEmpty,
+  EuiIcon,
+  EuiToolTip,
   htmlIdGenerator,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -192,51 +193,61 @@ export class TOCEntry extends Component<Props, State> {
 
   _renderQuickActions() {
     const quickActions = [
-      <EuiButtonIcon
-        key="toggleVisiblity"
-        iconType={getVisibilityToggleIcon(this.props.layer.isVisible())}
-        title={getVisibilityToggleLabel(this.props.layer.isVisible())}
-        aria-label={getVisibilityToggleLabel(this.props.layer.isVisible())}
-        onClick={this._toggleVisible}
-      />,
+      <EuiToolTip
+        content={getVisibilityToggleLabel(this.props.layer.isVisible())}
+        disableScreenReaderOutput
+      >
+        <EuiButtonIcon
+          key="toggleVisiblity"
+          iconType={getVisibilityToggleIcon(this.props.layer.isVisible())}
+          aria-label={getVisibilityToggleLabel(this.props.layer.isVisible())}
+          onClick={this._toggleVisible}
+        />
+      </EuiToolTip>,
     ];
 
     if (this.state.supportsFitToBounds) {
       quickActions.push(
-        <EuiButtonIcon
-          key="fitToBounds"
-          iconType="maximize"
-          title={FIT_TO_DATA_LABEL}
-          aria-label={FIT_TO_DATA_LABEL}
-          onClick={this._fitToBounds}
-        />
+        <EuiToolTip content={FIT_TO_DATA_LABEL} disableScreenReaderOutput>
+          <EuiButtonIcon
+            key="fitToBounds"
+            iconType="maximize"
+            aria-label={FIT_TO_DATA_LABEL}
+            onClick={this._fitToBounds}
+          />
+        </EuiToolTip>
       );
     }
 
     if (!this.props.isReadOnly) {
       quickActions.push(
-        <EuiButtonIcon
-          key="settings"
-          isDisabled={this.props.isEditButtonDisabled}
-          iconType="pencil"
-          aria-label={EDIT_LAYER_SETTINGS_LABEL}
-          title={EDIT_LAYER_SETTINGS_LABEL}
-          onClick={this._openLayerPanelWithCheck}
-        />
+        <EuiToolTip content={EDIT_LAYER_SETTINGS_LABEL} disableScreenReaderOutput>
+          <EuiButtonIcon
+            key="settings"
+            isDisabled={this.props.isEditButtonDisabled}
+            iconType="pencil"
+            aria-label={EDIT_LAYER_SETTINGS_LABEL}
+            onClick={this._openLayerPanelWithCheck}
+          />
+        </EuiToolTip>
       );
       quickActions.push(
-        <EuiButtonIcon
-          key="reorder"
-          iconType="dragVertical"
-          title={i18n.translate('xpack.maps.layerControl.tocEntry.grabButtonTitle', {
+        <EuiToolTip
+          content={i18n.translate('xpack.maps.layerControl.tocEntry.grabButtonTitle', {
             defaultMessage: 'Reorder layer',
           })}
-          aria-label={i18n.translate('xpack.maps.layerControl.tocEntry.grabButtonAriaLabel', {
-            defaultMessage: 'Reorder layer',
-          })}
-          className="mapTocEntry__grab"
-          {...this.props.dragHandleProps}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            key="reorder"
+            iconType="dragVertical"
+            aria-label={i18n.translate('xpack.maps.layerControl.tocEntry.grabButtonAriaLabel', {
+              defaultMessage: 'Reorder layer',
+            })}
+            className="mapTocEntry__grab"
+            {...this.props.dragHandleProps}
+          />
+        </EuiToolTip>
       );
     }
 

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/_toolbar_overlay.scss
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/_toolbar_overlay.scss
@@ -13,6 +13,7 @@
 
   .mapToolbarOverlay__buttonIcon-empty {
     color: $euiTextColor !important;
+    display: inline;
   }
 
   &:hover {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/feature_draw_controls/feature_edit_tools/feature_edit_tools.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/feature_draw_controls/feature_edit_tools/feature_edit_tools.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { EuiButtonIcon, EuiPanel } from '@elastic/eui';
+import { EuiButtonIcon, EuiPanel, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { DRAW_SHAPE } from '../../../../../common/constants';
@@ -54,126 +54,156 @@ export function FeatureEditTools(props: Props) {
       >
         {props.pointsOnly ? null : (
           <>
-            <EuiButtonIcon
-              className={classNames({
-                'mapToolbarOverlay__buttonIcon-empty': !drawLineSelected,
-              })}
-              key="line"
-              size="s"
-              onClick={() => toggleDrawShape(DRAW_SHAPE.LINE)}
-              iconType={VectorLineIcon}
-              aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawLineLabel', {
+            <EuiToolTip
+              content={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawLineTitle', {
                 defaultMessage: 'Draw line',
               })}
-              title={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawLineTitle', {
-                defaultMessage: 'Draw line',
-              })}
-              aria-pressed={drawLineSelected}
-              isSelected={drawLineSelected}
-              display={drawLineSelected ? 'fill' : 'empty'}
-              isDisabled={isWaiting}
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                className={classNames({
+                  'mapToolbarOverlay__buttonIcon-empty': !drawLineSelected,
+                })}
+                key="line"
+                size="s"
+                onClick={() => toggleDrawShape(DRAW_SHAPE.LINE)}
+                iconType={VectorLineIcon}
+                aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawLineLabel', {
+                  defaultMessage: 'Draw line',
+                })}
+                aria-pressed={drawLineSelected}
+                isSelected={drawLineSelected}
+                display={drawLineSelected ? 'fill' : 'empty'}
+                isDisabled={isWaiting}
+              />
+            </EuiToolTip>
 
-            <EuiButtonIcon
-              className={classNames({
-                'mapToolbarOverlay__buttonIcon-empty': !drawPolygonSelected,
-              })}
-              key="polygon"
-              size="s"
-              onClick={() => toggleDrawShape(DRAW_SHAPE.POLYGON)}
-              iconType="vectorTriangle"
-              aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPolygonLabel', {
+            <EuiToolTip
+              content={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPolygonTitle', {
                 defaultMessage: 'Draw polygon',
               })}
-              title={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPolygonTitle', {
-                defaultMessage: 'Draw polygon',
-              })}
-              aria-pressed={drawPolygonSelected}
-              isSelected={drawPolygonSelected}
-              display={drawPolygonSelected ? 'fill' : 'empty'}
-              isDisabled={isWaiting}
-            />
-            <EuiButtonIcon
-              className={classNames({
-                'mapToolbarOverlay__buttonIcon-empty': !drawCircleSelected,
-              })}
-              key="circle"
-              size="s"
-              onClick={() => toggleDrawShape(DRAW_SHAPE.DISTANCE)}
-              iconType={VectorCircleIcon}
-              aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawCircleLabel', {
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                className={classNames({
+                  'mapToolbarOverlay__buttonIcon-empty': !drawPolygonSelected,
+                })}
+                key="polygon"
+                size="s"
+                onClick={() => toggleDrawShape(DRAW_SHAPE.POLYGON)}
+                iconType="vectorTriangle"
+                aria-label={i18n.translate(
+                  'xpack.maps.toolbarOverlay.featureDraw.drawPolygonLabel',
+                  {
+                    defaultMessage: 'Draw polygon',
+                  }
+                )}
+                aria-pressed={drawPolygonSelected}
+                isSelected={drawPolygonSelected}
+                display={drawPolygonSelected ? 'fill' : 'empty'}
+                isDisabled={isWaiting}
+              />
+            </EuiToolTip>
+            <EuiToolTip
+              content={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawCircleTitle', {
                 defaultMessage: 'Draw circle',
               })}
-              title={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawCircleTitle', {
-                defaultMessage: 'Draw circle',
-              })}
-              aria-pressed={drawCircleSelected}
-              isSelected={drawCircleSelected}
-              display={drawCircleSelected ? 'fill' : 'empty'}
-              isDisabled={isWaiting}
-            />
-            <EuiButtonIcon
-              className={classNames({
-                'mapToolbarOverlay__buttonIcon-empty': !drawBBoxSelected,
-              })}
-              key="boundingBox"
-              size="s"
-              onClick={() => toggleDrawShape(DRAW_SHAPE.BOUNDS)}
-              iconType={VectorSquareIcon}
-              aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawBBoxLabel', {
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                className={classNames({
+                  'mapToolbarOverlay__buttonIcon-empty': !drawCircleSelected,
+                })}
+                key="circle"
+                size="s"
+                onClick={() => toggleDrawShape(DRAW_SHAPE.DISTANCE)}
+                iconType={VectorCircleIcon}
+                aria-label={i18n.translate(
+                  'xpack.maps.toolbarOverlay.featureDraw.drawCircleLabel',
+                  {
+                    defaultMessage: 'Draw circle',
+                  }
+                )}
+                aria-pressed={drawCircleSelected}
+                isSelected={drawCircleSelected}
+                display={drawCircleSelected ? 'fill' : 'empty'}
+                isDisabled={isWaiting}
+              />
+            </EuiToolTip>
+            <EuiToolTip
+              content={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawBBoxTitle', {
                 defaultMessage: 'Draw bounding box',
               })}
-              title={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawBBoxTitle', {
-                defaultMessage: 'Draw bounding box',
-              })}
-              aria-pressed={drawBBoxSelected}
-              isSelected={drawBBoxSelected}
-              display={drawBBoxSelected ? 'fill' : 'empty'}
-              isDisabled={isWaiting}
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                className={classNames({
+                  'mapToolbarOverlay__buttonIcon-empty': !drawBBoxSelected,
+                })}
+                key="boundingBox"
+                size="s"
+                onClick={() => toggleDrawShape(DRAW_SHAPE.BOUNDS)}
+                iconType={VectorSquareIcon}
+                aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawBBoxLabel', {
+                  defaultMessage: 'Draw bounding box',
+                })}
+                aria-pressed={drawBBoxSelected}
+                isSelected={drawBBoxSelected}
+                display={drawBBoxSelected ? 'fill' : 'empty'}
+                isDisabled={isWaiting}
+              />
+            </EuiToolTip>
           </>
         )}
-        <EuiButtonIcon
-          className={classNames({
-            'mapToolbarOverlay__buttonIcon-empty': !drawPointSelected,
-          })}
-          key="point"
-          size="s"
-          onClick={() => toggleDrawShape(DRAW_SHAPE.POINT)}
-          iconType="dot"
-          aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPointLabel', {
+        <EuiToolTip
+          content={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPointTitle', {
             defaultMessage: 'Draw point',
           })}
-          title={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPointTitle', {
-            defaultMessage: 'Draw point',
-          })}
-          aria-pressed={drawPointSelected}
-          isSelected={drawPointSelected}
-          display={drawPointSelected ? 'fill' : 'empty'}
-          isDisabled={isWaiting}
-        />
-        <EuiButtonIcon
-          className={classNames({
-            'mapToolbarOverlay__buttonIcon-empty': !deleteSelected,
-          })}
-          key="delete"
-          size="s"
-          onClick={() => toggleDrawShape(DRAW_SHAPE.DELETE)}
-          iconType="trash"
-          aria-label={i18n.translate(
-            'xpack.maps.toolbarOverlay.featureDraw.deletePointOrShapeLabel',
-            {
-              defaultMessage: 'Delete point or shape',
-            }
-          )}
-          title={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.deletePointOrShapeTitle', {
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            className={classNames({
+              'mapToolbarOverlay__buttonIcon-empty': !drawPointSelected,
+            })}
+            key="point"
+            size="s"
+            onClick={() => toggleDrawShape(DRAW_SHAPE.POINT)}
+            iconType="dot"
+            aria-label={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.drawPointLabel', {
+              defaultMessage: 'Draw point',
+            })}
+            aria-pressed={drawPointSelected}
+            isSelected={drawPointSelected}
+            display={drawPointSelected ? 'fill' : 'empty'}
+            isDisabled={isWaiting}
+          />
+        </EuiToolTip>
+        <EuiToolTip
+          content={i18n.translate('xpack.maps.toolbarOverlay.featureDraw.deletePointOrShapeTitle', {
             defaultMessage: 'Delete point or shape',
           })}
-          aria-pressed={deleteSelected}
-          isSelected={deleteSelected}
-          display={deleteSelected ? 'fill' : 'empty'}
-          isDisabled={isWaiting}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            className={classNames({
+              'mapToolbarOverlay__buttonIcon-empty': !deleteSelected,
+            })}
+            key="delete"
+            size="s"
+            onClick={() => toggleDrawShape(DRAW_SHAPE.DELETE)}
+            iconType="trash"
+            aria-label={i18n.translate(
+              'xpack.maps.toolbarOverlay.featureDraw.deletePointOrShapeLabel',
+              {
+                defaultMessage: 'Delete point or shape',
+              }
+            )}
+            aria-pressed={deleteSelected}
+            isSelected={deleteSelected}
+            display={deleteSelected ? 'fill' : 'empty'}
+            isDisabled={isWaiting}
+          />
+        </EuiToolTip>
       </EuiPanel>
     </TrackApplicationView>
   );

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/fit_to_data/fit_to_data.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/fit_to_data/fit_to_data.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { EuiButtonIcon, EuiPanel } from '@elastic/eui';
+import { EuiButtonIcon, EuiPanel, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 export interface Props {
@@ -30,19 +30,23 @@ export function FitToData(props: Props) {
   }
   return (
     <EuiPanel paddingSize="none" className="mapToolbarOverlay__button">
-      <EuiButtonIcon
-        className={classNames({
+      <EuiToolTip
+        content={title}
+        disableScreenReaderOutput
+        anchorClassName={classNames({
           'mapToolbarOverlay__buttonIcon-empty': !props.autoFitToDataBounds,
         })}
-        size="s"
-        onClick={props.fitToBounds}
-        data-test-subj="fitToData"
-        iconType="maximize"
-        aria-label={label}
-        title={title}
-        color="text"
-        display={props.autoFitToDataBounds ? 'fill' : 'empty'}
-      />
+      >
+        <EuiButtonIcon
+          size="s"
+          onClick={props.fitToBounds}
+          data-test-subj="fitToData"
+          iconType="maximize"
+          aria-label={label}
+          color="text"
+          display={props.autoFitToDataBounds ? 'fill' : 'empty'}
+        />
+      </EuiToolTip>
     </EuiPanel>
   );
 }

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_control.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_control.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiButtonIcon, EuiPopover, EuiPanel } from '@elastic/eui';
+import { EuiButtonIcon, EuiPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { MapCenter, MapSettings } from '../../../../common/descriptor_types';
 import { SetViewForm } from './set_view_form';
@@ -51,20 +51,24 @@ export class SetViewControl extends Component<Props, State> {
         panelPaddingSize="s"
         button={
           <EuiPanel paddingSize="none" className="mapToolbarOverlay__button">
-            <EuiButtonIcon
-              className="mapToolbarOverlay__buttonIcon-empty"
-              size="s"
-              onClick={this._togglePopover}
-              data-test-subj="toggleSetViewVisibilityButton"
-              iconType="crosshair"
-              color="text"
-              aria-label={i18n.translate('xpack.maps.setViewControl.goToButtonLabel', {
+            <EuiToolTip
+              content={i18n.translate('xpack.maps.setViewControl.goToButtonLabel', {
                 defaultMessage: 'Go to',
               })}
-              title={i18n.translate('xpack.maps.setViewControl.goToButtonLabel', {
-                defaultMessage: 'Go to',
-              })}
-            />
+              anchorClassName="mapToolbarOverlay__buttonIcon-empty"
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                size="s"
+                onClick={this._togglePopover}
+                data-test-subj="toggleSetViewVisibilityButton"
+                iconType="crosshair"
+                color="text"
+                aria-label={i18n.translate('xpack.maps.setViewControl.goToButtonLabel', {
+                  defaultMessage: 'Go to',
+                })}
+              />
+            </EuiToolTip>
           </EuiPanel>
         }
         isOpen={this.state.isPopoverOpen}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/timeslider_toggle_button/timeslider_toggle_button.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/timeslider_toggle_button/timeslider_toggle_button.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon, EuiPanel } from '@elastic/eui';
+import { EuiButtonIcon, EuiPanel, EuiToolTip } from '@elastic/eui';
 
 export interface Props {
   isTimesliderOpen: boolean;
@@ -35,20 +35,24 @@ export function TimesliderToggleButton(props: Props) {
 
   return (
     <EuiPanel paddingSize="none" className="mapToolbarOverlay__button">
-      <EuiButtonIcon
-        className={classNames({
+      <EuiToolTip
+        content={label}
+        disableScreenReaderOutput
+        anchorClassName={classNames({
           'mapToolbarOverlay__buttonIcon-empty': !props.isTimesliderOpen,
         })}
-        size="s"
-        onClick={onClick}
-        data-test-subj="timesliderToggleButton"
-        iconType="clockControl"
-        aria-label={label}
-        title={label}
-        color="text"
-        isSelected={props.isTimesliderOpen}
-        display={props.isTimesliderOpen ? 'fill' : 'empty'}
-      />
+      >
+        <EuiButtonIcon
+          size="s"
+          onClick={onClick}
+          data-test-subj="timesliderToggleButton"
+          iconType="clockControl"
+          aria-label={label}
+          color="text"
+          isSelected={props.isTimesliderOpen}
+          display={props.isTimesliderOpen ? 'fill' : 'empty'}
+        />
+      </EuiToolTip>
     </EuiPanel>
   );
 }

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/__snapshots__/tools_control.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/__snapshots__/tools_control.test.tsx.snap
@@ -13,16 +13,20 @@ exports[`Should render cancel button when drawing 1`] = `
           className="mapToolbarOverlay__button"
           paddingSize="none"
         >
-          <EuiButtonIcon
-            aria-label="Tools"
-            className="mapToolbarOverlay__buttonIcon-empty"
-            color="text"
-            iconType="wrench"
-            isDisabled={false}
-            onClick={[Function]}
-            size="s"
-            title="Tools"
-          />
+          <EuiToolTip
+            anchorClassName="mapToolbarOverlay__buttonIcon-empty"
+            content="Tools"
+            disableScreenReaderOutput={true}
+          >
+            <EuiButtonIcon
+              aria-label="Tools"
+              color="text"
+              iconType="wrench"
+              isDisabled={false}
+              onClick={[Function]}
+              size="s"
+            />
+          </EuiToolTip>
         </EuiPanel>
       }
       closePopover={[Function]}
@@ -116,16 +120,20 @@ exports[`renders 1`] = `
       className="mapToolbarOverlay__button"
       paddingSize="none"
     >
-      <EuiButtonIcon
-        aria-label="Tools"
-        className="mapToolbarOverlay__buttonIcon-empty"
-        color="text"
-        iconType="wrench"
-        isDisabled={false}
-        onClick={[Function]}
-        size="s"
-        title="Tools"
-      />
+      <EuiToolTip
+        anchorClassName="mapToolbarOverlay__buttonIcon-empty"
+        content="Tools"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Tools"
+          color="text"
+          iconType="wrench"
+          isDisabled={false}
+          onClick={[Function]}
+          size="s"
+        />
+      </EuiToolTip>
     </EuiPanel>
   }
   closePopover={[Function]}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/tools_control.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/tools_control.tsx
@@ -8,13 +8,14 @@
 import React, { Component } from 'react';
 import type { GeoShapeRelation } from '@elastic/elasticsearch/lib/api/types';
 import {
+  EuiButton,
   EuiButtonIcon,
-  EuiPopover,
   EuiContextMenu,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
   EuiPanel,
+  EuiPopover,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -202,20 +203,24 @@ export class ToolsControl extends Component<Props, State> {
   _renderToolsButton() {
     return (
       <EuiPanel paddingSize="none" className="mapToolbarOverlay__button">
-        <EuiButtonIcon
-          className="mapToolbarOverlay__buttonIcon-empty"
-          size="s"
-          color="text"
-          iconType="wrench"
-          onClick={this._togglePopover}
-          aria-label={i18n.translate('xpack.maps.toolbarOverlay.toolsControlTitle', {
+        <EuiToolTip
+          content={i18n.translate('xpack.maps.toolbarOverlay.toolsControlTitle', {
             defaultMessage: 'Tools',
           })}
-          title={i18n.translate('xpack.maps.toolbarOverlay.toolsControlTitle', {
-            defaultMessage: 'Tools',
-          })}
-          isDisabled={this.props.disableToolsControl}
-        />
+          disableScreenReaderOutput
+          anchorClassName="mapToolbarOverlay__buttonIcon-empty"
+        >
+          <EuiButtonIcon
+            size="s"
+            color="text"
+            iconType="wrench"
+            onClick={this._togglePopover}
+            aria-label={i18n.translate('xpack.maps.toolbarOverlay.toolsControlTitle', {
+              defaultMessage: 'Tools',
+            })}
+            isDisabled={this.props.disableToolsControl}
+          />
+        </EuiToolTip>
       </EuiPanel>
     );
   }


### PR DESCRIPTION
# Backport

This is a manual backport of pull request #271486.

## Excluded files (structural divergence on 9.4)

- `src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx` - file was moved to the `embeddable` plugin on main with renamed i18n keys; the 9.4 location and naming don't match.
- `src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx` - main switched the custom `SplitButton` to `EuiSplitButton` (with a new `tooltipProps` API). That refactor isn't on 9.4.