### PR TITLE
Fleet] Fix auth_metadata_missing on elastic_agent.status_change document events

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/constants/fleet_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/constants/fleet_es_assets.ts
@@ -301,9 +301,10 @@ processors:
 
           // Some datasets are written by Kibana rather than agents.
           // Kibana is trusted to accurately report agent.id for these datasets.
-          if ((ctx?._security?.username == 'elastic/kibana' || ctx?._security?.username == 'kibana_system')
+          if (ctx?._security?.authentication_type != null
               && params?.kibana_user_allowed_datasets != null
-              && params.kibana_user_allowed_datasets.contains(ctx?.data_stream?.dataset)) {
+              && params.kibana_user_allowed_datasets.contains(ctx?.data_stream?.dataset)
+              && is_user_trusted(ctx, params.kibana_trusted_users)) {
             return "verified";
           }
 
@@ -340,6 +341,11 @@ processors:
           - username: cloud-internal-agent-server
             realm: found
           - username: elastic
+            realm: reserved
+        kibana_trusted_users:
+          - username: elastic/kibana
+            realm: _service_account
+          - username: kibana_system
             realm: reserved
         # Datasets written by Kibana (elastic/kibana user) that are allowed to bypass API key verification.
         kibana_user_allowed_datasets:

--- a/x-pack/platform/plugins/shared/fleet/server/constants/fleet_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/constants/fleet_es_assets.ts
@@ -301,7 +301,7 @@ processors:
 
           // Some datasets are written by Kibana rather than agents.
           // Kibana is trusted to accurately report agent.id for these datasets.
-          if (ctx?._security?.username == 'elastic/kibana'
+          if ((ctx?._security?.username == 'elastic/kibana' || ctx?._security?.username == 'kibana_system')
               && params?.kibana_user_allowed_datasets != null
               && params.kibana_user_allowed_datasets.contains(ctx?.data_stream?.dataset)) {
             return "verified";

--- a/x-pack/platform/plugins/shared/fleet/server/constants/fleet_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/constants/fleet_es_assets.ts
@@ -223,7 +223,7 @@ on_failure:
       value:
         - 'failed in Fleet agent event_ingested_pipeline: {{ _ingest.on_failure_message }}'`;
 
-export const FLEET_FINAL_PIPELINE_VERSION = 4;
+export const FLEET_FINAL_PIPELINE_VERSION = 5;
 
 // If the content is updated you probably need to update the FLEET_FINAL_PIPELINE_VERSION too to allow upgrade of the pipeline
 export const FLEET_FINAL_PIPELINE_CONTENT = `---
@@ -299,6 +299,14 @@ processors:
             return "missing";
           }
 
+          // Some datasets are written by Kibana rather than agents.
+          // Kibana is trusted to accurately report agent.id for these datasets.
+          if (ctx?._security?.username == 'elastic/kibana'
+              && params?.kibana_user_allowed_datasets != null
+              && params.kibana_user_allowed_datasets.contains(ctx?.data_stream?.dataset)) {
+            return "verified";
+          }
+
           // Check auth metadata from API key.
           if (ctx?._security?.authentication_type == null
               // Agents only use API keys.
@@ -333,6 +341,9 @@ processors:
             realm: found
           - username: elastic
             realm: reserved
+        # Datasets written by Kibana (elastic/kibana user) that are allowed to bypass API key verification.
+        kibana_user_allowed_datasets:
+          - elastic_agent.status_change
   - remove:
       field: _security
       ignore_missing: true

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/final_pipeline.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/final_pipeline.ts
@@ -6,10 +6,13 @@
  */
 
 import expect from '@kbn/expect';
+import { createEsClientForFtrConfig, kibanaServerTestUser } from '@kbn/test';
 import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
 
 const TEST_INDEX = 'logs-log.log-test';
+
+const AGENT_TEST_INDEX = 'logs-elastic_agent.status_change-default';
 
 const FINAL_PIPELINE_ID = '.fleet_final_pipeline-1';
 
@@ -45,6 +48,12 @@ export default function (providerContext: FtrProviderContext) {
         .set('kbn-xsrf', 'xxxx')
         .send({ force: true })
         .expect(200);
+
+      await supertest
+        .post(`/api/fleet/epm/packages/elastic_agent`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
     });
 
     after(async () => {
@@ -53,9 +62,15 @@ export default function (providerContext: FtrProviderContext) {
         .set('kbn-xsrf', 'xxxx')
         .send({ force: true })
         .expect(200);
+
+      await supertest
+        .delete(`/api/fleet/epm/packages/elastic_agent`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
       await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
       const res = await es.search({
-        index: TEST_INDEX,
+        index: [TEST_INDEX, AGENT_TEST_INDEX].join(','),
       });
 
       for (const hit of res.hits.hits) {
@@ -230,8 +245,11 @@ export default function (providerContext: FtrProviderContext) {
     ];
 
     it('For a doc written by elastic/kibana user to a kibana_user_allowed_datasets should write verified status', async () => {
-      // Mirrors what AgentStatusChangeTask writes using asInternalUser (elastic/kibana service account)
-      const res = await es.index({
+      const config = getService('config');
+      const esAsKibanaSystem = createEsClientForFtrConfig(config, {
+        authOverride: kibanaServerTestUser,
+      });
+      const res = await esAsKibanaSystem.index({
         index: 'logs-elastic_agent.status_change-default',
         document: {
           '@timestamp': '2020-01-01T09:09:00',

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/final_pipeline.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/final_pipeline.ts
@@ -82,7 +82,7 @@ export default function (providerContext: FtrProviderContext) {
       await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxxx');
       const pipelineRes = await es.ingest.getPipeline({ id: FINAL_PIPELINE_ID });
       expect(pipelineRes).to.have.property(FINAL_PIPELINE_ID);
-      expect(pipelineRes[FINAL_PIPELINE_ID].version).to.be(4);
+      expect(pipelineRes[FINAL_PIPELINE_ID].version).to.be(5);
     });
 
     it('should correctly setup the final pipeline and apply to fleet managed index template', async () => {
@@ -228,6 +228,33 @@ export default function (providerContext: FtrProviderContext) {
         event: { agent: { id: 'agent1' } },
       },
     ];
+
+    it('For a doc written by elastic/kibana user to a kibana_user_allowed_datasets should write verified status', async () => {
+      // Mirrors what AgentStatusChangeTask writes using asInternalUser (elastic/kibana service account)
+      const res = await es.index({
+        index: 'logs-elastic_agent.status_change-default',
+        document: {
+          '@timestamp': '2020-01-01T09:09:00',
+          data_stream: {
+            type: 'logs',
+            dataset: 'elastic_agent.status_change',
+            namespace: 'default',
+          },
+          agent: {
+            id: 'agent1',
+          },
+        },
+      });
+
+      const doc = await es.get({
+        id: res._id,
+        index: res._index,
+      });
+      // @ts-expect-error
+      const event = doc._source.event;
+
+      expect(event.agent_id_status).to.be('verified');
+    });
 
     for (const scenario of scenarios) {
       it(`Should write the correct event.agent_id_status for ${scenario.name}`, async () => {


### PR DESCRIPTION
## Summary

Resolve  #266222

  Fixes `event.agent_id_status: auth_metadata_missing` being set on all `logs-elastic_agent.status_change` documents.

  The `logs-elastic_agent.status_change` data stream goes through the Fleet final pipeline, which verifies that incoming documents were submitted by the agent they claim to represent (via API key metadata).
  However, status change documents are written by Kibana's internal service account (`elastic/kibana`), not by the agent itself — so the pipeline always stamped them with `event.agent_id_status:
  "auth_metadata_missing"`, which looks like a security alert to users.

  ## Changes

  The pipeline now accepts documents from `elastic/kibana` for a configurable list of datasets (`kibana_user_allowed_datasets`). When the writer is `elastic/kibana` and the document's `data_stream.dataset` is in
  that list, the pipeline returns `"verified"` directly, bypassing the API key check. `elastic_agent.status_change` is the first entry in that list.

  Pipeline version bumped `4 → 5` to trigger an upgrade on next Kibana restart.

  ## Testing

  - FTR test added to `final_pipeline.ts` asserting that a document indexed to `logs-elastic_agent.status_change-default` by the internal Kibana user gets `event.agent_id_status: "verified"` instead of
  `"auth_metadata_missing"`.

<img width="581" height="392" alt="Screenshot 2026-06-18 at 11 10 02 AM" src="https://github.com/user-attachments/assets/2532b9d6-caec-41db-9aaa-83528235ed57" />

