### PR TITLE
[8.19] [Profiling] Stabilize Scout API setup tests (#253221)

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/worker/profiling/profiling_setup_fixture.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/worker/profiling/profiling_setup_fixture.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { BulkOperationType, BulkResponseItem } from '@elastic/elasticsearch/lib/api/types';
 import { test as base } from '@kbn/scout';
 import path from 'path';
 import fs from 'fs';
@@ -37,21 +38,39 @@ export const profilingSetupFixture = base.extend<{}, { profilingSetup: Profiling
       };
 
       const setupResources = async (): Promise<void> => {
-        try {
-          log.info('Setting up profiling resources');
-          await kbnClient.request({
-            description: 'Setup profiling resources',
-            path: '/internal/profiling/setup/es_resources',
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              'kbn-xsrf': 'reporting',
-            },
-          });
-          log.info('Profiling resources set up successfully');
-        } catch (error) {
-          log.error(`Error setting up profiling resources: ${error}`);
-          throw error;
+        const maxAttempts = 3;
+        const delayMs = 5_000;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+          try {
+            log.info(`Setting up profiling resources (attempt ${attempt}/${maxAttempts})`);
+            await kbnClient.request({
+              description: 'Setup profiling resources',
+              path: '/internal/profiling/setup/es_resources',
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                'kbn-xsrf': 'reporting',
+              },
+              retries: 0,
+            });
+            log.info('Profiling resources set up successfully');
+            return;
+          } catch (error: any) {
+            const status = error?.response?.status ?? error?.originalError?.response?.status;
+            const body = error?.response?.data ?? error?.originalError?.response?.data;
+            log.error(
+              `Error setting up profiling resources POST /internal/profiling/setup/es_resources: status=${status} body=${JSON.stringify(
+                body
+              )}`
+            );
+
+            if (attempt >= maxAttempts) {
+              throw error;
+            }
+            log.info(`Retrying setupResources in ${delayMs}ms...`);
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
         }
       };
 
