### PR TITLE
[SharedUX] Update docs for product intercept setting min version

### DIFF
--- a/docs/reference/configuration-reference/product-intercept-settings.md
+++ b/docs/reference/configuration-reference/product-intercept-settings.md
@@ -4,7 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/product-intercept-settings-kb.html
 applies_to:
   deployment:
-    self: ga 9.1
+    self: ga 8.19.4
 ---
 
 # Product intercept settings in {{kib}} [product-intercept-settings-kb]

--- a/docs/reference/configuration-reference/product-intercept-settings.yml
+++ b/docs/reference/configuration-reference/product-intercept-settings.yml
@@ -1,6 +1,6 @@
 ---
 # This file is used to generate "Product intercept settings" page in the product docs
-# For the schema and an example refer to the automated settings reference: 
+# For the schema and an example refer to the automated settings reference:
 # https://github.com/elastic/docs-builder/blob/main/docs/syntax/automated_settings.md
 
 product: Kibana
@@ -21,7 +21,7 @@ groups:
         datatype: bool
         default: true
         applies_to:
-          stack: ga 9.1
+          stack: ga 8.19.4
           ech: ga
           self: ga
 
@@ -31,6 +31,6 @@ groups:
         datatype: string
         default: '90d'
         applies_to:
-          stack: ga 9.1
+          stack: ga 8.19.4
           ech: ga
           self: ga


### PR DESCRIPTION
## Summary

As part of the work for [[MVP] Product Intercept Dialog](https://github.com/elastic/kibana/pull/209571) we added two new settings to the Cloud settings allowlist on this Cloud PR: https://github.com/elastic/cloud/pull/141517

Kibana's above-mentioned PR was introduced in 9.1 but then [backported](https://github.com/elastic/kibana/pull/232961) to 8.19.4. Settings min version was not updated to match that backport. 

This docs PR updates documentation to match the min version to the accurate one:
- https://www.elastic.co/docs/reference/kibana/configuration-reference/product-intercept-settings
- https://www.elastic.co/docs/reference/kibana/cloud/elastic-cloud-kibana-settings

Related Cloud PR that updates the min version of the setting https://github.com/elastic/cloud/pull/156510


