### PR TITLE
[9.4] [ResponseOps] Make alerts-as-data total_fields.limit configurable (#274024)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/alerts_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/alerts_service.test.ts
@@ -171,7 +171,7 @@ const getIndexTemplatePutBody = (opts?: GetIndexTemplatePutBodyOpts) => {
               },
             }),
         'index.mapping.ignore_malformed': true,
-        'index.mapping.total_fields.limit': 2500,
+        'index.mapping.total_fields.limit': 2800,
         'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
       },
       mappings: {
@@ -477,7 +477,7 @@ describe('Alerts Service', () => {
               ...existingIndexTemplate.index_template.template,
               settings: {
                 ...existingIndexTemplate.index_template.template?.settings,
-                'index.mapping.total_fields.limit': 2500,
+                'index.mapping.total_fields.limit': 2800,
                 'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
               },
             },
@@ -873,7 +873,7 @@ describe('Alerts Service', () => {
                     }),
                 'index.mapping.ignore_malformed': true,
                 'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                'index.mapping.total_fields.limit': 2500,
+                'index.mapping.total_fields.limit': 2800,
               },
               mappings: {
                 _meta: {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/alerts_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/alerts_service.ts
@@ -62,7 +62,24 @@ import type { ClearAlertFlappingHistoryParams } from './lib/clear_alert_flapping
 import { clearAlertFlappingHistory } from './lib/clear_alert_flapping_history';
 import type { IsExistingAlertParams } from './lib/is_existing_alert';
 import { isExistingAlert } from './lib/is_existing_alert';
-export const TOTAL_FIELDS_LIMIT = 2500;
+/**
+ * Default field limit for alerts-as-data (`.alerts-*`) indices, their index
+ * templates and component templates.
+ *
+ * Usage:
+ * - `AlertsService` uses it only as a fallback when `totalFieldsLimit` is not
+ *   provided (e.g. in tests). In production the value comes from
+ *   `xpack.alerting.alertsService.totalFieldsLimit` (see `config.ts`), so keep
+ *   that config default in sync with this constant.
+ * - Re-exported from `@kbn/alerting-plugin/server` and consumed directly by
+ *   `rule_registry` (`resource_installer.ts`) when installing its own
+ *   technical/component templates, and by the AAD integration tests.
+ *
+ * Note: other plugins (alerting_v2, security_solution siem_migrations /
+ * workflow_insights, elastic_assistant, ecs_data_quality_dashboard) define
+ * their own local field-limit constants and are NOT affected by this value.
+ */
+export const TOTAL_FIELDS_LIMIT = 2800;
 const LEGACY_ALERT_CONTEXT = 'legacy-alert';
 export const ECS_CONTEXT = `ecs`;
 export const ECS_COMPONENT_TEMPLATE_NAME = getComponentTemplateName({ name: ECS_CONTEXT });
@@ -75,6 +92,12 @@ interface AlertsServiceParams {
   dataStreamAdapter: DataStreamAdapter;
   elasticsearchAndSOAvailability$: Observable<boolean>;
   isServerless: boolean;
+  /**
+   * Field limit applied to alerts-as-data indices/templates. Defaults to
+   * `TOTAL_FIELDS_LIMIT` when not provided (e.g. in tests). In production this
+   * is sourced from `xpack.alerting.alertsService.totalFieldsLimit`.
+   */
+  totalFieldsLimit?: number;
 }
 
 export interface CreateAlertsClientParams extends LegacyAlertsClientParams {
@@ -135,6 +158,14 @@ interface IAlertsService {
 export type PublicAlertsService = Pick<IAlertsService, 'getContextInitializationPromise'>;
 export type PublicFrameworkAlertsService = PublicAlertsService & {
   enabled: () => boolean;
+  /**
+   * Field limit applied to alerts-as-data (`.alerts-*`) resources, sourced from
+   * `xpack.alerting.alertsService.totalFieldsLimit`. Consumed by `rule_registry`
+   * so its technical/component templates and indices use the same configurable
+   * limit as the alerting framework. Optional so existing mocks remain valid;
+   * consumers fall back to `TOTAL_FIELDS_LIMIT` when it is not provided.
+   */
+  getTotalFieldsLimit?: () => number;
 };
 
 export class AlertsService implements IAlertsService {
@@ -145,12 +176,14 @@ export class AlertsService implements IAlertsService {
   private registeredContexts: Map<string, IRuleTypeAlerts> = new Map();
   private commonInitPromise: Promise<InitializationPromise>;
   private dataStreamAdapter: DataStreamAdapter;
+  private totalFieldsLimit: number;
 
   constructor(private readonly options: AlertsServiceParams) {
     this.initialized = false;
 
     this.isServerless = options.isServerless;
     this.dataStreamAdapter = options.dataStreamAdapter;
+    this.totalFieldsLimit = options.totalFieldsLimit ?? TOTAL_FIELDS_LIMIT;
 
     // Kick off initialization of common assets and save the promise
     this.commonInitPromise = this.initializeCommon(
@@ -357,7 +390,7 @@ export class AlertsService implements IAlertsService {
             logger: this.options.logger,
             esClient,
             template: getComponentTemplate({ fieldMap: alertFieldMap, includeSettings: true }),
-            totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+            totalFieldsLimit: this.totalFieldsLimit,
           }),
         () =>
           createOrUpdateComponentTemplate({
@@ -368,7 +401,7 @@ export class AlertsService implements IAlertsService {
               name: LEGACY_ALERT_CONTEXT,
               includeSettings: true,
             }),
-            totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+            totalFieldsLimit: this.totalFieldsLimit,
           }),
         () =>
           createOrUpdateComponentTemplate({
@@ -379,7 +412,7 @@ export class AlertsService implements IAlertsService {
               name: ECS_CONTEXT,
               includeSettings: true,
             }),
-            totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+            totalFieldsLimit: this.totalFieldsLimit,
           }),
       ];
 
@@ -455,7 +488,7 @@ export class AlertsService implements IAlertsService {
             logger: this.options.logger,
             esClient,
             template: componentTemplate,
-            totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+            totalFieldsLimit: this.totalFieldsLimit,
           })
       );
       componentTemplateRefs.push(componentTemplate.name);
@@ -481,7 +514,7 @@ export class AlertsService implements IAlertsService {
             indexPatterns: indexTemplateAndPattern,
             kibanaVersion: this.options.kibanaVersion,
             namespace,
-            totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+            totalFieldsLimit: this.totalFieldsLimit,
             dataStreamAdapter: this.dataStreamAdapter,
           }),
         }),
