### PR TITLE
[Inference UI] Fix Claude Sonnet 4.6 Spam issue

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_eis_models.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_eis_models.ts
@@ -6,13 +6,16 @@
  */
 
 import { useMemo } from 'react';
-import { isEisEndpoint } from '../utils/eis_utils';
+import { isEisEndpoint, isHiddenEisEndpoint } from '../utils/eis_utils';
 import { useQueryInferenceEndpoints } from './use_inference_endpoints';
 
 export const useEisModels = () => {
   const { data: allEndpoints, ...rest } = useQueryInferenceEndpoints();
 
-  const data = useMemo(() => allEndpoints?.filter(isEisEndpoint), [allEndpoints]);
+  const data = useMemo(
+    () => allEndpoints?.filter(isEisEndpoint).filter((ep) => !isHiddenEisEndpoint(ep)),
+    [allEndpoints]
+  );
 
   return { data, ...rest };
 };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/eis_utils.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/eis_utils.ts
@@ -23,6 +23,13 @@ export type EisInferenceEndpoint = InferenceAPIConfigResponse & {
 export const isEisEndpoint = (ep: InferenceAPIConfigResponse): ep is EisInferenceEndpoint =>
   ep.service === 'elastic';
 
+// Inference ID prefixes for internal Elastic endpoints kept for backwards
+// compatibility that must not be surfaced in the UI.
+const HIDDEN_EIS_INFERENCE_ID_PREFIXES = ['.gp-llm-v2', '.rainbow-sprinkles'];
+
+export const isHiddenEisEndpoint = (ep: InferenceAPIConfigResponse): boolean =>
+  HIDDEN_EIS_INFERENCE_ID_PREFIXES.some((prefix) => ep.inference_id.startsWith(prefix));
+
 export type TaskTypeCategory = 'LLM' | 'Embedding' | 'Rerank';
 
 export const TASK_TYPE_CATEGORY: Partial<Record<InferenceTaskType, TaskTypeCategory>> = {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/dynamic_connectors.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/dynamic_connectors.test.ts
@@ -226,7 +226,7 @@ describe('DynamicConnectorsPoller', () => {
       await wait();
 
       expect(mockClient.inference.get).toHaveBeenCalledTimes(2);
-      expect(mockActions.registerDynamicConnector).toHaveBeenCalledTimes(13);
+      expect(mockActions.registerDynamicConnector).toHaveBeenCalledTimes(11);
       expect(mockLogger.error).toHaveBeenCalledTimes(2);
     })
   );

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.test.ts
@@ -89,6 +89,30 @@ describe('filterPreconfiguredEndpoints', () => {
     expect(filterPreconfiguredEndpoints([])).toEqual([]);
   });
 
+  it('filters out endpoints with inference IDs starting with .gp-llm-v2', () => {
+    const endpoint = makeEndpoint({ inference_id: '.gp-llm-v2-chat_completion' });
+    expect(filterPreconfiguredEndpoints([endpoint])).toEqual([]);
+  });
+
+  it('filters out all .gp-llm-v2 variant inference IDs', () => {
+    const endpoint1 = makeEndpoint({ inference_id: '.gp-llm-v2' });
+    const endpoint2 = makeEndpoint({ inference_id: '.gp-llm-v2-chat_completion' });
+    const endpoint3 = makeEndpoint({ inference_id: '.gp-llm-v2-completion' });
+    expect(filterPreconfiguredEndpoints([endpoint1, endpoint2, endpoint3])).toEqual([]);
+  });
+
+  it('filters out endpoints with inference IDs starting with .rainbow-sprinkles', () => {
+    const endpoint = makeEndpoint({ inference_id: '.rainbow-sprinkles-elastic' });
+    expect(filterPreconfiguredEndpoints([endpoint])).toEqual([]);
+  });
+
+  it('does not filter out non-blocked endpoints that otherwise qualify', () => {
+    const valid = makeEndpoint();
+    const gp = makeEndpoint({ inference_id: '.gp-llm-v2-chat_completion' });
+    const rainbow = makeEndpoint({ inference_id: '.rainbow-sprinkles-elastic' });
+    expect(filterPreconfiguredEndpoints([valid, gp, rainbow])).toEqual([valid]);
+  });
+
   it('filters the EIS mock endpoints to only chat_completion endpoints with kibana-connector property', () => {
     const results = filterPreconfiguredEndpoints(mockEISPreconfiguredEndpoints);
     expect(results.length).toBeGreaterThan(0);
@@ -97,6 +121,13 @@ describe('filterPreconfiguredEndpoints', () => {
       expect(ep.metadata?.heuristics?.properties).toContain('kibana-connector');
       expect(endpoint.task_type).toBe('chat_completion');
     });
+  });
+
+  it('excludes .gp-llm-v2 and .rainbow-sprinkles endpoints from the EIS mock list', () => {
+    const results = filterPreconfiguredEndpoints(mockEISPreconfiguredEndpoints);
+    const resultIds = results.map((ep) => ep.inference_id);
+    expect(resultIds.every((id) => !id.startsWith('.gp-llm-v2'))).toBe(true);
+    expect(resultIds.every((id) => !id.startsWith('.rainbow-sprinkles'))).toBe(true);
   });
 });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.ts
@@ -15,11 +15,19 @@ import {
 const CHAT_COMPLETION_TASK_TYPE = 'chat_completion';
 const KIBANA_CONNECTOR_PROPERTY = 'kibana-connector';
 
+// Inference ID prefixes for internal Elastic endpoints kept for backwards
+// compatibility that must not be surfaced in the UI.
+const HIDDEN_INFERENCE_ID_PREFIXES = ['.gp-llm-v2', '.rainbow-sprinkles'];
+
+const isHiddenInferenceEndpoint = (inferenceId: string): boolean =>
+  HIDDEN_INFERENCE_ID_PREFIXES.some((prefix) => inferenceId.startsWith(prefix));
+
 export function filterPreconfiguredEndpoints(
   endpoints: InferenceInferenceEndpointInfo[]
 ): InferenceInferenceEndpointInfo[] {
   return endpoints.filter(
     (endpoint) =>
+      !isHiddenInferenceEndpoint(endpoint.inference_id) &&
       isInferenceEndpointWithMetadata(endpoint) &&
       endpoint.metadata?.heuristics?.properties?.includes(KIBANA_CONNECTOR_PROPERTY) &&
       endpoint.task_type === CHAT_COMPLETION_TASK_TYPE


### PR DESCRIPTION
## Summary

Internal Elastic endpoints with inference IDs prefixed .gp-llm-v2* and .rainbow-sprinkles* are legacy endpoints. They are kept for backwards compatibility that shouldn't be shown in the UI. On 9.4.x they are not filtered, so they showed up as Claude Sonnet model cards on the EIS page.

The fix already exists in main ([#267452](https://github.com/elastic/kibana/pull/267452)) but was never backported to 9.4.

### Screen recording

https://github.com/user-attachments/assets/726d1edb-29f8-4977-99cc-3cc9e06edb55



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



