### PR TITLE
[Index Management] Fix data stream search bar dropping text starting with "or"

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_list.tsx
@@ -317,9 +317,7 @@ export const DataStreamList: React.FunctionComponent<RouteComponentProps<MatchPa
         <EuiSpacer size="l" />
 
         <DataStreamTable
-          filters={
-            isDeepLink && decodedDataStreamName !== undefined ? decodedDataStreamName : ''
-          }
+          filters={isDeepLink && decodedDataStreamName !== undefined ? decodedDataStreamName : ''}
           dataStreams={filteredDataStreams}
           isLoading={isLoading}
           reload={reload}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_list.tsx
@@ -318,9 +318,7 @@ export const DataStreamList: React.FunctionComponent<RouteComponentProps<MatchPa
 
         <DataStreamTable
           filters={
-            isDeepLink && decodedDataStreamName !== undefined
-              ? `name="${decodedDataStreamName}"`
-              : ''
+            isDeepLink && decodedDataStreamName !== undefined ? decodedDataStreamName : ''
           }
           dataStreams={filteredDataStreams}
           isLoading={isLoading}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.test.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
 import type { ScopedHistory } from '@kbn/core/public';
 import { MAX_DATA_RETENTION } from '../../../../../../common/constants';
 import type { DataStream } from '../../../../../../common/types';
@@ -147,6 +148,8 @@ jest.mock('../../components', () => ({
   FilterListButton: () => null,
 }));
 
