### PR TITLE
[Response Ops] Replace inline watch() with useWatch() in alerting v2 rule form

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useMemo, useRef } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { Parser, isColumn } from '@elastic/esql';
 import { useQuery } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
@@ -49,12 +49,13 @@ export function AlertConditionStep({
   onKindChange,
   isEditing,
 }: AlertConditionStepProps) {
-  const { setValue, watch } = useFormContext<ComposeFormValues>();
-  const isAlert = watch('kind') === 'alert';
-  const timeField = watch('timeField') ?? '@timestamp';
-  const grouping = watch('grouping');
+  const { setValue, control } = useFormContext<ComposeFormValues>();
+  const kind = useWatch({ control, name: 'kind' });
+  const isAlert = kind === 'alert';
+  const timeField = useWatch({ control, name: 'timeField' }) ?? '@timestamp';
+  const grouping = useWatch({ control, name: 'grouping' });
   const groupFields = grouping?.fields ?? [];
-  const query = watch('query');
+  const query = useWatch({ control, name: 'query' });
 
   const baseQuery = query.format === 'composed' ? query.base : '';
   const alertBlock = query.format === 'composed' ? query.breach.segment : '';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/notifications_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/notifications_step.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { ActionForm, createInitialActionFormValue, isActionValid } from '../../../actions_form';
@@ -26,8 +26,8 @@ const notificationsSubtext = i18n.translate(
 );
 
 export const NotificationsStep = () => {
-  const { watch, setValue } = useFormContext<ComposeFormValues>();
-  const notifications = watch('notifications');
+  const { setValue, control } = useFormContext<ComposeFormValues>();
+  const notifications = useWatch({ control, name: 'notifications' });
   const [touched, setTouched] = useState(false);
 
   const defaultWorkflows = useMemo(() => createInitialActionFormValue(), []);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -75,8 +75,8 @@ export const RuleBuilderAlertConditionStep: React.FC<RuleBuilderStepProps> = ({
 }) => {
   const { state: thresholdValues, setState: onThresholdValuesChange } =
     useBuilderState<ThresholdFormValues>();
-  const { setValue, watch } = useFormContext<ComposeFormValues>();
-  const isAlert = watch('kind') === 'alert';
+  const { setValue, control } = useFormContext<ComposeFormValues>();
+  const isAlert = useWatch({ control, name: 'kind' }) === 'alert';
 
   const { data: indexOptions, isLoading: isLoadingIndices } = useIndexSources({
     http: services.http,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -8,16 +8,16 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiTextArea, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
 
 const DESCRIPTION_ROW_ID = 'ruleV2FormDescriptionField';
 
 export const DescriptionField = () => {
-  const { control, watch } = useFormContext<FormValues>();
+  const { control } = useFormContext<FormValues>();
   const { layout } = useRuleFormMeta();
-  const descriptionValue = watch('metadata.description');
+  const descriptionValue = useWatch({ control, name: 'metadata.description' });
 
   // Show the input if there's already a description value
   const [isInputVisible, setIsInputVisible] = useState(() => Boolean(descriptionValue));


### PR DESCRIPTION
## Summary

- Replaces inline `watch()` calls from `useFormContext` with `useWatch()` in four alerting v2 rule form components
- `useWatch` isolates re-renders to only the subscribing component, rather than triggering re-renders from the form context level — improving rendering performance for leaf components that observe specific field values

### Files changed

- `compose_discover_form/alert_condition_step.tsx` — 4 watched fields (`kind`, `timeField`, `grouping`, `query`)
- `rule_builder/threshold/alert_condition_step.tsx` — 1 watched field (`kind`)
- `compose_discover_form/notifications_step.tsx` — 1 watched field (`notifications`)
- `form/fields/description_field.tsx` — 1 watched field (`metadata.description`)

## Test plan

- [ ] Verify compose discover form alert condition step still reacts to kind/timeField/grouping/query changes
- [ ] Verify threshold rule builder mode toggle works correctly
- [ ] Verify notifications step still displays and updates action workflows
- [ ] Verify description field visibility toggle and form binding still work
- [ ] Run existing Jest tests for affected components


Made with [Cursor](https://cursor.com)