### PR TITLE
[9.3] chore(deps): upgrade ws from 7.5.10 to 7.5.11 (#273797)

### DIFF
--- a/oas_docs/package-lock.json
+++ b/oas_docs/package-lock.json
@@ -3139,9 +3139,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -35234,9 +35234,9 @@ write-file-atomic@^4.0.2:
     signal-exit "^3.0.7"
 
 ws@^7.0.0, ws@^7.2.0, ws@^7.3.1, ws@^7.4.2:
-  version "7.5.10"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+  version "7.5.11"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 ws@^8.18.0, ws@^8.19.0, ws@^8.2.3, ws@^8.20.1, ws@^8.21.0, ws@^8.9.0:
   version "8.21.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [chore(deps): upgrade ws from 7.5.10 to 7.5.11 (#273797)](https://github.com/elastic/kibana/pull/273797)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-06-18T09:55:59Z","message":"chore(deps): upgrade ws from 7.5.10 to 7.5.11 (#273797)\n\n## Summary\n\nUpgrades `ws` to eliminate all instances of vulnerable/outdated\nversions:\n\n- **`ws@7.5.10` → `ws@7.5.11`** in `yarn.lock` and\n`oas_docs/package-lock.json`\n- **`ws@8.18.3` removed** from `yarn.lock` by bumping its parent\npackages to versions that declare `ws@~8.21.0` instead of `ws@~8.18.3`:\n  - `engine.io` `6.6.5` → `6.6.9`\n  - `socket.io-adapter` `2.5.6` → `2.5.8`\n- `ws@~8.21.0` consolidates into the existing `ws@8.21.0` lockfile entry\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` succeeds\n- [ ] No type errors introduced\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"93a5a57dbf34e227d42cb6488e13c875533a2bf5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport missing","backport:all-open","v9.5.0"],"title":"chore(deps): upgrade ws from 7.5.10 to 7.5.11","number":273797,"url":"https://github.com/elastic/kibana/pull/273797","mergeCommit":{"message":"chore(deps): upgrade ws from 7.5.10 to 7.5.11 (#273797)\n\n## Summary\n\nUpgrades `ws` to eliminate all instances of vulnerable/outdated\nversions:\n\n- **`ws@7.5.10` → `ws@7.5.11`** in `yarn.lock` and\n`oas_docs/package-lock.json`\n- **`ws@8.18.3` removed** from `yarn.lock` by bumping its parent\npackages to versions that declare `ws@~8.21.0` instead of `ws@~8.18.3`:\n  - `engine.io` `6.6.5` → `6.6.9`\n  - `socket.io-adapter` `2.5.6` → `2.5.8`\n- `ws@~8.21.0` consolidates into the existing `ws@8.21.0` lockfile entry\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` succeeds\n- [ ] No type errors introduced\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"93a5a57dbf34e227d42cb6488e13c875533a2bf5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273797","number":273797,"mergeCommit":{"message":"chore(deps): upgrade ws from 7.5.10 to 7.5.11 (#273797)\n\n## Summary\n\nUpgrades `ws` to eliminate all instances of vulnerable/outdated\nversions:\n\n- **`ws@7.5.10` → `ws@7.5.11`** in `yarn.lock` and\n`oas_docs/package-lock.json`\n- **`ws@8.18.3` removed** from `yarn.lock` by bumping its parent\npackages to versions that declare `ws@~8.21.0` instead of `ws@~8.18.3`:\n  - `engine.io` `6.6.5` → `6.6.9`\n  - `socket.io-adapter` `2.5.6` → `2.5.8`\n- `ws@~8.21.0` consolidates into the existing `ws@8.21.0` lockfile entry\n\n## Test plan\n\n- [ ] `yarn kbn bootstrap` succeeds\n- [ ] No type errors introduced\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"93a5a57dbf34e227d42cb6488e13c875533a2bf5"}}]}] BACKPORT-->