### PR TITLE
[Fleet] Remove duplicate category in integrations search bar

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
@@ -493,7 +493,6 @@ const SearchBar: React.FC<SearchBarProps> = ({ categories, availableSubCategorie
                   </span>
                 </EuiScreenReaderOnly>
                 {categoryBadgeLabel}
-                {categoryBadgeLabel}
               </>
             }
             data-test-subj="epmList.categoryBadge"


### PR DESCRIPTION
## Summary
No tracking issue, found while working at https://github.com/elastic/kibana/pull/273929

Remove duplicate category in integrations search bar. This duplicate was added by mistake in a previous PR.


<img width="352" height="85" alt="Screenshot 2026-06-19 at 10 32 11" src="https://github.com/user-attachments/assets/39beece7-5e93-478d-8722-c74be5aaceae" />






