### PR TITLE
[Flaky] Fix no_api_integration_key_callout.test.ts (fixes #271627)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts/no_api_integration_key_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts/no_api_integration_key_callout.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import {
   NO_INTEGRATION_CALLOUT_DISMISS_BUTTON_TEST_ID,
@@ -53,7 +53,7 @@ describe('NoApiIntegrationKeyCallOut', () => {
 
     expect(button).toBeInTheDocument();
 
-    button.click();
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(queryByTestId(NO_INTEGRATION_CALLOUT_DISMISS_BUTTON_TEST_ID)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test `NoApiIntegrationKeyCallOut should hide when dismiss button is clicked` was intermittently timing out (5000ms Jest default) because it used the raw DOM `.click()` method (`button.click()`) to trigger the dismiss action on an EuiButton. In React 18 concurrent mode, native DOM `.click()` bypasses React's synthetic event system and `act()` tracking, so the state update triggered by the click (`setIsCalloutDismissed(true)`) is never flushed into the React rendering cycle. As a result, the subsequent `waitFor(() => expect(queryByTestId(...)).not.toBeInTheDocument())` keeps polling until it exceeds the 5000ms Jest timeout, since the component never actually re-renders to hide the button. The fix was to replace `button.click()` with `fireEvent.click(button)` from `@testing-library/react` and add `fireEvent` to the import. `fireEvent.click` dispatches a synthetic React-aware click event that is properly wrapped in `act()`, ensuring the state update is synchronously flushed before the `waitFor` assertion runs.

**Changes**

- 27a96882ee1c fix(test): replace native button.click() with fireEvent.click() in NoApiIntegrationKeyCallOut test

Fixes #271627




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`