### PR TITLE
[9.4] feat(security-threat-hunting, security-entity-analytics): replace title props and wrap EuiButtonIcon with EuiToolTip (#271511)

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_button.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_button.tsx
@@ -35,12 +35,14 @@ export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({
       />
     </EuiToolTip>
   ) : (
-    <EuiButtonIcon
-      data-test-subj="showExtraActionsButton"
-      aria-label={SHOW_MORE_ACTIONS}
-      iconType={extraActionsIconType ?? 'boxesVertical'}
-      color={extraActionsColor}
-      onClick={onClick}
-    />
+    <EuiToolTip content={SHOW_MORE_ACTIONS} disableScreenReaderOutput>
+      <EuiButtonIcon
+        data-test-subj="showExtraActionsButton"
+        aria-label={SHOW_MORE_ACTIONS}
+        iconType={extraActionsIconType ?? 'boxesVertical'}
+        color={extraActionsColor}
+        onClick={onClick}
+      />
+    </EuiToolTip>
   );
 };

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.tsx
@@ -24,6 +24,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiTitle,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import {
@@ -315,13 +316,15 @@ const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdi
                       />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
-                      <EuiButtonIcon
-                        color="danger"
-                        onClick={() => removeItem(item.id)}
-                        iconType="minusCircle"
-                        aria-label={i18nAuth.DELETE_BUTTON}
-                        css={{ marginTop: '28px' }}
-                      />
+                      <EuiToolTip content={i18nAuth.DELETE_BUTTON} disableScreenReaderOutput>
+                        <EuiButtonIcon
+                          color="danger"
+                          onClick={() => removeItem(item.id)}
+                          iconType="minusCircle"
+                          aria-label={i18nAuth.DELETE_BUTTON}
+                          css={{ marginTop: '28px' }}
+                        />
+                      </EuiToolTip>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 ))}

--- a/x-pack/solutions/security/packages/expandable-flyout/src/components/preview_section.tsx
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/components/preview_section.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexItem,
   EuiSplitPanel,
   EuiText,
+  EuiToolTip,
   transparentize,
   useEuiTheme,
 } from '@elastic/eui';
