### PR TITLE
[Cases] Scaffold redesign user actions view with improved show-more button

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_view_activity.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_view_activity.test.tsx
@@ -230,7 +230,7 @@ describe('Case View Page activity tab', () => {
     });
 
     const caseViewActivity = await screen.findByTestId('case-view-activity');
-    expect(await within(caseViewActivity).findAllByTestId('user-actions-list')).toHaveLength(2);
+    expect(await within(caseViewActivity).findAllByTestId('user-actions-list')).toHaveLength(1);
     expect(
       await within(caseViewActivity).findByTestId('case-view-status-action-button')
     ).toBeInTheDocument();
@@ -540,7 +540,7 @@ describe('Case View Page activity tab', () => {
 
         renderWithTestingProviders(<CaseViewActivity {...caseProps} />);
 
-        const userActions = within((await screen.findAllByTestId('user-actions-list'))[1]);
+        const userActions = within((await screen.findAllByTestId('user-actions-list'))[0]);
 
         expect(await userActions.findByText('cases_no_connectors')).toBeInTheDocument();
         expect(await userActions.findByText('Valid Chimpanzee')).toBeInTheDocument();
@@ -565,7 +565,7 @@ describe('Case View Page activity tab', () => {
 
         renderWithTestingProviders(<CaseViewActivity {...caseProps} />);
 
-        const userActions = within((await screen.findAllByTestId('user-actions-list'))[1]);
+        const userActions = within((await screen.findAllByTestId('user-actions-list'))[0]);
 
         expect(await userActions.findByText('Fuzzy Marten')).toBeInTheDocument();
         expect(await userActions.findByText('Unknown')).toBeInTheDocument();
@@ -640,7 +640,7 @@ describe('Case View Page activity tab', () => {
 
         renderWithTestingProviders(<CaseViewActivity {...caseProps} />);
 
-        const userActions = within((await screen.findAllByTestId('user-actions-list'))[1]);
+        const userActions = within((await screen.findAllByTestId('user-actions-list'))[0]);
 
         expect(await userActions.findByText('Participant 1')).toBeInTheDocument();
         expect(await userActions.findByText('participant_2@elastic.co')).toBeInTheDocument();

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_view_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_view_activity.tsx
@@ -32,7 +32,7 @@ import { EditConnector } from '../../../edit_connector';
 import { StatusActionButton } from '../../../status/button';
 import { CaseViewAttachButton } from '../../../case_view/components/case_view_attach_button';
 import { EditTags } from '../../../case_view/components/edit_tags';
-import { UserActions } from '../../../user_actions';
+import { UserActions } from '../../user_actions';
 import { UserList } from '../../../case_view/components/user_list';
 import { useOnUpdateField } from '../../../case_view/use_on_update_field';
 import { useCasesContext } from '../../../cases_context/use_cases_context';
@@ -48,7 +48,7 @@ import type {
 } from '../../../user_actions_activity_bar/types';
 import { CASE_VIEW_PAGE_TABS } from '../../../../../common/types';
 import { CaseViewTabs } from '../../../case_view/case_view_tabs';
-import { Description } from '../../description';
+import { Description } from '../../../description';
 import { EditCategory } from '../../../case_view/components/edit_category';
 import { parseCaseUsers } from '../../../utils';
 import { CustomFields } from '../../../case_view/components/custom_fields';

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_build_user_actions.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_build_user_actions.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { EuiThemeComputed } from '@elastic/eui';
+
+import { useBuildUserActions } from './use_build_user_actions';
+import { builderMap } from '../../../user_actions/builder';
+import { basicCase, getUserAction } from '../../../../containers/mock';
+import { casesConfigurationsMock } from '../../../../containers/configure/mock';
+import { getCaseConnectorsMockResponse } from '../../../../common/mock/connectors';
+import { ExternalReferenceAttachmentTypeRegistry } from '../../../../client/attachment_framework/external_reference_registry';
+import { PersistableStateAttachmentTypeRegistry } from '../../../../client/attachment_framework/persistable_state_registry';
+import { UnifiedAttachmentTypeRegistry } from '../../../../client/attachment_framework/unified_attachment_registry';
+import { UserActionTypes } from '../../../../../common/types/domain';
+
+jest.mock('../../../user_actions/builder');
+
+const builderMapMock = jest.mocked(builderMap);
+
+const defaultArgs = {
+  caseUserActions: [],
+  attachments: [],
+  caseData: basicCase,
+  casesConfiguration: casesConfigurationsMock,
+  caseConnectors: getCaseConnectorsMockResponse(),
+  userProfiles: new Map(),
+  currentUserProfile: undefined,
+  appId: 'securitySolution',
+  externalReferenceAttachmentTypeRegistry: new ExternalReferenceAttachmentTypeRegistry(),
+  persistableStateAttachmentTypeRegistry: new PersistableStateAttachmentTypeRegistry(),
+  unifiedAttachmentTypeRegistry: new UnifiedAttachmentTypeRegistry(),
+  manageMarkdownEditIds: [],
+  selectedOutlineCommentId: '',
+  loadingCommentIds: [],
+  euiTheme: {} as EuiThemeComputed<{}>,
+  handleOutlineComment: jest.fn(),
+  handleDeleteComment: jest.fn(),
+};
+
+describe('useBuildUserActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty array when caseUserActions is empty', () => {
+    const { result } = renderHook(() => useBuildUserActions(defaultArgs));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('skips unsupported user action types', () => {
+    const unsupportedAction = getUserAction(UserActionTypes.delete_case, 'delete');
+
+    const { result } = renderHook(() =>
+      useBuildUserActions({ ...defaultArgs, caseUserActions: [unsupportedAction] })
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('builds comment props from supported user actions', () => {
+    const commentAction = getUserAction(UserActionTypes.comment, 'create');
+    const mockBuiltComment = { username: 'elastic', children: null };
+    const buildMock = jest.fn().mockReturnValue([mockBuiltComment]);
+
+    builderMapMock.comment.mockReturnValue({ build: buildMock });
+
+    const { result } = renderHook(() =>
+      useBuildUserActions({ ...defaultArgs, caseUserActions: [commentAction] })
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockBuiltComment);
+    expect(builderMapMock.comment).toHaveBeenCalled();
+  });
+
+  it('accumulates results from multiple user actions', () => {
+    const action1 = getUserAction(UserActionTypes.comment, 'create');
+    const action2 = getUserAction(UserActionTypes.title, 'update');
+
+    const buildMock1 = jest.fn().mockReturnValue([{ username: 'user1' }]);
+    const buildMock2 = jest.fn().mockReturnValue([{ username: 'user2' }]);
+
+    builderMapMock.comment.mockReturnValue({ build: buildMock1 });
+    builderMapMock.title.mockReturnValue({ build: buildMock2 });
+
+    const { result } = renderHook(() =>
+      useBuildUserActions({ ...defaultArgs, caseUserActions: [action1, action2] })
+    );
+
+    expect(result.current).toHaveLength(2);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_build_user_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_build_user_actions.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { EuiCommentProps, EuiThemeComputed } from '@elastic/eui';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+
+import type {
+  AttachmentUIV2,
+  UserActionUI,
+  CasesConfigurationUI,
+  CaseUI,
+  CaseConnectors,
+} from '../../../../containers/types';
+import type { CurrentUserProfile } from '../../../types';
+import type { ExternalReferenceAttachmentTypeRegistry } from '../../../../client/attachment_framework/external_reference_registry';
+import type { PersistableStateAttachmentTypeRegistry } from '../../../../client/attachment_framework/persistable_state_registry';
+import type { UnifiedAttachmentTypeRegistry } from '../../../../client/attachment_framework/unified_attachment_registry';
+import { isUserActionTypeSupported } from '../../../user_actions/helpers';
+import { builderMap } from '../../../user_actions/builder';
+
+interface UseBuildUserActionsArgs {
+  caseUserActions: UserActionUI[];
+  attachments: AttachmentUIV2[];
+  caseData: CaseUI;
+  casesConfiguration: CasesConfigurationUI;
+  caseConnectors: CaseConnectors;
+  userProfiles: Map<string, UserProfileWithAvatar>;
+  currentUserProfile: CurrentUserProfile;
+  appId: string;
+  externalReferenceAttachmentTypeRegistry: ExternalReferenceAttachmentTypeRegistry;
+  persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
+  unifiedAttachmentTypeRegistry: UnifiedAttachmentTypeRegistry;
+  manageMarkdownEditIds: string[];
+  selectedOutlineCommentId: string;
+  loadingCommentIds: string[];
+  euiTheme: EuiThemeComputed<{}>;
+  handleOutlineComment: (id: string) => void;
+  handleDeleteComment: (id: string, successToasterTitle: string) => void;
+}
+
+export const useBuildUserActions = ({
+  caseUserActions,
+  attachments,
+  caseData,
+  casesConfiguration,
+  caseConnectors,
+  userProfiles,
+  currentUserProfile,
+  appId,
+  externalReferenceAttachmentTypeRegistry,
+  persistableStateAttachmentTypeRegistry,
+  unifiedAttachmentTypeRegistry,
+  manageMarkdownEditIds,
+  selectedOutlineCommentId,
+  loadingCommentIds,
+  euiTheme,
+  handleOutlineComment,
+  handleDeleteComment,
+}: UseBuildUserActionsArgs): EuiCommentProps[] => {
+  return useMemo(() => {
+    if (!caseUserActions) {
+      return [];
+    }
+
+    return caseUserActions.reduce<EuiCommentProps[]>((userActions, userAction, index) => {
+      if (!isUserActionTypeSupported(userAction.type)) {
+        return userActions;
+      }
+
+      const builder = builderMap[userAction.type];
+
+      if (builder == null) {
+        return userActions;
+      }
+
+      const userActionBuilder = builder({
+        appId,
+        caseData,
+        casesConfiguration,
+        caseConnectors,
+        externalReferenceAttachmentTypeRegistry,
+        persistableStateAttachmentTypeRegistry,
+        unifiedAttachmentTypeRegistry,
+        userAction,
+        userProfiles,
+        currentUserProfile,
+        attachments,
+        index,
+        manageMarkdownEditIds,
+        selectedOutlineCommentId,
+        loadingCommentIds,
+        euiTheme,
+        handleOutlineComment,
+        handleDeleteComment,
+      });
+      return [...userActions, ...userActionBuilder.build()];
+    }, []);
+  }, [
+    caseUserActions,
+    appId,
+    caseData,
+    casesConfiguration,
+    caseConnectors,
+    externalReferenceAttachmentTypeRegistry,
+    persistableStateAttachmentTypeRegistry,
+    unifiedAttachmentTypeRegistry,
+    userProfiles,
+    currentUserProfile,
+    attachments,
+    manageMarkdownEditIds,
+    selectedOutlineCommentId,
+    loadingCommentIds,
+    euiTheme,
+    handleOutlineComment,
+    handleDeleteComment,
+  ]);
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_builder_context.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_builder_context.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useBuilderContext } from './use_builder_context';
+import { useCasesContext } from '../../../cases_context/use_cases_context';
+import { basicCase } from '../../../../containers/mock';
+import { casesConfigurationsMock } from '../../../../containers/configure/mock';
+import { getCaseConnectorsMockResponse } from '../../../../common/mock/connectors';
+
+jest.mock('@elastic/eui', () => ({
+  ...jest.requireActual('@elastic/eui'),
+  useEuiTheme: () => ({ euiTheme: { colors: {}, size: {} } }),
+}));
+
+jest.mock('../../../cases_context/use_cases_context');
+
+const useCasesContextMock = useCasesContext as jest.Mock;
+
+const mockExternalRefRegistry = { list: jest.fn() };
+const mockPersistableRegistry = { list: jest.fn() };
+const mockUnifiedRegistry = { list: jest.fn() };
+
+const defaultArgs = {
+  caseData: basicCase,
+  casesConfiguration: casesConfigurationsMock,
+  caseConnectors: getCaseConnectorsMockResponse(),
+  userProfiles: new Map(),
+  currentUserProfile: undefined,
+  manageMarkdownEditIds: [],
+  selectedOutlineCommentId: '',
+  loadingCommentIds: [],
+  handleOutlineComment: jest.fn(),
+  handleDeleteComment: jest.fn(),
+};
+
+describe('useBuilderContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCasesContextMock.mockReturnValue({
+      owner: ['securitySolution'],
+      externalReferenceAttachmentTypeRegistry: mockExternalRefRegistry,
+      persistableStateAttachmentTypeRegistry: mockPersistableRegistry,
+      unifiedAttachmentTypeRegistry: mockUnifiedRegistry,
+    });
+  });
+
+  it('returns context with appId from owner', () => {
+    const { result } = renderHook(() => useBuilderContext(defaultArgs));
+
+    expect(result.current.appId).toBe('securitySolution');
+  });
+
+  it('includes registries from cases context', () => {
+    const { result } = renderHook(() => useBuilderContext(defaultArgs));
+
+    expect(result.current.externalReferenceAttachmentTypeRegistry).toBe(mockExternalRefRegistry);
+    expect(result.current.persistableStateAttachmentTypeRegistry).toBe(mockPersistableRegistry);
+    expect(result.current.unifiedAttachmentTypeRegistry).toBe(mockUnifiedRegistry);
+  });
+
+  it('passes through input args', () => {
+    const { result } = renderHook(() => useBuilderContext(defaultArgs));
+
+    expect(result.current.caseData).toBe(defaultArgs.caseData);
+    expect(result.current.manageMarkdownEditIds).toBe(defaultArgs.manageMarkdownEditIds);
+    expect(result.current.handleOutlineComment).toBe(defaultArgs.handleOutlineComment);
+    expect(result.current.handleDeleteComment).toBe(defaultArgs.handleDeleteComment);
+  });
+
+  it('includes euiTheme', () => {
+    const { result } = renderHook(() => useBuilderContext(defaultArgs));
+
+    expect(result.current.euiTheme).toBeDefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_builder_context.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_builder_context.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useEuiTheme } from '@elastic/eui';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+
+import type { CaseConnectors, CaseUI, CasesConfigurationUI } from '../../../../containers/types';
+import type { CurrentUserProfile } from '../../../types';
+import { useCasesContext } from '../../../cases_context/use_cases_context';
+
+interface UseBuilderContextArgs {
+  caseData: CaseUI;
+  casesConfiguration: CasesConfigurationUI;
+  caseConnectors: CaseConnectors;
+  userProfiles: Map<string, UserProfileWithAvatar>;
+  currentUserProfile: CurrentUserProfile;
+  manageMarkdownEditIds: string[];
+  selectedOutlineCommentId: string;
+  loadingCommentIds: string[];
+  handleOutlineComment: (id: string) => void;
+  handleDeleteComment: (id: string, successToasterTitle: string) => void;
+}
+
+export const useBuilderContext = ({
+  caseData,
+  casesConfiguration,
+  caseConnectors,
+  userProfiles,
+  currentUserProfile,
+  manageMarkdownEditIds,
+  selectedOutlineCommentId,
+  loadingCommentIds,
+  handleOutlineComment,
+  handleDeleteComment,
+}: UseBuilderContextArgs) => {
+  const { euiTheme } = useEuiTheme();
+  const {
+    externalReferenceAttachmentTypeRegistry,
+    persistableStateAttachmentTypeRegistry,
+    unifiedAttachmentTypeRegistry,
+    owner,
+  } = useCasesContext();
+
+  return useMemo(
+    () => ({
+      appId: owner[0],
+      caseData,
+      casesConfiguration,
+      caseConnectors,
+      userProfiles,
+      currentUserProfile,
+      externalReferenceAttachmentTypeRegistry,
+      persistableStateAttachmentTypeRegistry,
+      unifiedAttachmentTypeRegistry,
+      manageMarkdownEditIds,
+      selectedOutlineCommentId,
+      loadingCommentIds,
+      euiTheme,
+      handleOutlineComment,
+      handleDeleteComment,
+    }),
+    [
+      owner,
+      caseData,
+      casesConfiguration,
+      caseConnectors,
+      userProfiles,
+      currentUserProfile,
+      externalReferenceAttachmentTypeRegistry,
+      persistableStateAttachmentTypeRegistry,
+      unifiedAttachmentTypeRegistry,
+      manageMarkdownEditIds,
+      selectedOutlineCommentId,
+      loadingCommentIds,
+      euiTheme,
+      handleOutlineComment,
+      handleDeleteComment,
+    ]
+  );
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_builder_context.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_builder_context.ts
@@ -48,7 +48,7 @@ export const useBuilderContext = ({
 
   return useMemo(
     () => ({
-      appId: owner[0],
+      appId: owner[0] ?? '',
       caseData,
       casesConfiguration,
       caseConnectors,

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.test.tsx
@@ -46,7 +46,7 @@ describe('useCommentsList', () => {
     );
 
     expect(result.current).toHaveLength(3);
-    expect(result.current[1]['data-test-subj']).toBe('cases-show-more-user-actions');
+    expect(result.current[1]['data-test-subj']).toBe('cases-show-more-user-actions-wrapper');
   });
 
   it('appends add-comment entry when shouldShowCommentEditor is true', () => {
@@ -69,7 +69,7 @@ describe('useCommentsList', () => {
     );
 
     expect(result.current).toHaveLength(4);
-    expect(result.current[1]['data-test-subj']).toBe('cases-show-more-user-actions');
+    expect(result.current[1]['data-test-subj']).toBe('cases-show-more-user-actions-wrapper');
     expect(result.current[3]['data-test-subj']).toBe('add-comment');
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import type { EuiCommentProps } from '@elastic/eui';
+
+import { useCommentsList } from './use_comments_list';
+
+describe('useCommentsList', () => {
+  const infiniteAction: EuiCommentProps = {
+    username: 'user1',
+    children: <div>{'Infinite action'}</div>,
+  };
+
+  const lastPageAction: EuiCommentProps = {
+    username: 'user2',
+    children: <div>{'Last page action'}</div>,
+  };
+
+  const defaultArgs = {
+    builtInfiniteActions: [infiniteAction],
+    builtLastPageActions: [lastPageAction],
+    hasNextPage: false,
+    remainingActionCount: 0,
+    fetchNextPage: jest.fn(),
+    isFetchingNextPage: false,
+    shouldShowCommentEditor: false,
+    currentUserProfile: undefined,
+    commentEditor: <div>{'Editor'}</div>,
+  };
+
+  it('returns infinite + last page actions when no next page', () => {
+    const { result } = renderHook(() => useCommentsList(defaultArgs));
+
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('inserts show-more entry between infinite and last page actions when hasNextPage', () => {
+    const { result } = renderHook(() =>
+      useCommentsList({ ...defaultArgs, hasNextPage: true, remainingActionCount: 5 })
+    );
+
+    expect(result.current).toHaveLength(3);
+    expect(result.current[1]['data-test-subj']).toBe('cases-show-more-user-actions');
+  });
+
+  it('appends add-comment entry when shouldShowCommentEditor is true', () => {
+    const { result } = renderHook(() =>
+      useCommentsList({ ...defaultArgs, shouldShowCommentEditor: true })
+    );
+
+    expect(result.current).toHaveLength(3);
+    expect(result.current[2]['data-test-subj']).toBe('add-comment');
+  });
+
+  it('includes both show-more and add-comment when both conditions are met', () => {
+    const { result } = renderHook(() =>
+      useCommentsList({
+        ...defaultArgs,
+        hasNextPage: true,
+        remainingActionCount: 3,
+        shouldShowCommentEditor: true,
+      })
+    );
+
+    expect(result.current).toHaveLength(4);
+    expect(result.current[1]['data-test-subj']).toBe('cases-show-more-user-actions');
+    expect(result.current[3]['data-test-subj']).toBe('add-comment');
+  });
+
+  it('returns empty list when no actions and no editor', () => {
+    const { result } = renderHook(() =>
+      useCommentsList({
+        ...defaultArgs,
+        builtInfiniteActions: [],
+        builtLastPageActions: [],
+      })
+    );
+
+    expect(result.current).toHaveLength(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.tsx
@@ -50,7 +50,7 @@ export const useCommentsList = ({
     if (hasNextPage) {
       items.push({
         username: '',
-        'data-test-subj': 'cases-show-more-user-actions',
+        'data-test-subj': 'cases-show-more-user-actions-wrapper',
         timelineAvatar: 'list',
         timelineAvatarAriaLabel: i18n.SHOW_MORE_ACTIVITIES_ARIA,
         className: 'showMoreActivities',

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.tsx
@@ -54,6 +54,7 @@ export const useCommentsList = ({
         timelineAvatar: 'list',
         timelineAvatarAriaLabel: i18n.SHOW_MORE_ACTIVITIES_ARIA,
         className: 'showMoreActivities',
+        verticalAlign: 'center',
         children: (
           <ShowMoreActivities
             count={remainingActionCount}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_comments_list.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import type { EuiCommentProps } from '@elastic/eui';
+
+import type { CurrentUserProfile } from '../../../types';
+import { UserToolTip } from '../../../user_profiles/user_tooltip';
+import { Username } from '../../../user_profiles/username';
+import { HoverableAvatar } from '../../../user_profiles/hoverable_avatar';
+import { ShowMoreActivities } from '../show_more_activities';
+import * as i18n from '../translations';
+
+interface UseCommentsListArgs {
+  builtInfiniteActions: EuiCommentProps[];
+  builtLastPageActions: EuiCommentProps[];
+  hasNextPage: boolean | undefined;
+  remainingActionCount: number;
+  fetchNextPage: (() => void) | undefined;
+  isFetchingNextPage: boolean;
+  shouldShowCommentEditor: boolean;
+  currentUserProfile: CurrentUserProfile;
+  commentEditor: React.ReactNode;
+}
+
+export const useCommentsList = ({
+  builtInfiniteActions,
+  builtLastPageActions,
+  hasNextPage,
+  remainingActionCount,
+  fetchNextPage,
+  isFetchingNextPage,
+  shouldShowCommentEditor,
+  currentUserProfile,
+  commentEditor,
+}: UseCommentsListArgs): EuiCommentProps[] => {
+  const handleShowMore = useCallback(() => {
+    if (fetchNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage]);
+
+  return useMemo<EuiCommentProps[]>(() => {
+    const items: EuiCommentProps[] = [...builtInfiniteActions];
+
+    if (hasNextPage) {
+      items.push({
+        username: '',
+        'data-test-subj': 'cases-show-more-user-actions',
+        timelineAvatar: 'list',
+        timelineAvatarAriaLabel: i18n.SHOW_MORE_ACTIVITIES_ARIA,
+        className: 'showMoreActivities',
+        children: (
+          <ShowMoreActivities
+            count={remainingActionCount}
+            onClick={handleShowMore}
+            isLoading={isFetchingNextPage}
+          />
+        ),
+      });
+    }
+
+    items.push(...builtLastPageActions);
+
+    if (shouldShowCommentEditor) {
+      items.push({
+        username: (
+          <UserToolTip userInfo={currentUserProfile}>
+            <Username userInfo={currentUserProfile} />
+          </UserToolTip>
+        ),
+        'data-test-subj': 'add-comment',
+        timelineAvatar: <HoverableAvatar userInfo={currentUserProfile} />,
+        className: 'isEdit',
+        children: commentEditor,
+      });
+    }
+
+    return items;
+  }, [
+    builtInfiniteActions,
+    hasNextPage,
+    remainingActionCount,
+    handleShowMore,
+    isFetchingNextPage,
+    builtLastPageActions,
+    shouldShowCommentEditor,
+    currentUserProfile,
+    commentEditor,
+  ]);
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_highlight_linked_comment.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_highlight_linked_comment.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useHighlightLinkedComment } from './use_highlight_linked_comment';
+import { useCaseViewParams } from '../../../../common/navigation';
+
+jest.mock('../../../../common/navigation');
+
+const useCaseViewParamsMock = useCaseViewParams as jest.Mock;
+
+describe('useHighlightLinkedComment', () => {
+  const handleOutlineComment = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls handleOutlineComment when commentId is present', () => {
+    useCaseViewParamsMock.mockReturnValue({ detailName: 'case-1', commentId: 'comment-1' });
+
+    renderHook(() => useHighlightLinkedComment(handleOutlineComment));
+
+    expect(handleOutlineComment).toHaveBeenCalledWith('comment-1');
+  });
+
+  it('does not call handleOutlineComment when commentId is absent', () => {
+    useCaseViewParamsMock.mockReturnValue({ detailName: 'case-1' });
+
+    renderHook(() => useHighlightLinkedComment(handleOutlineComment));
+
+    expect(handleOutlineComment).not.toHaveBeenCalled();
+  });
+
+  it('only calls handleOutlineComment once on re-renders', () => {
+    useCaseViewParamsMock.mockReturnValue({ detailName: 'case-1', commentId: 'comment-1' });
+
+    const { rerender } = renderHook(() => useHighlightLinkedComment(handleOutlineComment));
+
+    rerender();
+    rerender();
+
+    expect(handleOutlineComment).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_highlight_linked_comment.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_highlight_linked_comment.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { useCaseViewParams } from '../../../../common/navigation';
+
+/**
+ * Highlights a comment when navigating to a deep-link URL containing a commentId.
+ * Fires once on initial load to outline the linked comment.
+ */
+export const useHighlightLinkedComment = (handleOutlineComment: (id: string) => void) => {
+  const { commentId } = useCaseViewParams();
+  const [hasHighlighted, setHasHighlighted] = useState(false);
+
+  useEffect(() => {
+    if (commentId != null && !hasHighlighted) {
+      setHasHighlighted(true);
+      handleOutlineComment(commentId);
+    }
+  }, [commentId, hasHighlighted, handleOutlineComment]);
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useUserActionsPagination } from './use_user_actions_pagination';
+import { useInfiniteFindCaseUserActions } from '../../../../containers/use_infinite_find_case_user_actions';
+
+jest.mock('../../../../containers/use_infinite_find_case_user_actions');
+
+const useInfiniteFindCaseUserActionsMock = useInfiniteFindCaseUserActions as jest.Mock;
+
+describe('useUserActionsPagination', () => {
+  const defaultParams = {
+    userActivityQueryParams: {
+      type: 'all' as const,
+      sortOrder: 'asc' as const,
+      page: 1,
+      perPage: 10,
+    },
+    caseId: 'case-1',
+    lastPage: 2,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useInfiniteFindCaseUserActionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      hasNextPage: false,
+      fetchNextPage: jest.fn(),
+      isFetchingNextPage: false,
+    });
+  });
+
+  it('returns empty arrays when loading', () => {
+    const { result } = renderHook(() => useUserActionsPagination(defaultParams));
+
+    expect(result.current.infiniteCaseUserActions).toEqual([]);
+    expect(result.current.infiniteLatestAttachments).toEqual([]);
+    expect(result.current.remainingActionCount).toBe(0);
+  });
+
+  it('does not return showBottomList', () => {
+    const { result } = renderHook(() => useUserActionsPagination(defaultParams));
+
+    expect(result.current).not.toHaveProperty('showBottomList');
+  });
+
+  it('computes remainingActionCount from pages', () => {
+    useInfiniteFindCaseUserActionsMock.mockReturnValue({
+      data: {
+        pages: [
+          { userActions: [{ id: '1' }, { id: '2' }], latestAttachments: [], total: 10 },
+          { userActions: [{ id: '3' }], latestAttachments: [], total: 10 },
+        ],
+      },
+      isLoading: false,
+      hasNextPage: true,
+      fetchNextPage: jest.fn(),
+      isFetchingNextPage: false,
+    });
+
+    const { result } = renderHook(() => useUserActionsPagination(defaultParams));
+
+    expect(result.current.remainingActionCount).toBe(7);
+  });
+
+  it('flattens user actions from all pages', () => {
+    useInfiniteFindCaseUserActionsMock.mockReturnValue({
+      data: {
+        pages: [
+          { userActions: [{ id: '1' }], latestAttachments: [{ id: 'a1' }], total: 2 },
+          { userActions: [{ id: '2' }], latestAttachments: [{ id: 'a2' }], total: 2 },
+        ],
+      },
+      isLoading: false,
+      hasNextPage: false,
+      fetchNextPage: jest.fn(),
+      isFetchingNextPage: false,
+    });
+
+    const { result } = renderHook(() => useUserActionsPagination(defaultParams));
+
+    expect(result.current.infiniteCaseUserActions).toHaveLength(2);
+    expect(result.current.infiniteLatestAttachments).toHaveLength(2);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.test.ts
@@ -44,10 +44,11 @@ describe('useUserActionsPagination', () => {
     expect(result.current.remainingActionCount).toBe(0);
   });
 
-  it('does not return showBottomList', () => {
+  it('does not return showBottomList or lastPage', () => {
     const { result } = renderHook(() => useUserActionsPagination(defaultParams));
 
     expect(result.current).not.toHaveProperty('showBottomList');
+    expect(result.current).not.toHaveProperty('lastPage');
   });
 
   it('computes remainingActionCount from pages', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+
+import { useInfiniteFindCaseUserActions } from '../../../../containers/use_infinite_find_case_user_actions';
+import type { AttachmentUIV2, UserActionUI } from '../../../../containers/types';
+import type { UserActivityParams } from '../../../user_actions_activity_bar/types';
+
+interface UserActionsPagination {
+  userActivityQueryParams: UserActivityParams;
+  caseId: string;
+  lastPage: number;
+}
+
+export const useUserActionsPagination = ({
+  userActivityQueryParams,
+  caseId,
+  lastPage,
+}: UserActionsPagination) => {
+  const {
+    data: caseInfiniteUserActionsData,
+    isLoading: isLoadingInfiniteUserActions,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteFindCaseUserActions(caseId, userActivityQueryParams, true);
+
+  const infiniteCaseUserActions = useMemo<{
+    userActions: UserActionUI[];
+    latestAttachments: AttachmentUIV2[];
+  }>(() => {
+    if (!caseInfiniteUserActionsData?.pages?.length || isLoadingInfiniteUserActions) {
+      return { userActions: [], latestAttachments: [] };
+    }
+
+    const userActionsData: UserActionUI[] = [];
+    const latestAttachments: AttachmentUIV2[] = [];
+
+    caseInfiniteUserActionsData.pages.forEach((page) => userActionsData.push(...page.userActions));
+    caseInfiniteUserActionsData.pages.forEach((page) =>
+      latestAttachments.push(...page.latestAttachments)
+    );
+
+    return { userActions: userActionsData, latestAttachments };
+  }, [caseInfiniteUserActionsData, isLoadingInfiniteUserActions]);
+
+  const remainingActionCount = useMemo(() => {
+    if (!caseInfiniteUserActionsData?.pages?.length) {
+      return 0;
+    }
+
+    const lastPageData =
+      caseInfiniteUserActionsData.pages[caseInfiniteUserActionsData.pages.length - 1];
+    const loadedCount = caseInfiniteUserActionsData.pages.reduce(
+      (sum, page) => sum + page.userActions.length,
+      0
+    );
+
+    return Math.max(lastPageData.total - loadedCount, 0);
+  }, [caseInfiniteUserActionsData]);
+
+  return {
+    lastPage,
+    isLoadingInfiniteUserActions,
+    infiniteCaseUserActions: infiniteCaseUserActions.userActions,
+    infiniteLatestAttachments: infiniteCaseUserActions.latestAttachments,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    remainingActionCount,
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/hooks/use_user_actions_pagination.ts
@@ -14,13 +14,11 @@ import type { UserActivityParams } from '../../../user_actions_activity_bar/type
 interface UserActionsPagination {
   userActivityQueryParams: UserActivityParams;
   caseId: string;
-  lastPage: number;
 }
 
 export const useUserActionsPagination = ({
   userActivityQueryParams,
   caseId,
-  lastPage,
 }: UserActionsPagination) => {
   const {
     data: caseInfiniteUserActionsData,
@@ -65,7 +63,6 @@ export const useUserActionsPagination = ({
   }, [caseInfiniteUserActionsData]);
 
   return {
-    lastPage,
     isLoadingInfiniteUserActions,
     infiniteCaseUserActions: infiniteCaseUserActions.userActions,
     infiniteLatestAttachments: infiniteCaseUserActions.latestAttachments,

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+
+import { UserActions } from '.';
+import { basicCase } from '../../../containers/mock';
+import { getCaseConnectorsMockResponse } from '../../../common/mock/connectors';
+import { casesConfigurationsMock } from '../../../containers/configure/mock';
+import { useInfiniteFindCaseUserActions } from '../../../containers/use_infinite_find_case_user_actions';
+import { useFindCaseUserActions } from '../../../containers/use_find_case_user_actions';
+import { renderWithTestingProviders } from '../../../common/mock';
+import type { CaseUserActionsStats } from '../../../containers/types';
+import type { UserActivityParams } from '../../user_actions_activity_bar/types';
+
+jest.mock('../../../containers/use_infinite_find_case_user_actions');
+jest.mock('../../../containers/use_find_case_user_actions');
+jest.mock('../../../common/lib/kibana');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ detailName: 'case-id' }),
+}));
+
+const useInfiniteFindCaseUserActionsMock = useInfiniteFindCaseUserActions as jest.Mock;
+const useFindCaseUserActionsMock = useFindCaseUserActions as jest.Mock;
+
+const userActionsStats: CaseUserActionsStats = {
+  total: 5,
+  totalDeletions: 0,
+  totalComments: 2,
+  totalCommentDeletions: 0,
+  totalCommentCreations: 2,
+  totalHiddenCommentUpdates: 0,
+  totalOtherActions: 3,
+  totalOtherActionDeletions: 0,
+};
+
+const userActivityQueryParams: UserActivityParams = {
+  type: 'all',
+  sortOrder: 'asc',
+  page: 1,
+  perPage: 10,
+};
+
+const defaultProps = {
+  caseConnectors: getCaseConnectorsMockResponse(),
+  data: basicCase,
+  userActivityQueryParams,
+  userActionsStats,
+  statusActionButton: null,
+  attachActionButton: null,
+  currentUserProfile: undefined,
+  userProfiles: new Map(),
+  casesConfiguration: casesConfigurationsMock,
+  onUpdateField: jest.fn(),
+};
+
+describe('UserActions (redesign)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useInfiniteFindCaseUserActionsMock.mockReturnValue({
+      data: { pages: [] },
+      isLoading: false,
+      hasNextPage: false,
+      fetchNextPage: jest.fn(),
+      isFetchingNextPage: false,
+    });
+    useFindCaseUserActionsMock.mockReturnValue({
+      data: { userActions: [], latestAttachments: [] },
+      isLoading: false,
+    });
+  });
+
+  it('renders the user actions list when loaded', async () => {
+    renderWithTestingProviders(<UserActions {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-actions-list')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading skeleton while data is loading', () => {
+    useInfiniteFindCaseUserActionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      hasNextPage: false,
+      fetchNextPage: jest.fn(),
+      isFetchingNextPage: false,
+    });
+    useFindCaseUserActionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    renderWithTestingProviders(<UserActions {...defaultProps} />);
+
+    expect(screen.getByTestId('user-actions-loading')).toBeInTheDocument();
+  });
+
+  it('renders the comment list container', async () => {
+    renderWithTestingProviders(<UserActions {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-actions-list')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexItem, EuiSkeletonText } from '@elastic/eui';
+import React, { useMemo } from 'react';
+
+import { AddComment } from '../../add_comment';
+import { useCaseViewParams } from '../../../common/navigation';
+import type { UserActionTreeProps } from '../../user_actions/types';
+import { useUserActionsHandler } from '../../user_actions/use_user_actions_handler';
+import { NEW_COMMENT_ID } from '../../user_actions/constants';
+import { UserActionsList } from './user_actions_list';
+import { useUserActionsPagination } from './hooks/use_user_actions_pagination';
+import { useLastPageUserActions } from '../../user_actions/use_user_actions_last_page';
+import { useLastPage } from '../../user_actions/use_last_page';
+import { useUserPermissions } from '../../user_actions/use_user_permissions';
+import { useBuildUserActions } from './hooks/use_build_user_actions';
+import { useBuilderContext } from './hooks/use_builder_context';
+import { useCommentsList } from './hooks/use_comments_list';
+
+export const UserActions = React.memo((props: UserActionTreeProps) => {
+  const {
+    currentUserProfile,
+    data: caseData,
+    statusActionButton,
+    attachActionButton,
+    userActivityQueryParams,
+    userActionsStats,
+    caseConnectors,
+    userProfiles,
+    casesConfiguration,
+  } = props;
+  const { detailName: caseId } = useCaseViewParams();
+
+  const { lastPage } = useLastPage({ userActivityQueryParams, userActionsStats });
+
+  const {
+    infiniteCaseUserActions,
+    infiniteLatestAttachments,
+    isLoadingInfiniteUserActions,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    remainingActionCount,
+  } = useUserActionsPagination({
+    userActivityQueryParams,
+    caseId: caseData.id,
+    lastPage,
+  });
+
+  const { isLoadingLastPageUserActions, lastPageUserActions, lastPageAttachments } =
+    useLastPageUserActions({
+      userActivityQueryParams,
+      caseId: caseData.id,
+      lastPage,
+    });
+
+  const { getCanAddUserComments } = useUserPermissions();
+  const shouldShowCommentEditor = getCanAddUserComments(userActivityQueryParams);
+
+  const actionsHandler = useUserActionsHandler();
+
+  const {
+    commentRefs,
+    handleManageMarkdownEditId,
+    handleManageQuote,
+    handleUpdate,
+    loadingCommentIds,
+    manageMarkdownEditIds,
+    selectedOutlineCommentId,
+    handleOutlineComment,
+    handleDeleteComment,
+  } = actionsHandler;
+
+  const builderContext = useBuilderContext({
+    caseData,
+    casesConfiguration,
+    caseConnectors,
+    userProfiles,
+    currentUserProfile,
+    manageMarkdownEditIds,
+    selectedOutlineCommentId,
+    loadingCommentIds,
+    handleOutlineComment,
+    handleDeleteComment,
+  });
+
+  const builtInfiniteActions = useBuildUserActions({
+    caseUserActions: infiniteCaseUserActions,
+    attachments: infiniteLatestAttachments,
+    ...builderContext,
+  });
+
+  const builtLastPageActions = useBuildUserActions({
+    caseUserActions: lastPageUserActions,
+    attachments: lastPageAttachments,
+    ...builderContext,
+  });
+
+  const commentEditor = useMemo(
+    () => (
+      <AddComment
+        id={NEW_COMMENT_ID}
+        caseId={caseId}
+        ref={(element) => (commentRefs.current[NEW_COMMENT_ID] = element)}
+        onCommentPosted={handleUpdate}
+        onCommentSaving={handleManageMarkdownEditId.bind(null, NEW_COMMENT_ID)}
+        showLoading={false}
+        statusActionButton={statusActionButton}
+        attachActionButton={attachActionButton}
+      />
+    ),
+    [
+      caseId,
+      handleUpdate,
+      handleManageMarkdownEditId,
+      statusActionButton,
+      attachActionButton,
+      commentRefs,
+    ]
+  );
+
+  const allComments = useCommentsList({
+    builtInfiniteActions,
+    builtLastPageActions,
+    hasNextPage,
+    remainingActionCount,
+    fetchNextPage,
+    isFetchingNextPage,
+    shouldShowCommentEditor,
+    currentUserProfile,
+    commentEditor,
+  });
+
+  return (
+    <EuiSkeletonText
+      lines={8}
+      data-test-subj="user-actions-loading"
+      isLoading={
+        isLoadingLastPageUserActions ||
+        loadingCommentIds.includes(NEW_COMMENT_ID) ||
+        isLoadingInfiniteUserActions
+      }
+    >
+      <EuiFlexItem>
+        <UserActionsList
+          comments={allComments}
+          caseData={caseData}
+          userProfiles={userProfiles}
+          commentRefs={commentRefs}
+          handleManageQuote={handleManageQuote}
+          actionsHandler={actionsHandler}
+        />
+      </EuiFlexItem>
+    </EuiSkeletonText>
+  );
+});
+
+UserActions.displayName = 'UserActions';

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.tsx
@@ -49,7 +49,6 @@ export const UserActions = React.memo((props: UserActionTreeProps) => {
   } = useUserActionsPagination({
     userActivityQueryParams,
     caseId: caseData.id,
-    lastPage,
   });
 
   const { isLoadingLastPageUserActions, lastPageUserActions, lastPageAttachments } =

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/show_more_activities.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/show_more_activities.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ShowMoreActivities } from './show_more_activities';
+
+const onClickMock = jest.fn();
+
+describe('ShowMoreActivities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly with count', () => {
+    render(<ShowMoreActivities count={5} onClick={onClickMock} />);
+
+    expect(screen.getByTestId('cases-show-more-user-actions')).toBeInTheDocument();
+    expect(screen.getByText('5 more activities')).toBeInTheDocument();
+  });
+
+  it('renders singular form for count of 1', () => {
+    render(<ShowMoreActivities count={1} onClick={onClickMock} />);
+
+    expect(screen.getByText('1 more activity')).toBeInTheDocument();
+  });
+
+  it('marks as aria-disabled when isLoading is true', () => {
+    render(<ShowMoreActivities count={5} onClick={onClickMock} isLoading={true} />);
+
+    expect(screen.getByTestId('cases-show-more-user-actions')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('calls onClick on click', async () => {
+    render(<ShowMoreActivities count={5} onClick={onClickMock} />);
+
+    await userEvent.click(screen.getByTestId('cases-show-more-user-actions'));
+    expect(onClickMock).toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/show_more_activities.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/show_more_activities.test.tsx
@@ -30,13 +30,10 @@ describe('ShowMoreActivities', () => {
     expect(screen.getByText('1 more activity')).toBeInTheDocument();
   });
 
-  it('marks as aria-disabled when isLoading is true', () => {
+  it('is disabled when isLoading is true', () => {
     render(<ShowMoreActivities count={5} onClick={onClickMock} isLoading={true} />);
 
-    expect(screen.getByTestId('cases-show-more-user-actions')).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    expect(screen.getByTestId('cases-show-more-user-actions')).toBeDisabled();
   });
 
   it('calls onClick on click', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/show_more_activities.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/show_more_activities.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, useEuiTheme } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+
+import * as i18n from './translations';
+
+interface ShowMoreActivitiesProps {
+  count: number;
+  onClick: () => void;
+  isLoading?: boolean;
+}
+
+export const ShowMoreActivities = React.memo<ShowMoreActivitiesProps>(
+  ({ count, onClick, isLoading = false }) => {
+    const { euiTheme } = useEuiTheme();
+
+    const buttonCss = useMemo(
+      () => css`
+        display: flex;
+        align-items: center;
+        width: 100%;
+        height: ${euiTheme.size.xxl};
+        padding: 0 ${euiTheme.size.m};
+        background: ${euiTheme.colors.backgroundBaseSubdued};
+        border: ${euiTheme.border.thin};
+        border-radius: ${euiTheme.border.radius.medium};
+        cursor: pointer;
+
+        &:hover {
+          background: ${euiTheme.colors.backgroundBaseDisabled};
+        }
+
+        &:disabled {
+          cursor: not-allowed;
+          opacity: 0.5;
+        }
+      `,
+      [euiTheme]
+    );
+
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={isLoading}
+        data-test-subj="cases-show-more-user-actions"
+        css={buttonCss}
+      >
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="arrowRight" size="s" color="subdued" aria-hidden={true} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s" color="subdued">
+              {i18n.MORE_ACTIVITIES(count)}
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </button>
+    );
+  }
+);
+
+ShowMoreActivities.displayName = 'ShowMoreActivities';

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/translations.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const MORE_ACTIVITIES = (count: number) =>
+  i18n.translate('xpack.cases.caseView.redesign.userActions.moreActivities', {
+    values: { count },
+    defaultMessage: '{count} more {count, plural, =1 {activity} other {activities}}',
+  });
+
+export const SHOW_MORE_ACTIVITIES_ARIA = i18n.translate(
+  'xpack.cases.caseView.redesign.userActions.showMoreActivitiesAria',
+  { defaultMessage: 'Show more activities' }
+);

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/user_actions_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/user_actions_list.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { basicCase } from '../../../containers/mock';
+import { UserActionsList } from './user_actions_list';
+import { renderWithTestingProviders } from '../../../common/mock';
+
+const actionsHandlerMock = {
+  loadingCommentIds: [],
+  selectedOutlineCommentId: '',
+  manageMarkdownEditIds: [],
+  commentRefs: { current: {} },
+  handleManageMarkdownEditId: jest.fn(),
+  handleOutlineComment: jest.fn(),
+  handleSaveComment: jest.fn(),
+  handleDeleteComment: jest.fn(),
+  handleManageQuote: jest.fn(),
+  handleUpdate: jest.fn(),
+};
+
+const defaultProps = {
+  comments: [] as React.ComponentProps<typeof UserActionsList>['comments'],
+  commentRefs: { current: {} },
+  handleManageQuote: jest.fn(),
+  caseData: basicCase,
+  userProfiles: new Map(),
+  actionsHandler: actionsHandlerMock,
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ detailName: 'case-id' }),
+}));
+
+jest.mock('../../../common/lib/kibana');
+
+describe('UserActionsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders list correctly', async () => {
+    renderWithTestingProviders(<UserActionsList {...defaultProps} />);
+
+    expect(await screen.findByTestId('user-actions-list')).toBeInTheDocument();
+  });
+
+  it('renders provided comments', async () => {
+    const comments = [
+      {
+        username: 'elastic',
+        children: <div data-test-subj="test-comment">{'Test comment'}</div>,
+      },
+    ];
+
+    renderWithTestingProviders(<UserActionsList {...defaultProps} comments={comments} />);
+
+    expect(await screen.findByTestId('test-comment')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/user_actions_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/user_actions_list.tsx
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import type { EuiCommentProps } from '@elastic/eui';
+import type { EuiCommentProps, EuiThemeComputed } from '@elastic/eui';
 import { EuiCommentList, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 
 import React, { useMemo } from 'react';
 
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { scaledMarkdownImages } from '../../utils';
 import type { CaseUI } from '../../../containers/types';
 import type { AddCommentRefObject } from '../../add_comment';
 import type { UserActionMarkdownRefObject } from '../../user_actions/markdown_form';
@@ -18,6 +20,45 @@ import type { UseUserActionsHandler } from '../../user_actions/use_user_actions_
 import { useCasesContext } from '../../cases_context/use_cases_context';
 import { CommentRenderingProvider } from '../../user_actions/comment/comment_rendering_context';
 import { useHighlightLinkedComment } from './hooks/use_highlight_linked_comment';
+
+const getCommentListCss = (euiTheme: EuiThemeComputed<{}>) => css`
+  & .userAction__comment.outlined .euiCommentEvent {
+    outline: solid 5px ${euiTheme.colors.borderBaseSubdued};
+    margin: 0.5em;
+    transition: 0.8s;
+  }
+
+  ${scaledMarkdownImages}
+
+  & .draftFooter {
+    & .euiCommentEvent__body {
+      padding: 0;
+    }
+  }
+
+  & .euiComment.isEdit {
+    & .euiCommentEvent {
+      border: none;
+      box-shadow: none;
+    }
+
+    & .euiCommentEvent__body {
+      padding: 0;
+    }
+
+    & .euiCommentEvent__header {
+      display: none;
+    }
+  }
+
+  & .comment-action.empty-comment [class*='euiCommentEvent-regular'] {
+    box-shadow: none;
+    .euiCommentEvent__header {
+      padding: ${euiTheme.size.m} ${euiTheme.size.s};
+      border-bottom: 0;
+    }
+  }
+`;
 
 export interface UserActionListProps {
   comments: EuiCommentProps[];
@@ -87,7 +128,11 @@ export const UserActionsList = React.memo(
 
     return (
       <CommentRenderingProvider value={commentRenderingContext}>
-        <EuiCommentList comments={comments} data-test-subj="user-actions-list" />
+        <EuiCommentList
+          css={getCommentListCss(euiTheme)}
+          comments={comments}
+          data-test-subj="user-actions-list"
+        />
       </CommentRenderingProvider>
     );
   }

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/user_actions_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/user_actions_list.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiCommentProps } from '@elastic/eui';
+import { EuiCommentList, useEuiTheme } from '@elastic/eui';
+
+import React, { useMemo } from 'react';
+
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import type { CaseUI } from '../../../containers/types';
+import type { AddCommentRefObject } from '../../add_comment';
+import type { UserActionMarkdownRefObject } from '../../user_actions/markdown_form';
+import type { UseUserActionsHandler } from '../../user_actions/use_user_actions_handler';
+import { useCasesContext } from '../../cases_context/use_cases_context';
+import { CommentRenderingProvider } from '../../user_actions/comment/comment_rendering_context';
+import { useHighlightLinkedComment } from './hooks/use_highlight_linked_comment';
+
+export interface UserActionListProps {
+  comments: EuiCommentProps[];
+  commentRefs: React.MutableRefObject<
+    Record<string, AddCommentRefObject | UserActionMarkdownRefObject | null | undefined>
+  >;
+  handleManageQuote: (quote: string) => void;
+  caseData: CaseUI;
+  userProfiles: Map<string, UserProfileWithAvatar>;
+  actionsHandler: UseUserActionsHandler;
+}
+
+export const UserActionsList = React.memo(
+  ({
+    comments,
+    caseData,
+    userProfiles,
+    commentRefs,
+    handleManageQuote,
+    actionsHandler,
+  }: UserActionListProps) => {
+    const { owner } = useCasesContext();
+    const { euiTheme } = useEuiTheme();
+
+    const {
+      loadingCommentIds,
+      selectedOutlineCommentId,
+      manageMarkdownEditIds,
+      handleManageMarkdownEditId,
+      handleOutlineComment,
+      handleSaveComment,
+      handleDeleteComment,
+    } = actionsHandler;
+
+    useHighlightLinkedComment(handleOutlineComment);
+
+    const commentRenderingContext = useMemo(
+      () => ({
+        appId: owner[0] ?? '',
+        caseData,
+        userProfiles,
+        commentRefs,
+        manageMarkdownEditIds,
+        selectedOutlineCommentId,
+        loadingCommentIds,
+        euiTheme,
+        handleManageMarkdownEditId,
+        handleSaveComment,
+        handleManageQuote,
+        handleDeleteComment,
+      }),
+      [
+        owner,
+        caseData,
+        userProfiles,
+        commentRefs,
+        manageMarkdownEditIds,
+        selectedOutlineCommentId,
+        loadingCommentIds,
+        euiTheme,
+        handleManageMarkdownEditId,
+        handleSaveComment,
+        handleManageQuote,
+        handleDeleteComment,
+      ]
+    );
+
+    return (
+      <CommentRenderingProvider value={commentRenderingContext}>
+        <EuiCommentList comments={comments} data-test-subj="user-actions-list" />
+      </CommentRenderingProvider>
+    );
+  }
+);
+
+UserActionsList.displayName = 'UserActionsList';


### PR DESCRIPTION
## What & Why

Scaffolds the user actions view for the Cases redesign page under `cases_redesign/user_actions/`, keeping the original view untouched. The main visible change is a new "show more activities" button that replaces the original's workaround-heavy implementation with a clean native `<button>` and Emotion styling. The redesign also improves code splitting by extracting logic into focused hooks (`useBuilderContext`, `useCommentsList`, `useBuildUserActions`, `useHighlightLinkedComment`, `useUserActionsPagination`), reducing component complexity and removing hacks from the original implementation.
<img width="1327" height="260" alt="image" src="https://github.com/user-attachments/assets/8e410296-9fa3-4acb-89d9-664a88030b23" />

## How to Test

1. Start Kibana locally, open a case with enough user actions to trigger pagination.
2. Confirm the redesign page shows the "X more activities" button between paginated sections.
3. Click it and verify additional actions load inline.
4. Confirm the original case view is completely unaffected.

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)