### PR TITLE
[8.19] [UII] Add callout when deleting Fleet Server integration from a policy (#273850)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { act, fireEvent } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 
 import { EuiContextMenuItem } from '@elastic/eui';
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
@@ -11,7 +11,7 @@ import { act, fireEvent } from '@testing-library/react';
 
 import { EuiContextMenuItem } from '@elastic/eui';
 
-import type { AgentPolicy, PackagePolicy } from '../types';
+import type { AgentPolicy, PackagePolicy, PackagePolicyPackage } from '../types';
 import { createIntegrationsTestRendererMock } from '../mock';
 
 import { sendGetAgents, useMultipleAgentPolicies } from '../hooks';
@@ -42,14 +42,19 @@ const sendGetAgentsMock = sendGetAgents as jest.MockedFunction<typeof sendGetAge
 function renderMenu({
   agentPolicies,
   packagePolicyIds,
+  packagePolicyPackage,
 }: {
   agentPolicies: AgentPolicy[];
   packagePolicyIds: string[];
+  packagePolicyPackage?: PackagePolicyPackage;
 }) {
   const renderer = createIntegrationsTestRendererMock();
 
   const utils = renderer.render(
-    <PackagePolicyDeleteProvider agentPolicies={agentPolicies}>
+    <PackagePolicyDeleteProvider
+      agentPolicies={agentPolicies}
+      packagePolicyPackage={packagePolicyPackage}
+    >
       {(deletePackagePoliciesPrompt) => {
         return (
           <EuiContextMenuItem
@@ -256,5 +261,66 @@ describe('PackagePolicyDeleteProvider', () => {
       utils.getByText('This action can not be undone. Are you sure you wish to continue?')
     ).toBeInTheDocument();
     expect(utils.getAllByText(/integration will stop data ingestion./).length).toBe(1);
+  });
+
+  it('When deleting the Fleet Server integration show a specific warning', async () => {
+    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: false });
+    sendGetAgentsMock.mockResolvedValue({
+      data: { statusSummary: {}, items: [], total: 0 },
+    } as any);
+    const agentPolicies = createMockAgentPolicies();
+    const { utils } = renderMenu({
+      agentPolicies,
+      packagePolicyIds: ['integration-0001'],
+      packagePolicyPackage: { name: 'fleet_server' } as PackagePolicyPackage,
+    });
+    const button = utils.getByTestId('deleteIntegrationBtn');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(utils.getByTestId('fleetServerDeleteCallOut').textContent).toContain(
+        'will lose their connection to Fleet'
+      );
+    });
+  });
+
+  it('Shows the Fleet Server warning even when multiple agent policies are present', async () => {
+    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: true });
+    sendGetAgentsMock.mockResolvedValue({
+      data: { statusSummary: {}, items: [], total: 0 },
+    } as any);
+    const agentPolicies = createMockAgentPolicies(undefined, true);
+    const { utils } = renderMenu({
+      agentPolicies,
+      packagePolicyIds: ['integration-0001'],
+      packagePolicyPackage: { name: 'fleet_server' } as PackagePolicyPackage,
+    });
+    const button = utils.getByTestId('deleteIntegrationBtn');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(utils.getByTestId('fleetServerDeleteCallOut')).toBeInTheDocument();
+      expect(utils.getByTestId('sharedAgentPolicyCallOut')).toBeInTheDocument();
+    });
+  });
+
+  it('Does not show the Fleet Server warning when deleting a non-Fleet Server integration', async () => {
+    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: false });
+    sendGetAgentsMock.mockResolvedValue({
+      data: { statusSummary: {}, items: [], total: 0 },
+    } as any);
+    const agentPolicies = createMockAgentPolicies();
+    const { utils } = renderMenu({
+      agentPolicies,
+      packagePolicyIds: ['integration-0001'],
+      packagePolicyPackage: { name: 'nginx' } as PackagePolicyPackage,
+    });
+    const button = utils.getByTestId('deleteIntegrationBtn');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(utils.getByTestId('confirmModalBodyText')).toBeInTheDocument();
+    });
+    expect(utils.queryByTestId('fleetServerDeleteCallOut')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.test.tsx
@@ -274,7 +274,7 @@ describe('PackagePolicyDeleteProvider', () => {
       packagePolicyIds: ['integration-0001'],
       packagePolicyPackage: { name: 'fleet_server' } as PackagePolicyPackage,
     });
-    const button = utils.getByTestId('deleteIntegrationBtn');
+    const button = utils.getByRole('button');
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -295,12 +295,14 @@ describe('PackagePolicyDeleteProvider', () => {
       packagePolicyIds: ['integration-0001'],
       packagePolicyPackage: { name: 'fleet_server' } as PackagePolicyPackage,
     });
-    const button = utils.getByTestId('deleteIntegrationBtn');
+    const button = utils.getByRole('button');
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(utils.getByTestId('fleetServerDeleteCallOut')).toBeInTheDocument();
-      expect(utils.getByTestId('sharedAgentPolicyCallOut')).toBeInTheDocument();
+      expect(
+        utils.getByText('This integration is shared by multiple agent policies.')
+      ).toBeInTheDocument();
     });
   });
 
