### PR TITLE
[Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -61,7 +61,7 @@ import {
   TIMELINE_CONTEXT_MENU_BTN,
   TOOLTIP,
 } from '../screens/alerts';
-import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
+import { REFRESH_BUTTON } from '../screens/security_header';
 import {
   ENRICHMENT_QUERY_END_INPUT,
   ENRICHMENT_QUERY_RANGE_PICKER,
@@ -457,7 +457,6 @@ export const waitForAlerts = () => {
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
-  cy.get(LOADING_INDICATOR).should('not.exist');
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {


### PR DESCRIPTION
## Summary

### What
Removes `cy.get(LOADING_INDICATOR).should('not.exist')` from the shared `waitForAlerts()` Cypress helper and drops the now-unused `LOADING_INDICATOR` import.

### Why
`LOADING_INDICATOR` maps to `[data-test-subj="globalLoadingIndicator"]` — the chrome-level EUI spinner driven by `http.getLoadingCount$()`. It fires for *any* in-flight HTTP request app-wide (telemetry, capabilities, session pings), not just the alerts search. `waitForAlertsToPopulate()` calls `refreshPage()` in a retry loop, which piles up unrelated network requests and keeps the spinner mounted indefinitely. The 150 s timeout was exhausted before those chrome requests settled.

The four preceding checks already guarantee the alerts table is fully settled:
- `waitForPageFilters()` — page filter controls ready
- `cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500)` — alerts search idle
- `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')` — datagrid not updating
- `cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist')` — table not loading

The global spinner check was redundant and harmful.

Fixes #272791
Fixes #274536
Fixes #274543
Fixes #274544
Fixes #274608
Fixes #274616

## Changes

- `cypress/tasks/alerts.ts`: removed `cy.get(LOADING_INDICATOR).should('not.exist')` from `waitForAlerts()` and dropped the `LOADING_INDICATOR` named import (still exported from `screens/security_header.ts` and used by other task files)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

**Low risk — test helper only.** No production code touched. The removed assertion was redundant (already covered by the preceding four checks). The only failure mode is if the alerts table could be unsettled after all four preceding guards pass, which is not possible given they include a network-idle wait on the alerts search endpoint itself. The change makes existing tests more reliable; it does not loosen any business-logic assertion.

### Release note

> No user-facing changes — test helper fix only.

**Suggested label:** `release_note:skip`

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->