### PR TITLE
[Chrome Next] Add 's' app-header padding option and clarify bleed semantics

### DIFF
--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -62,16 +62,20 @@ is no size knob to set.
 
 ## Padding
 
-`padding` controls the header's **horizontal** layout only. Vertical padding is standardized
-internally (independent of the `padding` prop and the title size) so the header keeps a consistent
-height — 48px for a single row, regardless of title size or whether only a back button is present.
+`padding` controls the header's **outer** spacing. The scalar values only add symmetric horizontal
+padding; the `bleed` variant additionally breaks the header out of a surrounding padded container.
+The header's **internal vertical padding** is standardized regardless of this prop (and of the title
+size), so the header keeps a consistent height — 48px for a single row, whether or not only a back
+button is present.
 
 - `'none'` — no horizontal padding, no bleed.
+- `'s'` — symmetric horizontal padding (compact).
 - `'m'` — symmetric horizontal padding (default for inline headers).
-- `{ bleed: 'm' | 'l' }` — negative margin on left/right + top, cancelling a padded container so the
-  header spans to its edges and sits flush at the top; content is auto re-inset to stay aligned with
-  the page gutter. Set `bleed` to your container's padding when rendering inline inside a padded page
-  template.
+- `{ bleed: 'm' | 'l' }` — for a header rendered inline inside a padded section (e.g. an
+  `EuiPageSection`). Set `bleed` to the section's **symmetric** padding: the header breaks out to that
+  section's top/left/right edges via negative margin so it spans full width and sits flush at the top,
+  and its content is auto re-inset by the same amount to stay aligned with the page gutter. (The
+  single value applies to both the sides and the top because the section's padding is symmetric.)
 
 ## Chrome Next flag and runtime checks
 

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.stories.tsx
@@ -26,7 +26,7 @@ import { AppHeaderView } from './app_header';
 interface ComposedHeaderStoryProps {
   title: string;
   editable: boolean;
-  padding: 'none' | 'm' | 'bleed-l';
+  padding: 'none' | 's' | 'm' | 'bleed-l';
   width: number;
   showBack: boolean;
   showTabs: boolean;
@@ -152,7 +152,7 @@ const meta: Meta<ComposedHeaderStoryProps> = {
   argTypes: {
     padding: {
       control: 'inline-radio',
-      options: ['none', 'm', 'bleed-l'],
+      options: ['none', 's', 'm', 'bleed-l'],
       description: "Horizontal padding. `bleed-l` cancels a padded container (`{ bleed: 'l' }`).",
     },
   },

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
@@ -30,9 +30,10 @@ export interface AppHeaderShellProps {
   padding?: AppHeaderPadding;
 }
 
-// Resolves the horizontal-only padding contract. Vertical padding is standardized internally
+// Resolves the outer spacing contract: horizontal padding for the scalar values, and the breakout
+// margin for the `bleed` variant. The header's internal vertical padding is standardized separately
 // (see `useHeaderStyles`) so the header keeps a consistent height regardless of this prop.
-const resolveHorizontalPadding = (
+const resolvePadding = (
   sticky: boolean,
   padding: AppHeaderPadding | undefined,
   euiTheme: ReturnType<typeof useEuiTheme>['euiTheme']
@@ -43,12 +44,13 @@ const resolveHorizontalPadding = (
     return { paddingInline: undefined, bleedMargin: undefined };
   }
 
-  if (resolved === 'm') {
-    return { paddingInline: euiTheme.size.m, bleedMargin: undefined };
+  if (resolved === 's' || resolved === 'm') {
+    return { paddingInline: euiTheme.size[resolved], bleedMargin: undefined };
   }
 
-  // `{ bleed }`: pull the header out to its padded container's edges (negative margin) and
-  // re-inset the content by the same amount so it stays aligned with the page gutter.
+  // `{ bleed }`: pull the header out to its padded container's top/left/right edges (negative margin)
+  // and re-inset the content by the same amount so it stays aligned with the page gutter. The value
+  // mirrors the container's symmetric padding, so it applies equally to the sides and the top.
   const value = resolved.bleed === 'l' ? euiTheme.size.l : euiTheme.size.m;
   return { paddingInline: value, bleedMargin: value };
 };
@@ -63,7 +65,7 @@ const useHeaderStyles = (
   const { euiTheme } = useEuiTheme();
 
   return useMemo(() => {
-    const { paddingInline, bleedMargin } = resolveHorizontalPadding(sticky, padding, euiTheme);
+    const { paddingInline, bleedMargin } = resolvePadding(sticky, padding, euiTheme);
 
     // Vertical padding is internal (independent of the `padding` prop). The primary row floors at a
     // consistent 48px regardless of title size; content is centered within it.

--- a/src/core/packages/chrome/app-header/src/types.ts
+++ b/src/core/packages/chrome/app-header/src/types.ts
@@ -38,17 +38,21 @@ export type AppHeaderTab = CoreAppHeaderTab;
 export type AppHeaderTitle = CoreAppHeaderTitle;
 export type AppHeaderTitleSaveResult = CoreAppHeaderTitleSaveResult;
 
-// Controls the header's HORIZONTAL layout only. Vertical padding is standardized internally so
-// the header keeps a consistent height regardless of this value.
+// Controls the header's outer spacing. The scalar values (`'none' | 's' | 'm'`) only add symmetric
+// horizontal padding; the `bleed` variant additionally breaks the header out of a surrounding
+// padded container (see below). The header's INTERNAL vertical padding is standardized regardless of
+// this value, so the header keeps a consistent height.
 export type AppHeaderPadding =
   | 'none' // no horizontal padding, no bleed
+  | 's' // symmetric horizontal padding (compact)
   | 'm' // symmetric horizontal padding
   | {
       /**
-       * Negative margin on left/right + top: cancels a padded container so the header spans to
-       * its edges and sits flush at the top. Set this to your container's padding when rendering
-       * the header inline inside a padded page template. Content is auto re-inset to match, so it
-       * stays aligned with the page gutter.
+       * Set this to the SYMMETRIC padding of the surrounding section (e.g. an `EuiPageSection`'s
+       * `paddingSize`). The header breaks out to that section's top/left/right edges via negative
+       * margin so it spans full width and sits flush at the top, and its content is auto re-inset by
+       * the same amount to stay aligned with the page gutter. The header's internal vertical padding
+       * is unaffected.
        */
       bleed: 'm' | 'l';
     };


### PR DESCRIPTION
## Summary

Small follow-up to the app-header padding work.

- **New `'s'` padding option**: `AppHeaderPadding` now accepts `'s'` (8px compact symmetric horizontal padding) alongside `'m'` - needed for discover to align horizontally with the content https://github.com/elastic/kibana/pull/273664
- **Clarified `bleed` semantics (no behavior change)**: `bleed` was commented as "horizontal only", but it also breaks the header out of its container's **top** edge so it sits flush. The type docs, README, and the resolve helper name now describe it accurately — set `bleed` to the surrounding section's *symmetric* padding (e.g. an `EuiPageSection`'s `paddingSize`); the header breaks out to that section's top/left/right edges and re-insets its content to the gutter, while the header's internal vertical padding stays standardized.