### PR TITLE
[Alerting v2] [Rule management] Consolidate alerting v2 request mappers and add YAML mode Scout UI tests

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/README.md
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/README.md
@@ -161,7 +161,7 @@ interface FormValues {
 }
 ```
 
-> The form keeps a simple `{ breach, recover? }` shape internally. It is translated to the canonical API shape (`{ format: 'standalone', breach: { query }, recovery?: { query } }`) by `mapFormValuesToRuleRequest`, with a top-level `recovery_strategy: 'query'` emitted alongside when a recovery query is present. The form does not currently surface `no_data`, `no_data_strategy`, or `recovery_strategy: 'no_breach'`; they are dropped on round-trip and need to be set through the canonical API or the Compose Discover flyout if required.
+> The form keeps a simple `{ breach, recover? }` shape internally. It is translated to the canonical API shape (`{ format: 'standalone', breach: { query }, recovery?: { query } }`) by `mapFormValuesToCreateRequest`, with a top-level `recovery_strategy: 'query'` emitted alongside when a recovery query is present. The form does not currently surface `no_data`, `no_data_strategy`, or `recovery_strategy: 'no_breach'`; they are dropped on round-trip and need to be set through the canonical API or the Compose Discover flyout if required.
 
 ## Required Services
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -35,9 +35,9 @@ import { ComposeDiscoverForm, getSteps } from './compose_discover_form';
 import {
   composeFormToCreateRequest,
   composeFormToUpdateRequest,
-  mapRuleToComposeFormValues,
   mapYamlFormValuesToComposeFormValues,
 } from './compose_mappers';
+import { mapRuleResponseToFormValues } from '../../form/utils/rule_request_mappers';
 import { HorizontalMinimalStepper, type MinimalStep } from './horizontal_minimal_stepper';
 import { QuerySandboxFlyout } from './query_sandbox_flyout';
 import { isAlertTabDisabled } from './compose_discover_tabs';
@@ -103,7 +103,7 @@ export interface ComposeDiscoverFlyoutProps {
   historyKey: symbol;
   mode?: ComposeDiscoverMode;
   /** The existing rule — provided when mode === 'edit'. Used to seed the RHF form. */
-  rule?: Parameters<typeof mapRuleToComposeFormValues>[0];
+  rule?: Parameters<typeof mapRuleResponseToFormValues>[0];
   /** The ID of the rule being edited. Required when mode === 'edit'. */
   ruleId?: string;
   onClose: () => void;
@@ -179,7 +179,7 @@ export function ComposeDiscoverFlyout({
   const baseServices = services;
 
   const initialMapped =
-    (mode === 'edit' || mode === 'clone') && rule ? mapRuleToComposeFormValues(rule) : undefined;
+    (mode === 'edit' || mode === 'clone') && rule ? mapRuleResponseToFormValues(rule) : undefined;
   const initialKind = initialMapped?.kind ?? 'alert';
   const hasInitialCustomRecovery =
     initialMapped?.query?.format === 'composed' && !!initialMapped.query.recovery?.segment?.trim();
@@ -223,7 +223,7 @@ export function ComposeDiscoverFlyout({
   // ── Form values (submitted to the API) ──
   const defaultValues = useMemo<FormValues>(() => {
     if (rule) {
-      const mapped = mapRuleToComposeFormValues(rule);
+      const mapped = mapRuleResponseToFormValues(rule);
       if (mode === 'clone') {
         return {
           ...mapped,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.test.ts
@@ -391,9 +391,14 @@ describe('mapRuleToComposeFormValues', () => {
     expect(result.stateTransitionRecoveryDelayMode).toBe('immediate');
   });
 
-  it('sets stateTransition to undefined when absent from response', () => {
+  it('initializes stateTransition with null fields when absent from response', () => {
     const result = mapRuleToComposeFormValues(baseRuleResponse);
-    expect(result.stateTransition).toBeUndefined();
+    expect(result.stateTransition).toEqual({
+      pendingCount: null,
+      pendingTimeframe: null,
+      recoveringCount: null,
+      recoveringTimeframe: null,
+    });
   });
 
   it('splits artifacts by field ownership when present', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.test.ts
@@ -12,9 +12,9 @@ import type { ComposeFormValues } from './compose_form_types';
 import {
   composeFormToCreateRequest,
   composeFormToUpdateRequest,
-  mapRuleToComposeFormValues,
   mapYamlFormValuesToComposeFormValues,
 } from './compose_mappers';
+import { mapRuleResponseToFormValues } from '../../form/utils/rule_request_mappers';
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 
@@ -254,11 +254,11 @@ describe('composeFormToUpdateRequest', () => {
   });
 });
 
-// ── mapRuleToComposeFormValues ───────────────────────────────────────────────
+// ── mapRuleResponseToFormValues ───────────────────────────────────────────────
 
-describe('mapRuleToComposeFormValues', () => {
+describe('mapRuleResponseToFormValues', () => {
   it('maps basic required fields', () => {
-    const result = mapRuleToComposeFormValues(baseRuleResponse);
+    const result = mapRuleResponseToFormValues(baseRuleResponse);
     expect(result.kind).toBe('alert');
     expect(result.timeField).toBe('@timestamp');
     expect(result.metadata).toEqual({
@@ -272,18 +272,18 @@ describe('mapRuleToComposeFormValues', () => {
   });
 
   it('maps schedule with lookback', () => {
-    const result = mapRuleToComposeFormValues(baseRuleResponse);
+    const result = mapRuleResponseToFormValues(baseRuleResponse);
     expect(result.schedule).toEqual({ every: '5m', lookback: '2m' });
   });
 
   it('defaults lookback to 1m when absent', () => {
     const rule = { ...baseRuleResponse, schedule: { every: '10m' } } as RuleResponse;
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.schedule.lookback).toBe('1m');
   });
 
   it('maps composed query from rule response', () => {
-    const result = mapRuleToComposeFormValues(baseRuleResponse);
+    const result = mapRuleResponseToFormValues(baseRuleResponse);
     expect(result.query.format).toBe('composed');
     if (result.query.format === 'composed') {
       expect(result.query.base).toBe(BASE);
@@ -302,14 +302,14 @@ describe('mapRuleToComposeFormValues', () => {
         recovery: { segment: RECOVERY_SEGMENT },
       },
     };
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     if (result.query.format === 'composed') {
       expect(result.query.recovery?.segment).toBe(RECOVERY_SEGMENT);
     }
   });
 
   it('omits recovery when absent from query', () => {
-    const result = mapRuleToComposeFormValues(baseRuleResponse);
+    const result = mapRuleResponseToFormValues(baseRuleResponse);
     if (result.query.format === 'composed') {
       expect(result.query.recovery).toBeUndefined();
     }
@@ -325,7 +325,7 @@ describe('mapRuleToComposeFormValues', () => {
         breach: { segment: ALERT_SEGMENT },
       },
     };
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     if (result.query.format === 'composed') {
       expect(result.query.recovery).toBeUndefined();
     }
@@ -336,7 +336,7 @@ describe('mapRuleToComposeFormValues', () => {
       ...baseRuleResponse,
       query: { format: 'standalone', breach: { query: 'FROM logs-* | LIMIT 10' } },
     } as RuleResponse;
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.query).toEqual({
       format: 'standalone',
       breach: { query: 'FROM logs-* | LIMIT 10' },
@@ -353,7 +353,7 @@ describe('mapRuleToComposeFormValues', () => {
         recovery: { query: 'FROM logs-* | WHERE status == "ok"' },
       },
     };
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.query).toEqual({
       format: 'standalone',
       breach: { query: 'FROM logs-*' },
@@ -366,12 +366,12 @@ describe('mapRuleToComposeFormValues', () => {
       ...baseRuleResponse,
       grouping: { fields: ['host.name'] },
     } as RuleResponse;
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.grouping).toEqual({ fields: ['host.name'] });
   });
 
   it('omits grouping when absent', () => {
-    const result = mapRuleToComposeFormValues(baseRuleResponse);
+    const result = mapRuleResponseToFormValues(baseRuleResponse);
     expect(result.grouping).toBeUndefined();
   });
 
@@ -380,7 +380,7 @@ describe('mapRuleToComposeFormValues', () => {
       ...baseRuleResponse,
       state_transition: { pending_count: 3, pending_timeframe: '10m' },
     } as RuleResponse;
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.stateTransition).toEqual({
       pendingCount: 3,
       pendingTimeframe: '10m',
@@ -392,7 +392,7 @@ describe('mapRuleToComposeFormValues', () => {
   });
 
   it('initializes stateTransition with null fields when absent from response', () => {
-    const result = mapRuleToComposeFormValues(baseRuleResponse);
+    const result = mapRuleResponseToFormValues(baseRuleResponse);
     expect(result.stateTransition).toEqual({
       pendingCount: null,
       pendingTimeframe: null,
@@ -410,7 +410,7 @@ describe('mapRuleToComposeFormValues', () => {
         { id: 'dashboard-id', type: 'dashboard', value: 'dashboard-123' },
       ],
     } as RuleResponse;
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.artifacts).toEqual([{ id: 'host-id', type: 'host', value: 'host-a' }]);
     expect(result.runbookArtifacts).toEqual([
       { id: 'runbook-id', type: 'runbook', value: 'steps here' },
@@ -425,7 +425,7 @@ describe('mapRuleToComposeFormValues', () => {
       ...baseRuleResponse,
       state_transition: { recovering_count: 5 },
     } as RuleResponse;
-    const result = mapRuleToComposeFormValues(rule);
+    const result = mapRuleResponseToFormValues(rule);
     expect(result.stateTransitionRecoveryDelayMode).toBe('recoveries');
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.ts
@@ -17,7 +17,6 @@ import {
   mapFormValuesToCreateRequest as baseCreateRequest,
   mapFormValuesToUpdateRequest as baseUpdateRequest,
   mapRuleResponseToFormValues,
-  type RuleRequestCommon,
 } from '../../form/utils/rule_request_mappers';
 import type { ComposeFormValues } from './compose_form_types';
 
@@ -32,7 +31,7 @@ import type { ComposeFormValues } from './compose_form_types';
  */
 const applyDelayModeFilter = (
   formValues: ComposeFormValues
-): RuleRequestCommon['state_transition'] | undefined => {
+): CreateRuleData['state_transition'] | undefined => {
   if (formValues.kind !== 'alert') return undefined;
 
   const alertMode =
@@ -43,7 +42,7 @@ const applyDelayModeFilter = (
     deriveRecoveryDelayModeFromStateTransition(formValues.stateTransition);
 
   const st = formValues.stateTransition;
-  const out: NonNullable<RuleRequestCommon['state_transition']> = {};
+  const out: NonNullable<CreateRuleData['state_transition']> = {};
 
   if (alertMode === DELAY_MODE.immediate) {
     out.pending_count = 0;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { RuleResponse, CreateRuleData, UpdateRuleData } from '@kbn/alerting-v2-schemas';
+import type { CreateRuleData, UpdateRuleData } from '@kbn/alerting-v2-schemas';
 import { splitArtifactsByType } from '../../form/utils/artifact_mappers';
 import { DELAY_MODE } from '../../form/types';
 import type { FormValues } from '../../form/types';
@@ -16,7 +16,6 @@ import {
 import {
   mapFormValuesToCreateRequest as baseCreateRequest,
   mapFormValuesToUpdateRequest as baseUpdateRequest,
-  mapRuleResponseToFormValues,
 } from '../../form/utils/rule_request_mappers';
 import type { ComposeFormValues } from './compose_form_types';
 
@@ -86,9 +85,6 @@ export const composeFormToUpdateRequest = (
     state_transition: applyDelayModeFilter(formValues) ?? null,
   };
 };
-
-export const mapRuleToComposeFormValues = (rule: RuleResponse): ComposeFormValues =>
-  mapRuleResponseToFormValues(rule) as ComposeFormValues;
 
 /** Bridge YAML parse output into compose form values for the Discover flyout. */
 export const mapYamlFormValuesToComposeFormValues = (parsed: FormValues): ComposeFormValues => ({

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_mappers.ts
@@ -5,98 +5,75 @@
  * 2.0.
  */
 
-import type { RuleResponse, CreateRuleData, UpdateRuleData, Query } from '@kbn/alerting-v2-schemas';
-import {
-  mapArtifacts,
-  mergeArtifactsByType,
-  splitArtifactsByType,
-} from '../../form/utils/artifact_mappers';
+import type { RuleResponse, CreateRuleData, UpdateRuleData } from '@kbn/alerting-v2-schemas';
+import { splitArtifactsByType } from '../../form/utils/artifact_mappers';
+import { DELAY_MODE } from '../../form/types';
 import type { FormValues } from '../../form/types';
+import {
+  deriveAlertDelayModeFromStateTransition,
+  deriveRecoveryDelayModeFromStateTransition,
+} from '../../form/types';
+import {
+  mapFormValuesToCreateRequest as baseCreateRequest,
+  mapFormValuesToUpdateRequest as baseUpdateRequest,
+  mapRuleResponseToFormValues,
+  type RuleRequestCommon,
+} from '../../form/utils/rule_request_mappers';
 import type { ComposeFormValues } from './compose_form_types';
 
-const DELAY_IMMEDIATE = 'immediate';
-const DELAY_BREACHES = 'breaches';
-const DELAY_DURATION = 'duration';
+/**
+ * Applies GUI delay-mode logic to the state_transition block.
+ *
+ * The base `rule_request_mappers` do a naive camelCase→snake_case passthrough
+ * (sufficient for the API, which validates via Zod). This function filters
+ * the transition fields based on the delay-mode enum the user selected in the
+ * form UI, ensuring the submitted payload only contains the fields that match
+ * the active mode (immediate / breaches / duration).
+ */
+const applyDelayModeFilter = (
+  formValues: ComposeFormValues
+): RuleRequestCommon['state_transition'] | undefined => {
+  if (formValues.kind !== 'alert') return undefined;
 
-const mapStateTransition = (formValues: ComposeFormValues) => {
-  const { kind, stateTransition } = formValues;
-  if (kind !== 'alert') return undefined;
+  const alertMode =
+    formValues.stateTransitionAlertDelayMode ??
+    deriveAlertDelayModeFromStateTransition(formValues.stateTransition);
+  const recoveryMode =
+    formValues.stateTransitionRecoveryDelayMode ??
+    deriveRecoveryDelayModeFromStateTransition(formValues.stateTransition);
 
-  const alertMode = formValues.stateTransitionAlertDelayMode;
-  const recoveryMode = formValues.stateTransitionRecoveryDelayMode;
+  const st = formValues.stateTransition;
+  const out: NonNullable<RuleRequestCommon['state_transition']> = {};
 
-  const out: Record<string, number | string> = {};
-
-  if (alertMode === DELAY_IMMEDIATE) {
+  if (alertMode === DELAY_MODE.immediate) {
     out.pending_count = 0;
-  } else if (alertMode === DELAY_BREACHES && stateTransition?.pendingCount != null) {
-    out.pending_count = stateTransition.pendingCount;
-  } else if (alertMode === DELAY_DURATION) {
-    if (stateTransition?.pendingTimeframe != null)
-      out.pending_timeframe = stateTransition.pendingTimeframe;
-    if (stateTransition?.pendingCount != null) out.pending_count = stateTransition.pendingCount;
+  } else if (alertMode === DELAY_MODE.breaches && st?.pendingCount != null) {
+    out.pending_count = st.pendingCount;
+  } else if (alertMode === DELAY_MODE.duration) {
+    if (st?.pendingTimeframe != null) out.pending_timeframe = st.pendingTimeframe;
+    if (st?.pendingCount != null) out.pending_count = st.pendingCount;
   }
 
-  if (recoveryMode === DELAY_IMMEDIATE) {
+  if (recoveryMode === DELAY_MODE.immediate) {
     out.recovering_count = 0;
-  } else if (recoveryMode !== DELAY_DURATION && stateTransition?.recoveringCount != null) {
-    out.recovering_count = stateTransition.recoveringCount;
-  } else if (recoveryMode === DELAY_DURATION) {
-    if (stateTransition?.recoveringTimeframe != null)
-      out.recovering_timeframe = stateTransition.recoveringTimeframe;
-    if (stateTransition?.recoveringCount != null)
-      out.recovering_count = stateTransition.recoveringCount;
+  } else if (recoveryMode !== DELAY_MODE.duration && st?.recoveringCount != null) {
+    out.recovering_count = st.recoveringCount;
+  } else if (recoveryMode === DELAY_MODE.duration) {
+    if (st?.recoveringTimeframe != null) out.recovering_timeframe = st.recoveringTimeframe;
+    if (st?.recoveringCount != null) out.recovering_count = st.recoveringCount;
   }
 
   return Object.keys(out).length ? out : undefined;
-};
-
-/**
- * Maps the compose form query to the API query shape. Recovery strategy is
- * inferred from presence of the recovery block and set as a top-level field
- * in `composeFormToCreateRequest`.
- */
-const composeQueryToApiQuery = (q: ComposeFormValues['query']): Query => {
-  if (q.format === 'composed') {
-    return {
-      format: 'composed',
-      base: q.base,
-      breach: { segment: q.breach.segment },
-      ...(q.recovery ? { recovery: { segment: q.recovery.segment } } : {}),
-    };
-  }
-  return {
-    format: 'standalone',
-    breach: { query: q.breach.query },
-    ...(q.recovery ? { recovery: { query: q.recovery.query } } : {}),
-  };
 };
 
 export const composeFormToCreateRequest = (
   formValues: ComposeFormValues,
   builderType?: string
 ): CreateRuleData => {
-  const artifacts = mapArtifacts(mergeArtifactsByType(formValues));
-  const hasRecovery = formValues.query.recovery != null;
-
+  const request = baseCreateRequest(formValues, builderType);
   return {
-    kind: formValues.kind,
-    metadata: {
-      name: formValues.metadata.name,
-      description: formValues.metadata.description,
-      owner: formValues.metadata.owner,
-      ...(formValues.metadata.tags?.length ? { tags: formValues.metadata.tags } : {}),
-      ...(builderType ? { builder_type: builderType } : {}),
-    },
-    time_field: formValues.timeField,
-    schedule: { every: formValues.schedule.every, lookback: formValues.schedule.lookback },
-    query: composeQueryToApiQuery(formValues.query),
-    ...(hasRecovery ? { recovery_strategy: 'query' as const } : {}),
-    grouping: formValues.grouping?.fields?.length
-      ? { fields: formValues.grouping.fields }
-      : undefined,
-    state_transition: mapStateTransition(formValues),
-    ...(artifacts ? { artifacts } : {}),
+    ...request,
+    state_transition: applyDelayModeFilter(formValues),
   };
 };
 
@@ -104,103 +81,18 @@ export const composeFormToUpdateRequest = (
   formValues: ComposeFormValues,
   builderType?: string
 ): UpdateRuleData => {
-  const { kind, ...request } = composeFormToCreateRequest(formValues, builderType);
-  const { grouping, state_transition, artifacts, metadata, ...rest } = request;
+  const request = baseUpdateRequest(formValues, builderType);
   return {
-    ...rest,
-    metadata: {
-      ...metadata,
-      builder_type: metadata.builder_type ?? null,
-    },
-    grouping: grouping ?? null,
-    state_transition: state_transition ?? null,
-    artifacts: artifacts ?? null,
+    ...request,
+    state_transition: applyDelayModeFilter(formValues) ?? null,
   };
 };
 
-// ---------------------------------------------------------------------------
-// API response → ComposeFormValues
-// ---------------------------------------------------------------------------
-
-/**
- * Maps the API query shape to the compose form's narrower shape. A
- * `recovery_strategy` of `'no_breach'` (or absent) is not surfaced by this
- * form — only `'query'` maps a recovery block onto the form.
- */
-const apiQueryToRuleQuery = (
-  q: RuleResponse['query'],
-  recoveryStrategy?: RuleResponse['recovery_strategy']
-): ComposeFormValues['query'] => {
-  if (q.format === 'composed') {
-    return {
-      format: 'composed',
-      base: q.base,
-      breach: { segment: q.breach.segment },
-      ...(recoveryStrategy === 'query' && q.recovery
-        ? { recovery: { segment: q.recovery.segment } }
-        : {}),
-    };
-  }
-  return {
-    format: 'standalone',
-    breach: { query: q.breach.query },
-    ...(recoveryStrategy === 'query' && q.recovery
-      ? { recovery: { query: q.recovery.query } }
-      : {}),
-  };
-};
-
-const deriveAlertDelayMode = (
-  st?: ComposeFormValues['stateTransition']
-): ComposeFormValues['stateTransitionAlertDelayMode'] => {
-  if (st?.pendingTimeframe != null) return DELAY_DURATION;
-  if (st?.pendingCount != null && st.pendingCount > 0) return DELAY_BREACHES;
-  return DELAY_IMMEDIATE;
-};
-
-const deriveRecoveryDelayMode = (
-  st?: ComposeFormValues['stateTransition']
-): ComposeFormValues['stateTransitionRecoveryDelayMode'] => {
-  if (st?.recoveringTimeframe != null) return DELAY_DURATION;
-  if (st?.recoveringCount != null && st.recoveringCount > 0) return 'recoveries';
-  return DELAY_IMMEDIATE;
-};
+export const mapRuleToComposeFormValues = (rule: RuleResponse): ComposeFormValues =>
+  mapRuleResponseToFormValues(rule) as ComposeFormValues;
 
 /** Bridge YAML parse output into compose form values for the Discover flyout. */
 export const mapYamlFormValuesToComposeFormValues = (parsed: FormValues): ComposeFormValues => ({
   ...parsed,
   ...splitArtifactsByType(parsed.artifacts),
 });
-
-export const mapRuleToComposeFormValues = (rule: RuleResponse): ComposeFormValues => {
-  const stateTransition: ComposeFormValues['stateTransition'] = rule.state_transition
-    ? {
-        pendingCount: rule.state_transition.pending_count ?? null,
-        pendingTimeframe: rule.state_transition.pending_timeframe ?? null,
-        recoveringCount: rule.state_transition.recovering_count ?? null,
-        recoveringTimeframe: rule.state_transition.recovering_timeframe ?? null,
-      }
-    : undefined;
-
-  return {
-    kind: rule.kind,
-    metadata: {
-      name: rule.metadata.name,
-      description: rule.metadata.description,
-      enabled: rule.enabled,
-      owner: rule.metadata.owner,
-      tags: rule.metadata.tags,
-    },
-    timeField: rule.time_field,
-    schedule: {
-      every: rule.schedule.every,
-      lookback: rule.schedule.lookback ?? '1m',
-    },
-    query: apiQueryToRuleQuery(rule.query, rule.recovery_strategy),
-    ...(rule.grouping ? { grouping: { fields: rule.grouping.fields } } : {}),
-    stateTransition,
-    stateTransitionAlertDelayMode: deriveAlertDelayMode(stateTransition),
-    stateTransitionRecoveryDelayMode: deriveRecoveryDelayMode(stateTransition),
-    ...splitArtifactsByType(rule.artifacts),
-  };
-};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.test.tsx
@@ -11,7 +11,7 @@ import { useFormContext } from 'react-hook-form';
 import { AlertDelayField } from './alert_delay_field';
 import { RecoveryDelayField } from './recovery_delay_field';
 import type { FormValues } from '../types';
-import { mapFormValuesToUpdateRequest } from '../utils/rule_request_mappers';
+import { composeFormToUpdateRequest } from '../../flyout/compose_discover/compose_mappers';
 import { createFormWrapper, createMockServices } from '../../test_utils';
 
 let getFormValues: (() => FormValues) | undefined;
@@ -181,7 +181,7 @@ describe('AlertDelayField', () => {
     expect(values.stateTransition?.pendingTimeframe).toBeNull();
     expect(values.stateTransition?.recoveringCount).toBe(3);
 
-    expect(mapFormValuesToUpdateRequest(values).state_transition).toEqual({
+    expect(composeFormToUpdateRequest(values).state_transition).toEqual({
       pending_count: 0,
       recovering_count: 3,
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
@@ -11,7 +11,7 @@ import { useFormContext } from 'react-hook-form';
 import { RecoveryDelayField } from './recovery_delay_field';
 import { AlertDelayField } from './alert_delay_field';
 import type { FormValues } from '../types';
-import { mapFormValuesToUpdateRequest } from '../utils/rule_request_mappers';
+import { composeFormToUpdateRequest } from '../../flyout/compose_discover/compose_mappers';
 import { createFormWrapper, createMockServices } from '../../test_utils';
 
 let getFormValues: (() => FormValues) | undefined;
@@ -181,7 +181,7 @@ describe('RecoveryDelayField', () => {
     expect(values.stateTransition?.recoveringTimeframe).toBeNull();
     expect(values.stateTransition?.pendingCount).toBe(2);
 
-    expect(mapFormValuesToUpdateRequest(values).state_transition).toEqual({
+    expect(composeFormToUpdateRequest(values).state_transition).toEqual({
       pending_count: 2,
       recovering_count: 0,
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
@@ -23,12 +23,10 @@ export {
 export type { RuleFormServices, RuleFormMeta, RuleFormLayout } from './contexts';
 export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './contexts';
 export {
-  mapFormValuesToRuleRequest,
   mapFormValuesToCreateRequest,
   mapFormValuesToUpdateRequest,
   mapRuleResponseToFormValues,
 } from './utils/rule_request_mappers';
-export type { RuleRequestCommon } from './utils/rule_request_mappers';
 
 // Field groups — for composing custom form layouts
 export { RuleDetailsFieldGroup } from './field_groups/rule_details_field_group';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
@@ -38,8 +38,13 @@ describe('rule_request_mappers', () => {
       const result = mapFormValuesToCreateRequest(baseFormValues);
 
       expect(result).toEqual({
-        kind: 'alert',
-        metadata: { name: 'Test Rule', owner: 'test-owner', tags: ['tag1', 'tag2'] },
+        kind: 'signal',
+        metadata: {
+          name: 'Test Rule',
+          description: undefined,
+          owner: 'test-owner',
+          tags: ['tag1', 'tag2'],
+        },
         time_field: '@timestamp',
         schedule: { every: '5m', lookback: '1m' },
         query: { format: 'standalone', breach: { query: 'FROM logs-* | LIMIT 10' } },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
@@ -5,16 +5,14 @@
  * 2.0.
  */
 
-import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+import type { RuleResponse, CreateRuleData } from '@kbn/alerting-v2-schemas';
 import { DASHBOARD_ARTIFACT_TYPE, RUNBOOK_ARTIFACT_TYPE } from '@kbn/alerting-v2-constants';
 import type { FormValues } from '../types';
 import {
-  mapFormValuesToRuleRequest,
   mapFormValuesToCreateRequest,
   mapFormValuesToUpdateRequest,
   mapRuleResponseToFormValues,
 } from './rule_request_mappers';
-import type { RuleRequestCommon } from './rule_request_mappers';
 
 describe('rule_request_mappers', () => {
   const baseFormValues: FormValues = {
@@ -35,11 +33,12 @@ describe('rule_request_mappers', () => {
     stateTransitionRecoveryDelayMode: 'immediate',
   };
 
-  describe('mapFormValuesToRuleRequest', () => {
-    it('maps basic form values to the common API shape', () => {
-      const result = mapFormValuesToRuleRequest(baseFormValues);
+  describe('mapFormValuesToCreateRequest', () => {
+    it('maps basic form values to the create API shape', () => {
+      const result = mapFormValuesToCreateRequest(baseFormValues);
 
       expect(result).toEqual({
+        kind: 'alert',
         metadata: { name: 'Test Rule', owner: 'test-owner', tags: ['tag1', 'tag2'] },
         time_field: '@timestamp',
         schedule: { every: '5m', lookback: '1m' },
@@ -49,19 +48,13 @@ describe('rule_request_mappers', () => {
       });
     });
 
-    it('does not include kind in the common shape', () => {
-      const result = mapFormValuesToRuleRequest(baseFormValues);
-
-      expect(result).not.toHaveProperty('kind');
-    });
-
     it('maps grouping fields when present', () => {
       const formValues: FormValues = {
         ...baseFormValues,
         grouping: { fields: ['host.name', 'service.name'] },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.grouping).toEqual({ fields: ['host.name', 'service.name'] });
     });
@@ -72,7 +65,7 @@ describe('rule_request_mappers', () => {
         grouping: { fields: [] },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.grouping).toBeUndefined();
     });
@@ -88,7 +81,7 @@ describe('rule_request_mappers', () => {
         },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.state_transition).toEqual({
         pending_count: 3,
@@ -109,13 +102,13 @@ describe('rule_request_mappers', () => {
         },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.state_transition).toEqual({ pending_count: 5 });
     });
 
     it('returns undefined state_transition when stateTransition is undefined', () => {
-      const result = mapFormValuesToRuleRequest(baseFormValues);
+      const result = mapFormValuesToCreateRequest(baseFormValues);
 
       expect(result.state_transition).toBeUndefined();
     });
@@ -126,7 +119,7 @@ describe('rule_request_mappers', () => {
         stateTransition: {},
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.state_transition).toBeUndefined();
     });
@@ -138,7 +131,7 @@ describe('rule_request_mappers', () => {
         stateTransition: { pendingCount: 3, pendingTimeframe: '10m' },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.state_transition).toEqual({
         pending_count: 3,
@@ -158,7 +151,7 @@ describe('rule_request_mappers', () => {
         },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.metadata).toEqual({
         name: 'My Rule',
@@ -175,7 +168,7 @@ describe('rule_request_mappers', () => {
         artifacts: [{ id: 'artifact-1', type: 'host', value: 'host-a' }],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([{ id: 'artifact-1', type: 'host', value: 'host-a' }]);
     });
@@ -192,7 +185,7 @@ describe('rule_request_mappers', () => {
         ],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([
         { id: 'artifact-1', type: 'host', value: 'host-a' },
@@ -210,7 +203,7 @@ describe('rule_request_mappers', () => {
         ],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([
         { id: 'artifact-1', type: 'host', value: 'host-a' },
@@ -227,7 +220,7 @@ describe('rule_request_mappers', () => {
         ],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([{ id: 'artifact-1', type: 'host', value: 'host-a' }]);
     });
@@ -238,7 +231,7 @@ describe('rule_request_mappers', () => {
         artifacts: [{ id: 'runbook-id', type: RUNBOOK_ARTIFACT_TYPE, value: '   ' }],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toBeUndefined();
     });
@@ -249,13 +242,13 @@ describe('rule_request_mappers', () => {
         artifacts: [],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toBeUndefined();
     });
 
     it('omits artifacts when artifacts are undefined', () => {
-      const result = mapFormValuesToRuleRequest(baseFormValues);
+      const result = mapFormValuesToCreateRequest(baseFormValues);
 
       expect(result.artifacts).toBeUndefined();
     });
@@ -270,7 +263,7 @@ describe('rule_request_mappers', () => {
         },
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.query).toEqual({
         format: 'standalone',
@@ -281,7 +274,7 @@ describe('rule_request_mappers', () => {
     });
 
     it('omits recovery_strategy when query.recovery is absent', () => {
-      const result = mapFormValuesToRuleRequest(baseFormValues);
+      const result = mapFormValuesToCreateRequest(baseFormValues);
 
       expect(result.recovery_strategy).toBeUndefined();
     });
@@ -295,7 +288,7 @@ describe('rule_request_mappers', () => {
         ],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([
         { id: 'artifact-1', type: 'host', value: 'host-a' },
@@ -309,7 +302,7 @@ describe('rule_request_mappers', () => {
         artifacts: [{ id: '', type: RUNBOOK_ARTIFACT_TYPE, value: 'Runbook with missing id' }],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toHaveLength(1);
       expect(result.artifacts?.[0]).toEqual({
@@ -328,7 +321,7 @@ describe('rule_request_mappers', () => {
         ],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([
         { id: 'artifact-1', type: 'host', value: 'host-a' },
@@ -345,7 +338,7 @@ describe('rule_request_mappers', () => {
         ],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toEqual([{ id: 'artifact-1', type: 'host', value: 'host-a' }]);
     });
@@ -356,7 +349,7 @@ describe('rule_request_mappers', () => {
         artifacts: [{ id: '', type: DASHBOARD_ARTIFACT_TYPE, value: 'dashboard-123' }],
       };
 
-      const result = mapFormValuesToRuleRequest(formValues);
+      const result = mapFormValuesToCreateRequest(formValues);
 
       expect(result.artifacts).toHaveLength(1);
       expect(result.artifacts?.[0]).toEqual({
@@ -365,22 +358,7 @@ describe('rule_request_mappers', () => {
         value: 'dashboard-123',
       });
     });
-  });
-
-  describe('mapFormValuesToCreateRequest', () => {
-    it('includes kind along with the common request shape', () => {
-      const result = mapFormValuesToCreateRequest(baseFormValues);
-
-      expect(result.kind).toBe('signal');
-      expect(result.metadata).toEqual({
-        name: 'Test Rule',
-        owner: 'test-owner',
-        tags: ['tag1', 'tag2'],
-      });
-      expect(result.time_field).toBe('@timestamp');
-    });
-
-    it('includes description in the create request when provided', () => {
+    it('includes description when provided', () => {
       const formValues: FormValues = {
         ...baseFormValues,
         metadata: {
@@ -393,26 +371,13 @@ describe('rule_request_mappers', () => {
 
       expect(result.metadata.description).toBe('Create rule description');
     });
-
-    it('produces a superset of mapFormValuesToRuleRequest', () => {
-      const common = mapFormValuesToRuleRequest(baseFormValues);
-      const create = mapFormValuesToCreateRequest(baseFormValues);
-      const createRequest = create as typeof create & {
-        artifacts?: RuleRequestCommon['artifacts'];
-      };
-
-      // Every key in common should be present in create with the same value
-      for (const key of Object.keys(common) as Array<keyof typeof common>) {
-        expect(createRequest[key]).toEqual(common[key]);
-      }
-    });
   });
 
   describe('mapFormValuesToUpdateRequest', () => {
     it('coerces undefined optional fields to null for explicit removal', () => {
       const result = mapFormValuesToUpdateRequest(baseFormValues);
       const updateRequest = result as typeof result & {
-        artifacts?: RuleRequestCommon['artifacts'] | null;
+        artifacts?: CreateRuleData['artifacts'] | null;
       };
 
       expect(updateRequest.grouping).toBeNull();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
@@ -77,13 +77,15 @@ describe('rule_request_mappers', () => {
       expect(result.grouping).toBeUndefined();
     });
 
-    it('maps state_transition for alert kind with pending count and timeframe', () => {
+    it('passes through state_transition fields as snake_case', () => {
       const formValues: FormValues = {
         ...baseFormValues,
-        kind: 'alert',
-        stateTransitionAlertDelayMode: 'duration',
-        stateTransitionRecoveryDelayMode: 'immediate',
-        stateTransition: { pendingCount: 3, pendingTimeframe: '10m' },
+        stateTransition: {
+          pendingCount: 3,
+          pendingTimeframe: '10m',
+          recoveringCount: 4,
+          recoveringTimeframe: '15m',
+        },
       };
 
       const result = mapFormValuesToRuleRequest(formValues);
@@ -91,26 +93,45 @@ describe('rule_request_mappers', () => {
       expect(result.state_transition).toEqual({
         pending_count: 3,
         pending_timeframe: '10m',
-        recovering_count: 0,
+        recovering_count: 4,
+        recovering_timeframe: '15m',
       });
     });
 
-    it('maps state_transition with only pending count (no timeframe)', () => {
+    it('omits null state_transition fields', () => {
       const formValues: FormValues = {
         ...baseFormValues,
-        kind: 'alert',
-        stateTransitionAlertDelayMode: 'breaches',
-        stateTransitionRecoveryDelayMode: 'immediate',
-        stateTransition: { pendingCount: 5 },
+        stateTransition: {
+          pendingCount: 5,
+          pendingTimeframe: null,
+          recoveringCount: null,
+          recoveringTimeframe: null,
+        },
       };
 
       const result = mapFormValuesToRuleRequest(formValues);
 
-      expect(result.state_transition).toEqual({ pending_count: 5, recovering_count: 0 });
-      expect(result.state_transition).not.toHaveProperty('pending_timeframe');
+      expect(result.state_transition).toEqual({ pending_count: 5 });
     });
 
-    it('returns undefined state_transition for signal kind even with stateTransition data', () => {
+    it('returns undefined state_transition when stateTransition is undefined', () => {
+      const result = mapFormValuesToRuleRequest(baseFormValues);
+
+      expect(result.state_transition).toBeUndefined();
+    });
+
+    it('returns undefined state_transition when stateTransition is empty', () => {
+      const formValues: FormValues = {
+        ...baseFormValues,
+        stateTransition: {},
+      };
+
+      const result = mapFormValuesToRuleRequest(formValues);
+
+      expect(result.state_transition).toBeUndefined();
+    });
+
+    it('does not filter state_transition by kind (API handles validation)', () => {
       const formValues: FormValues = {
         ...baseFormValues,
         kind: 'signal',
@@ -119,104 +140,9 @@ describe('rule_request_mappers', () => {
 
       const result = mapFormValuesToRuleRequest(formValues);
 
-      expect(result.state_transition).toBeUndefined();
-    });
-
-    it('emits pending_count: 0 and recovering_count: 0 for alert kind when both modes are immediate', () => {
-      const formValues: FormValues = {
-        ...baseFormValues,
-        kind: 'alert',
-        stateTransition: {},
-      };
-
-      const result = mapFormValuesToRuleRequest(formValues);
-
-      expect(result.state_transition).toEqual({ pending_count: 0, recovering_count: 0 });
-    });
-
-    it('emits pending_count: 0 and recovering_count: 0 for alert kind when stateTransition is undefined', () => {
-      const formValues: FormValues = {
-        ...baseFormValues,
-        kind: 'alert',
-      };
-
-      const result = mapFormValuesToRuleRequest(formValues);
-
-      expect(result.state_transition).toEqual({ pending_count: 0, recovering_count: 0 });
-    });
-
-    it('emits pending_count: 0 when alert delay mode is immediate even if pendingCount is stale', () => {
-      const formValues: FormValues = {
-        ...baseFormValues,
-        kind: 'alert',
-        stateTransitionAlertDelayMode: 'immediate',
-        stateTransitionRecoveryDelayMode: 'recoveries',
-        stateTransition: {
-          pendingCount: 2,
-          pendingTimeframe: null,
-          recoveringCount: 3,
-          recoveringTimeframe: null,
-        },
-      };
-
-      expect(mapFormValuesToUpdateRequest(formValues).state_transition).toEqual({
-        pending_count: 0,
-        recovering_count: 3,
-      });
-    });
-
-    it('maps state_transition with recovering count and timeframe', () => {
-      const formValues: FormValues = {
-        ...baseFormValues,
-        kind: 'alert',
-        stateTransitionAlertDelayMode: 'immediate',
-        stateTransitionRecoveryDelayMode: 'duration',
-        stateTransition: { recoveringCount: 4, recoveringTimeframe: '15m' },
-      };
-
-      const result = mapFormValuesToRuleRequest(formValues);
-
       expect(result.state_transition).toEqual({
-        pending_count: 0,
-        recovering_count: 4,
-        recovering_timeframe: '15m',
-      });
-    });
-
-    it('maps state_transition with only recovering count (no timeframe)', () => {
-      const formValues: FormValues = {
-        ...baseFormValues,
-        kind: 'alert',
-        stateTransitionAlertDelayMode: 'immediate',
-        stateTransitionRecoveryDelayMode: 'recoveries',
-        stateTransition: { recoveringCount: 3 },
-      };
-
-      const result = mapFormValuesToRuleRequest(formValues);
-
-      expect(result.state_transition).toEqual({ pending_count: 0, recovering_count: 3 });
-      expect(result.state_transition).not.toHaveProperty('recovering_timeframe');
-    });
-
-    it('maps state_transition with both pending and recovering fields', () => {
-      const formValues: FormValues = {
-        ...baseFormValues,
-        kind: 'alert',
-        stateTransitionAlertDelayMode: 'breaches',
-        stateTransitionRecoveryDelayMode: 'duration',
-        stateTransition: {
-          pendingCount: 2,
-          recoveringCount: 5,
-          recoveringTimeframe: '10m',
-        },
-      };
-
-      const result = mapFormValuesToRuleRequest(formValues);
-
-      expect(result.state_transition).toEqual({
-        pending_count: 2,
-        recovering_count: 5,
-        recovering_timeframe: '10m',
+        pending_count: 3,
+        pending_timeframe: '10m',
       });
     });
 
@@ -505,8 +431,6 @@ describe('rule_request_mappers', () => {
         ...baseFormValues,
         kind: 'alert',
         grouping: { fields: ['host.name'] },
-        stateTransitionAlertDelayMode: 'duration',
-        stateTransitionRecoveryDelayMode: 'immediate',
         stateTransition: { pendingCount: 2, pendingTimeframe: '5m' },
       };
 
@@ -516,7 +440,6 @@ describe('rule_request_mappers', () => {
       expect(result.state_transition).toEqual({
         pending_count: 2,
         pending_timeframe: '5m',
-        recovering_count: 0,
       });
     });
 
@@ -539,6 +462,7 @@ describe('rule_request_mappers', () => {
         name: 'Test Rule',
         owner: 'test-owner',
         tags: ['tag1', 'tag2'],
+        builder_type: null,
       });
       expect(result.time_field).toBe('@timestamp');
       expect(result.schedule).toEqual({ every: '5m', lookback: '1m' });
@@ -804,7 +728,6 @@ describe('rule_request_mappers', () => {
       expect(createPayload.state_transition).toEqual({
         pending_count: 3,
         pending_timeframe: '10m',
-        recovering_count: 0,
       });
     });
   });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -89,7 +89,6 @@ export const mapFormValuesToCreateRequest = (
   };
 };
 
-
 export const mapFormValuesToUpdateRequest = (
   formValues: FormValues,
   builderType?: string

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -136,7 +136,7 @@ const apiQueryToRuleQuery = (
   };
 };
 
-export const mapRuleResponseToFormValues = (rule: RuleResponse): Partial<FormValues> => {
+export const mapRuleResponseToFormValues = (rule: RuleResponse): FormValues => {
   const stateTransition: StateTransition = {
     pendingCount: rule.state_transition?.pending_count ?? null,
     pendingTimeframe: rule.state_transition?.pending_timeframe ?? null,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -11,12 +11,7 @@ import {
   deriveAlertDelayModeFromStateTransition,
   deriveRecoveryDelayModeFromStateTransition,
 } from '../types';
-import {
-  mapArtifacts,
-  mergeArtifactsByType,
-  splitArtifactsByType,
-  type RuleArtifactPayload,
-} from './artifact_mappers';
+import { mapArtifacts, mergeArtifactsByType, splitArtifactsByType } from './artifact_mappers';
 
 // ---------------------------------------------------------------------------
 // FormValues → API request
@@ -63,9 +58,9 @@ const mapGrouping = (grouping: FormValues['grouping']) =>
  */
 const mapStateTransition = (
   st?: StateTransition
-): RuleRequestCommon['state_transition'] | undefined => {
+): CreateRuleData['state_transition'] | undefined => {
   if (!st) return undefined;
-  const out: NonNullable<RuleRequestCommon['state_transition']> = {};
+  const out: NonNullable<CreateRuleData['state_transition']> = {};
   if (st.pendingCount != null) out.pending_count = st.pendingCount;
   if (st.pendingTimeframe != null) out.pending_timeframe = st.pendingTimeframe;
   if (st.recoveringCount != null) out.recovering_count = st.recoveringCount;
@@ -73,41 +68,16 @@ const mapStateTransition = (
   return Object.keys(out).length ? out : undefined;
 };
 
-/**
- * Common rule request shape shared between create and update payloads.
- * Contains all fields except `kind` (only required for create).
- */
-export interface RuleRequestCommon {
-  metadata: {
-    name: string;
-    description?: string;
-    owner?: string;
-    tags?: string[];
-    builder_type?: string;
-  };
-  time_field: string;
-  schedule: { every: string; lookback?: string };
-  query: Query;
-  recovery_strategy?: 'query';
-  grouping?: { fields: string[] };
-  state_transition?: {
-    pending_count?: number;
-    pending_timeframe?: string;
-    recovering_count?: number;
-    recovering_timeframe?: string;
-  };
-  artifacts?: RuleArtifactPayload;
-}
-
-export const mapFormValuesToRuleRequest = (
+export const mapFormValuesToCreateRequest = (
   formValues: FormValues,
   builderType?: string
-): RuleRequestCommon => {
-  const { metadata, timeField, schedule, query, grouping, stateTransition } = formValues;
+): CreateRuleData => {
+  const { kind, metadata, timeField, schedule, query, grouping, stateTransition } = formValues;
   const mappedArtifacts = mapArtifacts(mergeArtifactsByType(formValues));
   const hasRecovery = query.recovery != null;
 
   return {
+    kind,
     metadata: mapMetadata(metadata, builderType),
     time_field: timeField,
     schedule: mapSchedule(schedule),
@@ -119,20 +89,13 @@ export const mapFormValuesToRuleRequest = (
   };
 };
 
-export const mapFormValuesToCreateRequest = (
-  formValues: FormValues,
-  builderType?: string
-): CreateRuleData => ({
-  kind: formValues.kind,
-  ...mapFormValuesToRuleRequest(formValues, builderType),
-});
 
 export const mapFormValuesToUpdateRequest = (
   formValues: FormValues,
   builderType?: string
 ): UpdateRuleData => {
-  const { grouping, state_transition, artifacts, metadata, ...rest } =
-    mapFormValuesToRuleRequest(formValues, builderType);
+  const { kind, grouping, state_transition, artifacts, metadata, ...rest } =
+    mapFormValuesToCreateRequest(formValues, builderType);
 
   return {
     ...rest,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -6,7 +6,6 @@
  */
 
 import type { RuleResponse, CreateRuleData, Query, UpdateRuleData } from '@kbn/alerting-v2-schemas';
-import { DELAY_MODE } from '../types';
 import type { FormValues, StateTransition, RuleQuery } from '../types';
 import {
   deriveAlertDelayModeFromStateTransition,
@@ -23,11 +22,12 @@ import {
 // FormValues → API request
 // ---------------------------------------------------------------------------
 
-const mapMetadata = (metadata: FormValues['metadata']) => ({
+const mapMetadata = (metadata: FormValues['metadata'], builderType?: string) => ({
   name: metadata.name,
   description: metadata.description,
   owner: metadata.owner,
   ...(metadata.tags?.length ? { tags: metadata.tags } : {}),
+  ...(builderType ? { builder_type: builderType } : {}),
 });
 
 const mapSchedule = (schedule: FormValues['schedule']) => ({
@@ -48,53 +48,29 @@ const mapQuery = (query: RuleQuery): Query => {
     format: 'standalone',
     breach: { query: query.breach.query },
     ...(query.recovery ? { recovery: { query: query.recovery.query } } : {}),
+    ...(query.no_data ? { no_data: { query: query.no_data.query } } : {}),
   };
 };
 
 const mapGrouping = (grouping: FormValues['grouping']) =>
   grouping?.fields?.length ? { fields: grouping.fields } : undefined;
 
-const mapStateTransition = (formValues: FormValues) => {
-  const { kind, stateTransition } = formValues;
-  if (kind !== 'alert') return undefined;
-
-  const alertMode =
-    formValues.stateTransitionAlertDelayMode ??
-    deriveAlertDelayModeFromStateTransition(stateTransition);
-  const recoveryMode =
-    formValues.stateTransitionRecoveryDelayMode ??
-    deriveRecoveryDelayModeFromStateTransition(stateTransition);
-
+/**
+ * Passthrough serialization of state transition (camelCase → snake_case).
+ * Field-level filtering by delay mode is intentionally not done here —
+ * the API's Zod schema handles validation, and the server's director
+ * strategies only read the fields relevant to the configured strategy.
+ */
+const mapStateTransition = (
+  st?: StateTransition
+): RuleRequestCommon['state_transition'] | undefined => {
+  if (!st) return undefined;
   const out: NonNullable<RuleRequestCommon['state_transition']> = {};
-
-  if (alertMode === DELAY_MODE.immediate) {
-    out.pending_count = 0;
-  } else if (alertMode === DELAY_MODE.breaches && stateTransition?.pendingCount != null) {
-    out.pending_count = stateTransition.pendingCount;
-  } else if (alertMode === DELAY_MODE.duration) {
-    if (stateTransition?.pendingTimeframe != null) {
-      out.pending_timeframe = stateTransition.pendingTimeframe;
-    }
-    if (stateTransition?.pendingCount != null) {
-      out.pending_count = stateTransition.pendingCount;
-    }
-  }
-
-  if (recoveryMode === DELAY_MODE.immediate) {
-    out.recovering_count = 0;
-  } else if (recoveryMode !== DELAY_MODE.duration && stateTransition?.recoveringCount != null) {
-    out.recovering_count = stateTransition.recoveringCount;
-  } else if (recoveryMode === DELAY_MODE.duration) {
-    if (stateTransition?.recoveringTimeframe != null) {
-      out.recovering_timeframe = stateTransition.recoveringTimeframe;
-    }
-    if (stateTransition?.recoveringCount != null) {
-      out.recovering_count = stateTransition.recoveringCount;
-    }
-  }
-
-  if (Object.keys(out).length === 0) return undefined;
-  return out;
+  if (st.pendingCount != null) out.pending_count = st.pendingCount;
+  if (st.pendingTimeframe != null) out.pending_timeframe = st.pendingTimeframe;
+  if (st.recoveringCount != null) out.recovering_count = st.recoveringCount;
+  if (st.recoveringTimeframe != null) out.recovering_timeframe = st.recoveringTimeframe;
+  return Object.keys(out).length ? out : undefined;
 };
 
 /**
@@ -102,7 +78,13 @@ const mapStateTransition = (formValues: FormValues) => {
  * Contains all fields except `kind` (only required for create).
  */
 export interface RuleRequestCommon {
-  metadata: { name: string; description?: string; owner?: string; tags?: string[] };
+  metadata: {
+    name: string;
+    description?: string;
+    owner?: string;
+    tags?: string[];
+    builder_type?: string;
+  };
   time_field: string;
   schedule: { every: string; lookback?: string };
   query: Query;
@@ -117,33 +99,47 @@ export interface RuleRequestCommon {
   artifacts?: RuleArtifactPayload;
 }
 
-export const mapFormValuesToRuleRequest = (formValues: FormValues): RuleRequestCommon => {
-  const { metadata, timeField, schedule, query, grouping } = formValues;
+export const mapFormValuesToRuleRequest = (
+  formValues: FormValues,
+  builderType?: string
+): RuleRequestCommon => {
+  const { metadata, timeField, schedule, query, grouping, stateTransition } = formValues;
   const mappedArtifacts = mapArtifacts(mergeArtifactsByType(formValues));
   const hasRecovery = query.recovery != null;
 
   return {
-    metadata: mapMetadata(metadata),
+    metadata: mapMetadata(metadata, builderType),
     time_field: timeField,
     schedule: mapSchedule(schedule),
     query: mapQuery(query),
     ...(hasRecovery ? { recovery_strategy: 'query' as const } : {}),
     grouping: mapGrouping(grouping),
-    state_transition: mapStateTransition(formValues),
+    state_transition: mapStateTransition(stateTransition),
     ...(mappedArtifacts ? { artifacts: mappedArtifacts } : {}),
   };
 };
 
-export const mapFormValuesToCreateRequest = (formValues: FormValues): CreateRuleData => ({
+export const mapFormValuesToCreateRequest = (
+  formValues: FormValues,
+  builderType?: string
+): CreateRuleData => ({
   kind: formValues.kind,
-  ...mapFormValuesToRuleRequest(formValues),
+  ...mapFormValuesToRuleRequest(formValues, builderType),
 });
 
-export const mapFormValuesToUpdateRequest = (formValues: FormValues): UpdateRuleData => {
-  const { grouping, state_transition, artifacts, ...rest } = mapFormValuesToRuleRequest(formValues);
+export const mapFormValuesToUpdateRequest = (
+  formValues: FormValues,
+  builderType?: string
+): UpdateRuleData => {
+  const { grouping, state_transition, artifacts, metadata, ...rest } =
+    mapFormValuesToRuleRequest(formValues, builderType);
 
   return {
     ...rest,
+    metadata: {
+      ...metadata,
+      builder_type: metadata.builder_type ?? null,
+    },
     grouping: grouping ?? null,
     state_transition: state_transition ?? null,
     artifacts: artifacts ?? null,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { dump } from 'js-yaml';
+import { dump, load } from 'js-yaml';
 import {
   formValuesToYamlObject,
   parseYamlToFormValues,
@@ -527,6 +527,26 @@ describe('yaml_form_utils', () => {
       expect(yaml).toContain('kind: alert');
       expect(yaml).toContain('name: Test');
       expect(yaml).toContain("time_field: '@timestamp'");
+    });
+
+    it('serialized YAML contains no null or undefined values for omitted optional fields', () => {
+      const yaml = serializeFormToYaml({
+        kind: 'alert',
+        metadata: { name: 'r', enabled: true },
+        timeField: '@timestamp',
+        schedule: { every: '5m', lookback: '1m' },
+        query: { format: 'standalone', breach: { query: 'FROM logs-*' } },
+        stateTransitionAlertDelayMode: 'immediate',
+        stateTransitionRecoveryDelayMode: 'immediate',
+      });
+
+      expect(yaml).not.toContain(': null');
+      expect(yaml).not.toContain(': undefined');
+
+      const parsed = load(yaml) as Record<string, unknown>;
+      const metadata = parsed.metadata as Record<string, unknown>;
+      expect(metadata).not.toHaveProperty('description');
+      expect(metadata).not.toHaveProperty('owner');
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts
@@ -12,7 +12,8 @@ import {
   deriveAlertDelayModeFromStateTransition,
   deriveRecoveryDelayModeFromStateTransition,
 } from '../types';
-import { mergeArtifactsByType, splitArtifactsByType } from './artifact_mappers';
+import { splitArtifactsByType } from './artifact_mappers';
+import { mapFormValuesToCreateRequest } from './rule_request_mappers';
 
 export type YamlParseResult = { values: FormValues; error: null } | { values: null; error: string };
 
@@ -35,101 +36,30 @@ const parseArtifacts = (artifacts: unknown): FormValues['artifacts'] => {
   return parsedArtifacts.length ? parsedArtifacts : undefined;
 };
 
-interface YamlStateTransition {
-  pending_count?: number;
-  pending_timeframe?: string;
-  recovering_count?: number;
-  recovering_timeframe?: string;
-}
-
-interface YamlComposedQuery {
-  format: 'composed';
-  base: string;
-  breach: { segment: string };
-  recovery?: { segment: string };
-}
-
-interface YamlStandaloneQuery {
-  format: 'standalone';
-  breach: { query: string };
-  recovery?: { query: string };
-  no_data?: { query: string };
-}
-
-type YamlQuery = YamlComposedQuery | YamlStandaloneQuery;
-
-interface YamlRuleObject {
-  kind: string;
-  metadata: { name: string; description?: string; owner?: string; tags?: string[] };
-  time_field: string;
-  schedule: { every: string; lookback: string };
-  query: YamlQuery;
-  recovery_strategy?: string;
-  grouping?: { fields: string[] };
-  state_transition?: YamlStateTransition;
-  artifacts?: Array<{ id: string; type: string; value: string }>;
-}
-
-const serializeStateTransition = (st?: StateTransition): YamlStateTransition | undefined => {
-  if (!st) return undefined;
-  const out: YamlStateTransition = {};
-  if (st.pendingCount != null) out.pending_count = st.pendingCount;
-  if (st.pendingTimeframe != null) out.pending_timeframe = st.pendingTimeframe;
-  if (st.recoveringCount != null) out.recovering_count = st.recoveringCount;
-  if (st.recoveringTimeframe != null) out.recovering_timeframe = st.recoveringTimeframe;
-  return Object.keys(out).length ? out : undefined;
-};
-
-const serializeQuery = (query: RuleQuery): YamlQuery => {
-  if (query.format === 'composed') {
-    return {
-      format: 'composed',
-      base: query.base,
-      breach: { segment: query.breach.segment },
-      ...(query.recovery ? { recovery: { segment: query.recovery.segment } } : {}),
-    };
+/**
+ * Strip undefined/null values from an object tree so js-yaml produces clean output.
+ */
+const stripEmpty = (obj: Record<string, unknown>): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value == null) continue;
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      const cleaned = stripEmpty(value as Record<string, unknown>);
+      if (Object.keys(cleaned).length) result[key] = cleaned;
+    } else {
+      result[key] = value;
+    }
   }
-  return {
-    format: 'standalone',
-    breach: { query: query.breach.query },
-    ...(query.recovery ? { recovery: { query: query.recovery.query } } : {}),
-    ...(query.no_data ? { no_data: { query: query.no_data.query } } : {}),
-  };
+  return result;
 };
 
 /**
- * Convert FormValues to YAML-compatible object (snake_case keys for API compatibility).
- *
- * Note: `metadata.enabled` is intentionally NOT serialized. The API's `metadataSchema`
- * is strict and only accepts { name, description?, owner?, tags? }; `enabled` lives at
- * the top level of the update/response schemas, never under metadata, and is not part
- * of the create payload at all.
+ * Convert FormValues to a YAML-compatible object by reusing the shared
+ * create-request mapper, then stripping undefined/null values so the
+ * YAML output stays clean (no `description: null` noise).
  */
-export const formValuesToYamlObject = (values: FormValues): YamlRuleObject => {
-  const st = serializeStateTransition(values.stateTransition);
-  const hasRecovery = values.query.recovery != null;
-  const allArtifacts = mergeArtifactsByType(values);
-
-  return {
-    kind: values.kind,
-    metadata: {
-      name: values.metadata.name,
-      ...(values.metadata.description && { description: values.metadata.description }),
-      ...(values.metadata.owner && { owner: values.metadata.owner }),
-      ...(values.metadata.tags?.length && { tags: values.metadata.tags }),
-    },
-    time_field: values.timeField,
-    schedule: {
-      every: values.schedule.every,
-      lookback: values.schedule.lookback,
-    },
-    query: serializeQuery(values.query),
-    ...(hasRecovery ? { recovery_strategy: 'query' } : {}),
-    ...(values.grouping?.fields?.length && { grouping: { fields: values.grouping.fields } }),
-    ...(st && { state_transition: st }),
-    ...(allArtifacts?.length && { artifacts: allArtifacts }),
-  };
-};
+export const formValuesToYamlObject = (values: FormValues): Record<string, unknown> =>
+  stripEmpty(mapFormValuesToCreateRequest(values) as unknown as Record<string, unknown>);
 
 /**
  * Lenient extractor for a nested `{ query: string }` or `{ segment: string }` block.

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -32,7 +32,6 @@ export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './form';
 export {
   deriveAlertDelayModeFromStateTransition,
   deriveRecoveryDelayModeFromStateTransition,
-  mapFormValuesToRuleRequest,
   mapFormValuesToCreateRequest,
   mapFormValuesToUpdateRequest,
   mapRuleResponseToFormValues,
@@ -51,7 +50,6 @@ export type {
   RuleFormServices,
   RuleFormMeta,
   RuleFormLayout,
-  RuleRequestCommon,
   RuleNotificationsValue,
   RuleQuery,
   ComposedQuery,

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
@@ -7,6 +7,7 @@
 
 import type { Locator, ScoutPage } from '@kbn/scout';
 import { KibanaCodeEditorWrapper } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 export class ComposeDiscoverPage {
   public readonly flyout: Locator;
@@ -140,5 +141,75 @@ export class ComposeDiscoverPage {
     const runbookModal = this.page.getByRole('dialog', { name: 'Add Runbook' });
     await runbookModal.getByLabel('Runbook').fill(text);
     await runbookModal.getByRole('button', { name: 'Add Runbook' }).click();
+  }
+
+  /**
+   * Returns the raw YAML string from the YAML-mode Monaco editor.
+   *
+   * The sandbox query editors may also be mounted, so the YAML model is
+   * identified by looking for the model whose content starts with "kind:".
+   */
+  async getYamlEditorValue(): Promise<string> {
+    const yamlEditor = this.page.testSubj.locator('ruleV2FormYamlEditor');
+    await expect(yamlEditor).toBeVisible({ timeout: 30_000 });
+
+    let result = '';
+    await expect(async () => {
+      result = await this.page.evaluate(() => {
+        const monacoEnv = (window as any).MonacoEnvironment;
+        if (!monacoEnv?.monaco?.editor) {
+          throw new Error('MonacoEnvironment.monaco.editor is not available');
+        }
+        const models = monacoEnv.monaco.editor.getModels() as Array<{ getValue(): string }>;
+        const yamlModel = models.find((m) => m.getValue().trimStart().startsWith('kind:'));
+        if (!yamlModel) {
+          throw new Error('YAML model not found among Monaco models');
+        }
+        return yamlModel.getValue();
+      });
+    }).toPass({ timeout: 30_000 });
+
+    return result;
+  }
+
+  /**
+   * Replaces the full content of the YAML-mode Monaco editor via executeEdits,
+   * which fires all change listeners (including React's onChange prop).
+   */
+  async setYamlEditorValue(value: string): Promise<void> {
+    const yamlEditor = this.page.testSubj.locator('ruleV2FormYamlEditor');
+    await expect(yamlEditor).toBeVisible({ timeout: 30_000 });
+
+    await this.page.evaluate((newValue) => {
+      const monacoEnv = (window as any).MonacoEnvironment;
+      if (!monacoEnv?.monaco?.editor) {
+        throw new Error('MonacoEnvironment.monaco.editor is not available');
+      }
+
+      const models = monacoEnv.monaco.editor.getModels() as Array<{
+        getValue(): string;
+        getFullModelRange(): any;
+        uri: { toString(): string };
+      }>;
+      const yamlModel = models.find((m) => m.getValue().trimStart().startsWith('kind:'));
+      if (!yamlModel) {
+        throw new Error('YAML model not found among Monaco models');
+      }
+
+      const editors = monacoEnv.monaco.editor.getEditors() as Array<{
+        getModel(): { uri: { toString(): string } } | null;
+        executeEdits(source: string, edits: any[]): void;
+        focus(): void;
+      }>;
+      const editor = editors.find(
+        (e) => e.getModel()?.uri?.toString() === yamlModel.uri.toString()
+      );
+      if (!editor) {
+        throw new Error('YAML editor instance not found');
+      }
+
+      const fullRange = yamlModel.getFullModelRange();
+      editor.executeEdits('scout-test', [{ range: fullRange, text: newValue }]);
+    }, value);
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
@@ -173,8 +173,19 @@ export class ComposeDiscoverPage {
   }
 
   /**
+   * Switches the edit-mode toggle from Form view to YAML view and waits for
+   * the YAML badge to appear.
+   */
+  async switchToYamlMode(): Promise<void> {
+    const editModeToggle = this.page.testSubj.locator('composeDiscoverEditModeToggle');
+    await editModeToggle.getByRole('button', { name: 'YAML view' }).click();
+    await expect(this.page.testSubj.locator('composeDiscoverYamlBadge')).toBeVisible();
+  }
+
+  /**
    * Replaces the full content of the YAML-mode Monaco editor via executeEdits,
-   * which fires all change listeners (including React's onChange prop).
+   * focuses the editor beforehand and fires blur afterward so the form
+   * re-parses the new YAML content through its `onBlurSync` handler.
    */
   async setYamlEditorValue(value: string): Promise<void> {
     const yamlEditor = this.page.testSubj.locator('ruleV2FormYamlEditor');
@@ -208,8 +219,13 @@ export class ComposeDiscoverPage {
         throw new Error('YAML editor instance not found');
       }
 
+      editor.focus();
       const fullRange = yamlModel.getFullModelRange();
       editor.executeEdits('scout-test', [{ range: fullRange, text: newValue }]);
+
+      document
+        .querySelector('[data-test-subj="ruleV2FormYamlEditor"] textarea.inputarea')
+        ?.dispatchEvent(new Event('blur', { bubbles: true }));
     }, value);
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/yaml_mode.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/yaml_mode.spec.ts
@@ -47,8 +47,7 @@ test.describe('YAML mode — view and edit rules', { tag: tags.deploymentAgnosti
     await esClient.indices.delete({ index: TEST_INDEX }, { ignore: [404] });
   });
 
-  test('view API-created rule in YAML mode — correct shape, no null/undefined noise', async ({
-    page,
+  test('view API-created rule in YAML mode — correct shape', async ({
     pageObjects,
     apiServices,
   }) => {
@@ -77,9 +76,7 @@ test.describe('YAML mode — view and edit rules', { tag: tags.deploymentAgnosti
     });
 
     await test.step('switch to YAML mode', async () => {
-      const editModeToggle = page.testSubj.locator('composeDiscoverEditModeToggle');
-      await editModeToggle.locator('button').last().click();
-      await expect(page.testSubj.locator('composeDiscoverYamlBadge')).toBeVisible();
+      await pageObjects.composeDiscover.switchToYamlMode();
     });
 
     await test.step('YAML has the expected structure with all seeded fields', async () => {
@@ -108,18 +105,6 @@ test.describe('YAML mode — view and edit rules', { tag: tags.deploymentAgnosti
         },
       });
     });
-
-    await test.step('absent optional fields are omitted — no null or undefined values anywhere', async () => {
-      const yamlString = await pageObjects.composeDiscover.getYamlEditorValue();
-
-      expect(yamlString).not.toContain(': null');
-      expect(yamlString).not.toContain(': undefined');
-
-      const parsed = load(yamlString) as Record<string, unknown>;
-      const metadata = parsed.metadata as Record<string, unknown>;
-      expect(metadata).not.toHaveProperty('description');
-      expect(metadata).not.toHaveProperty('owner');
-    });
   });
 
   test('edit rule name in YAML mode and save', async ({ page, pageObjects, apiServices }) => {
@@ -145,49 +130,14 @@ test.describe('YAML mode — view and edit rules', { tag: tags.deploymentAgnosti
       await expect(pageObjects.rulesList.rulesListTable).toBeVisible({ timeout: 60_000 });
       await pageObjects.composeDiscover.openEditFlyout(ruleId!);
       await expect(pageObjects.composeDiscover.flyout).toBeVisible();
-
-      const editModeToggle = page.testSubj.locator('composeDiscoverEditModeToggle');
-      await editModeToggle.locator('button').last().click();
-      await expect(page.testSubj.locator('composeDiscoverYamlBadge')).toBeVisible();
+      await pageObjects.composeDiscover.switchToYamlMode();
     });
 
     await test.step('edit the rule name in the YAML editor', async () => {
       const yaml = await pageObjects.composeDiscover.getYamlEditorValue();
-      const updatedYaml = yaml.replace(RULE_NAME, EDITED_RULE_NAME);
-
-      // Set the new value and trigger onChange by dispatching an input event
-      // through the Monaco textarea after programmatic edit
-      await page.evaluate(
-        ({ newValue, oldName }) => {
-          const monacoEnv = (window as any).MonacoEnvironment;
-          const models = monacoEnv.monaco.editor.getModels();
-          const yamlModel = models.find((m: any) => m.getValue().includes(oldName));
-          if (!yamlModel) throw new Error('YAML model not found');
-
-          const editors = monacoEnv.monaco.editor.getEditors();
-          const editor = editors.find(
-            (e: any) => e.getModel()?.uri?.toString() === yamlModel.uri.toString()
-          );
-          if (!editor) throw new Error('YAML editor not found');
-
-          // Select all text and replace via executeEdits with the editor focused
-          editor.focus();
-          const fullRange = yamlModel.getFullModelRange();
-          editor.executeEdits('scout-test', [{ range: fullRange, text: newValue }]);
-
-          // Manually fire the blur → re-parse cycle
-          const textarea = document.querySelector(
-            '[data-test-subj="ruleV2FormYamlEditor"] textarea.inputarea'
-          ) as HTMLTextAreaElement;
-          if (textarea) {
-            textarea.dispatchEvent(new Event('blur', { bubbles: true }));
-          }
-        },
-        { newValue: updatedYaml, oldName: RULE_NAME }
+      await pageObjects.composeDiscover.setYamlEditorValue(
+        yaml.replace(RULE_NAME, EDITED_RULE_NAME)
       );
-
-      // Give the form time to parse and re-validate
-      await page.waitForTimeout(1000);
     });
 
     await test.step('save via YAML mode submit', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/yaml_mode.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/yaml_mode.spec.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { load } from 'js-yaml';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { buildCreateRuleData, test } from '../fixtures';
+
+const TEST_INDEX = 'test-yaml-mode';
+const RULE_NAME = 'scout-yaml-mode-view';
+const EDITED_RULE_NAME = 'scout-yaml-mode-edited';
+
+test.describe('YAML mode — view and edit rules', { tag: tags.deploymentAgnostic }, () => {
+  test.beforeAll(async ({ esClient, apiServices }) => {
+    await apiServices.alertingV2.rules.cleanUp();
+    await esClient.indices.create(
+      {
+        index: TEST_INDEX,
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            message: { type: 'text' },
+          },
+        },
+      },
+      { ignore: [400] }
+    );
+    await esClient.index({
+      index: TEST_INDEX,
+      document: { '@timestamp': new Date().toISOString(), message: 'hello' },
+      refresh: 'wait_for',
+    });
+  });
+
+  test.beforeEach(async ({ browserAuth, page, pageObjects }) => {
+    await browserAuth.loginAsAlertingV2Editor();
+    await pageObjects.rulesList.goto();
+    await expect(page.testSubj.locator('rulesListLoading')).toBeHidden({ timeout: 60_000 });
+  });
+
+  test.afterAll(async ({ esClient, apiServices }) => {
+    await apiServices.alertingV2.rules.cleanUp();
+    await esClient.indices.delete({ index: TEST_INDEX }, { ignore: [404] });
+  });
+
+  test('view API-created rule in YAML mode — correct shape, no null/undefined noise', async ({
+    page,
+    pageObjects,
+    apiServices,
+  }) => {
+    let ruleId: string;
+
+    await test.step('seed a rule via API (no description, no owner — optional fields absent)', async () => {
+      const rule = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({
+          metadata: { name: RULE_NAME, tags: ['yaml-test'] },
+          query: {
+            format: 'standalone',
+            breach: { query: `FROM ${TEST_INDEX} | STATS count = COUNT(*)` },
+          },
+          grouping: { fields: ['message'] },
+          state_transition: { pending_count: 3, pending_timeframe: '10m' },
+        })
+      );
+      ruleId = rule.id;
+    });
+
+    await test.step('refresh rules list and open edit flyout', async () => {
+      await pageObjects.rulesList.goto();
+      await expect(pageObjects.rulesList.rulesListTable).toBeVisible({ timeout: 60_000 });
+      await pageObjects.composeDiscover.openEditFlyout(ruleId!);
+      await expect(pageObjects.composeDiscover.flyout).toBeVisible();
+    });
+
+    await test.step('switch to YAML mode', async () => {
+      const editModeToggle = page.testSubj.locator('composeDiscoverEditModeToggle');
+      await editModeToggle.locator('button').last().click();
+      await expect(page.testSubj.locator('composeDiscoverYamlBadge')).toBeVisible();
+    });
+
+    await test.step('YAML has the expected structure with all seeded fields', async () => {
+      const yamlString = await pageObjects.composeDiscover.getYamlEditorValue();
+      const parsed = load(yamlString) as Record<string, unknown>;
+
+      expect(parsed).toMatchObject({
+        kind: 'alert',
+        metadata: {
+          name: RULE_NAME,
+          tags: ['yaml-test'],
+        },
+        time_field: '@timestamp',
+        schedule: {
+          every: expect.any(String),
+          lookback: expect.any(String),
+        },
+        query: {
+          format: 'standalone',
+          breach: { query: expect.stringContaining(TEST_INDEX) },
+        },
+        grouping: { fields: ['message'] },
+        state_transition: {
+          pending_count: 3,
+          pending_timeframe: '10m',
+        },
+      });
+    });
+
+    await test.step('absent optional fields are omitted — no null or undefined values anywhere', async () => {
+      const yamlString = await pageObjects.composeDiscover.getYamlEditorValue();
+
+      expect(yamlString).not.toContain(': null');
+      expect(yamlString).not.toContain(': undefined');
+
+      const parsed = load(yamlString) as Record<string, unknown>;
+      const metadata = parsed.metadata as Record<string, unknown>;
+      expect(metadata).not.toHaveProperty('description');
+      expect(metadata).not.toHaveProperty('owner');
+    });
+  });
+
+  test('edit rule name in YAML mode and save', async ({ page, pageObjects, apiServices }) => {
+    let ruleId: string;
+
+    await test.step('seed a rule via API', async () => {
+      const rule = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({
+          metadata: { name: RULE_NAME },
+          query: {
+            format: 'standalone',
+            breach: { query: `FROM ${TEST_INDEX} | LIMIT 10` },
+          },
+          grouping: { fields: ['message'] },
+          state_transition: { pending_count: 1 },
+        })
+      );
+      ruleId = rule.id;
+    });
+
+    await test.step('open edit flyout and switch to YAML mode', async () => {
+      await pageObjects.rulesList.goto();
+      await expect(pageObjects.rulesList.rulesListTable).toBeVisible({ timeout: 60_000 });
+      await pageObjects.composeDiscover.openEditFlyout(ruleId!);
+      await expect(pageObjects.composeDiscover.flyout).toBeVisible();
+
+      const editModeToggle = page.testSubj.locator('composeDiscoverEditModeToggle');
+      await editModeToggle.locator('button').last().click();
+      await expect(page.testSubj.locator('composeDiscoverYamlBadge')).toBeVisible();
+    });
+
+    await test.step('edit the rule name in the YAML editor', async () => {
+      const yaml = await pageObjects.composeDiscover.getYamlEditorValue();
+      const updatedYaml = yaml.replace(RULE_NAME, EDITED_RULE_NAME);
+
+      // Set the new value and trigger onChange by dispatching an input event
+      // through the Monaco textarea after programmatic edit
+      await page.evaluate(
+        ({ newValue, oldName }) => {
+          const monacoEnv = (window as any).MonacoEnvironment;
+          const models = monacoEnv.monaco.editor.getModels();
+          const yamlModel = models.find((m: any) => m.getValue().includes(oldName));
+          if (!yamlModel) throw new Error('YAML model not found');
+
+          const editors = monacoEnv.monaco.editor.getEditors();
+          const editor = editors.find(
+            (e: any) => e.getModel()?.uri?.toString() === yamlModel.uri.toString()
+          );
+          if (!editor) throw new Error('YAML editor not found');
+
+          // Select all text and replace via executeEdits with the editor focused
+          editor.focus();
+          const fullRange = yamlModel.getFullModelRange();
+          editor.executeEdits('scout-test', [{ range: fullRange, text: newValue }]);
+
+          // Manually fire the blur → re-parse cycle
+          const textarea = document.querySelector(
+            '[data-test-subj="ruleV2FormYamlEditor"] textarea.inputarea'
+          ) as HTMLTextAreaElement;
+          if (textarea) {
+            textarea.dispatchEvent(new Event('blur', { bubbles: true }));
+          }
+        },
+        { newValue: updatedYaml, oldName: RULE_NAME }
+      );
+
+      // Give the form time to parse and re-validate
+      await page.waitForTimeout(1000);
+    });
+
+    await test.step('save via YAML mode submit', async () => {
+      const yamlSubmit = page.testSubj.locator('composeDiscoverYamlSubmit');
+      await expect(yamlSubmit).toBeEnabled({ timeout: 30_000 });
+      await yamlSubmit.click();
+      await expect(pageObjects.composeDiscover.flyout).toBeHidden({ timeout: 30_000 });
+    });
+
+    await test.step('verify rule name updated via API', async () => {
+      await expect
+        .poll(async () => (await apiServices.alertingV2.rules.get(ruleId!)).metadata.name, {
+          timeout: 30_000,
+        })
+        .toBe(EDITED_RULE_NAME);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Remove `RuleRequestCommon`**: Replace the hand-rolled interface with `CreateRuleData` and its property types from `@kbn/alerting-v2-schemas`, eliminating type duplication.
- **Remove `mapFormValuesToRuleRequest`**: The intermediate helper is gone — `mapFormValuesToCreateRequest` now returns the full `CreateRuleData` (including `kind`) directly, and `mapFormValuesToUpdateRequest` destructures `kind` out of it.
- **Remove `mapRuleToComposeFormValues`**: `mapRuleResponseToFormValues` now returns `FormValues` (not `Partial`), so the passthrough wrapper and `as ComposeFormValues` cast are unnecessary. The flyout calls `mapRuleResponseToFormValues` directly.
- **Simplify `rule_request_mappers`**: `mapStateTransition` is now a naive camelCase→snake_case passthrough — the API's Zod schema handles validation and the server's director strategies only read the fields relevant to the configured strategy.
- **Move delay-mode business logic to `compose_mappers`**: The GUI-specific filtering of `state_transition` fields by delay mode (immediate / breaches / duration) now lives in `applyDelayModeFilter` inside `compose_mappers.ts`, which is the only consumer that needs it.
- **Consolidate YAML serialization**: `yaml_form_utils.ts` now reuses `mapFormValuesToCreateRequest` with a `stripEmpty` helper to produce clean YAML output (no `description: null` noise), eliminating ~90 lines of duplicated serialization logic.
- **Add Scout UI tests for YAML mode**: Two new deployment-agnostic tests:
  1. View an API-created rule in YAML mode — verifies correct shape and absence of null/undefined noise for omitted optional fields.
  2. Edit a rule name in YAML mode and save — verifies the round-trip through Monaco `executeEdits` → form re-parse → API update.

### Changed files
| File | What changed |
|---|---|
| `rule_request_mappers.ts` | Removed `RuleRequestCommon`, `mapFormValuesToRuleRequest`; `mapFormValuesToCreateRequest` returns `CreateRuleData` directly; `mapRuleResponseToFormValues` returns `FormValues` (not `Partial`) |
| `compose_mappers.ts` | Removed `mapRuleToComposeFormValues`; thin wrapper over base mappers + `applyDelayModeFilter` for GUI delay-mode logic |
| `compose_discover_flyout.tsx` | Imports `mapRuleResponseToFormValues` directly instead of the removed wrapper |
| `yaml_form_utils.ts` | Reuses `mapFormValuesToCreateRequest` + `stripEmpty`; removed ~90 lines of duplicated serialization |
| `compose_discover_page.ts` | Added `getYamlEditorValue()` and `setYamlEditorValue()` page object methods for YAML Monaco editor |
| `yaml_mode.spec.ts` | New Scout UI test file with view + edit tests |
| `index.ts`, `form/index.tsx` | Removed `RuleRequestCommon` and `mapFormValuesToRuleRequest` re-exports |
| `README.md` | Updated reference from `mapFormValuesToRuleRequest` to `mapFormValuesToCreateRequest` |
| `*test*` files | Updated to use `mapFormValuesToCreateRequest`, `mapRuleResponseToFormValues`, and `CreateRuleData` types |

## Test plan

- [x] Scout UI tests pass locally (2/2 passed)
- [ ] Existing `compose_mappers.test.ts` and `rule_request_mappers.test.ts` unit tests pass
- [ ] CI green