### PR TITLE
[9.4] [Fleet] Add accessible names to overlays for require-aria-label-for-modals (#274152)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/index.tsx
@@ -73,7 +73,7 @@ const Header: React.FunctionComponent<{
   return (
     <>
       <EuiTitle size="m">
-        <h2 data-test-subj="addFleetServerHeader">
+        <h2 data-test-subj="addFleetServerHeader" id="FleetAddFleetServerFlyoutTitle">
           <FormattedMessage
             id="xpack.fleet.fleetServerFlyout.title"
             defaultMessage="Add a Fleet Server"
@@ -134,7 +134,12 @@ export const FleetServerFlyout: React.FunctionComponent<Props> = ({ onClose }) =
   }
 
   return (
-    <EuiFlyout data-test-subj="fleetServerFlyout" onClose={onClose} maxWidth={MAX_FLYOUT_WIDTH}>
+    <EuiFlyout
+      data-test-subj="fleetServerFlyout"
+      onClose={onClose}
+      maxWidth={MAX_FLYOUT_WIDTH}
+      aria-labelledby="FleetAddFleetServerFlyoutTitle"
+    >
       <EuiFlyoutHeader hasBorder aria-labelledby="FleetAddFleetServerFlyoutTitle">
         <Header
           tabs={tabs}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.tsx
@@ -77,6 +77,9 @@ export const DatasetFilter: React.FunctionComponent<{
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.agentLogs.datasetFilterAriaLabel', {
+        defaultMessage: 'Dataset filter',
+      })}
       button={
         <EuiFilterButton
           data-test-subj="agentList.datasetFilterBtn"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
@@ -31,6 +31,9 @@ export const LogLevelFilter: React.FunctionComponent<{
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.agentLogs.logLevelFilterAriaLabel', {
+        defaultMessage: 'Log level filter',
+      })}
       button={
         <EuiFilterButton
           data-test-subj="agentList.logLevelFilterBtn"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_policy_outputs_summary.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_policy_outputs_summary.tsx
@@ -94,6 +94,9 @@ export const AgentPolicyOutputsSummary: React.FC<{
             +{data?.integrations.length}
           </EuiBadge>
           <EuiPopover
+            aria-label={i18n.translate('xpack.fleet.agentPolicyOutputsSummary.popoverAriaLabel', {
+              defaultMessage: 'Output integrations',
+            })}
             data-test-subj="outputPopover"
             isOpen={isPopoverOpen}
             closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_status_filter.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_status_filter.tsx
@@ -227,6 +227,9 @@ export const AgentStatusFilter: React.FC<{
       onDismiss={dismissInactiveAgentsCallout}
     >
       <EuiPopover
+        aria-label={i18n.translate('xpack.fleet.agentList.statusFilterAriaLabel', {
+          defaultMessage: 'Status filter',
+        })}
         ownFocus
         zIndex={Number(euiTheme.levels.header) - 1}
         button={

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/agent_policy_filter.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/agent_policy_filter.tsx
@@ -10,6 +10,7 @@ import type { EuiSelectableOption } from '@elastic/eui';
 import { useEuiTheme } from '@elastic/eui';
 import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 import type { AgentPolicy } from '../../../../../../../../common';
 
@@ -57,6 +58,9 @@ export const AgentPolicyFilter: React.FunctionComponent<Props> = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.agentList.policyFilterAriaLabel', {
+        defaultMessage: 'Agent policy filter',
+      })}
       ownFocus
       zIndex={Number(euiTheme.levels.header) - 1}
       button={

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.tsx
@@ -10,6 +10,7 @@ import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic
 import { EuiHorizontalRule } from '@elastic/eui';
 import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 interface Props {
   tags: string[];
@@ -50,6 +51,9 @@ export const TagsFilter: React.FunctionComponent<Props> = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.agentList.tagsFilterAriaLabel', {
+        defaultMessage: 'Tags filter',
+      })}
       ownFocus
       zIndex={Number(euiTheme.levels.header) - 1}
       button={

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -204,6 +204,9 @@ export const SearchAndFilterBar: React.FunctionComponent<SearchAndFilterBarProps
                 {hasAddOptions ? (
                   <EuiFlexItem grow={false}>
                     <EuiPopover
+                      aria-label={i18n.translate('xpack.fleet.agentList.addMenuAriaLabel', {
+                        defaultMessage: 'Add menu',
+                      })}
                       anchorPosition="downRight"
                       panelPaddingSize="none"
                       button={

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.tsx
@@ -116,6 +116,9 @@ export const TagOptions: React.FC<Props> = ({ tagName, isTagHovered, onTagsUpdat
       )}
       {tagOptionsVisible && (
         <EuiWrappingPopover
+          aria-label={i18n.translate('xpack.fleet.tagOptions.popoverAriaLabel', {
+            defaultMessage: 'Tag options',
+          })}
           isOpen={true}
           button={tagOptionsButton!}
           closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -203,6 +203,9 @@ export const TagsAddRemove: React.FC<Props> = ({
   return (
     <>
       <EuiWrappingPopover
+        aria-label={i18n.translate('xpack.fleet.tagsAddRemove.popoverAriaLabel', {
+          defaultMessage: 'Add / remove tags',
+        })}
         isOpen={isPopoverOpen}
         button={button!}
         closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/hierarchical_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/hierarchical_actions_menu.tsx
@@ -210,6 +210,9 @@ export const HierarchicalActionsMenu: React.FC<HierarchicalActionsMenuProps> = (
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.hierarchicalMenu.popoverAriaLabel', {
+        defaultMessage: 'Menu',
+      })}
       anchorPosition={anchorPosition}
       panelPaddingSize="none"
       button={buttonElement}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/components/header/deployment_details.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/components/header/deployment_details.tsx
@@ -47,6 +47,9 @@ export const DeploymentDetails = () => {
       docLinks={docLinks}
     >
       <EuiPopover
+        aria-label={i18n.translate('xpack.fleet.integrations.connectionDetailsPopoverAriaLabel', {
+          defaultMessage: 'Connection details',
+        })}
         isOpen={isOpen}
         closePopover={() => setIsOpen(false)}
         button={button}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 import { useLocalSearch, searchIdField } from '../../../../hooks';
 
@@ -277,6 +278,9 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
             {hiddenSubCategoriesItems?.length ? (
               <EuiFlexItem grow={false}>
                 <EuiPopover
+                  aria-label={i18n.translate('xpack.fleet.epmList.subcategoriesPopoverAriaLabel', {
+                    defaultMessage: 'More subcategories',
+                  })}
                   data-test-subj="epmList.showMoreSubCategoriesButton"
                   id="moreSubCategories"
                   button={

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/status_filter.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/status_filter.tsx
@@ -67,6 +67,9 @@ export const StatusFilter: React.FC<StatusFilterProps> = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.epm.statusFilter.ariaLabel', {
+        defaultMessage: 'Status filter',
+      })}
       id={popoverId}
       isOpen={isOpen}
       closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/create_new_integration.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/create_new_integration.tsx
@@ -55,6 +55,9 @@ export const CreateNewIntegrationButton: React.FC = () => {
       </EuiFlexItem>
       <EuiFlexItem grow={false} style={{ display: 'flex' }}>
         <EuiPopover
+          aria-label={i18n.translate('xpack.fleet.epmList.createNewIntegrationDropdownAriaLabel', {
+            defaultMessage: 'More integration creation options',
+          })}
           isOpen={isPopoverOpen}
           closePopover={() => setIsPopoverOpen(false)}
           panelPaddingSize="none"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_agents_cell.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_agents_cell.tsx
@@ -19,6 +19,7 @@ import {
   EuiFlexItem,
   EuiPopoverFooter,
   EuiButtonEmpty,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -155,6 +156,7 @@ export const AgentsCountBreakDown = ({
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const closePopover = () => setIsPopoverOpen(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const getKuery = (agentPolicyId: string) =>
     `${AGENTS_PREFIX}.policy_id : "${agentPolicyId}"${
@@ -172,6 +174,7 @@ export const AgentsCountBreakDown = ({
   return (
     <>
       <EuiPopover
+        aria-labelledby={popoverTitleId}
         data-test-subj="agentCountsPopover"
         isOpen={isPopoverOpen}
         closePopover={closePopover}
@@ -186,7 +189,7 @@ export const AgentsCountBreakDown = ({
           </EuiButtonEmpty>
         }
       >
-        <EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId}>
           {i18n.translate('xpack.fleet.agentsCountsBreakdown.popover.title', {
             defaultMessage: 'Agents breakdown',
           })}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installation_version_status.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installation_version_status.tsx
@@ -18,6 +18,7 @@ import {
   EuiLoadingSpinner,
 } from '@elastic/eui';
 import { FormattedDate, FormattedMessage, FormattedTime } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 import { useAuthz } from '../../../../../../../hooks';
 import type { InstallFailedAttempt } from '../../../../../../../../common/types';
@@ -205,7 +206,14 @@ const InstallUpgradeFailedVersionStatus: React.FunctionComponent<{
   const latestAttempt = item.installationInfo?.latest_install_failed_attempts?.[0];
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={() => setIsPopoverOpen(false)}>
+    <EuiPopover
+      aria-label={i18n.translate('xpack.fleet.epmInstalledIntegrations.statusPopoverAriaLabel', {
+        defaultMessage: 'Installation status details',
+      })}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={() => setIsPopoverOpen(false)}
+    >
       <EuiCallOut
         css={{ maxWidth: 400 }}
         color="danger"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installed_integration_action_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installed_integration_action_menu.tsx
@@ -14,6 +14,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 import type { InstalledPackageUIPackageListItem } from '../types';
 import { useInstalledIntegrationsActions } from '../hooks/use_installed_integrations_actions';
@@ -205,6 +206,10 @@ export const InstalledIntegrationsActionMenu: React.FunctionComponent<{
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate(
+          'xpack.fleet.epmInstalledIntegrations.bulkActionPopoverAriaLabel',
+          { defaultMessage: 'Actions menu' }
+        )}
         id="fleet.epmInstalledIntegrations.bulkActionPopover"
         button={button}
         isOpen={isPopoverOpen}

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.tsx
@@ -151,6 +151,7 @@ export const AgentlessEnrollmentFlyout = ({
       data-test-subj="agentlessEnrollmentFlyout"
       onClose={onClose}
       maxWidth={MAX_FLYOUT_WIDTH}
+      aria-labelledby="FleetAgentlessEnrollmentFlyoutTitle"
     >
       <EuiFlyoutHeader hasBorder aria-labelledby="FleetAgentlessEnrollmentFlyoutTitle">
         <EuiTitle size="m">

--- a/x-pack/platform/plugins/shared/fleet/public/components/context_menu_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/context_menu_actions.tsx
@@ -86,6 +86,9 @@ export const ContextMenuActions = React.memo<Props>(
 
     return (
       <EuiPopover
+        aria-label={i18n.translate('xpack.fleet.contextMenuActions.popoverAriaLabel', {
+          defaultMessage: 'Actions menu',
+        })}
         anchorPosition="downRight"
         panelPaddingSize="none"
         button={

--- a/x-pack/platform/plugins/shared/fleet/public/components/multiple_agent_policy_summary_line.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/multiple_agent_policy_summary_line.tsx
@@ -18,6 +18,7 @@ import {
   EuiLink,
   EuiIconTip,
   EuiText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { CSSProperties } from 'react';
@@ -42,6 +43,7 @@ export const MultipleAgentPoliciesSummaryLine = memo<{
   const { getHref } = useLink();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const closePopover = () => setIsPopoverOpen(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const [policiesModalEnabled, setPoliciesModalEnabled] = useState(false);
   const authz = useAuthz();
   const canManageAgentPolicies =
@@ -142,12 +144,13 @@ export const MultipleAgentPoliciesSummaryLine = memo<{
                       +{policies.length - 1}
                     </EuiBadge>
                     <EuiPopover
+                      aria-labelledby={popoverTitleId}
                       data-test-subj="agentPoliciesPopover"
                       isOpen={isPopoverOpen}
                       closePopover={closePopover}
                       anchorPosition="downCenter"
                     >
-                      <EuiPopoverTitle>
+                      <EuiPopoverTitle id={popoverTitleId}>
                         {i18n.translate('xpack.fleet.agentPolicySummaryLine.popover.title', {
                           defaultMessage: 'This integration is shared by',
                         })}

--- a/x-pack/platform/plugins/shared/fleet/public/components/platform_selector.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/platform_selector.tsx
@@ -162,6 +162,9 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
               </EuiFilterButton>
             ))}
             <EuiPopover
+              aria-label={i18n.translate('xpack.fleet.agentEnrollment.morePlatformsLabel', {
+                defaultMessage: 'More platforms',
+              })}
               button={
                 <EuiFilterButton
                   iconType="chevronSingleDown"

--- a/x-pack/platform/plugins/shared/fleet/public/components/uninstall_command_flyout/uninstall_command_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/uninstall_command_flyout/uninstall_command_flyout.tsx
@@ -15,6 +15,7 @@ import {
   EuiText,
   EuiTitle,
   useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -185,15 +186,18 @@ export const UninstallCommandFlyout: React.FunctionComponent<UninstallCommandFly
   onClose,
   target,
 }) => {
+  const flyoutTitleId = useGeneratedHtmlId();
+
   return (
     <EuiFlyout
       onClose={onClose}
       data-test-subj="uninstall-command-flyout"
       maxWidth={MAX_FLYOUT_WIDTH}
+      aria-labelledby={flyoutTitleId}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2>
+          <h2 id={flyoutTitleId}>
             <FormattedMessage
               id="xpack.fleet.agentUninstallCommandFlyout.title"
               defaultMessage="Uninstall agent"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Add accessible names to overlays for require-aria-label-for-modals (#274152)](https://github.com/elastic/kibana/pull/274152)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-22T11:12:05Z","message":"[Fleet] Add accessible names to overlays for require-aria-label-for-modals (#274152)\n\nCloses: https://github.com/elastic/kibana/issues/274150\n\nResolves the 28 `@elastic/eui/require-aria-label-for-modals` violations\nacross 24 Fleet files. Each flagged `EuiPopover`, `EuiWrappingPopover`,\nand `EuiFlyout` lacked a programmatic accessible name.\n\nFixes follow `.agents/skills/accessibility/SKILL.md` (overlays guide),\napplying the smallest change that fits the canonical pattern:\n\n- **Titleless filter/menu popovers** → localized `aria-label`:\n  ```tsx\n  <EuiPopover\n\naria-label={i18n.translate('xpack.fleet.agentLogs.datasetFilterAriaLabel',\n{\n      defaultMessage: 'Dataset filter',\n    })}\n    button={/* EuiFilterButton */}\n  >\n  ```\n- **Overlays with a visible title** → `useGeneratedHtmlId` +\n`aria-labelledby` wired to the title element\n(`package_policy_agents_cell`, `multiple_agent_policy_summary_line`,\n`uninstall_command_flyout`):\n  ```tsx\n  const popoverTitleId = useGeneratedHtmlId();\n  <EuiPopover aria-labelledby={popoverTitleId} ...>\n    <EuiPopoverTitle id={popoverTitleId}>{/* title */}</EuiPopoverTitle>\n  ```\n- **Flyouts with an existing title id** → reuse it via `aria-labelledby`\non `EuiFlyout` (`agentless_enrollment_flyout`;\n`fleet_server_instructions` also gets the missing `id` added to its\n`<h2>`, since the pre-existing reference was orphaned).\n- Added `import { i18n } from '@kbn/i18n'` where only `FormattedMessage`\nwas previously imported; reused the existing label key in\n`create_new_integration`.\n\nNew i18n keys are unique and namespaced; all assistive-tech strings are\nlocalized.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"f202a9c7129de6c27dff3e199211a059c5568464","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","Team:Fleet","backport:version","a11y:agent-pr","v9.5.0","v9.4.4"],"title":"[Fleet] Add accessible names to overlays for require-aria-label-for-modals","number":274152,"url":"https://github.com/elastic/kibana/pull/274152","mergeCommit":{"message":"[Fleet] Add accessible names to overlays for require-aria-label-for-modals (#274152)\n\nCloses: https://github.com/elastic/kibana/issues/274150\n\nResolves the 28 `@elastic/eui/require-aria-label-for-modals` violations\nacross 24 Fleet files. Each flagged `EuiPopover`, `EuiWrappingPopover`,\nand `EuiFlyout` lacked a programmatic accessible name.\n\nFixes follow `.agents/skills/accessibility/SKILL.md` (overlays guide),\napplying the smallest change that fits the canonical pattern:\n\n- **Titleless filter/menu popovers** → localized `aria-label`:\n  ```tsx\n  <EuiPopover\n\naria-label={i18n.translate('xpack.fleet.agentLogs.datasetFilterAriaLabel',\n{\n      defaultMessage: 'Dataset filter',\n    })}\n    button={/* EuiFilterButton */}\n  >\n  ```\n- **Overlays with a visible title** → `useGeneratedHtmlId` +\n`aria-labelledby` wired to the title element\n(`package_policy_agents_cell`, `multiple_agent_policy_summary_line`,\n`uninstall_command_flyout`):\n  ```tsx\n  const popoverTitleId = useGeneratedHtmlId();\n  <EuiPopover aria-labelledby={popoverTitleId} ...>\n    <EuiPopoverTitle id={popoverTitleId}>{/* title */}</EuiPopoverTitle>\n  ```\n- **Flyouts with an existing title id** → reuse it via `aria-labelledby`\non `EuiFlyout` (`agentless_enrollment_flyout`;\n`fleet_server_instructions` also gets the missing `id` added to its\n`<h2>`, since the pre-existing reference was orphaned).\n- Added `import { i18n } from '@kbn/i18n'` where only `FormattedMessage`\nwas previously imported; reused the existing label key in\n`create_new_integration`.\n\nNew i18n keys are unique and namespaced; all assistive-tech strings are\nlocalized.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"f202a9c7129de6c27dff3e199211a059c5568464"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274152","number":274152,"mergeCommit":{"message":"[Fleet] Add accessible names to overlays for require-aria-label-for-modals (#274152)\n\nCloses: https://github.com/elastic/kibana/issues/274150\n\nResolves the 28 `@elastic/eui/require-aria-label-for-modals` violations\nacross 24 Fleet files. Each flagged `EuiPopover`, `EuiWrappingPopover`,\nand `EuiFlyout` lacked a programmatic accessible name.\n\nFixes follow `.agents/skills/accessibility/SKILL.md` (overlays guide),\napplying the smallest change that fits the canonical pattern:\n\n- **Titleless filter/menu popovers** → localized `aria-label`:\n  ```tsx\n  <EuiPopover\n\naria-label={i18n.translate('xpack.fleet.agentLogs.datasetFilterAriaLabel',\n{\n      defaultMessage: 'Dataset filter',\n    })}\n    button={/* EuiFilterButton */}\n  >\n  ```\n- **Overlays with a visible title** → `useGeneratedHtmlId` +\n`aria-labelledby` wired to the title element\n(`package_policy_agents_cell`, `multiple_agent_policy_summary_line`,\n`uninstall_command_flyout`):\n  ```tsx\n  const popoverTitleId = useGeneratedHtmlId();\n  <EuiPopover aria-labelledby={popoverTitleId} ...>\n    <EuiPopoverTitle id={popoverTitleId}>{/* title */}</EuiPopoverTitle>\n  ```\n- **Flyouts with an existing title id** → reuse it via `aria-labelledby`\non `EuiFlyout` (`agentless_enrollment_flyout`;\n`fleet_server_instructions` also gets the missing `id` added to its\n`<h2>`, since the pre-existing reference was orphaned).\n- Added `import { i18n } from '@kbn/i18n'` where only `FormattedMessage`\nwas previously imported; reused the existing label key in\n`create_new_integration`.\n\nNew i18n keys are unique and namespaced; all assistive-tech strings are\nlocalized.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"f202a9c7129de6c27dff3e199211a059c5568464"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->