### PR TITLE
[9.4] [UII] Optimize enrollment key and revision reconciliation during Fleet setup (#272604)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -2564,6 +2564,9 @@ describe('Agent policy', () => {
           total: 1,
           hits: [{ _source: { policy_id: 'policy123', revision_idx: 1 } }],
         },
+        aggregations: {
+          policies: { buckets: [{ key: 'policy123', latest_revision: { value: 1 } }] },
+        },
       } as any);
 
       await agentPolicyService.deployPolicy(soClient, 'policy123');
@@ -2607,6 +2610,9 @@ describe('Agent policy', () => {
         hits: {
           total: 1,
           hits: [{ _source: { policy_id: 'policy123', revision_idx: 2 } }],
+        },
+        aggregations: {
+          policies: { buckets: [{ key: 'policy123', latest_revision: { value: 2 } }] },
         },
       } as any);
 
@@ -3662,6 +3668,52 @@ describe('Agent policy', () => {
       expect(vars.namespace).toBeUndefined();
       expect(vars.cloud_connector_id).toBeUndefined();
       expect(vars.cloud_connector_name).toBeUndefined();
+    });
+  });
+
+  describe('getLatestFleetPolicyRevisions', () => {
+    it('returns an empty map without querying when no policy ids are provided', async () => {
+      const esClient = elasticsearchServiceMock.createInternalClient();
+
+      const result = await agentPolicyService.getLatestFleetPolicyRevisions(esClient, []);
+
+      expect(result).toEqual(new Map());
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+
+    it('maps each policy id to its latest deployed revision, omitting policies with none', async () => {
+      const esClient = elasticsearchServiceMock.createInternalClient();
+      esClient.search.mockResolvedValue({
+        aggregations: {
+          policies: {
+            buckets: [
+              { key: 'policy1', latest_revision: { value: 3 } },
+              { key: 'policy2', latest_revision: { value: 1 } },
+              { key: 'policy3', latest_revision: { value: null } },
+            ],
+          },
+        },
+      } as any);
+
+      const result = await agentPolicyService.getLatestFleetPolicyRevisions(esClient, [
+        'policy1',
+        'policy2',
+        'policy3',
+      ]);
+
+      expect(result).toEqual(
+        new Map([
+          ['policy1', 3],
+          ['policy2', 1],
+        ])
+      );
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: AGENT_POLICY_INDEX,
+          size: 0,
+          query: { terms: { policy_id: ['policy1', 'policy2', 'policy3'] } },
+        })
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -1986,21 +1986,21 @@ class AgentPolicyService {
             fleetServerPolicies.map((fsp) => fsp.policy_id).filter((id) => !hasVersionSuffix(id))
           ),
         ];
-        await pMap(
-          deployedPolicyIds,
-          async (policyId) => {
-            const latestFleetPolicy = await this.getLatestFleetPolicyRevision(esClient, policyId);
-            const soRevision = policiesMap[policyId]?.revision;
-            if (latestFleetPolicy && soRevision && latestFleetPolicy.revision_idx !== soRevision) {
-              logger.warn(
-                `Policy [${policyId}] has mismatched revisions after deploy: ` +
-                  `.kibana_ingest revision [${soRevision}], ` +
-                  `.fleet-policies revision_idx [${latestFleetPolicy.revision_idx}]`
-              );
-            }
-          },
-          { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20 }
+        const latestRevisionByPolicyId = await this.getLatestFleetPolicyRevisions(
+          esClient,
+          deployedPolicyIds
         );
+        for (const policyId of deployedPolicyIds) {
+          const latestRevisionIdx = latestRevisionByPolicyId.get(policyId);
+          const soRevision = policiesMap[policyId]?.revision;
+          if (latestRevisionIdx !== undefined && soRevision && latestRevisionIdx !== soRevision) {
+            logger.warn(
+              `Policy [${policyId}] has mismatched revisions after deploy: ` +
+                `.kibana_ingest revision [${soRevision}], ` +
+                `.fleet-policies revision_idx [${latestRevisionIdx}]`
+            );
+          }
+        }
 
         for (const agentPolicy of policies) {
           if (!agentPolicy.supports_agentless) {
@@ -2094,29 +2094,43 @@ class AgentPolicyService {
     }
   }
 
-  public async getLatestFleetPolicyRevision(
+  /**
+   * Resolve the latest deployed revision (`revision_idx` in `.fleet-policies`) for many agent
+   * policies in a single aggregation. Returns a map keyed by policy id; policies without a
+   * deployed revision are omitted from the map.
+   */
+  public async getLatestFleetPolicyRevisions(
     esClient: ElasticsearchClient,
-    agentPolicyId: string
-  ): Promise<Pick<FleetServerPolicy, 'revision_idx' | 'policy_id'> | null> {
-    const res = await esClient.search<Pick<FleetServerPolicy, 'revision_idx' | 'policy_id'>>({
-      index: AGENT_POLICY_INDEX,
-      ignore_unavailable: true,
-      rest_total_hits_as_int: true,
-      _source: ['revision_idx', 'policy_id'],
-      query: {
-        term: {
-          policy_id: agentPolicyId,
-        },
-      },
-      size: 1,
-      sort: [{ revision_idx: { order: 'desc' } }],
-    });
-
-    if ((res.hits.total as number) === 0) {
-      return null;
+    agentPolicyIds: string[]
+  ): Promise<Map<string, number>> {
+    const latestRevisionByPolicyId = new Map<string, number>();
+    if (agentPolicyIds.length === 0) {
+      return latestRevisionByPolicyId;
     }
 
-    return res.hits.hits[0]._source ?? null;
+    const res = await esClient.search<
+      unknown,
+      { policies: { buckets: Array<{ key: string; latest_revision: { value: number | null } }> } }
+    >({
+      index: AGENT_POLICY_INDEX,
+      ignore_unavailable: true,
+      size: 0,
+      query: { terms: { policy_id: agentPolicyIds } },
+      aggs: {
+        policies: {
+          terms: { field: 'policy_id', size: agentPolicyIds.length, execution_hint: 'map' },
+          aggs: { latest_revision: { max: { field: 'revision_idx' } } },
+        },
+      },
+    });
+
+    for (const bucket of res.aggregations?.policies?.buckets ?? []) {
+      if (bucket.latest_revision.value !== null) {
+        latestRevisionByPolicyId.set(bucket.key, bucket.latest_revision.value);
+      }
+    }
+
+    return latestRevisionByPolicyId;
   }
 
   public async getFleetServerPolicy(

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.test.ts
@@ -8,9 +8,10 @@
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 
+import { ENROLLMENT_API_KEYS_INDEX } from '../../../common/constants';
 import { appContextService } from '../app_context';
 import { agentPolicyService } from '../agent_policy';
-import { ensureDefaultEnrollmentAPIKeyForAgentPolicy } from '../api_keys';
+import { generateEnrollmentAPIKey } from '../api_keys';
 
 import { scheduleDeployAgentPoliciesTask } from '../agent_policies/deploy_agent_policies_task';
 
@@ -22,12 +23,35 @@ jest.mock('../api_keys');
 jest.mock('../agent_policies/bump_agent_policies_task');
 jest.mock('../agent_policies/deploy_agent_policies_task');
 
-const mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy = jest.mocked(
-  ensureDefaultEnrollmentAPIKeyForAgentPolicy
-);
+const mockedGenerateEnrollmentAPIKey = jest.mocked(generateEnrollmentAPIKey);
 
 const mockedAgentPolicyService = jest.mocked(agentPolicyService);
 const mockedAppContextService = jest.mocked(appContextService);
+
+// Provide the data setup reads: the latest deployed revision per policy (via
+// `agentPolicyService.getLatestFleetPolicyRevisions`) and the policies that already have an
+// enrollment API key (via an aggregation on `.fleet-enrollment-api-keys`).
+const mockSetupQueries = (
+  esClient: ReturnType<typeof elasticsearchServiceMock.createInternalClient>,
+  {
+    revisions = {},
+    policiesWithKeys = [],
+  }: { revisions?: Record<string, number>; policiesWithKeys?: string[] }
+) => {
+  mockedAgentPolicyService.getLatestFleetPolicyRevisions.mockResolvedValue(
+    new Map(Object.entries(revisions))
+  );
+  esClient.search.mockImplementation((async (params: any) => {
+    if (params.index === ENROLLMENT_API_KEYS_INDEX) {
+      return {
+        aggregations: {
+          policies: { buckets: policiesWithKeys.map((key) => ({ key })) },
+        },
+      };
+    }
+    return {};
+  }) as any);
+};
 
 describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
   beforeEach(() => {
@@ -38,8 +62,9 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
       savedObjectsClientMock.create()
     );
 
-    mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy.mockReset();
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockReset();
+    mockedGenerateEnrollmentAPIKey.mockReset();
+    mockedAgentPolicyService.getLatestFleetPolicyRevisions.mockReset();
+    mockedAgentPolicyService.getLatestFleetPolicyRevisions.mockResolvedValue(new Map());
     mockedAgentPolicyService.deployPolicies.mockReset();
     mockedAgentPolicyService.deployPolicies.mockImplementation(async () => {});
     jest.mocked(scheduleDeployAgentPoliciesTask).mockReset();
@@ -61,23 +86,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     const logger = loggingSystemMock.createLogger();
     const esClient = elasticsearchServiceMock.createInternalClient();
     const soClient = savedObjectsClientMock.create();
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockImplementation(
-      async (_, agentPolicyId) => {
-        if (agentPolicyId === 'policy1') {
-          return {
-            revision_idx: 1,
-          } as any;
-        }
-
-        if (agentPolicyId === 'policy2') {
-          return {
-            revision_idx: 2,
-          } as any;
-        }
-
-        return null;
-      }
-    );
+    mockSetupQueries(esClient, { revisions: { policy1: 1, policy2: 2 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,
@@ -85,10 +94,33 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
       soClient,
     });
 
-    expect(mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy).toBeCalledTimes(2);
+    expect(mockedGenerateEnrollmentAPIKey).toBeCalledTimes(2);
     expect(mockedAgentPolicyService.deployPolicies).not.toBeCalled();
     expect(logger.warn).not.toHaveBeenCalledWith(
       expect.stringContaining('has mismatched revisions')
+    );
+  });
+
+  it('should only generate enrollment keys for policies that are missing one', async () => {
+    const logger = loggingSystemMock.createLogger();
+    const esClient = elasticsearchServiceMock.createInternalClient();
+    const soClient = savedObjectsClientMock.create();
+    mockSetupQueries(esClient, {
+      revisions: { policy1: 1, policy2: 2 },
+      policiesWithKeys: ['policy1'],
+    });
+
+    await ensureAgentPoliciesFleetServerKeysAndPolicies({
+      logger,
+      esClient,
+      soClient,
+    });
+
+    expect(mockedGenerateEnrollmentAPIKey).toBeCalledTimes(1);
+    expect(mockedGenerateEnrollmentAPIKey).toBeCalledWith(
+      soClient,
+      esClient,
+      expect.objectContaining({ agentPolicyId: 'policy2', name: 'Default', forceRecreate: true })
     );
   });
 
@@ -96,23 +128,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     const logger = loggingSystemMock.createLogger();
     const esClient = elasticsearchServiceMock.createInternalClient();
     const soClient = savedObjectsClientMock.create();
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockImplementation(
-      async (_, agentPolicyId) => {
-        if (agentPolicyId === 'policy1') {
-          return {
-            revision_idx: 1,
-          } as any;
-        }
-
-        if (agentPolicyId === 'policy2') {
-          return {
-            revision_idx: 1,
-          } as any;
-        }
-
-        return null;
-      }
-    );
+    mockSetupQueries(esClient, { revisions: { policy1: 1, policy2: 1 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,
@@ -120,7 +136,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
       soClient,
     });
 
-    expect(mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy).toBeCalledTimes(2);
+    expect(mockedGenerateEnrollmentAPIKey).toBeCalledTimes(2);
     expect(scheduleDeployAgentPoliciesTask).toBeCalledWith(undefined, [
       { id: 'policy2', spaceId: undefined },
     ]);
@@ -133,17 +149,8 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     const logger = loggingSystemMock.createLogger();
     const esClient = elasticsearchServiceMock.createInternalClient();
     const soClient = savedObjectsClientMock.create();
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockImplementation(
-      async (_, agentPolicyId) => {
-        if (agentPolicyId === 'policy1') {
-          return {
-            revision_idx: 1,
-          } as any;
-        }
-
-        return null;
-      }
-    );
+    // policy2 has no deployed revision so it is omitted from the aggregation buckets
+    mockSetupQueries(esClient, { revisions: { policy1: 1 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,
@@ -151,7 +158,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
       soClient,
     });
 
-    expect(mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy).toBeCalledTimes(2);
+    expect(mockedGenerateEnrollmentAPIKey).toBeCalledTimes(2);
     expect(scheduleDeployAgentPoliciesTask).toBeCalledWith(undefined, [
       { id: 'policy2', spaceId: undefined },
     ]);
@@ -175,17 +182,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     } as any);
 
     // fleet-server-policy is out of sync; policy1 is up to date
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockImplementation(
-      async (_, agentPolicyId) => {
-        if (agentPolicyId === 'fleet-server-policy') {
-          return { revision_idx: 1 } as any;
-        }
-        if (agentPolicyId === 'policy1') {
-          return { revision_idx: 1 } as any;
-        }
-        return null;
-      }
-    );
+    mockSetupQueries(esClient, { revisions: { 'fleet-server-policy': 1, policy1: 1 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,
@@ -220,9 +217,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     } as any);
 
     // Both are out of sync
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockResolvedValue({
-      revision_idx: 1,
-    } as any);
+    mockSetupQueries(esClient, { revisions: { 'fleet-server-policy': 1, policy1: 1 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,
@@ -241,7 +236,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     ]);
   });
 
-  it('should throw if preconfigured fleet server policy deploy fails due to ES bulk error', async () => {
+  it('should log an error and still schedule regular policies if a preconfigured fleet server policy deploy fails', async () => {
     const logger = loggingSystemMock.createLogger();
     const esClient = elasticsearchServiceMock.createInternalClient();
     const soClient = savedObjectsClientMock.create();
@@ -254,19 +249,24 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
           is_default_fleet_server: true,
           is_preconfigured: true,
         },
+        { id: 'policy1', revision: 3 },
       ],
     } as any);
 
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockResolvedValue({
-      revision_idx: 1,
-    } as any);
+    mockSetupQueries(esClient, { revisions: { 'fleet-server-policy': 1, policy1: 1 } });
     mockedAgentPolicyService.deployPolicies.mockRejectedValue(
       new Error('ES bulk operation failed')
     );
 
-    await expect(
-      ensureAgentPoliciesFleetServerKeysAndPolicies({ logger, esClient, soClient })
-    ).rejects.toThrow('ES bulk operation failed');
+    await ensureAgentPoliciesFleetServerKeysAndPolicies({ logger, esClient, soClient });
+
+    expect(logger.error).toBeCalledWith(
+      expect.stringContaining('Failed to deploy fleet server policies [fleet-server-policy]')
+    );
+    // A fleet server deploy failure must not prevent regular outdated policies from being scheduled
+    expect(scheduleDeployAgentPoliciesTask).toBeCalledWith(undefined, [
+      { id: 'policy1', spaceId: undefined },
+    ]);
   });
 
   it('should synchronously deploy preconfigured fleet server policies identified by has_fleet_server flag', async () => {
@@ -280,9 +280,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
       ],
     } as any);
 
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockResolvedValue({
-      revision_idx: 1,
-    } as any);
+    mockSetupQueries(esClient, { revisions: { 'custom-fs-policy': 1 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,
@@ -315,9 +313,7 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
       ],
     } as any);
 
-    mockedAgentPolicyService.getLatestFleetPolicyRevision.mockResolvedValue({
-      revision_idx: 1,
-    } as any);
+    mockSetupQueries(esClient, { revisions: { 'user-fs-policy': 1 } });
 
     await ensureAgentPoliciesFleetServerKeysAndPolicies({
       logger,

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.ts
@@ -8,12 +8,45 @@
 import type { ElasticsearchClient, SavedObjectsClientContract, Logger } from '@kbn/core/server';
 import pMap from 'p-map';
 
+import { ENROLLMENT_API_KEYS_INDEX } from '../../../common/constants';
+
 import { agentPolicyService } from '../agent_policy';
-import { ensureDefaultEnrollmentAPIKeyForAgentPolicy } from '../api_keys';
+import { generateEnrollmentAPIKey } from '../api_keys';
 import { SO_SEARCH_LIMIT, MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20 } from '../../constants';
 import { appContextService } from '../app_context';
 import { scheduleDeployAgentPoliciesTask } from '../agent_policies/deploy_agent_policies_task';
 import { scheduleBumpAgentPoliciesTask } from '../agent_policies/bump_agent_policies_task';
+
+/**
+ * Return the set of agent policy ids that already have at least one enrollment API key.
+ */
+async function getPolicyIdsWithEnrollmentAPIKeys(
+  esClient: ElasticsearchClient,
+  agentPolicyIds: string[]
+): Promise<Set<string>> {
+  const policyIdsWithKeys = new Set<string>();
+  if (agentPolicyIds.length === 0) {
+    return policyIdsWithKeys;
+  }
+
+  const res = await esClient.search<unknown, { policies: { buckets: Array<{ key: string }> } }>({
+    index: ENROLLMENT_API_KEYS_INDEX,
+    ignore_unavailable: true,
+    size: 0,
+    query: { terms: { policy_id: agentPolicyIds } },
+    aggs: {
+      policies: {
+        terms: { field: 'policy_id', size: agentPolicyIds.length, execution_hint: 'map' },
+      },
+    },
+  });
+
+  for (const bucket of res.aggregations?.policies?.buckets ?? []) {
+    policyIdsWithKeys.add(bucket.key);
+  }
+
+  return policyIdsWithKeys;
+}
 
 export async function ensureAgentPoliciesFleetServerKeysAndPolicies({
   logger,
@@ -37,31 +70,47 @@ export async function ensureAgentPoliciesFleetServerKeysAndPolicies({
     perPage: SO_SEARCH_LIMIT,
   });
 
-  const outdatedAgentPolicyIds: Array<{ id: string; spaceId?: string }> = [];
+  const agentPolicyIds = agentPolicies.map((agentPolicy) => agentPolicy.id);
+
+  // Resolve the latest deployed revision and which policies already have an enrollment API key
+  const [latestRevisionByPolicyId, policyIdsWithEnrollmentKeys] = await Promise.all([
+    agentPolicyService.getLatestFleetPolicyRevisions(esClient, agentPolicyIds),
+    getPolicyIdsWithEnrollmentAPIKeys(esClient, agentPolicyIds),
+  ]);
+
+  // Generate a default enrollment API key only for policies that are missing one
+  const policiesMissingEnrollmentKey = agentPolicies.filter(
+    (agentPolicy) => !policyIdsWithEnrollmentKeys.has(agentPolicy.id)
+  );
   await pMap(
-    agentPolicies,
-    async (agentPolicy) => {
-      const [latestFleetPolicy] = await Promise.all([
-        agentPolicyService.getLatestFleetPolicyRevision(esClient, agentPolicy.id),
-        ensureDefaultEnrollmentAPIKeyForAgentPolicy(soClient, esClient, agentPolicy.id),
-      ]);
-
-      if (latestFleetPolicy && latestFleetPolicy.revision_idx !== agentPolicy.revision) {
-        logger.warn(
-          `Policy [${agentPolicy.id}] has mismatched revisions: ` +
-            `.kibana_ingest revision [${agentPolicy.revision}], ` +
-            `.fleet-policies revision_idx [${latestFleetPolicy.revision_idx}]`
-        );
-      }
-
-      if ((latestFleetPolicy?.revision_idx ?? -1) < agentPolicy.revision) {
-        outdatedAgentPolicyIds.push({ id: agentPolicy.id, spaceId: agentPolicy.space_ids?.[0] });
-      }
-    },
+    policiesMissingEnrollmentKey,
+    (agentPolicy) =>
+      generateEnrollmentAPIKey(soClient, esClient, {
+        name: `Default`,
+        agentPolicyId: agentPolicy.id,
+        forceRecreate: true,
+      }),
     {
       concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20,
     }
   );
+
+  const outdatedAgentPolicyIds: Array<{ id: string; spaceId?: string }> = [];
+  for (const agentPolicy of agentPolicies) {
+    const latestRevisionIdx = latestRevisionByPolicyId.get(agentPolicy.id);
+
+    if (latestRevisionIdx !== undefined && latestRevisionIdx !== agentPolicy.revision) {
+      logger.warn(
+        `Policy [${agentPolicy.id}] has mismatched revisions: ` +
+          `.kibana_ingest revision [${agentPolicy.revision}], ` +
+          `.fleet-policies revision_idx [${latestRevisionIdx}]`
+      );
+    }
+
+    if ((latestRevisionIdx ?? -1) < agentPolicy.revision) {
+      outdatedAgentPolicyIds.push({ id: agentPolicy.id, spaceId: agentPolicy.space_ids?.[0] });
+    }
+  }
 
   await scheduleBumpAgentPoliciesTask(appContextService.getTaskManagerStart()!);
 
@@ -102,12 +151,16 @@ export async function ensureAgentPoliciesFleetServerKeysAndPolicies({
           ids.length === 1 ? 'policy' : 'policies'
         } [${ids.join(', ')}] in space [${spaceId}] during setup`
       );
-      await agentPolicyService.deployPolicies(
-        appContextService.getInternalUserSOClientForSpaceId(spaceId),
-        ids,
-        undefined,
-        { throwOnAnyError: true }
-      );
+      try {
+        await agentPolicyService.deployPolicies(
+          appContextService.getInternalUserSOClientForSpaceId(spaceId),
+          ids,
+          undefined,
+          { throwOnAnyError: true }
+        );
+      } catch (e) {
+        logger.error(`Failed to deploy fleet server policies [${ids.join(', ')}]: ${e.message}`);
+      }
     }
   }
 

--- a/x-pack/platform/test/fleet_api_integration/apis/fleet_setup.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/fleet_setup.ts
@@ -8,7 +8,10 @@
 import expect from '@kbn/expect';
 import { v4 as uuidV4 } from 'uuid';
 import { INGEST_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common/constants';
+import {
+  ENROLLMENT_API_KEYS_INDEX,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+} from '@kbn/fleet-plugin/common/constants';
 
 import type { FtrProviderContext } from '../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../helpers';
@@ -66,6 +69,67 @@ export default function (providerContext: FtrProviderContext) {
         .sort();
 
       expect(installedPackages).to.eql(['endpoint']);
+    });
+
+    describe('default enrollment API key reconciliation', () => {
+      before(async () => {
+        await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxxx').expect(200);
+      });
+
+      async function createAgentPolicy() {
+        const { body } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({ name: `enrollment-key-test-${uuidV4()}`, namespace: 'default' })
+          .expect(200);
+
+        return body.item.id as string;
+      }
+
+      async function getEnrollmentKeysForPolicy(policyId: string) {
+        const { body } = await supertest
+          .get(`/api/fleet/enrollment_api_keys`)
+          .query({ kuery: `policy_id:"${policyId}"` })
+          .expect(200);
+
+        return body.items as Array<{ id: string; policy_id: string; name: string }>;
+      }
+
+      it('creates a default enrollment API key for a policy that is missing one', async () => {
+        const policyId = await createAgentPolicy();
+        // Creating the policy already provisions a Default enrollment API key
+        expect(await getEnrollmentKeysForPolicy(policyId)).to.have.length(1);
+
+        // Simulate a policy with no enrollment key by deleting the key document directly
+        await es.deleteByQuery({
+          index: ENROLLMENT_API_KEYS_INDEX,
+          refresh: true,
+          conflicts: 'proceed',
+          query: { term: { policy_id: policyId } },
+        });
+        expect(await getEnrollmentKeysForPolicy(policyId)).to.have.length(0);
+
+        await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxxx').expect(200);
+
+        await retry.tryForTime(30_000, async () => {
+          const keys = await getEnrollmentKeysForPolicy(policyId);
+          expect(keys).to.have.length(1);
+          // generateEnrollmentAPIKey appends a unique suffix, e.g. `Default (<uuid>)`
+          expect(keys[0].name).to.match(/^Default/);
+        });
+      });
+
+      it('does not create a duplicate enrollment API key when one already exists', async () => {
+        const policyId = await createAgentPolicy();
+        const keysBefore = await getEnrollmentKeysForPolicy(policyId);
+        expect(keysBefore).to.have.length(1);
+
+        await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxxx').expect(200);
+
+        const keysAfter = await getEnrollmentKeysForPolicy(policyId);
+        expect(keysAfter).to.have.length(1);
+        expect(keysAfter[0].id).to.eql(keysBefore[0].id);
+      });
     });
 
     describe('upgrade managed package policies', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[UII] Optimize enrollment key and revision reconciliation during Fleet setup (#272604)](https://github.com/elastic/kibana/pull/272604)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-06-19T06:11:55Z","message":"[UII] Optimize enrollment key and revision reconciliation during Fleet setup (#272604)\n\n## Summary\n\n(No related issue, found while working on\nhttps://github.com/elastic/kibana/pull/272428)\n\n`POST /api/fleet/setup` is slow for large number of agent policies. This\nis due to `ensureAgentPoliciesFleetServerKeysAndPolicies` issuing **two\nES searches per agent policy**: one for the latest deployed revision\n(`.fleet-policies`) and one to check for an existing enrollment API key\n(`.fleet-enrollment-api-keys`). With ~10k policies that's ~20k searches\nper call, saturating the Node event loop and blocking the request thread\n.\n\nThis replaces the per-policy fan-out with **two bulk aggregations**:\n- latest `revision_idx` per policy via a single `terms` + `max`\naggregation, and\n- the set of policies that already have an enrollment key via a single\n`terms` aggregation,\n\nthen only generates a default enrollment key for policies actually\nmissing one. Behavior is unchanged; the work is just done in 2 queries\ninstead of 2*(number of policies).\n\n**Result:** on my local environment with 10k policies, `POST\n/api/fleet/setup` response time is reduced from ~6.2s → ~0.3s (~95%\nfaster).\n\n## Release note\nImprove Fleet setup performance at scale by reconciling agent policy\nenrollment keys and revisions with bulk aggregations instead of\nper-policy Elasticsearch queries.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c8051aa9e20b4ab3865deff0ba868adf40b0f937","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:Fleet","backport:all-open","v9.5.0"],"title":"[UII] Optimize enrollment key and revision reconciliation during Fleet setup","number":272604,"url":"https://github.com/elastic/kibana/pull/272604","mergeCommit":{"message":"[UII] Optimize enrollment key and revision reconciliation during Fleet setup (#272604)\n\n## Summary\n\n(No related issue, found while working on\nhttps://github.com/elastic/kibana/pull/272428)\n\n`POST /api/fleet/setup` is slow for large number of agent policies. This\nis due to `ensureAgentPoliciesFleetServerKeysAndPolicies` issuing **two\nES searches per agent policy**: one for the latest deployed revision\n(`.fleet-policies`) and one to check for an existing enrollment API key\n(`.fleet-enrollment-api-keys`). With ~10k policies that's ~20k searches\nper call, saturating the Node event loop and blocking the request thread\n.\n\nThis replaces the per-policy fan-out with **two bulk aggregations**:\n- latest `revision_idx` per policy via a single `terms` + `max`\naggregation, and\n- the set of policies that already have an enrollment key via a single\n`terms` aggregation,\n\nthen only generates a default enrollment key for policies actually\nmissing one. Behavior is unchanged; the work is just done in 2 queries\ninstead of 2*(number of policies).\n\n**Result:** on my local environment with 10k policies, `POST\n/api/fleet/setup` response time is reduced from ~6.2s → ~0.3s (~95%\nfaster).\n\n## Release note\nImprove Fleet setup performance at scale by reconciling agent policy\nenrollment keys and revisions with bulk aggregations instead of\nper-policy Elasticsearch queries.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c8051aa9e20b4ab3865deff0ba868adf40b0f937"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272604","number":272604,"mergeCommit":{"message":"[UII] Optimize enrollment key and revision reconciliation during Fleet setup (#272604)\n\n## Summary\n\n(No related issue, found while working on\nhttps://github.com/elastic/kibana/pull/272428)\n\n`POST /api/fleet/setup` is slow for large number of agent policies. This\nis due to `ensureAgentPoliciesFleetServerKeysAndPolicies` issuing **two\nES searches per agent policy**: one for the latest deployed revision\n(`.fleet-policies`) and one to check for an existing enrollment API key\n(`.fleet-enrollment-api-keys`). With ~10k policies that's ~20k searches\nper call, saturating the Node event loop and blocking the request thread\n.\n\nThis replaces the per-policy fan-out with **two bulk aggregations**:\n- latest `revision_idx` per policy via a single `terms` + `max`\naggregation, and\n- the set of policies that already have an enrollment key via a single\n`terms` aggregation,\n\nthen only generates a default enrollment key for policies actually\nmissing one. Behavior is unchanged; the work is just done in 2 queries\ninstead of 2*(number of policies).\n\n**Result:** on my local environment with 10k policies, `POST\n/api/fleet/setup` response time is reduced from ~6.2s → ~0.3s (~95%\nfaster).\n\n## Release note\nImprove Fleet setup performance at scale by reconciling agent policy\nenrollment keys and revisions with bulk aggregations instead of\nper-policy Elasticsearch queries.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"c8051aa9e20b4ab3865deff0ba868adf40b0f937"}}]}] BACKPORT-->