### PR TITLE
[Security Solution] Fix related integration version validation to accept semver range expressions

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations_help_info.tsx
@@ -45,7 +45,7 @@ export function RelatedIntegrationsHelpInfo(): JSX.Element {
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.ruleDescription.relatedIntegrations.fieldRelatedIntegrationsHelpText"
-          defaultMessage="Choose the {integrationsDocLink} this rule depends on, and correct if necessary each integration’s version constraint in {semverLink} format. Only tilde, caret, and plain versions are supported, such as ~1.2.3, ^1.2.3, or 1.2.3."
+          defaultMessage="Choose the {integrationsDocLink} this rule depends on, and correct if necessary each integration’s version constraint in {semverLink} range format. Supported examples: ^1.2.3, ~1.2.3, 1.2.3, >=1.2.3, or ^1.2.3 || ^2.0.0."
           values={{
             integrationsDocLink: (
               <EuiLink href={docLinks.links.securitySolution.createDetectionRules} target="_blank">

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/translations.ts
@@ -74,7 +74,7 @@ export const VERSION_DEPENDENCY_INVALID = i18n.translate(
   'xpack.securitySolution.detectionEngine.ruleDescription.relatedIntegrations.validation.versionInvalid',
   {
     defaultMessage:
-      'Version constraint is invalid. Only tilde, caret or plain version supported e.g. ~1.2.3, ^1.2.3 or 1.2.3.',
+      'Version constraint is invalid. Use a valid semver range expression e.g. ^1.2.3, ~1.2.3, 1.2.3, >=1.2.3, or ^1.2.3 || ^2.0.0.',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.test.ts
@@ -15,6 +15,12 @@ describe('validateRelatedIntegration', () => {
       ['simple package version dependency', { package: 'some-package', version: '1.2.3' }],
       ['caret package version dependency', { package: 'some-package', version: '^1.2.3' }],
       ['tilde package version dependency', { package: 'some-package', version: '~1.2.3' }],
+      ['OR range-set version dependency', { package: 'some-package', version: '^8.2.0 || ^9.0.0' }],
+      ['greater-than-or-equal version dependency', { package: 'some-package', version: '>=1.0.0' }],
+      [
+        'tilde with leading spaces (semver normalizes whitespace)',
+        { package: 'some-package', version: ' ~ 1.2.3' },
+      ],
     ])(`validates %s`, (_, relatedIntegration) => {
       const arg = {
         value: relatedIntegration,
@@ -82,9 +88,9 @@ describe('validateRelatedIntegration', () => {
     });
 
     it.each([
-      ['invalid format version', { package: 'some-package', version: '^1.2.' }],
-      ['unexpected version spaces', { package: 'some-package', version: ' ~ 1.2.3' }],
-    ])(`validates %s`, (_, relatedIntegration) => {
+      ['invalid version', { package: 'some-package', version: '^1.2.' }],
+      ['invalid operator', { package: 'some-package', version: '>!=1.0.0' }],
+    ])(`validates %s`, (_: unknown, relatedIntegration: unknown) => {
       const arg = {
         value: relatedIntegration,
         path: 'form.path.to.field',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import semver from 'semver';
+
 import type { RelatedIntegration } from '../../../../../common/api/detection_engine';
 import type { FormData, ERROR_CODE, ValidationFunc } from '../../../../shared_imports';
 import * as i18n from './translations';
@@ -28,7 +30,7 @@ export function validateRelatedIntegration(
     };
   }
 
-  if (!SEMVER_PATTERN.test(value.version)) {
+  if (!semver.validRange(value.version)) {
     return {
       code: 'ERR_FIELD_FORMAT',
       path: `${path}.version`,
@@ -36,5 +38,3 @@ export function validateRelatedIntegration(
     };
   }
 }
-
-const SEMVER_PATTERN = /^(\~|\^)?\d+\.\d+\.\d+$/;


### PR DESCRIPTION
**Fixes: #274097**

## Summary

The version constraint validator for related integrations in the Rule
Creation/Editing pages used a hand-rolled regex that only accepted plain,
tilde, or caret single-version strings (e.g. `^1.2.3`). This rejected any
valid semver range-set expression such as `^8.2.0 || ^9.0.0`, preventing
users from saving rules that contained such constraints.

This PR replaces the regex with `semver.validRange()` (from the `semver`
library already used elsewhere in the component) to accept any valid
semver range expression, and updates the validation error message and the
help popover text accordingly.

## Details

- `validate_related_integration.ts` — replace `SEMVER_PATTERN` regex with `semver.validRange(value.version)`; import `semver`
- `translations.ts` — update `VERSION_DEPENDENCY_INVALID` message to describe valid semver range syntax instead of listing only tilde/caret
- `related_integrations_help_info.tsx` — update the help popover text to describe semver range format with an OR range-set example
- `validate_related_integration.test.ts` — add success cases for `^8.2.0 || ^9.0.0` and `>=1.0.0`; move `~ 1.2.3` to the success section (semver normalizes leading whitespace)

## How to test

Unit tests cover the updated logic:
```
node scripts/jest x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.test.ts
```

Manual steps:
1. Open a detection rule in the UI whose `related_integrations` entry has version `^8.2.0 || ^9.0.0`.
2. Make any change and attempt to save — the validation error should no longer appear.
3. Enter an invalid version like `^1.2.` — the validation error should still appear.

## Release note

Fixed UI validation for related integration version constraints to accept any valid semver range expression, including OR range-sets like `^8.2.0 || ^9.0.0`.

## Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)