### PR TITLE
feat(agent_context_layer): add tags to SML upsert + list filter

### DIFF
--- a/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
@@ -92,6 +92,7 @@ export interface SmlHttpItem {
   created_at: string;
   updated_at: string;
   spaces: string[];
+  tags: string[];
   /**
    * Permissions required to access the underlying element. Always
    * present; inner arrays may be empty.

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
@@ -40,7 +40,7 @@ const MAX_SML_CONTENT_LENGTH = 50_000;
 const MAX_SML_REFERENCES = 100;
 const MAX_SML_PERMISSIONS = 100;
 const MAX_SML_TAGS = 100;
-const MAX_SML_TAG_LENGTH = 200;
+const MAX_SML_TAG_LENGTH = 100;
 
 const ChunkSchema = z.object({
   type: z
@@ -75,10 +75,20 @@ const ChunkSchema = z.object({
     .optional()
     .describe('Optional Kibana privilege strings required to view the chunk later.'),
   tags: z
-    .array(z.string().max(MAX_SML_TAG_LENGTH))
+    .array(
+      z
+        .string()
+        .max(MAX_SML_TAG_LENGTH)
+        .regex(
+          /^[a-z0-9][a-z0-9_-]*$/,
+          'Tag must be lowercase alphanumeric and may contain hyphens or underscores (e.g. "otel", "my-tag", "v2_data").'
+        )
+    )
     .max(MAX_SML_TAGS)
     .optional()
-    .describe('Optional tags for grouping and retrieval (e.g. ["otel", "claude-code"]).'),
+    .describe(
+      'Optional tags for grouping and retrieval. Must be lowercase alphanumeric; hyphens and underscores are allowed (e.g. ["otel", "my-tag"]). Tags are matched with OR semantics on the list endpoint.'
+    ),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
@@ -39,6 +39,8 @@ const MAX_SML_DESCRIPTION_LENGTH = 8192;
 const MAX_SML_CONTENT_LENGTH = 50_000;
 const MAX_SML_REFERENCES = 100;
 const MAX_SML_PERMISSIONS = 100;
+const MAX_SML_TAGS = 100;
+const MAX_SML_TAG_LENGTH = 200;
 
 const ChunkSchema = z.object({
   type: z
@@ -72,6 +74,11 @@ const ChunkSchema = z.object({
     .max(MAX_SML_PERMISSIONS)
     .optional()
     .describe('Optional Kibana privilege strings required to view the chunk later.'),
+  tags: z
+    .array(z.string().max(MAX_SML_TAG_LENGTH))
+    .max(MAX_SML_TAGS)
+    .optional()
+    .describe('Optional tags for grouping and retrieval (e.g. ["otel", "claude-code"]).'),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/common.ts
@@ -21,6 +21,7 @@ export const toSmlHttpItem = (doc: SmlDocument): SmlHttpItem => ({
   created_at: doc.created_at,
   updated_at: doc.updated_at,
   spaces: doc.spaces,
+  tags: doc.tags ?? [],
   permissions: doc.permissions,
   ingestion_method: doc.ingestion_method,
 });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/list.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/list.test.ts
@@ -103,6 +103,22 @@ describe('registerListRoute', () => {
     });
   });
 
+  it('passes tags filter to sml.listDocuments when provided (comma-delimited)', async () => {
+    mockSmlService.listDocuments.mockResolvedValue({ total: 0, results: [] });
+    await callHandler({ page: 1, per_page: 20, tags: 'otel,claude-code' });
+    expect(mockSmlService.listDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ['otel', 'claude-code'] })
+    );
+  });
+
+  it('omits tags from sml.listDocuments when not provided', async () => {
+    mockSmlService.listDocuments.mockResolvedValue({ total: 0, results: [] });
+    await callHandler({ page: 1, per_page: 20 });
+    expect(mockSmlService.listDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: undefined })
+    );
+  });
+
   it('falls back to default space when spaces plugin is unavailable', async () => {
     const localRouter = httpServiceMock.createRouter();
     registerListRoute({

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/list.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/list.ts
@@ -43,6 +43,7 @@ export const registerListRoute = ({
           }),
           type: schema.maybe(schema.string({ minLength: 1 })),
           origin_uri: schema.maybe(schema.string({ minLength: 1, maxLength: 512 })),
+          tags: schema.maybe(schema.string({ maxLength: 2000 })),
         }),
       },
       options: { access: 'internal' },
@@ -56,17 +57,26 @@ export const registerListRoute = ({
           per_page: perPage,
           type,
           origin_uri: originUri,
+          tags: tagsParam,
         } = request.query as {
           page: number;
           per_page: number;
           type?: string;
           origin_uri?: string;
+          tags?: string;
         };
         const coreContext = await ctx.core;
         const esClient = coreContext.elasticsearch.client;
 
         const [, startDeps] = await coreSetup.getStartServices();
         const spaceId = startDeps.spaces?.spacesService?.getSpaceId(request) ?? 'default';
+
+        const tags = tagsParam
+          ? tagsParam
+              .split(',')
+              .map((t) => t.trim())
+              .filter(Boolean)
+          : undefined;
 
         const { results } = await sml.listDocuments({
           spaceId,
@@ -75,6 +85,7 @@ export const registerListRoute = ({
           perPage,
           type,
           originUri,
+          tags,
         });
 
         // TODO: Push permission filtering into the ES query for accurate pagination.

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/list.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/list.ts
@@ -43,7 +43,15 @@ export const registerListRoute = ({
           }),
           type: schema.maybe(schema.string({ minLength: 1 })),
           origin_uri: schema.maybe(schema.string({ minLength: 1, maxLength: 512 })),
-          tags: schema.maybe(schema.string({ maxLength: 2000 })),
+          tags: schema.maybe(
+            schema.string({
+              maxLength: 2000,
+              meta: {
+                description:
+                  'Comma-delimited list of tags to filter by (OR semantics — returns documents matching any supplied tag). Tag values must be lowercase alphanumeric with optional hyphens or underscores. Example: `?tags=otel,my-tag`.',
+              },
+            })
+          ),
         }),
       },
       options: { access: 'internal' },

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/upsert.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/upsert.test.ts
@@ -98,6 +98,21 @@ describe('registerUpsertRoute', () => {
     });
   });
 
+  it('forwards tags to sml.upsertDocument when provided', async () => {
+    mockSmlService.upsertDocument.mockResolvedValue({ document: sampleDocument, created: true });
+    const bodyWithTags = {
+      ...validBody,
+      tags: ['otel', 'claude-code'],
+    };
+    await callHandler({ params: { id: 'chunk-1' }, body: bodyWithTags });
+    expect(mockSmlService.upsertDocument).toHaveBeenCalledWith({
+      id: 'chunk-1',
+      spaceId: 'test-space',
+      document: expect.objectContaining({ tags: ['otel', 'claude-code'] }),
+      esClient: expect.any(Object),
+    });
+  });
+
   it('returns 200 with created=false when the document already existed', async () => {
     mockSmlService.upsertDocument.mockResolvedValue({ document: sampleDocument, created: false });
     const response = await callHandler({ params: { id: 'chunk-1' }, body: validBody });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/upsert.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/upsert.ts
@@ -38,6 +38,7 @@ export const registerUpsertRoute = ({
           title: schema.string({ minLength: 1 }),
           origin_id: schema.string({ minLength: 1 }),
           content: schema.string(),
+          tags: schema.maybe(schema.arrayOf(schema.string({ maxLength: 200 }), { maxSize: 100 })),
           permissions: schema.maybe(
             schema.object({
               kibana: schema.maybe(

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/upsert.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/upsert.ts
@@ -38,7 +38,28 @@ export const registerUpsertRoute = ({
           title: schema.string({ minLength: 1 }),
           origin_id: schema.string({ minLength: 1 }),
           content: schema.string(),
-          tags: schema.maybe(schema.arrayOf(schema.string({ maxLength: 200 }), { maxSize: 100 })),
+          tags: schema.maybe(
+            schema.arrayOf(
+              schema.string({
+                maxLength: 100,
+                validate: (v) =>
+                  /^[a-z0-9][a-z0-9_-]*$/.test(v)
+                    ? undefined
+                    : 'must be lowercase alphanumeric and may contain hyphens or underscores (e.g. "my-tag", "otel_v2")',
+                meta: {
+                  description:
+                    'A single tag value. Must be lowercase alphanumeric; hyphens and underscores are allowed (e.g. "otel", "my-tag", "v2_data"). Commas are not allowed — use separate array entries.',
+                },
+              }),
+              {
+                maxSize: 100,
+                meta: {
+                  description:
+                    'Optional tags for grouping and retrieval. Tags are matched with OR semantics on the list endpoint — a document is returned if it has any of the requested tags. Maximum 100 tags per document; each tag is at most 100 characters.',
+                },
+              }
+            )
+          ),
           permissions: schema.maybe(
             schema.object({
               kibana: schema.maybe(

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -1905,6 +1905,52 @@ describe('SmlService', () => {
       expect(filters).toHaveLength(1); // only the space filter
     });
 
+    it('adds a terms: { tags } filter when tags are provided', async () => {
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      esClient.search.mockResolvedValue({
+        hits: { total: 0, hits: [] },
+      } as any);
+
+      await smlService.listDocuments({
+        spaceId: 'default',
+        esClient: scopedClient,
+        tags: ['otel', 'claude-code'],
+      });
+
+      const call = esClient.search.mock.calls[0]![0]! as {
+        query?: { bool?: { filter?: unknown[] } };
+      };
+      const filters = call.query!.bool!.filter!;
+      expect(filters).toContainEqual({ terms: { tags: ['otel', 'claude-code'] } });
+    });
+
+    it('does not add a tags filter when tags is omitted', async () => {
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      esClient.search.mockResolvedValue({
+        hits: { total: 0, hits: [] },
+      } as any);
+
+      await smlService.listDocuments({
+        spaceId: 'default',
+        esClient: scopedClient,
+      });
+
+      const call = esClient.search.mock.calls[0]![0]! as {
+        query?: { bool?: { filter?: unknown[] } };
+      };
+      const filters = call.query!.bool!.filter! as Array<Record<string, unknown>>;
+      // Only the space filter should be present — no terms: { tags: ... } entry
+      expect(filters).toHaveLength(1);
+      const hasTagsFilter = filters.some((f) => 'terms' in f && 'tags' in (f.terms as object));
+      expect(hasTagsFilter).toBe(false);
+    });
+
     it('returns empty results when index does not exist', async () => {
       const service = createSmlService();
       service.setup({ logger });
@@ -2280,6 +2326,134 @@ describe('SmlService', () => {
         })
       ).rejects.toThrow('boom');
       expect(smlClient.index).not.toHaveBeenCalled();
+    });
+
+    it('stores provided tags on create', async () => {
+      smlClient.get.mockRejectedValue(createNotFoundError());
+
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      const result = await smlService.upsertDocument({
+        id: 'doc-tag-create',
+        spaceId: 'default',
+        document: {
+          type: 'lens',
+          title: 'Tagged Doc',
+          origin_id: 'ref-1',
+          content: 'c',
+          tags: ['otel', 'claude-code'],
+        },
+        esClient: scopedClient,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.document.tags).toEqual(['otel', 'claude-code']);
+      expect(smlClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({ tags: ['otel', 'claude-code'] }),
+        })
+      );
+    });
+
+    it('defaults tags to [] on create when caller omits the field', async () => {
+      smlClient.get.mockRejectedValue(createNotFoundError());
+
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      const result = await smlService.upsertDocument({
+        id: 'doc-no-tags',
+        spaceId: 'default',
+        document: {
+          type: 'lens',
+          title: 'No Tags',
+          origin_id: 'ref-1',
+          content: 'c',
+        },
+        esClient: scopedClient,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.document.tags).toEqual([]);
+    });
+
+    it('replaces existing tags when caller provides new tags on update', async () => {
+      smlClient.get.mockResolvedValue({
+        found: true,
+        _source: {
+          id: 'doc-1',
+          type: 'lens',
+          title: 'Old',
+          origin_id: 'ref-1',
+          content: 'old',
+          created_at: '2023-01-01T00:00:00.000Z',
+          updated_at: '2023-06-01T00:00:00.000Z',
+          spaces: ['default'],
+          tags: ['old-tag'],
+          permissions: makePermissions(),
+        },
+      });
+
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      const result = await smlService.upsertDocument({
+        id: 'doc-1',
+        spaceId: 'default',
+        document: {
+          type: 'lens',
+          title: 'New',
+          origin_id: 'ref-1',
+          content: 'new',
+          tags: ['new-tag', 'another'],
+        },
+        esClient: scopedClient,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.document.tags).toEqual(['new-tag', 'another']);
+    });
+
+    it('preserves existing tags on update when caller omits the field', async () => {
+      smlClient.get.mockResolvedValue({
+        found: true,
+        _source: {
+          id: 'doc-1',
+          type: 'lens',
+          title: 'Old',
+          origin_id: 'ref-1',
+          content: 'old',
+          created_at: '2023-01-01T00:00:00.000Z',
+          updated_at: '2023-06-01T00:00:00.000Z',
+          spaces: ['default'],
+          tags: ['keep-me'],
+          permissions: makePermissions(),
+        },
+      });
+
+      const service = createSmlService();
+      service.setup({ logger });
+      const smlService = service.start({ logger });
+
+      const result = await smlService.upsertDocument({
+        id: 'doc-1',
+        spaceId: 'default',
+        document: {
+          type: 'lens',
+          title: 'New',
+          origin_id: 'ref-1',
+          content: 'new',
+          // tags omitted intentionally
+        },
+        esClient: scopedClient,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.document.tags).toEqual(['keep-me']);
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -162,7 +162,7 @@ class SmlServiceImpl implements SmlServiceInstance {
       getDocuments: async ({ ids, spaceId, esClient }) => {
         return getDocumentsByIds({ ids, spaceId, esClient, logger });
       },
-      listDocuments: async ({ spaceId, esClient, page, perPage, type, originUri }) => {
+      listDocuments: async ({ spaceId, esClient, page, perPage, type, originUri, tags }) => {
         return listDocuments({
           spaceId,
           esClient,
@@ -171,6 +171,7 @@ class SmlServiceImpl implements SmlServiceInstance {
           perPage,
           type,
           originId: originUri,
+          tags,
         });
       },
       upsertDocument: async ({ id, spaceId, document, esClient }) => {
@@ -1263,6 +1264,7 @@ const listDocuments = async ({
   perPage = 20,
   type,
   originId,
+  tags,
 }: {
   spaceId: string;
   esClient: IScopedClusterClient;
@@ -1271,6 +1273,7 @@ const listDocuments = async ({
   perPage?: number;
   type?: string;
   originId?: string;
+  tags?: string[];
 }): Promise<{ total: number; results: SmlDocument[] }> => {
   const filters: Array<Record<string, unknown>> = [
     {
@@ -1285,6 +1288,9 @@ const listDocuments = async ({
   }
   if (originId) {
     filters.push({ term: { 'origin.uri': originId } });
+  }
+  if (tags && tags.length > 0) {
+    filters.push({ terms: { tags } });
   }
 
   try {
@@ -1325,6 +1331,7 @@ const listDocuments = async ({
           spaces: source.spaces ?? [],
           permissions: source.permissions ?? emptyPermissions(),
           ingestion_method: source.ingestion_method ?? 'crawled',
+          ...(source.tags !== undefined ? { tags: source.tags } : {}),
         };
       });
 
@@ -1416,6 +1423,8 @@ const upsertDocument = async ({
       kibana: { privileges: document.permissions?.kibana?.privileges ?? [] },
       elasticsearch: { indices: document.permissions?.elasticsearch?.indices ?? [] },
     },
+    // On create: default to []. On update: preserve existing tags if caller omits the field.
+    tags: document.tags ?? existing?.tags ?? [],
     // HTTP upserts are by definition manual writes; tagging here lets the crawler
     // (and origin-mode indexAttachment) skip these entries to avoid clobbering them.
     ingestion_method: 'manual',

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -350,6 +350,11 @@ export interface SmlDocumentInput {
   origin_id: string;
   content: string;
   /**
+   * Free-form labels for filtering and retrieval. Optional — when absent
+   * on an update, the existing document's tags are preserved.
+   */
+  tags?: string[];
+  /**
    * Permissions required to access the underlying element. Optional on
    * input — when omitted, the upsert handler normalizes to an empty
    * `{ kibana: { privileges: [] }, elasticsearch: { indices: [] } }`.
@@ -573,6 +578,7 @@ export interface SmlService {
     perPage?: number;
     type?: string;
     originUri?: string;
+    tags?: string[];
   }) => Promise<{ total: number; results: SmlDocument[] }>;
 
   /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
@@ -145,6 +145,7 @@ export const createContextEngineAddEntryStepDefinition = ({
             title: chunk.title,
             content: chunk.content,
             ...(chunk.description !== undefined ? { description: chunk.description } : {}),
+            ...(chunk.tags !== undefined ? { tags: chunk.tags } : {}),
             ...(chunk.user_id !== undefined ? { user_id: chunk.user_id } : {}),
             ...(chunk.references !== undefined
               ? { references: chunk.references.map((uri) => ({ uri })) }


### PR DESCRIPTION
## Summary

- Adds `tags?: string[]` to the SML upsert route body (`PUT /internal/agent_context_layer/sml/:id`) so KIs can be tagged at write time. On create defaults to `[]`; on update preserves existing tags when the field is omitted.
- Adds `?tags=foo,bar` (comma-delimited) query param to the list route (`GET /internal/agent_context_layer/sml`) for tag-based retrieval — enabling workflows to find the most recently written KI of a given type (high-water-mark pattern). Tag filter uses **OR semantics** — a document matches if it has any of the supplied tags.
- Adds `tags` field to the `contextEngine.addEntry` workflow step's chunk schema so workflow-authored KIs can be tagged at write time.
- `SmlHttpItem.tags: string[]` is now always present in responses (normalized with `?? []`).

### Tag format

Tags must be **lowercase alphanumeric**, with hyphens and underscores allowed, starting with an alphanumeric character (e.g. `otel`, `my-tag`, `v2_data`). Commas are not allowed — use separate array entries. Max 100 characters per tag, 100 tags per document. The `?tags=` query param is comma-delimited; tag values must not contain commas.

## How to test

**Prerequisites:** Kibana running in serverless mode with the experimental features UI setting enabled (`agentBuilder:enableExperimentalFeatures = true`).

### 1. Write a tagged KI via the upsert route

```
PUT kbn:/internal/agent_context_layer/sml/hello-world-1
{
  "type": "custom",
  "title": "Hello World",
  "origin_id": "hello-world-1",
  "content": "This is a hello world knowledge item.",
  "tags": ["test-tag", "hello-world"]
}
```

Expected: `201` with `item.tags: ["test-tag", "hello-world"]`.

### 2. Verify tags filter on list

```
GET kbn:/internal/agent_context_layer/sml?tags=test-tag
```

Expected: the KI from step 1 appears in `items[]` with `tags: ["test-tag", "hello-world"]`.

```
GET kbn:/internal/agent_context_layer/sml?tags=other-tag
```

Expected: KI from step 1 does **not** appear.

```
GET kbn:/internal/agent_context_layer/sml?tags=test-tag,other-tag
```

Expected: KI from step 1 appears (OR semantics — matches because it has `test-tag`).

### 3. Verify tags survive an update that omits the field

```
PUT kbn:/internal/agent_context_layer/sml/hello-world-1
{
  "type": "custom",
  "title": "Hello World (updated)",
  "origin_id": "hello-world-1",
  "content": "Updated content."
}
```

Expected: `200` with `item.tags: ["test-tag", "hello-world"]` (tags preserved).

### 4. Verify directly on the ES index (Dev Tools)

```
GET .chat-sml-data/_search
{
  "query": { "terms": { "tags": ["test-tag"] } }
}
```

Expected: the document appears with `"tags": ["test-tag", "hello-world"]` in `_source`.

### 5. Verify tag format validation

```
PUT kbn:/internal/agent_context_layer/sml/bad-tags
{
  "type": "custom",
  "title": "Bad Tags",
  "origin_id": "bad-tags",
  "content": "Test.",
  "tags": ["has space", "has,comma", "HAS_UPPER"]
}
```

Expected: `400` — each tag fails validation (spaces, commas, and uppercase are not allowed).

## References

Closes elastic/search-team#14968
