### PR TITLE
[Flaky] Fix event_rendered_view.cy.ts (fixes #274079)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts
@@ -41,7 +41,13 @@ describe(`Event Rendered View`, { tags: ['@ess', '@serverless'] }, () => {
     createRule(getNewRule());
     visit(ALERTS_URL);
     waitForAlerts();
+    // Set up intercept before switching views to avoid a race condition where the
+    // search request starts after waitForNetworkIdle's 500ms idle window has passed.
+    cy.intercept('POST', '/internal/search/privateRuleRegistryAlertsSearchStrategy').as(
+      'alertsSearch'
+    );
     switchAlertTableToEventRenderedView();
+    cy.wait('@alertsSearch');
     waitForAlerts();
   });
 


### PR DESCRIPTION
## Summary

### What
## Approach and Hypothesis

### Why
The test was tracked as flaky in issue #274079.

Fixes #274079

### Changes

- b68e7fe49e7d fix(test): prevent race condition in event_rendered_view beforeEach

---
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.





### Release note

> No user-facing changes.

**Suggested label:** `release_note:skip`