### PR TITLE
[Cases][XSOAR] - mark user errors properly in xsoar

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/xsoar/xsoar.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/xsoar/xsoar.test.ts
@@ -10,6 +10,7 @@ import { actionsConfigMock } from '@kbn/actions-plugin/server/actions_config.moc
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
 import { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
+import { TaskErrorSource, getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
 import type { XSOARRunActionParams } from '@kbn/connector-schemas/xsoar';
 import {
   CONNECTOR_ID,
@@ -522,6 +523,19 @@ describe('XSOARConnector', () => {
       await expect(connector.run(malformedIncident, connectorUsageCollector)).rejects.toThrowError(
         `Error parsing Body: SyntaxError: Expected property name or '}' in JSON at position 1`
       );
+    });
+
+    it('marks malformed incident body errors as user errors', async () => {
+      expect.assertions(2);
+
+      try {
+        await connector.run(malformedIncident, connectorUsageCollector);
+      } catch (error) {
+        expect(error.message).toContain(
+          `Error parsing Body: SyntaxError: Expected property name or '}' in JSON at position 1`
+        );
+        expect(getErrorSource(error)).toBe(TaskErrorSource.USER);
+      }
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/xsoar/xsoar.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/xsoar/xsoar.ts
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import type { ServiceParams } from '@kbn/actions-plugin/server';
 import { SubActionConnector } from '@kbn/actions-plugin/server';
 import type { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
+import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import type { AxiosError } from 'axios';
 import type {
   Config,
@@ -93,13 +94,20 @@ export class XSOARConnector extends SubActionConnector<Config, Secrets> {
 
       this.logger.error(`error on ${this.ConnectorId} XSOAR event: ${errMessage}: ${err.message}`);
 
-      throw new Error(
-        i18n.translate('xpack.stackConnectors.xsoar.incidentBodyParsingError', {
-          defaultMessage: 'Error parsing Body: {err}',
-          values: {
-            err: err.toString(),
-          },
-        })
+      // The incident body is user-supplied input, so a JSON parsing failure here is always a
+      // user error. Mark it as such so it does not count against the connector's execution
+      // success rate. This is a SyntaxError with no HTTP status, so the createAndThrowUserError
+      // helper (which keys off Axios response status codes) does not apply here.
+      throw createTaskRunError(
+        new Error(
+          i18n.translate('xpack.stackConnectors.xsoar.incidentBodyParsingError', {
+            defaultMessage: 'Error parsing Body: {err}',
+            values: {
+              err: err.toString(),
+            },
+          })
+        ),
+        TaskErrorSource.USER
       );
     }
   }


### PR DESCRIPTION
## Summary

This PR just marks a JSON parse error properly as a user error to help with error log noise


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->