@@ -85,9 +104,20 @@ export const profilingSetupFixture = base.extend<{}, { profilingSetup: Profiling
           });
 
           if (response.errors) {
-            const erroredItems = response.items?.filter((item: any) => item?.index?.error);
+            const erroredItems = response.items?.filter(
+              (item: Partial<Record<BulkOperationType, BulkResponseItem>>) => {
+                const action = item?.index ?? item?.create ?? item?.update ?? item?.delete;
+                return action?.error;
+              }
+            );
             log.error(
               `Some errors occurred during bulk indexing: ${JSON.stringify(erroredItems, null, 2)}`
+            );
+
+            throw new Error(
+              `Bulk indexing had ${
+                erroredItems?.length ?? 0
+              } errors — profiling data may be incomplete`
             );
           } else {
             log.info(`Successfully indexed ${response.items?.length || 0} profiling documents`);
@@ -100,21 +130,42 @@ export const profilingSetupFixture = base.extend<{}, { profilingSetup: Profiling
       const cleanup = async (): Promise<void> => {
         log.info(`Unloading Profiling data`);
 
-        const indices = await esClient.cat.indices({ format: 'json' });
+        const ignoreNotFound = (error: any) => {
+          if (error?.meta?.statusCode === 404) return undefined;
+          throw error;
+        };
 
-        const profilingIndices = indices
-          .filter((index) => index.index !== undefined)
-          .map((index) => index.index)
-          .filter((index) => {
-            return index!.startsWith('profiling') || index!.startsWith('.profiling');
-          }) as string[];
+        // Disable resource management so the ES profiling plugin stops
+        // recreating data streams. This must happen before deleting
+        // indices, otherwise the plugin immediately recreates them.
+        await esClient.cluster.putSettings({
+          persistent: {
+            xpack: { profiling: { templates: { enabled: null } } },
+          },
+        });
 
+        // ES profiling resources are mostly data streams (.profiling-stackframes-*,
+        // .profiling-stacktraces-*, .profiling-executables-*, .profiling-hosts-*,
+        // profiling-events-*). Deleting data streams first avoids the 400
+        // "cannot_delete_data_stream_index" error from trying indices.delete() on
+        // data-stream backing indices.
         await Promise.all([
-          ...profilingIndices.map((index) => esClient.indices.delete({ index })),
-          esClient.indices.deleteDataStream({
-            name: 'profiling-*',
-          }),
+          esClient.indices.deleteDataStream({ name: 'profiling-*' }).catch(ignoreNotFound),
+          esClient.indices.deleteDataStream({ name: '.profiling-*' }).catch(ignoreNotFound),
         ]);
+
+        // Delete any remaining plain indices (e.g. created by bulk create ops
+        // against non-existent aliases).
+        const remaining = (await esClient.cat.indices({ format: 'json' }))
+          .map((index) => index.index)
+          .filter(
+            (name): name is string =>
+              !!name && (name.startsWith('profiling') || name.startsWith('.profiling'))
+          );
+
+        for (const index of remaining) {
+          await esClient.indices.delete({ index, ignore_unavailable: true }).catch(ignoreNotFound);
+        }
 
         log.info('Unloaded Profiling data');
       };

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/.meta/api/standard.json
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/.meta/api/standard.json
@@ -1,8 +1,36 @@
 {
-  "sha1": "90bd13f6210737e4784c51c7176f13a07fcd1b80",
+  "sha1": "b205018d699fea94e932b74aabc2eba708523365",
   "tests": [
     {
-      "id": "405beff6794306f-a54347ac1e57e7e",
+      "id": "bd41f0240dfdfcb-9b0e8252d0034ea",
+      "title": "Reset profiling state after API tests",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts",
+        "line": 13,
+        "column": 1
+      }
+    },
+    {
+      "id": "1219f91050e9ce3-f2cd2d3cdc77643",
+      "title": "Ingest data to Elasticsearch",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts",
+        "line": 13,
+        "column": 1
+      }
+    },
+    {
+      "id": "95bab923ba9cb11-a54347ac1e57e7e",
       "title": "Profiling is not setup and no data is loaded Admin users",
       "expectedStatus": "passed",
       "tags": [
@@ -10,13 +38,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_no_setup.spec.ts",
-        "line": 28,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts",
+        "line": 29,
         "column": 12
       }
     },
     {
-      "id": "405beff6794306f-429a339166c2e77",
+      "id": "95bab923ba9cb11-429a339166c2e77",
       "title": "Profiling is not setup and no data is loaded Viewer users",
       "expectedStatus": "passed",
       "tags": [
@@ -24,13 +52,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_no_setup.spec.ts",
-        "line": 42,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts",
+        "line": 43,
         "column": 12
       }
     },
     {
-      "id": "f24ba03baeb5e26-0723e6c11fe5d87",
+      "id": "44934ca34264be6-0723e6c11fe5d87",
       "title": "APM integration not installed but setup completed Admin user",
       "expectedStatus": "passed",
       "tags": [
@@ -38,13 +66,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts",
-        "line": 28,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts",
+        "line": 33,
         "column": 12
       }
     },
     {
-      "id": "f24ba03baeb5e26-76b2ff68d4e7a1b",
+      "id": "44934ca34264be6-76b2ff68d4e7a1b",
       "title": "APM integration not installed but setup completed Viewer user",
       "expectedStatus": "passed",
       "tags": [
@@ -52,13 +80,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts",
-        "line": 43,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts",
+        "line": 48,
         "column": 12
       }
     },
     {
-      "id": "da6d82a4243ce6c-271837831195e95",
+      "id": "5102c2676cabaad-271837831195e95",
       "title": "Profiling is setup and data is loaded Admin user",
       "expectedStatus": "passed",
       "tags": [
@@ -66,13 +94,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts",
-        "line": 23,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts",
+        "line": 38,
         "column": 10
       }
     },
     {
-      "id": "da6d82a4243ce6c-7018203930dfa66",
+      "id": "5102c2676cabaad-7018203930dfa66",
       "title": "Profiling is setup and data is loaded Viewer user",
       "expectedStatus": "passed",
       "tags": [
@@ -80,13 +108,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts",
-        "line": 37,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts",
+        "line": 52,
         "column": 10
       }
     },
     {
-      "id": "8b3eca81b16d245-3ee5b04db1c974d",
+      "id": "76ee1162fe3336b-3ee5b04db1c974d",
       "title": "Collector integration is not installed collector integration missing",
       "expectedStatus": "passed",
       "tags": [
@@ -94,13 +122,13 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts",
-        "line": 24,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts",
+        "line": 32,
         "column": 10
       }
     },
     {
-      "id": "8b3eca81b16d245-7029a2aca281cbb",
+      "id": "76ee1162fe3336b-7029a2aca281cbb",
       "title": "Collector integration is not installed Symbolizer integration is not installed",
       "expectedStatus": "passed",
       "tags": [
@@ -108,8 +136,8 @@
         "@cloud-stateful-classic"
       ],
       "location": {
-        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts",
-        "line": 52,
+        "file": "x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts",
+        "line": 60,
         "column": 10
       }
     }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/playwright.config.ts
@@ -9,4 +9,5 @@ import { createPlaywrightConfig } from '@kbn/scout-oblt';
 
 export default createPlaywrightConfig({
   testDir: './tests',
+  runGlobalSetup: true,
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/00_has_no_setup.spec.ts
@@ -12,20 +12,21 @@ import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
 apiTest.describe(
-  'APM integration not installed but setup completed',
+  'Profiling is not setup and no data is loaded',
   { tag: tags.stateful.classic },
   () => {
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
-    apiTest.beforeAll(async ({ profilingSetup, requestAuth }) => {
-      if (!(await profilingSetup.checkStatus()).has_setup) {
-        await profilingSetup.setupResources();
-      }
+
+    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
+      await profilingSetup.cleanup();
+      await profilingHelper.cleanupPolicies();
+
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
     });
 
-    apiTest('Admin user', async ({ apiClient }) => {
+    apiTest('Admin users', async ({ apiClient }) => {
       const adminRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...adminApiCreditials.apiKeyHeader,
@@ -33,14 +34,13 @@ apiTest.describe(
           'kbn-xsrf': 'reporting',
         },
       });
-
       const adminStatus = adminRes.body;
-      expect(adminStatus.has_setup).toBe(true);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_setup).toBe(false);
+      expect(adminStatus.has_data).toBeDefined();
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
     });
 
-    apiTest('Viewer user', async ({ apiClient }) => {
+    apiTest('Viewer users', async ({ apiClient }) => {
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...viewerApiCreditials.apiKeyHeader,
@@ -48,11 +48,10 @@ apiTest.describe(
           'kbn-xsrf': 'reporting',
         },
       });
-
       const readStatus = readRes.body;
-      expect(readStatus.has_setup).toBe(true);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_setup).toBe(false);
+      expect(readStatus.has_data).toBeDefined();
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/01_has_setup_apm_not_installed.spec.ts
@@ -12,20 +12,25 @@ import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
 apiTest.describe(
-  'Profiling is not setup and no data is loaded',
+  'APM integration not installed but setup completed',
   { tag: tags.stateful.classic },
   () => {
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
+
     apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
-      await profilingHelper.cleanupPolicies();
-      await profilingHelper.installPolicies();
-      await profilingSetup.cleanup();
+      const status = await profilingSetup.checkStatus();
+
+      if (!status.has_setup) {
+        await profilingHelper.installPolicies();
+        await profilingSetup.setupResources();
+      }
+
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
     });
 
-    apiTest('Admin users', async ({ apiClient }) => {
+    apiTest('Admin user', async ({ apiClient }) => {
       const adminRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...adminApiCreditials.apiKeyHeader,
@@ -33,13 +38,14 @@ apiTest.describe(
           'kbn-xsrf': 'reporting',
         },
       });
+
       const adminStatus = adminRes.body;
-      expect(adminStatus.has_setup).toBe(false);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      expect(adminStatus.has_setup).toBe(true);
+      expect(adminStatus.has_data).toBeDefined();
+      expect(adminStatus.pre_8_9_1_data).toBeDefined();
     });
 
-    apiTest('Viewer users', async ({ apiClient }) => {
+    apiTest('Viewer user', async ({ apiClient }) => {
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...viewerApiCreditials.apiKeyHeader,
@@ -47,10 +53,11 @@ apiTest.describe(
           'kbn-xsrf': 'reporting',
         },
       });
+
       const readStatus = readRes.body;
-      expect(readStatus.has_setup).toBe(false);
-      expect(readStatus.has_data).toBe(false);
-      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_setup).toBe(true);
+      expect(readStatus.has_data).toBeDefined();
+      expect(readStatus.pre_8_9_1_data).toBeDefined();
       expect(readStatus.has_required_role).toBe(false);
     });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/02_has_setup_with_data.spec.ts
@@ -14,8 +14,23 @@ import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/cons
 apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.classic }, () => {
   let viewerApiCreditials: RoleApiCredentials;
   let adminApiCreditials: RoleApiCredentials;
-  apiTest.beforeAll(async ({ requestAuth, profilingSetup }) => {
-    await profilingSetup.loadData(esArchiversPath);
+
+  apiTest.beforeAll(async ({ requestAuth, profilingHelper, profilingSetup }) => {
+    let status = await profilingSetup.checkStatus();
+
+    if (!status.has_setup) {
+      await profilingHelper.installPolicies();
+      await profilingSetup.setupResources();
+    }
+
+    if (!status.has_data) {
+      await profilingSetup.loadData(esArchiversPath);
+    }
+
+    status = await profilingSetup.checkStatus();
+    expect(status.has_setup).toBe(true);
+    expect(status.has_data).toBe(true);
+
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
     adminApiCreditials = await requestAuth.getApiKey('admin');
   });
@@ -31,7 +46,7 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
     const adminStatus = adminRes.body;
     expect(adminStatus.has_setup).toBe(true);
     expect(adminStatus.has_data).toBe(true);
-    expect(adminStatus.pre_8_9_1_data).toBe(false);
+    expect(adminStatus.pre_8_9_1_data).toBeDefined();
   });
 
   apiTest('Viewer user', async ({ apiClient }) => {
@@ -46,7 +61,7 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.c
     const readStatus = readRes.body;
     expect(readStatus.has_setup).toBe(true);
     expect(readStatus.has_data).toBe(true);
-    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBeDefined();
     expect(readStatus.has_required_role).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/03_has_setup_with_integrations.spec.ts
@@ -13,21 +13,29 @@ import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
 apiTest.describe('Collector integration is not installed', { tag: tags.stateful.classic }, () => {
   let viewerApiCreditials: RoleApiCredentials;
-  apiTest.beforeAll(async ({ requestAuth, profilingSetup }) => {
+
+  apiTest.beforeAll(async ({ requestAuth, profilingSetup, profilingHelper }) => {
+    // Start from a clean data state so `has_data` is false for these assertions.
     await profilingSetup.cleanup();
+    // Ensure the collector + symbolizer policies exist so the tests below can delete them.
+    // setupResources is fast here because the bundled packages were already installed in global setup.
+    await profilingHelper.installPolicies();
+    await profilingSetup.setupResources();
+
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
   });
+
   apiTest.afterAll(async ({ profilingHelper }) => {
-    profilingHelper.cleanupPolicies();
+    await profilingHelper.cleanupPolicies();
   });
 
   apiTest('collector integration missing', async ({ profilingHelper, apiServices, apiClient }) => {
-    const ids = await profilingHelper.getPoliciyIds();
+    const ids = await profilingHelper.getPolicyIds();
     const collectorId = ids.collectorId;
 
-    await apiServices.fleet.package_policies.delete(collectorId!);
-
     expect(collectorId).toBeDefined();
+
+    await apiServices.fleet.package_policies.delete(collectorId!);
 
     const adminRes = await apiClient.get(esResourcesEndpoint);
     const adminStatus = adminRes.body;
@@ -52,29 +60,18 @@ apiTest.describe('Collector integration is not installed', { tag: tags.stateful.
   apiTest(
     'Symbolizer integration is not installed',
     async ({ profilingHelper, apiClient, apiServices }) => {
-      const ids = await profilingHelper.getPoliciyIds();
-
+      const ids = await profilingHelper.getPolicyIds();
       const symbolizerId = ids.symbolizerId;
-
-      await apiServices.fleet.package_policies.delete(symbolizerId!);
 
       expect(symbolizerId).toBeDefined();
 
-      const adminRes = await apiClient.get(esResourcesEndpoint, {
-        headers: {
-          ...viewerApiCreditials.apiKeyHeader,
-          'content-type': 'application/json',
-          'kbn-xsrf': 'reporting',
-        },
-      });
-      const adminStatus = adminRes.body;
-      expect(adminStatus.has_setup).toBe(false);
-      expect(adminStatus.has_data).toBe(false);
-      expect(adminStatus.pre_8_9_1_data).toBe(false);
+      await apiServices.fleet.package_policies.delete(symbolizerId!);
 
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
           ...viewerApiCreditials.apiKeyHeader,
+          'content-type': 'application/json',
+          'kbn-xsrf': 'reporting',
         },
       });
       const readStatus = readRes.body;

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeTests, globalSetupHook as obltGlobalSetupHook, tags } from '@kbn/scout-oblt';
+import { apiTest as profilingFixtures } from '../../common/fixtures';
+
+const globalSetupHook = mergeTests(obltGlobalSetupHook, profilingFixtures);
+
+globalSetupHook(
+  'Ingest data to Elasticsearch',
+  { tag: tags.stateful.classic },
+  async ({ log, apiServices, profilingSetup, profilingHelper }) => {
+    log.info('Running profiling API global setup...');
+    await apiServices.fleet.internal.setup();
+    log.info('Fleet infrastructure setup completed');
+
+    // Pre-install the profiler Fleet packages once here, under the larger global-hook
+    // timeout budget. The first install of the bundled profiler_collector / profiler_symbolizer
+    // packages can take ~1 minute, which previously exceeded the 60s per-spec `beforeAll`
+    // budget and made `01_has_setup_apm_not_installed` flaky (see issue #253221).
+    // Per-spec teardown only removes the package policies and ES data streams, not the
+    // installed Fleet packages, so later `setupResources()` calls stay fast.
+    const status = await profilingSetup.checkStatus();
+    if (!status.has_setup) {
+      await profilingHelper.installPolicies();
+      await profilingSetup.setupResources();
+    }
+    log.info('Profiling resources pre-installed');
+  }
+);

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeTests, globalTeardownHook as obltGlobalTeardownHook, tags } from '@kbn/scout-oblt';
+import { apiTest as profilingFixtures } from '../../common/fixtures';
+
+const globalTeardownHook = mergeTests(obltGlobalTeardownHook, profilingFixtures);
+
+globalTeardownHook(
+  'Reset profiling state after API tests',
+  { tag: tags.stateful.classic },
+  async ({ profilingSetup, log, profilingHelper }) => {
+    log.info('Running profiling API global teardown...');
+
+    // Cleanup policies
+    await profilingHelper.cleanupPolicies({ includeAgentPolicy: true });
+
+    // Reset profiling ES resources (data streams + indices)
+    await profilingSetup.cleanup();
+
+    log.info('Profiling API global teardown complete');
+  }
+);

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { AgentPolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { apiTest as base } from '@kbn/scout-oblt';
 import { COLLECTOR_PACKAGE_POLICY_NAME, SYMBOLIZER_PACKAGE_POLICY_NAME } from './constants';
 
 export interface ProfilingHelper {
   installPolicies: () => Promise<void>;
-  cleanupPolicies: () => Promise<void>;
-  getPoliciyIds: () => Promise<{ collectorId?: string; symbolizerId?: string }>;
+  cleanupPolicies: (opts?: { includeAgentPolicy?: boolean }) => Promise<void>;
+  getPolicyIds: () => Promise<{ collectorId?: string; symbolizerId?: string }>;
 }
 
 const APM_AGENT_POLICY_ID = 'policy-elastic-agent-on-cloud';
@@ -24,49 +24,67 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
         log.info('Checking if APM agent policy exists, creating if needed...');
         const getPolicyResponse = await apiServices.fleet.agent_policies.get({
           page: 1,
-          perPage: 10,
+          perPage: 1000,
         });
         const apmPolicyData = getPolicyResponse.data.items.find(
-          (policy: { id: string }) => policy.id === 'policy-elastic-agent-on-cloud'
+          (policy: { id: string }) => policy.id === APM_AGENT_POLICY_ID
         );
 
         if (!apmPolicyData) {
-          await apiServices.fleet.agent_policies.create(
-            'Elastic APM',
-            'default',
-            false, // sysMonitoring
-            {
-              id: APM_AGENT_POLICY_ID,
-              description: 'Elastic APM agent policy created via Fleet API',
-            }
-          );
+          await apiServices.fleet.agent_policies.create('Elastic APM', 'default', false, {
+            id: APM_AGENT_POLICY_ID,
+            description: 'Elastic APM agent policy created via Fleet API',
+          });
           log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' is created`);
         } else {
           log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' already exists`);
         }
       };
-      const cleanupPolicies = async (): Promise<void> => {
+
+      const cleanupPolicies = async (
+        opts: { includeAgentPolicy?: boolean } = {}
+      ): Promise<void> => {
+        const { includeAgentPolicy = false } = opts;
         log.info('Cleaning up profiling resources...');
 
         const res = await apiServices.fleet.package_policies.get();
-        const policies: PackagePolicy[] = res.data.items;
+        const packagePolicies: PackagePolicy[] = res.data.items;
 
-        const collectorId = policies.find(
-          (item) => item.name === 'elastic-universal-profiling-collector'
+        const collectorId = packagePolicies.find(
+          (item) => item.name === COLLECTOR_PACKAGE_POLICY_NAME
         )?.id;
-        const symbolizerId = policies.find(
-          (item) => item.name === 'elastic-universal-profiling-symbolizer'
+        const symbolizerId = packagePolicies.find(
+          (item) => item.name === SYMBOLIZER_PACKAGE_POLICY_NAME
         )?.id;
+
+        let apmPolicyPromise = Promise.resolve();
+        if (includeAgentPolicy) {
+          const getPolicyResponse = await apiServices.fleet.agent_policies.get({
+            page: 1,
+            perPage: 1000,
+          });
+          const agentPolicies: AgentPolicy[] = getPolicyResponse.data.items;
+          const apmId = agentPolicies.find(
+            (policy: { id: string }) => policy.id === APM_AGENT_POLICY_ID
+          )?.id;
+
+          if (apmId) {
+            apmPolicyPromise = apiServices.fleet.agent_policies.delete(apmId);
+          }
+        }
 
         await Promise.all([
           collectorId ? apiServices.fleet.package_policies.delete(collectorId) : Promise.resolve(),
           symbolizerId
             ? apiServices.fleet.package_policies.delete(symbolizerId)
             : Promise.resolve(),
+          apmPolicyPromise,
         ]);
+
+        log.info('Profiling resources cleaned up');
       };
 
-      const getPoliciyIds = async (): Promise<{ collectorId?: string; symbolizerId?: string }> => {
+      const getPolicyIds = async (): Promise<{ collectorId?: string; symbolizerId?: string }> => {
         const res = await apiServices.fleet.package_policies.get();
         const policies: PackagePolicy[] = res.data.items;
 
@@ -81,7 +99,7 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
       await use({
         installPolicies,
         cleanupPolicies,
-        getPoliciyIds,
+        getPolicyIds,
       });
     },
     { scope: 'worker' },


### PR DESCRIPTION
## Summary

Fixes the 8.19 flake of the profiling Scout API test **`APM integration not installed but setup completed - Admin user`** (https://github.com/elastic/kibana/issues/253221).

The stabilization work that landed on `main` was never backported to `8.19`, so the test kept failing there. This PR brings the profiling Scout API test suite to **functional parity** with `main`, adapted to 8.19's existing APIs. **It is test-only — no product/server code is changed.**

### Root cause
The flake is a `beforeAll` timeout. The first install of the bundled `profiler_collector` / `profiler_symbolizer` Fleet packages takes ~1 minute, which exceeds the 60s per-spec `beforeAll` budget. On 8.19 nothing moved that cold install out of the per-spec hook.

### What changed
- **Ordered specs** (`00_`/`01_`/`02_`/`03_`) so setup state flows deterministically between files.
- **Added `global.setup.ts` / `global.teardown.ts`** and **hoisted the expensive Fleet package install + `setupResources()` into global setup** (which runs under the larger global-hook timeout budget). Per-spec teardown only removes package policies and ES data — not the installed packages — so subsequent `setupResources()` calls are fast. This is the durable de-flake.
- **Ported `profiling_setup_fixture`** with setup retry/backoff and a more thorough ES cleanup. Kept on 8.19's existing `/internal/profiling/setup/es_resources` route.
- **Adapted `common/fixtures`** to 8.19's positional Fleet API (`agent_policies.create(name, namespace, sysMonitoring, params)`), and renamed `getPoliciyIds` → `getPolicyIds`.
- **`03_has_setup_with_integrations`** keeps 8.19's existing assertions (it does **not** rely on the `type` field that `main`'s server response added), so no server changes are required.

### Scope note
Full byte-for-byte parity with `main`'s `03` spec would require backporting a server-side change to the profiling status response (`type` / serverless support). That is intentionally **out of scope** here to keep this PR test-only.

## Test plan
- [ ] CI: profiling Scout API tests green on `8.19` (stateful classic, cloud + local)
- [x] `node scripts/type_check` for `profiling/test/scout` and `kbn-scout-oblt` projects pass
- [x] `node scripts/eslint` on changed files passes
- [x] Scout test config manifest regenerated (`update-test-config-manifests`)