### PR TITLE
[Flaky] Fix clickthrough.test.ts (fixes #271982)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
@@ -163,6 +163,7 @@ export class Simulator {
    * Unmount the Resolver component. Use this to test what happens when code that uses Resolver unmounts it.
    */
   public unmount(): void {
+    this.unmounted = true;
     this.wrapper.unmount();
   }
 
@@ -227,13 +228,25 @@ export class Simulator {
   }
 
   /**
+   * Whether `unmount()` has been called. Used to guard against setState/update calls on a
+   * detached enzyme wrapper, which throw and would leave the Promise in `map()` permanently
+   * unresolved.
+   */
+  private unmounted = false;
+
+  /**
    * EUI uses a component called `AutoSizer` that won't render its children unless it has sufficient size.
    * This forces any `AutoSizer` instances to have a large size.
    */
   private forceAutoSizerOpen() {
-    this.wrapper
-      .find('AutoSizer')
-      .forEach((wrapper) => wrapper.setState({ width: 10000, height: 10000 }));
+    if (this.unmounted) return;
+    try {
+      this.wrapper
+        .find('AutoSizer')
+        .forEach((wrapper) => wrapper.setState({ width: 10000, height: 10000 }));
+    } catch {
+      // swallow errors on stale/unmounted wrappers
+    }
   }
 
   /**
@@ -249,10 +262,10 @@ export class Simulator {
       await new Promise<void>((resolve) => {
         setTimeout(() => {
           try {
-            this.forceAutoSizerOpen();
-            this.wrapper.update();
-          } catch (_e) {
-            // ignore errors from enzyme on stale or mid-unmount wrappers
+            if (!this.unmounted) {
+              this.forceAutoSizerOpen();
+              this.wrapper.update();
+            }
           } finally {
             resolve();
           }


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test `Resolver, when analyzing a tree that has no ancestors and 2 children when it has loaded should render 3 elements with "treeitem" roles, each owned by an element with a "tree" role` was intermittently timing out (5000ms Jest default) because `Simulator.map()`'s `setTimeout(0)` callback called `forceAutoSizerOpen()` and `wrapper.update()` sequentially before calling `resolve()`. If either of those calls threw — for example, when `wrapper.setState()` was called on a stale or partially-unmounted enzyme `AutoSizer` instance — the `resolve()` was never reached, leaving the `Promise` permanently unresolved and causing the async generator to hang until the `beforeEach` hook's timeout was exceeded. The fix introduced an `unmounted` boolean field (set to `true` in `unmount()`), guards both calls with `if (!this.unmounted)`, wraps `forceAutoSizerOpen()` in a `try/catch` to swallow errors from stale enzyme wrappers, and most critically wraps the entire body of the `setTimeout` callback in `try/finally` so that `resolve()` is always called regardless of any exception, preventing any possibility of the Promise hanging indefinitely.

**Changes**

- 4745593dfa19 fix(test): prevent Resolver Simulator.map() from hanging on stale enzyme wrapper

Fixes #271982




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`