### PR TITLE
[Cases] Fix perPage cutoff when pushing a case

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/push.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/push.ts
@@ -28,6 +28,7 @@ import {
   CASE_COMMENT_SAVED_OBJECT,
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
+  MAX_DOCS_PER_PAGE,
   OWNER_FIELD,
 } from '../../../common/constants';
 import { UNIFIED_ALERT_TYPES_ARRAY } from '../../../common/utils/attachments';
@@ -232,7 +233,7 @@ export const push = async (
         id: caseId,
         options: {
           page: 1,
-          perPage: theCase?.totalComment ?? 0,
+          perPage: MAX_DOCS_PER_PAGE,
         },
       }),
     ]);


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/274441

### Before
When pushing a case to an external connector, `pushed_at` and `pushed_by` are stamped on a small subset of attachments. When this was introduced ([#88655](https://github.com/elastic/kibana/pull/88655), Feb 2021) `totalComment` was the total count of all attachments. The field has since been narrowed to count only user-type comments, but this call site was never updated.

Behaviors: 
- After a case is pushed, not all attachments have `push_by` and `push_at` (see discover)
- Alert count comment is repeated in external service every time the case is pushed. This is because the guard is based on whether the alert has `pushed_at`, and since not all alerts get stamped, `hasUnpushedAlert` is always true.

### After
- After a case is pushed, all attachments have `push_by` and `push_at` (see discover)
- Alert count comment does not show up in in external service every time the case is pushed (unless more alerts are added)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->