### PR TITLE
Fix workflow executions list API 500 on large ES documents

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/lib/search_workflow_executions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/lib/search_workflow_executions.test.ts
@@ -10,7 +10,10 @@
 import { errors } from '@elastic/elasticsearch';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { loggerMock } from '@kbn/logging-mocks';
-import { searchWorkflowExecutions } from './search_workflow_executions';
+import {
+  searchWorkflowExecutions,
+  WORKFLOW_EXECUTION_LIST_SOURCE_INCLUDES,
+} from './search_workflow_executions';
 
 describe('searchWorkflowExecutions', () => {
   let mockEsClient: jest.Mocked<ElasticsearchClient>;
@@ -70,6 +73,28 @@ describe('searchWorkflowExecutions', () => {
   });
 
   describe('search options', () => {
+    it('should request only list metadata fields from Elasticsearch', async () => {
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          total: { value: 0 },
+          hits: [],
+        },
+      } as any);
+
+      await searchWorkflowExecutions({
+        esClient: mockEsClient,
+        logger: mockLogger,
+        workflowExecutionIndex: '.workflows-executions',
+        query: { term: { workflowId: 'workflow-1' } },
+      });
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _source: { includes: [...WORKFLOW_EXECUTION_LIST_SOURCE_INCLUDES] },
+        })
+      );
+    });
+
     it('should forward collapse to Elasticsearch search', async () => {
       mockEsClient.search.mockResolvedValue({
         hits: {

--- a/src/platform/plugins/shared/workflows_management/server/api/lib/search_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/lib/search_workflow_executions.ts
@@ -28,6 +28,23 @@ interface SearchWorkflowExecutionsParams {
   page?: number;
 }
 
+/** Fields required to build {@link WorkflowExecutionListDto} without fetching full execution snapshots. */
+export const WORKFLOW_EXECUTION_LIST_SOURCE_INCLUDES = [
+  'spaceId',
+  'stepId',
+  'status',
+  'error',
+  'isTestRun',
+  'startedAt',
+  'finishedAt',
+  'duration',
+  'workflowId',
+  'triggeredBy',
+  'executedBy',
+  'createdBy',
+  'concurrencyGroupKey',
+] as const;
+
 export const searchWorkflowExecutions = async ({
   esClient,
   logger,
@@ -44,6 +61,7 @@ export const searchWorkflowExecutions = async ({
     const response = await esClient.search<EsWorkflowExecution>({
       index: workflowExecutionIndex,
       query,
+      _source: { includes: [...WORKFLOW_EXECUTION_LIST_SOURCE_INCLUDES] },
       sort,
       size,
       from,


### PR DESCRIPTION
## Summary

- Add `_source.includes` filtering in `search_workflow_executions.ts` so the list API fetches only the metadata fields it returns.
- Export `WORKFLOW_EXECUTION_LIST_SOURCE_INCLUDES` and add a unit test asserting the ES search request uses source filtering.

This prevents the list endpoint from downloading full execution snapshots (`yaml`, `workflowDefinition`, `context`, `stepExecutionIds`, etc.), which could produce responses larger than Node's max string size and surface as HTTP 500.

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/server/api/lib/search_workflow_executions.test.ts`

## References

Closes elastic/kibana#274169