### PR TITLE
extend codeql dos exclusions

### DIFF
--- a/.github/codeql/custom-queries/dos/KibanaDoSExclusions.qll
+++ b/.github/codeql/custom-queries/dos/KibanaDoSExclusions.qll
@@ -41,6 +41,15 @@ predicate shouldExcludeFileFromDoSRules(Expr e) {
     // Saved-object type sub-schemas (e.g. cases/server/saved_object_types/*/schemas/*)
     path.regexpMatch(".*/saved_object_types/.*/schemas/.*")
     or
+    // Endpoint saved-object attribute mappings (data-at-rest, not HTTP input)
+    path.regexpMatch(".*/endpoint/lib/.*/saved_objects/mappings\\.ts")
+    or
+    // Osquery saved-query saved-object schemas (data-at-rest, not HTTP input)
+    path.regexpMatch(".*/osquery/server/lib/saved_query/schemas\\.ts")
+    or
+    // Endpoint metadata Task Manager task-state schema (internal task state, not HTTP input)
+    path.regexpMatch(".*/endpoint/lib/metadata/task_state\\.ts")
+    or
     // Dashboard saved-object attribute schemas
     path.regexpMatch(".*/dashboard_saved_object/schema/.*")
     or
@@ -63,6 +72,9 @@ predicate shouldExcludeFileFromDoSRules(Expr e) {
     or
     // Agent-builder tool parameter schemas (AI tool arguments, not HTTP routes)
     path.regexpMatch(".*/agent_builder/tools/.*")
+    or
+    // Agent-builder skill-nested tool parameter schemas (AI tool arguments, not HTTP routes)
+    path.regexpMatch(".*/agent_builder/skills/.*/tools/.*")
     or
     // Benchmark tooling config schemas
     path.regexpMatch(".*/kbn-bench/.*")


### PR DESCRIPTION
## Summary

Add new codeql dos exclusions for unbounded strings/arrays on schemas that are data-at-rest or tool args rather than HTTP request payload validators.

| Added pattern                                   | Targets                                                                                                           | Reasoning                                                                                 |
|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| `.*/agent_builder/skills/.*/tools/.*`           | skill-nested tool schemas under `security_solution/server/agent_builder/skills/**/tools/**`                       | Skill-nested agent-builder tool parameter schemas are tool args, not HTTP route payloads. |
| `.*/endpoint/lib/.*/saved_objects/mappings\.ts` | `endpoint/lib/reference_data/saved_objects/mappings.ts`, `endpoint/lib/scripts_library/saved_objects/mappings.ts` | Endpoint saved-object attribute mappings are data-at-rest, not HTTP input.                |
| `.*/osquery/server/lib/saved_query/schemas\.ts` | `osquery/server/lib/saved_query/schemas.ts`                                                                       | Osquery saved-query saved-object schemas (data-at-rest).                                  |
| `.*/endpoint/lib/metadata/task_state\.ts`       | `endpoint/lib/metadata/task_state.ts`                                                                             | Endpoint metadata Task Manager task-state schema — internal task state, not HTTP input.   |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



