### PR TITLE
[9.4] [Lens as code] Fix datatable columnOrder when using split_by (#273564)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/datatable.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/utils/validator/normalizers/datatable.ts
@@ -116,29 +116,15 @@ const isVisualizationStateColumnId = (id: string): boolean =>
   isRowColumnId(id) || isSplitMetricColumnId(id) || isMetricColumnId(id);
 
 /**
- * Canonical order for the original side: rows → split_metrics_by → metrics
+ * Canonical order for datasource columnOrder: split_metrics_by → rows → metrics
  * → everything else (refs and any unknowns).
- */
-const sortVisualizationStateColumnsToCanonicalOrder = (ids: string[]): string[] => [
-  ...ids.filter((id) => isRowColumnId(id)),
-  ...ids.filter((id) => isSplitMetricColumnId(id)),
-  ...ids.filter((id) => isMetricColumnId(id)),
-  ...ids.filter((id) => !isVisualizationStateColumnId(id)),
-];
-
-/**
- * Stable partition for the transformed side: move non-visualization-state
- * columns (refs and any unknowns) to the end while preserving the relative
- * order of everything else.
  *
- * Refs (e.g. the `max` referenced by a `counter_rate`) are hidden at render
- * time (`getTableSpec` filters via `isReferenced`), so their position inside
- * `columnOrder` does not affect the rendering. The transform interleaves
- * them with their owning metric via `processMetricColumnsWithReferences`.
- * We normalize that purely cosmetic placement to ease testing.
+ * Matches Lens datatable editor nesting (split outer, rows inner, metrics last).
  */
-const moveNonVisualizationStateColumnsToEnd = (ids: readonly string[]): string[] => [
-  ...ids.filter(isVisualizationStateColumnId),
+const sortDatasourceColumnsToCanonicalOrder = (ids: string[]): string[] => [
+  ...ids.filter((id) => isSplitMetricColumnId(id)),
+  ...ids.filter((id) => isRowColumnId(id)),
+  ...ids.filter((id) => isMetricColumnId(id)),
   ...ids.filter((id) => !isVisualizationStateColumnId(id)),
 ];
 
@@ -499,51 +485,19 @@ export const normalizeDatatable: AttributesNormalizer<DatatableAttributes> = (at
     },
   };
 
-  // Align datasource column order for round-trip comparison.
-  //
-  // - `original`: full canonical sort (rows → splits → metrics → refs).
-  //   The API model has three separate arrays (`rows`, `split_metrics_by`,
-  //   `metrics`) and cannot represent arbitrary cross-group orderings, so any
-  //   non-canonical original must be normalized to canonical form before
-  //   comparison (lossy by design).
-  //
-  // - `transformed`: only push refs to the end (stable). Non-ref ordering is
-  //   the transform's emit order and stays untouched.
-  //   We only move the metric_ref columns to the end, because they
-  //   don't affect the rendering column order.
-  const sortDatasourceColumns: NormalizerConfig<DatatableAttributes> = {
+  // ES|QL text-based layers keep columns in editor order (often metrics first).
+  // fromAPIFormat emits split → rows → metrics for nesting; normalize originals only.
+  const sortEsqlDatasourceColumns: NormalizerConfig<DatatableAttributes> = {
     original: (attrs) => {
-      const formBasedLayer = Object.values(
-        getFormBasedDatasourceState(attrs.state.datasourceStates)?.layers ?? {}
-      )[0];
-      if (formBasedLayer) {
-        formBasedLayer.columnOrder = sortVisualizationStateColumnsToCanonicalOrder(
-          formBasedLayer.columnOrder
-        );
-      }
-
       const textBasedLayer = Object.values(attrs.state.datasourceStates.textBased?.layers ?? {})[0];
       if (textBasedLayer) {
         const byId = new Map(textBasedLayer.columns.map((c) => [c.columnId, c]));
-        const orderedIds = sortVisualizationStateColumnsToCanonicalOrder(
+        const orderedIds = sortDatasourceColumnsToCanonicalOrder(
           textBasedLayer.columns.map((c) => c.columnId)
         );
         textBasedLayer.columns = orderedIds.map((id) => byId.get(id)!);
       }
 
-      return attrs;
-    },
-    transformed: (attrs) => {
-      const formBasedLayer = Object.values(
-        getFormBasedDatasourceState(attrs.state.datasourceStates)?.layers ?? {}
-      )[0];
-      if (formBasedLayer) {
-        formBasedLayer.columnOrder = moveNonVisualizationStateColumnsToEnd(
-          formBasedLayer.columnOrder
-        );
-      }
-
-      // ESQL has no refs, so the transform's emit order is already canonical.
       return attrs;
     },
   };
@@ -559,7 +513,7 @@ export const normalizeDatatable: AttributesNormalizer<DatatableAttributes> = (at
     alignId,
     deduplicateColumns,
     sortColumns,
-    sortDatasourceColumns,
+    sortEsqlDatasourceColumns,
     alignLegacyTypes,
     getColorMappingNormalizer<DatatableAttributes>('state.visualization.columns.*.colorMapping'),
     getPaletteNormalizer<DatatableAttributes>('state.visualization.columns.*.palette'),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.test.ts
@@ -7,8 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DatatableConfig, DatatableConfigESQL } from '../../../../schema';
-import { buildVisualizationState, getValueColumns } from '.';
+import type {
+  DatatableConfig,
+  DatatableConfigESQL,
+  DatatableConfigNoESQL,
+} from '../../../../schema';
+import type { TermsIndexPatternColumn } from '@kbn/lens-common';
+import { buildFormBasedLayer, buildVisualizationState, getValueColumns } from '.';
+import { DEFAULT_LAYER_ID } from '../../../../constants';
 
 describe('Datatable ES|QL column ordering', () => {
   describe('buildVisualizationState', () => {
@@ -61,8 +67,133 @@ describe('Datatable ES|QL column ordering', () => {
     });
   });
 
+  describe('buildFormBasedLayer', () => {
+    it('should order datasource columnOrder as split_metrics_by, rows, then metrics', () => {
+      const config: DatatableConfigNoESQL = {
+        type: 'data_table',
+        data_source: {
+          type: 'data_view_reference',
+          ref_id: 'logstash-*',
+        },
+        sampling: 1,
+        ignore_global_filters: false,
+        metrics: [{ operation: 'median', field: 'bytes' }],
+        rows: [
+          {
+            operation: 'terms',
+            fields: ['geo.src'],
+            limit: 7,
+            rank_by: { type: 'metric', metric_index: 0, direction: 'desc' },
+          },
+        ],
+        split_metrics_by: [
+          {
+            operation: 'terms',
+            fields: ['response.raw'],
+            limit: 3,
+            other_bucket: { include_documents_without_field: false },
+            rank_by: { type: 'metric', metric_index: 0, direction: 'desc' },
+          },
+        ],
+      };
+
+      const layers = buildFormBasedLayer(config);
+      const layer = layers[DEFAULT_LAYER_ID];
+
+      expect(layer.columnOrder).toEqual([
+        'datatable_accessor_split_metric_by_0',
+        'datatable_accessor_row_0',
+        'datatable_accessor_metric_0',
+      ]);
+    });
+
+    it('should place reference columns after all visible metrics in columnOrder', () => {
+      const config: DatatableConfigNoESQL = {
+        type: 'data_table',
+        data_source: {
+          type: 'data_view_reference',
+          ref_id: 'metrics-*',
+        },
+        sampling: 1,
+        ignore_global_filters: false,
+        rows: [
+          {
+            operation: 'date_histogram',
+            field: '@timestamp',
+            suggested_interval: 'auto',
+            include_empty_rows: false,
+            use_original_time_range: false,
+          },
+          { operation: 'terms', fields: ['pipeline.name'], limit: 10 },
+        ],
+        metrics: [
+          {
+            operation: 'counter_rate',
+            field: 'elasticsearch.ingest_pipeline.total.count',
+          },
+          {
+            operation: 'counter_rate',
+            field: 'elasticsearch.ingest_pipeline.total.time_in_millis',
+          },
+        ],
+      };
+
+      const layers = buildFormBasedLayer(config);
+      const layer = layers[DEFAULT_LAYER_ID];
+
+      expect(layer.columnOrder).toEqual([
+        'datatable_accessor_row_0',
+        'datatable_accessor_row_1',
+        'datatable_accessor_metric_0',
+        'datatable_accessor_metric_1',
+        'datatable_accessor_metric_ref_0',
+        'datatable_accessor_metric_ref_1',
+      ]);
+    });
+
+    it('should resolve rank_by.metric_index against visible metrics when references exist', () => {
+      const config: DatatableConfigNoESQL = {
+        type: 'data_table',
+        data_source: {
+          type: 'data_view_reference',
+          ref_id: 'metrics-*',
+        },
+        sampling: 1,
+        ignore_global_filters: false,
+        rows: [
+          {
+            operation: 'terms',
+            fields: ['pipeline.name'],
+            limit: 10,
+            rank_by: { type: 'metric', metric_index: 1, direction: 'desc' },
+          },
+        ],
+        metrics: [
+          {
+            operation: 'counter_rate',
+            field: 'elasticsearch.ingest_pipeline.total.count',
+          },
+          {
+            operation: 'counter_rate',
+            field: 'elasticsearch.ingest_pipeline.total.time_in_millis',
+          },
+        ],
+      };
+
+      const layers = buildFormBasedLayer(config);
+      const layer = layers[DEFAULT_LAYER_ID];
+      const rowColumn = layer.columns.datatable_accessor_row_0 as TermsIndexPatternColumn;
+
+      expect(rowColumn.operationType).toBe('terms');
+      expect(rowColumn.params.orderBy).toEqual({
+        type: 'column',
+        columnId: 'datatable_accessor_metric_1',
+      });
+    });
+  });
+
   describe('getValueColumns', () => {
-    test('returns value columns for rows, split_metrics_by, and metrics', () => {
+    test('returns value columns for split_metrics_by, rows, and metrics', () => {
       const config = {
         type: 'data_table',
         metrics: [{ column: 'bytes' }, { column: 'requests' }],
@@ -74,13 +205,13 @@ describe('Datatable ES|QL column ordering', () => {
 
       expect(result).toEqual([
         {
-          columnId: 'datatable_accessor_row_0',
-          fieldName: 'host',
+          columnId: 'datatable_accessor_split_metric_by_0',
+          fieldName: 'region',
           meta: { type: 'string' },
         },
         {
-          columnId: 'datatable_accessor_split_metric_by_0',
-          fieldName: 'region',
+          columnId: 'datatable_accessor_row_0',
+          fieldName: 'host',
           meta: { type: 'string' },
         },
         {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.ts
@@ -45,24 +45,18 @@ export function buildFormBasedLayer(
   const metricsConverted = config.metrics.map(
     (metric) => fromMetricAPItoLensState(metric, inferDatatypeFromColor(metric.color, 'number')) // Infer datatype from color config for last_value operations
   );
-  const allMetricColumnsWithIds = processMetricColumnsWithReferences(
+  const { metricColumns, referencesColumns } = processMetricColumnsWithReferences(
     metricsConverted,
     (index) => getAccessorName(METRIC_ACCESSOR_PREFIX, index),
     (index) => getAccessorName(`${METRIC_ACCESSOR_PREFIX}_ref`, index)
   );
 
-  // Add row columns
-  if (config.rows) {
-    config.rows.forEach((row, index) => {
-      const bucketColumn = fromBucketLensApiToLensState(row, allMetricColumnsWithIds);
-      addLayerColumn(defaultLayer, getAccessorName(ROW_ACCESSOR_PREFIX, index), bucketColumn);
-    });
-  }
-
-  // Add split_metrics_by columns
+  // Split metrics by columns must precede row columns in columnOrder so ES aggregation
+  // nesting matches the Lens datatable editor (nestingOrder: split=0, rows=1).
+  // fromBucketLensApiToLensState resolves rank_by.metric_index against visible metrics only.
   if (config.split_metrics_by) {
     config.split_metrics_by.forEach((splitBy, index) => {
-      const bucketColumn = fromBucketLensApiToLensState(splitBy, allMetricColumnsWithIds);
+      const bucketColumn = fromBucketLensApiToLensState(splitBy, metricColumns);
       addLayerColumn(
         defaultLayer,
         getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index),
@@ -71,7 +65,17 @@ export function buildFormBasedLayer(
     });
   }
 
-  for (const { id, column } of allMetricColumnsWithIds) {
+  if (config.rows) {
+    config.rows.forEach((row, index) => {
+      const bucketColumn = fromBucketLensApiToLensState(row, metricColumns);
+      addLayerColumn(defaultLayer, getAccessorName(ROW_ACCESSOR_PREFIX, index), bucketColumn);
+    });
+  }
+
+  for (const { id, column } of metricColumns) {
+    addLayerColumn(defaultLayer, id, column);
+  }
+  for (const { id, column } of referencesColumns) {
     addLayerColumn(defaultLayer, id, column);
   }
 
@@ -80,15 +84,15 @@ export function buildFormBasedLayer(
 
 export function getValueColumns(config: DatatableConfigESQL) {
   return [
+    ...(config.split_metrics_by ?? []).map((splitBy, index) =>
+      getValueColumn(getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index), splitBy)
+    ),
     ...(config.rows ?? []).map((row, index) =>
       getValueColumn(
         getAccessorName(ROW_ACCESSOR_PREFIX, index),
         row,
         inferDatatypeFromColor(row.color, 'string')
       )
-    ),
-    ...(config.split_metrics_by ?? []).map((splitBy, index) =>
-      getValueColumn(getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index), splitBy)
     ),
     ...(config.metrics ?? []).map((metric, index) =>
       getValueColumn(

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.test.ts
@@ -7,9 +7,68 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getLegendTruncateAfterLines } from './utils';
+import type { CounterRateIndexPatternColumn, MaxIndexPatternColumn } from '@kbn/lens-common';
+import { getLegendTruncateAfterLines, processMetricColumnsWithReferences } from './utils';
+import { LENS_EMPTY_AS_NULL_DEFAULT_VALUE } from '../columns/utils';
+
+const createCounterRateColumn = (): CounterRateIndexPatternColumn => ({
+  customLabel: false,
+  filter: undefined,
+  operationType: 'counter_rate',
+  label: '',
+  isBucketed: false,
+  dataType: 'number',
+  params: {},
+  references: [],
+});
+
+const createMaxReferenceColumn = (): MaxIndexPatternColumn => ({
+  operationType: 'max',
+  sourceField: 'bytes',
+  label: 'Max of bytes',
+  customLabel: false,
+  isBucketed: false,
+  dataType: 'number',
+  params: { emptyAsNull: LENS_EMPTY_AS_NULL_DEFAULT_VALUE },
+});
 
 describe('utils', () => {
+  describe('processMetricColumnsWithReferences', () => {
+    it('returns visible metrics and references as separate arrays', () => {
+      const mainMetric = createCounterRateColumn();
+      const refMetric = createMaxReferenceColumn();
+
+      const result = processMetricColumnsWithReferences(
+        [[mainMetric, refMetric]],
+        (index) => `metric_${index}`,
+        (index) => `metric_ref_${index}`
+      );
+
+      expect(result.metricColumns).toEqual([{ column: mainMetric, id: 'metric_0' }]);
+      expect(result.referencesColumns).toEqual([{ column: refMetric, id: 'metric_ref_0' }]);
+      expect(mainMetric.references).toEqual(['metric_ref_0']);
+    });
+
+    it('keeps metrics and references in separate arrays (not interleaved)', () => {
+      const counterRate0 = createCounterRateColumn();
+      const counterRate1 = createCounterRateColumn();
+      const maxRef0 = createMaxReferenceColumn();
+      const maxRef1 = createMaxReferenceColumn();
+
+      const { metricColumns, referencesColumns } = processMetricColumnsWithReferences(
+        [
+          [counterRate0, maxRef0],
+          [counterRate1, maxRef1],
+        ],
+        (index) => `metric_${index}`,
+        (index) => `metric_ref_${index}`
+      );
+
+      expect(metricColumns.map(({ id }) => id)).toEqual(['metric_0', 'metric_1']);
+      expect(referencesColumns.map(({ id }) => id)).toEqual(['metric_ref_0', 'metric_ref_1']);
+    });
+  });
+
   describe('getLegendTruncateAfterLines', () => {
     it.each<
       [input: Parameters<typeof getLegendTruncateAfterLines>['0'], expected: number | undefined]

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.ts
@@ -125,20 +125,32 @@ export function getDataViewsMetadata(
 }
 
 /**
+ * A metric column with its assigned accessor id.
+ */
+interface MetricColumnWithId {
+  column: AnyMetricLensStateColumn;
+  id: string;
+}
+
+/**
  * Processes converted metric columns and their optional reference columns,
  * assigning IDs.
  */
-export function processMetricColumnsWithReferences<T extends AnyMetricLensStateColumn>(
-  convertedMetrics: T[][],
+export function processMetricColumnsWithReferences(
+  convertedMetrics: AnyMetricLensStateColumn[][],
   getAccessorName: (index: number) => string,
   getRefAccessorName: (index: number) => string
-): Array<{ column: T; id: string }> {
-  const result: Array<{ column: T; id: string }> = [];
+): {
+  metricColumns: MetricColumnWithId[];
+  referencesColumns: MetricColumnWithId[];
+} {
+  const metricColumns: MetricColumnWithId[] = [];
+  const referencesColumns: MetricColumnWithId[] = [];
 
   for (const [index, convertedColumns] of Object.entries(convertedMetrics)) {
     const [mainMetric, refMetric] = convertedColumns;
     const id = getAccessorName(Number(index));
-    result.push({ column: mainMetric, id });
+    metricColumns.push({ column: mainMetric, id });
 
     if (refMetric) {
       // Use a different format for reference column ids
@@ -148,11 +160,11 @@ export function processMetricColumnsWithReferences<T extends AnyMetricLensStateC
       if ('references' in mainMetric && Array.isArray(mainMetric.references)) {
         mainMetric.references = [refId];
       }
-      result.push({ column: refMetric, id: refId });
+      referencesColumns.push({ column: refMetric, id: refId });
     }
   }
 
-  return result;
+  return { metricColumns, referencesColumns };
 }
 
 type LegendTruncateAfterLines = TypeOf<typeof legendTruncateAfterLinesSchema>;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
@@ -283,14 +283,15 @@ export function buildFormBasedXYLayer(layer: unknown, i: number) {
   if (isAPIDataLayer(layer)) {
     // convert metrics in buckets, do not flat yet
     const yColumnsConverted = layer.y.map((col) => fromMetricAPItoLensState(col));
-    const yColumnsWithIds = processMetricColumnsWithReferences(
+    const { metricColumns, referencesColumns } = processMetricColumnsWithReferences(
       yColumnsConverted,
       (index) => getAccessorNameForXY(layer, METRIC_ACCESSOR_PREFIX, index),
       (index) => getAccessorNameForXY(layer, `${METRIC_ACCESSOR_PREFIX}_ref`, index)
     );
-    const xColumns = layer.x ? fromBucketLensApiToLensState(layer.x, yColumnsWithIds) : undefined;
+    // fromBucketLensApiToLensState resolves rank_by.metric_index against visible metrics only.
+    const xColumns = layer.x ? fromBucketLensApiToLensState(layer.x, metricColumns) : undefined;
     const breakdownColumns = layer.breakdown_by
-      ? fromBucketLensApiToLensState(layer.breakdown_by, yColumnsWithIds)
+      ? fromBucketLensApiToLensState(layer.breakdown_by, metricColumns)
       : undefined;
 
     // Add bucketed coluns first
@@ -309,7 +310,10 @@ export function buildFormBasedXYLayer(layer: unknown, i: number) {
     }
 
     // then metric ones
-    for (const { id, column } of yColumnsWithIds) {
+    for (const { id, column } of metricColumns) {
+      addLayerColumn(newLayer, id, column);
+    }
+    for (const { id, column } of referencesColumns) {
       addLayerColumn(newLayer, id, column);
     }
   }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.test.ts
@@ -116,6 +116,79 @@ describe('Buckets Transforms', () => {
         fromBucketLensApiToLensState({ operation: 'unsupported', field: 'value' } as any, [])
       ).toThrowError('Unsupported bucket operation');
     });
+
+    describe('terms rank_by metric_index with reference metrics', () => {
+      const counterRateMetric = (
+        label: string
+      ): { column: AnyMetricLensStateColumn; id: string } => ({
+        column: {
+          operationType: 'counter_rate',
+          label,
+          dataType: 'number',
+          isBucketed: false,
+          references: [],
+        },
+        id: label,
+      });
+
+      const maxReferenceMetric = (
+        label: string
+      ): { column: AnyMetricLensStateColumn; id: string } => ({
+        column: {
+          operationType: 'max',
+          sourceField: 'bytes',
+          label,
+          dataType: 'number',
+          isBucketed: false,
+        },
+        id: label,
+      });
+
+      const visibleMetricColumns = [counterRateMetric('metric_0'), counterRateMetric('metric_1')];
+      const referenceColumns = [
+        maxReferenceMetric('metric_ref_0'),
+        maxReferenceMetric('metric_ref_1'),
+      ];
+      const interleavedMetricColumns = [
+        visibleMetricColumns[0],
+        referenceColumns[0],
+        visibleMetricColumns[1],
+        referenceColumns[1],
+      ];
+
+      const termsWithSecondMetricRank: LensApiTermsOperation = {
+        operation: 'terms',
+        fields: ['host.name'],
+        limit: 10,
+        rank_by: { type: 'metric', metric_index: 1, direction: 'desc' },
+      };
+
+      it('resolves metric_index against visible API metrics only', () => {
+        const result = fromBucketLensApiToLensState(
+          termsWithSecondMetricRank,
+          visibleMetricColumns
+        );
+        if (!isLensStateColumnOfType<TermsIndexPatternColumn>('terms', result)) {
+          fail();
+        }
+
+        expect(result.params.orderBy).toEqual({ type: 'column', columnId: 'metric_1' });
+      });
+
+      it('resolves metric_index incorrectly when metrics and refs are interleaved', () => {
+        const result = fromBucketLensApiToLensState(
+          termsWithSecondMetricRank,
+          interleavedMetricColumns
+        );
+        if (!isLensStateColumnOfType<TermsIndexPatternColumn>('terms', result)) {
+          fail();
+        }
+
+        // Documents the old accidental layout: index 1 pointed at a hidden ref, not metric_1.
+        expect(result.params.orderBy).toEqual({ type: 'column', columnId: 'metric_ref_0' });
+        expect(result.params.orderBy).not.toEqual({ type: 'column', columnId: 'metric_1' });
+      });
+    });
   });
 
   describe('fromBucketLensStateToAPI', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.ts
@@ -38,6 +38,10 @@ import type {
   AnyMetricLensStateColumn,
 } from './types';
 
+/**
+ * @param columns Visible API metrics only — not internal reference columns (e.g. max for
+ * counter_rate). Terms rank_by.metric_index indexes into this array.
+ */
 export function fromBucketLensApiToLensState(
   options: LensApiBucketOperations,
   columns: { column: AnyMetricLensStateColumn; id: string }[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens as code] Fix datatable columnOrder when using split_by (#273564)](https://github.com/elastic/kibana/pull/273564)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-06-17T11:24:45Z","message":"[Lens as code] Fix datatable columnOrder when using split_by (#273564)\n\n## Summary\n\nFixing the first issue discovered with `lens.apiFormat=true` in CI:\nhttps://github.com/elastic/kibana/issues/268821 and covering 2\nsubsequent problems:\n\n### 1. Navigation / persistent context (FTR 124) (discovered in the\nmentioned issue)\n- **Test:**\n`x-pack/platform/test/functional/apps/lens/group2/persistent_context.ts`\n— \"Navigation search - filters, time and query reflect the visualization\nstate\"\n- **Config:** `lens/group2/config.ts` — [FTR #124\nlogs](https://buildkite.com/elastic/kibana-pull-request/builds/440880#019e180e-52e5-4e56-85af-3a0cb0118603)\n- **Error:** `TimeoutError: Waiting for [data-test-subj=\"lnsDataTable\"]\nheader column`\n- **Context:** After navigating from empty state to an existing\nvisualization, the data table does not render. Navigation loads saved\nstate through `deserializeState` → `transformFromApiConfig` →\n`fromAPIFormat()`, and the rebuilt datasource `columnOrder` does not\nmatch what Lens expects for aggregation nesting.\n\n\n### 2. Integration round-trip — reference metric column order (new\ndiscover after fixing the previous)\n- **Test:** `config_builder/tests/integrations/charts.test.ts` —\n`[Elasticsearch] Ingest Pipeline Detail (panel: 9)`\n- **Error:** Round-trip validator mismatch on `columnOrder` (metrics and\ninternal reference columns in the wrong order)\n- **Context:** Panel uses multiple `counter_rate` metrics, each with a\nhidden `max` reference column. `fromAPIFormat()` interleaved visible\nmetrics and refs (`metric_0, ref_0, metric_1, ref_1, …`) instead of\ngrouping all visible metrics before all refs (`metric_0, metric_1, …,\nref_0, ref_1, …`), which is how Lens saved objects and `getColumnOrder`\nlay them out.\n\n\n## Root cause\n\nBoth bugs are in **`buildFormBasedLayer`**\n(`datatable/to_state/index.ts`) and shared metric processing when\nrebuilding form-based datasource state from the API config.\n\n### Issue 1: Split / row aggregation nesting\nFor datatables, **`columnOrder` in the form-based layer controls ES\naggregation nesting**, not the display order in `visualization.columns`.\n| Path | `columnOrder` (buckets) | Result |\n|------|-------------------------|--------|\n| Saved object (working) | split → rows → metrics | Correct ES request,\ntable renders |\n| `fromAPIFormat` (broken) | rows → split → metrics | Inverted nesting,\ninvalid/wrong query, table never renders |\n\nChecking the two format reconstructed and the resulting requests it was\nclear that the columnOrder array drives the ES aggregation and can't be\njust \"normalized\" away in tests, but needs to be correctly reconstruct.\n\nThankfully in datatable chart the order is specific. The Lens datatable\neditor enforces split-before-rows via `nestingOrder` (split=0, rows=1).\nUsers cannot flip that order in the UI, but the API→state transform was\nemitting rows first.\n\nThe fix was to add split columns, then rows, then metrics in\n`buildFormBasedLayer`. Display order in `buildVisualizationState` stays\nrows → split → metrics (unchanged).\n\nAlso removed the form-based `columnOrder` normalizer in\n`tests/utils/validator/normalizers/datatable.ts` — it was\nreordering rows→split→metrics before comparison and masked this bug in\nunit tests.\n\n\n### Issue 2: Reference columns in `columnOrder`\n`processMetricColumnsWithReferences` returned a single flat array with\nmetric/ref pairs interleaved. `buildFormBasedLayer` (and XY\n`state_layers.ts`) appended columns in that order, producing:\n\nrows → counter_rate → max → counter_rate → max → …   ❌\n\nSaved objects and Lens `getColumnOrder` use:\n\nrows → counter_rate → counter_rate → … → max → max → … ✓\n\nThe fix:`processMetricColumnsWithReferences` now returns `{\nmetricColumns, referencesColumns }`. Callers add visible metrics first,\nthen reference columns.\n\n**Related fix:** `fromBucketLensApiToLensState` must receive **visible\nmetrics only** when resolving `terms` `rank_by.metric_index` — refs are\nnot part of the API metrics array. Passing an interleaved array was\nwrong for `metric_index > 0` (index 1 would resolve to a hidden `max`\nref instead of the second chart metric).","sha":"2b59d048da4c02d89ee2f5d660f233e4634dfb93","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Visualizations","release_note:skip","backport missing","backport:version","v9.5.0","v9.4.3"],"title":"[Lens as code] Fix datatable columnOrder when using split_by","number":273564,"url":"https://github.com/elastic/kibana/pull/273564","mergeCommit":{"message":"[Lens as code] Fix datatable columnOrder when using split_by (#273564)\n\n## Summary\n\nFixing the first issue discovered with `lens.apiFormat=true` in CI:\nhttps://github.com/elastic/kibana/issues/268821 and covering 2\nsubsequent problems:\n\n### 1. Navigation / persistent context (FTR 124) (discovered in the\nmentioned issue)\n- **Test:**\n`x-pack/platform/test/functional/apps/lens/group2/persistent_context.ts`\n— \"Navigation search - filters, time and query reflect the visualization\nstate\"\n- **Config:** `lens/group2/config.ts` — [FTR #124\nlogs](https://buildkite.com/elastic/kibana-pull-request/builds/440880#019e180e-52e5-4e56-85af-3a0cb0118603)\n- **Error:** `TimeoutError: Waiting for [data-test-subj=\"lnsDataTable\"]\nheader column`\n- **Context:** After navigating from empty state to an existing\nvisualization, the data table does not render. Navigation loads saved\nstate through `deserializeState` → `transformFromApiConfig` →\n`fromAPIFormat()`, and the rebuilt datasource `columnOrder` does not\nmatch what Lens expects for aggregation nesting.\n\n\n### 2. Integration round-trip — reference metric column order (new\ndiscover after fixing the previous)\n- **Test:** `config_builder/tests/integrations/charts.test.ts` —\n`[Elasticsearch] Ingest Pipeline Detail (panel: 9)`\n- **Error:** Round-trip validator mismatch on `columnOrder` (metrics and\ninternal reference columns in the wrong order)\n- **Context:** Panel uses multiple `counter_rate` metrics, each with a\nhidden `max` reference column. `fromAPIFormat()` interleaved visible\nmetrics and refs (`metric_0, ref_0, metric_1, ref_1, …`) instead of\ngrouping all visible metrics before all refs (`metric_0, metric_1, …,\nref_0, ref_1, …`), which is how Lens saved objects and `getColumnOrder`\nlay them out.\n\n\n## Root cause\n\nBoth bugs are in **`buildFormBasedLayer`**\n(`datatable/to_state/index.ts`) and shared metric processing when\nrebuilding form-based datasource state from the API config.\n\n### Issue 1: Split / row aggregation nesting\nFor datatables, **`columnOrder` in the form-based layer controls ES\naggregation nesting**, not the display order in `visualization.columns`.\n| Path | `columnOrder` (buckets) | Result |\n|------|-------------------------|--------|\n| Saved object (working) | split → rows → metrics | Correct ES request,\ntable renders |\n| `fromAPIFormat` (broken) | rows → split → metrics | Inverted nesting,\ninvalid/wrong query, table never renders |\n\nChecking the two format reconstructed and the resulting requests it was\nclear that the columnOrder array drives the ES aggregation and can't be\njust \"normalized\" away in tests, but needs to be correctly reconstruct.\n\nThankfully in datatable chart the order is specific. The Lens datatable\neditor enforces split-before-rows via `nestingOrder` (split=0, rows=1).\nUsers cannot flip that order in the UI, but the API→state transform was\nemitting rows first.\n\nThe fix was to add split columns, then rows, then metrics in\n`buildFormBasedLayer`. Display order in `buildVisualizationState` stays\nrows → split → metrics (unchanged).\n\nAlso removed the form-based `columnOrder` normalizer in\n`tests/utils/validator/normalizers/datatable.ts` — it was\nreordering rows→split→metrics before comparison and masked this bug in\nunit tests.\n\n\n### Issue 2: Reference columns in `columnOrder`\n`processMetricColumnsWithReferences` returned a single flat array with\nmetric/ref pairs interleaved. `buildFormBasedLayer` (and XY\n`state_layers.ts`) appended columns in that order, producing:\n\nrows → counter_rate → max → counter_rate → max → …   ❌\n\nSaved objects and Lens `getColumnOrder` use:\n\nrows → counter_rate → counter_rate → … → max → max → … ✓\n\nThe fix:`processMetricColumnsWithReferences` now returns `{\nmetricColumns, referencesColumns }`. Callers add visible metrics first,\nthen reference columns.\n\n**Related fix:** `fromBucketLensApiToLensState` must receive **visible\nmetrics only** when resolving `terms` `rank_by.metric_index` — refs are\nnot part of the API metrics array. Passing an interleaved array was\nwrong for `metric_index > 0` (index 1 would resolve to a hidden `max`\nref instead of the second chart metric).","sha":"2b59d048da4c02d89ee2f5d660f233e4634dfb93"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273564","number":273564,"mergeCommit":{"message":"[Lens as code] Fix datatable columnOrder when using split_by (#273564)\n\n## Summary\n\nFixing the first issue discovered with `lens.apiFormat=true` in CI:\nhttps://github.com/elastic/kibana/issues/268821 and covering 2\nsubsequent problems:\n\n### 1. Navigation / persistent context (FTR 124) (discovered in the\nmentioned issue)\n- **Test:**\n`x-pack/platform/test/functional/apps/lens/group2/persistent_context.ts`\n— \"Navigation search - filters, time and query reflect the visualization\nstate\"\n- **Config:** `lens/group2/config.ts` — [FTR #124\nlogs](https://buildkite.com/elastic/kibana-pull-request/builds/440880#019e180e-52e5-4e56-85af-3a0cb0118603)\n- **Error:** `TimeoutError: Waiting for [data-test-subj=\"lnsDataTable\"]\nheader column`\n- **Context:** After navigating from empty state to an existing\nvisualization, the data table does not render. Navigation loads saved\nstate through `deserializeState` → `transformFromApiConfig` →\n`fromAPIFormat()`, and the rebuilt datasource `columnOrder` does not\nmatch what Lens expects for aggregation nesting.\n\n\n### 2. Integration round-trip — reference metric column order (new\ndiscover after fixing the previous)\n- **Test:** `config_builder/tests/integrations/charts.test.ts` —\n`[Elasticsearch] Ingest Pipeline Detail (panel: 9)`\n- **Error:** Round-trip validator mismatch on `columnOrder` (metrics and\ninternal reference columns in the wrong order)\n- **Context:** Panel uses multiple `counter_rate` metrics, each with a\nhidden `max` reference column. `fromAPIFormat()` interleaved visible\nmetrics and refs (`metric_0, ref_0, metric_1, ref_1, …`) instead of\ngrouping all visible metrics before all refs (`metric_0, metric_1, …,\nref_0, ref_1, …`), which is how Lens saved objects and `getColumnOrder`\nlay them out.\n\n\n## Root cause\n\nBoth bugs are in **`buildFormBasedLayer`**\n(`datatable/to_state/index.ts`) and shared metric processing when\nrebuilding form-based datasource state from the API config.\n\n### Issue 1: Split / row aggregation nesting\nFor datatables, **`columnOrder` in the form-based layer controls ES\naggregation nesting**, not the display order in `visualization.columns`.\n| Path | `columnOrder` (buckets) | Result |\n|------|-------------------------|--------|\n| Saved object (working) | split → rows → metrics | Correct ES request,\ntable renders |\n| `fromAPIFormat` (broken) | rows → split → metrics | Inverted nesting,\ninvalid/wrong query, table never renders |\n\nChecking the two format reconstructed and the resulting requests it was\nclear that the columnOrder array drives the ES aggregation and can't be\njust \"normalized\" away in tests, but needs to be correctly reconstruct.\n\nThankfully in datatable chart the order is specific. The Lens datatable\neditor enforces split-before-rows via `nestingOrder` (split=0, rows=1).\nUsers cannot flip that order in the UI, but the API→state transform was\nemitting rows first.\n\nThe fix was to add split columns, then rows, then metrics in\n`buildFormBasedLayer`. Display order in `buildVisualizationState` stays\nrows → split → metrics (unchanged).\n\nAlso removed the form-based `columnOrder` normalizer in\n`tests/utils/validator/normalizers/datatable.ts` — it was\nreordering rows→split→metrics before comparison and masked this bug in\nunit tests.\n\n\n### Issue 2: Reference columns in `columnOrder`\n`processMetricColumnsWithReferences` returned a single flat array with\nmetric/ref pairs interleaved. `buildFormBasedLayer` (and XY\n`state_layers.ts`) appended columns in that order, producing:\n\nrows → counter_rate → max → counter_rate → max → …   ❌\n\nSaved objects and Lens `getColumnOrder` use:\n\nrows → counter_rate → counter_rate → … → max → max → … ✓\n\nThe fix:`processMetricColumnsWithReferences` now returns `{\nmetricColumns, referencesColumns }`. Callers add visible metrics first,\nthen reference columns.\n\n**Related fix:** `fromBucketLensApiToLensState` must receive **visible\nmetrics only** when resolving `terms` `rank_by.metric_index` — refs are\nnot part of the API metrics array. Passing an interleaved array was\nwrong for `metric_index > 0` (index 1 would resolve to a hidden `max`\nref instead of the second chart metric).","sha":"2b59d048da4c02d89ee2f5d660f233e4634dfb93"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->