@@ -119,12 +120,14 @@ export const PreviewSection: React.FC<PreviewSectionProps> = memo(
 
     const closeButton = (
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          iconType="cross"
-          onClick={closePreviewPanel}
-          data-test-subj={PREVIEW_SECTION_CLOSE_BUTTON_TEST_ID}
-          aria-label={CLOSE_BUTTON}
-        />
+        <EuiToolTip content={CLOSE_BUTTON} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="cross"
+            onClick={closePreviewPanel}
+            data-test-subj={PREVIEW_SECTION_CLOSE_BUTTON_TEST_ID}
+            aria-label={CLOSE_BUTTON}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     );
     const header = (

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/comment_actions/base_comment_actions.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/comment_actions/base_comment_actions.tsx
@@ -43,12 +43,14 @@ const BaseCommentActionsComponent: React.FC<Props> = ({ message, children }) => 
         <EuiToolTip position="top" content={COPY_TO_CLIPBOARD}>
           <EuiCopy textToCopy={getSelfContainedContent(content)}>
             {(copy) => (
-              <EuiButtonIcon
-                aria-label={COPY_TO_CLIPBOARD}
-                color="primary"
-                iconType="copy"
-                onClick={copy}
-              />
+              <EuiToolTip content={COPY_TO_CLIPBOARD} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  aria-label={COPY_TO_CLIPBOARD}
+                  color="primary"
+                  iconType="copy"
+                  onClick={copy}
+                />
+              </EuiToolTip>
             )}
           </EuiCopy>
         </EuiToolTip>

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_summary_grid.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_summary_grid.tsx
@@ -129,14 +129,16 @@ const EntityIdCell: React.FC<{ entityId?: string }> = ({ entityId }) => {
         <EuiToolTip content={LABELS.copy}>
           <EuiCopy textToCopy={entityId}>
             {(copy) => (
-              <EuiButtonIcon
-                iconType="copy"
-                aria-label={LABELS.copy}
-                onClick={copy}
-                iconSize="s"
-                color="text"
-                data-test-subj="entityAttachmentGridEntityIdCopy"
-              />
+              <EuiToolTip content={LABELS.copy} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  iconType="copy"
+                  aria-label={LABELS.copy}
+                  onClick={copy}
+                  iconSize="s"
+                  color="text"
+                  data-test-subj="entityAttachmentGridEntityIdCopy"
+                />
+              </EuiToolTip>
             )}
           </EuiCopy>
         </EuiToolTip>

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
@@ -328,14 +328,19 @@ export const EntityTable: React.FC<EntityTableProps> = ({ entities }) => {
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
               {canNavigate && (
                 <EuiFlexItem grow={false}>
-                  <EuiButtonIcon
-                    iconType={icon}
-                    display="empty"
-                    size="xs"
-                    aria-label={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
-                    data-test-subj="entityAttachmentTableOpenEntity"
-                    onClick={() => handleOpenEntity(row)}
-                  />
+                  <EuiToolTip
+                    content={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
+                    disableScreenReaderOutput
+                  >
+                    <EuiButtonIcon
+                      iconType={icon}
+                      display="empty"
+                      size="xs"
+                      aria-label={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
+                      data-test-subj="entityAttachmentTableOpenEntity"
+                      onClick={() => handleOpenEntity(row)}
+                    />
+                  </EuiToolTip>
                 </EuiFlexItem>
               )}
               <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
@@ -12,8 +12,9 @@ import {
   EuiFlexItem,
   EuiInMemoryTable,
   EuiText,
-  useEuiTheme,
+  EuiToolTip,
   type EuiBasicTableColumn,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -194,29 +195,34 @@ export const EntityListTable: React.FC<{
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType={icon}
-                  display="empty"
-                  aria-label={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
-                  onClick={() => {
-                    const displayName = row.entity_name ?? row.entity_id;
-                    const rightPanel = buildEntityRightPanel({
-                      identifierType: row.entity_type,
-                      identifier: displayName,
-                      entityStoreId: row.entity_id,
-                    });
-                    // Close the canvas first: both navigation helpers only
-                    // update the URL (and, when wired, the Agent Builder
-                    // sidebar). Leaving the canvas open would overlay the
-                    // expandable flyout that the URL change is about to open.
-                    closeCanvas?.();
-                    if (rightPanel) {
-                      navigateWithFlyout({ preview: [], right: rightPanel });
-                    } else {
-                      navigateToHome();
-                    }
-                  }}
-                />
+                <EuiToolTip
+                  content={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    iconType={icon}
+                    display="empty"
+                    aria-label={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
+                    onClick={() => {
+                      const displayName = row.entity_name ?? row.entity_id;
+                      const rightPanel = buildEntityRightPanel({
+                        identifierType: row.entity_type,
+                        identifier: displayName,
+                        entityStoreId: row.entity_id,
+                      });
+                      // Close the canvas first: both navigation helpers only
+                      // update the URL (and, when wired, the Agent Builder
+                      // sidebar). Leaving the canvas open would overlay the
+                      // expandable flyout that the URL change is about to open.
+                      closeCanvas?.();
+                      if (rightPanel) {
+                        navigateWithFlyout({ preview: [], right: rightPanel });
+                      } else {
+                        navigateToHome();
+                      }
+                    }}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
               <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
                 <EuiText

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiIcon,
   EuiLoadingElastic,
   EuiLoadingSpinner,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -74,7 +75,7 @@ const LoadingCalloutComponent: React.FC<Props> = ({
       <EuiFlexGroup alignItems="center" data-test-subj="leftContent" gutterSize="none">
         <EuiFlexItem grow={false}>
           {isTerminalState ? (
-            <EuiIcon type="logoElastic" size="l" />
+            <EuiIcon type="logoElastic" size="l" aria-hidden={true} />
           ) : (
             <EuiLoadingElastic data-test-subj="loadingElastic" size="l" />
           )}
@@ -216,13 +217,15 @@ const LoadingCalloutComponent: React.FC<Props> = ({
                   `}
                 />
               ) : (
-                <EuiButtonIcon
-                  aria-label={i18n.CLOSE}
-                  disabled={isDismissing}
-                  iconType="cross"
-                  onClick={dismissGeneration}
-                  data-test-subj="dismissButton"
-                />
+                <EuiToolTip content={i18n.CLOSE} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-label={i18n.CLOSE}
+                    disabled={isDismissing}
+                    iconType="cross"
+                    onClick={dismissGeneration}
+                    data-test-subj="dismissButton"
+                  />
+                </EuiToolTip>
               )}
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiSwitch,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -113,14 +114,16 @@ const SummaryComponent: React.FC<Props> = ({
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                aria-label={ANONYMIZATION_ARIAL_LABEL}
-                data-test-subj="anonymizationSettings"
-                iconType="gear"
-                onClick={showAnonymizationModal}
-                size="s"
-                color="text"
-              />
+              <EuiToolTip content={ANONYMIZATION_ARIAL_LABEL} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  aria-label={ANONYMIZATION_ARIAL_LABEL}
+                  data-test-subj="anonymizationSettings"
+                  iconType="gear"
+                  onClick={showAnonymizationModal}
+                  size="s"
+                  color="text"
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/schedules_table/columns/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/schedules_table/columns/actions.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import type { AttackDiscoverySchedule } from '@kbn/elastic-assistant-common';
 
 import * as i18n from './translations';
@@ -29,14 +29,16 @@ const Action = ({ isDisabled, deleteSchedule, scheduleId }: ActionProps) => {
       <EuiFlexItem grow={false}>
         <WithMissingPrivileges>
           {(enabled) => (
-            <EuiButtonIcon
-              data-test-subj="deleteButton"
-              aria-label={i18n.DELETE_ACTIONS_BUTTON_ARIAL_LABEL}
-              color="danger"
-              iconType="trash"
-              onClick={onScheduleDeleteChange}
-              disabled={isDisabled || !enabled}
-            />
+            <EuiToolTip content={i18n.DELETE_ACTIONS_BUTTON_ARIAL_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                data-test-subj="deleteButton"
+                aria-label={i18n.DELETE_ACTIONS_BUTTON_ARIAL_LABEL}
+                color="danger"
+                iconType="trash"
+                onClick={onScheduleDeleteChange}
+                disabled={isDisabled || !enabled}
+              />
+            </EuiToolTip>
           )}
         </WithMissingPrivileges>
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_section/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_section/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexItem,
   EuiIconTip,
   EuiTitle,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import React, { useCallback } from 'react';
@@ -153,18 +154,22 @@ const HeaderSectionComponent: React.FC<HeaderSectionProps> = ({
                   >
                     {toggleQuery && (
                       <EuiFlexItem grow={false}>
-                        <EuiButtonIcon
-                          data-test-subj="query-toggle-header"
-                          aria-label={[toggleAriaLabel, i18n.QUERY_BUTTON_TITLE(toggleStatus)]
-                            .filter(Boolean) // remove undefined, empty string, null
-                            .join(' ')}
-                          color="text"
-                          display="empty"
-                          iconType={toggleStatus ? 'chevronSingleDown' : 'chevronSingleRight'}
-                          onClick={toggle}
-                          size="s"
-                          title={i18n.QUERY_BUTTON_TITLE(toggleStatus)}
-                        />
+                        <EuiToolTip
+                          content={i18n.QUERY_BUTTON_TITLE(toggleStatus)}
+                          disableScreenReaderOutput
+                        >
+                          <EuiButtonIcon
+                            data-test-subj="query-toggle-header"
+                            aria-label={[toggleAriaLabel, i18n.QUERY_BUTTON_TITLE(toggleStatus)]
+                              .filter(Boolean) // remove undefined, empty string, null
+                              .join(' ')}
+                            color="text"
+                            display="empty"
+                            iconType={toggleStatus ? 'chevronSingleDown' : 'chevronSingleRight'}
+                            onClick={toggle}
+                            size="s"
+                          />
+                        </EuiToolTip>
                       </EuiFlexItem>
                     )}
                     <EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonEmpty, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import React from 'react';
 
 import { InputsModelId } from '../../store/inputs/constants';
@@ -89,16 +89,17 @@ const InspectButtonComponent: React.FC<InspectButtonProps> = ({
         </EuiButtonEmpty>
       )}
       {(inputId === InputsModelId.global || compact) && showInspectButton && (
-        <EuiButtonIcon
-          className={BUTTON_CLASS}
-          aria-label={i18n.INSPECT}
-          data-test-subj="inspect-icon-button"
-          iconSize="m"
-          iconType="inspect"
-          isDisabled={isButtonDisabled}
-          title={i18n.INSPECT}
-          onClick={handleClick}
-        />
+        <EuiToolTip content={i18n.INSPECT} disableScreenReaderOutput>
+          <EuiButtonIcon
+            className={BUTTON_CLASS}
+            aria-label={i18n.INSPECT}
+            data-test-subj="inspect-icon-button"
+            iconSize="m"
+            iconType="inspect"
+            isDisabled={isButtonDisabled}
+            onClick={handleClick}
+          />
+        </EuiToolTip>
       )}
       {isShowingModal && request !== null && response !== null && (
         <ModalInspectQuery

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/clipboard/clipboard.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/clipboard/clipboard.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import classNames from 'classnames';
 import copy from 'copy-to-clipboard';
 import React from 'react';
@@ -62,14 +62,16 @@ export const Clipboard = ({
   });
 
   return (
-    <EuiButtonIcon
-      aria-label={i18n.COPY_TO_THE_CLIPBOARD}
-      className={className}
-      data-test-subj="clipboard"
-      iconType="copy"
-      onClick={onClick}
-    >
-      {children}
-    </EuiButtonIcon>
+    <EuiToolTip content={i18n.COPY_TO_THE_CLIPBOARD} disableScreenReaderOutput>
+      <EuiButtonIcon
+        aria-label={i18n.COPY_TO_THE_CLIPBOARD}
+        className={className}
+        data-test-subj="clipboard"
+        iconType="copy"
+        onClick={onClick}
+      >
+        {children}
+      </EuiButtonIcon>
+    </EuiToolTip>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx
@@ -7,11 +7,11 @@
 
 import React, { useState } from 'react';
 import {
-  EuiCheckbox,
   EuiButtonIcon,
-  EuiPopover,
+  EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPopover,
   EuiPopoverTitle,
   EuiSpacer,
   EuiToolTip,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/open_flyout_row_control_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/open_flyout_row_control_column.tsx
@@ -7,7 +7,7 @@
 
 import React, { memo, useCallback } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import type { Alert } from '@kbn/alerting-types';
 import { i18n } from '@kbn/i18n';
 import { EasePanelKey } from '../../../../flyout/ease/constants/panel_keys';
@@ -41,16 +41,23 @@ export const OpenFlyoutRowControlColumn = memo(({ alert }: ActionsCellProps) => 
   );
 
   return (
-    <EuiButtonIcon
-      aria-label={i18n.translate('xpack.securitySolution.alertSummary.table.flyoutIcon', {
+    <EuiToolTip
+      content={i18n.translate('xpack.securitySolution.alertSummary.table.flyoutIcon', {
         defaultMessage: 'Open flyout',
       })}
-      color="primary"
-      data-test-subj={ROW_ACTION_FLYOUT_ICON_TEST_ID}
-      iconType="maximize"
-      onClick={onOpenFlyout}
-      size="xs"
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        aria-label={i18n.translate('xpack.securitySolution.alertSummary.table.flyoutIcon', {
+          defaultMessage: 'Open flyout',
+        })}
+        color="primary"
+        data-test-subj={ROW_ACTION_FLYOUT_ICON_TEST_ID}
+        iconType="maximize"
+        onClick={onOpenFlyout}
+        size="xs"
+      />
+    </EuiToolTip>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.tsx
@@ -8,11 +8,11 @@
 import React, { useCallback, useState } from 'react';
 import type { EuiSwitchEvent } from '@elastic/eui';
 import {
-  EuiPopover,
   EuiButtonIcon,
-  EuiSwitch,
   EuiFormRow,
+  EuiPopover,
   EuiSpacer,
+  EuiSwitch,
   EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_host_table.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_host_table.test.tsx.snap
@@ -69,20 +69,24 @@ exports[`Authentication Host Table Component rendering it renders the host authe
                   <div
                     class="euiFlexItem emotion-euiFlexItem-growZero"
                   >
-                    <button
-                      aria-label="Open"
-                      class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                      data-test-subj="query-toggle-header"
-                      title="Open"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                      id="generated-id_euiToolTipAnchor"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="chevronSingleDown"
-                      />
-                    </button>
+                      <button
+                        aria-label="Open"
+                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                        data-test-subj="query-toggle-header"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="chevronSingleDown"
+                        />
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -103,21 +107,25 @@ exports[`Authentication Host Table Component rendering it renders the host authe
               <div
                 class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  aria-label="Inspect"
-                  class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                  data-test-subj="inspect-icon-button"
-                  disabled=""
-                  title="Inspect"
-                  type="button"
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                  id="generated-id_euiToolTipAnchor"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="inspect"
-                  />
-                </button>
+                  <button
+                    aria-label="Inspect"
+                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                    data-test-subj="inspect-icon-button"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="inspect"
+                    />
+                  </button>
+                </span>
               </div>
             </div>
           </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_user_table.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_user_table.test.tsx.snap
@@ -69,20 +69,24 @@ exports[`Authentication User Table Component rendering it renders the user authe
                   <div
                     class="euiFlexItem emotion-euiFlexItem-growZero"
                   >
-                    <button
-                      aria-label="Open"
-                      class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                      data-test-subj="query-toggle-header"
-                      title="Open"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                      id="generated-id_euiToolTipAnchor"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="chevronSingleDown"
-                      />
-                    </button>
+                      <button
+                        aria-label="Open"
+                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                        data-test-subj="query-toggle-header"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="chevronSingleDown"
+                        />
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -103,21 +107,25 @@ exports[`Authentication User Table Component rendering it renders the user authe
               <div
                 class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  aria-label="Inspect"
-                  class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                  data-test-subj="inspect-icon-button"
-                  disabled=""
-                  title="Inspect"
-                  type="button"
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                  id="generated-id_euiToolTipAnchor"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="inspect"
-                  />
-                </button>
+                  <button
+                    aria-label="Inspect"
+                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                    data-test-subj="inspect-icon-button"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="inspect"
+                    />
+                  </button>
+                </span>
               </div>
             </div>
           </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/__snapshots__/index.test.tsx.snap
@@ -114,20 +114,24 @@ exports[`Paginated Table Component rendering it renders the default load more ta
                       <div
                         class="euiFlexItem emotion-euiFlexItem-growZero"
                       >
-                        <button
-                          aria-label="Open"
-                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                          data-test-subj="query-toggle-header"
-                          title="Open"
-                          type="button"
+                        <span
+                          class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                          id="generated-id_euiToolTipAnchor"
                         >
-                          <span
-                            aria-hidden="true"
-                            class="euiButtonIcon__icon"
-                            color="inherit"
-                            data-euiicon-type="chevronSingleDown"
-                          />
-                        </button>
+                          <button
+                            aria-label="Open"
+                            class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                            data-test-subj="query-toggle-header"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="chevronSingleDown"
+                            />
+                          </button>
+                        </span>
                       </div>
                       <div
                         class="euiFlexItem emotion-euiFlexItem-grow-1"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/uncommon_process_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/uncommon_process_table/__snapshots__/index.test.tsx.snap
@@ -89,20 +89,24 @@ exports[`Uncommon Process Table Component rendering it renders the default Uncom
                   <div
                     class="euiFlexItem emotion-euiFlexItem-growZero"
                   >
-                    <button
-                      aria-label="Open"
-                      class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                      data-test-subj="query-toggle-header"
-                      title="Open"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                      id="generated-id_euiToolTipAnchor"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="chevronSingleDown"
-                      />
-                    </button>
+                      <button
+                        aria-label="Open"
+                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                        data-test-subj="query-toggle-header"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="chevronSingleDown"
+                        />
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -123,21 +127,25 @@ exports[`Uncommon Process Table Component rendering it renders the default Uncom
               <div
                 class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  aria-label="Inspect"
-                  class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                  data-test-subj="inspect-icon-button"
-                  disabled=""
-                  title="Inspect"
-                  type="button"
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                  id="generated-id_euiToolTipAnchor"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="inspect"
-                  />
-                </button>
+                  <button
+                    aria-label="Inspect"
+                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                    data-test-subj="inspect-icon-button"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="inspect"
+                    />
+                  </button>
+                </span>
               </div>
             </div>
           </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/__snapshots__/index.test.tsx.snap
@@ -41,21 +41,25 @@ exports[`IP Overview Component rendering it renders the default IP Overview 1`] 
   <div
     class="euiFlexGroup e1v2bxdw0 emotion-euiFlexGroup-responsive-m-flexStart-stretch-row-OverviewWrapper"
   >
-    <button
-      aria-label="Inspect"
-      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-      data-test-subj="inspect-icon-button"
-      disabled=""
-      title="Inspect"
-      type="button"
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+      id="generated-id_euiToolTipAnchor"
     >
-      <span
-        aria-hidden="true"
-        class="euiButtonIcon__icon"
-        color="inherit"
-        data-euiicon-type="inspect"
-      />
-    </button>
+      <button
+        aria-label="Inspect"
+        class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+        data-test-subj="inspect-icon-button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="inspect"
+        />
+      </button>
+    </span>
     <div
       class="euiFlexItem emotion-euiFlexItem-grow-1"
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_dns_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_dns_table/__snapshots__/index.test.tsx.snap
@@ -89,20 +89,24 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
                   <div
                     class="euiFlexItem emotion-euiFlexItem-growZero"
                   >
-                    <button
-                      aria-label="Open"
-                      class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                      data-test-subj="query-toggle-header"
-                      title="Open"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                      id="generated-id_euiToolTipAnchor"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="chevronSingleDown"
-                      />
-                    </button>
+                      <button
+                        aria-label="Open"
+                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                        data-test-subj="query-toggle-header"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="chevronSingleDown"
+                        />
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -136,21 +140,25 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               <div
                 class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  aria-label="Inspect"
-                  class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                  data-test-subj="inspect-icon-button"
-                  disabled=""
-                  title="Inspect"
-                  type="button"
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                  id="generated-id_euiToolTipAnchor"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="inspect"
-                  />
-                </button>
+                  <button
+                    aria-label="Inspect"
+                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                    data-test-subj="inspect-icon-button"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="inspect"
+                    />
+                  </button>
+                </span>
               </div>
             </div>
           </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_http_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_http_table/__snapshots__/index.test.tsx.snap
@@ -106,20 +106,24 @@ exports[`NetworkHttp Table Component rendering it renders the default NetworkHtt
                     <div
                       class="euiFlexItem emotion-euiFlexItem-growZero"
                     >
-                      <button
-                        aria-label="Open"
-                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                        data-test-subj="query-toggle-header"
-                        title="Open"
-                        type="button"
+                      <span
+                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                        id="generated-id_euiToolTipAnchor"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="euiButtonIcon__icon"
-                          color="inherit"
-                          data-euiicon-type="chevronSingleDown"
-                        />
-                      </button>
+                        <button
+                          aria-label="Open"
+                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                          data-test-subj="query-toggle-header"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="chevronSingleDown"
+                          />
+                        </button>
+                      </span>
                     </div>
                     <div
                       class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -140,21 +144,25 @@ exports[`NetworkHttp Table Component rendering it renders the default NetworkHtt
                 <div
                   class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <button
-                    aria-label="Inspect"
-                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                    data-test-subj="inspect-icon-button"
-                    disabled=""
-                    title="Inspect"
-                    type="button"
+                  <span
+                    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    id="generated-id_euiToolTipAnchor"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="euiButtonIcon__icon"
-                      color="inherit"
-                      data-euiicon-type="inspect"
-                    />
-                  </button>
+                    <button
+                      aria-label="Inspect"
+                      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                      data-test-subj="inspect-icon-button"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="inspect"
+                      />
+                    </button>
+                  </span>
                 </div>
               </div>
             </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/__snapshots__/index.test.tsx.snap
@@ -126,20 +126,24 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
                     <div
                       class="euiFlexItem emotion-euiFlexItem-growZero"
                     >
-                      <button
-                        aria-label="Open"
-                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                        data-test-subj="query-toggle-header"
-                        title="Open"
-                        type="button"
+                      <span
+                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                        id="generated-id_euiToolTipAnchor"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="euiButtonIcon__icon"
-                          color="inherit"
-                          data-euiicon-type="chevronSingleDown"
-                        />
-                      </button>
+                        <button
+                          aria-label="Open"
+                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                          data-test-subj="query-toggle-header"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="chevronSingleDown"
+                          />
+                        </button>
+                      </span>
                     </div>
                     <div
                       class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -160,21 +164,25 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
                 <div
                   class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <button
-                    aria-label="Inspect"
-                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                    data-test-subj="inspect-icon-button"
-                    disabled=""
-                    title="Inspect"
-                    type="button"
+                  <span
+                    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    id="generated-id_euiToolTipAnchor"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="euiButtonIcon__icon"
-                      color="inherit"
-                      data-euiicon-type="inspect"
-                    />
-                  </button>
+                    <button
+                      aria-label="Inspect"
+                      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                      data-test-subj="inspect-icon-button"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="inspect"
+                      />
+                    </button>
+                  </span>
                 </div>
               </div>
             </div>
@@ -802,20 +810,24 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
                     <div
                       class="euiFlexItem emotion-euiFlexItem-growZero"
                     >
-                      <button
-                        aria-label="Open"
-                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                        data-test-subj="query-toggle-header"
-                        title="Open"
-                        type="button"
+                      <span
+                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                        id="generated-id_euiToolTipAnchor"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="euiButtonIcon__icon"
-                          color="inherit"
-                          data-euiicon-type="chevronSingleDown"
-                        />
-                      </button>
+                        <button
+                          aria-label="Open"
+                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                          data-test-subj="query-toggle-header"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="chevronSingleDown"
+                          />
+                        </button>
+                      </span>
                     </div>
                     <div
                       class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -836,21 +848,25 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
                 <div
                   class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <button
-                    aria-label="Inspect"
-                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                    data-test-subj="inspect-icon-button"
-                    disabled=""
-                    title="Inspect"
-                    type="button"
+                  <span
+                    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    id="generated-id_euiToolTipAnchor"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="euiButtonIcon__icon"
-                      color="inherit"
-                      data-euiicon-type="inspect"
-                    />
-                  </button>
+                    <button
+                      aria-label="Inspect"
+                      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                      data-test-subj="inspect-icon-button"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="inspect"
+                      />
+                    </button>
+                  </span>
                 </div>
               </div>
             </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/__snapshots__/index.test.tsx.snap
@@ -126,20 +126,24 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
                     <div
                       class="euiFlexItem emotion-euiFlexItem-growZero"
                     >
-                      <button
-                        aria-label="Open"
-                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                        data-test-subj="query-toggle-header"
-                        title="Open"
-                        type="button"
+                      <span
+                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                        id="generated-id_euiToolTipAnchor"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="euiButtonIcon__icon"
-                          color="inherit"
-                          data-euiicon-type="chevronSingleDown"
-                        />
-                      </button>
+                        <button
+                          aria-label="Open"
+                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                          data-test-subj="query-toggle-header"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="chevronSingleDown"
+                          />
+                        </button>
+                      </span>
                     </div>
                     <div
                       class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -160,21 +164,25 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
                 <div
                   class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <button
-                    aria-label="Inspect"
-                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                    data-test-subj="inspect-icon-button"
-                    disabled=""
-                    title="Inspect"
-                    type="button"
+                  <span
+                    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    id="generated-id_euiToolTipAnchor"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="euiButtonIcon__icon"
-                      color="inherit"
-                      data-euiicon-type="inspect"
-                    />
-                  </button>
+                    <button
+                      aria-label="Inspect"
+                      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                      data-test-subj="inspect-icon-button"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="inspect"
+                      />
+                    </button>
+                  </span>
                 </div>
               </div>
             </div>
@@ -942,20 +950,24 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
                     <div
                       class="euiFlexItem emotion-euiFlexItem-growZero"
                     >
-                      <button
-                        aria-label="Open"
-                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                        data-test-subj="query-toggle-header"
-                        title="Open"
-                        type="button"
+                      <span
+                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                        id="generated-id_euiToolTipAnchor"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="euiButtonIcon__icon"
-                          color="inherit"
-                          data-euiicon-type="chevronSingleDown"
-                        />
-                      </button>
+                        <button
+                          aria-label="Open"
+                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                          data-test-subj="query-toggle-header"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="chevronSingleDown"
+                          />
+                        </button>
+                      </span>
                     </div>
                     <div
                       class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -976,21 +988,25 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
                 <div
                   class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <button
-                    aria-label="Inspect"
-                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                    data-test-subj="inspect-icon-button"
-                    disabled=""
-                    title="Inspect"
-                    type="button"
+                  <span
+                    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    id="generated-id_euiToolTipAnchor"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="euiButtonIcon__icon"
-                      color="inherit"
-                      data-euiicon-type="inspect"
-                    />
-                  </button>
+                    <button
+                      aria-label="Inspect"
+                      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                      data-test-subj="inspect-icon-button"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="inspect"
+                      />
+                    </button>
+                  </span>
                 </div>
               </div>
             </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/tls_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/tls_table/__snapshots__/index.test.tsx.snap
@@ -126,20 +126,24 @@ exports[`Tls Table Component Rendering it renders the default Domains table 1`] 
                     <div
                       class="euiFlexItem emotion-euiFlexItem-growZero"
                     >
-                      <button
-                        aria-label="Open"
-                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                        data-test-subj="query-toggle-header"
-                        title="Open"
-                        type="button"
+                      <span
+                        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                        id="generated-id_euiToolTipAnchor"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="euiButtonIcon__icon"
-                          color="inherit"
-                          data-euiicon-type="chevronSingleDown"
-                        />
-                      </button>
+                        <button
+                          aria-label="Open"
+                          class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                          data-test-subj="query-toggle-header"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="chevronSingleDown"
+                          />
+                        </button>
+                      </span>
                     </div>
                     <div
                       class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -160,21 +164,25 @@ exports[`Tls Table Component Rendering it renders the default Domains table 1`] 
                 <div
                   class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <button
-                    aria-label="Inspect"
-                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                    data-test-subj="inspect-icon-button"
-                    disabled=""
-                    title="Inspect"
-                    type="button"
+                  <span
+                    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    id="generated-id_euiToolTipAnchor"
                   >
-                    <span
-                      aria-hidden="true"
-                      class="euiButtonIcon__icon"
-                      color="inherit"
-                      data-euiicon-type="inspect"
-                    />
-                  </button>
+                    <button
+                      aria-label="Inspect"
+                      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                      data-test-subj="inspect-icon-button"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="inspect"
+                      />
+                    </button>
+                  </span>
                 </div>
               </div>
             </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/users_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/users_table/__snapshots__/index.test.tsx.snap
@@ -89,20 +89,24 @@ exports[`Users Table Component Rendering it renders the default Users table 1`] 
                   <div
                     class="euiFlexItem emotion-euiFlexItem-growZero"
                   >
-                    <button
-                      aria-label="Open"
-                      class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
-                      data-test-subj="query-toggle-header"
-                      title="Open"
-                      type="button"
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                      id="generated-id_euiToolTipAnchor"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="chevronSingleDown"
-                      />
-                    </button>
+                      <button
+                        aria-label="Open"
+                        class="euiButtonIcon emotion-euiButtonIcon-s-empty-text"
+                        data-test-subj="query-toggle-header"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="chevronSingleDown"
+                        />
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="euiFlexItem emotion-euiFlexItem-grow-1"
@@ -123,21 +127,25 @@ exports[`Users Table Component Rendering it renders the default Users table 1`] 
               <div
                 class="euiFlexItem emotion-euiFlexItem-growZero"
               >
-                <button
-                  aria-label="Inspect"
-                  class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                  data-test-subj="inspect-icon-button"
-                  disabled=""
-                  title="Inspect"
-                  type="button"
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                  id="generated-id_euiToolTipAnchor"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="inspect"
-                  />
-                </button>
+                  <button
+                    aria-label="Inspect"
+                    class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                    data-test-subj="inspect-icon-button"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="inspect"
+                    />
+                  </button>
+                </span>
               </div>
             </div>
           </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/utils/table_tab_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/utils/table_tab_columns.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon, EuiText, type EuiBasicTableColumn } from '@elastic/eui';
+import { EuiButtonIcon, EuiText, EuiToolTip, type EuiBasicTableColumn } from '@elastic/eui';
 import type { BrowserFields, TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { getFieldFromBrowserField } from '../tabs/table_tab';
 import { TableFieldNameCell } from '../components/table_field_name_cell';
@@ -84,17 +84,19 @@ export const getTableTabColumns: ColumnsProvider = ({
     field: 'isPinned',
     render: (isPinned: boolean, data: TimelineEventsDetailsItem) => {
       return (
-        <EuiButtonIcon
-          aria-label={isPinned ? UNPIN : PIN}
-          className={isPinned ? 'flyout_table__unPinAction' : 'flyout_table__pinAction'}
-          iconType={isPinned ? 'pinFill' : 'pin'}
-          color="text"
-          iconSize="m"
-          onClick={() => {
-            onTogglePinned(data.field, isPinned ? 'unpin' : 'pin');
-          }}
-          data-test-subj={FLYOUT_TABLE_PIN_ACTION_TEST_ID}
-        />
+        <EuiToolTip content={isPinned ? UNPIN : PIN} disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label={isPinned ? UNPIN : PIN}
+            className={isPinned ? 'flyout_table__unPinAction' : 'flyout_table__pinAction'}
+            iconType={isPinned ? 'pinFill' : 'pin'}
+            color="text"
+            iconSize="m"
+            onClick={() => {
+              onTogglePinned(data.field, isPinned ? 'unpin' : 'pin');
+            }}
+            data-test-subj={FLYOUT_TABLE_PIN_ACTION_TEST_ID}
+          />
+        </EuiToolTip>
       );
     },
     width: '32px',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/related_attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/related_attacks.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { PageScope } from '../../../data_view_manager/constants';
@@ -55,18 +55,29 @@ export const RelatedAttacks: React.FC<RelatedAttacksProps> = ({
         ? [
             {
               render: (row: Record<string, unknown>) => (
-                <EuiButtonIcon
-                  iconType="expand"
-                  data-test-subj={`${CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TEST_ID}AlertPreviewButton`}
-                  onClick={() => onShowAttack(row.id as string, row.index as string)}
-                  aria-label={i18n.translate(
+                <EuiToolTip
+                  content={i18n.translate(
                     'xpack.securitySolution.flyout.correlations.relatedAttacksPreviewButtonLabel',
                     {
                       defaultMessage: 'Preview attack with id {id}',
                       values: { id: row.id as string },
                     }
                   )}
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    iconType="expand"
+                    data-test-subj={`${CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TEST_ID}AlertPreviewButton`}
+                    onClick={() => onShowAttack(row.id as string, row.index as string)}
+                    aria-label={i18n.translate(
+                      'xpack.securitySolution.flyout.correlations.relatedAttacksPreviewButtonLabel',
+                      {
+                        defaultMessage: 'Preview attack with id {id}',
+                        values: { id: row.id as string },
+                      }
+                    )}
+                  />
+                </EuiToolTip>
               ),
               width: '5%',
             } as CorrelationsCustomTableColumn,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/utils/get_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/utils/get_columns.tsx
@@ -33,18 +33,29 @@ export const getColumns = ({
 }): Array<EuiBasicTableColumn<Record<string, unknown>>> => [
   {
     render: (row: Record<string, unknown>) => (
-      <EuiButtonIcon
-        iconType="expand"
-        data-test-subj={`${dataTestSubj}AlertPreviewButton`}
-        onClick={() => onShowAlert(row.id as string, row.index as string)}
-        aria-label={i18n.translate(
+      <EuiToolTip
+        content={i18n.translate(
           'xpack.securitySolution.flyout.correlations.alertPreview.ariaLabel',
           {
             defaultMessage: 'Preview alert with id {id}',
             values: { id: row.id as string },
           }
         )}
-      />
+        disableScreenReaderOutput
+      >
+        <EuiButtonIcon
+          iconType="expand"
+          data-test-subj={`${dataTestSubj}AlertPreviewButton`}
+          onClick={() => onShowAlert(row.id as string, row.index as string)}
+          aria-label={i18n.translate(
+            'xpack.securitySolution.flyout.correlations.alertPreview.ariaLabel',
+            {
+              defaultMessage: 'Preview alert with id {id}',
+              values: { id: row.id as string },
+            }
+          )}
+        />
+      </EuiToolTip>
     ),
     width: '5%',
   },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/expandable_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/expandable_panel.tsx
@@ -108,20 +108,30 @@ export const ExpandablePanel: FC<PropsWithChildren<ExpandablePanelPanelProps>> =
 
   const toggleIcon = useMemo(
     () => (
-      <EuiButtonIcon
-        data-test-subj={`${dataTestSubj}ToggleIcon`}
-        aria-label={i18n.translate(
+      <EuiToolTip
+        content={i18n.translate(
           'xpack.securitySolution.flyout.shared.ExpandablePanelButtonIconAriaLabel',
           {
             defaultMessage: 'Expandable panel toggle',
           }
         )}
-        color="text"
-        display="empty"
-        iconType={toggleStatus ? 'chevronSingleDown' : 'chevronSingleRight'}
-        onClick={toggleQuery}
-        size="xs"
-      />
+        disableScreenReaderOutput
+      >
+        <EuiButtonIcon
+          data-test-subj={`${dataTestSubj}ToggleIcon`}
+          aria-label={i18n.translate(
+            'xpack.securitySolution.flyout.shared.ExpandablePanelButtonIconAriaLabel',
+            {
+              defaultMessage: 'Expandable panel toggle',
+            }
+          )}
+          color="text"
+          display="empty"
+          iconType={toggleStatus ? 'chevronSingleDown' : 'chevronSingleRight'}
+          onClick={toggleQuery}
+          size="xs"
+        />
+      </EuiToolTip>
     ),
     [dataTestSubj, toggleStatus, toggleQuery]
   );
@@ -153,6 +163,7 @@ export const ExpandablePanel: FC<PropsWithChildren<ExpandablePanelPanelProps>> =
                   margin: ${euiTheme.size.s} 0;
                 `}
                 data-test-subj={`${dataTestSubj}TitleIcon`}
+                aria-hidden={true}
               />
             </EuiFlexItem>
           )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/notes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/notes.tsx
@@ -15,6 +15,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -143,16 +144,18 @@ export const Notes = memo(({ documentId, onShowNotes, disabled = false }: NotesP
 
   const addNoteButtonIcon = useMemo(
     () => (
-      <EuiButtonIcon
-        onClick={onShowNotes}
-        iconType="plusInCircle"
-        disabled={cannotAddNotes}
-        css={css`
-          margin-left: ${euiTheme.size.xs};
-        `}
-        aria-label={ADD_NOTE_BUTTON}
-        data-test-subj={NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID}
-      />
+      <EuiToolTip content={ADD_NOTE_BUTTON} disableScreenReaderOutput>
+        <EuiButtonIcon
+          onClick={onShowNotes}
+          iconType="plusInCircle"
+          disabled={cannotAddNotes}
+          css={css`
+            margin-left: ${euiTheme.size.xs};
+          `}
+          aria-label={ADD_NOTE_BUTTON}
+          data-test-subj={NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID}
+        />
+      </EuiToolTip>
     ),
     [euiTheme.size.xs, cannotAddNotes, onShowNotes]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/delete_note_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/delete_note_button.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback, useEffect, useState } from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
 import { useUserPrivileges } from '../../common/components/user_privileges';
@@ -87,16 +87,17 @@ export const DeleteNoteButtonIcon = memo(({ note, index }: DeleteNoteButtonIconP
   }
 
   return (
-    <EuiButtonIcon
-      data-test-subj={`${DELETE_NOTE_BUTTON_TEST_ID}-${index}`}
-      title={DELETE_NOTE}
-      aria-label={DELETE_NOTE}
-      color="text"
-      iconType="trash"
-      onClick={() => deleteNoteFc(note.noteId)}
-      disabled={deletingNoteId !== note.noteId && deleteStatus === ReqStatus.Loading}
-      isLoading={deletingNoteId === note.noteId && deleteStatus === ReqStatus.Loading}
-    />
+    <EuiToolTip content={DELETE_NOTE} disableScreenReaderOutput>
+      <EuiButtonIcon
+        data-test-subj={`${DELETE_NOTE_BUTTON_TEST_ID}-${index}`}
+        aria-label={DELETE_NOTE}
+        color="text"
+        iconType="trash"
+        onClick={() => deleteNoteFc(note.noteId)}
+        disabled={deletingNoteId !== note.noteId && deleteStatus === ReqStatus.Loading}
+        isLoading={deletingNoteId === note.noteId && deleteStatus === ReqStatus.Loading}
+      />
+    </EuiToolTip>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_timeline_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_timeline_button.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback } from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useQueryTimelineById } from '../../timelines/components/open_timeline/helpers';
 import { OPEN_TIMELINE_BUTTON_TEST_ID } from './test_ids';
@@ -49,15 +49,16 @@ export const OpenTimelineButtonIcon = memo(({ note, index }: OpenTimelineButtonI
   );
 
   return (
-    <EuiButtonIcon
-      data-test-subj={`${OPEN_TIMELINE_BUTTON_TEST_ID}-${index}`}
-      title={OPEN_TIMELINE}
-      aria-label={OPEN_TIMELINE}
-      color="text"
-      iconType="timelineWithArrow"
-      onClick={() => openTimeline(note)}
-      disabled={!canReadTimelines}
-    />
+    <EuiToolTip content={OPEN_TIMELINE} disableScreenReaderOutput>
+      <EuiButtonIcon
+        data-test-subj={`${OPEN_TIMELINE_BUTTON_TEST_ID}-${index}`}
+        aria-label={OPEN_TIMELINE}
+        color="text"
+        iconType="timelineWithArrow"
+        onClick={() => openTimeline(note)}
+        disabled={!canReadTimelines}
+      />
+    </EuiToolTip>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/host_overview/__snapshots__/index.test.tsx.snap
@@ -42,21 +42,25 @@ exports[`Host Summary Component it renders the default Host Summary 1`] = `
     class="euiFlexGroup e1v2bxdw0 emotion-euiFlexGroup-responsive-m-flexStart-stretch-row-OverviewWrapper"
     data-test-subj="host-overview"
   >
-    <button
-      aria-label="Inspect"
-      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-      data-test-subj="inspect-icon-button"
-      disabled=""
-      title="Inspect"
-      type="button"
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+      id="generated-id_euiToolTipAnchor"
     >
-      <span
-        aria-hidden="true"
-        class="euiButtonIcon__icon"
-        color="inherit"
-        data-euiicon-type="inspect"
-      />
-    </button>
+      <button
+        aria-label="Inspect"
+        class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+        data-test-subj="inspect-icon-button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="inspect"
+        />
+      </button>
+    </span>
     <div
       class="euiFlexItem emotion-euiFlexItem-grow-1"
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/user_overview/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/user_overview/__snapshots__/index.test.tsx.snap
@@ -42,21 +42,25 @@ exports[`User Summary Component it renders the default User Summary 1`] = `
     class="euiFlexGroup e1v2bxdw0 emotion-euiFlexGroup-responsive-m-flexStart-stretch-row-OverviewWrapper"
     data-test-subj="user-overview"
   >
-    <button
-      aria-label="Inspect"
-      class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-      data-test-subj="inspect-icon-button"
-      disabled=""
-      title="Inspect"
-      type="button"
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+      id="generated-id_euiToolTipAnchor"
     >
-      <span
-        aria-hidden="true"
-        class="euiButtonIcon__icon"
-        color="inherit"
-        data-euiicon-type="inspect"
-      />
-    </button>
+      <button
+        aria-label="Inspect"
+        class="euiButtonIcon inspectButtonComponent emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+        data-test-subj="inspect-icon-button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="inspect"
+        />
+      </button>
+    </span>
     <div
       class="euiFlexItem emotion-euiFlexItem-grow-1"
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_steps/lookups/missing_lookups_list/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_steps/lookups/missing_lookups_list/index.tsx
@@ -184,14 +184,16 @@ const OmitLookupButton = React.memo<OmitLookupButtonProps>(
 
     const button = useMemo(
       () => (
-        <EuiButtonIcon
-          onClick={onClick}
-          iconType="cross"
-          color="text"
-          aria-label={CONFIGS[migrationSource].label}
-          data-test-subj={testId}
-          isDisabled={isDisabled}
-        />
+        <EuiToolTip content={CONFIGS[migrationSource].label} disableScreenReaderOutput>
+          <EuiButtonIcon
+            onClick={onClick}
+            iconType="cross"
+            color="text"
+            aria-label={CONFIGS[migrationSource].label}
+            data-test-subj={testId}
+            isDisabled={isDisabled}
+          />
+        </EuiToolTip>
       ),
       [onClick, migrationSource, testId, isDisabled]
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/migration_result_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/migration_result_panel.tsx
@@ -8,18 +8,19 @@
 import React, { useCallback, useMemo } from 'react';
 import moment from 'moment';
 import {
+  EuiAccordion,
+  EuiBadge,
+  EuiBasicTable,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPanel,
+  EuiHealth,
   EuiHorizontalRule,
   EuiIcon,
-  EuiBasicTable,
-  EuiHealth,
-  EuiText,
-  EuiAccordion,
-  EuiButtonIcon,
+  EuiPanel,
   EuiSpacer,
-  EuiBadge,
+  EuiText,
+  EuiToolTip,
   type EuiBasicTableColumn,
 } from '@elastic/eui';
 import { Chart, BarSeries, Settings, ScaleType } from '@elastic/charts';
@@ -99,14 +100,23 @@ export const DashboardMigrationResultPanel = React.memo<DashboardMigrationResult
               </EuiBadge>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType={isCollapsed ? 'chevronSingleDown' : 'chevronSingleUp'}
-                onClick={toggleCollapsed}
-                aria-label={
+              <EuiToolTip
+                content={
                   isCollapsed ? i18n.DASHBOARD_MIGRATION_EXPAND : i18n.DASHBOARD_MIGRATION_COLLAPSE
                 }
-                data-test-subj="collapseButton"
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  iconType={isCollapsed ? 'chevronSingleDown' : 'chevronSingleUp'}
+                  onClick={toggleCollapsed}
+                  aria-label={
+                    isCollapsed
+                      ? i18n.DASHBOARD_MIGRATION_EXPAND
+                      : i18n.DASHBOARD_MIGRATION_COLLAPSE
+                  }
+                  data-test-subj="collapseButton"
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPanel>
@@ -131,7 +141,7 @@ export const DashboardMigrationResultPanel = React.memo<DashboardMigrationResult
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type={AssistantIcon} size="m" />
+                    <EuiIcon type={AssistantIcon} size="m" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <PanelText size="s" semiBold>

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_result_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_result_panel.tsx
@@ -8,18 +8,19 @@
 import React, { useCallback, useMemo } from 'react';
 import moment from 'moment';
 import {
+  EuiAccordion,
+  EuiBadge,
+  EuiBasicTable,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPanel,
+  EuiHealth,
   EuiHorizontalRule,
   EuiIcon,
-  EuiBasicTable,
-  EuiHealth,
-  EuiText,
-  EuiAccordion,
-  EuiButtonIcon,
+  EuiPanel,
   EuiSpacer,
-  EuiBadge,
+  EuiText,
+  EuiToolTip,
   type EuiBasicTableColumn,
   useEuiTheme,
 } from '@elastic/eui';
@@ -110,11 +111,18 @@ export const RuleMigrationResultPanel = React.memo<RuleMigrationResultPanelProps
               <EuiBadge css={completeBadgeStyles}>{i18n.RULE_MIGRATION_COMPLETE_BADGE}</EuiBadge>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType={isCollapsed ? 'chevronSingleDown' : 'chevronSingleUp'}
-                onClick={toggleCollapsed}
-                aria-label={isCollapsed ? i18n.RULE_MIGRATION_EXPAND : i18n.RULE_MIGRATION_COLLAPSE}
-              />
+              <EuiToolTip
+                content={isCollapsed ? i18n.RULE_MIGRATION_EXPAND : i18n.RULE_MIGRATION_COLLAPSE}
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  iconType={isCollapsed ? 'chevronSingleDown' : 'chevronSingleUp'}
+                  onClick={toggleCollapsed}
+                  aria-label={
+                    isCollapsed ? i18n.RULE_MIGRATION_EXPAND : i18n.RULE_MIGRATION_COLLAPSE
+                  }
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPanel>
@@ -139,7 +147,7 @@ export const RuleMigrationResultPanel = React.memo<RuleMigrationResultPanelProps
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type={AssistantIcon} size="m" />
+                    <EuiIcon type={AssistantIcon} size="m" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <PanelText size="s" semiBold>

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/common/copy_to_clipboard.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/components/common/copy_to_clipboard.tsx
@@ -7,7 +7,13 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import { EuiButtonEmpty, EuiButtonIcon, EuiContextMenuItem, EuiCopy } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiCopy,
+  EuiToolTip,
+} from '@elastic/eui';
 import { COPY_TITLE } from './translations';
 
 const COPY_ICON = 'copy';
@@ -89,16 +95,18 @@ export const CopyToClipboardButtonIcon: FC<CopyToClipboardProps> = ({
 }) => (
   <EuiCopy textToCopy={value}>
     {(copy) => (
-      <EuiButtonIcon
-        aria-label={COPY_TITLE}
-        iconType={COPY_ICON}
-        iconSize="s"
-        color="primary"
-        onClick={copy}
-        data-test-subj={dataTestSub}
-      >
-        {COPY_TITLE}
-      </EuiButtonIcon>
+      <EuiToolTip content={COPY_TITLE} disableScreenReaderOutput>
+        <EuiButtonIcon
+          aria-label={COPY_TITLE}
+          iconType={COPY_ICON}
+          iconSize="s"
+          color="primary"
+          onClick={copy}
+          data-test-subj={dataTestSub}
+        >
+          {COPY_TITLE}
+        </EuiButtonIcon>
+      </EuiToolTip>
     )}
   </EuiCopy>
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_toolbar_options.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_toolbar_options.test.tsx
@@ -44,13 +44,17 @@ describe('useToolbarOptions()', () => {
       }
     `);
     expect(result.result.current.additionalControls.right).toMatchInlineSnapshot(`
-      <EuiButtonIcon
-        aria-label="Inspect"
-        data-test-subj="tiIndicatorsGridInspect"
-        iconType="inspect"
-        onClick={[Function]}
-        title="Inspect"
-      />
+      <EuiToolTip
+        content="Inspect"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Inspect"
+          data-test-subj="tiIndicatorsGridInspect"
+          iconType="inspect"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     `);
   });
 
@@ -88,13 +92,17 @@ describe('useToolbarOptions()', () => {
       }
     `);
     expect(result.result.current.additionalControls.right).toMatchInlineSnapshot(`
-      <EuiButtonIcon
-        aria-label="Inspect"
-        data-test-subj="tiIndicatorsGridInspect"
-        iconType="inspect"
-        onClick={[Function]}
-        title="Inspect"
-      />
+      <EuiToolTip
+        content="Inspect"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Inspect"
+          data-test-subj="tiIndicatorsGridInspect"
+          iconType="inspect"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     `);
   });
 
@@ -132,13 +140,17 @@ describe('useToolbarOptions()', () => {
       }
     `);
     expect(result.result.current.additionalControls.right).toMatchInlineSnapshot(`
-      <EuiButtonIcon
-        aria-label="Inspect"
-        data-test-subj="tiIndicatorsGridInspect"
-        iconType="inspect"
-        onClick={[Function]}
-        title="Inspect"
-      />
+      <EuiToolTip
+        content="Inspect"
+        disableScreenReaderOutput={true}
+      >
+        <EuiButtonIcon
+          aria-label="Inspect"
+          data-test-subj="tiIndicatorsGridInspect"
+          iconType="inspect"
+          onClick={[Function]}
+        />
+      </EuiToolTip>
     `);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_toolbar_options.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/hooks/use_toolbar_options.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import type { EuiDataGridColumn } from '@elastic/eui';
-import { EuiButtonIcon, EuiText } from '@elastic/eui';
+import { EuiButtonIcon, EuiText, EuiToolTip } from '@elastic/eui';
 import type { BrowserField } from '@kbn/rule-registry-plugin/common';
 import { useInspector } from '../../../hooks/use_inspector';
 import { IndicatorsFieldBrowser } from '../components/table/field_browser';
@@ -58,13 +58,14 @@ export const useToolbarOptions = ({
           ),
         },
         right: (
-          <EuiButtonIcon
-            aria-label={INSPECT_BUTTON_TITLE}
-            iconType="inspect"
-            title={INSPECT_BUTTON_TITLE}
-            data-test-subj={INSPECT_BUTTON_TEST_ID}
-            onClick={handleOpenInspector}
-          />
+          <EuiToolTip content={INSPECT_BUTTON_TITLE} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={INSPECT_BUTTON_TITLE}
+              iconType="inspect"
+              data-test-subj={INSPECT_BUTTON_TEST_ID}
+              onClick={handleOpenInspector}
+            />
+          </EuiToolTip>
         ),
       },
     }),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/add_to_favorites/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/add_to_favorites/index.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { State } from '../../../common/store';
 import { selectTimelineById } from '../../store/selectors';
@@ -59,17 +59,18 @@ export const AddToFavoritesButton = React.memo<AddToFavoritesButtonProps>(({ tim
   );
 
   return (
-    <EuiButtonIcon
-      iconType={isFavorite ? 'starFill' : 'star'}
-      isSelected={isFavorite}
-      disabled={isDisabled}
-      aria-label={label}
-      title={label}
-      data-test-subj={`timeline-favorite-${isFavorite ? 'filled' : 'empty'}-star`}
-      onClick={handleClick}
-    >
-      {label}
-    </EuiButtonIcon>
+    <EuiToolTip content={label} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType={isFavorite ? 'starFill' : 'star'}
+        isSelected={isFavorite}
+        disabled={isDisabled}
+        aria-label={label}
+        data-test-subj={`timeline-favorite-${isFavorite ? 'filled' : 'empty'}-star`}
+        onClick={handleClick}
+      >
+        {label}
+      </EuiButtonIcon>
+    </EuiToolTip>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_columns.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiLink } from '@elastic/eui';
+import { EuiButtonIcon, EuiLink, EuiToolTip } from '@elastic/eui';
 import type { EuiBasicTableColumn, EuiTableDataType } from '@elastic/eui';
 import { omit } from 'lodash/fp';
 import React from 'react';
@@ -49,21 +49,28 @@ export const getCommonColumns = ({
     isExpander: true,
     render: ({ notes, savedObjectId }: OpenTimelineResult) =>
       notes != null && notes.length > 0 && savedObjectId != null ? (
-        <EuiButtonIcon
-          data-test-subj="expand-notes"
-          onClick={() =>
-            itemIdToExpandedNotesRowMap[savedObjectId] != null
-              ? onToggleShowNotes(omit(savedObjectId, itemIdToExpandedNotesRowMap))
-              : onToggleShowNotes({
-                  ...itemIdToExpandedNotesRowMap,
-                  [savedObjectId]: <NotePreviews notes={notes} timelineId={TimelineId.active} />,
-                })
-          }
-          aria-label={itemIdToExpandedNotesRowMap[savedObjectId] ? i18n.COLLAPSE : i18n.EXPAND}
-          iconType={
-            itemIdToExpandedNotesRowMap[savedObjectId] ? 'chevronSingleDown' : 'chevronSingleRight'
-          }
-        />
+        <EuiToolTip
+          content={itemIdToExpandedNotesRowMap[savedObjectId] ? i18n.COLLAPSE : i18n.EXPAND}
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="expand-notes"
+            onClick={() =>
+              itemIdToExpandedNotesRowMap[savedObjectId] != null
+                ? onToggleShowNotes(omit(savedObjectId, itemIdToExpandedNotesRowMap))
+                : onToggleShowNotes({
+                    ...itemIdToExpandedNotesRowMap,
+                    [savedObjectId]: <NotePreviews notes={notes} timelineId={TimelineId.active} />,
+                  })
+            }
+            aria-label={itemIdToExpandedNotesRowMap[savedObjectId] ? i18n.COLLAPSE : i18n.EXPAND}
+            iconType={
+              itemIdToExpandedNotesRowMap[savedObjectId]
+                ? 'chevronSingleDown'
+                : 'chevronSingleRight'
+            }
+          />
+        </EuiToolTip>
       ) : null,
     width: ACTION_COLUMN_WIDTH,
   },

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.tsx
@@ -215,7 +215,7 @@ export const renderEventModule = ({
             }
           >
             <EuiLink href={endpointRefUrl} target="_blank">
-              <EuiIcon type={endPointSvg} size="m" />
+              <EuiIcon type={endPointSvg} size="m" aria-hidden={true} />
             </EuiLink>
           </EuiToolTip>
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/timelines/public/components/clipboard/clipboard.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/clipboard/clipboard.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import classNames from 'classnames';
 import copy from 'copy-to-clipboard';
 import React from 'react';
@@ -62,15 +62,17 @@ export const Clipboard = ({
   });
 
   return (
-    <EuiButtonIcon
-      aria-label={i18n.COPY_TO_THE_CLIPBOARD}
-      className={className}
-      data-test-subj="clipboard"
-      iconSize="s"
-      iconType="copy"
-      onClick={onClick}
-    >
-      {children}
-    </EuiButtonIcon>
+    <EuiToolTip content={i18n.COPY_TO_THE_CLIPBOARD} disableScreenReaderOutput>
+      <EuiButtonIcon
+        aria-label={i18n.COPY_TO_THE_CLIPBOARD}
+        className={className}
+        data-test-subj="clipboard"
+        iconSize="s"
+        iconType="copy"
+        onClick={onClick}
+      >
+        {children}
+      </EuiButtonIcon>
+    </EuiToolTip>
   );
 };

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.test.tsx
@@ -18,6 +18,7 @@ import AddToTimelineButton, {
 import type { DataProvider } from '../../../../common/types';
 import { IS_OPERATOR } from '../../../../common/types';
 import { TestProviders } from '../../../mock';
+import { PRESS } from '../../tooltip_with_keyboard_shortcut';
 import * as i18n from './translations';
 
 const coreStart = coreMock.createStart();
@@ -134,29 +135,33 @@ describe('add to timeline', () => {
     });
   });
 
-  test('it renders a tooltip when `showTooltip` is true', () => {
-    const { container } = render(
+  test('it renders the keyboard shortcut tooltip content when `showTooltip` is true', async () => {
+    render(
       <TestProviders>
         <AddToTimelineButton
           field={field}
-          ownFocus={false}
+          ownFocus={true}
           showTooltip={true}
           startServices={coreStart}
         />
       </TestProviders>
     );
 
-    expect(container?.firstChild).toHaveClass('euiToolTipAnchor');
+    fireEvent.mouseOver(screen.getByRole('button'));
+
+    expect(await screen.findByText(PRESS)).toBeInTheDocument();
   });
 
-  test('it does NOT render a tooltip when `showTooltip` is false (default)', () => {
-    const { container } = render(
+  test('it does NOT render keyboard shortcut tooltip content when `showTooltip` is false (default)', () => {
+    render(
       <TestProviders>
-        <AddToTimelineButton field={field} ownFocus={false} startServices={coreStart} />
+        <AddToTimelineButton field={field} ownFocus={true} startServices={coreStart} />
       </TestProviders>
     );
 
-    expect(container?.firstChild).not.toHaveClass('euiToolTipAnchor');
+    fireEvent.mouseOver(screen.getByRole('button'));
+
+    expect(screen.queryByText(PRESS)).not.toBeInTheDocument();
   });
 
   describe('when the user clicks the button', () => {

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/add_to_timeline.tsx
@@ -154,15 +154,17 @@ const AddToTimelineButton: React.FC<AddToTimelineButtonProps> = React.memo(
             {i18n.ADD_TO_TIMELINE}
           </Component>
         ) : (
-          <EuiButtonIcon
-            aria-label={i18n.ADD_TO_TIMELINE}
-            buttonRef={defaultFocusedButtonRef}
-            className="timelines__hoverActionButton"
-            data-test-subj="add-to-timeline"
-            iconSize="s"
-            iconType="timeline"
-            onClick={handleStartDragToTimeline}
-          />
+          <EuiToolTip content={i18n.ADD_TO_TIMELINE} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={i18n.ADD_TO_TIMELINE}
+              buttonRef={defaultFocusedButtonRef}
+              className="timelines__hoverActionButton"
+              data-test-subj="add-to-timeline"
+              iconSize="s"
+              iconType="timeline"
+              onClick={handleStartDragToTimeline}
+            />
+          </EuiToolTip>
         ),
       [Component, defaultFocusedButtonRef, handleStartDragToTimeline]
     );

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
@@ -84,16 +84,18 @@ const FilterForValueButton: React.FC<FilterForValueProps> = React.memo(
             {FILTER_FOR_VALUE}
           </Component>
         ) : (
-          <EuiButtonIcon
-            aria-label={FILTER_FOR_VALUE}
-            buttonRef={defaultFocusedButtonRef}
-            className="timelines__hoverActionButton"
-            data-test-subj="filter-for-value"
-            iconSize="s"
-            iconType="plusCircle"
-            onClick={filterForValueFn}
-            size={size}
-          />
+          <EuiToolTip content={FILTER_FOR_VALUE} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={FILTER_FOR_VALUE}
+              buttonRef={defaultFocusedButtonRef}
+              className="timelines__hoverActionButton"
+              data-test-subj="filter-for-value"
+              iconSize="s"
+              iconType="plusCircle"
+              onClick={filterForValueFn}
+              size={size}
+            />
+          </EuiToolTip>
         ),
       [Component, defaultFocusedButtonRef, filterForValueFn, size]
     );

--- a/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
+++ b/x-pack/solutions/security/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
@@ -82,16 +82,18 @@ const FilterOutValueButton: React.FC<HoverActionComponentProps & FilterValueFnAr
             {FILTER_OUT_VALUE}
           </Component>
         ) : (
-          <EuiButtonIcon
-            aria-label={FILTER_OUT_VALUE}
-            buttonRef={defaultFocusedButtonRef}
-            className="timelines__hoverActionButton"
-            data-test-subj="filter-out-value"
-            iconSize="s"
-            iconType="minusCircle"
-            onClick={filterOutValueFn}
-            size={size}
-          />
+          <EuiToolTip content={FILTER_OUT_VALUE} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={FILTER_OUT_VALUE}
+              buttonRef={defaultFocusedButtonRef}
+              className="timelines__hoverActionButton"
+              data-test-subj="filter-out-value"
+              iconSize="s"
+              iconType="minusCircle"
+              onClick={filterOutValueFn}
+              size={size}
+            />
+          </EuiToolTip>
         ),
       [Component, defaultFocusedButtonRef, filterOutValueFn, size]
     );


### PR DESCRIPTION
# Backport

This is an automatic backport of pull request #271511.

## Excluded files

- `x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/share_url_icon_button.tsx` — does not exist on 9.4, skipped.