### PR TITLE
[maps] fix Save and return doesn't work for Maps through Visualize library

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -326,10 +326,7 @@ export class SavedMap {
         pageTitle: this._getPageTitle(),
         isByValue: this.isByValue(),
         getHasUnsavedChanges: this.hasUnsavedChanges,
-        originatingApp:
-          this.hasOriginatingApp() || this._isFromDashboardListing()
-            ? this._originatingApp
-            : undefined,
+        originatingApp: this.hasSaveAndReturnConfig() ? this._originatingApp : undefined,
         incomingBreadcrumbs: this._breadcrumbs,
         getAppNameFromId: this._getStateTransfer().getAppNameFromId,
         history,
@@ -352,16 +349,6 @@ export class SavedMap {
     return this._originatingApp ? this.getAppNameFromId(this._originatingApp) : undefined;
   }
 
-  private _isFromDashboardListing(): boolean {
-    return (
-      this._originatingApp === 'dashboards' && Boolean(this._originatingPath?.includes('/list/'))
-    );
-  }
-
-  public hasOriginatingApp(): boolean {
-    return !!this._originatingApp && !this._isFromDashboardListing();
-  }
-
   public getOriginatingPath(): string | undefined {
     return this._originatingPath;
   }
@@ -374,9 +361,10 @@ export class SavedMap {
     return this._tags;
   }
 
-  public hasSaveAndReturnConfig() {
-    const hasOriginatingApp = this.hasOriginatingApp();
-    return hasOriginatingApp;
+  public hasSaveAndReturnConfig(): boolean {
+    return Boolean(
+      this._originatingApp && this._originatingPath && !this._originatingPath.includes('/list/')
+    );
   }
 
   public getTitle(): string {
@@ -410,7 +398,7 @@ export class SavedMap {
 
   public isByValue(): boolean {
     const hasSavedObjectId = !!this.getSavedObjectId();
-    return this.hasOriginatingApp() && !hasSavedObjectId;
+    return this.hasSaveAndReturnConfig() && !hasSavedObjectId;
   }
 
   public async save({

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -363,7 +363,11 @@ export class SavedMap {
 
   public hasSaveAndReturnConfig(): boolean {
     return Boolean(
-      this._originatingApp && this._originatingPath && !this._originatingPath.includes('/list/')
+      this._originatingApp &&
+        this._originatingPath &&
+        // TODO remove this check in editors (lens does this too)
+        // instead, embeddable state transform should provide hasSaveAndReturnConfig
+        !this._originatingPath.includes('/list/')
     );
   }
 

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/top_nav_config.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/top_nav_config.tsx
@@ -89,7 +89,9 @@ export function getTopNavConfig({
     }
   );
 
-  if (savedMap.hasOriginatingApp()) {
+  const hasSaveAndReturnConfig = savedMap.hasSaveAndReturnConfig();
+
+  if (hasSaveAndReturnConfig) {
     topNavConfigs.push({
       label: i18n.translate('xpack.maps.topNav.cancel', {
         defaultMessage: 'Cancel',
@@ -107,7 +109,6 @@ export function getTopNavConfig({
   }
 
   if (getMapsCapabilities().save) {
-    const hasSaveAndReturnConfig = savedMap.hasSaveAndReturnConfig();
     const mapDescription = savedMap.getAttributes().description
       ? savedMap.getAttributes().description!
       : '';
@@ -188,7 +189,7 @@ export function getTopNavConfig({
 
         let saveModal: React.ReactElement<ShowSaveModalMinimalSaveModalProps>;
 
-        if (savedMap.hasOriginatingApp()) {
+        if (hasSaveAndReturnConfig) {
           saveModal = (
             <SavedObjectSaveModalOrigin
               {...saveModalProps}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/273690

Regression from https://github.com/elastic/kibana/pull/241795. https://github.com/elastic/kibana/pull/241795 added tabs to dashboard listing page. One tab displays the visualize listing table.

As a result of https://github.com/elastic/kibana/pull/241795, users can create a new map visualization from dashboard app visualize listing page and visualize app visualize listing page.

https://github.com/elastic/kibana/issues/273690 caused because maps opened from visualize app visualize listing page incorrectly signaled that embeddable state transfer supported "save and return". Lens avoided this problem because of custom logic in https://github.com/elastic/kibana/blob/9.4/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx#L585 and https://github.com/elastic/kibana/blob/9.4/x-pack/platform/plugins/shared/lens/public/app_plugin/app_helpers.ts#L36. This  PR solves the problem by applying the same logic from the lens application to maps application.

This fix is a short-term solution so that the problem can be resolved quickly and easily backported. Longer term, a better solution is needed so that editor applications do not need to interrogate the `originatingPath` and exclude paths with `/list/`.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->