### PR TITLE
[Cases] Fix bulk update and push case inclusion

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
@@ -40,6 +40,7 @@ import {
 } from './utils';
 
 import type {
+  AttachmentV2,
   CaseCustomFields,
   CustomFieldsConfiguration,
   Observable,
@@ -50,6 +51,7 @@ import {
   CaseStatuses,
   CustomFieldTypes,
   UserActionActions,
+  UserActionTypes,
   CaseSeverity,
   ConnectorTypes,
 } from '../../../common/types/domain';
@@ -58,7 +60,7 @@ import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
 import { userProfiles, userProfilesMap } from '../user_profiles.mock';
 import { mappings, mockCases } from '../../mocks';
-import type { ObservablePost } from '../../../common/types/api';
+import type { ObservablePost, CaseUserActionsDeprecatedResponse } from '../../../common/types/api';
 import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
 
 const allComments = [
@@ -477,6 +479,66 @@ describe('utils', () => {
           commentId: 'comment-user-1',
         },
       ]);
+    });
+
+    it('counts unified alert attachments toward the alerts total', async () => {
+      const unifiedAlertSingle = {
+        ...omit(commentAlert, ['alertId', 'index', 'rule']),
+        id: 'unified-alert-1',
+        type: 'security.alert',
+        attachmentId: 'alert-id-3',
+      } as unknown as AttachmentV2;
+      const unifiedAlertMulti = {
+        ...omit(commentAlert, ['alertId', 'index', 'rule']),
+        id: 'unified-alert-2',
+        type: 'security.alert',
+        attachmentId: ['alert-id-4', 'alert-id-5'],
+      } as unknown as AttachmentV2;
+
+      const res = await createIncident({
+        theCase: {
+          ...theCase,
+          // 1 legacy alert (1 id) + 2 unified alerts (1 + 2 ids) = 4 alerts total
+          comments: [commentAlert, unifiedAlertSingle, unifiedAlertMulti],
+        },
+        userActions,
+        connector,
+        alerts: [],
+        casesConnectors,
+        spaceId: 'default',
+      });
+
+      expect(res.comments).toEqual([
+        {
+          comment: 'Elastic Alerts attached to the case: 4',
+          commentId: 'mock-id-1-total-alerts',
+        },
+      ]);
+    });
+
+    it('skips the alerts summary when every alert (legacy or unified) has been pushed', async () => {
+      const pushedAt = '2019-11-25T21:55:00.177Z';
+      const unifiedAlertPushed = {
+        ...omit(commentAlert, ['alertId', 'index', 'rule']),
+        id: 'unified-alert-1',
+        type: 'security.alert',
+        attachmentId: ['alert-id-3', 'alert-id-4'],
+        pushed_at: pushedAt,
+      } as unknown as AttachmentV2;
+
+      const res = await createIncident({
+        theCase: {
+          ...theCase,
+          comments: [{ ...commentAlertMultipleIds, pushed_at: pushedAt }, unifiedAlertPushed],
+        },
+        userActions,
+        connector,
+        alerts: [],
+        casesConnectors,
+        spaceId: 'default',
+      });
+
+      expect(res.comments).toEqual([]);
     });
 
     it('adds the backlink to cases correctly', async () => {
@@ -949,6 +1011,46 @@ describe('utils', () => {
           comment:
             'Elastic Alerts attached to the case: 1\n\nFor more details, view the alerts in Kibana\nAlerts URL: https://example.com/s/test-space/app/security/cases/mock-id-1/?tabId=alerts',
           commentId: 'mock-id-1-total-alerts',
+        },
+      ]);
+    });
+
+    it('formats unified `comment` attachments using data.content', () => {
+      const unifiedComment = {
+        ...omit(commentObj, ['comment']),
+        id: 'comment-unified-1',
+        type: 'comment',
+        data: { content: 'Unified comment body' },
+      } as unknown as AttachmentV2;
+
+      const userActionsWithUnified = [
+        ...userActions,
+        {
+          ...userActions.find((action) => action.type === UserActionTypes.comment)!,
+          comment_id: unifiedComment.id,
+        },
+      ] as CaseUserActionsDeprecatedResponse;
+
+      const theCase = {
+        ...flattenCaseSavedObject({ savedObject: mockCases[0] }),
+        comments: [unifiedComment],
+        totalComments: 1,
+      };
+
+      const latestPushInfo = getLatestPushInfo('not-exists', userActionsWithUnified);
+
+      expect(
+        formatComments({
+          userActions: userActionsWithUnified,
+          theCase,
+          latestPushInfo,
+          userProfiles: userProfilesMap,
+          spaceId: 'default',
+        })
+      ).toEqual([
+        {
+          comment: 'Unified comment body\n\nAdded by elastic.',
+          commentId: 'comment-unified-1',
         },
       ]);
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -30,6 +30,7 @@ import type {
 import type { Template } from '../../../common/types/domain/template/latest';
 import { AttachmentType, CaseStatuses, UserActionTypes } from '../../../common/types/domain';
 import type {
+  AttachmentRequestV2,
   CasePostRequest,
   CaseRequestCustomFields,
   CaseUserActionsDeprecatedResponse,
@@ -39,10 +40,15 @@ import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { isPushedUserAction } from '../../../common/utils/user_actions';
 import type { CasesClientGetAlertsResponse } from '../alerts/types';
 import type { ExternalServiceComment, ExternalServiceIncident } from './types';
-import { getAlertIds } from '../utils';
 import type { CasesConnectorsMap } from '../../connectors';
 import { getCaseViewPath } from '../../common/utils';
-import { isLegacyAttachmentRequest } from '../../../common/utils/attachments';
+import {
+  isCommentAttachmentType,
+  isLegacyAttachmentRequest,
+  isUnifiedAlertAttachment,
+  toStringArray,
+} from '../../../common/utils/attachments';
+import { COMMENT_ATTACHMENT_TYPE } from '../../../common/constants/attachments';
 import * as i18n from './translations';
 
 interface CreateIncidentArgs {
@@ -93,33 +99,17 @@ export const getLatestPushInfo = (
 };
 
 /**
- * Builds the connector-comment string that gets posted alongside the case to
- * external incident systems (ServiceNow, Jira, Resilient, Swimlane).
- *
- * The legacy `actions` branch is intentionally absent: legacy `actions`
- * attachments are projected to the unified `security.endpoint` shape on read
- * (see `actionsAttachmentTransformer`), so they never surface here as
- * `AttachmentType.actions`. The user-facing host-isolation comment now lives
- * on the unified attachment's `data.content`, which the registry-hook
- * redesign tracked in https://github.com/elastic/kibana/issues/262574 will
- * surface to push-to-connector. Today host-isolation comments are not pushed
- * (matches existing behavior for the `externalReference` + `endpoint` shape
- * that has been in place since multi-EDR support landed).
- *
- * Likewise the `alert` branch below is currently unreachable because
- * `formatComments` filters alerts out before this function is called; that
- * dead code is preserved here intentionally as a placeholder for the same
- * registry-hook redesign (#262574), which will fold both alert and unified
- * attachment formatting into per-type registrations.
+ * Returns the body text for a comment pushed to an external incident system
+ * (ServiceNow, Jira, Resilient, Swimlane).
  */
 const getCommentContent = (comment: AttachmentV2): string => {
-  if (isLegacyAttachmentRequest(comment)) {
-    if (comment.type === AttachmentType.user) {
-      return comment.comment;
-    } else if (comment.type === AttachmentType.alert) {
-      const ids = getAlertIds(comment);
-      return `Alert with ids ${ids.join(', ')} added to case`;
-    }
+  if (isLegacyAttachmentRequest(comment) && comment.type === AttachmentType.user) {
+    return comment.comment;
+  }
+
+  if (comment.type === COMMENT_ATTACHMENT_TYPE && 'data' in comment) {
+    const content = comment.data?.content;
+    return typeof content === 'string' ? content : '';
   }
 
   return '';
@@ -131,6 +121,19 @@ interface CountAlertsInfo {
   totalAlerts: number;
 }
 
+// Returns the number of alert ids on the attachment, or `null` when the
+// attachment is not an alert
+const countAlertIds = (comment: AttachmentV2): number | null => {
+  if (isLegacyAttachmentRequest(comment) && comment.type === AttachmentType.alert) {
+    return toStringArray(comment.alertId).length;
+  }
+  const asRequest = comment as AttachmentRequestV2;
+  if (isUnifiedAlertAttachment(asRequest)) {
+    return toStringArray(asRequest.attachmentId).length;
+  }
+  return null;
+};
+
 const getAlertsInfo = (
   comments: Case['comments']
 ): { totalAlerts: number; hasUnpushedAlertComments: boolean } => {
@@ -138,14 +141,16 @@ const getAlertsInfo = (
 
   const res =
     comments?.reduce<CountAlertsInfo>(({ totalComments, pushed, totalAlerts }, comment) => {
-      if (isLegacyAttachmentRequest(comment) && comment.type === AttachmentType.alert) {
-        return {
-          totalComments: totalComments + 1,
-          pushed: comment.pushed_at != null ? pushed + 1 : pushed,
-          totalAlerts: totalAlerts + (Array.isArray(comment.alertId) ? comment.alertId.length : 1),
-        };
+      const alertIdCount = countAlertIds(comment);
+      if (alertIdCount === null) {
+        return { totalComments, pushed, totalAlerts };
       }
-      return { totalComments, pushed, totalAlerts };
+
+      return {
+        totalComments: totalComments + 1,
+        pushed: comment.pushed_at != null ? pushed + 1 : pushed,
+        totalAlerts: totalAlerts + alertIdCount,
+      };
     }, countingInfo) ?? countingInfo;
 
   return {
@@ -279,13 +284,8 @@ export const formatComments = ({
   );
 
   const commentsToBeUpdated = theCase.comments?.filter(
-    // We push only user-authored comments. `AttachmentType.actions` was dropped
-    // when legacy `actions` attachments were folded into `security.endpoint`
-    // (the unified type does not surface here as legacy `actions`). The
-    // registry-hook redesign tracked in
-    // https://github.com/elastic/kibana/issues/262574 will let unified
-    // attachment types opt into push-to-connector formatting.
-    (comment) => comment.type === AttachmentType.user && commentsIdsToBeUpdated.has(comment.id)
+    // Push only user-authored comments — legacy `user` and unified `comment`.
+    (comment) => isCommentAttachmentType(comment.type) && commentsIdsToBeUpdated.has(comment.id)
   );
 
   let comments: ExternalServiceComment[] = [];

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -920,6 +920,134 @@ describe('AttachmentService', () => {
         expect(persistedAttributes).not.toHaveProperty('foo');
       });
     });
+
+    describe('per-attachment SO type resolution (flag ON)', () => {
+      // When the unified SO is registered, bulkUpdate must probe each id
+      // and write to the bucket that actually owns the row
+      const buildServiceWithFlagOn = () =>
+        new AttachmentService({
+          log: mockLogger,
+          unsecuredSavedObjectsClient,
+          config: createAttachmentServiceConfig(true),
+        });
+
+      const unifiedCommentAttrs = {
+        type: 'comment',
+        data: { content: 'hello' },
+        owner: SECURITY_SOLUTION_OWNER,
+        created_at: '2024-01-01T00:00:00.000Z',
+        created_by: { username: 'u', full_name: null, email: null },
+        pushed_at: null,
+        pushed_by: null,
+        updated_at: null,
+        updated_by: null,
+      } as const;
+
+      // Mock `get` such that `unifiedId` resolves to the unified bucket and
+      // `legacyId` to the legacy bucket; everything else 404s.
+      const mockResolveByBucket = (legacyId: string, unifiedId: string) => {
+        unsecuredSavedObjectsClient.get.mockImplementation((type: string, id: string) => {
+          if (type === CASE_ATTACHMENT_SAVED_OBJECT && id === unifiedId) {
+            return Promise.resolve({ ...createUserAttachment(), id, type });
+          }
+          if (type === CASE_COMMENT_SAVED_OBJECT && id === legacyId) {
+            return Promise.resolve(createUserAttachment());
+          }
+          return Promise.reject(Object.assign(new Error('Not found'), { statusCode: 404 }));
+        });
+      };
+
+      it('writes to both buckets when ids resolve to different SOs', async () => {
+        mockResolveByBucket('legacy-id', 'unified-id');
+        unsecuredSavedObjectsClient.bulkUpdate
+          .mockResolvedValueOnce({
+            saved_objects: [
+              {
+                id: 'unified-id',
+                type: CASE_ATTACHMENT_SAVED_OBJECT,
+                attributes: unifiedCommentAttrs,
+                references: [],
+                version: 'v2',
+              },
+            ],
+          })
+          .mockResolvedValueOnce({
+            saved_objects: [{ ...createUserAttachment(), id: 'legacy-id' }],
+          });
+
+        const res = await buildServiceWithFlagOn().bulkUpdate({
+          comments: [
+            {
+              savedObjectId: 'unified-id',
+              updatedAttributes: unifiedCommentAttrs,
+            },
+            {
+              savedObjectId: 'legacy-id',
+              updatedAttributes: createUserAttachment().attributes,
+            },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(2);
+        const [unifiedCall, legacyCall] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls;
+        expect(unifiedCall[0]).toEqual([
+          expect.objectContaining({ type: CASE_ATTACHMENT_SAVED_OBJECT, id: 'unified-id' }),
+        ]);
+        expect(legacyCall[0]).toEqual([
+          expect.objectContaining({ type: CASE_COMMENT_SAVED_OBJECT, id: 'legacy-id' }),
+        ]);
+
+        expect(res.saved_objects).toHaveLength(2);
+        expect(res.saved_objects[0].id).toBe('unified-id');
+        expect(res.saved_objects[0].type).toBe(CASE_ATTACHMENT_SAVED_OBJECT);
+        expect(res.saved_objects[1].id).toBe('legacy-id');
+        expect(res.saved_objects[1].type).toBe(CASE_COMMENT_SAVED_OBJECT);
+      });
+
+      it('issues a single bulkUpdate when every id lives in cases-comments', async () => {
+        mockResolveByBucket('legacy-id', '__none__');
+        unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+          saved_objects: [{ ...createUserAttachment(), id: 'legacy-id' }],
+        });
+
+        await buildServiceWithFlagOn().bulkUpdate({
+          comments: [
+            {
+              savedObjectId: 'legacy-id',
+              updatedAttributes: createUserAttachment().attributes,
+            },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+        const [requests] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0];
+        expect(requests).toEqual([
+          expect.objectContaining({ type: CASE_COMMENT_SAVED_OBJECT, id: 'legacy-id' }),
+        ]);
+      });
+    });
+
+    it('skips the per-attachment SO probe when config.attachments.enabled is false', async () => {
+      const serviceWithFlagOff = new AttachmentService({
+        log: mockLogger,
+        unsecuredSavedObjectsClient,
+        config: createAttachmentServiceConfig(false),
+      });
+      unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+        saved_objects: [createUserAttachment()],
+      });
+
+      await serviceWithFlagOff.bulkUpdate({
+        comments: [
+          {
+            savedObjectId: '1',
+            updatedAttributes: createUserAttachment().attributes,
+          },
+        ],
+      });
+
+      expect(unsecuredSavedObjectsClient.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('bulkDelete', () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -9,6 +9,7 @@ import Boom from '@hapi/boom';
 import type {
   SavedObject,
   SavedObjectsBulkResponse,
+  SavedObjectsBulkUpdateObject,
   SavedObjectsBulkUpdateResponse,
   SavedObjectsFindResponse,
   SavedObjectsFindResult,
@@ -163,15 +164,6 @@ export class AttachmentService {
    */
   public get isUnifiedAttachmentsEnabled(): boolean {
     return this.context.config.attachments?.enabled === true;
-  }
-
-  private async getAttachmentSavedObjectType(
-    savedObjectId: string
-  ): Promise<typeof CASE_ATTACHMENT_SAVED_OBJECT | typeof CASE_COMMENT_SAVED_OBJECT | null> {
-    return resolveAttachmentSavedObjectType(
-      this.context.unsecuredSavedObjectsClient,
-      savedObjectId
-    );
   }
 
   /**
@@ -634,7 +626,10 @@ export class AttachmentService {
     try {
       this.context.log.debug(`Attempting to UPDATE attachment ${savedObjectId}`);
 
-      const soType = await this.getAttachmentSavedObjectType(savedObjectId);
+      const soType = await resolveAttachmentSavedObjectType(
+        this.context.unsecuredSavedObjectsClient,
+        savedObjectId
+      );
       if (soType === null) {
         throw new Error(`Attachment ${savedObjectId} not found`);
       }
@@ -714,57 +709,61 @@ export class AttachmentService {
         `Attempting to UPDATE attachments ${comments.map((c) => c.savedObjectId).join(', ')}`
       );
 
-      const savedObjectType = getAttachmentSavedObjectType(this.context.config);
+      const defaultSavedObjectType = getAttachmentSavedObjectType(this.context.config);
+      const perAttachmentTypes = this.isUnifiedAttachmentsEnabled
+        ? (
+            await Promise.all(
+              comments.map((c) =>
+                resolveAttachmentSavedObjectType(
+                  this.context.unsecuredSavedObjectsClient,
+                  c.savedObjectId
+                )
+              )
+            )
+          ).map((soType) => soType ?? defaultSavedObjectType)
+        : comments.map(() => defaultSavedObjectType);
 
-      if (savedObjectType === CASE_ATTACHMENT_SAVED_OBJECT) {
-        const res =
-          await this.context.unsecuredSavedObjectsClient.bulkUpdate<UnifiedAttachmentAttributes>(
-            comments.map((c) => {
-              const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
-                c.updatedAttributes
-              );
-              const transformer = getTransformerForPatchAttributes(
-                decodedAttributes,
-                requestWithoutType
-              );
-              const unifiedAttributes = transformer.toUnifiedSchema(decodedAttributes);
+      const unifiedRequests: Array<{
+        index: number;
+        payload: SavedObjectsBulkUpdateObject<UnifiedAttachmentAttributes>;
+      }> = [];
+      const legacyRequests: Array<{
+        index: number;
+        payload: SavedObjectsBulkUpdateObject<AttachmentPersistedAttributes>;
+      }> = [];
 
-              return {
-                ...c.options,
-                type: CASE_ATTACHMENT_SAVED_OBJECT,
-                id: c.savedObjectId,
-                attributes: unifiedAttributes,
-              };
-            }),
-            { refresh }
-          );
-        return this.transformAndDecodeBulkUpdateResponse(res, comments, requestWithoutType);
-      }
+      for (let i = 0; i < comments.length; i++) {
+        const c = comments[i];
+        const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(c.updatedAttributes);
+        const transformer = getTransformerForPatchAttributes(decodedAttributes, requestWithoutType);
 
-      const res =
-        await this.context.unsecuredSavedObjectsClient.bulkUpdate<AttachmentPersistedAttributes>(
-          comments.map((c) => {
-            const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
-              c.updatedAttributes
-            );
-            assertAlertAttachmentHasRuleName(decodedAttributes as Record<string, unknown>);
-            const transformer = getTransformerForPatchAttributes(
-              decodedAttributes,
-              requestWithoutType
-            );
-            const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
-            const {
-              attributes: extractedAttributes,
-              references: extractedReferences,
-              didDeleteOperation,
-            } = extractAttachmentSORefsFromAttributes(
-              legacyAttributes,
-              c.options?.references ?? []
-            );
+        // If unified attachment, transform to unified schema
+        if (perAttachmentTypes[i] === CASE_ATTACHMENT_SAVED_OBJECT) {
+          const unifiedAttributes = transformer.toUnifiedSchema(decodedAttributes);
+          unifiedRequests.push({
+            index: i,
+            payload: {
+              ...c.options,
+              type: CASE_ATTACHMENT_SAVED_OBJECT,
+              id: c.savedObjectId,
+              attributes: unifiedAttributes,
+            },
+          });
+        } else {
+          // for legacy attachments, transform to legacy schema
+          assertAlertAttachmentHasRuleName(decodedAttributes as Record<string, unknown>);
+          const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
+          const {
+            attributes: extractedAttributes,
+            references: extractedReferences,
+            didDeleteOperation,
+          } = extractAttachmentSORefsFromAttributes(legacyAttributes, c.options?.references ?? []);
 
-            const shouldUpdateRefs = extractedReferences.length > 0 || didDeleteOperation;
+          const shouldUpdateRefs = extractedReferences.length > 0 || didDeleteOperation;
 
-            return {
+          legacyRequests.push({
+            index: i,
+            payload: {
               ...c.options,
               type: CASE_COMMENT_SAVED_OBJECT,
               id: c.savedObjectId,
@@ -775,12 +774,44 @@ export class AttachmentService {
                * to prevent this.
                */
               references: shouldUpdateRefs ? extractedReferences : undefined,
-            };
-          }),
-          { refresh }
-        );
+            },
+          });
+        }
+      }
 
-      return this.transformAndDecodeBulkUpdateResponse(res, comments, requestWithoutType);
+      const mergedSavedObjects: Array<
+        SavedObjectsUpdateResponse<
+          AttachmentPersistedAttributes | UnifiedAttachmentPersistedAttributes
+        >
+      > = new Array(comments.length);
+
+      if (unifiedRequests.length > 0) {
+        const res =
+          await this.context.unsecuredSavedObjectsClient.bulkUpdate<UnifiedAttachmentAttributes>(
+            unifiedRequests.map((r) => r.payload),
+            { refresh }
+          );
+        res.saved_objects.forEach((so, k) => {
+          mergedSavedObjects[unifiedRequests[k].index] = so;
+        });
+      }
+
+      if (legacyRequests.length > 0) {
+        const res =
+          await this.context.unsecuredSavedObjectsClient.bulkUpdate<AttachmentPersistedAttributes>(
+            legacyRequests.map((r) => r.payload),
+            { refresh }
+          );
+        res.saved_objects.forEach((so, k) => {
+          mergedSavedObjects[legacyRequests[k].index] = so;
+        });
+      }
+
+      return this.transformAndDecodeBulkUpdateResponse(
+        { saved_objects: mergedSavedObjects },
+        comments,
+        requestWithoutType
+      );
     } catch (error) {
       this.context.log.error(
         `Error on UPDATE attachments ${comments.map((c) => c.savedObjectId).join(', ')}: ${error}`


### PR DESCRIPTION
## Summary

This PR fixes 2 issues related to push case:

- `bulkUpdate` (used exclusively by push case) used to derive the saved object type based on feature flag, this is incorrect for update because the attachments already exist in either SO. This PR resolves the saved object type for that id, then merge them and perform bulk update for either/both types.
- Factor in unified shape when pushing comments and aggregating alerts


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.