### PR TITLE
[9.3] Fix FIPS Pipeline - Leave OSS enabled (#273776)

### DIFF
--- a/src/core/test-helpers/kbn-server/src/create_root.ts
+++ b/src/core/test-helpers/kbn-server/src/create_root.ts
@@ -82,11 +82,34 @@ export function createRootWithSettings(
    * Most of these integration tests expect OSS to default to true, but FIPS
    * requires the security plugin to be enabled
    */
-  let oss = true;
+  const oss = true;
   if (getFips() === 1) {
     set(settings, 'xpack.security.fipsMode.enabled', true);
-    oss = false;
-    delete cliArgs.oss;
+    // Keep oss=true to avoid loading all xpack plugins on startup — heavy plugins like
+    // streams, fleet, and reporting do significant ES initialization that exhausts the
+    // test cluster. Instead, inject only the minimal set of xpack plugins required for
+    // FIPS security compliance, including the full requiredBundles transitive closure for
+    // the security plugin (spaces, remoteClusters, indexManagement, runtimeFields).
+    const existingPaths = Array.isArray(settings?.plugins?.paths)
+      ? (settings.plugins.paths as string[])
+      : [];
+    set(settings, 'plugins.paths', [
+      ...existingPaths,
+      join(REPO_ROOT, 'x-pack/platform/plugins/shared/licensing'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/shared/features'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/shared/task_manager'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/shared/security'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/shared/spaces'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/private/remote_clusters'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/shared/index_management'),
+      join(REPO_ROOT, 'x-pack/platform/plugins/private/runtime_fields'),
+    ]);
+    if (cliArgs.serverless) {
+      // spaces config keys use schema.literal(false) with no defaultValue in serverless
+      // mode; set them explicitly since the spaces plugin is now loaded via plugins.paths.
+      set(settings, 'xpack.spaces.allowFeatureVisibility', false);
+      set(settings, 'xpack.spaces.allowSolutionVisibility', false);
+    }
   }
 
   const env = Env.createDefault(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix FIPS Pipeline - Leave OSS enabled (#273776)](https://github.com/elastic/kibana/pull/273776)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryan","email":"ryan.godfrey@elastic.co"},"sourceCommit":{"committedDate":"2026-06-22T15:29:44Z","message":"Fix FIPS Pipeline - Leave OSS enabled (#273776)\n\nFixes: \n- https://github.com/elastic/kibana/issues/204302\n- https://github.com/elastic/kibana/issues/240653\n\n## Summary\n\nThis FIPS pipeline needs to enable the security plugin in order to run\ntests with FIPS enabled. This PR changes the way tests enable security\nwhen the `oss` flag is provided by leaving the `oss` flag set to true\nand adding on only the required plugins to run with FIPS enabled.","sha":"3e49ec9b206854bd59cbcf91608c7645475785fa","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","Feature:FIPS","ci:enable-fips-140-3-agent","v9.5.0"],"title":"Fix FIPS Pipeline - Leave OSS enabled","number":273776,"url":"https://github.com/elastic/kibana/pull/273776","mergeCommit":{"message":"Fix FIPS Pipeline - Leave OSS enabled (#273776)\n\nFixes: \n- https://github.com/elastic/kibana/issues/204302\n- https://github.com/elastic/kibana/issues/240653\n\n## Summary\n\nThis FIPS pipeline needs to enable the security plugin in order to run\ntests with FIPS enabled. This PR changes the way tests enable security\nwhen the `oss` flag is provided by leaving the `oss` flag set to true\nand adding on only the required plugins to run with FIPS enabled.","sha":"3e49ec9b206854bd59cbcf91608c7645475785fa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273776","number":273776,"mergeCommit":{"message":"Fix FIPS Pipeline - Leave OSS enabled (#273776)\n\nFixes: \n- https://github.com/elastic/kibana/issues/204302\n- https://github.com/elastic/kibana/issues/240653\n\n## Summary\n\nThis FIPS pipeline needs to enable the security plugin in order to run\ntests with FIPS enabled. This PR changes the way tests enable security\nwhen the `oss` flag is provided by leaving the `oss` flag set to true\nand adding on only the required plugins to run with FIPS enabled.","sha":"3e49ec9b206854bd59cbcf91608c7645475785fa"}},{"url":"https://github.com/elastic/kibana/pull/274401","number":274401,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->