### PR TITLE
[8.19] [UII] Avoid decrypting all outputs during Fleet setup (#273848)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/output.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/output.test.ts
@@ -526,6 +526,36 @@ describe('Output Service', () => {
         );
       });
 
+      it('should set preset: balanced by default when creating a new remote ES output', async () => {
+        const soClient = getMockedSoClient({});
+        mockedAppContextService.getEncryptedSavedObjectsSetup.mockReturnValue({
+          canEncrypt: true,
+        } as any);
+
+        await outputService.create(
+          soClient,
+          esClientMock,
+          {
+            is_default: false,
+            is_default_monitoring: false,
+            name: 'Test',
+            type: 'remote_elasticsearch',
+          },
+          {
+            id: 'output-1',
+          }
+        );
+
+        expect(soClient.create).toBeCalledWith(
+          OUTPUT_SAVED_OBJECT_TYPE,
+          // Preset should be inferred as balanced if not provided
+          expect.objectContaining({
+            preset: 'balanced',
+          }),
+          expect.anything()
+        );
+      });
+
       it('should set preset: custom when config_yaml contains a reserved key', async () => {
         const soClient = getMockedSoClient({});
 
@@ -2201,6 +2231,7 @@ describe('Output Service', () => {
       expect(soClient.update).toBeCalledWith(expect.anything(), expect.anything(), {
         type: 'remote_elasticsearch',
         service_token: null,
+        preset: 'balanced',
       });
     });
 
@@ -2376,6 +2407,17 @@ describe('Output Service', () => {
     });
   });
 
