### PR TITLE
[content list] feat: support match-all (AND) filtering in query text

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
@@ -138,6 +138,15 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
       items = items.filter((item) => matchesUserFilter(item, includeCreators));
     }
 
+    // Apply createdBy match-all (AND) filters. Each value must match individually, so
+    // multiple distinct creators yield nothing since an item has a single creator.
+    const includeAllCreators = createdByFilter?.includeAll;
+    if (includeAllCreators && includeAllCreators.length > 0) {
+      items = items.filter((item) =>
+        includeAllCreators.every((creator) => matchesUserFilter(item, [creator]))
+      );
+    }
+
     // Apply createdBy exclude filters.
     const excludeCreators = createdByFilter?.exclude;
     if (excludeCreators && excludeCreators.length > 0) {
@@ -520,6 +529,15 @@ export const createSimpleMockFindItems = (
     const includeCreators = createdByFilter?.include;
     if (includeCreators && includeCreators.length > 0) {
       items = items.filter((item) => matchesUserFilter(item, includeCreators));
+    }
+
+    // Apply createdBy match-all (AND) filters. Each value must match individually, so
+    // multiple distinct creators yield nothing since an item has a single creator.
+    const includeAllCreators = createdByFilter?.includeAll;
+    if (includeAllCreators && includeAllCreators.length > 0) {
+      items = items.filter((item) =>
+        includeAllCreators.every((creator) => matchesUserFilter(item, [creator]))
+      );
     }
 
     // Apply createdBy exclude filters.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
@@ -19,10 +19,14 @@ import { mockFavoritesClient } from './services';
 /** Shape compatible with `ActiveFilters` from `@kbn/content-list-provider`. Defined locally to avoid circular dependency. */
 interface MockFindItemsFilters {
   search?: string;
-  tag?: { include?: string[]; exclude?: string[] };
-  createdBy?: { include?: string[]; exclude?: string[] };
+  tag?: { include?: string[]; includeAll?: string[]; exclude?: string[] };
+  createdBy?: { include?: string[]; includeAll?: string[]; exclude?: string[] };
   starred?: { state: 'include' | 'exclude' };
 }
+
+/** Whether an item carries the given tag id in its references. */
+const itemHasTag = (item: UserContentCommonSchema, tag: string): boolean =>
+  item.references?.some((ref) => ref.id === tag) ?? false;
 
 /**
  * Extracts tag IDs from a `UserContentCommonSchema` item's `references` array.
@@ -112,17 +116,19 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
     const tagFilter = filters.tag;
     const includeTags = tagFilter?.include;
     if (includeTags && includeTags.length > 0) {
-      items = items.filter((item) =>
-        includeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
-      );
+      items = items.filter((item) => includeTags.some((tag) => itemHasTag(item, tag)));
+    }
+
+    // Apply tag match-all (AND) filters
+    const includeAllTags = tagFilter?.includeAll;
+    if (includeAllTags && includeAllTags.length > 0) {
+      items = items.filter((item) => includeAllTags.every((tag) => itemHasTag(item, tag)));
     }
 
     // Apply tag exclude filters
     const excludeTags = tagFilter?.exclude;
     if (excludeTags && excludeTags.length > 0) {
-      items = items.filter(
-        (item) => !excludeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
-      );
+      items = items.filter((item) => !excludeTags.some((tag) => itemHasTag(item, tag)));
     }
 
     // Apply createdBy include filters (UIDs from query model).
@@ -494,17 +500,19 @@ export const createSimpleMockFindItems = (
     const tagFilter = filters.tag;
     const includeTags = tagFilter?.include;
     if (includeTags && includeTags.length > 0) {
-      items = items.filter((item) =>
-        includeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
-      );
+      items = items.filter((item) => includeTags.some((tag) => itemHasTag(item, tag)));
+    }
+
+    // Apply tag match-all (AND) filters
+    const includeAllTags = tagFilter?.includeAll;
+    if (includeAllTags && includeAllTags.length > 0) {
+      items = items.filter((item) => includeAllTags.every((tag) => itemHasTag(item, tag)));
     }
 
     // Apply tag exclude filters
     const excludeTags = tagFilter?.exclude;
     if (excludeTags && excludeTags.length > 0) {
-      items = items.filter(
-        (item) => !excludeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
-      );
+      items = items.filter((item) => !excludeTags.some((tag) => itemHasTag(item, tag)));
     }
 
     // Apply createdBy include filters (UIDs from query model).

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.test.ts
@@ -305,6 +305,64 @@ describe('createClientStrategy', () => {
       expect(result.items[0].id).toBe('1');
     });
 
+    it('applies tag match-all (includeAll) filter, keeping only items with every tag', async () => {
+      const both: UserContentCommonSchema = {
+        ...createMockItem('1'),
+        references: [
+          { type: 'tag', id: 'tag-1', name: 'tag-1' },
+          { type: 'tag', id: 'tag-2', name: 'tag-2' },
+        ],
+      };
+      const onlyOne: UserContentCommonSchema = {
+        ...createMockItem('2'),
+        references: [{ type: 'tag', id: 'tag-1', name: 'tag-1' }],
+      };
+      const mockFindItems = createMockFindItems([both, onlyOne]);
+      const { findItems } = createClientStrategy(mockFindItems, undefined, undefined, {
+        tag: tagFilter,
+      });
+
+      const result = await findItems(
+        createParams({ filters: { tag: { includeAll: ['tag-1', 'tag-2'] } } })
+      );
+
+      expect(result.items.map((i) => i.id)).toEqual(['1']);
+    });
+
+    it('intersects match-any (include) and match-all (includeAll) buckets', async () => {
+      const prodImportant: UserContentCommonSchema = {
+        ...createMockItem('1'),
+        references: [
+          { type: 'tag', id: 'prod', name: 'prod' },
+          { type: 'tag', id: 'important', name: 'important' },
+        ],
+      };
+      const devImportant: UserContentCommonSchema = {
+        ...createMockItem('2'),
+        references: [
+          { type: 'tag', id: 'dev', name: 'dev' },
+          { type: 'tag', id: 'important', name: 'important' },
+        ],
+      };
+      const prodOnly: UserContentCommonSchema = {
+        ...createMockItem('3'),
+        references: [{ type: 'tag', id: 'prod', name: 'prod' }],
+      };
+      const mockFindItems = createMockFindItems([prodImportant, devImportant, prodOnly]);
+      const { findItems } = createClientStrategy(mockFindItems, undefined, undefined, {
+        tag: tagFilter,
+      });
+
+      // (prod OR dev) AND important
+      const result = await findItems(
+        createParams({
+          filters: { tag: { include: ['prod', 'dev'], includeAll: ['important'] } },
+        })
+      );
+
+      expect(result.items.map((i) => i.id)).toEqual(['1', '2']);
+    });
+
     it('applies starred filter via decorate + IncludeExcludeFlag', async () => {
       const mockItems = [createMockItem('1'), createMockItem('2'), createMockItem('3')];
       const mockFindItems = createMockFindItems(mockItems);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.ts
@@ -198,7 +198,9 @@ const extractTagIds = (refs?: Array<{ type: string; id: string }>): string[] | u
  * Safely narrow an `ActiveFilters` value to an {@link IncludeExcludeFilter}.
  */
 const asIncludeExclude = (value: ActiveFilters[string]): IncludeExcludeFilter | undefined =>
-  value != null && typeof value === 'object' && ('include' in value || 'exclude' in value)
+  value != null &&
+  typeof value === 'object' &&
+  ('include' in value || 'includeAll' in value || 'exclude' in value)
     ? (value as IncludeExcludeFilter)
     : undefined;
 
@@ -243,10 +245,15 @@ export const filterItems = (
       continue;
     }
 
-    const { include, exclude } = fieldFilter;
+    const { include, includeAll, exclude } = fieldFilter;
     if (include?.length) {
       result = result.filter((item) =>
         include.some((filterValue) => matchesFilterValue(item, customFilter, filterValue))
+      );
+    }
+    if (includeAll?.length) {
+      result = result.filter((item) =>
+        includeAll.every((filterValue) => matchesFilterValue(item, customFilter, filterValue))
       );
     }
     if (exclude?.length) {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.test.ts
@@ -27,6 +27,11 @@ describe('datasource type utilities', () => {
       expect(getIncludeExcludeFilter(filter)).toBe(filter);
     });
 
+    it('returns the filter for an object with only `includeAll` (match-all).', () => {
+      const filter: IncludeExcludeFilter = { includeAll: ['a', 'b'] };
+      expect(getIncludeExcludeFilter(filter)).toBe(filter);
+    });
+
     it('returns `undefined` for a string value.', () => {
       expect(getIncludeExcludeFilter('search text')).toBeUndefined();
     });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
@@ -13,8 +13,15 @@ import type { ContentListItem } from '../item';
  * Include/exclude filter shape used by tag, type, lastResponse, and other filter dimensions.
  */
 export interface IncludeExcludeFilter {
-  /** Values that items must match (include filter). */
+  /** Match-any (OR) values: an item matches if it has at least one. */
   include?: string[];
+  /**
+   * Match-all (AND) values: an item matches only if it has every one.
+   *
+   * Optional and additive — data sources that ignore it fall back to
+   * match-any semantics on {@link IncludeExcludeFilter.include}.
+   */
+  includeAll?: string[];
   /** Values that items must not match (exclude filter). */
   exclude?: string[];
 }
@@ -49,13 +56,15 @@ export interface ActiveFilters {
 }
 
 /**
- * Returns the filter value as {@link IncludeExcludeFilter} if it has `include` or `exclude`
- * arrays; otherwise `undefined`.
+ * Returns the filter value as {@link IncludeExcludeFilter} if it has an
+ * `include`, `includeAll`, or `exclude` array; otherwise `undefined`.
  */
 export const getIncludeExcludeFilter = (
   value: IncludeExcludeFilter | IncludeExcludeFlag | string | undefined
 ): IncludeExcludeFilter | undefined =>
-  value != null && typeof value === 'object' && ('include' in value || 'exclude' in value)
+  value != null &&
+  typeof value === 'object' &&
+  ('include' in value || 'includeAll' in value || 'exclude' in value)
     ? (value as IncludeExcludeFilter)
     : undefined;
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/url_sync/legacy_decoder.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/url_sync/legacy_decoder.test.ts
@@ -57,14 +57,14 @@ describe('legacy_decoder', () => {
         { filter: 'graph', created_by: 'jane@example.com', favorites: 'true' },
         validSortFields
       )?.state.queryText
-    ).toBe('graph createdBy:"jane@example.com" is:starred');
+    ).toBe('graph createdBy:("jane@example.com") is:starred');
   });
 
