### PR TITLE
[Fleet] Skip knowledge base re-indexing when already current for package version

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
@@ -14,6 +14,7 @@ import type { InstallContext } from '../_state_machine_package_install';
 
 import { stepSaveKnowledgeBase, cleanupKnowledgeBaseStep } from './step_save_knowledge_base';
 import { getIntegrationKnowledgeSetting } from '../../get_integration_knowledge_setting';
+import { getPackageKnowledgeBase } from '../../get';
 
 // Mock the app context service
 jest.mock('../../../../app_context', () => ({
@@ -49,6 +50,10 @@ jest.mock('../../../../license', () => ({
 
 jest.mock('../../get_integration_knowledge_setting', () => ({
   getIntegrationKnowledgeSetting: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../get', () => ({
+  getPackageKnowledgeBase: jest.fn().mockResolvedValue(undefined),
 }));
 
 let esClient: jest.Mocked<ElasticsearchClient>;
@@ -386,7 +391,12 @@ describe('stepSaveKnowledgeBase', () => {
       });
     });
 
-    it('should use saveKnowledgeBaseContentToIndex for reinstalls of same version', async () => {
+    it('should skip saveKnowledgeBaseContentToIndex when knowledge base already indexed for same version', async () => {
+      (getPackageKnowledgeBase as jest.Mock).mockResolvedValueOnce({
+        package: { name: 'test-package' },
+        items: [{ fileName: 'guide.md', content: '# Guide', version: '1.0.0' }],
+      });
+
       const entries: ArchiveEntry[] = [
         {
           path: 'test-package-1.0.0/docs/knowledge_base/guide.md',
@@ -397,13 +407,26 @@ describe('stepSaveKnowledgeBase', () => {
       const mockArchiveIterator = createMockArchiveIterator(entries);
       const context = createMockContext(mockArchiveIterator);
 
-      // Mock existing installed package with same version
-      context.installedPkg = {
-        attributes: {
-          name: 'test-package',
-          version: '1.0.0', // Same version as new package
+      await stepSaveKnowledgeBase(context);
+
+      expect(saveKnowledgeBaseContentToIndex).not.toHaveBeenCalled();
+    });
+
+    it('should re-index when knowledge base exists but is at an older version', async () => {
+      (getPackageKnowledgeBase as jest.Mock).mockResolvedValueOnce({
+        package: { name: 'test-package' },
+        items: [{ fileName: 'guide.md', content: '# Guide', version: '0.9.0' }],
+      });
+
+      const entries: ArchiveEntry[] = [
+        {
+          path: 'test-package-1.0.0/docs/knowledge_base/guide.md',
+          buffer: Buffer.from('# Guide', 'utf8'),
         },
-      } as any;
+      ];
+
+      const mockArchiveIterator = createMockArchiveIterator(entries);
+      const context = createMockContext(mockArchiveIterator);
 
       await stepSaveKnowledgeBase(context);
 
@@ -411,12 +434,7 @@ describe('stepSaveKnowledgeBase', () => {
         esClient,
         pkgName: 'test-package',
         pkgVersion: '1.0.0',
-        knowledgeBaseContent: [
-          {
-            fileName: 'guide.md',
-            content: '# Guide',
-          },
-        ],
+        knowledgeBaseContent: [{ fileName: 'guide.md', content: '# Guide' }],
       });
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
@@ -16,6 +16,7 @@ import {
   saveKnowledgeBaseContentToIndex,
   deletePackageKnowledgeBase,
 } from '../../knowledge_base_index';
+import { getPackageKnowledgeBase } from '../../get';
 import type { InstallContext } from '../_state_machine_package_install';
 import { INSTALL_STATES } from '../../../../../../common/types';
 import { withPackageSpan } from '../../utils';
@@ -106,6 +107,17 @@ export async function stepSaveKnowledgeBase(
   // You can adjust the license requirement as needed (e.g., isGoldPlus(), isPlatinum(), isEnterprise())
   if (!licenseService.isEnterprise()) {
     logger.debug(`Knowledge base step: Skipping knowledge base save - requires Enterprise license`);
+    return { esReferences };
+  }
+
+  const existing = await getPackageKnowledgeBase({ esClient, pkgName: packageInfo.name });
+  if (
+    existing?.items.length &&
+    existing.items.every((item) => item.version === packageInfo.version)
+  ) {
+    logger.debug(
+      `Knowledge base already indexed for ${packageInfo.name}@${packageInfo.version}, skipping`
+    );
     return { esReferences };
   }
 


### PR DESCRIPTION
## Summary

Backport of #274370 to `deploy-fix@1782109360`.

When a Fleet global asset (e.g. `FLEET_FINAL_PIPELINE_VERSION`) is bumped, all installed packages are reinstalled via `runReinstallPackagesForGlobalAssetUpdate`. `stepSaveKnowledgeBase` was unconditionally writing to `.integration_knowledge` on every reinstall, triggering ELSER inference on old Serverless projects where `semantic_text` was hardcoded to ELSER on EIS — causing unexpected ML node costs (~$7.50 per project per pipeline version bump).

This was last triggered by #274005 (bumped `FLEET_FINAL_PIPELINE_VERSION` 4 → 5 on 2026-06-19).

## Changes

Add a version-check guard in `stepSaveKnowledgeBase`: if the knowledge base is already indexed for the current package version, skip the re-index and return early.

Closes elastic/ingest-dev#8478

🤖 Generated with [Claude Code](https://claude.com/claude-code)