### PR TITLE
[Flaky] Fix timelines_table closeTimeline flakiness (fixes #268877)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -291,13 +291,17 @@ export const attachTimelineToExistingCase = () => {
 };
 
 export const closeTimeline = () => {
-  cy.get(CLOSE_TIMELINE_BTN).click();
-  // Assert on the CSS class that directly applies `display: none` to the overlay mask.
-  // This is more reliable than any visibility check because:
-  // - The class is applied synchronously by React (not affected by CSS animations/opacity)
-  // - Works regardless of how many events the timeline contains
-  // - Not affected by other elements (flyouts, etc.) covering the badge
-  cy.get(TIMELINE_WRAPPER).should('have.class', 'timeline-portal-overlay-mask--hidden');
+  // Retry clicking the close button until the overlay mask gets the --hidden class.
+  // A single click can land during a React re-render (e.g. after markAsFavorite triggers a
+  // timelines-list refresh) and silently not register. Mirroring the recurse pattern used
+  // in openTimelineUsingToggle makes the close robust against that race.
+  recurse(
+    () => {
+      cy.get(CLOSE_TIMELINE_BTN).filter(':visible').click();
+      return cy.get(TIMELINE_WRAPPER);
+    },
+    ($timelineWrapper) => $timelineWrapper.hasClass('timeline-portal-overlay-mask--hidden')
+  );
 };
 
 export const createNewTimeline = () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -291,14 +291,20 @@ export const attachTimelineToExistingCase = () => {
 };
 
 export const closeTimeline = () => {
-  // Retry clicking the close button until the overlay mask gets the --hidden class.
-  // A single click can land during a React re-render (e.g. after markAsFavorite triggers a
-  // timelines-list refresh) and silently not register. Mirroring the recurse pattern used
-  // in openTimelineUsingToggle makes the close robust against that race.
+  // Retry closing the timeline until the overlay mask gets the --hidden class.
+  // Each iteration first checks whether the overlay is already hidden to avoid
+  // clicking a button that is no longer in the visible portal. When the overlay is
+  // still open, .should('be.visible') retries until the close button is actionable,
+  // letting any concurrent React re-renders (e.g. from markAsFavorite's Redux
+  // dispatches) settle before the click is issued.
   recurse(
     () => {
-      cy.get(CLOSE_TIMELINE_BTN).filter(':visible').click();
-      return cy.get(TIMELINE_WRAPPER);
+      return cy.get(TIMELINE_WRAPPER).then(($wrapper) => {
+        if (!$wrapper.hasClass('timeline-portal-overlay-mask--hidden')) {
+          cy.get(CLOSE_TIMELINE_BTN).should('be.visible').click();
+        }
+        return cy.get(TIMELINE_WRAPPER);
+      });
     },
     ($timelineWrapper) => $timelineWrapper.hasClass('timeline-portal-overlay-mask--hidden')
   );


### PR DESCRIPTION
## Summary

Fixes #268877

`closeTimeline()` made a single click and waited up to 150s for the overlay mask to acquire `--hidden`. When `markAsFavorite()` triggers a timelines-list GET refresh, React can still be reconciling when the close button is clicked — the click lands during the reconciliation and the `onClick` handler never fires, so `showTimeline({ show: false })` is never dispatched.

**Fix:** Replaced the single-click + long assert with a `recurse`-until-stable pattern (same approach used by `openTimelineUsingToggle`). The close button is clicked (filtered to `:visible`) and the loop exits as soon as the overlay mask acquires the `--hidden` class.

## Risk

Low — retry loop is bounded and matches existing patterns in the same file.