### PR TITLE
[content list] feat: shift+click match-all (AND) in filter popovers

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.test.tsx
@@ -13,9 +13,11 @@ import { render, screen } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react';
 import {
   FilterCountBadge,
+  FilterStateIcon,
   ModifierKeyTip,
   getCheckedState,
   isExcludeModifier,
+  isMatchAllModifier,
   useFieldQueryFilter,
 } from './filter_utils';
 
@@ -26,16 +28,26 @@ describe('filter utilities', () => {
     });
   });
 
+  describe('isMatchAllModifier', () => {
+    it('returns true only when Shift is pressed', () => {
+      expect(isMatchAllModifier({ shiftKey: true })).toBe(true);
+      expect(isMatchAllModifier({ shiftKey: false })).toBe(false);
+    });
+  });
+
   describe('getCheckedState', () => {
-    it('maps include and exclude states to EuiSelectable checked values', () => {
+    it('maps include, includeAll, and exclude states to EuiSelectable checked values', () => {
       expect(getCheckedState('include')).toBe('on');
+      expect(getCheckedState('includeAll')).toBe('on');
       expect(getCheckedState('exclude')).toBe('off');
       expect(getCheckedState(undefined)).toBeUndefined();
     });
   });
 
   describe('useFieldQueryFilter', () => {
-    it('reads OR-field clauses and simple clauses from the query', () => {
+    it('reads OR-field clauses (match-any/exclude) and bare scalar clauses (match-all)', () => {
+      // `tag:Archived` is a bare scalar → match-all (`includeAll`); the OR-group
+      // clauses are match-any (`include`) and exclude.
       const query = Query.parse('tag:Archived')
         .addOrFieldValue('tag', 'Production', true, 'eq')
         .addOrFieldValue('tag', 'Internal', false, 'eq');
@@ -50,10 +62,55 @@ describe('filter utilities', () => {
       expect(result.current.selection).toEqual({
         Production: 'include',
         Internal: 'exclude',
-        Archived: 'include',
+        Archived: 'includeAll',
       });
       expect(result.current.activeCount).toBe(3);
       expect(result.current.getState('Internal')).toBe('exclude');
+      expect(result.current.getState('Archived')).toBe('includeAll');
+    });
+
+    it('writes a bare scalar clause when toggling a value to match-all', () => {
+      const onChange = jest.fn();
+
+      const { result } = renderHook(() =>
+        useFieldQueryFilter({
+          fieldName: 'tag',
+          query: Query.parse(''),
+          onChange,
+        })
+      );
+
+      act(() => {
+        result.current.toggle('Production', 'includeAll');
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      // Match-all is a bare scalar clause, not an OR-group.
+      expect(onChange.mock.calls[0][0].text).toBe('tag:Production');
+    });
+
+    it('switches a match-any clause to match-all and back', () => {
+      const onChange = jest.fn();
+
+      const { result, rerender } = renderHook(
+        ({ currentQuery }) =>
+          useFieldQueryFilter({ fieldName: 'tag', query: currentQuery, onChange }),
+        { initialProps: { currentQuery: Query.parse('tag:(Production)') } }
+      );
+
+      act(() => {
+        result.current.toggle('Production', 'includeAll');
+      });
+
+      expect(onChange.mock.calls[0][0].text).toBe('tag:Production');
+
+      rerender({ currentQuery: onChange.mock.calls[0][0] as Query });
+
+      act(() => {
+        result.current.toggle('Production', 'include');
+      });
+
+      expect(onChange.mock.calls[1][0].text).toBe('tag:(Production)');
     });
 
     it('replaces the current value in single-selection mode and clears it when toggled again', () => {
@@ -136,6 +193,25 @@ describe('filter utilities', () => {
       render(<ModifierKeyTip />);
 
       expect(screen.getByText(/\+ click exclude/)).toBeInTheDocument();
+      expect(screen.getByText(/\+ click match all/)).toBeInTheDocument();
+    });
+
+    it('hides the match-all hint when match-all is disabled', () => {
+      render(<ModifierKeyTip showMatchAll={false} />);
+
+      expect(screen.getByText(/\+ click exclude/)).toBeInTheDocument();
+      expect(screen.queryByText(/\+ click match all/)).not.toBeInTheDocument();
+    });
+
+    it('renders the filter state icon for each mode', () => {
+      const { rerender } = render(<FilterStateIcon state="include" />);
+      expect(screen.getByText('Included (match any)')).toBeInTheDocument();
+
+      rerender(<FilterStateIcon state="includeAll" />);
+      expect(screen.getByText('Required (match all)')).toBeInTheDocument();
+
+      rerender(<FilterStateIcon state="exclude" />);
+      expect(screen.getByText('Excluded')).toBeInTheDocument();
     });
 
     it('renders the filter count badge with active styling', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
@@ -122,7 +122,7 @@ export const FilterStateIcon = ({ state }: { state: FilterType | null | undefine
   if (state === 'exclude') {
     return <EuiIcon type="cross" color="danger" aria-label={filterStateIconLabels.exclude} />;
   }
-  return <EuiIcon type="empty" />;
+  return <EuiIcon type="empty" aria-hidden={true} />;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
@@ -12,6 +12,7 @@ import {
   EuiPopoverFooter,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiText,
   EuiTextColor,
   EuiBadge,
@@ -36,11 +37,26 @@ export const isExcludeModifier = (e: { metaKey: boolean; ctrlKey: boolean }): bo
   return (isMac && e.metaKey) || (!isMac && e.ctrlKey);
 };
 
+/**
+ * Checks if the match-all modifier key (Shift) is pressed.
+ *
+ * @param e - An event object containing a `shiftKey` property.
+ * @returns `true` if Shift is pressed.
+ */
+export const isMatchAllModifier = (e: { shiftKey: boolean }): boolean => e.shiftKey;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Filter types and utilities.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type FilterType = 'include' | 'exclude';
+/**
+ * The boolean mode applied to a single filter value:
+ *
+ * - `'include'` — match-any (OR), written as an OR-group clause (`tag:(a or b)`).
+ * - `'includeAll'` — match-all (AND), written as a bare scalar clause (`tag:a`).
+ * - `'exclude'` — negated, written as a negated OR-group (`-tag:(a)`).
+ */
+export type FilterType = 'include' | 'includeAll' | 'exclude';
 export type FilterSelection = Record<string, FilterType>;
 
 /**
@@ -51,18 +67,62 @@ const toArray = (item: unknown): unknown[] => (Array.isArray(item) ? item : [ite
 /**
  * Maps filter state to `EuiSelectable` checked state.
  *
- * - `'include'` → `'on'` (green checkmark).
- * - `'exclude'` → `'off'` (red X).
+ * Both match modes report `'on'` so the option counts as selected; the visual
+ * distinction (check vs. green plus) is drawn by {@link FilterStateIcon}.
+ *
+ * - `'include'` / `'includeAll'` → `'on'`.
+ * - `'exclude'` → `'off'`.
  * - `undefined` → `undefined` (no indicator).
  */
 export const getCheckedState = (state: FilterType | null | undefined): 'on' | 'off' | undefined => {
-  if (state === 'include') {
+  if (state === 'include' || state === 'includeAll') {
     return 'on';
   }
   if (state === 'exclude') {
     return 'off';
   }
   return undefined;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `FilterStateIcon` component.
+// Leading status icon rendered per option (the list hides EUI's default icons).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const filterStateIconLabels = {
+  include: i18n.translate('contentManagement.contentList.filter.includeIconLabel', {
+    defaultMessage: 'Included (match any)',
+  }),
+  includeAll: i18n.translate('contentManagement.contentList.filter.includeAllIconLabel', {
+    defaultMessage: 'Required (match all)',
+  }),
+  exclude: i18n.translate('contentManagement.contentList.filter.excludeIconLabel', {
+    defaultMessage: 'Excluded',
+  }),
+};
+
+/**
+ * Leading status icon for a filter option: a check for match-any, a green plus
+ * for match-all, a cross for exclude, and an empty spacer when inactive (so
+ * rows stay aligned).
+ */
+export const FilterStateIcon = ({ state }: { state: FilterType | null | undefined }) => {
+  if (state === 'includeAll') {
+    return (
+      <EuiIcon
+        type="plusInCircleFilled"
+        color="success"
+        aria-label={filterStateIconLabels.includeAll}
+      />
+    );
+  }
+  if (state === 'include') {
+    return <EuiIcon type="check" color="success" aria-label={filterStateIconLabels.include} />;
+  }
+  if (state === 'exclude') {
+    return <EuiIcon type="cross" color="danger" aria-label={filterStateIconLabels.exclude} />;
+  }
+  return <EuiIcon type="empty" />;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -126,7 +186,8 @@ export const useFieldQueryFilter = ({
 
     const result: FilterSelection = {};
 
-    // Read OR-field clauses (`field:(A or B)`) — the primary format written by the UI.
+    // OR-group clauses (`field:(A or B)`) are match-any/exclude — the format the
+    // popover writes for plain and Cmd/Ctrl clicks.
     const includeOrClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, true, 'eq');
     if (includeOrClause) {
       toArray(includeOrClause.value).forEach((v) => {
@@ -141,20 +202,20 @@ export const useFieldQueryFilter = ({
       });
     }
 
-    // Also read simple field clauses (`field:value` or `-field:value`) so that
-    // values typed manually by the user are reflected as active in the popover.
-    // Only write if the key isn't already captured by an OR-field clause above —
-    // OR-clauses are the primary format written by the UI and take precedence.
+    // Bare scalar clauses (`field:value`) are match-all (written by Shift+click,
+    // or typed manually); negated scalars are exclude. OR-groups above win when
+    // the same value appears in both forms.
     const simpleClauses = parsedQuery.ast.getFieldClauses(fieldName);
     if (simpleClauses) {
       simpleClauses.forEach((clause) => {
-        const type: FilterType = clause.match === 'must' ? 'include' : 'exclude';
-        toArray(clause.value).forEach((v) => {
-          const key = String(v);
-          if (!result[key]) {
-            result[key] = type;
-          }
-        });
+        if (Array.isArray(clause.value)) {
+          return;
+        }
+        const type: FilterType = clause.match === 'must' ? 'includeAll' : 'exclude';
+        const key = String(clause.value);
+        if (!result[key]) {
+          result[key] = type;
+        }
       });
     }
 
@@ -191,7 +252,12 @@ export const useFieldQueryFilter = ({
       }
 
       if (currentState !== targetType) {
-        q = q.addOrFieldValue(fieldName, value, targetType === 'include', 'eq');
+        // Match-all is a bare scalar clause (`field:value`); match-any and
+        // exclude are OR-group clauses (`field:(value)` / `-field:(value)`).
+        q =
+          targetType === 'includeAll'
+            ? q.addSimpleFieldValue(fieldName, value, true, 'eq')
+            : q.addOrFieldValue(fieldName, value, targetType === 'include', 'eq');
       }
 
       onChange?.(q);
@@ -225,14 +291,18 @@ export const useFieldQueryFilter = ({
  * Props for the {@link ModifierKeyTip} component.
  */
 export interface ModifierKeyTipProps {
+  /** Whether to show the Shift = match all hint. @default true */
+  showMatchAll?: boolean;
   /** Optional additional content to display below the tip. */
   children?: React.ReactNode;
 }
 
 /**
- * Footer component that displays the modifier key shortcut for exclude.
+ * Footer component that displays the modifier-key shortcuts: Cmd/Ctrl+click to
+ * exclude and (when {@link ModifierKeyTipProps.showMatchAll} is set) Shift+click
+ * to require a value (match all).
  */
-export const ModifierKeyTip = ({ children }: ModifierKeyTipProps) => {
+export const ModifierKeyTip = ({ showMatchAll = true, children }: ModifierKeyTipProps) => {
   return (
     <EuiPopoverFooter paddingSize="m">
       <EuiFlexGroup direction="column" alignItems="center" gutterSize="s" responsive={false}>
@@ -246,6 +316,17 @@ export const ModifierKeyTip = ({ children }: ModifierKeyTipProps) => {
             </EuiTextColor>
           </EuiText>
         </EuiFlexItem>
+        {showMatchAll && (
+          <EuiFlexItem>
+            <EuiText size="xs">
+              <EuiTextColor color="subdued">
+                {i18n.translate('contentManagement.contentList.filter.matchAllKeyHelpText', {
+                  defaultMessage: '⇧ + click match all',
+                })}
+              </EuiTextColor>
+            </EuiText>
+          </EuiFlexItem>
+        )}
         {children}
       </EuiFlexGroup>
     </EuiPopoverFooter>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
@@ -224,6 +224,42 @@ describe('SelectableFilterPopover', () => {
     expect(onChange.mock.calls[0][0].text).toBe('createdBy:(Production)');
   });
 
+  it('renders a lone match-all value as a plain include (no green plus)', async () => {
+    render(
+      <SelectableFilterPopover
+        fieldName="tag"
+        title="Tags"
+        query={Query.parse('tag:Production')}
+        options={options}
+        renderOption={(option, { state }) => <span>{`${option.label}=${state ?? 'none'}`}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    // A single required value is indistinguishable from match-any, so it shows
+    // as `include` rather than `includeAll`.
+    expect(await screen.findByText('Production=include')).toBeInTheDocument();
+    expect(screen.getByText('Archived=none')).toBeInTheDocument();
+  });
+
+  it('renders match-all values as includeAll once a field has two or more', async () => {
+    render(
+      <SelectableFilterPopover
+        fieldName="tag"
+        title="Tags"
+        query={Query.parse('tag:Production tag:Archived')}
+        options={options}
+        renderOption={(option, { state }) => <span>{`${option.label}=${state ?? 'none'}`}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    expect(await screen.findByText('Production=includeAll')).toBeInTheDocument();
+    expect(screen.getByText('Archived=includeAll')).toBeInTheDocument();
+  });
+
   it('omits the match-all hint when allowMatchAll is false', async () => {
     render(
       <SelectableFilterPopover

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
@@ -165,4 +165,82 @@ describe('SelectableFilterPopover', () => {
 
     expect(onChange.mock.calls[0][0].text).toContain('-tag:(Production)');
   });
+
+  it('uses Shift to add a match-all (bare scalar) filter', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <SelectableFilterPopover
+        fieldName="tag"
+        title="Tags"
+        query={Query.parse('')}
+        onChange={onChange}
+        options={options}
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    const productionOption = await screen.findByText('Production');
+
+    fireEvent.mouseDown(productionOption, { shiftKey: true });
+    fireEvent.click(productionOption, { shiftKey: true });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    // Match-all is written as a bare scalar clause, not an OR-group.
+    expect(onChange.mock.calls[0][0].text).toBe('tag:Production');
+  });
+
+  it('falls back to match-any when Shift is used but allowMatchAll is false', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <SelectableFilterPopover
+        fieldName="createdBy"
+        title="Creators"
+        query={Query.parse('')}
+        onChange={onChange}
+        options={options}
+        allowMatchAll={false}
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Creators'));
+
+    const productionOption = await screen.findByText('Production');
+
+    fireEvent.mouseDown(productionOption, { shiftKey: true });
+    fireEvent.click(productionOption, { shiftKey: true });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    expect(onChange.mock.calls[0][0].text).toBe('createdBy:(Production)');
+  });
+
+  it('omits the match-all hint when allowMatchAll is false', async () => {
+    render(
+      <SelectableFilterPopover
+        fieldName="createdBy"
+        title="Creators"
+        query={Query.parse('')}
+        options={options}
+        allowMatchAll={false}
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Creators'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/\+ click exclude/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/\+ click match all/)).not.toBeInTheDocument();
+  });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
@@ -230,16 +230,23 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
     return selectedKeys.filter((value) => validOptionValues.has(value)).length;
   }, [selection, validOptionValues, options.length]);
 
+  // For a single value, match-all and match-any are identical, so the green
+  // plus only carries meaning once a field has 2+ required values. Below that,
+  // (or when match-all is disabled) match-all clauses render as a plain include.
+  const matchAllCount = useMemo(
+    () => Object.values(selection).filter((type) => type === 'includeAll').length,
+    [selection]
+  );
+
   // Build selectable options with view rendering.
   const selectableOptions = useMemo((): Array<InternalSelectableOption<T>> => {
+    const showMatchAllIcon = allowMatchAll && matchAllCount >= 2;
     return options.map((option) => {
       const queryValue = option.value ?? option.key;
       const selectedValue = selection[queryValue] ? queryValue : option.key;
       const rawState: FilterType | undefined = selection[queryValue] ?? selection[option.key];
-      // When match-all is disabled, render any match-all clause as a plain
-      // include so the field never shows a green plus.
       const state: FilterType | undefined =
-        !allowMatchAll && rawState === 'includeAll' ? 'include' : rawState;
+        rawState === 'includeAll' && !showMatchAllIcon ? 'include' : rawState;
       const checked = getCheckedState(state);
       const isActive = checked !== undefined;
       const count = option.count ?? 0;
@@ -254,7 +261,7 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
         view: renderOption(option, { checked, isActive, state }),
       };
     });
-  }, [options, selection, renderOption, allowMatchAll]);
+  }, [options, selection, renderOption, allowMatchAll, matchAllCount]);
 
   // Build a lookup from key → checked state for stable comparison that
   // doesn't rely on index alignment (safe if `EuiSelectable` reorders options).

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
@@ -21,9 +21,11 @@ import { FilterPopoverHeader } from './filter_popover_header';
 import {
   useFieldQueryFilter,
   isExcludeModifier,
+  isMatchAllModifier,
   getCheckedState,
   ModifierKeyTip,
   FilterCountBadge,
+  FilterStateIcon,
   type FilterType,
 } from './filter_utils';
 
@@ -67,6 +69,8 @@ export interface SelectableFilterPopoverProps<T extends object = Record<string, 
     state: {
       checked: 'on' | 'off' | undefined;
       isActive: boolean;
+      /** The value's filter mode, or `undefined` when inactive. */
+      state: FilterType | undefined;
     }
   ) => React.ReactNode;
   /**
@@ -76,6 +80,13 @@ export interface SelectableFilterPopoverProps<T extends object = Record<string, 
    * @default false
    */
   singleSelection?: boolean;
+  /**
+   * Allow Shift+click to mark a value as match-all (AND). Disable for fields
+   * where match-all is meaningless (e.g. a single-valued `createdBy`).
+   *
+   * @default true
+   */
+  allowMatchAll?: boolean;
   /** Whether the options are loading. */
   isLoading?: boolean;
   /** Empty state message to display. */
@@ -154,6 +165,7 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
   options,
   renderOption,
   singleSelection = false,
+  allowMatchAll = true,
   isLoading,
   emptyMessage,
   noMatchesMessage,
@@ -189,12 +201,15 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
   });
 
   // Track the modifier key state from the most recent user interaction so
-  // `handleSelectChange` can distinguish include from exclude. Capture-phase
-  // handlers fire before `EuiSelectable` processes the event, guaranteeing
-  // the ref is set before `onChange` runs.
-  const lastModifierRef = useRef(false);
+  // `handleSelectChange` can distinguish include / match-all / exclude.
+  // Capture-phase handlers fire before `EuiSelectable` processes the event,
+  // guaranteeing the ref is set before `onChange` runs.
+  const lastModifierRef = useRef<{ exclude: boolean; matchAll: boolean }>({
+    exclude: false,
+    matchAll: false,
+  });
   const handleInteractionCapture = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
-    lastModifierRef.current = isExcludeModifier(e);
+    lastModifierRef.current = { exclude: isExcludeModifier(e), matchAll: isMatchAllModifier(e) };
   }, []);
 
   // The badge count is derived from the parsed query (`selection`), so it must
@@ -220,7 +235,11 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
     return options.map((option) => {
       const queryValue = option.value ?? option.key;
       const selectedValue = selection[queryValue] ? queryValue : option.key;
-      const state: FilterType | undefined = selection[queryValue] ?? selection[option.key];
+      const rawState: FilterType | undefined = selection[queryValue] ?? selection[option.key];
+      // When match-all is disabled, render any match-all clause as a plain
+      // include so the field never shows a green plus.
+      const state: FilterType | undefined =
+        !allowMatchAll && rawState === 'includeAll' ? 'include' : rawState;
       const checked = getCheckedState(state);
       const isActive = checked !== undefined;
       const count = option.count ?? 0;
@@ -232,10 +251,10 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
         checked,
         data: option.data,
         count,
-        view: renderOption(option, { checked, isActive }),
+        view: renderOption(option, { checked, isActive, state }),
       };
     });
-  }, [options, selection, renderOption]);
+  }, [options, selection, renderOption, allowMatchAll]);
 
   // Build a lookup from key → checked state for stable comparison that
   // doesn't rely on index alignment (safe if `EuiSelectable` reorders options).
@@ -249,8 +268,15 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
   // `lastModifierRef` to support Cmd/Ctrl+click for exclude.
   const handleSelectChange = useCallback(
     (updatedOptions: Array<InternalSelectableOption<T>>) => {
-      const filterType: FilterType =
-        !singleSelection && lastModifierRef.current ? 'exclude' : 'include';
+      const { exclude, matchAll } = lastModifierRef.current;
+      let filterType: FilterType = 'include';
+      if (!singleSelection) {
+        if (exclude) {
+          filterType = 'exclude';
+        } else if (matchAll && allowMatchAll) {
+          filterType = 'includeAll';
+        }
+      }
 
       if (singleSelection) {
         const newlyChecked = updatedOptions.find(
@@ -275,7 +301,7 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
         }
       }
     },
-    [prevCheckedByKey, toggleValue, singleSelection]
+    [prevCheckedByKey, toggleValue, singleSelection, allowMatchAll]
   );
 
   // Don't show count badge on button for single-select (only one value can be selected).
@@ -307,6 +333,7 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
           onChange={handleSelectChange}
           searchable
           searchProps={{ compressed: true }}
+          listProps={singleSelection ? undefined : { showIcons: false }}
           data-test-subj={`${dataTestSubj}-list`}
           aria-label={title}
         >
@@ -336,7 +363,9 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
         </EuiSelectable>
       </div>
       {/* Only show modifier key tip for multi-select (exclude not supported in single-select). */}
-      {!singleSelection && <ModifierKeyTip>{footerContent}</ModifierKeyTip>}
+      {!singleSelection && (
+        <ModifierKeyTip showMatchAll={allowMatchAll}>{footerContent}</ModifierKeyTip>
+      )}
       {singleSelection && footerContent}
     </FilterPopover>
   );
@@ -356,18 +385,33 @@ export interface StandardOptionRenderProps {
   count?: number;
   /** Whether the filter is active. */
   isActive: boolean;
+  /**
+   * The value's filter mode, used to draw the leading status icon (check for
+   * match-any, green plus for match-all, cross for exclude). The popover hides
+   * EUI's default icons in favor of this.
+   */
+  state?: FilterType;
 }
 
 /**
- * Standard option layout with content and optional count badge.
+ * Standard option layout with a leading status icon, content, and optional
+ * count badge.
  *
- * Include/exclude is handled by `SelectableFilterPopover`'s modifier key
- * tracking — no click handler is needed on individual options.
+ * Include / match-all / exclude is handled by `SelectableFilterPopover`'s
+ * modifier-key tracking — no click handler is needed on individual options.
  */
-export const StandardFilterOption = ({ children, count, isActive }: StandardOptionRenderProps) => {
+export const StandardFilterOption = ({
+  children,
+  count,
+  isActive,
+  state,
+}: StandardOptionRenderProps) => {
   return (
-    <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
-      <EuiFlexItem grow={false}>{children}</EuiFlexItem>
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <FilterStateIcon state={state} />
+      </EuiFlexItem>
+      <EuiFlexItem>{children}</EuiFlexItem>
       {count !== undefined && (
         <EuiFlexItem grow={false}>
           <FilterCountBadge count={count} isActive={isActive} />

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.tsx
@@ -96,8 +96,11 @@ export const TagFilterRenderer = ({
   const panelMinWidth = euiTheme.base * 24;
 
   const renderOption = useCallback(
-    (option: SelectableFilterOption<Tag>, state: { isActive: boolean }) => (
-      <StandardFilterOption count={option.count} isActive={state.isActive}>
+    (
+      option: SelectableFilterOption<Tag>,
+      { isActive, state }: { isActive: boolean; state?: 'include' | 'includeAll' | 'exclude' }
+    ) => (
+      <StandardFilterOption count={option.count} isActive={isActive} state={state}>
         <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiHealth

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/user_field/user_field_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/user_field/user_field_filter_renderer.tsx
@@ -105,7 +105,10 @@ export const UserFieldFilterRenderer = ({
   );
 
   const renderOption = useCallback(
-    (option: SelectableFilterOption<UserProfileEntry>, state: { isActive: boolean }) => {
+    (
+      option: SelectableFilterOption<UserProfileEntry>,
+      { isActive, state }: { isActive: boolean; state?: 'include' | 'includeAll' | 'exclude' }
+    ) => {
       const testSubj = `${fieldName}-searchbar-option-${option.key}`;
       const isSentinel = SENTINEL_KEYS.has(option.key);
       const avatar = isSentinel ? (
@@ -121,7 +124,7 @@ export const UserFieldFilterRenderer = ({
       );
 
       return (
-        <StandardFilterOption count={option.count} isActive={state.isActive}>
+        <StandardFilterOption count={option.count} isActive={isActive} state={state}>
           <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>{avatar}</EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -146,6 +149,7 @@ export const UserFieldFilterRenderer = ({
       onChange={onChange}
       options={options}
       renderOption={renderOption}
+      allowMatchAll={false}
       isLoading={facetsQuery.isLoading}
       emptyMessage={emptyMessage}
       noMatchesMessage={noMatchesMessage}


### PR DESCRIPTION
> [!NOTE]
> Stacked on #274435. Because this is stacked, review #274435 first — the diff here is only the popover UX layer.

## Summary

Second of two stacked PRs adding **AND** (match-all) filtering to the Content List toolbar. #274435 taught the query model to understand match-all in the query _text_; this PR adds the popover UX on top.

Interaction model in the multi-select filter popovers (tags, etc.):

- **Click** → match-any (OR), written as an OR-group (`tag:(a)`) — unchanged.
- **Shift + click** → match-all (AND), written as a bare scalar (`tag:a`); the item must have **every** such value.
- **Cmd/Ctrl + click** → exclude (`-tag:(a)`) — unchanged.

Each option now renders its own **leading status icon** — a check for match-any, a **green plus** for match-all, a cross for exclude — and the footer gains a "⇧ + click match all" hint. EUI's default check/cross icons are hidden in favor of these.

Fields where match-all is meaningless (e.g. single-valued `createdBy`) opt out via `allowMatchAll={false}`, which hides the match-all hint and renders any stray match-all clause as a plain include.

## Changes

- `SelectableFilterPopover`: tracks the Shift modifier, routes to the `includeAll` bucket, hides EUI's default icons, exposes the per-value `state` to `renderOption`, and adds the `allowMatchAll` prop.
- `useFieldQueryFilter`: reads/writes bare scalar (`includeAll`) clauses; `toggle` writes a scalar for match-all and an OR-group for match-any/exclude.
- `FilterStateIcon` renders the check / green-plus / cross indicators.
- Tag and user-field renderers pass `state` through; the user-field (createdBy) renderer sets `allowMatchAll={false}`.

## Validation

- `node scripts/jest` — toolbar package green (incl. new shift/match-all and `allowMatchAll` cases).
- `node scripts/type_check --project .../kbn-content-list-toolbar/tsconfig.json`.
- `node scripts/eslint` + `node scripts/i18n_check` on changed files.

## Test plan

- [ ] Shift+click a tag → value shows a green plus and the query becomes `tag:value` (bare scalar).
- [ ] Plain click → check icon and `tag:(value)` (OR-group); Cmd/Ctrl+click → cross and `-tag:(value)`.
- [ ] Mixed selection (some clicked, some shift-clicked) renders the correct icon per value.
- [ ] `createdBy` filter shows no match-all hint and never renders a green plus.