### PR TITLE
[Security Solution] Fix flaky install_table sort: guard against React state race in sortByTableColumn

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/table_pagination.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/table_pagination.ts
@@ -54,6 +54,14 @@ export const sortByTableColumn = (columnName: string, direction: 'asc' | 'desc' 
   cy.get(TABLE_SORT_COLUMN_BTN).contains(columnName).click({ force: true });
 
   if (direction === 'desc') {
+    // Wait for the ascending sort indicator before clicking to toggle to descending.
+    // EuiBasicTable is controlled: its onChange computes the next direction from the
+    // current `sorting` prop. Without this guard, the second click can fire before
+    // React commits the first click's state update, causing EUI to see an unsorted
+    // column and toggle to 'asc' again instead of 'desc'.
+    cy.get(`${TABLE_SORT_COLUMN_BTN}.euiTableHeaderButton-isSorted`)
+      .contains(columnName)
+      .should('exist');
     cy.get(TABLE_SORT_COLUMN_BTN).contains(columnName).click({ force: true });
   }
 };


### PR DESCRIPTION
## Summary

Closes #268242

## What
Fixes a race condition in the `sortByTableColumn` Cypress helper that caused intermittent failures when sorting a table column to `desc` direction.

## Why
`EuiBasicTable` is a controlled component: its `onChange` handler computes the *next* sort direction from the current `sorting` prop. When `sortByTableColumn` was called with `direction: 'desc'`, it clicked the column header twice — once to sort ascending, once to toggle to descending. Without a guard between clicks, the second click could fire before React committed the first state update, so EUI saw the column as still unsorted and toggled back to `asc` instead of `desc`.

The fix adds a `.should('exist')` assertion on `.euiTableHeaderButton-isSorted` before the second click, ensuring React has fully committed the ascending sort before we proceed.

## Changes

- `x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/table_pagination.ts`: Added a wait assertion between the two clicks in `sortByTableColumn` for the `desc` direction case.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — this change only affects the Cypress test helper, not production code. The added assertion makes failures louder (test times out if sort never fires) rather than producing false passes.

### Release note

> No user-facing changes — test helper fix only.

**Suggested label:** `release_note:skip`