### PR TITLE
[Security Solution] Fix flaky test: replace userEvent with fireEvent in alert context menu test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { AlertContextMenu } from './alert_context_menu';
 import { TestProviders } from '../../../../common/mock';
@@ -384,7 +384,6 @@ describe('Alert table context menu', () => {
     });
 
     test('it shows the document workflow panel when run workflow action is clicked', async () => {
-      const user = userEvent.setup({ pointerEventsCheck: 0 });
       mockUseRunDocumentWorkflowPanel.mockReturnValue({
         runWorkflowMenuItem: mockDocumentWorkflowMenuItem,
         runDocumentWorkflowPanel: mockDocumentWorkflowPanel,
@@ -396,8 +395,8 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await user.click(wrapper.getByTestId(actionMenuButton));
-      await user.click(wrapper.getByTestId(runDocumentWorkflowActionButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(runDocumentWorkflowActionButton));
 
       await waitFor(() => {
         expect(wrapper.getByTestId(documentWorkflowPanelContent)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

### What
Replaces `userEvent.setup()` + `user.click()` with synchronous `fireEvent.click()` in the `alert_context_menu.test.tsx` test for the document workflow panel.

### Why
The test was intermittently exceeding Jest's 5000ms timeout. The `userEvent` API simulates full pointer-event dispatch (async, with pointer-events checks), which introduced enough overhead to tip the test over the timeout threshold in CI. Switching to `fireEvent.click()` makes the interactions synchronous and resolves the flakiness.

Fixes #272112

## Changes

- Replace `import { render, waitFor }` with `import { render, waitFor, fireEvent }` in `alert_context_menu.test.tsx`
- Remove `const user = userEvent.setup({ pointerEventsCheck: 0 })` setup
- Replace two `await user.click(...)` calls with synchronous `fireEvent.click(...)` calls

---

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — test-only change, no production code modified. Replacing async `userEvent` with synchronous `fireEvent` is a well-established pattern for eliminating timeout-induced flakiness in Jest tests. No user-facing behaviour is affected.

### Release note

> No user-facing changes.

**Suggested label:** `release_note:skip`