### PR TITLE
[Search] Notification Center schema: severity and CTA

### DIFF
--- a/x-pack/platform/plugins/shared/notification_center/README.md
+++ b/x-pack/platform/plugins/shared/notification_center/README.md
@@ -98,6 +98,17 @@ The structure of the notification document is defined in [`common/`](./common):
   `.kibana-notification-center` data stream. We use Zod because the shape is shared across
   server and browser code.
 
+### Severity
+
+`severity` is one of `info | warning | error | critical`. It is **optional on submit and
+defaults to `info`**. Severity drives the per-document retention TTL applied by the cleanup task.
+
+### Call-to-action (CTA)
+
+`cta` is optional: `{ link, linkText }`. `link` must be an **internal** root-relative path
+(starts with `/`), validated with `isInternalURL` from `@kbn/std` — external,
+protocol-relative (`//host`), and backslash (`/\host`) URLs are rejected.
+
 ## Notification id conventions
 
 A notification's `notification_id` is a deterministic idempotency key.

--- a/x-pack/platform/plugins/shared/notification_center/common/index.ts
+++ b/x-pack/platform/plugins/shared/notification_center/common/index.ts
@@ -16,7 +16,7 @@ export {
 } from './feature_flags';
 export type { NotificationTypeId } from './feature_flags';
 
