### PR TITLE
[Agent Builder] Visualization Creation: Fix `ESQL` query corruption when generating inline visualizations

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/graph_lens.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/graph_lens.test.ts
@@ -51,10 +51,12 @@ describe('createVisualizationGraph', () => {
   const events = {} as ToolEventEmitter;
   const esClient = { asCurrentUser: {} } as IScopedClusterClient;
 
-  const createMockModel = () =>
+  const createMockModel = (invokeResult: string = '```json\n{"type":"metric"}\n```') =>
     ({
       chatModel: {
-        invoke: jest.fn().mockResolvedValue('```json\n{"type":"metric"}\n```'),
+        // invoke resolves to a message-like object; graph_lens reads `.content` via
+        // extractTextFromMessage.
+        invoke: jest.fn().mockResolvedValue({ content: invokeResult }),
         withStructuredOutput: jest.fn(),
       },
     } as const);
@@ -105,7 +107,7 @@ describe('createVisualizationGraph', () => {
     );
     const parsedExistingConfig = {
       type: 'metric',
-      dataset: {
+      data_source: {
         type: 'esql',
         query: 'FROM logs-* | STATS count = COUNT(*)',
       },
@@ -135,5 +137,118 @@ describe('createVisualizationGraph', () => {
     expect(finalState.esqlQuery).toBe(
       'FROM logs-* | WHERE response.code != 503 | STATS count = COUNT(*)'
     );
+  });
+
+  it('injects the validated esql query, overwriting any query emitted by the config LLM', async () => {
+    const canonicalQuery = 'TS metrics-* | STATS avg = AVG(cpu) BY host';
+    // The config LLM corrupts the query (TS -> FROM) in the data_source it emits.
+    const corruptedConfig =
+      '```json\n' +
+      JSON.stringify({
+        type: 'metric',
+        data_source: { type: 'esql', query: 'FROM metrics-* | STATS avg = AVG(cpu) BY host' },
+      }) +
+      '\n```';
+
+    const graph = createVisualizationGraph(
+      createMockModel(corruptedConfig) as never,
+      logger,
+      events,
+      esClient,
+      false
+    );
+
+    const finalState = await graph.invoke({
+      nlQuery: 'Average cpu by host',
+      index: 'metrics-*',
+      chartType: SupportedChartType.Metric,
+      schema: {},
+      existingConfig: undefined,
+      parsedExistingConfig: null,
+      esqlQuery: canonicalQuery,
+      currentAttempt: 0,
+      actions: [],
+      validatedConfig: null,
+      error: null,
+    });
+
+    const validated = finalState.validatedConfig as {
+      data_source?: { type: string; query: string };
+    };
+    expect(validated.data_source).toEqual({ type: 'esql', query: canonicalQuery });
+  });
+
+  it('injects data_source when the config LLM omits it (single-dataset config)', async () => {
+    const canonicalQuery = 'FROM logs-* | STATS count = COUNT(*)';
+    const configWithoutDataSource = '```json\n' + JSON.stringify({ type: 'metric' }) + '\n```';
+
+    const graph = createVisualizationGraph(
+      createMockModel(configWithoutDataSource) as never,
+      logger,
+      events,
+      esClient,
+      false
+    );
+
+    const finalState = await graph.invoke({
+      nlQuery: 'Count logs',
+      index: 'logs-*',
+      chartType: SupportedChartType.Metric,
+      schema: {},
+      existingConfig: undefined,
+      parsedExistingConfig: null,
+      esqlQuery: canonicalQuery,
+      currentAttempt: 0,
+      actions: [],
+      validatedConfig: null,
+      error: null,
+    });
+
+    const validated = finalState.validatedConfig as {
+      data_source?: { type: string; query: string };
+    };
+    expect(validated.data_source).toEqual({ type: 'esql', query: canonicalQuery });
+  });
+
+  it('injects data_source into every layer when the config LLM omits it (XY multi-layer)', async () => {
+    const canonicalQuery =
+      'FROM logs-* | STATS count = COUNT(*) BY bucket = BUCKET(@timestamp, 75, ?_tstart, ?_tend)';
+    const xyConfigWithoutDataSource =
+      '```json\n' +
+      JSON.stringify({
+        type: 'xy',
+        layers: [{ type: 'series' }, { type: 'series' }],
+      }) +
+      '\n```';
+
+    const graph = createVisualizationGraph(
+      createMockModel(xyConfigWithoutDataSource) as never,
+      logger,
+      events,
+      esClient,
+      false
+    );
+
+    const finalState = await graph.invoke({
+      nlQuery: 'Count logs over time',
+      index: 'logs-*',
+      chartType: SupportedChartType.XY,
+      schema: {},
+      existingConfig: undefined,
+      parsedExistingConfig: null,
+      esqlQuery: canonicalQuery,
+      currentAttempt: 0,
+      actions: [],
+      validatedConfig: null,
+      error: null,
+    });
+
+    const validated = finalState.validatedConfig as {
+      layers?: Array<{ data_source?: { type: string; query: string } }>;
+    };
+    expect(validated.layers).toHaveLength(2);
+    for (const layer of validated.layers ?? []) {
+      expect(layer.data_source).toEqual({ type: 'esql', query: canonicalQuery });
+    }
   });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/graph_lens.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/graph_lens.ts
@@ -232,11 +232,8 @@ export const createVisualizationGraph = (
         throw new Error('Response is not a valid JSON object');
       }
 
-      // Pin the validated ES|QL query into the config's data_source(s). The query was already
-      // AST-validated and executed in generateESQLNode, so it is the single source of truth; the
-      // config-generation LLM is not allowed to own it. This overwrites whatever data_source the
-      // LLM emitted (or adds one when omitted) and runs before validation, so the validated and
-      // finalized config — and each retry attempt — always carries the known-good query.
+      // Pin the validated ES|QL query before config validation. ES|QL generation owns the query;
+      // config generation only binds columns from it.
       if (esqlQuery) {
         for (const carrier of getEsqlDataSourceCarriers(configResponse)) {
           carrier.data_source = { type: 'esql', query: esqlQuery };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/graph_lens.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/graph_lens.ts
@@ -38,6 +38,24 @@ const validateConfigForChartType = (
   config: unknown
 ): VisualizationConfig => chartTypeRegistry[chartType].schema.validate(config);
 
+interface EsqlDataSourceCarrier {
+  data_source?: { type?: string; query?: string };
+}
+
+/**
+ * Returns the objects that carry a `data_source` for this config shape:
+ * XY-ESQL configs keep one `data_source` per layer; every other ESQL chart
+ * (metric, gauge, tagcloud, ...) carries it on the config itself. Used both to
+ * read existing queries (edits) and to inject the validated query (generation).
+ */
+const getEsqlDataSourceCarriers = (config: unknown): EsqlDataSourceCarrier[] => {
+  if (!config || typeof config !== 'object') return [];
+  const { layers } = config as { layers?: unknown };
+  return Array.isArray(layers)
+    ? (layers as EsqlDataSourceCarrier[])
+    : [config as EsqlDataSourceCarrier];
+};
+
 /**
  * Helper to extract ESQL queries from a visualization config.
  * Handles both single-dataset configs (metric, gauge, tagcloud) and layers-based configs (XY).
@@ -47,25 +65,10 @@ function getExistingEsqlQueries(config: VisualizationConfig | null): string[] {
   if (!config) return [];
 
   const queries: string[] = [];
-
-  // For XY charts, check all layers' datasets
-  if ('layers' in config && Array.isArray(config.layers)) {
-    for (const layer of config.layers) {
-      if (layer && 'dataset' in layer && layer.dataset) {
-        const dataset = layer.dataset as { type?: string; query?: string };
-        if (dataset.type === 'esql' && dataset.query && !queries.includes(dataset.query)) {
-          queries.push(dataset.query);
-        }
-      }
-    }
-    return queries;
-  }
-
-  // For single-dataset configs (metric, gauge, tagcloud)
-  if ('dataset' in config && config.dataset) {
-    const dataset = config.dataset as { type?: string; query?: string };
-    if (dataset.type === 'esql' && dataset.query) {
-      queries.push(dataset.query);
+  for (const carrier of getEsqlDataSourceCarriers(config)) {
+    const dataSource = carrier.data_source;
+    if (dataSource?.type === 'esql' && dataSource.query && !queries.includes(dataSource.query)) {
+      queries.push(dataSource.query);
     }
   }
 
@@ -227,6 +230,17 @@ export const createVisualizationGraph = (
       // Verify it's a valid object
       if (!configResponse || typeof configResponse !== 'object') {
         throw new Error('Response is not a valid JSON object');
+      }
+
+      // Pin the validated ES|QL query into the config's data_source(s). The query was already
+      // AST-validated and executed in generateESQLNode, so it is the single source of truth; the
+      // config-generation LLM is not allowed to own it. This overwrites whatever data_source the
+      // LLM emitted (or adds one when omitted) and runs before validation, so the validated and
+      // finalized config — and each retry attempt — always carries the known-good query.
+      if (esqlQuery) {
+        for (const carrier of getEsqlDataSourceCarriers(configResponse)) {
+          carrier.data_source = { type: 'esql', query: esqlQuery };
+        }
       }
 
       action = {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/visualization/prompts.ts
@@ -51,11 +51,11 @@ ${
     : ''
 }
 
-DATASET RULES:
-1. The 'dataset' field must contain: { type: "esql", query: ${esqlQueryJson} }
-2. For ES|QL column bindings use { column: '<esql column name>', ...other options }
-3. All field names must match those available in the ES|QL query result
-4. Follow the schema definition strictly
+DATA SOURCE RULES:
+1. The ES|QL query is owned and injected by the system automatically. DO NOT output a 'data_source' field, and do not restate, copy, or modify the query anywhere in the config.
+2. The configuration is built around this query; its result columns are the only columns available to bind: ${esqlQueryJson}
+3. For ES|QL column bindings use { column: '<esql column name>', ...other options }, and every bound column must be one produced by that query.
+4. Follow the schema definition strictly, with the single exception that you must omit the 'data_source' field.
 
 TITLE RULES:
 - Omit the 'title' field when the chart already displays the information within itself (e.g. metric, gauge, tagcloud, waffle charts show their value and label directly).


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/267896

Inline Lens visualizations generated by Agent (`manage_dashboard`, `create_visualization`, and inline dashboard editing) could render broken because the generated ESQL query was getting silently corrupted.

The flow builds the visualization in two stages: it first generates and validates an ESQL query, then asks the LLM to build the Lens config around that query. The bug was in the handoff between the two, we passed the validated query to the LLM as plain text and let it write the query back into the config, so it was free to mess it up. 
The fix stops the LLM from owning the query, after it returns the config we deterministically inject the already-validated query into `data_source`, and the prompt now tells it not to emit `data_source` at all. The validated query stays the single source of truth.

### What changed
- Inject the validated query: after parsing the LLM config and before validation, set `data_source` to `{type: 'esql', query: <validated_query>}`. A small helper handles both shapes - XY charts carry a `data_source` per layer, every other chart carries it on the config itself. 
- Prompt: The data_source rules now say the query is system-owned and to omit `data_source` entirely, the query is still shown so the model knows which columns it can bind to.
- Field name fix: `getExistingEsqlQueries` was still reading the old `dataset` field. Lens renamed `dataset` -> `data_source` in #260914.