@@ -489,7 +522,7 @@ export class AlertsService implements IAlertsService {
         await createConcreteWriteIndex({
           logger: this.options.logger,
           esClient,
-          totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+          totalFieldsLimit: this.totalFieldsLimit,
           indexPatterns: indexTemplateAndPattern,
           dataStreamAdapter: this.dataStreamAdapter,
         }),

--- a/x-pack/platform/plugins/shared/alerting/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/config.test.ts
@@ -12,6 +12,9 @@ describe('config validation', () => {
     const config: Record<string, unknown> = {};
     expect(configSchema.validate(config)).toMatchInlineSnapshot(`
       Object {
+        "alertsService": Object {
+          "totalFieldsLimit": 2800,
+        },
         "cancelAlertsOnRuleTimeout": true,
         "enableFrameworkAlerts": true,
         "healthCheck": Object {

--- a/x-pack/platform/plugins/shared/alerting/server/config.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/config.ts
@@ -76,6 +76,13 @@ export const configSchema = schema.object({
   }),
   maxEphemeralActionsPerAlert: schema.maybe(schema.number()),
   enableFrameworkAlerts: schema.boolean({ defaultValue: true }),
+  alertsService: schema.object({
+    // Field limit applied to alerts-as-data (.alerts-*) indices, their index
+    // templates and component templates. Raise this above the alert mapping's
+    // field count to avoid the framework's reset-then-increase churn against
+    // Elasticsearch. Keep the default in sync with `TOTAL_FIELDS_LIMIT`.
+    totalFieldsLimit: schema.number({ defaultValue: 2800, min: 2500, max: 5000 }),
+  }),
   cancelAlertsOnRuleTimeout: schema.boolean({ defaultValue: true }),
   rules: rulesSchema,
   rulesSettings: schema.object({

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -355,6 +355,7 @@ export class AlertingPlugin {
             .then(([{ elasticsearch }]) => elasticsearch.client.asInternalUser),
           elasticsearchAndSOAvailability$,
           isServerless: this.isServerless,
+          totalFieldsLimit: this.config.alertsService.totalFieldsLimit,
         });
       }
     }
@@ -583,6 +584,7 @@ export class AlertingPlugin {
       },
       frameworkAlerts: {
         enabled: () => this.config.enableFrameworkAlerts,
+        getTotalFieldsLimit: () => this.config.alertsService.totalFieldsLimit,
         getContextInitializationPromise: (
           context: string,
           namespace: string

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/create/create_rule_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/create/create_rule_route.test.ts
@@ -46,6 +46,9 @@ describe('createRuleRoute', () => {
       removalDelay: '1h',
     },
     enableFrameworkAlerts: true,
+    alertsService: {
+      totalFieldsLimit: 2800,
+    },
     cancelAlertsOnRuleTimeout: true,
     rules: {
       minimumScheduleInterval: {

--- a/x-pack/platform/plugins/shared/alerting/server/test_utils/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/test_utils/index.ts
@@ -55,6 +55,9 @@ export function generateAlertingConfig(overwrites: Partial<AlertingConfig> = {})
       interval: '5m',
     },
     enableFrameworkAlerts: false,
+    alertsService: {
+      totalFieldsLimit: 2800,
+    },
     invalidateApiKeysTask: {
       interval: '5m',
       removalDelay: '1h',

--- a/x-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service/resource_installer.test.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service/resource_installer.test.ts
@@ -563,7 +563,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -577,7 +577,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -607,7 +607,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -625,7 +625,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -707,7 +707,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -721,7 +721,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -751,7 +751,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })
@@ -769,7 +769,7 @@ describe('resourceInstaller', () => {
                     hidden: true,
                     'index.mapping.ignore_malformed': true,
                     'index.mapping.total_fields.ignore_dynamic_beyond_limit': true,
-                    'index.mapping.total_fields.limit': 2500,
+                    'index.mapping.total_fields.limit': 2800,
                   },
                 }),
               })

--- a/x-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service/resource_installer.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service/resource_installer.ts
@@ -44,6 +44,15 @@ export type IResourceInstaller = PublicMethodsOf<ResourceInstaller>;
 export class ResourceInstaller {
   constructor(private readonly options: ConstructorOptions) {}
 
+  /**
+   * Field limit applied to all rule registry alerts-as-data resources. Sourced
+   * from the alerting framework contract (`xpack.alerting.alertsService.totalFieldsLimit`)
+   * so it stays in sync with the framework, falling back to `TOTAL_FIELDS_LIMIT`.
+   */
+  private getTotalFieldsLimit(): number {
+    return this.options.frameworkAlerts.getTotalFieldsLimit?.() ?? TOTAL_FIELDS_LIMIT;
+  }
+
   // -----------------------------------------------------------------------------------------------
   // Common resources
 
@@ -96,7 +105,7 @@ export class ResourceInstaller {
                       ...ecsComponentTemplate,
                       name: ECS_COMPONENT_TEMPLATE_NAME,
                     },
-                    totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+                    totalFieldsLimit: this.getTotalFieldsLimit(),
                   }),
                 ]),
             createOrUpdateComponentTemplate({
@@ -106,7 +115,7 @@ export class ResourceInstaller {
                 ...technicalComponentTemplate,
                 name: TECHNICAL_COMPONENT_TEMPLATE_NAME,
               },
-              totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+              totalFieldsLimit: this.getTotalFieldsLimit(),
             }),
           ]);
         } catch (err) {
@@ -174,7 +183,7 @@ export class ResourceInstaller {
                   },
                   _meta: ct._meta,
                 },
-                totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+                totalFieldsLimit: this.getTotalFieldsLimit(),
               });
             })
           );
@@ -256,7 +265,7 @@ export class ResourceInstaller {
         indexPatterns,
         kibanaVersion: indexInfo.kibanaVersion,
         namespace,
-        totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+        totalFieldsLimit: this.getTotalFieldsLimit(),
         dataStreamAdapter: this.options.dataStreamAdapter,
       }),
     });
@@ -264,7 +273,7 @@ export class ResourceInstaller {
     await createConcreteWriteIndex({
       logger: this.options.logger,
       esClient: clusterClient,
-      totalFieldsLimit: TOTAL_FIELDS_LIMIT,
+      totalFieldsLimit: this.getTotalFieldsLimit(),
       indexPatterns,
       dataStreamAdapter: this.options.dataStreamAdapter,
     });

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
@@ -177,7 +177,7 @@ export default function createAlertsAsDataInstallResourcesTest({ getService }: F
             mapping: {
               ignore_malformed: 'true',
               total_fields: {
-                limit: '2500',
+                limit: '2800',
                 ignore_dynamic_beyond_limit: 'true',
               },
             },
@@ -214,7 +214,7 @@ export default function createAlertsAsDataInstallResourcesTest({ getService }: F
         expect(contextIndex[indexName].settings?.index?.mapping).to.eql({
           ignore_malformed: 'true',
           total_fields: {
-            limit: '2500',
+            limit: '2800',
             ignore_dynamic_beyond_limit: 'true',
           },
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps] Make alerts-as-data total_fields.limit configurable (#274024)](https://github.com/elastic/kibana/pull/274024)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-19T15:04:28Z","message":"[ResponseOps] Make alerts-as-data total_fields.limit configurable (#274024)\n\n## Summary\n\nAdds a new config option `xpack.alerting.alertsService.totalFieldsLimit`\n(default `2800`, min `1`, max `5000`) that controls the\n`index.mapping.total_fields.limit` applied to alerts-as-data\n(`.alerts-*`) indices, their index templates, and component templates.\n\nI am trying to keep the changes to a minimum, therefore kept the\n`TOTAL_FIELDS_LIMIT` const since it is used by `rule_registry` and\nintegration tests.\n\n### Why\n\nAs the cumulative alerts-as-data mapping grows across releases, it can\napproach the previously hardcoded limit (`2500`). When a mapping update\nexceeds the limit, the framework falls into a reset-then-increase\nrecovery loop against Elasticsearch. On an already-pressured cluster\nthis contributes to mapping-update churn. Making the limit configurable\nlets operators raise it above the current field count so the mapping\nupdate succeeds in one shot, avoiding the churn.\n\n### What changed\n\n- New config `xpack.alerting.alertsService.totalFieldsLimit` (default\n`2800`, max `5000`).\n- `AlertsService` uses the configured value (falls back to the\n`TOTAL_FIELDS_LIMIT` constant when not provided, e.g. in tests).\n- The value is exposed on the alerting `frameworkAlerts` setup contract\nand consumed by `rule_registry`'s `ResourceInstaller`, so the alerting\nframework and rule registry share a **single source of truth** for the\nsame `.alerts-*` resources (preview/adhoc and legacy paths included).\nThis prevents the two installers from disagreeing on the limit for\nshared component templates.\n- Default constant bumped from `2500` → `2800`; the config default is\nkept in sync.\n\n### Notes\n\n- `rule_registry` intentionally reads the same alerting config rather\nthan defining its own limit: its indices are the same `.alerts-*` family\nthe alerting framework manages and they share component templates, so a\ndivergent limit would re-introduce reset/bump oscillation.\n- Other plugins (`alerting_v2`, security_solution\n`siem_migrations`/`workflow_insights`, `elastic_assistant`,\n`ecs_data_quality_dashboard`) keep their own local constants — they own\nstandalone, independent indices and are unaffected.\n\n## Risk\n\nLow. Default behavior is unchanged aside from the limit moving from\n`2500` to `2800`. The setting only raises a field-count ceiling.\n\n## Test plan\n\n- [x] `node scripts/type_check` for `alerting` and `rule_registry`\n- [x] `jest` for `alerting` alerts_service and `rule_registry`\nresource_installer suites\n- [ ] Verify in a deployment that setting\n`xpack.alerting.alertsService.totalFieldsLimit` raises the limit on\n`.alerts-*` indices/templates and avoids the reset/bump loop\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Dima Arnautov <arnautov.dima@gmail.com>","sha":"f1b60e64a0a0b8e8ca7abb3ed2b40dbdb771e4e2","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Feature:Alerting","Team:ResponseOps","Feature:Alerting/Alerts-as-Data","backport:version","v9.5.0","v9.4.3"],"title":"[ResponseOps] Make alerts-as-data total_fields.limit configurable","number":274024,"url":"https://github.com/elastic/kibana/pull/274024","mergeCommit":{"message":"[ResponseOps] Make alerts-as-data total_fields.limit configurable (#274024)\n\n## Summary\n\nAdds a new config option `xpack.alerting.alertsService.totalFieldsLimit`\n(default `2800`, min `1`, max `5000`) that controls the\n`index.mapping.total_fields.limit` applied to alerts-as-data\n(`.alerts-*`) indices, their index templates, and component templates.\n\nI am trying to keep the changes to a minimum, therefore kept the\n`TOTAL_FIELDS_LIMIT` const since it is used by `rule_registry` and\nintegration tests.\n\n### Why\n\nAs the cumulative alerts-as-data mapping grows across releases, it can\napproach the previously hardcoded limit (`2500`). When a mapping update\nexceeds the limit, the framework falls into a reset-then-increase\nrecovery loop against Elasticsearch. On an already-pressured cluster\nthis contributes to mapping-update churn. Making the limit configurable\nlets operators raise it above the current field count so the mapping\nupdate succeeds in one shot, avoiding the churn.\n\n### What changed\n\n- New config `xpack.alerting.alertsService.totalFieldsLimit` (default\n`2800`, max `5000`).\n- `AlertsService` uses the configured value (falls back to the\n`TOTAL_FIELDS_LIMIT` constant when not provided, e.g. in tests).\n- The value is exposed on the alerting `frameworkAlerts` setup contract\nand consumed by `rule_registry`'s `ResourceInstaller`, so the alerting\nframework and rule registry share a **single source of truth** for the\nsame `.alerts-*` resources (preview/adhoc and legacy paths included).\nThis prevents the two installers from disagreeing on the limit for\nshared component templates.\n- Default constant bumped from `2500` → `2800`; the config default is\nkept in sync.\n\n### Notes\n\n- `rule_registry` intentionally reads the same alerting config rather\nthan defining its own limit: its indices are the same `.alerts-*` family\nthe alerting framework manages and they share component templates, so a\ndivergent limit would re-introduce reset/bump oscillation.\n- Other plugins (`alerting_v2`, security_solution\n`siem_migrations`/`workflow_insights`, `elastic_assistant`,\n`ecs_data_quality_dashboard`) keep their own local constants — they own\nstandalone, independent indices and are unaffected.\n\n## Risk\n\nLow. Default behavior is unchanged aside from the limit moving from\n`2500` to `2800`. The setting only raises a field-count ceiling.\n\n## Test plan\n\n- [x] `node scripts/type_check` for `alerting` and `rule_registry`\n- [x] `jest` for `alerting` alerts_service and `rule_registry`\nresource_installer suites\n- [ ] Verify in a deployment that setting\n`xpack.alerting.alertsService.totalFieldsLimit` raises the limit on\n`.alerts-*` indices/templates and avoids the reset/bump loop\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Dima Arnautov <arnautov.dima@gmail.com>","sha":"f1b60e64a0a0b8e8ca7abb3ed2b40dbdb771e4e2"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274024","number":274024,"mergeCommit":{"message":"[ResponseOps] Make alerts-as-data total_fields.limit configurable (#274024)\n\n## Summary\n\nAdds a new config option `xpack.alerting.alertsService.totalFieldsLimit`\n(default `2800`, min `1`, max `5000`) that controls the\n`index.mapping.total_fields.limit` applied to alerts-as-data\n(`.alerts-*`) indices, their index templates, and component templates.\n\nI am trying to keep the changes to a minimum, therefore kept the\n`TOTAL_FIELDS_LIMIT` const since it is used by `rule_registry` and\nintegration tests.\n\n### Why\n\nAs the cumulative alerts-as-data mapping grows across releases, it can\napproach the previously hardcoded limit (`2500`). When a mapping update\nexceeds the limit, the framework falls into a reset-then-increase\nrecovery loop against Elasticsearch. On an already-pressured cluster\nthis contributes to mapping-update churn. Making the limit configurable\nlets operators raise it above the current field count so the mapping\nupdate succeeds in one shot, avoiding the churn.\n\n### What changed\n\n- New config `xpack.alerting.alertsService.totalFieldsLimit` (default\n`2800`, max `5000`).\n- `AlertsService` uses the configured value (falls back to the\n`TOTAL_FIELDS_LIMIT` constant when not provided, e.g. in tests).\n- The value is exposed on the alerting `frameworkAlerts` setup contract\nand consumed by `rule_registry`'s `ResourceInstaller`, so the alerting\nframework and rule registry share a **single source of truth** for the\nsame `.alerts-*` resources (preview/adhoc and legacy paths included).\nThis prevents the two installers from disagreeing on the limit for\nshared component templates.\n- Default constant bumped from `2500` → `2800`; the config default is\nkept in sync.\n\n### Notes\n\n- `rule_registry` intentionally reads the same alerting config rather\nthan defining its own limit: its indices are the same `.alerts-*` family\nthe alerting framework manages and they share component templates, so a\ndivergent limit would re-introduce reset/bump oscillation.\n- Other plugins (`alerting_v2`, security_solution\n`siem_migrations`/`workflow_insights`, `elastic_assistant`,\n`ecs_data_quality_dashboard`) keep their own local constants — they own\nstandalone, independent indices and are unaffected.\n\n## Risk\n\nLow. Default behavior is unchanged aside from the limit moving from\n`2500` to `2800`. The setting only raises a field-count ceiling.\n\n## Test plan\n\n- [x] `node scripts/type_check` for `alerting` and `rule_registry`\n- [x] `jest` for `alerting` alerts_service and `rule_registry`\nresource_installer suites\n- [ ] Verify in a deployment that setting\n`xpack.alerting.alertsService.totalFieldsLimit` raises the limit on\n`.alerts-*` indices/templates and avoids the reset/bump loop\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: Dima Arnautov <arnautov.dima@gmail.com>","sha":"f1b60e64a0a0b8e8ca7abb3ed2b40dbdb771e4e2"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->