### PR TITLE
[Scout] Extend official reviewer with Security Solution additive checklist

### DIFF
--- a/.github/agents/scout-reviewer.md
+++ b/.github/agents/scout-reviewer.md
@@ -27,7 +27,7 @@ The general skill instructs you to check for and apply a solution-specific exten
 
 `x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md`
 
-Skill invocation is disabled in this environment — read the file directly with the file tool. Apply its Security-specific checks once, only to files under those paths. Ignore any output format instructions and the `## Skill improvement` section — use the workflow's collapsible inline-comment format defined in this file.
+Skill invocation is disabled in this environment — read the file directly with the file tool. Apply its Security-specific checks **after completing the general skill's full checklist**, once, and only to files under those paths. Ignore any output format instructions and the `## Skill improvement` section — use the workflow's collapsible inline-comment format defined in this file.
 
 On PR updates, review only the new changes and stay high-signal — not nitpicky.
 

--- a/.github/agents/scout-reviewer.md
+++ b/.github/agents/scout-reviewer.md
@@ -21,6 +21,16 @@ Do not run this check on backport PRs (they usually have `backport` label and/or
 
 Follow `.claude/skills/scout-best-practices-reviewer/SKILL.md` for the checklist, reuse rules, and migration parity. Ignore any output formatting in that file — use the format below. Use the GitHub tools and local file inspection to explore as needed.
 
+### Solution-specific checklists
+
+After applying the general checklist, check whether any changed in-scope file is under a **Security Solution Scout path**:
+- `x-pack/solutions/security/plugins/security_solution/test/scout/`
+- `x-pack/solutions/security/packages/kbn-scout-security/`
+
+If so, **additionally read and apply** `x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md` for those files. This is an **additive** checklist — the general skill runs first for all in-scope Scout files; the Security-specific checks are layered on top and applied **only to files under the Security Solution Scout paths above**. Skill invocation is disabled in this environment — read the file directly with the file tool.
+
+Ignore any output format instructions and the `## Skill improvement` section in the Security skill file — use the workflow's collapsible inline-comment format defined in this file.
+
 On PR updates, review only the new changes and stay high-signal — not nitpicky.
 
 ## Non-negotiable checks

--- a/.github/agents/scout-reviewer.md
+++ b/.github/agents/scout-reviewer.md
@@ -23,13 +23,11 @@ Follow `.claude/skills/scout-best-practices-reviewer/SKILL.md` for the checklist
 
 ### Solution-specific checklists
 
-After applying the general checklist, check whether any changed in-scope file is under a **Security Solution Scout path**:
-- `x-pack/solutions/security/plugins/security_solution/test/scout/`
-- `x-pack/solutions/security/packages/kbn-scout-security/`
+The general skill instructs you to check for and apply a solution-specific extension when one exists. For Security Solution Scout files (`x-pack/solutions/security/plugins/security_solution/test/scout/` or `x-pack/solutions/security/packages/kbn-scout-security/`), that extension is at:
 
-If so, **additionally read and apply** `x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md` for those files. This is an **additive** checklist — the general skill runs first for all in-scope Scout files; the Security-specific checks are layered on top and applied **only to files under the Security Solution Scout paths above**. Skill invocation is disabled in this environment — read the file directly with the file tool.
+`x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md`
 
-Ignore any output format instructions and the `## Skill improvement` section in the Security skill file — use the workflow's collapsible inline-comment format defined in this file.
+Skill invocation is disabled in this environment — read the file directly with the file tool. Apply its Security-specific checks once, only to files under those paths. Ignore any output format instructions and the `## Skill improvement` section — use the workflow's collapsible inline-comment format defined in this file.
 
 On PR updates, review only the new changes and stay high-signal — not nitpicky.
 


### PR DESCRIPTION
## Summary

The official `reviewer-scout` workflow (merged in #268871) currently applies only the general Scout best practices checklist. This PR extends its agent instructions to also apply the Security Solution–specific additive checklist when a PR touches Security Scout code.

**What changes:**
- Adds a `### Solution-specific checklists` subsection to `.github/agents/scout-reviewer.md`
- When any changed in-scope file is under `x-pack/solutions/security/plugins/security_solution/test/scout/` or `x-pack/solutions/security/packages/kbn-scout-security/`, the agent additionally reads and applies `x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer/SKILL.md`
- The Security checklist is **additive** — the general checklist still runs for all Scout files; Security-specific checks are layered on top and scoped to Security files only
- No workflow trigger changes needed — the auto-labeler from #274285 already labels Security Scout PRs with `reviewer:scout`
- No lock file change — `scout-reviewer.md` is runtime-imported (not compiled in)

## Test plan

- [ ] Merge and open a non-draft PR touching a file under `x-pack/solutions/security/plugins/security_solution/test/scout/` — confirm `reviewer:scout` label is applied automatically, the `reviewer-scout` run fires, and its inline comments cite Security-specific check items from the Security skill
- [ ] Open a PR touching only a non-Security Scout file (e.g. `src/platform/packages/shared/kbn-scout/**`) — confirm the reviewer applies only the general checklist (no Security-specific findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)