### PR TITLE
[9.3] [Discover] Fix issue displaying null values in ES|QL summary column (#273610)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.test.ts
@@ -150,4 +150,66 @@ describe('formatHit', () => {
       ['_score', undefined, '_score'],
     ]);
   });
+
+  it('skips nullish values before limiting fields when configured', () => {
+    const rowWithNullishFields = buildDataTableRecord(
+      {
+        _id: 'doc-001',
+        _source: {
+          field_1: null,
+          field_2: undefined,
+          source: 'void_realm',
+          status: 'missing_in_action',
+        },
+      },
+      dataViewMock
+    );
+
+    formatHit(rowWithNullishFields, dataViewMock, () => true, 2, fieldFormatsMock, undefined);
+
+    const formatted = formatHit(
+      rowWithNullishFields,
+      dataViewMock,
+      () => true,
+      2,
+      fieldFormatsMock,
+      { skipNullishValues: true }
+    );
+
+    expect(
+      formatted.map(([fieldDisplayName, , fieldName]) => [fieldDisplayName, fieldName])
+    ).toEqual([
+      ['source', 'source'],
+      ['status', 'status'],
+    ]);
+  });
+
+  it('keeps non-nullish falsy values when skipping nullish values', () => {
+    const rowWithFalsyFields = buildDataTableRecord(
+      {
+        _id: 'doc-002',
+        _source: {
+          field_1: null,
+          a_empty_string: '',
+          b_zero: 0,
+          c_false_value: false,
+          d_source: 'void_realm',
+        },
+      },
+      dataViewMock
+    );
+
+    const formatted = formatHit(rowWithFalsyFields, dataViewMock, () => true, 3, fieldFormatsMock, {
+      skipNullishValues: true,
+    });
+
+    expect(
+      formatted.map(([fieldDisplayName, , fieldName]) => [fieldDisplayName, fieldName])
+    ).toEqual([
+      ['a_empty_string', 'a_empty_string'],
+      ['b_zero', 'b_zero'],
+      ['c_false_value', 'c_false_value'],
+      ['and 1 more field', null],
+    ]);
+  });
 });

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.ts
@@ -27,9 +27,13 @@ type PartialHitPair = [
   fieldName: string | null
 ];
 
+interface FormatHitReactOptions {
+  skipNullishValues?: boolean;
+}
+
 const formattedHitCache = new WeakMap<
   EsHitRecord,
