### PR TITLE
[Profiling] Bound Profiling indicesSchema and Name string values with maxLength (code scanning alert)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/common/index.ts
+++ b/x-pack/solutions/observability/plugins/profiling/common/index.ts
@@ -18,6 +18,11 @@ export const INDEX_EXECUTABLES = 'profiling-executables';
 const BASE_ROUTE_PATH = '/internal/profiling';
 const PUBLIC_BASE_ROUTE_PATH = '/api/profiling';
 
+// Upper bounds for unbounded query-string inputs, used to prevent
+// resource-exhaustion via oversized values forwarded to Elasticsearch.
+export const MAX_KUERY_LENGTH = 2048;
+export const MAX_NAME_LENGTH = 1024;
+
 export function getRoutePaths() {
   return {
     TopN: `${BASE_ROUTE_PATH}/topn`,

--- a/x-pack/solutions/observability/plugins/profiling/server/routes/apm.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/apm.ts
@@ -11,15 +11,15 @@ import { termQuery } from '@kbn/observability-plugin/server';
 import { keyBy } from 'lodash';
 import type { RouteRegisterParameters } from '.';
 import { IDLE_SOCKET_TIMEOUT } from '.';
-import { getRoutePaths } from '../../common';
+import { getRoutePaths, MAX_NAME_LENGTH } from '../../common';
 import { handleRouteHandlerError } from '../utils/handle_route_error_handler';
 import { getClient } from './compat';
 
 const querySchema = schema.object({
   timeFrom: schema.number(),
   timeTo: schema.number(),
-  functionName: schema.string(),
-  serviceNames: schema.arrayOf(schema.string(), { maxSize: 10 }),
+  functionName: schema.string({ maxLength: MAX_NAME_LENGTH }),
+  serviceNames: schema.arrayOf(schema.string({ maxLength: MAX_NAME_LENGTH }), { maxSize: 10 }),
 });
 
 type QuerySchemaType = TypeOf<typeof querySchema>;

--- a/x-pack/solutions/observability/plugins/profiling/server/routes/flamechart.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/flamechart.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 import { kqlQuery } from '@kbn/observability-plugin/server';
 import type { RouteRegisterParameters } from '.';
 import { IDLE_SOCKET_TIMEOUT } from '.';
-import { getRoutePaths } from '../../common';
+import { getRoutePaths, MAX_KUERY_LENGTH } from '../../common';
 import { handleRouteHandlerError } from '../utils/handle_route_error_handler';
 import { getClient } from './compat';
 
@@ -34,7 +34,7 @@ export function registerFlameChartSearchRoute({
         query: schema.object({
           timeFrom: schema.number(),
           timeTo: schema.number(),
-          kuery: schema.string(),
+          kuery: schema.string({ maxLength: MAX_KUERY_LENGTH }),
         }),
       },
     },

--- a/x-pack/solutions/observability/plugins/profiling/server/routes/functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/functions.ts
@@ -11,7 +11,7 @@ import { kqlQuery } from '@kbn/observability-plugin/server';
 import { SERVICE_NAME } from '@kbn/observability-shared-plugin/common';
 import type { RouteRegisterParameters } from '.';
 import { IDLE_SOCKET_TIMEOUT } from '.';
-import { getRoutePaths } from '../../common';
+import { getRoutePaths, MAX_KUERY_LENGTH } from '../../common';
 import { handleRouteHandlerError } from '../utils/handle_route_error_handler';
 import { getClient } from './compat';
 
@@ -20,7 +20,7 @@ const querySchema = schema.object({
   timeTo: schema.number(),
   startIndex: schema.number(),
   endIndex: schema.number(),
-  kuery: schema.string(),
+  kuery: schema.string({ maxLength: MAX_KUERY_LENGTH }),
 });
 
 type QuerySchemaType = TypeOf<typeof querySchema>;

--- a/x-pack/solutions/observability/plugins/profiling/server/routes/storage_explorer/route.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/storage_explorer/route.ts
@@ -7,7 +7,7 @@
 import { schema } from '@kbn/config-schema';
 import { sumBy, values } from 'lodash';
 import type { RouteRegisterParameters } from '..';
-import { getRoutePaths } from '../../../common';
+import { getRoutePaths, MAX_KUERY_LENGTH } from '../../../common';
 import type { StorageExplorerSummaryAPIResponse } from '../../../common/storage_explorer';
 import { IndexLifecyclePhaseSelectOption } from '../../../common/storage_explorer';
 import { getClient } from '../compat';
@@ -43,7 +43,7 @@ export function registerStorageExplorerRoute({
           ]),
           timeFrom: schema.number(),
           timeTo: schema.number(),
-          kuery: schema.string(),
+          kuery: schema.string({ maxLength: MAX_KUERY_LENGTH }),
         }),
       },
     },
@@ -130,7 +130,7 @@ export function registerStorageExplorerRoute({
           ]),
           timeFrom: schema.number(),
           timeTo: schema.number(),
-          kuery: schema.string(),
+          kuery: schema.string({ maxLength: MAX_KUERY_LENGTH }),
         }),
       },
     },

--- a/x-pack/solutions/observability/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/topn.ts
@@ -16,7 +16,7 @@ import {
 import { profilingShowErrorFrames } from '@kbn/observability-plugin/common';
 import type { RouteRegisterParameters } from '.';
 import { IDLE_SOCKET_TIMEOUT } from '.';
-import { getRoutePaths, INDEX_EVENTS } from '../../common';
+import { getRoutePaths, INDEX_EVENTS, MAX_KUERY_LENGTH } from '../../common';
 import { computeBucketWidthFromTimeRangeAndBucketCount } from '../../common/histogram';
 import type { TopNResponse } from '../../common/topn';
 import { createTopNSamples, getTopNAggregationRequest } from '../../common/topn';
@@ -188,7 +188,7 @@ export function queryTopNCommon({
         query: schema.object({
           timeFrom: schema.number(),
           timeTo: schema.number(),
-          kuery: schema.string(),
+          kuery: schema.string({ maxLength: MAX_KUERY_LENGTH }),
         }),
       },
     },


### PR DESCRIPTION
## Summary

Similar to the PR https://github.com/elastic/kibana/pull/273732 that fixed these issues for APM, this PR aims to do the same for Profiling. 

These changes will prevent the `Unbounded string in schema validation` warnings in the profiling pages 


### Why these sizes:

These values are already being used in APM, specifically in:

https://github.com/elastic/kibana/blob/5aa60dbaf081f106dad98d3ae3ab63fa8e8b2e90/x-pack/solutions/observability/plugins/apm/common/embeddable/service_map_embeddable_schema.ts#L42-L43
