### PR TITLE
[Fleet] Write KB ES references even when skipping indexing

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.test.ts
@@ -391,7 +391,7 @@ describe('stepSaveKnowledgeBase', () => {
       });
     });
 
-    it('should skip saveKnowledgeBaseContentToIndex when knowledge base already indexed for same version', async () => {
+    it('should skip saveKnowledgeBaseContentToIndex but still ensure es references when knowledge base already indexed for same version', async () => {
       (getPackageKnowledgeBase as jest.Mock).mockResolvedValueOnce({
         package: { name: 'test-package' },
         items: [{ fileName: 'guide.md', content: '# Guide', version: '1.0.0' }],
@@ -410,6 +410,14 @@ describe('stepSaveKnowledgeBase', () => {
       await stepSaveKnowledgeBase(context);
 
       expect(saveKnowledgeBaseContentToIndex).not.toHaveBeenCalled();
+      // The es asset references must still be ensured so installed_es stays consistent even when
+      // the indexed content survived a saved-object reset (e.g. an install rollback).
+      const { optimisticallyAddEsAssetReferences } = jest.requireMock('../../es_assets_reference');
+      expect(optimisticallyAddEsAssetReferences).toHaveBeenCalledWith(
+        savedObjectsClient,
+        'test-package',
+        [{ id: 'test-package-guide.md', type: 'knowledge_base' }]
+      );
     });
 
     it('should re-index when knowledge base exists but is at an older version', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_knowledge_base.ts
@@ -116,9 +116,22 @@ export async function stepSaveKnowledgeBase(
     existing.items.every((item) => item.version === packageInfo.version)
   ) {
     logger.debug(
-      `Knowledge base already indexed for ${packageInfo.name}@${packageInfo.version}, skipping`
+      `Knowledge base already indexed for ${packageInfo.name}@${packageInfo.version}, skipping re-index`
     );
-    return { esReferences };
+
+    // The content is already current, so skip the (expensive) re-indexing. But still ensure the
+    // es asset references are present: they may be missing if the epm-packages saved object was
+    // reset while the indexed content survived (e.g. after an install rollback).
+    const knowledgeBaseAssetRefs = existing.items.map((item) => ({
+      id: `${packageInfo.name}-${item.fileName}`,
+      type: ElasticsearchAssetType.knowledgeBase,
+    }));
+    const updatedEsReferences = await optimisticallyAddEsAssetReferences(
+      savedObjectsClient,
+      packageInfo.name,
+      knowledgeBaseAssetRefs
+    );
+    return { esReferences: updatedEsReferences };
   }
 
   return await indexKnowledgeBase(

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/input_package_rollback.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/input_package_rollback.ts
@@ -100,8 +100,7 @@ export default function (providerContext: FtrProviderContext) {
       .send({ agentPolicyId });
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/270585
-  describe.skip('input package policy rollback', function () {
+  describe('input package policy rollback', function () {
     skipIfNoDockerRegistry(providerContext);
 
     let agentPolicyId: string;


### PR DESCRIPTION
## Summary

Resolves #270585

#274370 skips knowledge base indexing when they are already installed, but it also skips writing the ES asset references. This PR makes it so that the references are always written.

This pretty much only happens in the test case. The empty reference does not happen for the incident that the prior PR addresses (reinstalls do not overwrite the ES refs).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->