### PR TITLE
[Alerting V2] Fix workflow selector in Compose Discover flyout

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
@@ -22,7 +22,7 @@ import { ESQLVariableType } from '@kbn/esql-types';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import { AGENT_BUILDER_NEW_CONVERSATION_PATH, CREATE_WITH_AGENT_INITIAL_PROMPT } from './constants';
 
-const createMockServices = (): RuleFormServices => ({
+const createMockServices = (): RuleFormServices & { container: unknown } => ({
   http: httpServiceMock.createStartContract(),
   data: dataPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
@@ -30,6 +30,7 @@ const createMockServices = (): RuleFormServices => ({
   application: applicationServiceMock.createStartContract(),
   lens: lensPluginMock.createStartContract(),
   uiActions: uiActionsPluginMock.createStartContract(),
+  container: {},
 });
 
 let capturedSelectorProps: Record<string, unknown> = {};
@@ -69,7 +70,6 @@ jest.mock('./kibana_services', () => ({
     new Promise<RuleFormServices>((resolve) => {
       pendingResolvers.push(resolve);
     }),
-  getDiContainer: () => undefined,
 }));
 
 jest.mock('./services/rules_api', () => ({

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
@@ -69,6 +69,7 @@ jest.mock('./kibana_services', () => ({
     new Promise<RuleFormServices>((resolve) => {
       pendingResolvers.push(resolve);
     }),
+  getDiContainer: () => undefined,
 }));
 
 jest.mock('./services/rules_api', () => ({

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
@@ -22,7 +22,12 @@ import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
 import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
 import type { ComposeDiscoverFlyoutProps } from '@kbn/alerting-v2-rule-form';
-import { untilPluginStartServicesReady, type AlertingV2KibanaServices } from './kibana_services';
+import { Context } from '@kbn/core-di-browser';
+import {
+  untilPluginStartServicesReady,
+  getDiContainer,
+  type AlertingV2KibanaServices,
+} from './kibana_services';
 import { RuleCreateOptionsFlyout } from './components/rule_create_options/rule_create_options_flyout';
 import { RulesApi } from './services/rules_api';
 import { CREATE_WITH_AGENT_INITIAL_PROMPT, AGENT_BUILDER_NEW_CONVERSATION_PATH } from './constants';
@@ -285,11 +290,14 @@ const CreateRuleOptionsFlyoutInner = ({
 
 export const CreateRuleOptionsFlyout = (props: CreateRuleOptionsFlyoutProps) => {
   const queryClient = useMemo(() => new QueryClient(), []);
+  const container = getDiContainer();
   return (
     <EuiErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <CreateRuleOptionsFlyoutInner {...props} />
-      </QueryClientProvider>
+      <Context.Provider value={container}>
+        <QueryClientProvider client={queryClient}>
+          <CreateRuleOptionsFlyoutInner {...props} />
+        </QueryClientProvider>
+      </Context.Provider>
     </EuiErrorBoundary>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.tsx
@@ -23,11 +23,7 @@ import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
 import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
 import type { ComposeDiscoverFlyoutProps } from '@kbn/alerting-v2-rule-form';
 import { Context } from '@kbn/core-di-browser';
-import {
-  untilPluginStartServicesReady,
-  getDiContainer,
-  type AlertingV2KibanaServices,
-} from './kibana_services';
+import { untilPluginStartServicesReady, type AlertingV2KibanaServices } from './kibana_services';
 import { RuleCreateOptionsFlyout } from './components/rule_create_options/rule_create_options_flyout';
 import { RulesApi } from './services/rules_api';
 import { CREATE_WITH_AGENT_INITIAL_PROMPT, AGENT_BUILDER_NEW_CONVERSATION_PATH } from './constants';
@@ -243,30 +239,34 @@ const CreateRuleOptionsFlyoutInner = ({
 
   if (step.type === 'esql') {
     return (
-      <ComposeDiscoverFlyout
-        historyKey={historyKey}
-        mode="create"
-        onClose={onClose}
-        services={services}
-        onCreateRule={handleCreateRule}
-        isSaving={isSaving}
-        initialQuery={query}
-        esqlVariables={esqlVariables}
-      />
+      <Context.Provider value={services.container}>
+        <ComposeDiscoverFlyout
+          historyKey={historyKey}
+          mode="create"
+          onClose={onClose}
+          services={services}
+          onCreateRule={handleCreateRule}
+          isSaving={isSaving}
+          initialQuery={query}
+          esqlVariables={esqlVariables}
+        />
+      </Context.Provider>
     );
   }
 
   if (step.type === 'threshold') {
     return (
-      <ComposeDiscoverFlyout
-        historyKey={historyKey}
-        mode="create"
-        onClose={onClose}
-        services={services}
-        builderType="threshold"
-        onCreateRule={handleCreateRule}
-        isSaving={isSaving}
-      />
+      <Context.Provider value={services.container}>
+        <ComposeDiscoverFlyout
+          historyKey={historyKey}
+          mode="create"
+          onClose={onClose}
+          services={services}
+          builderType="threshold"
+          onCreateRule={handleCreateRule}
+          isSaving={isSaving}
+        />
+      </Context.Provider>
     );
   }
 
@@ -290,14 +290,11 @@ const CreateRuleOptionsFlyoutInner = ({
 
 export const CreateRuleOptionsFlyout = (props: CreateRuleOptionsFlyoutProps) => {
   const queryClient = useMemo(() => new QueryClient(), []);
-  const container = getDiContainer();
   return (
     <EuiErrorBoundary>
-      <Context.Provider value={container}>
-        <QueryClientProvider client={queryClient}>
-          <CreateRuleOptionsFlyoutInner {...props} />
-        </QueryClientProvider>
-      </Context.Provider>
+      <QueryClientProvider client={queryClient}>
+        <CreateRuleOptionsFlyoutInner {...props} />
+      </QueryClientProvider>
     </EuiErrorBoundary>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -32,7 +32,7 @@ import { ExecutionHistoryApi } from './services/execution_history_api';
 import { RulesApi } from './services/rules_api';
 import { registerTriggerDefinitions } from './lib/workflow_extensions/register_trigger_definitions';
 import { disableAlertingManagementUi } from './lib/disable_management_ui';
-import { setKibanaServices } from './kibana_services';
+import { setKibanaServices, setDiContainer } from './kibana_services';
 import type { AlertingV2PublicStart } from './types';
 import type { CreateRuleOptionsFlyoutProps } from './create_rule_options_flyout';
 
@@ -144,6 +144,7 @@ export const module = new ContainerModule(({ bind }) => {
 
     getStartServices().then(([coreStart]) => {
       const diContainer = coreStart.injection.getContainer();
+      setDiContainer(diContainer);
       setKibanaServices({
         http: coreStart.http,
         notifications: coreStart.notifications,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -32,7 +32,7 @@ import { ExecutionHistoryApi } from './services/execution_history_api';
 import { RulesApi } from './services/rules_api';
 import { registerTriggerDefinitions } from './lib/workflow_extensions/register_trigger_definitions';
 import { disableAlertingManagementUi } from './lib/disable_management_ui';
-import { setKibanaServices, setDiContainer } from './kibana_services';
+import { setKibanaServices } from './kibana_services';
 import type { AlertingV2PublicStart } from './types';
 import type { CreateRuleOptionsFlyoutProps } from './create_rule_options_flyout';
 
@@ -144,7 +144,6 @@ export const module = new ContainerModule(({ bind }) => {
 
     getStartServices().then(([coreStart]) => {
       const diContainer = coreStart.injection.getContainer();
-      setDiContainer(diContainer);
       setKibanaServices({
         http: coreStart.http,
         notifications: coreStart.notifications,
@@ -154,6 +153,7 @@ export const module = new ContainerModule(({ bind }) => {
         lens: diContainer.get(PluginStart('lens')) as LensPublicStart,
         expressions: diContainer.get(PluginStart('expressions')) as ExpressionsStart,
         uiActions: diContainer.get(PluginStart('uiActions')) as UiActionsStart,
+        container: diContainer,
       });
 
       const alertingEnabled = coreStart.settings.globalClient.get<boolean>(

--- a/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.test.ts
@@ -22,6 +22,7 @@ const createMockServices = (): AlertingV2KibanaServices => ({
   lens: lensPluginMock.createStartContract(),
   expressions: {} as AlertingV2KibanaServices['expressions'],
   uiActions: {} as AlertingV2KibanaServices['uiActions'],
+  container: {} as AlertingV2KibanaServices['container'],
 });
 
 describe('kibana_services', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.ts
@@ -13,11 +13,10 @@ import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 /** Services shared by rule UI, episodes UI, and other alerting_v2 surfaces. */
 export type AlertingV2KibanaServices = RuleFormServices & {
   expressions: ExpressionsStart;
+  container: Container;
 };
 
 const servicesReady$ = new BehaviorSubject<AlertingV2KibanaServices | undefined>(undefined);
-
-let pluginDiContainer: Container | undefined;
 
 export const untilPluginStartServicesReady = (): Promise<AlertingV2KibanaServices> => {
   if (servicesReady$.value) return Promise.resolve(servicesReady$.value);
@@ -34,9 +33,3 @@ export const untilPluginStartServicesReady = (): Promise<AlertingV2KibanaService
 export const setKibanaServices = (services: AlertingV2KibanaServices) => {
   servicesReady$.next(services);
 };
-
-export const setDiContainer = (container: Container) => {
-  pluginDiContainer = container;
-};
-
-export const getDiContainer = (): Container | undefined => pluginDiContainer;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { Container } from 'inversify';
 import { BehaviorSubject } from 'rxjs';
 import type { RuleFormServices } from '@kbn/alerting-v2-rule-form';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
@@ -15,6 +16,8 @@ export type AlertingV2KibanaServices = RuleFormServices & {
 };
 
 const servicesReady$ = new BehaviorSubject<AlertingV2KibanaServices | undefined>(undefined);
+
+let pluginDiContainer: Container | undefined;
 
 export const untilPluginStartServicesReady = (): Promise<AlertingV2KibanaServices> => {
   if (servicesReady$.value) return Promise.resolve(servicesReady$.value);
@@ -31,3 +34,9 @@ export const untilPluginStartServicesReady = (): Promise<AlertingV2KibanaService
 export const setKibanaServices = (services: AlertingV2KibanaServices) => {
   servicesReady$.next(services);
 };
+
+export const setDiContainer = (container: Container) => {
+  pluginDiContainer = container;
+};
+
+export const getDiContainer = (): Container | undefined => pluginDiContainer;


### PR DESCRIPTION
## Summary

Fixes elastic/rna-program#601

Clicking any "create simple action policy" option in the rule creation flyout (opened from Discover) throws:

> Error: The dependency injection container is not provided in the context. at useService at WorkflowReferenceSelector

### Root Cause

`WorkflowReferenceSelector` (and other `actions_form` components like `ConnectorSelector`) resolve services via `useService()` from `@kbn/core-di-browser`, which requires a DI `Context.Provider` ancestor in the React tree.

When the `ComposeDiscoverFlyout` is opened from the alerting_v2 management app, `mount.tsx` wraps the entire tree with `<Context.Provider value={container}>`, so everything works. However, when opened from **Discover** (via the Alerts menu → `CreateRuleOptionsFlyout`), the component is portaled to `document.body` by `runAppMenuAction` with only `KibanaRenderContextProvider` + `KibanaContextProvider` — no DI container is present.

### Fix

Wrap the `CreateRuleOptionsFlyout` component tree with `<Context.Provider value={container}>`, ensuring the plugin's Inversify container is available to all descendants regardless of where the flyout is rendered.

This follows the same pattern used by the [agent builder attachments](../blob/main/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_attachment_definition.tsx#L39-L42), which also render outside the main app tree and explicitly provide the DI container.

### How to test

1. Enable alerting v2:
   ```yaml
   # kibana.dev.yml
   xpack.alerting_v2.enabled: true
   uiSettings.globalOverrides.alerting:v2:enabled: true
   ```
2. Open Discover → run an ES|QL query
3. Open the Alerts menu → create a new rule
4. Proceed to the notifications/action policy step
5. Click any "create simple action policy" option
6. Verify the `WorkflowReferenceSelector` renders without error