### PR TITLE
[Alerting V2] Deduplicate shared fields across rule form modes

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.tsx
@@ -17,6 +17,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { useWatch } from 'react-hook-form';
 import type { ComposeDiscoverAction, ComposeDiscoverState, StepDefinition } from './types';
+import { isAlertConditionStepId } from './types';
 import type { ComposeFormValues } from './compose_form_types';
 
 const CREATE_RULE_BUTTON_LABEL = i18n.translate(
@@ -91,8 +92,7 @@ export const ComposeDiscoverFooter = ({
   const isAlert = useWatch<ComposeFormValues, 'kind'>({ name: 'kind' }) === 'alert';
   const watchedQuery = useWatch<ComposeFormValues, 'query'>({ name: 'query' });
 
-  const isConditionStep =
-    currentStep?.id === 'alertCondition' || currentStep?.id === 'builderCondition';
+  const isConditionStep = currentStep ? isAlertConditionStepId(currentStep.id) : false;
 
   const missingBreachQuery =
     currentStep?.id === 'alertCondition' &&

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
@@ -6,9 +6,8 @@
  */
 
 import React from 'react';
-import { useForm, FormProvider, useFormContext } from 'react-hook-form';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClientProvider } from '@kbn/react-query';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { createTestQueryClient, createMockServices } from '../../../test_utils';
@@ -27,13 +26,6 @@ jest.mock('@kbn/code-editor', () => ({
 jest.mock('@kbn/esql-utils', () => ({
   getEsqlColumns: jest.fn(async () => []),
 }));
-
-let getFormValues: (() => ComposeFormValues) | undefined;
-
-const CaptureFormGetValues = () => {
-  getFormValues = useFormContext<ComposeFormValues>().getValues;
-  return null;
-};
 
 const BASE_QUERY = 'FROM logs-*';
 const ALERT_BLOCK = '| WHERE count > 100';
@@ -95,37 +87,30 @@ const createComposeFormWrapper = (
 interface RenderOptions {
   isEditing?: boolean;
   formValueOverrides?: Partial<ComposeFormValues>;
-  captureForm?: boolean;
 }
 
 const renderStep = (
   stateOverrides: Partial<ComposeDiscoverState> = {},
-  { isEditing = false, formValueOverrides = {}, captureForm = false }: RenderOptions = {}
+  { isEditing = false, formValueOverrides = {} }: RenderOptions = {}
 ) => {
-  if (!captureForm) getFormValues = undefined;
   const state = createState({
     queryCommitted: true,
     ...stateOverrides,
   });
   const dispatch = jest.fn();
-  const onKindChange = jest.fn();
   const services = createMockServices();
 
   render(
-    <>
-      {captureForm && <CaptureFormGetValues />}
-      <AlertConditionStep
-        state={state}
-        dispatch={dispatch}
-        services={services}
-        onKindChange={onKindChange}
-        isEditing={isEditing}
-      />
-    </>,
+    <AlertConditionStep
+      state={state}
+      dispatch={dispatch}
+      services={services}
+      isEditing={isEditing}
+    />,
     { wrapper: createComposeFormWrapper(formValueOverrides, services) }
   );
 
-  return { dispatch, state, onKindChange };
+  return { dispatch, state };
 };
 
 const STANDALONE_QUERY: RuleQuery = {
@@ -312,185 +297,6 @@ describe('AlertConditionStep', () => {
       renderStep({ queryCommitted: true });
 
       expect(screen.getByTestId('composeDiscoverGroupFields')).toBeInTheDocument();
-    });
-  });
-
-  describe('mode select', () => {
-    it('is enabled when queryCommitted is true and not editing', () => {
-      renderStep({ queryCommitted: true }, { isEditing: false });
-
-      expect(screen.getByTestId('composeDiscoverModeSelect')).not.toBeDisabled();
-    });
-
-    it('is disabled when editing an existing rule', () => {
-      renderStep({ queryCommitted: true }, { isEditing: true });
-
-      expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
-    });
-
-    it('is disabled when query is not committed', () => {
-      renderStep({ queryCommitted: false }, { isEditing: false });
-
-      expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
-    });
-
-    it('shows Alert when kind is alert', () => {
-      renderStep({ queryCommitted: true }, { formValueOverrides: { kind: 'alert' } });
-
-      expect(screen.getByTestId('composeDiscoverModeSelect')).toHaveTextContent('Alert');
-    });
-
-    it('shows Signal when kind is signal', () => {
-      renderStep(
-        { queryCommitted: true },
-        { formValueOverrides: { kind: 'signal', query: STANDALONE_QUERY } }
-      );
-
-      expect(screen.getByTestId('composeDiscoverModeSelect')).toHaveTextContent('Signal');
-    });
-
-    it('calls onKindChange when Signal is selected', async () => {
-      const user = userEvent.setup({ pointerEventsCheck: 0 });
-      const { onKindChange } = renderStep(
-        { queryCommitted: true },
-        { formValueOverrides: { kind: 'alert' } }
-      );
-
-      await user.click(screen.getByTestId('composeDiscoverModeSelect'));
-      await user.click(screen.getByRole('option', { name: /Signal/ }));
-
-      expect(onKindChange).toHaveBeenCalledWith('signal');
-    });
-  });
-
-  describe('schedule and lookback', () => {
-    it('renders schedule and lookback fields', () => {
-      renderStep({ queryCommitted: true });
-
-      expect(screen.getByText('Schedule')).toBeInTheDocument();
-      expect(screen.getByText('Lookback Window')).toBeInTheDocument();
-    });
-  });
-
-  describe('alert delay', () => {
-    it('renders AlertDelayField when tracking is enabled', () => {
-      renderStep({}, { formValueOverrides: { kind: 'alert' } });
-
-      expect(screen.getByTestId('alertDelayFormRow')).toBeTruthy();
-    });
-
-    it('does not render AlertDelayField when tracking is disabled', () => {
-      renderStep(
-        {},
-        {
-          formValueOverrides: {
-            kind: 'signal',
-            query: { format: 'standalone', breach: { query: `${BASE_QUERY}\n${ALERT_BLOCK}` } },
-          },
-        }
-      );
-
-      expect(screen.queryByTestId('alertDelayFormRow')).toBeNull();
-    });
-
-    it('defaults to Immediate mode', () => {
-      renderStep(
-        {},
-        { formValueOverrides: { kind: 'alert', stateTransitionAlertDelayMode: 'immediate' } }
-      );
-
-      expect(screen.getByTestId('stateTransitionImmediateDescription').textContent).toContain(
-        'No delay - Alerts on first breach'
-      );
-    });
-
-    it('renders Breaches controls when alert delay mode is breaches', () => {
-      renderStep(
-        {},
-        {
-          formValueOverrides: {
-            stateTransitionAlertDelayMode: 'breaches',
-            stateTransition: { pendingCount: 5 },
-          },
-        }
-      );
-
-      expect(screen.getByTestId('stateTransitionCountInput')).toBeTruthy();
-    });
-
-    it('renders Duration controls when alert delay mode is duration', () => {
-      renderStep(
-        {},
-        {
-          formValueOverrides: {
-            stateTransitionAlertDelayMode: 'duration',
-            stateTransition: { pendingTimeframe: '10m' },
-          },
-        }
-      );
-
-      expect(screen.getByTestId('stateTransitionTimeframeNumberInput')).toBeTruthy();
-    });
-
-    it('switches between Immediate, Breaches, Duration, and back to Immediate', () => {
-      renderStep({}, { formValueOverrides: { stateTransitionAlertDelayMode: 'immediate' } });
-
-      const alertRow = screen.getByTestId('alertDelayFormRow');
-      fireEvent.click(within(alertRow).getByText('Breaches'));
-      expect(screen.getByTestId('stateTransitionCountInput')).toBeTruthy();
-
-      fireEvent.click(within(alertRow).getByText('Duration'));
-      expect(screen.getByTestId('stateTransitionTimeframeNumberInput')).toBeTruthy();
-
-      fireEvent.click(within(alertRow).getByText('Immediate'));
-      expect(screen.getByTestId('stateTransitionImmediateDescription')).toBeTruthy();
-      expect(screen.queryByTestId('stateTransitionCountInput')).toBeNull();
-      expect(screen.queryByTestId('stateTransitionTimeframeNumberInput')).toBeNull();
-    });
-
-    it('clears pending fields without affecting recovery fields when switching to Immediate', () => {
-      renderStep(
-        {},
-        {
-          captureForm: true,
-          formValueOverrides: {
-            stateTransitionAlertDelayMode: 'breaches',
-            stateTransitionRecoveryDelayMode: 'recoveries',
-            stateTransition: {
-              pendingCount: 2,
-              pendingTimeframe: null,
-              recoveringCount: 3,
-              recoveringTimeframe: null,
-            },
-          },
-        }
-      );
-
-      fireEvent.click(within(screen.getByTestId('alertDelayFormRow')).getByText('Immediate'));
-
-      const values = getFormValues!();
-      expect(values.stateTransition?.pendingCount).toBeNull();
-      expect(values.stateTransition?.pendingTimeframe).toBeNull();
-      expect(values.stateTransition?.recoveringCount).toBe(3);
-    });
-
-    it('uses default count when switching from immediate with pendingCount: 0 to breaches', () => {
-      renderStep(
-        {},
-        {
-          captureForm: true,
-          formValueOverrides: {
-            stateTransitionAlertDelayMode: 'immediate',
-            stateTransition: { pendingCount: 0 },
-          },
-        }
-      );
-
-      fireEvent.click(within(screen.getByTestId('alertDelayFormRow')).getByText('Breaches'));
-
-      const values = getFormValues!();
-      expect(values.stateTransitionAlertDelayMode).toBe('breaches');
-      expect(values.stateTransition?.pendingCount).toBe(2);
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
@@ -27,10 +27,6 @@ import type { ComposeDiscoverAction, ComposeDiscoverState } from '../types';
 import type { ComposeFormValues } from '../compose_form_types';
 import { QuerySummary } from '../query_summary';
 import type { RuleFormServices } from '../../../form/contexts/rule_form_context';
-import { ScheduleField } from '../../../form/fields/schedule_field';
-import { LookbackWindowField } from '../../../form/fields/lookback_window_field';
-import { AlertDelayField } from '../../../form/fields/alert_delay_field';
-import { ModeSelect } from '../../../form/fields/mode_select';
 import { useComposeDiscoverTimeField } from '../compose_discover_time_field_context';
 import { getTimeFieldResolutionQuery } from '../get_time_field_resolution_query';
 
@@ -38,7 +34,6 @@ interface AlertConditionStepProps {
   state: ComposeDiscoverState;
   dispatch: React.Dispatch<ComposeDiscoverAction>;
   services: RuleFormServices;
-  onKindChange: (kind: 'signal' | 'alert') => void;
   isEditing: boolean;
 }
 
@@ -46,7 +41,6 @@ export function AlertConditionStep({
   state,
   dispatch,
   services,
-  onKindChange,
   isEditing,
 }: AlertConditionStepProps) {
   const { setValue, watch } = useFormContext<ComposeFormValues>();
@@ -128,14 +122,6 @@ export function AlertConditionStep({
 
   return (
     <>
-      <ModeSelect
-        value={isAlert ? 'alert' : 'signal'}
-        onChange={onKindChange}
-        disabled={!state.queryCommitted || isEditing}
-        compressed
-        data-test-subj="composeDiscoverModeSelect"
-      />
-      <EuiSpacer size="m" />
       <EuiTitle size="xs">
         <h3>
           <FormattedMessage
@@ -326,19 +312,6 @@ export function AlertConditionStep({
           data-test-subj="composeDiscoverGroupFields"
         />
       </EuiFormRow>
-
-      {isAlert && (
-        <>
-          <EuiSpacer size="m" />
-          <AlertDelayField />
-        </>
-      )}
-
-      {/* Schedule and lookback -- connected to RHF via useFormContext() internally */}
-      <EuiSpacer size="m" />
-      <ScheduleField />
-      <EuiSpacer size="m" />
-      <LookbackWindowField />
     </>
   );
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -20,6 +20,19 @@ import type { ComposeFormValues } from '../compose_form_types';
 import type { ComposeDiscoverState } from '../types';
 import { createInitialState } from '../use_compose_discover_state';
 
+jest.mock('./alert_condition_step', () => ({
+  AlertConditionStep: () => <div data-test-subj="mockAlertConditionStep" />,
+}));
+
+jest.mock('../compose_discover_time_field_context', () => ({
+  useComposeDiscoverTimeField: () => ({
+    timeFieldOptions: [{ value: '@timestamp', text: '@timestamp' }],
+    isTimeFieldResolved: true,
+  }),
+  ComposeDiscoverTimeFieldContextProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
 const createState = (overrides: Partial<ComposeDiscoverState> = {}): ComposeDiscoverState => ({
   ...createInitialState({ mode: 'create' }),
   ...overrides,
@@ -283,5 +296,62 @@ describe('step validation', () => {
       'details',
       'notifications',
     ]);
+  });
+});
+
+describe('shell shared fields', () => {
+  const renderShell = (
+    stateOverrides: Partial<ComposeDiscoverState> = {},
+    formOverrides: Partial<ComposeFormValues> = {}
+  ) => {
+    const services = { ...createMockServices(), dashboard: mockDashboard };
+    return render(
+      <ComposeDiscoverForm
+        state={createState({ queryCommitted: true, ...stateOverrides })}
+        dispatch={jest.fn()}
+        services={services}
+        onRecoveryTypeChange={jest.fn()}
+        onKindChange={jest.fn()}
+        isEditing={false}
+      />,
+      { wrapper: createComposeFormWrapper({ ...BASE_COMPOSE_VALUES, ...formOverrides }, services) }
+    );
+  };
+
+  it('renders ModeSelect, AlertDelayField, ScheduleField, and LookbackWindowField on alert condition step', () => {
+    renderShell({ step: 0 }, { kind: 'alert' });
+
+    expect(screen.getByTestId('composeDiscoverModeSelect')).toBeInTheDocument();
+    expect(screen.getByTestId('alertDelayFormRow')).toBeInTheDocument();
+    expect(screen.getByText('Schedule')).toBeInTheDocument();
+    expect(screen.getByText('Lookback Window')).toBeInTheDocument();
+  });
+
+  it('does not render AlertDelayField when kind is signal', () => {
+    renderShell(
+      { step: 0 },
+      { kind: 'signal', query: { format: 'standalone', breach: { query: 'FROM logs-*' } } }
+    );
+
+    expect(screen.getByTestId('composeDiscoverModeSelect')).toBeInTheDocument();
+    expect(screen.queryByTestId('alertDelayFormRow')).not.toBeInTheDocument();
+    expect(screen.getByText('Schedule')).toBeInTheDocument();
+    expect(screen.getByText('Lookback Window')).toBeInTheDocument();
+  });
+
+  it('does not render shared fields on non-alert-condition steps', () => {
+    // step 2 = 'details' when isAlert=true (alertCondition -> recoveryCondition -> details)
+    renderShell({ step: 2 });
+
+    expect(screen.queryByTestId('composeDiscoverModeSelect')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('alertDelayFormRow')).not.toBeInTheDocument();
+    expect(screen.queryByText('Schedule')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lookback Window')).not.toBeInTheDocument();
+  });
+
+  it('disables ModeSelect when query is not committed', () => {
+    renderShell({ step: 0, queryCommitted: false });
+
+    expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -200,7 +200,7 @@ export const ComposeDiscoverForm = ({
       <ModeSelect
         value={isAlert ? 'alert' : 'signal'}
         onChange={onKindChange}
-        disabled={!state.queryCommitted || isEditing}
+        disabled={(!builderType && !state.queryCommitted) || isEditing}
         compressed
         data-test-subj="composeDiscoverModeSelect"
       />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useWatch } from 'react-hook-form';
 import { EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
@@ -16,14 +16,20 @@ import type {
   StepDefinition,
   StepRenderProps,
 } from '../types';
+import { isAlertConditionStepId } from '../types';
 import { getStepIds, getBuilderStepIds } from '../use_compose_discover_state';
 import type { ComposeFormValues } from '../compose_form_types';
 import { getBreachQuery } from '../compose_form_types';
 import type { RuleFormServices } from '../../../form/contexts/rule_form_context';
 import { RULE_BUILDER_REGISTRY } from '../rule_builder';
 import { isActionValid } from '../../../actions_form';
+import { ModeSelect } from '../../../form/fields/mode_select';
+import { AlertDelayField } from '../../../form/fields/alert_delay_field';
+import { ScheduleField } from '../../../form/fields/schedule_field';
+import { LookbackWindowField } from '../../../form/fields/lookback_window_field';
 import { AlertConditionStep } from './alert_condition_step';
 import { RecoveryConditionStep } from './recovery_condition_step';
+import { EsqlRecoveryContent } from './esql_recovery_content';
 import { DetailsAndArtifactsStep } from './details_and_artifacts_step';
 import { NotificationsStep } from './notifications_step';
 import { LinkedActionPoliciesStep } from './linked_action_policies_step';
@@ -51,7 +57,6 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
         state={props.state}
         dispatch={props.dispatch}
         services={props.services}
-        onKindChange={props.onKindChange}
         isEditing={props.isEditing}
       />
     ),
@@ -85,7 +90,7 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
         state={props.state}
         dispatch={props.dispatch}
         onRecoveryTypeChange={props.onRecoveryTypeChange}
-        renderBuilderRecovery={props.renderBuilderRecovery}
+        renderCustomRecovery={props.renderCustomRecovery}
       />
     ),
   },
@@ -125,7 +130,7 @@ const STEP_REGISTRY: Record<StepDefinition['id'], StepDefinition> = {
 
 interface ResolvedSteps {
   steps: StepDefinition[];
-  renderBuilderRecovery?: StepRenderProps['renderBuilderRecovery'];
+  renderCustomRecovery?: StepRenderProps['renderCustomRecovery'];
 }
 
 export const getSteps = (isAlert: boolean, builderType?: string): ResolvedSteps => {
@@ -153,7 +158,9 @@ export const getSteps = (isAlert: boolean, builderType?: string): ResolvedSteps 
     return base;
   });
 
-  return { steps, renderBuilderRecovery: definition?.renderRecoveryStep };
+  const renderCustomRecovery = definition?.renderRecoveryStep ?? EsqlRecoveryContent;
+
+  return { steps, renderCustomRecovery };
 };
 
 export const ComposeDiscoverForm = ({
@@ -167,16 +174,48 @@ export const ComposeDiscoverForm = ({
   builderType,
 }: Props) => {
   const isAlert = useWatch<ComposeFormValues, 'kind'>({ name: 'kind' }) === 'alert';
-  const { steps, renderBuilderRecovery } = getSteps(isAlert, builderType);
+  const { steps, renderCustomRecovery } = useMemo(
+    () => getSteps(isAlert, builderType),
+    [isAlert, builderType]
+  );
+  const currentStep = steps[state.step];
+  const isAlertConditionStep = isAlertConditionStepId(currentStep.id);
 
-  return steps[state.step].render({
+  const stepContent = currentStep.render({
     state,
     dispatch,
     services,
     onRecoveryTypeChange,
-    onKindChange,
     isEditing,
     ruleId,
-    renderBuilderRecovery,
+    renderCustomRecovery,
   });
+
+  if (!isAlertConditionStep) {
+    return stepContent;
+  }
+
+  return (
+    <>
+      <ModeSelect
+        value={isAlert ? 'alert' : 'signal'}
+        onChange={onKindChange}
+        disabled={!state.queryCommitted || isEditing}
+        compressed
+        data-test-subj="composeDiscoverModeSelect"
+      />
+      <EuiSpacer size="m" />
+      {stepContent}
+      {isAlert && (
+        <>
+          <EuiSpacer size="m" />
+          <AlertDelayField />
+        </>
+      )}
+      <EuiSpacer size="m" />
+      <ScheduleField />
+      <EuiSpacer size="m" />
+      <LookbackWindowField />
+    </>
+  );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_recovery_content.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/esql_recovery_content.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useWatch } from 'react-hook-form';
+import { EuiBadge, EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { CustomRecoveryRenderProps } from '../types';
+import type { ComposeFormValues } from '../compose_form_types';
+import { QuerySummary } from '../query_summary';
+
+export const EsqlRecoveryContent: React.FC<CustomRecoveryRenderProps> = ({ state, dispatch }) => {
+  const query = useWatch<ComposeFormValues, 'query'>({ name: 'query' });
+  const baseQuery = query?.format === 'composed' ? query.base : '';
+  const recoveryBlock = query?.format === 'composed' ? query.recovery?.segment ?? '' : '';
+  const hasValidRecoveryBlock = Boolean(recoveryBlock.trim());
+
+  return (
+    <>
+      <EuiText size="xs" color="subdued">
+        <strong>
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.recoveryCondition.baseQueryLabel"
+            defaultMessage="Base query"
+          />
+        </strong>
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <QuerySummary
+        query={baseQuery}
+        emptyMessage={i18n.translate(
+          'xpack.alertingV2.composeDiscover.recoveryCondition.noBaseQueryDefined',
+          { defaultMessage: 'No base query defined' }
+        )}
+      />
+      <EuiSpacer size="m" />
+      <EuiText size="xs" color="subdued">
+        <strong>
+          <FormattedMessage
+            id="xpack.alertingV2.composeDiscover.recoveryCondition.recoveryConditionLabel"
+            defaultMessage="Recovery condition"
+          />
+        </strong>
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <QuerySummary
+        query={recoveryBlock}
+        emptyMessage={i18n.translate(
+          'xpack.alertingV2.composeDiscover.recoveryCondition.noRecoveryConditionDefined',
+          { defaultMessage: 'No recovery condition defined' }
+        )}
+      />
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            size="s"
+            iconType="editorCodeBlock"
+            isDisabled={state.childOpen}
+            onClick={() =>
+              dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert: true })
+            }
+            data-test-subj="composeDiscoverEditRecovery"
+          >
+            <FormattedMessage
+              id="xpack.alertingV2.composeDiscover.recoveryCondition.editRecoveryButtonLabel"
+              defaultMessage="Edit recovery query"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+        {hasValidRecoveryBlock && (
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="success">
+              <FormattedMessage
+                id="xpack.alertingV2.composeDiscover.recoveryCondition.customConditionSetBadgeLabel"
+                defaultMessage="Custom condition set"
+              />
+            </EuiBadge>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.test.tsx
@@ -16,6 +16,7 @@ import { createInitialState } from '../use_compose_discover_state';
 import type { ComposeDiscoverState } from '../types';
 import type { ComposeFormValues, RuleQuery } from '../compose_form_types';
 import { RecoveryConditionStep } from './recovery_condition_step';
+import { EsqlRecoveryContent } from './esql_recovery_content';
 
 jest.mock('@kbn/code-editor', () => ({
   ...jest.requireActual('@kbn/code-editor'),
@@ -99,6 +100,7 @@ const renderRecoveryStep = (
       state={state}
       dispatch={dispatch}
       onRecoveryTypeChange={onRecoveryTypeChange}
+      renderCustomRecovery={EsqlRecoveryContent}
     />,
     { wrapper: createComposeFormWrapper(queryOverride, services) }
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/recovery_condition_step.tsx
@@ -6,24 +6,14 @@
  */
 
 import React from 'react';
-import { useWatch } from 'react-hook-form';
-import {
-  EuiBadge,
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiHorizontalRule,
-  EuiSpacer,
-  EuiSuperSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFormRow, EuiHorizontalRule, EuiSpacer, EuiSuperSelect, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
-import type { ComposeDiscoverAction, ComposeDiscoverState, RecoveryType } from '../types';
-import type { RuleBuilderRecoveryProps } from '../rule_builder/types';
-import type { ComposeFormValues } from '../compose_form_types';
-import { QuerySummary } from '../query_summary';
+import type {
+  ComposeDiscoverAction,
+  ComposeDiscoverState,
+  CustomRecoveryRenderProps,
+  RecoveryType,
+} from '../types';
 import { RecoveryDelayField } from '../../../form/fields/recovery_delay_field';
 
 const defaultRecoveryLabel = i18n.translate(
@@ -107,22 +97,15 @@ interface RecoveryConditionStepProps {
   state: ComposeDiscoverState;
   dispatch: React.Dispatch<ComposeDiscoverAction>;
   onRecoveryTypeChange: (type: RecoveryType) => void;
-  renderBuilderRecovery?: (props: RuleBuilderRecoveryProps) => React.ReactNode;
+  renderCustomRecovery?: (props: CustomRecoveryRenderProps) => React.ReactNode;
 }
 
 export function RecoveryConditionStep({
   state,
   dispatch,
   onRecoveryTypeChange,
-  renderBuilderRecovery,
+  renderCustomRecovery,
 }: RecoveryConditionStepProps) {
-  const query = useWatch<ComposeFormValues, 'query'>({ name: 'query' });
-  const baseQuery = query?.format === 'composed' ? query.base : '';
-  const recoveryBlock = query?.format === 'composed' ? query.recovery?.segment ?? '' : '';
-
-  const isBuilderMode = Boolean(renderBuilderRecovery);
-  const hasValidRecoveryBlock = Boolean(recoveryBlock.trim());
-
   return (
     <>
       <RecoveryTypeSelector
@@ -130,83 +113,12 @@ export function RecoveryConditionStep({
         onRecoveryTypeChange={onRecoveryTypeChange}
       />
 
-      {state.recoveryType === 'custom' && (
+      {state.recoveryType === 'custom' && renderCustomRecovery && (
         <>
           <EuiSpacer size="l" />
           <EuiHorizontalRule margin="none" />
           <EuiSpacer size="m" />
-
-          {isBuilderMode ? (
-            renderBuilderRecovery!({
-              state,
-              dispatch,
-            })
-          ) : (
-            <>
-              <EuiText size="xs" color="subdued">
-                <strong>
-                  <FormattedMessage
-                    id="xpack.alertingV2.composeDiscover.recoveryCondition.baseQueryLabel"
-                    defaultMessage="Base query"
-                  />
-                </strong>
-              </EuiText>
-              <EuiSpacer size="xs" />
-              <QuerySummary
-                query={baseQuery}
-                emptyMessage={i18n.translate(
-                  'xpack.alertingV2.composeDiscover.recoveryCondition.noBaseQueryDefined',
-                  { defaultMessage: 'No base query defined' }
-                )}
-              />
-              <EuiSpacer size="m" />
-              <EuiText size="xs" color="subdued">
-                <strong>
-                  <FormattedMessage
-                    id="xpack.alertingV2.composeDiscover.recoveryCondition.recoveryConditionLabel"
-                    defaultMessage="Recovery condition"
-                  />
-                </strong>
-              </EuiText>
-              <EuiSpacer size="xs" />
-              <QuerySummary
-                query={recoveryBlock}
-                emptyMessage={i18n.translate(
-                  'xpack.alertingV2.composeDiscover.recoveryCondition.noRecoveryConditionDefined',
-                  { defaultMessage: 'No recovery condition defined' }
-                )}
-              />
-              <EuiSpacer size="s" />
-              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    size="s"
-                    iconType="editorCodeBlock"
-                    isDisabled={state.childOpen}
-                    onClick={() =>
-                      dispatch({ type: 'OPEN_CHILD_FOR_STEP', step: state.step, isAlert: true })
-                    }
-                    data-test-subj="composeDiscoverEditRecovery"
-                  >
-                    <FormattedMessage
-                      id="xpack.alertingV2.composeDiscover.recoveryCondition.editRecoveryButtonLabel"
-                      defaultMessage="Edit recovery query"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
-                {hasValidRecoveryBlock && (
-                  <EuiFlexItem grow={false}>
-                    <EuiBadge color="success">
-                      <FormattedMessage
-                        id="xpack.alertingV2.composeDiscover.recoveryCondition.customConditionSetBadgeLabel"
-                        defaultMessage="Custom condition set"
-                      />
-                    </EuiBadge>
-                  </EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            </>
-          )}
+          {renderCustomRecovery({ state, dispatch })}
         </>
       )}
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/index.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-export type {
-  RuleBuilderDefinition,
-  RuleBuilderStepProps,
-  RuleBuilderRecoveryProps,
-  BuilderState,
-} from './types';
+export type { RuleBuilderDefinition, RuleBuilderStepProps, BuilderState } from './types';
 export { RULE_BUILDER_REGISTRY } from './registry';
 export { BuilderStateProvider, useBuilderState } from './builder_state_context';
 export { RuleBuilderAlertConditionStep } from './threshold/alert_condition_step';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { QueryClientProvider } from '@kbn/react-query';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
@@ -92,49 +92,6 @@ const Wrapper: React.FC<{
       </QueryClientProvider>
     </IntlProvider>
   );
-};
-
-const renderStep = ({
-  builderState = makeBuilderState(),
-  stateOverrides = {},
-  formValueOverrides = {},
-}: {
-  builderState?: ThresholdFormValues;
-  stateOverrides?: Partial<ComposeDiscoverState>;
-  formValueOverrides?: Partial<ComposeFormValues>;
-} = {}) => {
-  const state = createState(stateOverrides);
-  const dispatch = jest.fn();
-  const services = createMockServices();
-  const setBuilderState = jest.fn();
-  const queryClient = createTestQueryClient();
-  const defaultValues: ComposeFormValues = { ...BASE_COMPOSE_VALUES, ...formValueOverrides };
-
-  const StepWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const form = useForm<ComposeFormValues>({ defaultValues });
-    return (
-      <IntlProvider locale="en">
-        <QueryClientProvider client={queryClient}>
-          <FormProvider {...form}>
-            <RuleFormProvider services={services} meta={{ layout: 'flyout' }}>
-              <BuilderStateProvider
-                builderState={builderState}
-                setBuilderState={setBuilderState as (s: unknown) => void}
-              >
-                {children}
-              </BuilderStateProvider>
-            </RuleFormProvider>
-          </FormProvider>
-        </QueryClientProvider>
-      </IntlProvider>
-    );
-  };
-
-  render(<RuleBuilderAlertConditionStep state={state} dispatch={dispatch} services={services} />, {
-    wrapper: StepWrapper,
-  });
-
-  return { dispatch, services, setBuilderState };
 };
 
 describe('RuleBuilderAlertConditionStep', () => {
@@ -289,50 +246,5 @@ describe('RuleBuilderAlertConditionStep', () => {
     );
 
     expect(screen.getByText('Field is required.')).toBeInTheDocument();
-  });
-});
-
-describe('RuleBuilderAlertConditionStep - alert delay', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('renders AlertDelayField when kind is alert', () => {
-    renderStep({ formValueOverrides: { kind: 'alert' } });
-
-    expect(screen.getByTestId('alertDelayFormRow')).toBeTruthy();
-  });
-
-  it('does not render AlertDelayField when kind is signal', () => {
-    renderStep({
-      formValueOverrides: {
-        kind: 'signal',
-        query: { format: 'standalone', breach: { query: 'FROM logs-* | WHERE count > 100' } },
-      },
-    });
-
-    expect(screen.queryByTestId('alertDelayFormRow')).toBeNull();
-  });
-
-  it('defaults to Immediate mode', () => {
-    renderStep({ formValueOverrides: { stateTransitionAlertDelayMode: 'immediate' } });
-
-    const alertRow = screen.getByTestId('alertDelayFormRow');
-    expect(within(alertRow).getByTestId('stateTransitionImmediateDescription')).toBeTruthy();
-  });
-
-  it('switches between Immediate, Breaches, and Duration modes', () => {
-    renderStep({ formValueOverrides: { stateTransitionAlertDelayMode: 'immediate' } });
-
-    const alertRow = screen.getByTestId('alertDelayFormRow');
-
-    fireEvent.click(within(alertRow).getByText('Breaches'));
-    expect(screen.getByTestId('stateTransitionCountInput')).toBeTruthy();
-
-    fireEvent.click(within(alertRow).getByText('Duration'));
-    expect(screen.getByTestId('stateTransitionTimeframeNumberInput')).toBeTruthy();
-
-    fireEvent.click(within(alertRow).getByText('Immediate'));
-    expect(screen.getByTestId('stateTransitionImmediateDescription')).toBeTruthy();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -30,10 +30,6 @@ import {
 import type { ComposeFormValues } from '../../compose_form_types';
 import { useDataFields } from '../../../../form/hooks/use_data_fields';
 import { useIndexSources } from '../../../../form/hooks/use_index_sources';
-import { ScheduleField } from '../../../../form/fields/schedule_field';
-import { LookbackWindowField } from '../../../../form/fields/lookback_window_field';
-import { AlertDelayField } from '../../../../form/fields/alert_delay_field';
-import { ModeSelect } from '../../../../form/fields/mode_select';
 import type { RuleBuilderStepProps } from '../types';
 import { useBuilderState } from '../builder_state_context';
 import type {
@@ -344,23 +340,8 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
     [thresholdValues, onThresholdValuesChange]
   );
 
-  const handleModeChange = useCallback(
-    (kind: 'signal' | 'alert') => {
-      setValue('kind', kind);
-    },
-    [setValue]
-  );
-
   return (
     <>
-      {/* ── Mode select ── */}
-      <ModeSelect
-        value={isAlert ? 'alert' : 'signal'}
-        onChange={handleModeChange}
-        compressed
-        data-test-subj="ruleBuilderModeSelect"
-      />
-      <EuiSpacer size="m" />
       {/* ── Header with preview icon ── */}
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
@@ -918,19 +899,6 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
           defaultMessage="Add condition"
         />
       </EuiButtonEmpty>
-
-      {isAlert && (
-        <>
-          <EuiSpacer size="m" />
-          <AlertDelayField />
-        </>
-      )}
-
-      {/* ── Schedule and lookback ── */}
-      <EuiSpacer size="m" />
-      <ScheduleField />
-      <EuiSpacer size="m" />
-      <LookbackWindowField />
     </>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/recovery_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/recovery_condition_step.tsx
@@ -24,7 +24,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ComposeFormValues } from '../../compose_form_types';
-import type { RuleBuilderRecoveryProps } from '../types';
+import type { CustomRecoveryRenderProps } from '../../types';
 import { useBuilderState } from '../builder_state_context';
 import type { ThresholdFormValues, RecoveryCondition, RecoveryConfig } from './form_types';
 import {
@@ -36,7 +36,7 @@ import {
 import { COMPARATOR_OPTIONS, CONDITION_OPERATOR_OPTIONS } from './translations';
 import { buildRecoveryBlock } from './build_esql';
 
-export const BuilderRecoveryForm: React.FC<RuleBuilderRecoveryProps> = ({ state, dispatch }) => {
+export const BuilderRecoveryForm: React.FC<CustomRecoveryRenderProps> = ({ state, dispatch }) => {
   const { state: builderState, setState: onBuilderStateChange } =
     useBuilderState<ThresholdFormValues>();
   const { setValue, getValues } = useFormContext<ComposeFormValues>();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/types.ts
@@ -6,7 +6,11 @@
  */
 
 import type React from 'react';
-import type { ComposeDiscoverState, ComposeDiscoverAction } from '../types';
+import type {
+  ComposeDiscoverAction,
+  ComposeDiscoverState,
+  CustomRecoveryRenderProps,
+} from '../types';
 import type { RuleFormServices } from '../../../form/contexts/rule_form_context';
 
 export type BuilderState = unknown;
@@ -17,17 +21,12 @@ export interface RuleBuilderStepProps {
   services: RuleFormServices;
 }
 
-export interface RuleBuilderRecoveryProps {
-  state: ComposeDiscoverState;
-  dispatch: React.Dispatch<ComposeDiscoverAction>;
-}
-
 export interface RuleBuilderDefinition<TState = BuilderState> {
   type: string;
   stepTitle: string;
   createDefaultState: () => TState;
   renderStep: (props: RuleBuilderStepProps) => React.ReactNode;
-  renderRecoveryStep?: (props: RuleBuilderRecoveryProps) => React.ReactNode;
+  renderRecoveryStep?: (props: CustomRecoveryRenderProps) => React.ReactNode;
   validate?: (state: ComposeDiscoverState, builderState?: TState) => boolean;
   parseState?: (query: string, recoveryQuery?: string) => TState | null;
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
@@ -9,7 +9,7 @@ import type React from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { RuleFormServices } from '../../form/contexts/rule_form_context';
 import type { ComposeFormValues } from './compose_form_types';
-import type { BuilderState, RuleBuilderRecoveryProps } from './rule_builder/types';
+import type { BuilderState } from './rule_builder/types';
 
 export type ComposeDiscoverMode = 'create' | 'edit' | 'clone';
 
@@ -24,15 +24,22 @@ export type StepId =
   | 'details'
   | 'notifications';
 
+export const isAlertConditionStepId = (id: StepId): boolean =>
+  id === 'alertCondition' || id === 'builderCondition';
+
+export interface CustomRecoveryRenderProps {
+  state: ComposeDiscoverState;
+  dispatch: React.Dispatch<ComposeDiscoverAction>;
+}
+
 export interface StepRenderProps {
   state: ComposeDiscoverState;
   dispatch: React.Dispatch<ComposeDiscoverAction>;
   services: RuleFormServices;
   onRecoveryTypeChange: (type: RecoveryType) => void;
-  onKindChange: (kind: 'signal' | 'alert') => void;
   isEditing: boolean;
   ruleId?: string;
-  renderBuilderRecovery?: (props: RuleBuilderRecoveryProps) => React.ReactNode;
+  renderCustomRecovery?: (props: CustomRecoveryRenderProps) => React.ReactNode;
 }
 
 export interface StepDefinition {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
@@ -69,10 +69,10 @@ describe('createInitialState', () => {
     expect(withSignal.recoveryType).toBe('default');
   });
 
-  it('keeps the query preview closed in builder create mode', () => {
+  it('opens the query preview in builder create mode', () => {
     const state = createInitialState({ mode: 'create', isBuilderMode: true });
 
-    expect(state.childOpen).toBe(false);
+    expect(state.childOpen).toBe(true);
     expect(state.queryCommitted).toBe(false);
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
@@ -50,7 +50,7 @@ export const createInitialState = ({
     activeTab: defaultTabForTabs(
       getSandboxTabs(initialKind === 'alert', { step: 0, recoveryType })
     ),
-    childOpen: mode === 'create' && !isBuilderMode,
+    childOpen: mode === 'create',
     queryCommitted: mode === 'edit' || isQueryPrePopulated,
     yamlMode: false,
   };


### PR DESCRIPTION
## Summary

- Move shared alert condition fields (ModeSelect, AlertDelayField, ScheduleField, LookbackWindowField) out of individual ES|QL and Rule Builder step components so they are rendered once, automatically, for any alert condition step.
- Make custom recovery content pluggable so new builder types get shared UI for free without manual wiring.

## Test plan

- [x] All 813 existing tests pass (0 failures)
- [x] Added tests verifying shared fields render on alert condition steps and are absent on other steps
- [x] Verified signal mode correctly hides AlertDelayField
- [x] Verified ModeSelect disabled state when query is not committed