### PR TITLE
[Cases] Migrate cases list header to AppHeader (redesign)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { buildCasesPermissions, renderWithTestingProviders } from '../../../../common/mock';
+import { CasesListAppHeader } from './cases_list_app_header';
+
+jest.mock('../../../../common/navigation/hooks');
+
+jest.mock('@kbn/app-header', () => ({
+  AppHeader: ({
+    title,
+    menu,
+  }: {
+    title: string;
+    menu: {
+      items: Array<{ testId: string }>;
+      primaryActionItem?: { testId: string };
+    };
+  }) => (
+    <div data-test-subj="app-header">
+      <span data-test-subj="app-header-title">{title}</span>
+      <div data-test-subj="app-header-menu">
+        {menu?.items?.map((item) => (
+          <span key={item.testId} data-test-subj={item.testId} />
+        ))}
+        {menu?.primaryActionItem && <span data-test-subj={menu.primaryActionItem.testId} />}
+      </div>
+    </div>
+  ),
+}));
+
+describe('CasesListAppHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the app header with the Cases title and analytics test IDs', () => {
+    renderWithTestingProviders(<CasesListAppHeader />);
+
+    expect(screen.getByTestId('app-header')).toBeInTheDocument();
+    expect(screen.getByTestId('app-header-title')).toHaveTextContent('Cases');
+  });
+
+  it('displays the create new case menu item when the user has create privileges', () => {
+    renderWithTestingProviders(<CasesListAppHeader />, {
+      wrapperProps: { permissions: buildCasesPermissions({ create: true }) },
+    });
+
+    expect(screen.getByTestId('createNewCaseBtn')).toBeInTheDocument();
+  });
+
+  it('does not display the create new case menu item when the user does not have create privileges', () => {
+    renderWithTestingProviders(<CasesListAppHeader />, {
+      wrapperProps: { permissions: buildCasesPermissions({ create: false }) },
+    });
+
+    expect(screen.queryByTestId('createNewCaseBtn')).not.toBeInTheDocument();
+  });
+
+  it('displays the configure button when the user has settings privileges', () => {
+    renderWithTestingProviders(<CasesListAppHeader />, {
+      wrapperProps: { permissions: buildCasesPermissions({ settings: true }) },
+    });
+
+    expect(screen.getByTestId('configure-case-button')).toBeInTheDocument();
+  });
+
+  it('does not display the configure button when the user does not have settings privileges', () => {
+    renderWithTestingProviders(<CasesListAppHeader />, {
+      wrapperProps: { permissions: buildCasesPermissions({ settings: false }) },
+    });
+
+    expect(screen.queryByTestId('configure-case-button')).not.toBeInTheDocument();
+  });
+
+  it('displays both menu items when the user has create and settings privileges', () => {
+    renderWithTestingProviders(<CasesListAppHeader />, {
+      wrapperProps: { permissions: buildCasesPermissions({ create: true, settings: true }) },
+    });
+
+    expect(screen.getByTestId('createNewCaseBtn')).toBeInTheDocument();
+    expect(screen.getByTestId('configure-case-button')).toBeInTheDocument();
+  });
+
+  it('does not display any menu items when the user has no create or settings privileges', () => {
+    renderWithTestingProviders(<CasesListAppHeader />, {
+      wrapperProps: { permissions: buildCasesPermissions({ create: false, settings: false }) },
+    });
+
+    expect(screen.queryByTestId('createNewCaseBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('configure-case-button')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { AppHeader } from '@kbn/app-header';
 import { PAGE_TITLE } from '../../../../common/translations';
 import { useCreateCaseNavigation } from '../../../../common/navigation';
@@ -19,22 +19,14 @@ export const CasesListAppHeader: FC = () => {
   const { navigateToCreateCase } = useCreateCaseNavigation();
   const { navigateToConfigureCases } = useConfigureCasesNavigation();
 
-  const onNavigateToCreateCase = useCallback(() => {
-    navigateToCreateCase();
-  }, [navigateToCreateCase]);
-
-  const onNavigateToConfigureCases = useCallback(() => {
-    navigateToConfigureCases();
-  }, [navigateToConfigureCases]);
-
   const menu = useMemo(
     () =>
       getListMenu({
         permissions,
-        navigateToCreateCase: onNavigateToCreateCase,
-        navigateToConfigureCases: onNavigateToConfigureCases,
+        navigateToCreateCase,
+        navigateToConfigureCases,
       }),
-    [permissions, onNavigateToCreateCase, onNavigateToConfigureCases]
+    [permissions, navigateToCreateCase, navigateToConfigureCases]
   );
 
   return <AppHeader sticky={false} title={PAGE_TITLE} menu={menu} />;

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { AppHeader } from '@kbn/app-header';
+import { PAGE_TITLE } from '../../../../common/translations';
+import { useCreateCaseNavigation } from '../../../../common/navigation';
+import { useConfigureCasesNavigation } from '../../../../common/navigation/hooks';
+import { useCasesContext } from '../../../cases_context/use_cases_context';
+import { getListMenu } from './header_menu';
+
+export const CasesListAppHeader: FC = () => {
+  const { permissions } = useCasesContext();
+  const { navigateToCreateCase } = useCreateCaseNavigation();
+  const { navigateToConfigureCases } = useConfigureCasesNavigation();
+
+  const onNavigateToCreateCase = useCallback(() => {
+    navigateToCreateCase();
+  }, [navigateToCreateCase]);
+
+  const onNavigateToConfigureCases = useCallback(() => {
+    navigateToConfigureCases();
+  }, [navigateToConfigureCases]);
+
+  const menu = useMemo(
+    () =>
+      getListMenu({
+        permissions,
+        navigateToCreateCase: onNavigateToCreateCase,
+        navigateToConfigureCases: onNavigateToConfigureCases,
+      }),
+    [permissions, onNavigateToCreateCase, onNavigateToConfigureCases]
+  );
+
+  return <AppHeader sticky={false} title={PAGE_TITLE} menu={menu} />;
+};
+
+CasesListAppHeader.displayName = 'CasesListAppHeader';

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/header_menu.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/header_menu.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AppHeaderMenu } from '@kbn/app-header';
+import type { CasesPermissions } from '../../../../../common';
+import * as i18n from '../../../../common/translations';
+
+interface GetListMenuArgs {
+  permissions: CasesPermissions;
+  navigateToCreateCase: () => void;
+  navigateToConfigureCases: () => void;
+}
+
+export const getListMenu = ({
+  permissions,
+  navigateToCreateCase,
+  navigateToConfigureCases,
+}: GetListMenuArgs): AppHeaderMenu => {
+  const items = [
+    ...(permissions.settings
+      ? [
+          {
+            id: 'configureCases',
+            label: i18n.CONFIGURE_CASES_BUTTON,
+            iconType: 'gear' as const,
+            run: () => navigateToConfigureCases(),
+            testId: 'configure-case-button',
+            order: 100,
+          },
+        ]
+      : []),
+  ];
+
+  return {
+    items,
+    ...(permissions.create
+      ? {
+          primaryActionItem: {
+            id: 'createCase',
+            label: i18n.CREATE_CASE_TITLE,
+            iconType: 'plus' as const,
+            run: () => navigateToCreateCase(),
+            testId: 'createNewCaseBtn',
+          },
+        }
+      : {}),
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiFilterGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiFilterGroup, useEuiTheme } from '@elastic/eui';
 import { mergeWith, isEqual } from 'lodash';
 import { css } from '@emotion/react';
 import { MoreFiltersSelectable } from '../../../all_cases/table_filter_config/more_filters_selectable';
@@ -124,6 +124,8 @@ const CasesTableFiltersComponent = ({
     isLoading: isLoadingFilters,
   });
 
+  const { euiTheme } = useEuiTheme();
+
   const handleOnCreateCasePressed = useCallback(() => {
     if (onCreateCasePressed) {
       onCreateCasePressed();
@@ -136,6 +138,9 @@ const CasesTableFiltersComponent = ({
       justifyContent="flexStart"
       wrap={true}
       data-test-subj="cases-table-filters"
+      css={css`
+        padding-top: ${euiTheme.size.m};
+      `}
     >
       {isSelectorView && onCreateCasePressed ? (
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/index.tsx
@@ -5,30 +5,20 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { CasesDeepLinkId } from '../../../common/navigation';
-import { useGetActionLicense } from '../../../containers/use_get_action_license';
 import { CaseCallouts } from '../../callouts/case_callouts';
 import { useCasesBreadcrumbs } from '../../use_breadcrumbs';
-import { getActionLicenseError } from '../../use_push_to_service/helpers';
 import { AllCasesList } from './all_cases_list';
-import { CasesTableHeader } from '../../all_cases/header';
-import { useKibana } from '../../../common/lib/kibana';
+import { CasesListAppHeader } from './components/cases_list_app_header';
 
 export const AllCases: React.FC = () => {
   useCasesBreadcrumbs(CasesDeepLinkId.cases);
 
-  const { docLinks } = useKibana().services;
-  const { data: actionLicense = null } = useGetActionLicense();
-  const actionsErrors = useMemo(
-    () => getActionLicenseError(actionLicense, docLinks),
-    [actionLicense, docLinks]
-  );
-
   return (
     <>
       <CaseCallouts />
-      <CasesTableHeader actionsErrors={actionsErrors} />
+      <CasesListAppHeader />
       <AllCasesList />
     </>
   );


### PR DESCRIPTION
## What & Why

Migrates the cases list page header from the legacy `CasesTableHeader`/`HeaderPage`/`NavButtons` pattern to the platform `AppHeader` from `@kbn/app-header` within the `cases_redesign` feature-flagged path. This aligns the list page with the already-migrated cases details page and removes unused action license tooltip logic.

This change is behind the `xpack.cases.casesRedesign.list` feature flag. The legacy header in `all_cases/header.tsx` remains untouched and continues to serve the non-redesign path (`all_cases/index.tsx`). Only the redesigned entry point (`cases_redesign/all_cases/index.tsx`) is affected.
<img width="1670" height="379" alt="image" src="https://github.com/user-attachments/assets/3f1f417e-e924-4967-95aa-98b56c8ed156" />

## How to Test

1. Enable the redesign feature flag by adding `xpack.cases.casesRedesign.list: true` to `kibana.dev.yml`
2. Start Kibana and navigate to Cases list page
3. Verify the new inline header renders with the "Cases" title
4. Verify "Create case" button (outlined, with `+` icon) appears for users with create permissions
5. Verify "Settings" gear icon appears for users with settings permissions
6. Disable the flag (`xpack.cases.casesRedesign.list: false`) and confirm the legacy header still renders correctly

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.