### PR TITLE
[Security Solution] Fix related integrations version validation to allow semver ranges

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations_help_info.tsx
@@ -45,7 +45,7 @@ export function RelatedIntegrationsHelpInfo(): JSX.Element {
       <EuiText css={{ width: POPOVER_WIDTH }} size="s">
         <FormattedMessage
           id="xpack.securitySolution.detectionEngine.ruleDescription.relatedIntegrations.fieldRelatedIntegrationsHelpText"
-          defaultMessage="Choose the {integrationsDocLink} this rule depends on, and correct if necessary each integration’s version constraint in {semverLink} format. Only tilde, caret, and plain versions are supported, such as ~1.2.3, ^1.2.3, or 1.2.3."
+          defaultMessage="Choose the {integrationsDocLink} this rule depends on, and correct if necessary each integration’s version constraint in {semverLink} range format. Supported examples: ^1.2.3, ~1.2.3, 1.2.3, >=1.2.3, or ^1.2.3 || ^2.0.0."
           values={{
             integrationsDocLink: (
               <EuiLink href={docLinks.links.securitySolution.createDetectionRules} target="_blank">

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/translations.ts
@@ -74,7 +74,7 @@ export const VERSION_DEPENDENCY_INVALID = i18n.translate(
   'xpack.securitySolution.detectionEngine.ruleDescription.relatedIntegrations.validation.versionInvalid',
   {
     defaultMessage:
-      'Version constraint is invalid. Only tilde, caret or plain version supported e.g. ~1.2.3, ^1.2.3 or 1.2.3.',
+      'Version constraint is invalid. Use a valid semver range expression e.g. ^1.2.3, ~1.2.3, 1.2.3, >=1.2.3, or ^1.2.3 || ^2.0.0.',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.test.ts
@@ -15,6 +15,12 @@ describe('validateRelatedIntegration', () => {
       ['simple package version dependency', { package: 'some-package', version: '1.2.3' }],
       ['caret package version dependency', { package: 'some-package', version: '^1.2.3' }],
       ['tilde package version dependency', { package: 'some-package', version: '~1.2.3' }],
+      ['OR range-set version dependency', { package: 'some-package', version: '^8.2.0 || ^9.0.0' }],
+      ['greater-than-or-equal version dependency', { package: 'some-package', version: '>=1.0.0' }],
+      [
+        'tilde with leading spaces (semver normalizes whitespace)',
+        { package: 'some-package', version: ' ~ 1.2.3' },
+      ],
     ])(`validates %s`, (_, relatedIntegration) => {
       const arg = {
         value: relatedIntegration,
@@ -82,9 +88,9 @@ describe('validateRelatedIntegration', () => {
     });
 
     it.each([
-      ['invalid format version', { package: 'some-package', version: '^1.2.' }],
-      ['unexpected version spaces', { package: 'some-package', version: ' ~ 1.2.3' }],
-    ])(`validates %s`, (_, relatedIntegration) => {
+      ['invalid version', { package: 'some-package', version: '^1.2.' }],
+      ['invalid operator', { package: 'some-package', version: '>!=1.0.0' }],
+    ])(`validates %s`, (_: unknown, relatedIntegration: unknown) => {
       const arg = {
         value: relatedIntegration,
         path: 'form.path.to.field',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import semver from 'semver';
+
 import type { RelatedIntegration } from '../../../../../common/api/detection_engine';
 import type { FormData, ERROR_CODE, ValidationFunc } from '../../../../shared_imports';
 import * as i18n from './translations';
@@ -28,7 +30,7 @@ export function validateRelatedIntegration(
     };
   }
 
-  if (!SEMVER_PATTERN.test(value.version)) {
+  if (!semver.validRange(value.version)) {
     return {
       code: 'ERR_FIELD_FORMAT',
       path: `${path}.version`,
@@ -36,5 +38,3 @@ export function validateRelatedIntegration(
     };
   }
 }
-
-const SEMVER_PATTERN = /^(\~|\^)?\d+\.\d+\.\d+$/;


### PR DESCRIPTION
**Fixes: #274097**

## Summary

The version constraint validator for related integrations used a custom regex (`/^(\~|\^)?\d+\.\d+\.\d+$/`) that only accepted plain (`1.2.3`), tilde (`~1.2.3`), and caret (`^1.2.3`) versions. This caused valid semver range expressions — such as comparators (`>=1.0.0`) and range-sets (`^1.2.3 || ^2.0.0`) — to be incorrectly rejected.

The fix replaces the regex with `semver.validRange()`, which correctly validates the full semver range syntax.

## Details

- Replaced the custom `SEMVER_PATTERN` regex with `semver.validRange()` in `validate_related_integration.ts`
- Updated the validation error message (`translations.ts`) to describe the full set of supported range expressions
- Updated the help-info tooltip text to match the new broader support
- Added test cases for `||` range-sets, `>=` comparators, and leading whitespace (normalized by the semver library)
- Removed the `unexpected version spaces` invalid-case test, as `semver.validRange()` normalizes leading whitespace

## How to test

The change is covered by the updated unit tests in `validate_related_integration.test.ts`. Run them with:

```
node scripts/jest x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/validate_related_integration.test.ts
```

For manual testing:
1. Open the rule creation or rule editing page.
2. Add a related integration and enter a version constraint such as `>=1.0.0` or `^1.2.3 || ^2.0.0`.
3. Verify no validation error is shown.
4. Enter an invalid value (e.g. `^1.2.`) and verify the error message is shown with the updated wording.

## Release note

Fixed related integrations version constraint validation to accept the full semver range syntax, including comparators (e.g. `>=1.0.0`) and range-sets (e.g. `^1.2.3 || ^2.0.0`).

## Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