@@ -315,7 +317,7 @@ describe('PackagePolicyDeleteProvider', () => {
       packagePolicyIds: ['integration-0001'],
       packagePolicyPackage: { name: 'nginx' } as PackagePolicyPackage,
     });
-    const button = utils.getByTestId('deleteIntegrationBtn');
+    const button = utils.getByRole('button');
     fireEvent.click(button);
 
     await waitFor(() => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
@@ -18,11 +18,12 @@ import {
   sendGetAgents,
   useMultipleAgentPolicies,
 } from '../hooks';
-import { AGENTS_PREFIX } from '../../common/constants';
-import type { AgentPolicy } from '../types';
+import { AGENTS_PREFIX, FLEET_SERVER_PACKAGE } from '../../common/constants';
+import type { AgentPolicy, PackagePolicyPackage } from '../types';
 
 interface Props {
   agentPolicies?: AgentPolicy[];
+  packagePolicyPackage?: PackagePolicyPackage;
   children: (deletePackagePoliciesPrompt: DeletePackagePoliciesPrompt) => React.ReactElement;
 }
 
@@ -35,6 +36,7 @@ type OnSuccessCallback = (packagePoliciesDeleted: string[]) => void;
 
 export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
   agentPolicies,
+  packagePolicyPackage,
   children,
 }) => {
   const { notifications } = useStartServices();
@@ -61,6 +63,8 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
 
   const hasMultipleAgentPolicies =
     canUseMultipleAgentPolicies && agentPolicies && agentPolicies.length > 1;
+
+  const isDeletingFleetServer = packagePolicyPackage?.name === FLEET_SERVER_PACKAGE;
 
   const fetchAgentsCount = useMemo(
     () => async () => {
@@ -236,6 +240,28 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
         buttonColor="danger"
         confirmButtonDisabled={isLoading || isLoadingAgentsCount}
       >
+        {isDeletingFleetServer && (
+          <>
+            <EuiCallOut
+              announceOnMount={false}
+              color="danger"
+              iconType="warning"
+              title={
+                <FormattedMessage
+                  id="xpack.fleet.deletePackagePolicy.confirmModal.fleetServerWarningTitle"
+                  defaultMessage="This may disconnect agents from Fleet"
+                />
+              }
+              data-test-subj="fleetServerDeleteCallOut"
+            >
+              <FormattedMessage
+                id="xpack.fleet.deletePackagePolicy.confirmModal.fleetServerWarningMessage"
+                defaultMessage="If this policy is assigned to any Fleet Servers, deleting the Fleet Server integration will stop them from running. Agents that depend on those Fleet Servers will lose their connection to Fleet — you won't be able to manage them or send policy updates until you re-enroll each agent individually."
+              />
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
         {(hasMultipleAgentPolicies || isShared) && (
           <>
             <EuiCallOut

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_delete_provider.tsx
@@ -243,7 +243,6 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
         {isDeletingFleetServer && (
           <>
             <EuiCallOut
-              announceOnMount={false}
               color="danger"
               iconType="warning"
               title={


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[UII] Add callout when deleting Fleet Server integration from a policy (#273850)](https://github.com/elastic/kibana/pull/273850)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-06-18T16:44:24Z","message":"[UII] Add callout when deleting Fleet Server integration from a policy (#273850)\n\n## Summary\n\nResolves https://github.com/elastic/ingest-dev/issues/7825.\n\nAdd a callout to the confirmation modal for removing Fleet Server\nintegration:\n\n<img width=\"1254\" height=\"746\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/853b340c-e470-4202-88be-cd080afb762a\"\n/>\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Visha Angelova <91186315+vishaangelova@users.noreply.github.com>","sha":"a8f9d037b1602a5fbbdc45637b5409b7cf8dcaca","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:all-open","v9.5.0"],"title":"[UII] Add callout when deleting Fleet Server integration from a policy","number":273850,"url":"https://github.com/elastic/kibana/pull/273850","mergeCommit":{"message":"[UII] Add callout when deleting Fleet Server integration from a policy (#273850)\n\n## Summary\n\nResolves https://github.com/elastic/ingest-dev/issues/7825.\n\nAdd a callout to the confirmation modal for removing Fleet Server\nintegration:\n\n<img width=\"1254\" height=\"746\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/853b340c-e470-4202-88be-cd080afb762a\"\n/>\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Visha Angelova <91186315+vishaangelova@users.noreply.github.com>","sha":"a8f9d037b1602a5fbbdc45637b5409b7cf8dcaca"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273850","number":273850,"mergeCommit":{"message":"[UII] Add callout when deleting Fleet Server integration from a policy (#273850)\n\n## Summary\n\nResolves https://github.com/elastic/ingest-dev/issues/7825.\n\nAdd a callout to the confirmation modal for removing Fleet Server\nintegration:\n\n<img width=\"1254\" height=\"746\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/853b340c-e470-4202-88be-cd080afb762a\"\n/>\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Visha Angelova <91186315+vishaangelova@users.noreply.github.com>","sha":"a8f9d037b1602a5fbbdc45637b5409b7cf8dcaca"}},{"url":"https://github.com/elastic/kibana/pull/274031","number":274031,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/274032","number":274032,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->