+  describe('ensureDefaultOutput', () => {
+    it('returns the existing default output via targeted queries without creating a new one', async () => {
+      const soClient = getMockedSoClient({ defaultOutputId: 'existing-default-output' });
+
+      const output = await outputService.ensureDefaultOutput(soClient, esClientMock);
+
+      expect(output.id).toEqual('existing-default-output');
+      expect(soClient.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getDefaultDataOutputId', () => {
     it('work with a predefined id', async () => {
       const soClient = getMockedSoClient({
@@ -2544,66 +2586,62 @@ describe('Output Service', () => {
   });
 
   describe('backfillAllOutputPresets', () => {
-    it('should update non-preconfigured output', async () => {
+    beforeEach(() => {
+      mockedAgentPolicyService.bumpAllAgentPoliciesForOutput.mockClear();
+    });
+
+    it('backfills the preset for ES outputs that are missing one without decrypting all outputs', async () => {
       mockedPackagePolicyService.list.mockResolvedValue({ items: [] } as any);
       const soClient = getMockedSoClient({});
-
       soClient.find.mockResolvedValue({
+        page: 1,
+        per_page: 1,
+        total: 1,
         saved_objects: [
           {
-            ...mockOutputSO('non-preconfigured-output', {
+            ...mockOutputSO('output-without-preset', {
               is_preconfigured: false,
               type: 'elasticsearch',
             }),
             score: 0,
           },
         ],
-        total: 1,
-        per_page: 1,
-        page: 1,
       });
 
-      soClient.get.mockResolvedValue({
-        ...mockOutputSO('non-preconfigured-output', {
-          is_preconfigured: false,
-          type: 'elasticsearch',
-        }),
-      });
+      await expect(
+        outputService.backfillAllOutputPresets(soClient, esClientMock)
+      ).resolves.not.toThrow();
 
-      const promise = outputService.backfillAllOutputPresets(soClient, esClientMock);
-
-      await expect(promise).resolves.not.toThrow();
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: OUTPUT_SAVED_OBJECT_TYPE,
+          filter: expect.stringContaining('not ingest-outputs.attributes.preset:*'),
+        })
+      );
+      expect(soClient.update).toHaveBeenCalledWith(
+        OUTPUT_SAVED_OBJECT_TYPE,
+        outputIdToUuid('output-without-preset'),
+        expect.objectContaining({ preset: 'balanced' })
+      );
+      expect(mockedAgentPolicyService.bumpAllAgentPoliciesForOutput).toHaveBeenCalled();
     });
 
-    it('should update preconfigured output', async () => {
+    it('exits early without updating anything when no outputs are missing a preset', async () => {
       mockedPackagePolicyService.list.mockResolvedValue({ items: [] } as any);
       const soClient = getMockedSoClient({});
-
       soClient.find.mockResolvedValue({
-        saved_objects: [
-          {
-            ...mockOutputSO('preconfigured-output', {
-              is_preconfigured: true,
-              type: 'elasticsearch',
-            }),
-            score: 0,
-          },
-        ],
-        total: 1,
-        per_page: 1,
         page: 1,
+        per_page: 1,
+        total: 0,
+        saved_objects: [],
       });
 
-      soClient.get.mockResolvedValue({
-        ...mockOutputSO('preconfigured-output', {
-          is_preconfigured: true,
-          type: 'elasticsearch',
-        }),
-      });
+      await expect(
+        outputService.backfillAllOutputPresets(soClient, esClientMock)
+      ).resolves.not.toThrow();
 
-      const promise = outputService.backfillAllOutputPresets(soClient, esClientMock);
-
-      await expect(promise).resolves.not.toThrow();
+      expect(soClient.update).not.toHaveBeenCalled();
+      expect(mockedAgentPolicyService.bumpAllAgentPoliciesForOutput).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/output.ts
@@ -474,17 +474,21 @@ class OutputService {
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient
   ) {
-    const outputs = await this.list(soClient);
+    // Query the default outputs directly to avoid decrypting every output in the cluster.
+    const [defaultDataOutputs, defaultMonitoringOutputs] = await Promise.all([
+      this._getDefaultDataOutputsSO(),
+      this._getDefaultMonitoringOutputsSO(soClient),
+    ]);
 
-    const defaultOutput = outputs.items.find((o) => o.is_default);
-    const defaultMonitoringOutput = outputs.items.find((o) => o.is_default_monitoring);
+    const defaultOutput = defaultDataOutputs.saved_objects[0];
+    const hasDefaultMonitoringOutput = defaultMonitoringOutputs.saved_objects.length > 0;
 
     if (!defaultOutput) {
       const newDefaultOutput = {
         ...DEFAULT_OUTPUT,
         hosts: this.getDefaultESHosts(),
         ca_sha256: appContextService.getConfig()!.agents.elasticsearch.ca_sha256,
-        is_default_monitoring: !defaultMonitoringOutput,
+        is_default_monitoring: !hasDefaultMonitoringOutput,
       } as NewOutput;
 
       return await this.create(soClient, esClient, newDefaultOutput, {
@@ -493,7 +497,7 @@ class OutputService {
       });
     }
 
-    return defaultOutput;
+    return outputSavedObjectToOutput(defaultOutput);
   }
 
   public getDefaultESHosts(): string[] {
@@ -626,7 +630,7 @@ class OutputService {
       data.shipper = null;
     }
 
-    if (!data.preset && data.type === outputType.Elasticsearch) {
+    if (!data.preset && outputTypeSupportPresets(data.type)) {
       data.preset = getDefaultPresetForEsOutput(data.config_yaml ?? '', load);
     }
 
@@ -1098,7 +1102,7 @@ class OutputService {
       }
     }
 
-    if (!data.preset && data.type === outputType.Elasticsearch) {
+    if (!data.preset && data.type && outputTypeSupportPresets(data.type)) {
       updateData.preset = getDefaultPresetForEsOutput(data.config_yaml ?? '', load);
     }
 
@@ -1180,10 +1184,31 @@ class OutputService {
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient
   ) {
-    const outputs = await this.list(soClient);
+    // Only ES/remote-ES outputs missing a preset need backfilling. Query for just those to avoid
+    // decrypting every output, and bail out early when there are none.
+    const outputsWithoutPreset = await this.encryptedSoClient.find<OutputSOAttributes>({
+      type: OUTPUT_SAVED_OBJECT_TYPE,
+      perPage: SO_SEARCH_LIMIT,
+      filter:
+        `(${OUTPUT_SAVED_OBJECT_TYPE}.attributes.type:${outputType.Elasticsearch} or ` +
+        `${OUTPUT_SAVED_OBJECT_TYPE}.attributes.type:${outputType.RemoteElasticsearch}) and ` +
+        `not ${OUTPUT_SAVED_OBJECT_TYPE}.attributes.preset:*`,
+    });
+
+    if (!outputsWithoutPreset.saved_objects.length) {
+      return;
+    }
+
+    for (const output of outputsWithoutPreset.saved_objects) {
+      auditLoggingService.writeCustomSoAuditLog({
+        action: 'get',
+        id: output.id,
+        savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
+      });
+    }
 
     await pMap(
-      outputs.items.filter((output) => outputTypeSupportPresets(output.type) && !output.preset),
+      outputsWithoutPreset.saved_objects.map<Output>(outputSavedObjectToOutput),
       async (output) => {
         const preset = getDefaultPresetForEsOutput(output.config_yaml ?? '', load);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[UII] Avoid decrypting all outputs during Fleet setup (#273848)](https://github.com/elastic/kibana/pull/273848)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-06-18T15:50:29Z","message":"[UII] Avoid decrypting all outputs during Fleet setup (#273848)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/273373\n  \n`POST /api/fleet/setup` fetches and decrypts **every** output saved\nobject via `outputService.list()` when it runs. This means its response\ntime scales linearly with the total number of configured outputs.\n\nThis PR:\n1. Replaces `list()` usage in `ensureDefaultOutput()` with the targeted,\nnon-decrypting `_getDefaultDataOutputsSO()` and\n`_getDefaultMonitoringOutputsSO()` queries. Only the default outputs (at\nmost one each) are read, and they aren't decrypted.\n\n2. Replaces `list()` usage in `backfillAllOutputPresets()` with a single\nnon-decrypting `find` query filtered to ES/remote-ES outputs missing a\npreset. The per-output `update` still decrypts, but only for the handful\nof outputs that actually need backfill.\n\n3. Output service `create()` and `update()` only assigned default\npresets to `elasticsearch` outputs, but preset backfill method above\nalso executes on `remote_elasticsearch` outputs. Fixed the condition\nhere so that both types get presets on create/update, mitigating how\noften the backfill actually has to run.\n\n## Release note\nImproved `POST /api/fleet/setup` performance for deployments with a\nlarge number of configured outputs by no longer decrypting every output\non each call.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c669b172beae119c12d10f2910217d6a39f8c649","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:all-open","v9.5.0"],"title":"[UII] Avoid decrypting all outputs during Fleet setup","number":273848,"url":"https://github.com/elastic/kibana/pull/273848","mergeCommit":{"message":"[UII] Avoid decrypting all outputs during Fleet setup (#273848)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/273373\n  \n`POST /api/fleet/setup` fetches and decrypts **every** output saved\nobject via `outputService.list()` when it runs. This means its response\ntime scales linearly with the total number of configured outputs.\n\nThis PR:\n1. Replaces `list()` usage in `ensureDefaultOutput()` with the targeted,\nnon-decrypting `_getDefaultDataOutputsSO()` and\n`_getDefaultMonitoringOutputsSO()` queries. Only the default outputs (at\nmost one each) are read, and they aren't decrypted.\n\n2. Replaces `list()` usage in `backfillAllOutputPresets()` with a single\nnon-decrypting `find` query filtered to ES/remote-ES outputs missing a\npreset. The per-output `update` still decrypts, but only for the handful\nof outputs that actually need backfill.\n\n3. Output service `create()` and `update()` only assigned default\npresets to `elasticsearch` outputs, but preset backfill method above\nalso executes on `remote_elasticsearch` outputs. Fixed the condition\nhere so that both types get presets on create/update, mitigating how\noften the backfill actually has to run.\n\n## Release note\nImproved `POST /api/fleet/setup` performance for deployments with a\nlarge number of configured outputs by no longer decrypting every output\non each call.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c669b172beae119c12d10f2910217d6a39f8c649"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273848","number":273848,"mergeCommit":{"message":"[UII] Avoid decrypting all outputs during Fleet setup (#273848)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/273373\n  \n`POST /api/fleet/setup` fetches and decrypts **every** output saved\nobject via `outputService.list()` when it runs. This means its response\ntime scales linearly with the total number of configured outputs.\n\nThis PR:\n1. Replaces `list()` usage in `ensureDefaultOutput()` with the targeted,\nnon-decrypting `_getDefaultDataOutputsSO()` and\n`_getDefaultMonitoringOutputsSO()` queries. Only the default outputs (at\nmost one each) are read, and they aren't decrypted.\n\n2. Replaces `list()` usage in `backfillAllOutputPresets()` with a single\nnon-decrypting `find` query filtered to ES/remote-ES outputs missing a\npreset. The per-output `update` still decrypts, but only for the handful\nof outputs that actually need backfill.\n\n3. Output service `create()` and `update()` only assigned default\npresets to `elasticsearch` outputs, but preset backfill method above\nalso executes on `remote_elasticsearch` outputs. Fixed the condition\nhere so that both types get presets on create/update, mitigating how\noften the backfill actually has to run.\n\n## Release note\nImproved `POST /api/fleet/setup` performance for deployments with a\nlarge number of configured outputs by no longer decrypting every output\non each call.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c669b172beae119c12d10f2910217d6a39f8c649"}}]}] BACKPORT-->