-  { formattedHit: FormattedHit; maxEntries: number }
+  { formattedHit: FormattedHit; maxEntries: number; skipNullishValues: boolean }
 >();
 
 /**
@@ -41,17 +45,24 @@ const formattedHitCache = new WeakMap<
  * @param shouldShowFieldHandler
  * @param maxEntries
  * @param fieldFormats
+ * @param options
  */
 export function formatHit(
   hit: DataTableRecord,
   dataView: DataView,
   shouldShowFieldHandler: ShouldShowFieldInTableHandler,
   maxEntries: number,
-  fieldFormats: FieldFormatsStart
+  fieldFormats: FieldFormatsStart,
+  options?: FormatHitReactOptions
 ): FormattedHit {
+  const skipNullishValues = Boolean(options?.skipNullishValues);
   const cached = formattedHitCache.get(hit.raw);
 
-  if (cached && cached.maxEntries === maxEntries) {
+  if (
+    cached &&
+    cached.maxEntries === maxEntries &&
+    cached.skipNullishValues === skipNullishValues
+  ) {
     return cached.formattedHit;
   }
 
@@ -64,6 +75,10 @@ export function formatHit(
   // depending on whether the original hit had a highlight for it. That way we can ensure
   // highlighted fields are shown first in the document summary.
   for (const key of Object.keys(flattened)) {
+    if (skipNullishValues && (flattened[key] ?? null) === null) {
+      continue;
+    }
+
     // Retrieve the (display) name of the fields, if it's a mapped field on the data view
     const field = dataView.fields.getByName(key);
     const displayKey = field?.displayName;
@@ -126,7 +141,7 @@ export function formatHit(
 
   const formattedHit = renderedPairs as FormattedHit;
 
-  formattedHitCache.set(hit.raw, { formattedHit, maxEntries });
+  formattedHitCache.set(hit.raw, { formattedHit, maxEntries, skipNullishValues });
 
   return formattedHit;
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.test.tsx
@@ -9,11 +9,12 @@
 
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { mountWithIntl, renderWithI18n } from '@kbn/test-jest-helpers';
 import React from 'react';
 import SourceDocument from './source_document';
 import type { EsHitRecord } from '@kbn/discover-utils/src/types';
 import { buildDataTableRecord } from '@kbn/discover-utils';
+import { screen, within } from '@testing-library/dom';
 
 const mockServices = {
   fieldFormats: {
@@ -84,5 +85,41 @@ describe('Unified data table source document cell rendering', function () {
 
     expect(mockConvert).toHaveBeenCalled();
     expect(component.html()).toContain('my bar value');
+  });
+
+  it('does not let null fields consume the ES|QL document summary limit', () => {
+    const row = build({
+      _id: 'doc-001',
+      _source: {
+        field_1: null,
+        field_2: null,
+        field_3: null,
+        field_4: null,
+        field_5: null,
+        source: 'void_realm',
+        status: 'missing_in_action',
+      },
+    });
+
+    renderWithI18n(
+      <SourceDocument
+        columnId="_source"
+        dataView={dataViewMock}
+        fieldFormats={mockServices.fieldFormats as unknown as FieldFormatsStart}
+        isPlainRecord={true}
+        maxEntries={2}
+        row={row}
+        shouldShowFieldHandler={() => true}
+        useTopLevelObjectColumns={false}
+      />
+    );
+
+    const descriptionList = screen.getByTestId('discoverCellDescriptionList');
+    expect(within(descriptionList).getByText('source')).toBeVisible();
+    expect(within(descriptionList).getByText('void_realm')).toBeVisible();
+    expect(within(descriptionList).getByText('status')).toBeVisible();
+    expect(within(descriptionList).getByText('missing_in_action')).toBeVisible();
+    expect(within(descriptionList).queryByText('field_1')).not.toBeInTheDocument();
+    expect(within(descriptionList).queryByText(/and \d+ more fields/)).not.toBeInTheDocument();
   });
 });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
@@ -11,7 +11,6 @@ import React, { Fragment } from 'react';
 import { css } from '@emotion/react';
 import type {
   DataTableRecord,
-  EsHitRecord,
   FormattedHit,
   ShouldShowFieldInTableHandler,
 } from '@kbn/discover-utils/src/types';
@@ -30,6 +29,7 @@ import classnames from 'classnames';
 import { getInnerColumns } from '../utils/columns';
 
 const CELL_CLASS = 'unifiedDataTable__cellValue';
+const SKIP_NULLISH_VALUES_FORMAT_OPTIONS = { skipNullishValues: true };
 
 export function SourceDocument({
   useTopLevelObjectColumns,
@@ -59,13 +59,21 @@ export function SourceDocument({
   const styles = useMemoCss(componentStyles);
   const pairs: FormattedHit = useTopLevelObjectColumns
     ? getTopLevelObjectPairs(
-        row.raw,
+        row,
         columnId,
         dataView,
         shouldShowFieldHandler,
-        fieldFormats
+        fieldFormats,
+        Boolean(isPlainRecord)
       ).slice(0, maxEntries)
-    : formatHit(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats);
+    : formatHit(
+        row,
+        dataView,
+        shouldShowFieldHandler,
+        maxEntries,
+        fieldFormats,
+        isPlainRecord ? SKIP_NULLISH_VALUES_FORMAT_OPTIONS : undefined
+      );
 
   return (
     <EuiDescriptionList
@@ -76,9 +84,6 @@ export function SourceDocument({
       data-test-subj={dataTestSubj}
     >
       {pairs.map(([fieldDisplayName, value, fieldName]) => {
-        // temporary solution for text based mode. As there are a lot of unsupported fields we want to
-        // hide the empty one from the Document view
-        if (isPlainRecord && fieldName && (row.flattened[fieldName] ?? null) === null) return null;
         return (
           <Fragment key={fieldDisplayName}>
             <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
@@ -100,24 +105,29 @@ export function SourceDocument({
  * this is used for legacy stuff like displaying products of our ecommerce dataset
  */
 function getTopLevelObjectPairs(
-  row: EsHitRecord,
+  row: DataTableRecord,
   columnId: string,
   dataView: DataView,
   shouldShowFieldHandler: ShouldShowFieldInTableHandler,
-  fieldFormats: FieldFormatsStart
-) {
-  const innerColumns = getInnerColumns(row.fields as Record<string, unknown[]>, columnId);
+  fieldFormats: FieldFormatsStart,
+  skipNullishValues: boolean
+): FormattedHit {
+  const innerColumns = getInnerColumns(row.raw.fields as Record<string, unknown[]>, columnId);
   // Put the most important fields first
-  const highlights: Record<string, unknown> = (row.highlight as Record<string, unknown>) ?? {};
+  const highlights: Record<string, unknown> = (row.raw.highlight as Record<string, unknown>) ?? {};
   const highlightPairs: FormattedHit = [];
   const sourcePairs: FormattedHit = [];
   Object.entries(innerColumns).forEach(([key, values]) => {
+    if (skipNullishValues && (row.flattened[key] ?? null) === null) {
+      return;
+    }
+
     const subField = dataView.getFieldByName(key);
     const displayKey = dataView.fields.getByName
       ? dataView.fields.getByName(key)?.displayName
       : undefined;
     const formatted = values
-      .map((value: unknown) => formatFieldValue(value, row, fieldFormats, dataView, subField))
+      .map((value: unknown) => formatFieldValue(value, row.raw, fieldFormats, dataView, subField))
       .join(', ');
     const pairs = highlights[key] ? highlightPairs : sourcePairs;
     if (displayKey) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Fix issue displaying null values in ES|QL summary column (#273610)](https://github.com/elastic/kibana/pull/273610)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2026-06-18T14:55:02Z","message":"[Discover] Fix issue displaying null values in ES|QL summary column (#273610)\n\n## Summary\n\nThis PR fixes the Discover ES|QL document summary column so null and\nundefined fields no longer count toward\n`discover:maxDocFieldsDisplayed`. This lets fields with real values\nrender normally instead of being hidden behind an incorrect `and X more\nfields` message.\n\nThe fix skips nullish values before summary limiting and overflow\ncalculation, while keeping valid falsy values like empty strings, zero,\nand `false`. Tests cover the formatter behavior and the ES|QL source\ndocument rendering case.\n\nBefore:\n<img\nsrc=\"https://github.com/user-attachments/assets/f2e4e7ff-7fe2-4a81-80a4-9337fde75abc\"\n/>\n\nAfter:\n<img\nsrc=\"https://github.com/user-attachments/assets/ae14ad47-6fa9-435b-be92-2be8dbd4925c\"\n/>\n\nFixes #273562.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e2539dc85579942f3ce7f7184fceebe3857fa16f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:version","v9.5.0","v9.4.3","v9.3.6"],"title":"[Discover] Fix issue displaying null values in ES|QL summary column","number":273610,"url":"https://github.com/elastic/kibana/pull/273610","mergeCommit":{"message":"[Discover] Fix issue displaying null values in ES|QL summary column (#273610)\n\n## Summary\n\nThis PR fixes the Discover ES|QL document summary column so null and\nundefined fields no longer count toward\n`discover:maxDocFieldsDisplayed`. This lets fields with real values\nrender normally instead of being hidden behind an incorrect `and X more\nfields` message.\n\nThe fix skips nullish values before summary limiting and overflow\ncalculation, while keeping valid falsy values like empty strings, zero,\nand `false`. Tests cover the formatter behavior and the ES|QL source\ndocument rendering case.\n\nBefore:\n<img\nsrc=\"https://github.com/user-attachments/assets/f2e4e7ff-7fe2-4a81-80a4-9337fde75abc\"\n/>\n\nAfter:\n<img\nsrc=\"https://github.com/user-attachments/assets/ae14ad47-6fa9-435b-be92-2be8dbd4925c\"\n/>\n\nFixes #273562.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e2539dc85579942f3ce7f7184fceebe3857fa16f"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273610","number":273610,"mergeCommit":{"message":"[Discover] Fix issue displaying null values in ES|QL summary column (#273610)\n\n## Summary\n\nThis PR fixes the Discover ES|QL document summary column so null and\nundefined fields no longer count toward\n`discover:maxDocFieldsDisplayed`. This lets fields with real values\nrender normally instead of being hidden behind an incorrect `and X more\nfields` message.\n\nThe fix skips nullish values before summary limiting and overflow\ncalculation, while keeping valid falsy values like empty strings, zero,\nand `false`. Tests cover the formatter behavior and the ES|QL source\ndocument rendering case.\n\nBefore:\n<img\nsrc=\"https://github.com/user-attachments/assets/f2e4e7ff-7fe2-4a81-80a4-9337fde75abc\"\n/>\n\nAfter:\n<img\nsrc=\"https://github.com/user-attachments/assets/ae14ad47-6fa9-435b-be92-2be8dbd4925c\"\n/>\n\nFixes #273562.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e2539dc85579942f3ce7f7184fceebe3857fa16f"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->