### PR TITLE
[kbn-es] Clarify EIS CCM API key rejection error in `--eis` setup

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/eis/ccm_key_cache.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/ccm_key_cache.ts
@@ -12,7 +12,11 @@
  *
  * Stores the key at ~/.elastic/eis-ccm-key.json so that repeated `yarn es
  * snapshot --eis` runs don't require a Vault round-trip every time. The TTL
- * defaults to 7 days and is configurable via the EIS_CCM_KEY_TTL_HOURS env var.
+ * defaults to 24 hours and is configurable via the EIS_CCM_KEY_TTL_HOURS env
+ * var. It is intentionally short: since elastic/elasticsearch#139088,
+ * `PUT _inference/_ccm` validates the key against the EIS gateway, so a
+ * rotated-but-still-cached key hard-fails `--eis` startup. The shorter TTL
+ * (plus pre-use validation in `resolveCcmApiKey`) limits that window.
  *
  * Three read modes:
  *  - `readCachedKey` — returns the key only if within TTL.
@@ -33,7 +37,7 @@ interface CachedKey {
 
 const CACHE_DIR = path.join(os.homedir(), '.elastic');
 const CACHE_PATH = path.join(CACHE_DIR, 'eis-ccm-key.json');
-const DEFAULT_TTL_HOURS = 168;
+const DEFAULT_TTL_HOURS = 24;
 
 const getTtlMs = (): number => {
   const envHours = process.env.EIS_CCM_KEY_TTL_HOURS;
@@ -90,4 +94,17 @@ export const writeCachedKey = (key: string, vaultAddr: string): void => {
   }
 
   fs.writeFileSync(CACHE_PATH, JSON.stringify(entry, null, 2), { encoding: 'utf-8', mode: 0o600 });
+};
+
+/**
+ * Removes the cached key file. Used to evict a cached key that failed
+ * validation against the EIS gateway (e.g. it was rotated or revoked), so the
+ * next resolution falls back to Vault. No-op when the file is absent.
+ */
+export const clearCachedKey = (): void => {
+  try {
+    fs.rmSync(CACHE_PATH, { force: true });
+  } catch {
+    // Best-effort eviction — a failure here shouldn't break the resolve flow.
+  }
 };

--- a/src/platform/packages/shared/kbn-es/src/eis/ccm_key_cache.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/ccm_key_cache.ts
@@ -16,7 +16,7 @@
  * var. It is intentionally short: since elastic/elasticsearch#139088,
  * `PUT _inference/_ccm` validates the key against the EIS gateway, so a
  * rotated-but-still-cached key hard-fails `--eis` startup. The shorter TTL
- * (plus pre-use validation in `resolveCcmApiKey`) limits that window.
+ * limits that window before a fresh key is fetched from Vault.
  *
  * Three read modes:
  *  - `readCachedKey` — returns the key only if within TTL.
@@ -94,17 +94,4 @@ export const writeCachedKey = (key: string, vaultAddr: string): void => {
   }
 
   fs.writeFileSync(CACHE_PATH, JSON.stringify(entry, null, 2), { encoding: 'utf-8', mode: 0o600 });
-};
-
-/**
- * Removes the cached key file. Used to evict a cached key that failed
- * validation against the EIS gateway (e.g. it was rotated or revoked), so the
- * next resolution falls back to Vault. No-op when the file is absent.
- */
-export const clearCachedKey = (): void => {
-  try {
-    fs.rmSync(CACHE_PATH, { force: true });
-  } catch {
-    // Best-effort eviction — a failure here shouldn't break the resolve flow.
-  }
 };

