### PR TITLE
[Security Solution] De-duplicate redundant warnings in Rule Preview

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_logs.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_logs.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { TestProviders } from '../../../../common/mock/test_providers';
+import type { RulePreviewLogs } from '../../../../../common/api/detection_engine';
+import { PreviewLogs } from './preview_logs';
+
+const buildLog = (overrides: Partial<RulePreviewLogs> = {}): RulePreviewLogs => ({
+  errors: [],
+  warnings: [],
+  startedAt: '2024-09-05T15:43:46.972Z',
+  duration: 100,
+  requests: [],
+  ...overrides,
+});
+
+const renderPreviewLogs = (logs: RulePreviewLogs[]) =>
+  render(
+    <PreviewLogs
+      logs={logs}
+      hasNoiseWarning={false}
+      isAborted={false}
+      showElasticsearchRequests={false}
+      ruleType="query"
+    />,
+    { wrapper: TestProviders }
+  );
+
+describe('PreviewLogs', () => {
+  const MAX_ALERTS_WARNING =
+    'This rule reached the maximum alert limit for the rule execution. Some alerts were not created.';
+
+  it('renders a single warning callout when the same warning is reported by multiple invocations', () => {
+    const logs = [
+      buildLog({ warnings: [MAX_ALERTS_WARNING], startedAt: '2024-09-05T15:43:46.972Z' }),
+      buildLog({ warnings: [MAX_ALERTS_WARNING], startedAt: '2024-09-05T16:03:46.972Z' }),
+      buildLog({ warnings: [MAX_ALERTS_WARNING], startedAt: '2024-09-05T16:23:46.972Z' }),
+    ];
+
+    renderPreviewLogs(logs);
+
+    expect(screen.getAllByTestId('preview-warning')).toHaveLength(1);
+    expect(screen.getAllByText(MAX_ALERTS_WARNING)).toHaveLength(1);
+    // No "see all warnings" accordion is needed when only one unique warning remains.
+    expect(screen.queryByTestId('previewWarningAccordion')).not.toBeInTheDocument();
+  });
+
+  it('renders a single error callout when the same error is reported by multiple invocations', () => {
+    const errorMessage = 'Query execution failed.';
+    const logs = [
+      buildLog({ errors: [errorMessage], startedAt: '2024-09-05T15:43:46.972Z' }),
+      buildLog({ errors: [errorMessage], startedAt: '2024-09-05T16:03:46.972Z' }),
+    ];
+
+    renderPreviewLogs(logs);
+
+    expect(screen.getAllByTestId('preview-error')).toHaveLength(1);
+    expect(screen.getAllByText(errorMessage)).toHaveLength(1);
+  });
+
+  it('keeps distinct warnings from different invocations', () => {
+    const logs = [
+      buildLog({ warnings: ['First unique warning'], startedAt: '2024-09-05T15:43:46.972Z' }),
+      buildLog({ warnings: ['Second unique warning'], startedAt: '2024-09-05T16:03:46.972Z' }),
+    ];
+
+    renderPreviewLogs(logs);
+
+    expect(screen.getAllByTestId('preview-warning')).toHaveLength(2);
+    expect(screen.getByText('First unique warning')).toBeInTheDocument();
+    expect(screen.getByText('Second unique warning')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_logs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_logs.tsx
@@ -50,6 +50,22 @@ const addLogs = (
   allLogs: SortedLogs[]
 ) => (logs.length ? [{ startedAt, logs, duration }, ...allLogs] : allLogs);
 
+/**
+ * A rule preview runs the rule once per invocation across the preview time range, and every
+ * invocation that hits the same condition (e.g. the max alerts limit) reports an identical
+ * message. Without de-duplication the UI renders one callout per occurrence, so the same
+ * warning can appear many times. This keeps only the first occurrence of each message so a
+ * single consolidated callout is shown.
+ */
+const dedupeLogs = (logs: string[], seen: Set<string>): string[] =>
+  logs.filter((log) => {
+    if (seen.has(log)) {
+      return false;
+    }
+    seen.add(log);
+    return true;
+  });
+
 const PreviewLogsComponent: React.FC<PreviewLogsProps> = ({
   logs,
   hasNoiseWarning,
@@ -57,20 +73,25 @@ const PreviewLogsComponent: React.FC<PreviewLogsProps> = ({
   showElasticsearchRequests,
   ruleType,
 }) => {
-  const sortedLogs = useMemo(
-    () =>
-      logs.reduce<{
-        errors: SortedLogs[];
-        warnings: SortedLogs[];
-      }>(
-        ({ errors, warnings }, curr) => ({
-          errors: addLogs(curr.startedAt, curr.errors, curr.duration, errors),
-          warnings: addLogs(curr.startedAt, curr.warnings, curr.duration, warnings),
-        }),
-        { errors: [], warnings: [] }
-      ),
-    [logs]
-  );
+  const sortedLogs = useMemo(() => {
+    const seenErrors = new Set<string>();
+    const seenWarnings = new Set<string>();
+    return logs.reduce<{
+      errors: SortedLogs[];
+      warnings: SortedLogs[];
+    }>(
+      ({ errors, warnings }, curr) => ({
+        errors: addLogs(curr.startedAt, dedupeLogs(curr.errors, seenErrors), curr.duration, errors),
+        warnings: addLogs(
+          curr.startedAt,
+          dedupeLogs(curr.warnings, seenWarnings),
+          curr.duration,
+          warnings
+        ),
+      }),
+      { errors: [], warnings: [] }
+    );
+  }, [logs]);
   return (
     <>
       <EuiSpacer size="s" />


### PR DESCRIPTION
## Summary

Closes #211821

When a Rule Preview runs a query that exceeds the maximum alert limit, the same warning message was displayed **multiple times** instead of once.

### Root cause

A rule preview executes the rule **once per invocation** across the preview time range (see `use_preview_invocation_count.ts`). Each invocation that hits the same condition (e.g. the max-alerts limit) reports an identical message in its own `warnings[]`/`errors[]`. `PreviewLogsComponent` then rendered one `EuiCallOut` per occurrence, so the same warning appeared once for every invocation that hit the limit.

### Fix

De-duplicate identical warning and error message strings across invocations when building `sortedLogs`, keeping the first occurrence. This shows a single consolidated callout, matching the expected behavior in the issue ("A single warning message should be displayed"). Distinct messages from different invocations are still preserved.

### Testing

Added `preview_logs.test.tsx` covering:
- the same warning reported by multiple invocations renders a single callout (and no "see all warnings" accordion),
- the same error reported by multiple invocations renders a single callout,
- distinct warnings from different invocations are all preserved.

### Checklist

- [x] Added unit tests for the bug fix
- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) — N/A, no API change