-  it('decodes created_by values with EUI query escaping', () => {
+  it('decodes multiple created_by values as a single OR-group (match-any)', () => {
     expect(
       decodeLegacyParams({ created_by: ['jane@example.com', 'Jane Doe'] }, validSortFields)?.state
         .queryText
-    ).toBe('createdBy:"jane@example.com" createdBy:"Jane Doe"');
+    ).toBe('createdBy:("jane@example.com" or "Jane Doe")');
   });
 
   it('decodes favorites=true as is:starred', () => {
@@ -88,7 +88,7 @@ describe('legacy_decoder', () => {
       )
     ).toEqual({
       state: {
-        queryText: 'dashboard createdBy:"jane@example.com" is:starred',
+        queryText: 'dashboard createdBy:("jane@example.com") is:starred',
         sort: { field: 'updatedAt', direction: 'asc' },
       },
       consumed: ['s', 'sort', 'sortdir', 'created_by', 'favorites'],

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/url_sync/legacy_decoder.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/url_sync/legacy_decoder.ts
@@ -64,8 +64,11 @@ const buildQueryText = ({
 }): string | undefined => {
   let query = Query.parse('');
 
+  // Emit a single OR-group (`createdBy:(u1 or u2)`) so multi-user bookmarks
+  // keep match-any semantics. Separate simple clauses would now parse as
+  // match-all (AND), which is meaningless for a single-creator field.
   for (const user of createdBy) {
-    query = query.addSimpleFieldValue('createdBy', user);
+    query = query.addOrFieldValue('createdBy', user, true, 'eq');
   }
 
   if (favorites) {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/url_sync/url_sync.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/url_sync/url_sync.test.tsx
@@ -134,13 +134,13 @@ describe('ContentListUrlSync', () => {
 
     await waitFor(() => {
       expect(result.current.state.queryText).toBe(
-        'dashboard createdBy:"jane@example.com" is:starred'
+        'dashboard createdBy:("jane@example.com") is:starred'
       );
       expect(result.current.state.sort).toEqual({ field: 'updatedAt', direction: 'asc' });
     });
 
     expect(parseSearch(history.location.search)).toEqual({
-      q: 'dashboard createdBy:"jane@example.com" is:starred',
+      q: 'dashboard createdBy:("jane@example.com") is:starred',
       sort: 'updatedAt:asc',
       space: 'default',
     });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/parse_query_text.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/parse_query_text.test.ts
@@ -112,9 +112,9 @@ describe('parseQueryText', () => {
   });
 
   describe('field filter extraction', () => {
-    it('extracts a simple include field clause.', () => {
+    it('routes a bare scalar clause to `includeAll` (match-all term).', () => {
       const result = parseQueryText('tag:Production', fields, flags, schema);
-      expect(result.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      expect(result.filters.tag).toEqual({ include: [], includeAll: ['tag-1'], exclude: [] });
       expect(result.search).toBe('');
     });
 
@@ -123,9 +123,13 @@ describe('parseQueryText', () => {
       expect(result.filters.tag).toEqual({ include: [], exclude: ['tag-2'] });
     });
 
-    it('combines include and exclude for the same field.', () => {
+    it('combines a bare include scalar and an exclude for the same field.', () => {
       const result = parseQueryText('tag:Production -tag:Archived', fields, flags, schema);
-      expect(result.filters.tag).toEqual({ include: ['tag-1'], exclude: ['tag-2'] });
+      expect(result.filters.tag).toEqual({
+        include: [],
+        includeAll: ['tag-1'],
+        exclude: ['tag-2'],
+      });
     });
 
     it('extracts multiple fields simultaneously.', () => {
@@ -135,13 +139,55 @@ describe('parseQueryText', () => {
         flags,
         schema
       );
-      expect(result.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
-      expect(result.filters.createdBy).toEqual({ include: ['u_jane'], exclude: [] });
+      expect(result.filters.tag).toEqual({ include: [], includeAll: ['tag-1'], exclude: [] });
+      expect(result.filters.createdBy).toEqual({
+        include: [],
+        includeAll: ['u_jane'],
+        exclude: [],
+      });
     });
 
-    it('deduplicates repeated values for the same field.', () => {
+    it('routes a single OR-group clause to `include` (match-any).', () => {
+      const result = parseQueryText('tag:(Production or Archived)', fields, flags, schema);
+      expect(result.filters.tag).toEqual({ include: ['tag-1', 'tag-2'], exclude: [] });
+    });
+
+    it('routes separate bare scalar clauses to `includeAll` (match-all/AND).', () => {
+      const result = parseQueryText('tag:Production tag:Archived', fields, flags, schema);
+      expect(result.filters.tag).toEqual({
+        include: [],
+        includeAll: ['tag-1', 'tag-2'],
+        exclude: [],
+      });
+    });
+
+    it('keeps separate single-value OR-groups as match-any (non-breaking).', () => {
+      const result = parseQueryText('tag:(Production) tag:(Archived)', fields, flags, schema);
+      expect(result.filters.tag).toEqual({ include: ['tag-1', 'tag-2'], exclude: [] });
+    });
+
+    it('mixes a match-any group with a match-all scalar.', () => {
+      const result = parseQueryText('tag:(Production or Archived) tag:Beta', fields, flags, schema);
+      expect(result.filters.tag).toEqual({
+        include: ['tag-1', 'tag-2'],
+        includeAll: ['tag-3'],
+        exclude: [],
+      });
+    });
+
+    it('combines match-all scalars with an exclude clause.', () => {
+      const result = parseQueryText('tag:Production tag:Archived -tag:Beta', fields, flags, schema);
+      expect(result.filters.tag).toEqual({
+        include: [],
+        includeAll: ['tag-1', 'tag-2'],
+        exclude: ['tag-3'],
+      });
+    });
+
+    it('deduplicates repeated bare scalars into a single match-all value.', () => {
       const result = parseQueryText('tag:Production tag:Production', fields, flags, schema);
-      expect(result.filters.tag?.include).toEqual(['tag-1']);
+      expect(result.filters.tag?.includeAll).toEqual(['tag-1']);
+      expect(result.filters.tag?.include).toEqual([]);
     });
 
     it('keeps the raw display value when resolution fails so the filter still applies.', () => {
@@ -156,7 +202,7 @@ describe('parseQueryText', () => {
         flags,
         buildSchema([fieldWithNoFuzzy])
       );
-      expect(result.filters.tag).toEqual({ include: ['nonexistent'], exclude: [] });
+      expect(result.filters.tag).toEqual({ include: [], includeAll: ['nonexistent'], exclude: [] });
     });
 
     it('tracks referenced fields when the value cannot be resolved.', () => {
@@ -172,7 +218,8 @@ describe('parseQueryText', () => {
         buildSchema([fieldWithNoFuzzy])
       );
       expect(result.filters.createdBy).toEqual({
-        include: ['someone@example.com'],
+        include: [],
+        includeAll: ['someone@example.com'],
         exclude: [],
       });
       expect(result.referencedFields).toEqual(new Set(['createdBy']));
@@ -182,7 +229,8 @@ describe('parseQueryText', () => {
     it('sets unresolvedFields to empty when all values resolve.', () => {
       const result = parseQueryText('createdBy:jane@example.com', fields, flags, schema);
       expect(result.filters.createdBy).toEqual({
-        include: ['u_jane'],
+        include: [],
+        includeAll: ['u_jane'],
         exclude: [],
       });
       expect(result.unresolvedFields.size).toBe(0);
@@ -190,9 +238,9 @@ describe('parseQueryText', () => {
   });
 
   describe('fuzzy field resolution', () => {
-    it('uses fuzzy matching when exact resolution fails.', () => {
+    it('uses fuzzy matching when exact resolution fails (single match → match-all).', () => {
       const result = parseQueryText('tag:prod', fields, flags, schema);
-      expect(result.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      expect(result.filters.tag).toEqual({ include: [], includeAll: ['tag-1'], exclude: [] });
     });
 
     it('resolves multiple fuzzy matches into the include list.', () => {
@@ -213,7 +261,7 @@ describe('parseQueryText', () => {
     it('extracts flags alongside search text and field filters.', () => {
       const result = parseQueryText('dashboard tag:Production is:starred', fields, flags, schema);
       expect(result.flags).toEqual({ starred: true });
-      expect(result.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      expect(result.filters.tag).toEqual({ include: [], includeAll: ['tag-1'], exclude: [] });
       expect(result.search).toBe('dashboard');
     });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/parse_query_text.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/parse_query_text.ts
@@ -80,55 +80,74 @@ const resolveDisplayValue = (
   return { ids: [displayValue], resolved: false };
 };
 
-/** Extract include/exclude IDs for a field from the parsed query. */
+/**
+ * Extract include/exclude IDs for a field from the parsed query.
+ *
+ * Maps EUI clause structure to filter buckets, faithful to EUI search
+ * semantics (clauses are AND-combined; values inside an OR-group are
+ * OR-combined):
+ *
+ * - An OR-group clause (`field:(a or b)`, or the single-value `field:(a)`) is
+ *   match-any → {@link QueryFilterValue.include}. Keeping each group in this
+ *   bucket preserves the existing OR behavior of `field:(a) field:(b)`.
+ * - A bare scalar clause (`field:a`) is a standalone match-all constraint →
+ *   {@link QueryFilterValue.includeAll}, so `field:a field:b` is AND. A scalar
+ *   that fuzzy-expands to several IDs (`createdBy:jo` → two users) stays
+ *   match-any, since those IDs are one term.
+ *
+ * For a single value match-any and match-all are equivalent, so a lone
+ * `field:a` filters identically whether bucketed as include or includeAll.
+ */
 const extractFieldFilter = (
   query: InstanceType<typeof Query>,
   field: FieldDefinition
 ): { filter: QueryFilterValue | undefined; hasUnresolved: boolean } => {
-  const includeIds: string[] = [];
+  const anyIds: string[] = [];
+  const allIds: string[] = [];
   const excludeIds: string[] = [];
   let hasUnresolved = false;
 
-  const collectResolved = (displayValues: string[], target: string[]) => {
+  const resolve = (displayValues: string[]): string[] => {
+    const ids: string[] = [];
     for (const dv of displayValues) {
       const result = resolveDisplayValue(dv, field);
-      target.push(...result.ids);
+      ids.push(...result.ids);
       if (!result.resolved) {
         hasUnresolved = true;
       }
     }
+    return ids;
   };
 
-  // Simple field clauses: `field:value` or `-field:value`.
-  const simpleClauses = query.ast.getFieldClauses(field.fieldName);
-  if (simpleClauses) {
-    for (const clause of simpleClauses) {
-      const values = toStringArray(clause.value);
-      if (clause.match === 'must') {
-        collectResolved(values, includeIds);
-      } else if (clause.match === 'must_not') {
-        collectResolved(values, excludeIds);
-      }
+  // `getFieldClauses` returns every field clause — scalar (`field:value`) and
+  // array-valued OR-groups (`field:(a or b)`) alike.
+  const clauses = query.ast.getFieldClauses(field.fieldName) ?? [];
+  for (const clause of clauses) {
+    const isGroup = Array.isArray(clause.value);
+    const ids = resolve(toStringArray(clause.value));
+    if (clause.match === 'must') {
+      // A bare scalar that resolves to exactly one ID is a match-all term;
+      // groups and fuzzy-expanded scalars are match-any.
+      const target = isGroup || ids.length > 1 ? anyIds : allIds;
+      target.push(...ids);
+    } else if (clause.match === 'must_not') {
+      excludeIds.push(...ids);
     }
   }
 
-  // OR-field clauses: `field:(A or B)`.
-  const includeOr = query.ast.getOrFieldClause(field.fieldName, undefined, true, 'eq');
-  if (includeOr) {
-    collectResolved(toStringArray(includeOr.value), includeIds);
-  }
-  const excludeOr = query.ast.getOrFieldClause(field.fieldName, undefined, false, 'eq');
-  if (excludeOr) {
-    collectResolved(toStringArray(excludeOr.value), excludeIds);
-  }
-
-  const include = [...new Set(includeIds)];
+  const include = [...new Set(anyIds)];
+  const includeAll = [...new Set(allIds)];
   const exclude = [...new Set(excludeIds)];
 
-  if (include.length === 0 && exclude.length === 0) {
+  if (include.length === 0 && includeAll.length === 0 && exclude.length === 0) {
     return { filter: undefined, hasUnresolved };
   }
-  return { filter: { include, exclude }, hasUnresolved };
+
+  const filter: QueryFilterValue = { include, exclude };
+  if (includeAll.length > 0) {
+    filter.includeAll = includeAll;
+  }
+  return { filter, hasUnresolved };
 };
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/to_active_filters.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/to_active_filters.test.ts
@@ -69,6 +69,44 @@ describe('toFindItemsFilters', () => {
     expect(result.createdBy).toEqual({ include: ['u_jane'], exclude: [] });
   });
 
+  it('passes through `includeAll` (match-all) buckets.', () => {
+    const model: ContentListQueryModel = {
+      ...EMPTY_MODEL,
+      filters: {
+        tag: { include: [], includeAll: ['tag-1', 'tag-2'], exclude: ['tag-3'] },
+      },
+    };
+    expect(toFindItemsFilters(model).tag).toEqual({
+      include: [],
+      includeAll: ['tag-1', 'tag-2'],
+      exclude: ['tag-3'],
+    });
+  });
+
+  it('emits a field filter that only has match-all values.', () => {
+    const model: ContentListQueryModel = {
+      ...EMPTY_MODEL,
+      filters: {
+        tag: { include: [], includeAll: ['tag-1', 'tag-2'], exclude: [] },
+      },
+    };
+    expect(toFindItemsFilters(model).tag).toEqual({
+      include: [],
+      includeAll: ['tag-1', 'tag-2'],
+      exclude: [],
+    });
+  });
+
+  it('does not add an `includeAll` key when the bucket is empty.', () => {
+    const model: ContentListQueryModel = {
+      ...EMPTY_MODEL,
+      filters: {
+        tag: { include: ['tag-1'], includeAll: [], exclude: [] },
+      },
+    };
+    expect(toFindItemsFilters(model).tag).not.toHaveProperty('includeAll');
+  });
+
   it('skips field filters with empty include and exclude arrays.', () => {
     const model: ContentListQueryModel = {
       ...EMPTY_MODEL,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/to_active_filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/to_active_filters.ts
@@ -33,10 +33,12 @@ export const toFindItemsFilters = (model: ContentListQueryModel): ActiveFilters 
   }
 
   for (const [fieldName, filter] of Object.entries(model.filters)) {
-    if (filter.include.length > 0 || filter.exclude.length > 0) {
+    const includeAll = filter.includeAll ?? [];
+    if (filter.include.length > 0 || includeAll.length > 0 || filter.exclude.length > 0) {
       result[fieldName] = {
         include: filter.include,
         exclude: filter.exclude,
+        ...(includeAll.length > 0 ? { includeAll } : {}),
       };
     }
   }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/types.ts
@@ -16,11 +16,20 @@
 /**
  * Include/exclude filter for a single field dimension.
  *
- * Always uses arrays (never undefined) to avoid null-checking throughout.
+ * Mirrors EUI's search AST: values within a single OR-group clause
+ * (`field:(a or b)`) are match-any; separate `must` clauses
+ * (`field:a field:b`) are match-all (AND-combined).
  */
 export interface QueryFilterValue {
-  /** IDs that items must match. */
+  /** Match-any (OR) IDs: an item matches if it has at least one. */
   include: string[];
+  /**
+   * Match-all (AND) IDs: an item matches only if it has every one.
+   *
+   * Populated when the query expresses the field as separate `must` clauses
+   * (e.g. `tag:a tag:b`). Absent for the common match-any case.
+   */
+  includeAll?: string[];
   /** IDs that items must not match. */
   exclude: string[];
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/use_query_model.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query_model/use_query_model.test.tsx
@@ -121,8 +121,8 @@ describe('useQueryModel', () => {
 
     expect(result.current.model.search).toBe('dashboard status:open is:custom');
     expect(result.current.model.filters).toEqual({
-      createdBy: { include: ['u_jane'], exclude: [] },
-      tag: { include: ['tag-1'], exclude: ['tag-2'] },
+      createdBy: { include: [], includeAll: ['u_jane'], exclude: [] },
+      tag: { include: [], includeAll: ['tag-1'], exclude: ['tag-2'] },
     });
     expect(result.current.model.flags).toEqual({ starred: true });
     expect(result.current.model.referencedFields).toEqual(new Set(['tag', 'createdBy']));
@@ -139,8 +139,8 @@ describe('useQueryModel', () => {
     });
 
     expect(result.current.model.filters).toEqual({
-      createdBy: { include: ['u_jane'], exclude: [] },
-      tag: { include: ['tag-1'], exclude: [] },
+      createdBy: { include: [], includeAll: ['u_jane'], exclude: [] },
+      tag: { include: [], includeAll: ['tag-1'], exclude: [] },
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.test.tsx
@@ -235,7 +235,8 @@ describe('useContentListItems', () => {
 
       await waitFor(() => {
         expect(result.current.filters.filters.createdBy).toEqual({
-          include: ['u_jane'],
+          include: [],
+          includeAll: ['u_jane'],
           exclude: [],
         });
       });
@@ -244,7 +245,7 @@ describe('useContentListItems', () => {
         expect(
           userFindItems.mock.calls.some(([params]) => {
             const createdBy = getIncludeExcludeFilter(params.filters.createdBy);
-            return createdBy?.include?.includes('u_jane') && createdBy?.exclude?.length === 0;
+            return createdBy?.includeAll?.includes('u_jane') && createdBy?.exclude?.length === 0;
           })
         ).toBe(true);
       });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.test.tsx
@@ -469,7 +469,8 @@ describe('ContentListToolbar', () => {
         const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
         expect(lastCall[0].searchQuery).toBe('my query');
         expect(lastCall[0].filters.tag).toEqual({
-          include: ['tag-1'],
+          include: [],
+          includeAll: ['tag-1'],
           exclude: [],
         });
       });
@@ -527,7 +528,8 @@ describe('ContentListToolbar', () => {
         const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
         expect(lastCall[0].searchQuery).toBe('my query');
         expect(lastCall[0].filters.tag).toEqual({
-          include: ['tag-3'],
+          include: [],
+          includeAll: ['tag-3'],
           exclude: [],
         });
       });
@@ -553,7 +555,11 @@ describe('ContentListToolbar', () => {
       await waitFor(() => {
         const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
         expect(lastCall[0].searchQuery).toBe('my query');
-        expect(lastCall[0].filters.tag).toEqual({ include: ['Unknown'], exclude: [] });
+        expect(lastCall[0].filters.tag).toEqual({
+          include: [],
+          includeAll: ['Unknown'],
+          exclude: [],
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

First of two stacked PRs adding **AND** (match-all) filtering to the Content List toolbar. This PR is **logic only** — it teaches the query model to understand match-all semantics in the query text, with no popover UX changes yet. The UX (Shift+click, green plus) lands in the stacked follow-up.

Today every filter clause is treated as **match-any (OR)**: `tag:(a or b)` and the popover only ever emits OR-groups. This PR aligns the parser with EUI / `@kbn/es-query` native semantics so that the clause _structure_ determines the boolean mode:

- **OR-group clauses** — `tag:(a or b)` (and the single-value `tag:(a)`) → **match-any** (`include`). Existing behavior is preserved.
- **Bare scalar clauses** — `tag:a tag:b` → **match-all** (`includeAll`); an item must have _every_ such tag.
- **Negated clauses** — `-tag:(a)` → **exclude**.
- A scalar that **fuzzy-expands to multiple ids** (e.g. `createdBy:jo` resolving to several users) stays **match-any**, since a single typed token can't sensibly mean "match all".

### Why this is backward-compatible

`tag:(Production) tag:(Development)` is an **OR** proposition today, and it stays OR — only _bare_ scalars (`tag:a tag:b`) are interpreted as AND. Legacy URL hydration is updated to always emit OR-groups for `createdBy`, so multi-creator filters keep their OR meaning (an item has exactly one creator).

## Changes

- New `includeAll` bucket on `QueryFilterValue` / `IncludeExcludeFilter` alongside `include` and `exclude`.
- `parse_query_text` routes clauses to the right bucket using the per-clause structural rule above.
- Client-side `filterItems` applies `.every()` for `includeAll` (match-all) and `.some()` for `include` (match-any).
- Legacy decoder emits `createdBy` as an OR-group to preserve OR semantics.
- Storybook mock `findItems` honors `includeAll`.

## Validation

- `node scripts/jest` — content_list provider, provider-client, and toolbar packages green.
- `node scripts/type_check` on the affected packages.
- `node scripts/eslint` + `node scripts/i18n_check` on changed files.

## Test plan

- [ ] `tag:a tag:b` returns only items having **both** tags.
- [ ] `tag:(a or b)` still returns items having **either** tag.
- [ ] `tag:(Production) tag:(Development)` is unchanged (OR).
- [ ] Legacy URLs with multiple `createdBy` values hydrate as an OR-group.