-export { notificationSchema } from './notification_schema';
+export { notificationSchema, ctaSchema, SEVERITIES } from './notification_schema';
 
 export {
   NOTIFICATION_ID_SEPARATOR,
@@ -25,4 +25,4 @@ export {
 } from './notification_id';
 export type { StaticStateNotificationIdParts, EventNotificationIdParts } from './notification_id';
 
-export type { Notification } from './types';
+export type { Notification, Severity, Cta } from './types';

--- a/x-pack/platform/plugins/shared/notification_center/common/notification_schema.test.ts
+++ b/x-pack/platform/plugins/shared/notification_center/common/notification_schema.test.ts
@@ -16,6 +16,11 @@ const validNotification: Notification = {
   title: 'Inference endpoint deprecated',
   description: 'Your inference endpoint is deprecated and will stop working in a future version.',
   source_app_id: 'inference',
+  severity: 'warning',
+  cta: {
+    link: '/app/management/ml/inference',
+    linkText: 'View inference endpoints',
+  },
 };
 
 describe('notificationSchema', () => {
@@ -51,5 +56,85 @@ describe('notificationSchema', () => {
 
   it('rejects unknown top-level fields (strict)', () => {
     expect(() => notificationSchema.parse({ ...validNotification, unexpected: 'nope' })).toThrow();
+  });
+
+  describe('severity', () => {
+    it.each(['info', 'warning', 'error', 'critical'] as const)('accepts %s', (severity) => {
+      expect(notificationSchema.parse({ ...validNotification, severity })).toEqual({
+        ...validNotification,
+        severity,
+      });
+    });
+
+    it('is optional and defaults to info when omitted', () => {
+      const { severity: _severity, ...withoutSeverity } = validNotification;
+      expect(notificationSchema.parse(withoutSeverity)).toEqual({
+        ...withoutSeverity,
+        severity: 'info',
+      });
+    });
+
+    it('rejects an unknown severity', () => {
+      expect(() => notificationSchema.parse({ ...validNotification, severity: 'fatal' })).toThrow();
+    });
+  });
+
+  describe('cta', () => {
+    it('is optional', () => {
+      const { cta: _cta, ...withoutCta } = validNotification;
+      expect(notificationSchema.parse(withoutCta)).toEqual(withoutCta);
+    });
+
+    it.each(['link', 'linkText'] as const)('rejects an empty %s', (field) => {
+      expect(() =>
+        notificationSchema.parse({
+          ...validNotification,
+          cta: { ...validNotification.cta, [field]: '' },
+        })
+      ).toThrow();
+    });
+
+    it.each(['link', 'linkText'] as const)('rejects a %s longer than 200 characters', (field) => {
+      expect(() =>
+        notificationSchema.parse({
+          ...validNotification,
+          cta: { ...validNotification.cta, [field]: 'x'.repeat(201) },
+        })
+      ).toThrow();
+    });
+
+    it.each(['link', 'linkText'] as const)('requires %s', (field) => {
+      const { [field]: _omitted, ...partialCta } = validNotification.cta!;
+      expect(() => notificationSchema.parse({ ...validNotification, cta: partialCta })).toThrow();
+    });
+
+    it('rejects unknown cta fields (strict)', () => {
+      expect(() =>
+        notificationSchema.parse({
+          ...validNotification,
+          cta: { ...validNotification.cta, unexpected: 'nope' },
+        })
+      ).toThrow();
+    });
+
+    it('accepts an internal path link', () => {
+      const cta = { link: '/app/ml/inference', linkText: 'View' };
+      expect(notificationSchema.parse({ ...validNotification, cta }).cta).toEqual(cta);
+    });
+
+    it.each([
+      'http://evil.com',
+      'https://evil.com',
+      '//evil.com',
+      '/\\evil.com',
+      'app/ml/inference',
+    ])('rejects a non-internal link (%s)', (link) => {
+      expect(() =>
+        notificationSchema.parse({
+          ...validNotification,
+          cta: { ...validNotification.cta, link },
+        })
+      ).toThrow();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/notification_center/common/notification_schema.ts
+++ b/x-pack/platform/plugins/shared/notification_center/common/notification_schema.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from '@kbn/zod';
+import { isInternalURL } from '@kbn/std';
 
 /**
  * Severity of a notification, lowest to highest. Drives the per-document
@@ -21,20 +22,18 @@ export const ctaSchema = z
   .object({
     /**
      * Internal Kibana destination the call-to-action navigates to. Must be a
-     * relative path beginning with a single `/`. External, protocol-relative
-     * (`//host`), and backslash-prefixed (`/\host`) URLs are rejected — they
-     * resolve off-origin in the browser and would be an open-redirect surface.
+     * root-relative path beginning with a single `/`. External, protocol-relative
+     * (`//host`), and backslash-prefixed (`/\host`) URLs are rejected via
+     * `isInternalURL` — they resolve off-origin in the browser and would be an
+     * open-redirect surface.
      */
     link: z
       .string()
       .min(1)
       .max(200)
-      .refine(
-        (value) => value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\'),
-        {
-          message: 'link must be an internal path starting with a single "/"',
-        }
-      ),
+      .refine((value) => value.startsWith('/') && isInternalURL(value), {
+        message: 'link must be an internal path starting with a single "/"',
+      }),
     /** Human-readable label rendered for the link. */
     linkText: z.string().min(1).max(200),
   })

--- a/x-pack/platform/plugins/shared/notification_center/common/notification_schema.ts
+++ b/x-pack/platform/plugins/shared/notification_center/common/notification_schema.ts
@@ -8,6 +8,39 @@
 import { z } from '@kbn/zod';
 
 /**
+ * Severity of a notification, lowest to highest. Drives the per-document
+ * retention TTL applied by the Notification Center cleanup task.
+ */
+export const SEVERITIES = ['info', 'warning', 'error', 'critical'] as const;
+
+/**
+ * Call-to-action for a notification: a link the user can follow, with the text
+ * to render for that link.
+ */
+export const ctaSchema = z
+  .object({
+    /**
+     * Internal Kibana destination the call-to-action navigates to. Must be a
+     * relative path beginning with a single `/`. External, protocol-relative
+     * (`//host`), and backslash-prefixed (`/\host`) URLs are rejected — they
+     * resolve off-origin in the browser and would be an open-redirect surface.
+     */
+    link: z
+      .string()
+      .min(1)
+      .max(200)
+      .refine(
+        (value) => value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\'),
+        {
+          message: 'link must be an internal path starting with a single "/"',
+        }
+      ),
+    /** Human-readable label rendered for the link. */
+    linkText: z.string().min(1).max(200),
+  })
+  .strict();
+
+/**
  * The canonical notification document, as stored in the `.kibana-notification-center`
  * data stream. Documents are append-only and immutable; per-user state (read,
  * subscriptions, horizons) lives separately in `core.userStorage`.
@@ -30,5 +63,12 @@ export const notificationSchema = z
     description: z.string().min(1).max(2000),
     /** App id of the producing application, e.g. `inference`. */
     source_app_id: z.string().min(1).max(64),
+    /**
+     * Severity of the notification. Optional on submit; defaults to `info`.
+     * Drives severity-based retention.
+     */
+    severity: z.enum(SEVERITIES).default('info'),
+    /** Optional call-to-action link rendered with the notification. */
+    cta: ctaSchema.optional(),
   })
   .strict();

--- a/x-pack/platform/plugins/shared/notification_center/common/types.ts
+++ b/x-pack/platform/plugins/shared/notification_center/common/types.ts
@@ -6,10 +6,20 @@
  */
 
 import type { z } from '@kbn/zod';
-import type { notificationSchema } from './notification_schema';
+import type { notificationSchema, ctaSchema } from './notification_schema';
 
 /**
  * Notification document stored in the `.kibana-notification-center` data
  * stream. Derived from {@link notificationSchema} zod schema, which is the source of truth.
  */
 export type Notification = z.infer<typeof notificationSchema>;
+
+/**
+ * Severity of a notification. Derived from {@link notificationSchema}.
+ */
+export type Severity = Notification['severity'];
+
+/**
+ * Call-to-action for a notification. Derived from {@link ctaSchema}.
+ */
+export type Cta = z.infer<typeof ctaSchema>;

--- a/x-pack/platform/plugins/shared/notification_center/moon.yml
+++ b/x-pack/platform/plugins/shared/notification_center/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/core'
   - '@kbn/config-schema'
   - '@kbn/zod'
+  - '@kbn/std'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/notification_center/tsconfig.json
+++ b/x-pack/platform/plugins/shared/notification_center/tsconfig.json
@@ -9,5 +9,6 @@
     "@kbn/core",
     "@kbn/config-schema",
     "@kbn/zod",
+    "@kbn/std",
   ]
 }


### PR DESCRIPTION
## Summary

Notifications will be classified under several different severity levels which will be used for queries and cleanup tasks later on.

Each notification will include an optional call to action for a user to click an internal link in response to a notification.

This change adds those attributes, their constraints and various unit test updates.

Note that the plugin remains disabled.