### PR TITLE
Fix service overview responsiveness

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/react';
 import type { EuiPageHeaderProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -24,6 +25,16 @@ import { getNoDataConfig } from '../no_data_config';
 
 // Paths that must skip the no data screen
 const bypassNoDataScreenPaths = ['/settings', '/diagnostics'];
+
+// The header tabs and search bar are rendered inside EuiPageHeader's left-side flex item,
+// whose default `min-width: auto` makes it grow to its content's width. When the tabs are
+// wider than the available space (e.g. narrowed by the solution nav), that item expands
+// past the viewport instead of letting EuiTabs scroll, hiding content under the right edge.
+// Size containment makes this wrapper's inline size independent of its content, so the
+// flex item stays within the available width and EuiTabs scrolls. See issue #273717.
+const headerContentStyles = css`
+  contain: inline-size;
+`;
 
 /*
  * This template contains:
@@ -138,7 +149,7 @@ export function ApmMainTemplate({
   const callerChildren = pageHeader?.children;
   const callerTabs = pageHeader?.tabs;
   const headerChildren = (
-    <>
+    <div css={headerContentStyles}>
       {callerChildren}
       {callerTabs && callerTabs.length > 0 && (
         <EuiTabs bottomBorder={false} size="m">
@@ -155,7 +166,7 @@ export function ApmMainTemplate({
           {searchBar}
         </>
       )}
-    </>
+    </div>
   );
 
   return (

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_main_template/index.tsx
@@ -26,12 +26,7 @@ import { getNoDataConfig } from '../no_data_config';
 // Paths that must skip the no data screen
 const bypassNoDataScreenPaths = ['/settings', '/diagnostics'];
 
-// The header tabs and search bar are rendered inside EuiPageHeader's left-side flex item,
-// whose default `min-width: auto` makes it grow to its content's width. When the tabs are
-// wider than the available space (e.g. narrowed by the solution nav), that item expands
-// past the viewport instead of letting EuiTabs scroll, hiding content under the right edge.
-// Size containment makes this wrapper's inline size independent of its content, so the
-// flex item stays within the available width and EuiTabs scrolls. See issue #273717.
+// Garantee's responsiveness of the header content
 const headerContentStyles = css`
   contain: inline-size;
 `;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/273717

## Summary

- Make service overview header responsive


### Before and After

| Before | After |
|--------|--------|
| <img width="1264" height="957" alt="Before" src="https://github.com/user-attachments/assets/9decf915-f719-46d3-ae3e-83b5fab44826" /> | <img width="1261" height="952" alt="After" src="https://github.com/user-attachments/assets/8d394bce-5a04-49a6-bb7c-e74bf0155440" /> | 


