### PR TITLE
[Cases] Add sort dropdown to redesigned list view

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
@@ -156,6 +156,13 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       [deselectCases, setViewMode]
     );
 
+    const onSortOrderChange = useCallback(
+      (sortOrder: 'asc' | 'desc') => {
+        setQueryParams({ ...queryParams, sortField: SortFieldCase.createdAt, sortOrder });
+      },
+      [queryParams, setQueryParams]
+    );
+
     const { columns, isLoadingColumns, rowHeader } = useCasesColumns({
       filterStatus: filterOptions.status ?? [],
       userProfiles: userProfiles ?? new Map(),
@@ -244,6 +251,8 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           onSelectedColumnsChange={setSelectedColumns}
           listFields={selectedFields}
           onListFieldsChange={setSelectedFields}
+          sortOrder={queryParams.sortOrder}
+          onSortOrderChange={onSortOrderChange}
         />
         {!isSelectorView ? (
           <div

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/all_cases_list.tsx
@@ -158,9 +158,9 @@ export const AllCasesList = React.memo<AllCasesListProps>(
 
     const onSortOrderChange = useCallback(
       (sortOrder: 'asc' | 'desc') => {
-        setQueryParams({ ...queryParams, sortField: SortFieldCase.createdAt, sortOrder });
+        setQueryParams({ sortField: SortFieldCase.createdAt, sortOrder });
       },
-      [queryParams, setQueryParams]
+      [setQueryParams]
     );
 
     const { columns, isLoadingColumns, rowHeader } = useCasesColumns({

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/sort_filter.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/sort_filter.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithTestingProviders } from '../../../../common/mock';
+import { SortFilter } from './sort_filter';
+
+describe('SortFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a select with newest first and oldest first options', () => {
+    renderWithTestingProviders(<SortFilter sortOrder="desc" onChange={jest.fn()} />);
+
+    const select = screen.getByTestId('cases-list-sort-select');
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue('desc');
+  });
+
+  it('displays "Newest first" when sortOrder is desc', () => {
+    renderWithTestingProviders(<SortFilter sortOrder="desc" onChange={jest.fn()} />);
+
+    const select = screen.getByTestId('cases-list-sort-select');
+    expect(select).toHaveValue('desc');
+  });
+
+  it('displays "Oldest first" when sortOrder is asc', () => {
+    renderWithTestingProviders(<SortFilter sortOrder="asc" onChange={jest.fn()} />);
+
+    const select = screen.getByTestId('cases-list-sort-select');
+    expect(select).toHaveValue('asc');
+  });
+
+  it('calls onChange with "asc" when selecting oldest first', async () => {
+    const onChange = jest.fn();
+    renderWithTestingProviders(<SortFilter sortOrder="desc" onChange={onChange} />);
+
+    await userEvent.selectOptions(screen.getByTestId('cases-list-sort-select'), 'asc');
+
+    expect(onChange).toHaveBeenCalledWith('asc');
+  });
+
+  it('calls onChange with "desc" when selecting newest first', async () => {
+    const onChange = jest.fn();
+    renderWithTestingProviders(<SortFilter sortOrder="asc" onChange={onChange} />);
+
+    await userEvent.selectOptions(screen.getByTestId('cases-list-sort-select'), 'desc');
+
+    expect(onChange).toHaveBeenCalledWith('desc');
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/sort_filter.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/sort_filter.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiSelect } from '@elastic/eui';
+import * as i18n from '../translations';
+
+type SortOrder = 'asc' | 'desc';
+
+interface SortFilterProps {
+  sortOrder: SortOrder;
+  onChange: (sortOrder: SortOrder) => void;
+}
+
+const options = [
+  { value: 'desc', text: i18n.SORT_NEWEST_FIRST },
+  { value: 'asc', text: i18n.SORT_OLDEST_FIRST },
+];
+
+export const SortFilter: React.FC<SortFilterProps> = ({ sortOrder, onChange }) => {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onChange(e.target.value as SortOrder);
+    },
+    [onChange]
+  );
+
+  return (
+    <EuiSelect
+      data-test-subj="cases-list-sort-select"
+      options={options}
+      value={sortOrder}
+      onChange={handleChange}
+    />
+  );
+};
+
+SortFilter.displayName = 'SortFilter';

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.test.tsx
@@ -54,6 +54,8 @@ const props: CasesTableFiltersProps = {
   onSelectedColumnsChange: jest.fn(),
   listFields: [],
   onListFieldsChange: jest.fn(),
+  sortOrder: 'desc',
+  onSortOrderChange: jest.fn(),
 };
 
 describe('CasesTableFilters ', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/table_filters.tsx
@@ -26,6 +26,7 @@ import { TableSearch } from '../../../all_cases/search';
 import { DateRangeFilter } from '../../../all_cases/date_range_filter';
 import type { CasesColumnSelection } from '../types';
 import { ColumnsPopover } from './columns_popover';
+import { SortFilter } from './sort_filter';
 
 export interface CasesTableFiltersProps {
   countClosedCases: number | null;
@@ -46,6 +47,8 @@ export interface CasesTableFiltersProps {
   onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
   listFields: CasesColumnSelection[];
   onListFieldsChange: (fields: CasesColumnSelection[]) => void;
+  sortOrder: 'asc' | 'desc';
+  onSortOrderChange: (sortOrder: 'asc' | 'desc') => void;
 }
 
 const mergeCustomizer = (objValue: string | string[], srcValue: string | string[], key: string) => {
@@ -73,6 +76,8 @@ const CasesTableFiltersComponent = ({
   onSelectedColumnsChange,
   listFields,
   onListFieldsChange,
+  sortOrder,
+  onSortOrderChange,
 }: CasesTableFiltersProps) => {
   const { data: tags = [], isLoading: isLoadingTags } = useGetTags();
   const { data: categories = [], isLoading: isLoadingCategories } = useGetCategories();
@@ -178,6 +183,11 @@ const CasesTableFiltersComponent = ({
           )}
         </EuiFilterGroup>
       </EuiFlexItem>
+      {viewMode !== VIEW_TOGGLE_TABLE_ID && (
+        <EuiFlexItem grow={false}>
+          <SortFilter sortOrder={sortOrder} onChange={onSortOrderChange} />
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow={false}>
         {viewMode === VIEW_TOGGLE_TABLE_ID ? (
           <ColumnsPopover

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/translations.ts
@@ -82,6 +82,20 @@ export const LIST_FIELD_EVENTS = (count: number) =>
     defaultMessage: '{count} {count, plural, one {event} other {events}}',
   });
 
+export const SORT_NEWEST_FIRST = i18n.translate(
+  'xpack.cases.casesRedesign.tableFilters.newestFirst',
+  {
+    defaultMessage: 'Newest first',
+  }
+);
+
+export const SORT_OLDEST_FIRST = i18n.translate(
+  'xpack.cases.casesRedesign.tableFilters.oldestFirst',
+  {
+    defaultMessage: 'Oldest first',
+  }
+);
+
 export const SHOWING_CASES = (totalRules: number, pageSize: number) =>
   i18n.translate('xpack.cases.casesRedesign.caseTable.showingCasesTitle', {
     values: { totalRules, pageSize },


### PR DESCRIPTION
## What & Why
Adds a "Newest first" / "Oldest first" sort dropdown to the cases redesign list view so users can control sort order without relying on table column headers (which aren't available in the non-table view mode). The dropdown is only shown in list view mode, not the table view.
<img width="1654" height="751" alt="image" src="https://github.com/user-attachments/assets/53842e2f-87a8-4ffb-a585-e3c8e9a01971" />

## How to Test
1. Enable the cases redesign feature flag and navigate to the all cases page.
2. Switch to the **list view** mode — verify a sort dropdown appears in the filters bar with "Newest first" selected by default.
3. Change the selection to "Oldest first" and confirm the case list re-sorts by ascending creation date.
4. Switch to the **table view** mode — verify the sort dropdown is hidden (table headers handle sorting).

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)