+const renderWithIntl = (ui: React.ReactElement) => render(<I18nProvider>{ui}</I18nProvider>);
+
 const createDataStream = (overrides: Partial<DataStream> = {}): DataStream => ({
   name: 'my-data-stream',
   timeStampField: { name: '@timestamp' },
@@ -189,7 +192,7 @@ describe('DataStreamTable', () => {
       nextGenerationManagedBy: 'Data stream lifecycle',
     });
 
-    render(
+    renderWithIntl(
       <DataStreamTable
         dataStreams={[dataStream]}
         reload={jest.fn()}
@@ -216,7 +219,7 @@ describe('DataStreamTable', () => {
       lifecycle: undefined,
     });
 
-    render(
+    renderWithIntl(
       <DataStreamTable
         dataStreams={[dataStream]}
         reload={jest.fn()}
@@ -246,7 +249,7 @@ describe('DataStreamTable', () => {
       } as DataStream['lifecycle'],
     });
 
-    render(
+    renderWithIntl(
       <DataStreamTable
         dataStreams={[dataStream]}
         reload={jest.fn()}
@@ -274,7 +277,7 @@ describe('DataStreamTable', () => {
       } as DataStream['lifecycle'],
     });
 
-    render(
+    renderWithIntl(
       <DataStreamTable
         dataStreams={[dataStream]}
         reload={jest.fn()}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
@@ -416,10 +416,9 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
             fullWidth
             value={searchValue}
             onChange={(e) => setSearchValue(e.target.value)}
-            placeholder={i18n.translate(
-              'xpack.idxMgmt.dataStreamList.table.searchPlaceholder',
-              { defaultMessage: 'Search data streams' }
-            )}
+            placeholder={i18n.translate('xpack.idxMgmt.dataStreamList.table.searchPlaceholder', {
+              defaultMessage: 'Search data streams',
+            })}
             data-test-subj="dataStreamSearch"
           />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
@@ -20,6 +20,8 @@ import {
   EuiFlexItem,
   EuiSwitch,
   EuiIconTip,
+  EuiFieldSearch,
+  EuiSpacer,
   RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import type { ScopedHistory } from '@kbn/core/public';
@@ -93,6 +95,7 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
   const [dataStreamsToEditDataRetention, setDataStreamsToEditDataRetention] = useState<
     DataStream[]
   >([]);
+  const [searchValue, setSearchValue] = useState(filters ?? '');
   const { config } = useAppContext();
 
   const data = useMemo(() => {
@@ -101,6 +104,12 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
       isNextGenIlm: isNextGenIlm(dataStream),
     }));
   }, [dataStreams]);
+
+  const filteredData = useMemo(() => {
+    const q = searchValue.trim().toLowerCase();
+    if (!q) return data;
+    return data.filter((ds) => ds.name.toLowerCase().includes(q));
+  }, [data, searchValue]);
 
   const columns: Array<EuiBasicTableColumn<TableDataStream>> = [];
 
@@ -352,63 +361,6 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
     });
   }
 
-  const searchConfig = {
-    query: filters,
-    box: {
-      incremental: true,
-    },
-    toolsLeft:
-      selection.length > 0 && dataStreamActions.length > 0 ? (
-        <DataStreamActionsMenu
-          dataStreamActions={dataStreamActions}
-          selectedDataStreamsCount={selection.length}
-        />
-      ) : undefined,
-    toolsRight: [
-      <EuiFlexGroup gutterSize="s" key="includeStats">
-        <EuiFlexItem grow={false}>
-          <EuiSwitch
-            label={i18n.translate('xpack.idxMgmt.dataStreamListControls.includeStatsSwitchLabel', {
-              defaultMessage: 'Include stats',
-            })}
-            checked={includeStats}
-            onChange={(e) => setIncludeStats(e.target.checked)}
-            data-test-subj="includeStatsSwitch"
-          />
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          <EuiIconTip
-            content={i18n.translate(
-              'xpack.idxMgmt.dataStreamListControls.includeStatsSwitchToolTip',
-              {
-                defaultMessage: 'Including stats can increase reload times',
-              }
-            )}
-            position="top"
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>,
-      <FilterListButton<DataStreamFilterName>
-        filters={viewFilters}
-        onChange={onViewFilterChange}
-        key="filterListButton"
-      />,
-      <EuiButton
-        color="success"
-        iconType="refresh"
-        onClick={reload}
-        data-test-subj="reloadButton"
-        key="reloadButton"
-      >
-        <FormattedMessage
-          id="xpack.idxMgmt.dataStreamList.reloadDataStreamsButtonLabel"
-          defaultMessage="Reload"
-        />
-      </EuiButton>,
-    ],
-  };
-
   const { pageSize, sorting, onTableChange } = useEuiTablePersist<TableDataStream>({
     tableId: 'dataStreams',
     initialPageSize: 20,
@@ -449,11 +401,77 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
           dataStreams={dataStreamsToDelete}
         />
       ) : null}
+      <EuiFlexGroup gutterSize="s" alignItems="center">
+        {selection.length > 0 && dataStreamActions.length > 0 && (
+          <EuiFlexItem grow={false}>
+            <DataStreamActionsMenu
+              dataStreamActions={dataStreamActions}
+              selectedDataStreamsCount={selection.length}
+            />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem>
+          <EuiFieldSearch
+            incremental
+            fullWidth
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            placeholder={i18n.translate(
+              'xpack.idxMgmt.dataStreamList.table.searchPlaceholder',
+              { defaultMessage: 'Search data streams' }
+            )}
+            data-test-subj="dataStreamSearch"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiSwitch
+                label={i18n.translate(
+                  'xpack.idxMgmt.dataStreamListControls.includeStatsSwitchLabel',
+                  { defaultMessage: 'Include stats' }
+                )}
+                checked={includeStats}
+                onChange={(e) => setIncludeStats(e.target.checked)}
+                data-test-subj="includeStatsSwitch"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiIconTip
+                content={i18n.translate(
+                  'xpack.idxMgmt.dataStreamListControls.includeStatsSwitchToolTip',
+                  { defaultMessage: 'Including stats can increase reload times' }
+                )}
+                position="top"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <FilterListButton<DataStreamFilterName>
+                filters={viewFilters}
+                onChange={onViewFilterChange}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color="success"
+                iconType="refresh"
+                onClick={reload}
+                data-test-subj="reloadButton"
+              >
+                <FormattedMessage
+                  id="xpack.idxMgmt.dataStreamList.reloadDataStreamsButtonLabel"
+                  defaultMessage="Reload"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
       <EuiInMemoryTable
-        items={data}
+        items={filteredData}
         itemId="name"
         columns={columns}
-        search={searchConfig}
         sorting={sorting}
         selection={selectionConfig}
         pagination={pagination}


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/268722

## Summary

This PR replaces the built-in search with a plain `EuiFieldSearch` + substring filter, moving the toolbar items (bulk actions, Include stats, Filter, Reload) into an explicit row above the table.

## Test plan

- Go to Index Management -> Data Streams, type `orange`, `orc`, `and`, `not`.. all characters
stay and filter the list
- Toolbar (Include stats switch, Filter button, Reload button) still renders and works
- Selecting rows still shows the bulk actions menu


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->