### PR TITLE
[Visualize] Fix flaky test in `_area_chart.ts‎`

### DIFF
--- a/src/platform/test/functional/apps/visualize/replaced_vislib_chart_types_1/_area_chart.ts
+++ b/src/platform/test/functional/apps/visualize/replaced_vislib_chart_types_1/_area_chart.ts
@@ -525,6 +525,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const fromTime = 'Sep 20, 2015 @ 22:30:00.000';
           const toTime = 'Sep 20, 2015 @ 23:30:00.000';
           await timePicker.setAbsoluteRange(fromTime, toTime);
+          await visChart.waitForVisualizationRenderingStabilized();
           helperScaledLabelText = await testSubjects.getVisibleText('currentlyScaledText');
           expect(helperScaledLabelText).to.include.string('to 30 seconds');
         });
@@ -541,6 +542,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const fromTime = 'Sep 20, 2015 @ 21:30:00.000';
           const toTime = 'Sep 20, 2015 @ 23:30:00.000';
           await timePicker.setAbsoluteRange(fromTime, toTime);
+          await visChart.waitForVisualizationRenderingStabilized();
           helperScaledLabelText = await testSubjects.getVisibleText('currentlyScaledText');
           expect(helperScaledLabelText).to.include.string('to minute');
         });


### PR DESCRIPTION
Fix #274226

## Summary

The test `visualize app - new charts library visualize group1 area charts date histogram interval expanded accordion should display updated scaled label text after time range is changed` started failing on 2026-06-19 after #267950 defaulted `enableDateRangePicker` to `true`.

**Root cause:** The new `DateRangePicker`'s `setAbsoluteRangeNewPicker` path in the FTR `timePicker` page object completes faster than the legacy `EuiSuperDatePicker` path — it returns as soon as the picker button reflects the new date range, without waiting for the visualize sidebar to re-render its scaled interval label. The test then read `currentlyScaledText` before the recomputed value was on screen.

**Fix:** Add `visChart.waitForVisualizationRenderingStabilized()` between `setAbsoluteRange` and the scaled-label assertion in both affected tests.