### PR TITLE
[alerting_v2] Remove synchronous index refresh from rule executor pipeline

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.test.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from '@kbn/core/server';
-import type { DeeplyMockedApi } from '@kbn/core-elasticsearch-client-server-mocks';
 import { RuleExecutionPipeline } from './execution_pipeline';
 import type { RulePipelineState } from './types';
 import type { RuleExecutionMiddleware } from './middleware';
@@ -14,19 +12,12 @@ import { createLoggerService } from '../services/logger_service/logger_service.m
 import { pipeStream } from './stream_utils';
 import {
   createRuleExecutionPipelineInput,
-  createMockEsClient,
   createMockStep,
   createQueryPayload,
   createRuleResponse,
 } from './test_utils';
 
 describe('RuleExecutionPipeline', () => {
-  let mockEsClient: DeeplyMockedApi<ElasticsearchClient>;
-
-  beforeEach(() => {
-    mockEsClient = createMockEsClient();
-  });
-
   describe('execute', () => {
     it('executes all steps in order when all continue', async () => {
       const { loggerService } = createLoggerService();
@@ -55,7 +46,6 @@ describe('RuleExecutionPipeline', () => {
 
       const pipeline = new RuleExecutionPipeline(
         loggerService,
-        mockEsClient,
         [step1, step2, step3],
         []
       );
@@ -95,7 +85,6 @@ describe('RuleExecutionPipeline', () => {
 
       const pipeline = new RuleExecutionPipeline(
         loggerService,
-        mockEsClient,
         [step1, step2, step3],
         []
       );
@@ -136,7 +125,6 @@ describe('RuleExecutionPipeline', () => {
 
       const pipeline = new RuleExecutionPipeline(
         loggerService,
-        mockEsClient,
         [step1, step2, step3],
         []
       );
@@ -178,7 +166,7 @@ describe('RuleExecutionPipeline', () => {
         pipeStream(input, (state) => ({ type: 'continue', state }))
       );
 
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [step1, step2], []);
+      const pipeline = new RuleExecutionPipeline(loggerService, [step1, step2], []);
       const input = createRuleExecutionPipelineInput();
 
       await expect(pipeline.execute(input)).rejects.toThrow('Step failed');
@@ -186,7 +174,7 @@ describe('RuleExecutionPipeline', () => {
 
     it('returns empty completed result when no steps', async () => {
       const { loggerService } = createLoggerService();
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [], []);
+      const pipeline = new RuleExecutionPipeline(loggerService, [], []);
       const input = createRuleExecutionPipelineInput();
 
       const result = await pipeline.execute(input);
@@ -237,7 +225,6 @@ describe('RuleExecutionPipeline', () => {
 
       const pipeline = new RuleExecutionPipeline(
         loggerService,
-        mockEsClient,
         [step1],
         [middleware1, middleware2]
       );
@@ -269,7 +256,7 @@ describe('RuleExecutionPipeline', () => {
         })
       );
 
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [step], []);
+      const pipeline = new RuleExecutionPipeline(loggerService, [step], []);
       const input = createRuleExecutionPipelineInput();
 
       const result = await pipeline.execute(input);
@@ -289,7 +276,7 @@ describe('RuleExecutionPipeline', () => {
         })
       );
 
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [step], []);
+      const pipeline = new RuleExecutionPipeline(loggerService, [step], []);
       const input = createRuleExecutionPipelineInput({ abortSignal: abortController.signal });
 
       await pipeline.execute(input);
@@ -322,7 +309,6 @@ describe('RuleExecutionPipeline', () => {
 
       const pipeline = new RuleExecutionPipeline(
         loggerService,
-        mockEsClient,
         [step1],
         [errorMiddleware]
       );
@@ -332,55 +318,5 @@ describe('RuleExecutionPipeline', () => {
       expect(errorHandlerCalled).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('refreshes indices after all steps complete successfully', async () => {
-      const { loggerService } = createLoggerService();
-
-      const step = createMockStep('step1', (input) =>
-        pipeStream(input, (state) => ({ type: 'continue', state }))
-      );
-
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [step], []);
-      const input = createRuleExecutionPipelineInput();
-
-      await pipeline.execute(input);
-
-      expect(mockEsClient.indices.refresh).toHaveBeenCalledTimes(1);
-      expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({
-        index: '.rule-events',
-      });
-    });
-
-    it('does not throw when index refresh fails', async () => {
-      const { loggerService, mockLogger } = createLoggerService();
-      mockEsClient.indices.refresh.mockRejectedValue(new Error('Refresh failed'));
-
-      const step = createMockStep('step1', (input) =>
-        pipeStream(input, (state) => ({ type: 'continue', state }))
-      );
-
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [step], []);
-      const input = createRuleExecutionPipelineInput();
-
-      const result = await pipeline.execute(input);
-
-      expect(result.completed).toBe(true);
-      expect(mockLogger.error).toHaveBeenCalled();
-    });
-
-    it('does not refresh indices when pipeline halts', async () => {
-      const { loggerService } = createLoggerService();
-
-      const step = createMockStep('step1', (input) =>
-        pipeStream(input, (state) => ({ type: 'halt', reason: 'rule_disabled', state }))
-      );
-
-      const pipeline = new RuleExecutionPipeline(loggerService, mockEsClient, [step], []);
-      const input = createRuleExecutionPipelineInput();
-
-      const result = await pipeline.execute(input);
-
-      expect(result.completed).toBe(false);
-      expect(mockEsClient.indices.refresh).not.toHaveBeenCalled();
-    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.test.ts
@@ -44,11 +44,7 @@ describe('RuleExecutionPipeline', () => {
         })
       );
 
-      const pipeline = new RuleExecutionPipeline(
-        loggerService,
-        [step1, step2, step3],
-        []
-      );
+      const pipeline = new RuleExecutionPipeline(loggerService, [step1, step2, step3], []);
       const input = createRuleExecutionPipelineInput();
 
       const result = await pipeline.execute(input);
@@ -83,11 +79,7 @@ describe('RuleExecutionPipeline', () => {
         })
       );
 
-      const pipeline = new RuleExecutionPipeline(
-        loggerService,
-        [step1, step2, step3],
-        []
-      );
+      const pipeline = new RuleExecutionPipeline(loggerService, [step1, step2, step3], []);
       const input = createRuleExecutionPipelineInput();
 
       const result = await pipeline.execute(input);
@@ -123,11 +115,7 @@ describe('RuleExecutionPipeline', () => {
         })
       );
 
-      const pipeline = new RuleExecutionPipeline(
-        loggerService,
-        [step1, step2, step3],
-        []
-      );
+      const pipeline = new RuleExecutionPipeline(loggerService, [step1, step2, step3], []);
       const input = createRuleExecutionPipelineInput();
 
       const result = await pipeline.execute(input);
@@ -307,16 +295,11 @@ describe('RuleExecutionPipeline', () => {
         })
       );
 
-      const pipeline = new RuleExecutionPipeline(
-        loggerService,
-        [step1],
-        [errorMiddleware]
-      );
+      const pipeline = new RuleExecutionPipeline(loggerService, [step1], [errorMiddleware]);
       const input = createRuleExecutionPipelineInput();
 
       await expect(pipeline.execute(input)).rejects.toThrow('Step error');
       expect(errorHandlerCalled).toHaveBeenCalledWith(expect.any(Error));
     });
-
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execution_pipeline.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from '@kbn/core/server';
 import { inject, injectable, multiInject } from 'inversify';
 import type {
   RuleExecutionInput,
@@ -20,8 +19,6 @@ import {
   LoggerServiceToken,
   type LoggerServiceContract,
 } from '../services/logger_service/logger_service';
-import { EsServiceInternalToken } from '../services/es_service/tokens';
-import { ALERT_EVENTS_DATA_STREAM } from '../../resources/datastreams/alert_events';
 import { createExecutionContext } from '../execution_context';
 
 /**
@@ -49,7 +46,6 @@ export interface RuleExecutionPipelineContract {
 export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
   constructor(
     @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
-    @inject(EsServiceInternalToken) private readonly esClient: ElasticsearchClient,
     @multiInject(RuleExecutionStepsToken) private readonly steps: RuleExecutionStep[],
     @multiInject(RuleExecutionMiddlewaresToken)
     private readonly middlewares: RuleExecutionMiddleware[]
@@ -91,29 +87,10 @@ export class RuleExecutionPipeline implements RuleExecutionPipelineContract {
       }
     }
 
-    await this.refreshIndices();
-
     return {
       completed: true,
       finalState: pipelineState,
     };
-  }
-
-  /**
-   * Refreshes write indices once after the entire stream has been consumed,
-   * so documents written with `refresh: false` become searchable.
-   * Failures are logged but never propagate — the data is already persisted.
-   */
-  private async refreshIndices(): Promise<void> {
-    try {
-      await this.esClient.indices.refresh({ index: ALERT_EVENTS_DATA_STREAM });
-    } catch (error) {
-      this.logger.error({
-        error,
-        code: 'INDEX_REFRESH_ERROR',
-        type: 'RuleExecutionPipelineError',
-      });
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Removes the synchronous `GET /.rule-events/_refresh` call that was serializing every rule execution in the alerting v2 pipeline.

**Root cause:** `execution_pipeline.ts` called `this.esClient.indices.refresh({ index: '.rule-events' })` after each execution. Under 400 concurrent rules, these refreshes queue up serially — APM traces showed the refresh taking **4,173 ms out of 4,574 ms total** (91%) per execution.

**Why it's safe to remove:** The dispatcher (`fetch_episodes_step.ts`) uses a 10-minute lookback window (`LOOKBACK_WINDOW_MINUTES = 10`) from `previousStartedAt` and runs every 5 seconds. It never reads events written in the current execution cycle, so the default Elasticsearch 1-second `refresh_interval` is more than sufficient.

**Changes:**
- Removed `refreshIndices()` call and method from `RuleExecutionPipeline`
- Removed injected `ElasticsearchClient` dependency from the constructor (no longer needed)
- Removed now-obsolete refresh tests from `execution_pipeline.test.ts`

## Test plan

- [x] Unit tests pass (`execution_pipeline.test.ts` — 9 tests)
- [ ] Serverless perf test: 400 rules × 15 min, expect avg exec time < 1s (blocked on deployment of this fix to QA)

## Context

Part of [rna-program#381](https://github.com/elastic/rna-program/issues/381) — alerting v2 rule executor performance testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)