--- a/src/platform/packages/shared/kbn-es/src/eis/eis_setup.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/eis_setup.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import http from 'http';
+import https from 'https';
+import type { AddressInfo } from 'net';
+import { ToolingLog } from '@kbn/tooling-log';
+
+import { setCcmApiKey, type EisElasticsearchConnection } from './eis_setup';
+
+interface MockResponse {
+  statusCode: number;
+  body?: string;
+}
+
+describe('setCcmApiKey', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let queued: MockResponse[];
+  let requestCount: number;
+  const log = new ToolingLog();
+
+  const connection = (): EisElasticsearchConnection => ({
+    baseUrl,
+    credentials: { username: 'elastic', password: 'changeme' },
+    ssl: false,
+  });
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      requestCount += 1;
+      const next = queued.shift() ?? { statusCode: 200 };
+      // Close the socket after each response so no keep-alive handles linger
+      // and leave Jest waiting on open sockets after the suite finishes.
+      res.writeHead(next.statusCode, { 'Content-Type': 'application/json', Connection: 'close' });
+      res.end(next.body ?? '');
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    // eisHttpRequest uses the global agents; destroy any pooled sockets so Jest
+    // doesn't report lingering open handles after the suite finishes.
+    http.globalAgent.destroy();
+    https.globalAgent.destroy();
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
+  beforeEach(() => {
+    queued = [];
+    requestCount = 0;
+  });
+
+  it('resolves without error on a 2xx response', async () => {
+    queued = [{ statusCode: 200 }];
+    await expect(setCcmApiKey('essu_test', connection(), log)).resolves.toBeUndefined();
+    expect(requestCount).toBe(1);
+  });
+
+  it('surfaces the EIS validation reason and a refresh hint on 401, without retrying', async () => {
+    queued = [
+      {
+        statusCode: 401,
+        body: JSON.stringify({
+          error: { reason: 'Failed to validate the Cloud Connected Mode API key' },
+        }),
+      },
+    ];
+
+    const error = await setCcmApiKey('essu_stale', connection(), log).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    const cause = (error as Error & { cause?: Error }).cause;
+    expect(cause?.message).toContain('HTTP 401 — Elasticsearch rejected the CCM API key.');
+    expect(cause?.message).toContain('Failed to validate the Cloud Connected Mode API key');
+    expect(cause?.message).toContain('rm ~/.elastic/eis-ccm-key.json');
+    // 401 must fail fast — exactly one request, no retries.
+    expect(requestCount).toBe(1);
+  });
+
+  it('handles a string-shaped ES error body on 403', async () => {
+    queued = [{ statusCode: 403, body: JSON.stringify({ error: 'forbidden' }) }];
+
+    const error = await setCcmApiKey('essu_x', connection(), log).catch((e: Error) => e);
+    const cause = (error as Error & { cause?: Error }).cause;
+
+    expect(cause?.message).toContain('HTTP 403 — Elasticsearch rejected the CCM API key.');
+    expect(cause?.message).toContain('Elasticsearch said: forbidden');
+    expect(requestCount).toBe(1);
+  });
+
+  it('retries on a non-auth error and includes the ES reason in the final message', async () => {
+    queued = [
+      { statusCode: 500, body: JSON.stringify({ error: { reason: 'boom' } }) },
+      { statusCode: 500, body: JSON.stringify({ error: { reason: 'boom' } }) },
+      { statusCode: 500, body: JSON.stringify({ error: { reason: 'boom' } }) },
+    ];
+
+    const error = await setCcmApiKey('essu_x', connection(), log).catch((e: Error) => e);
+    const cause = (error as Error & { cause?: Error }).cause;
+
+    expect(cause?.message).toBe('HTTP 500 — boom');
+    expect(requestCount).toBe(3);
+  }, 15_000);
+});

--- a/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
@@ -30,7 +30,7 @@ import chalk from 'chalk';
 import { Client, HttpConnection } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
 
-import { readCachedKey, readStaleKey, writeCachedKey } from './ccm_key_cache';
+import { clearCachedKey, readCachedKey, readStaleKey, writeCachedKey } from './ccm_key_cache';
 import { waitUntilClusterReady } from '../utils/wait_until_cluster_ready';
 
 /** QA environment URL for the Elastic Inference Service. */
