### PR TITLE
[9.4] [Fleet] Enhancements to avoid Fleet OOMs (#274173)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/retry_data_stream_update.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/retry_data_stream_update.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import pRetry from 'p-retry';
+
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import type { Logger } from '@kbn/logging';
+
+const RETRIES = 4;
+const MIN_TIMEOUT_MS = 2_000;
+const MAX_TIMEOUT_MS = 30_000;
+const FACTOR = 2;
+
+const CLUSTER_EVENT_TIMEOUT_EXCEPTION = 'process_cluster_event_timeout_exception';
+
+const isClusterEventTimeoutError = (err: unknown): boolean => {
+  if (!(err instanceof EsErrors.ResponseError)) {
+    return false;
+  }
+  if (err.body?.error?.type === CLUSTER_EVENT_TIMEOUT_EXCEPTION) {
+    return true;
+  }
+  if (Array.isArray(err.body?.error?.root_cause)) {
+    return err.body.error.root_cause.some(
+      (cause: { type?: string }) => cause.type === CLUSTER_EVENT_TIMEOUT_EXCEPTION
+    );
+  }
+  return false;
+};
+
+const isTooManyRequestsError = (err: unknown): boolean =>
+  err instanceof EsErrors.ResponseError && err.statusCode === 429;
+
+/**
+ * Wraps an async operation that updates a data stream with jittered exponential-backoff retry
+ * logic that triggers specifically on `process_cluster_event_timeout_exception` and 429 errors.
+ * All other errors abort immediately and propagate unchanged.
+ *
+ * Confined to the package-install code path (does not touch retryTransientEsErrors).
+ */
+export const retryDataStreamUpdateOnClusterEventTimeout = async <T>(
+  operation: () => Promise<T>,
+  { logger, dataStreamName }: { logger: Logger; dataStreamName: string }
+): Promise<T> => {
+  return pRetry(operation, {
+    retries: RETRIES,
+    factor: FACTOR,
+    minTimeout: MIN_TIMEOUT_MS,
+    maxTimeout: MAX_TIMEOUT_MS,
+    randomize: true,
+    onFailedAttempt: (err) => {
+      if (!isClusterEventTimeoutError(err) && !isTooManyRequestsError(err)) {
+        throw new pRetry.AbortError(err);
+      }
+      logger.warn(
+        `Retrying data stream update for [${dataStreamName}] after cluster event timeout (attempt ${
+          err.attemptNumber
+        }/${RETRIES + 1}): ${err.message}`
+      );
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -2481,6 +2481,86 @@ describe('EPM template', () => {
 
       expect(esClient.indices.rollover).not.toHaveBeenCalled();
     });
+    it('should not rollover on total_fields limit error and should throw', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResponse({
+        data_streams: [{ name: 'test.prefix1-default' }],
+      } as any);
+      esClient.indices.simulateTemplate.mockImplementation(() => {
+        throw new errors.ResponseError({
+          statusCode: 400,
+          body: {
+            error: {
+              type: 'illegal_argument_exception',
+              reason: 'Limit of total fields [2500] has been exceeded',
+            },
+          },
+        } as any);
+      });
+      const logger = loggerMock.create();
+      await expect(
+        updateCurrentWriteIndices(esClient, logger, [
+          {
+            templateName: 'test',
+            indexTemplate: {
+              index_patterns: ['test.*-*'],
+              template: {
+                settings: { index: {} },
+                mappings: { properties: {} },
+              },
+            } as any,
+          },
+        ])
+      ).rejects.toThrow();
+
+      // Rollover must NOT be triggered for total_fields errors — it cannot fix them.
+      expect(esClient.transport.request).not.toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/test.prefix1-default/_rollover' })
+      );
+    });
+
+    it('should not rollover on total_fields limit error and should not throw when ignoreMappingUpdateErrors is set', async () => {
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResponse({
+        data_streams: [{ name: 'test.prefix1-default' }],
+      } as any);
+      esClient.indices.simulateTemplate.mockImplementation(() => {
+        throw new errors.ResponseError({
+          statusCode: 400,
+          body: {
+            error: {
+              type: 'illegal_argument_exception',
+              reason: 'Limit of total fields [2500] has been exceeded',
+            },
+          },
+        } as any);
+      });
+      const logger = loggerMock.create();
+      await expect(
+        updateCurrentWriteIndices(
+          esClient,
+          logger,
+          [
+            {
+              templateName: 'test',
+              indexTemplate: {
+                index_patterns: ['test.*-*'],
+                template: {
+                  settings: { index: {} },
+                  mappings: { properties: {} },
+                },
+              } as any,
+            },
+          ],
+          { ignoreMappingUpdateErrors: true }
+        )
+      ).resolves.not.toThrow();
+
+      expect(esClient.transport.request).not.toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/test.prefix1-default/_rollover' })
+      );
+    });
+
     it('should not rollover on unexpected error', async () => {
       const esClient = elasticsearchServiceMock.createElasticsearchClient();
       esClient.indices.getDataStream.mockResponse({

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -48,6 +48,7 @@ import { retryTransientEsErrors } from '../retry';
 import { PackageESError, PackageInvalidArchiveError } from '../../../../errors';
 
 import { getDefaultProperties, histogram, keyword, scaledFloat } from './mappings';
+import { retryDataStreamUpdateOnClusterEventTimeout } from './retry_data_stream_update';
 import { isUserSettingsTemplate, fillConstantKeywordValues } from './utils';
 
 interface Properties {
@@ -1029,12 +1030,25 @@ const MAPPER_EXCEPTION_REASONS_REQUIRING_ROLLOVER = [
   "[enabled] parameter can't be updated for the object mapping",
 ];
 
-function errorNeedRollover(err: any) {
+/**
+ * Returns true when the ES error indicates that the mapping change is incompatible with the
+ * current write index and a data-stream rollover is the right recovery action.
+ *
+ * `total_fields` limit breaches are deliberately excluded: they surface as
+ * `illegal_argument_exception` but a rollover cannot fix them — the new write index is built
+ * from the same index template and inherits the same field-count limit, so the oversized
+ * mapping would fail again immediately.  Callers should surface those errors clearly instead.
+ */
+function errorNeedRollover(err: any): boolean {
   if (
     isResponseError(err) &&
     err.statusCode === 400 &&
     err.body?.error?.type === 'illegal_argument_exception'
   ) {
+    // total_fields limit errors cannot be resolved by a rollover — skip them.
+    if (isTotalFieldsLimitError(err)) {
+      return false;
+    }
     return true;
   }
   if (
@@ -1048,21 +1062,31 @@ function errorNeedRollover(err: any) {
   }
 }
 
-const rolloverDataStream = (dataStreamName: string, esClient: ElasticsearchClient) => {
-  try {
-    // Do no wrap rollovers in retryTransientEsErrors since it is not idempotent
-    return esClient.transport.request({
-      method: 'POST',
-      path: `/${dataStreamName}/_rollover`,
-      querystring: {
-        lazy: true,
-      },
-    });
-  } catch (error) {
-    throw new PackageESError(
-      `Cannot rollover data stream [${dataStreamName}] due to error: ${error}`
-    );
-  }
+/**
+ * Returns true when the error is an ES `total_fields` limit breach
+ * (`index.mapping.total_fields.limit` exceeded).
+ */
+export function isTotalFieldsLimitError(err: any): boolean {
+  const reason: string = err.body?.error?.reason ?? '';
+  return reason.includes('Limit of total fields') && reason.includes('has been exceeded');
+}
+
+const rolloverDataStream = (
+  dataStreamName: string,
+  esClient: ElasticsearchClient,
+  logger: Logger
+) => {
+  return retryDataStreamUpdateOnClusterEventTimeout(
+    () =>
+      esClient.transport.request({
+        method: 'POST',
+        path: `/${dataStreamName}/_rollover`,
+        querystring: {
+          lazy: true,
+        },
+      }),
+    { logger, dataStreamName }
+  );
 };
 
 const updateAllDataStreams = async (
@@ -1176,9 +1200,23 @@ const updateExistingDataStream = async ({
         return;
       } else {
         logger.info(`Triggering a rollover for ${dataStreamName}`);
-        await rolloverDataStream(dataStreamName, esClient);
+        await rolloverDataStream(dataStreamName, esClient, logger);
         return;
       }
+    }
+    // total_fields limit errors cannot be resolved by a rollover (the new write index inherits
+    // the same limit from the index template).  Log clearly and skip the rollover so we don't
+    // add churn to an already-overloaded cluster.
+    if (isTotalFieldsLimitError(err)) {
+      logger.warn(
+        `Mappings update for ${dataStreamName} failed because the index mapping total_fields limit has been exceeded. ` +
+          `Skipping rollover as it would not resolve the issue. ` +
+          `The total_fields limit must be raised on the index template to allow this mapping update: ${err}`
+      );
+      if (options?.ignoreMappingUpdateErrors !== true) {
+        throw err;
+      }
+      return;
     }
     logger.error(`Mappings update for ${dataStreamName} failed due to unexpected error: ${err}`);
     logger.trace(`Attempted mappings: ${mappings}`);
@@ -1233,7 +1271,7 @@ const updateExistingDataStream = async ({
           ? `Dynamic dimension mappings changed for ${dataStreamName}, triggering a rollover`
           : `Index mode or source type has changed for ${dataStreamName}, triggering a rollover`
       );
-      await rolloverDataStream(dataStreamName, esClient);
+      await rolloverDataStream(dataStreamName, esClient, logger);
     }
   }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -1060,6 +1060,7 @@ function errorNeedRollover(err: any): boolean {
   ) {
     return true;
   }
+  return false;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.test.ts
@@ -69,7 +69,13 @@ mockedAppContextService.getSecuritySetup.mockImplementation(() => ({
   ...securityMock.createSetup(),
 }));
 
-jest.mock('../epm/elasticsearch/template/template');
+jest.mock('../epm/elasticsearch/template/template', () => ({
+  updateCurrentWriteIndices: jest.fn(),
+  isTotalFieldsLimitError: (err: any): boolean => {
+    const reason: string = err?.body?.error?.reason ?? '';
+    return reason.includes('Limit of total fields') && reason.includes('has been exceeded');
+  },
+}));
 jest.mock('../epm/elasticsearch/template/install', () => {
   return {
     prepareDataStreamTemplates: jest.fn().mockResolvedValue([
@@ -189,6 +195,12 @@ describe('experimental_datastream_features', () => {
     mockedUpdateCurrentWriteIndices.mockReset();
     esClient.cluster.getComponentTemplate.mockClear();
     esClient.cluster.putComponentTemplate.mockClear();
+    mockedAppContextService.getLogger.mockReturnValue({
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    } as any);
 
     esClient.cluster.getComponentTemplate.mockResolvedValueOnce({
       component_templates: [
@@ -583,6 +595,73 @@ describe('experimental_datastream_features', () => {
             _meta: { has_experimental_data_stream_indexing_features: true },
           })
         );
+      });
+
+      it('should not throw when updateCurrentWriteIndices rejects with a total_fields limit error', async () => {
+        const packagePolicy = getExistingTestPackagePolicy({
+          isSyntheticSourceEnabled: false,
+          isTSDBEnabled: true,
+          isDocValueOnlyNumeric: false,
+          isDocValueOnlyOther: false,
+        });
+
+        esClient.indices.getIndexTemplate.mockResolvedValueOnce({
+          index_templates: [
+            {
+              name: 'metrics-test.test',
+              index_template: {
+                template: { settings: {}, mappings: {} },
+                composed_of: [],
+                index_patterns: '',
+              },
+            },
+          ],
+        });
+
+        const totalFieldsError = Object.assign(new Error('ResponseError'), {
+          statusCode: 400,
+          body: {
+            error: {
+              type: 'illegal_argument_exception',
+              reason: 'Limit of total fields [2500] has been exceeded',
+            },
+          },
+        });
+        mockedUpdateCurrentWriteIndices.mockRejectedValueOnce(totalFieldsError);
+
+        // total_fields errors are non-fatal — the rollover wouldn't have helped anyway
+        await expect(
+          handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy })
+        ).resolves.not.toThrow();
+      });
+
+      it('should throw when updateCurrentWriteIndices rejects with an unexpected error', async () => {
+        const packagePolicy = getExistingTestPackagePolicy({
+          isSyntheticSourceEnabled: false,
+          isTSDBEnabled: true,
+          isDocValueOnlyNumeric: false,
+          isDocValueOnlyOther: false,
+        });
+
+        esClient.indices.getIndexTemplate.mockResolvedValueOnce({
+          index_templates: [
+            {
+              name: 'metrics-test.test',
+              index_template: {
+                template: { settings: {}, mappings: {} },
+                composed_of: [],
+                index_patterns: '',
+              },
+            },
+          ],
+        });
+
+        const unexpectedError = new Error('unexpected mapping error');
+        mockedUpdateCurrentWriteIndices.mockRejectedValueOnce(unexpectedError);
+
+        await expect(
+          handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy })
+        ).rejects.toThrow(unexpectedError);
       });
 
       it('should update existing write indices', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.ts
@@ -20,7 +20,10 @@ import type {
 } from '../../types';
 import { appContextService } from '../app_context';
 import { prepareDataStreamTemplates } from '../epm/elasticsearch/template/install';
-import { updateCurrentWriteIndices } from '../epm/elasticsearch/template/template';
+import {
+  isTotalFieldsLimitError,
+  updateCurrentWriteIndices,
+} from '../epm/elasticsearch/template/template';
 import { getInstalledPackageWithAssets } from '../epm/packages/get';
 import { updateDatastreamExperimentalFeatures } from '../epm/packages/update';
 
@@ -239,7 +242,24 @@ export async function handleExperimentalDatastreamFeatureOptIn({
 
   // Trigger rollover for updated datastreams
   if (updatedIndexTemplates.length > 0) {
-    await updateCurrentWriteIndices(esClient, appContextService.getLogger(), updatedIndexTemplates);
+    try {
+      await updateCurrentWriteIndices(
+        esClient,
+        appContextService.getLogger(),
+        updatedIndexTemplates
+      );
+    } catch (err) {
+      if (isTotalFieldsLimitError(err)) {
+        appContextService
+          .getLogger()
+          .warn(
+            `Mappings update for experimental datastream features failed because the index mapping total_fields limit has been exceeded. ` +
+              `The total_fields limit must be raised on the index template to allow this mapping update: ${err}`
+          );
+        return;
+      }
+      throw err;
+    }
   }
 
   // Update the installation object to persist the experimental feature map

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
+
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
 import { LockAcquisitionError } from '@kbn/lock-manager';
@@ -152,6 +154,71 @@ describe('setupFleet', () => {
     await setupFleet(soClient, esClient);
 
     expect(outputService.ensureDefaultOutput).toHaveBeenCalledWith(soClient, esClient);
+  });
+
+  it('should strip heavy ES connection metadata from ResponseError stored in nonFatalErrors', async () => {
+    const soClient = getMockedSoClient();
+
+    const responseError = new errors.ResponseError({
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason: 'Limit of total fields [2500] has been exceeded',
+        },
+      },
+      headers: {},
+      meta: {
+        connection: {
+          id: 'conn-1',
+          url: new URL('http://localhost:9200'),
+          deadCount: 0,
+          resurrectTimeout: 0,
+          roles: { data: true, ingest: true },
+          weight: 0,
+          status: 'alive',
+        },
+      } as any,
+      warnings: null,
+    } as any);
+
+    (ensurePreconfiguredPackagesAndPolicies as jest.Mock).mockResolvedValueOnce({
+      nonFatalErrors: [{ error: responseError, package: { name: 'test', version: '1.0.0' } }],
+    });
+
+    const result = await setupFleet(soClient, esClient);
+
+    expect(result.nonFatalErrors).toHaveLength(1);
+    const stored = result.nonFatalErrors[0] as any;
+    // name and message must be preserved
+    expect(stored.error.name).toBe(responseError.name);
+    expect(stored.error.message).toBe(responseError.message);
+    // heavy connection metadata must be stripped
+    expect(stored.error.meta).toBeUndefined();
+    // structural context (package) must be preserved
+    expect(stored.package).toEqual({ name: 'test', version: '1.0.0' });
+  });
+
+  it('should cap stored nonFatalErrors at 100 and log a warning', async () => {
+    const soClient = getMockedSoClient();
+    const startService = createAppContextStartContractMock();
+    mockedAppContextService.getLogger.mockReturnValue(startService.logger);
+
+    const manyErrors = Array.from({ length: 120 }, (_, i) => ({
+      error: new Error(`error ${i}`),
+      package: { name: 'test', version: '1.0.0' },
+    }));
+
+    (ensurePreconfiguredPackagesAndPolicies as jest.Mock).mockResolvedValueOnce({
+      nonFatalErrors: manyErrors,
+    });
+
+    const result = await setupFleet(soClient, esClient);
+
+    expect(result.nonFatalErrors).toHaveLength(100);
+    expect(startService.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('120 non-fatal errors')
+    );
   });
 
   it('should return non fatal errors when generateKeyPair result has errors', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
@@ -66,6 +66,9 @@ import { ensureCorrectAgentlessSettingsIds } from './agentless_settings_ids';
 import { getSpaceAwareSaveobjectsClients } from './epm/kibana/assets/saved_objects';
 import { ensureFleetGlobalEsAssets } from './setup/ensure_fleet_global_es_assets';
 
+/** Maximum number of non-fatal errors retained in memory after setup. */
+const MAX_NON_FATAL_ERRORS = 100;
+
 export interface SetupStatus {
   isInitialized: boolean;
   nonFatalErrors: Array<
@@ -303,7 +306,7 @@ async function createSetupSideEffects(
   const { savedObjectsImporter } = getSpaceAwareSaveobjectsClients();
   await createCCSIndexPatterns(esClient, soClient, savedObjectsImporter);
 
-  const nonFatalErrors = [
+  const rawNonFatalErrors = [
     ...preconfiguredPackagesNonFatalErrors,
     ...(messageSigningServiceNonFatalError ? [messageSigningServiceNonFatalError] : []),
     ...(backfillPackagePolicySupportsAgentlessError
@@ -315,9 +318,9 @@ async function createSetupSideEffects(
   logger.info('Scheduling async setup tasks');
   await scheduleSetupTask(appContextService.getTaskManagerStart()!);
 
-  if (nonFatalErrors.length > 0) {
+  if (rawNonFatalErrors.length > 0) {
     logger.info('Encountered non fatal errors during Fleet setup');
-    formatNonFatalErrors(nonFatalErrors)
+    formatNonFatalErrors(rawNonFatalErrors)
       .map((e) => JSON.stringify(e))
       .forEach((error) => {
         logger.info(error);
@@ -325,12 +328,46 @@ async function createSetupSideEffects(
       });
   }
 
+  // Strip heavy ES connection metadata and cap stored errors to prevent large ResponseError
+  // objects from being retained in the module-level promise.
+  // See https://github.com/elastic/kibana/issues/273921
+  if (rawNonFatalErrors.length > MAX_NON_FATAL_ERRORS) {
+    logger.warn(
+      `Fleet setup encountered ${rawNonFatalErrors.length} non-fatal errors; storing only the first ${MAX_NON_FATAL_ERRORS}`
+    );
+  }
+  const nonFatalErrors = rawNonFatalErrors
+    .slice(0, MAX_NON_FATAL_ERRORS)
+    .map(sanitizeNonFatalError);
+
   logger.info('Fleet setup completed');
 
   return {
     isInitialized: true,
     nonFatalErrors,
   };
+}
+
+/**
+ * Strips heavy ES client metadata (meta.connection, connection pool, TLS config, etc.)
+ * from any `ResponseError` stored inside a non-fatal error entry.  Each such object can
+ * retain ~10 MB of connection state, causing multi-GB heap growth when hundreds of errors
+ * accumulate in the module-level `awaitIfPending` promise.
+ *
+ * The entry's structural shape (package, agentPolicy, installType, …) is preserved so
+ * callers that inspect those fields continue to work.  Only the inner `.error` / `.errors`
+ * values are replaced with lightweight plain-Error objects carrying just name + message.
+ */
+function sanitizeNonFatalError(
+  e: SetupStatus['nonFatalErrors'][number]
+): SetupStatus['nonFatalErrors'][number] {
+  if ('error' in e) {
+    const slim = new Error(e.error.message);
+    slim.name = e.error.name;
+    return { ...e, error: slim } as typeof e;
+  }
+  // UpgradeManagedPackagePoliciesResult uses `errors: any` — nothing large to strip there.
+  return e;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup_utils.test.ts
@@ -90,6 +90,26 @@ describe('awaitIfPending', () => {
     });
   });
 
+  it('does not retain resolved value in module-level status after batch completes', async () => {
+    // Each new batch should execute the provided function and not reuse the previous result.
+    // This ensures the module-level `status` promise is cleared after resolution so the GC
+    // can reclaim any large objects (e.g. ResponseError with ES connection metadata) that were
+    // part of the resolved value.
+    const firstResult = { large: 'object' };
+    const secondResult = { different: 'object' };
+    const fnFirst = jest.fn().mockResolvedValue(firstResult);
+    const fnSecond = jest.fn().mockResolvedValue(secondResult);
+
+    const result1 = await awaitIfPending(fnFirst);
+    expect(result1).toBe(firstResult);
+    expect(fnFirst).toHaveBeenCalledTimes(1);
+
+    // After the first batch completes, a new call must run the new function — not reuse the old promise.
+    const result2 = await awaitIfPending(fnSecond);
+    expect(result2).toBe(secondResult);
+    expect(fnSecond).toHaveBeenCalledTimes(1);
+  });
+
   it('does not block other calls after batch is fulfilled. can call again for a new result', async () => {
     const fnA = jest
       .fn()

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup_utils.ts
@@ -34,5 +34,11 @@ export async function awaitIfPending<T>(asyncFunction: () => Promise<T>): Promis
     onReject(error);
   }
   isPending = false;
-  return status;
+  // Capture the settled promise to return, then clear the module-level reference so its
+  // resolved value (which may contain large ResponseError objects) can be garbage-collected.
+  // Concurrent callers that entered while isPending=true already hold their own reference
+  // to this same promise, so clearing it here does not affect them.
+  const settled = status;
+  status = undefined;
+  return settled;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Enhancements to avoid Fleet OOMs (#274173)](https://github.com/elastic/kibana/pull/274173)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-19T15:00:16Z","message":"[Fleet] Enhancements to avoid Fleet OOMs (#274173)\n\nFixes https://github.com/elastic/kibana/issues/273921\n\n## Summary\n\nFix Fleet setup memory leak: strip ES connection metadata from non-fatal\nerrors and skip rollover on `total_fields` limit breaches.\n\n- Strip `meta.connection` from `ResponseError` before storing in\n`nonFatalErrors`\n- Clear Setup `status` after resolution when `isPending` is false\n- In `errorNeedRollover`, treat `total_fields` limit errors differently\nthan the other `illegal_argument_exception` and skip rollover\n\n### Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n`total_fields` errors now propagate instead of silently triggering a\nrollover. Two call sites (`experimental_datastream_features.ts` and\n`namespace_datastream_templates.ts`) call `updateCurrentWriteIndices`\nwithout `ignoreMappingUpdateErrors`, so a `total_fields` error there\nwill now throw rather than being silently swallowed. If a cluster is\nalready at the field limit, these paths will start surfacing errors that\nwere previously hidden.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6ef617570f529f74a3b6a22f0e1e539dd72b70c3","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.5.0","v9.4.3"],"title":"[Fleet] Enhancements to avoid Fleet OOMs","number":274173,"url":"https://github.com/elastic/kibana/pull/274173","mergeCommit":{"message":"[Fleet] Enhancements to avoid Fleet OOMs (#274173)\n\nFixes https://github.com/elastic/kibana/issues/273921\n\n## Summary\n\nFix Fleet setup memory leak: strip ES connection metadata from non-fatal\nerrors and skip rollover on `total_fields` limit breaches.\n\n- Strip `meta.connection` from `ResponseError` before storing in\n`nonFatalErrors`\n- Clear Setup `status` after resolution when `isPending` is false\n- In `errorNeedRollover`, treat `total_fields` limit errors differently\nthan the other `illegal_argument_exception` and skip rollover\n\n### Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n`total_fields` errors now propagate instead of silently triggering a\nrollover. Two call sites (`experimental_datastream_features.ts` and\n`namespace_datastream_templates.ts`) call `updateCurrentWriteIndices`\nwithout `ignoreMappingUpdateErrors`, so a `total_fields` error there\nwill now throw rather than being silently swallowed. If a cluster is\nalready at the field limit, these paths will start surfacing errors that\nwere previously hidden.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6ef617570f529f74a3b6a22f0e1e539dd72b70c3"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274173","number":274173,"mergeCommit":{"message":"[Fleet] Enhancements to avoid Fleet OOMs (#274173)\n\nFixes https://github.com/elastic/kibana/issues/273921\n\n## Summary\n\nFix Fleet setup memory leak: strip ES connection metadata from non-fatal\nerrors and skip rollover on `total_fields` limit breaches.\n\n- Strip `meta.connection` from `ResponseError` before storing in\n`nonFatalErrors`\n- Clear Setup `status` after resolution when `isPending` is false\n- In `errorNeedRollover`, treat `total_fields` limit errors differently\nthan the other `illegal_argument_exception` and skip rollover\n\n### Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n`total_fields` errors now propagate instead of silently triggering a\nrollover. Two call sites (`experimental_datastream_features.ts` and\n`namespace_datastream_templates.ts`) call `updateCurrentWriteIndices`\nwithout `ignoreMappingUpdateErrors`, so a `total_fields` error there\nwill now throw rather than being silently swallowed. If a cluster is\nalready at the field limit, these paths will start surfacing errors that\nwere previously hidden.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6ef617570f529f74a3b6a22f0e1e539dd72b70c3"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->