@@ -78,6 +78,54 @@ export const eisHttpRequest = (
 
 export const createBasicAuth = (username: string, password: string): string =>
   Buffer.from(`${username}:${password}`).toString('base64');
+
+/**
+ * EIS gateway authorization path. Elasticsearch calls this endpoint (with the
+ * CCM key as a Bearer token) to validate the key before storing it via
+ * `PUT _inference/_ccm` (see elastic/elasticsearch#139088). We mirror that call
+ * here so we can validate a resolved key up front and avoid a confusing
+ * mid-startup failure.
+ */
+const EIS_AUTHORIZATIONS_PATH = '/api/v1/authorizations';
+
+/**
+ * Validates a CCM API key against the EIS gateway by mirroring the
+ * authorization call Elasticsearch performs. Returns `true` when the key is
+ * accepted, `false` when the gateway rejects it (401/403). Returns `true` on
+ * transient/unknown failures (network error, 5xx) so a flaky gateway doesn't
+ * block startup — ES will surface a real problem when it sets the key.
+ */
+export const validateCcmApiKey = async (
+  apiKey: string,
+  log: ToolingLog,
+  eisUrl: string = EIS_QA_URL
+): Promise<boolean> => {
+  try {
+    const { statusCode } = await eisHttpRequest(`${eisUrl}${EIS_AUTHORIZATIONS_PATH}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
+    if (statusCode === 401 || statusCode === 403) {
+      return false;
+    }
+
+    if (statusCode < 200 || statusCode >= 300) {
+      log.debug(
+        `EIS key validation returned HTTP ${statusCode}; treating as inconclusive and proceeding.`
+      );
+    }
+
+    return true;
+  } catch (error) {
+    log.debug(
+      `EIS key validation request failed (${
+        error instanceof Error ? error.message : String(error)
+      }); treating as inconclusive and proceeding.`
+    );
+    return true;
+  }
+};
 
 const VAULT_NOT_INSTALLED_MESSAGE = [
   'Vault is not installed or not in PATH.',
@@ -211,8 +259,9 @@ const getEisApiKeyFromVault = async (vaultAddr: string, log: ToolingLog): Promis
 
 /**
  * Resolves the CCM API key from (in priority order):
- * 1. KIBANA_EIS_CCM_API_KEY env var
- * 2. Local file cache (~/.elastic/eis-ccm-key.json)
+ * 1. KIBANA_EIS_CCM_API_KEY env var (returned as-is — the user opted in)
+ * 2. Local file cache (~/.elastic/eis-ccm-key.json), validated against the EIS
+ *    gateway before use; evicted and skipped if the gateway rejects it.
  * 3. Vault (with fallback to stale cache on failure)
  */
 export const resolveCcmApiKey = async (log: ToolingLog): Promise<string> => {
@@ -224,8 +273,15 @@ export const resolveCcmApiKey = async (log: ToolingLog): Promise<string> => {
 
   const cached = readCachedKey();
   if (cached) {
-    log.info('Using cached CCM API key from ~/.elastic/eis-ccm-key.json');
-    return cached;
+    if (await validateCcmApiKey(cached, log)) {
+      log.info('Using cached CCM API key from ~/.elastic/eis-ccm-key.json');
+      return cached;
+    }
+    log.warning(
+      'Cached CCM API key was rejected by the EIS gateway (likely rotated or revoked); ' +
+        'discarding it and re-fetching from Vault.'
+    );
+    clearCachedKey();
   }
 
   const vaultAddr = process.env.VAULT_ADDR || 'https://secrets.elastic.co:8200';

--- a/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
@@ -30,7 +30,7 @@ import chalk from 'chalk';
 import { Client, HttpConnection } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
 
-import { clearCachedKey, readCachedKey, readStaleKey, writeCachedKey } from './ccm_key_cache';
+import { readCachedKey, readStaleKey, writeCachedKey } from './ccm_key_cache';
 import { waitUntilClusterReady } from '../utils/wait_until_cluster_ready';
 
 /** QA environment URL for the Elastic Inference Service. */
@@ -78,59 +78,6 @@ export const eisHttpRequest = (
 
 export const createBasicAuth = (username: string, password: string): string =>
   Buffer.from(`${username}:${password}`).toString('base64');
-
-/**
- * EIS gateway authorization path. Elasticsearch calls this endpoint to validate
- * the CCM key before storing it via `PUT _inference/_ccm` (see
- * elastic/elasticsearch#139088). ES moved to the v2 endpoint in
- * elastic/elasticsearch#138249; we mirror that here so our pre-use validation
- * matches what ES actually does.
- */
-const EIS_AUTHORIZATIONS_PATH = '/api/v2/authorizations';
-
-/**
- * Validates a CCM API key against the EIS gateway by mirroring the
- * authorization call Elasticsearch performs. Returns `true` when the key is
- * accepted, `false` when the gateway rejects it (401/403). Returns `true` on
- * transient/unknown failures (network error, 5xx) so a flaky gateway doesn't
- * block startup — ES will surface a real problem when it sets the key.
- *
- * The key is sent with the `ApiKey` scheme to match Elasticsearch, which
- * switched from `Bearer` to `ApiKey` in elastic/elasticsearch#138590. The
- * gateway rejects `Bearer` with a 401, so using the wrong scheme here would
- * wrongly discard a perfectly valid key.
- */
-export const validateCcmApiKey = async (
-  apiKey: string,
-  log: ToolingLog,
-  eisUrl: string = EIS_QA_URL
-): Promise<boolean> => {
-  try {
-    const { statusCode } = await eisHttpRequest(`${eisUrl}${EIS_AUTHORIZATIONS_PATH}`, {
-      method: 'GET',
-      headers: { Authorization: `ApiKey ${apiKey}` },
-    });
-
-    if (statusCode === 401 || statusCode === 403) {
-      return false;
-    }
-
-    if (statusCode < 200 || statusCode >= 300) {
-      log.debug(
-        `EIS key validation returned HTTP ${statusCode}; treating as inconclusive and proceeding.`
-      );
-    }
-
-    return true;
-  } catch (error) {
-    log.debug(
-      `EIS key validation request failed (${
-        error instanceof Error ? error.message : String(error)
-      }); treating as inconclusive and proceeding.`
-    );
-    return true;
-  }
-};
 
 const VAULT_NOT_INSTALLED_MESSAGE = [
   'Vault is not installed or not in PATH.',
@@ -264,9 +211,8 @@ const getEisApiKeyFromVault = async (vaultAddr: string, log: ToolingLog): Promis
 
 /**
  * Resolves the CCM API key from (in priority order):
- * 1. KIBANA_EIS_CCM_API_KEY env var (returned as-is — the user opted in)
- * 2. Local file cache (~/.elastic/eis-ccm-key.json), validated against the EIS
- *    gateway before use; evicted and skipped if the gateway rejects it.
+ * 1. KIBANA_EIS_CCM_API_KEY env var
+ * 2. Local file cache (~/.elastic/eis-ccm-key.json)
  * 3. Vault (with fallback to stale cache on failure)
  */
 export const resolveCcmApiKey = async (log: ToolingLog): Promise<string> => {
@@ -278,15 +224,8 @@ export const resolveCcmApiKey = async (log: ToolingLog): Promise<string> => {
 
   const cached = readCachedKey();
   if (cached) {
-    if (await validateCcmApiKey(cached, log)) {
-      log.info('Using cached CCM API key from ~/.elastic/eis-ccm-key.json');
-      return cached;
-    }
-    log.warning(
-      'Cached CCM API key was rejected by the EIS gateway (likely rotated or revoked); ' +
-        'discarding it and re-fetching from Vault.'
-    );
-    clearCachedKey();
+    log.info('Using cached CCM API key from ~/.elastic/eis-ccm-key.json');
+    return cached;
   }
 
   const vaultAddr = process.env.VAULT_ADDR || 'https://secrets.elastic.co:8200';

--- a/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
@@ -288,6 +288,69 @@ export const waitForEisEsReady = async (
 };
 
 /**
+ * Extracts a human-readable detail from an Elasticsearch error response body.
+ * ES typically returns `{ "error": { "reason": "..." } }` or `{ "error": "..." }`.
+ * Falls back to the trimmed raw body when it isn't the expected shape.
+ */
+const extractEsErrorReason = (body: string | undefined): string | undefined => {
+  const trimmed = body?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as { error?: unknown };
+    const { error } = parsed;
+    if (typeof error === 'string') {
+      return error;
+    }
+    if (error && typeof error === 'object' && 'reason' in error) {
+      const { reason } = error as { reason?: unknown };
+      if (typeof reason === 'string') {
+        return reason;
+      }
+    }
+  } catch {
+    // Not JSON — fall through to returning the raw body.
+  }
+
+  return trimmed;
+};
+
+/**
+ * Builds the error thrown when ES rejects the CCM request with 401/403. The
+ * rejection is (almost always) the EIS gateway refusing the CCM API key during
+ * the validation step ES performs before storing it, so the message points at
+ * refreshing the key rather than at local ES credentials.
+ */
+const formatCcmKeyRejectedError = (statusCode: number, body: string | undefined): string => {
+  const reason = extractEsErrorReason(body);
+  return [
+    `HTTP ${statusCode} — Elasticsearch rejected the CCM API key.`,
+    ...(reason ? [`Elasticsearch said: ${reason}`] : []),
+    '',
+    'This usually means the EIS gateway rejected the CCM API key (rotated, expired,',
+    'or revoked) when Elasticsearch validated it. The local elastic/changeme',
+    'credentials are not the problem here.',
+    '',
+    'To refresh the key:',
+    '',
+    `  ${chalk.cyan('rm ~/.elastic/eis-ccm-key.json')}    # drop the stale cached key`,
+    `  ${chalk.cyan('vault login --method oidc')}          # re-authenticate to Vault`,
+    '',
+    'Then re-run with --eis. Or set a known-good key directly:',
+    '',
+    `  ${chalk.cyan('export KIBANA_EIS_CCM_API_KEY="<key>"')}`,
+  ].join('\n');
+};
+
+/** Builds the error thrown for any other non-2xx CCM response. */
+const formatCcmHttpError = (statusCode: number, body: string | undefined): string => {
+  const reason = extractEsErrorReason(body);
+  return reason ? `HTTP ${statusCode} — ${reason}` : `HTTP ${statusCode}`;
+};
+
+/**
  * Sets the CCM API key in Elasticsearch via PUT _inference/_ccm.
  */
 export const setCcmApiKey = async (
@@ -303,7 +366,7 @@ export const setCcmApiKey = async (
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const { statusCode } = await eisHttpRequest(
+      const { statusCode, data } = await eisHttpRequest(
         esUrl,
         {
           method: 'PUT',
@@ -322,11 +385,16 @@ export const setCcmApiKey = async (
         return;
       }
 
+      // As of elastic/elasticsearch#139088, PUT _inference/_ccm validates the
+      // key against the EIS gateway before storing it. A 401/403 here almost
+      // always means EIS rejected the CCM API key (rotated/expired), NOT that
+      // local ES basic auth failed — so surface the ES body and a refresh hint
+      // rather than implying a local credentials problem.
       if (statusCode === 401 || statusCode === 403) {
-        throw new Error(`HTTP ${statusCode} — Elasticsearch rejected the CCM request.`);
+        throw new Error(formatCcmKeyRejectedError(statusCode, data));
       }
 
-      throw new Error(`HTTP ${statusCode}`);
+      throw new Error(formatCcmHttpError(statusCode, data));
     } catch (error) {
       if (
         attempt < maxRetries &&

--- a/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
+++ b/src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts
@@ -80,13 +80,13 @@ export const createBasicAuth = (username: string, password: string): string =>
   Buffer.from(`${username}:${password}`).toString('base64');
 
 /**
- * EIS gateway authorization path. Elasticsearch calls this endpoint (with the
- * CCM key as a Bearer token) to validate the key before storing it via
- * `PUT _inference/_ccm` (see elastic/elasticsearch#139088). We mirror that call
- * here so we can validate a resolved key up front and avoid a confusing
- * mid-startup failure.
+ * EIS gateway authorization path. Elasticsearch calls this endpoint to validate
+ * the CCM key before storing it via `PUT _inference/_ccm` (see
+ * elastic/elasticsearch#139088). ES moved to the v2 endpoint in
+ * elastic/elasticsearch#138249; we mirror that here so our pre-use validation
+ * matches what ES actually does.
  */
-const EIS_AUTHORIZATIONS_PATH = '/api/v1/authorizations';
+const EIS_AUTHORIZATIONS_PATH = '/api/v2/authorizations';
 
 /**
  * Validates a CCM API key against the EIS gateway by mirroring the
@@ -94,6 +94,11 @@ const EIS_AUTHORIZATIONS_PATH = '/api/v1/authorizations';
  * accepted, `false` when the gateway rejects it (401/403). Returns `true` on
  * transient/unknown failures (network error, 5xx) so a flaky gateway doesn't
  * block startup — ES will surface a real problem when it sets the key.
+ *
+ * The key is sent with the `ApiKey` scheme to match Elasticsearch, which
+ * switched from `Bearer` to `ApiKey` in elastic/elasticsearch#138590. The
+ * gateway rejects `Bearer` with a 401, so using the wrong scheme here would
+ * wrongly discard a perfectly valid key.
  */
 export const validateCcmApiKey = async (
   apiKey: string,
@@ -103,7 +108,7 @@ export const validateCcmApiKey = async (
   try {
     const { statusCode } = await eisHttpRequest(`${eisUrl}${EIS_AUTHORIZATIONS_PATH}`, {
       method: 'GET',
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers: { Authorization: `ApiKey ${apiKey}` },
     });
 
     if (statusCode === 401 || statusCode === 403) {


### PR DESCRIPTION
## Summary

Starting Elasticsearch with `yarn es snapshot --eis` could fail with an opaque error that looked like a local `elastic`/`changeme` authentication problem:

```
ERROR EIS setup failed, stopping Elasticsearch...
ERROR Error: Failed to set CCM API key.
      Caused by: Error: HTTP 401 — Elasticsearch rejected the CCM request.
```

The actual cause is unrelated to local ES auth. As of [elastic/elasticsearch#139088](https://github.com/elastic/elasticsearch/pull/139088), `PUT _inference/_ccm` **validates** the CCM API key against the EIS gateway before storing it. When the cached/Vault CCM key has been rotated, expired, or revoked, EIS returns `401` and ES surfaces `Failed to validate the Cloud Connected Mode API key` — but `setCcmApiKey` discarded the response body and reported a generic message implying a local credentials issue.

This was made worse by the CCM key being cached at `~/.elastic/eis-ccm-key.json` with a **7-day TTL**, so a rotated-but-not-yet-expired key was silently reused on every run and hard-failed the whole `--eis` startup.

This PR makes the failure self-explanatory and shrinks the window in which a stale cached key can be reused.

## Changes

### 1. Clearer error on CCM key rejection (`eis_setup.ts`)

- `setCcmApiKey` now captures the Elasticsearch response body and surfaces its `error.reason` (handling both the `{ error: { reason } }` and `{ error: "..." }` shapes, falling back to the raw body).
- On `401`/`403`, the error explains that the EIS gateway rejected the CCM key (rotated/expired/revoked), explicitly notes that local `elastic`/`changeme` is **not** the problem, and gives actionable recovery steps:
  - `rm ~/.elastic/eis-ccm-key.json` (drop the stale cached key)
  - `vault login --method oidc` (re-authenticate to Vault)
  - or `export KIBANA_EIS_CCM_API_KEY="<key>"` (override directly)
- The retry-skip guard (`/HTTP (401|403)/`) is preserved, so auth failures still fail fast without retrying.

No behavior change on the success path; this only improves the error message on failure.

### 2. Shorter cache TTL (`ccm_key_cache.ts`)

- Default cache TTL reduced from **7 days → 24h** (still overridable via `EIS_CCM_KEY_TTL_HOURS`). Now that ES validates the key on `PUT _inference/_ccm`, a rotated-but-still-cached key hard-fails startup; the shorter TTL bounds how long a stale key lingers before the tooling re-fetches a fresh one from Vault. The cache TTL is independent of the key's server-side expiry, which is controlled on the EIS/Vault side, not in this repo.

### 3. Unit tests (`eis_setup.test.ts`)

- New tests for `setCcmApiKey` against a local HTTP stub server, covering: the `2xx` success path, the `401` fail-fast path (asserting the ES reason and the refresh hint are surfaced and that there is no retry), a `403` with a string-shaped error body, and the retry path for a non-auth `5xx` error.

### What changed since the first revision of this PR

An earlier revision added a client-side `validateCcmApiKey()` pre-check that re-issued ES's `GET …/authorizations` call before using the cached key, evicting it on rejection. That was **removed**: it duplicated the authorization call ES already performs on `PUT _inference/_ccm`, and it was brittle — when the EIS gateway changed its expected auth scheme (`Bearer` → `ApiKey`) and authorizations endpoint (`v1` → `v2`), the pre-check produced false negatives and discarded perfectly valid keys. Letting ES be the single source of truth for key validation (and surfacing its rejection clearly) is simpler and more robust. The unused `clearCachedKey()` helper was removed with it.

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/kbn-es/src/eis/eis_setup.test.ts` passes.
- [x] `node scripts/type_check --project src/platform/packages/shared/kbn-es/tsconfig.json` passes.
- [x] `node scripts/eslint src/platform/packages/shared/kbn-es/src/eis/eis_setup.ts src/platform/packages/shared/kbn-es/src/eis/ccm_key_cache.ts src/platform/packages/shared/kbn-es/src/eis/eis_setup.test.ts` passes.
- [ ] With a stale/invalid CCM key, `yarn es snapshot --eis` surfaces the new error pointing at EIS key validation and the refresh steps (rather than a generic local-auth message).
- [ ] With a valid key, `yarn es snapshot --eis` completes CCM setup successfully.
- [ ] `EIS_CCM_KEY_TTL_HOURS` still overrides the default cache TTL.
