### PR TITLE
[Agent Builder] HITL: Adapt UI for Confirmation and Authorization prompts

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -280,6 +280,31 @@ export const carriedOverTodos = (todos: TodoItem[] | undefined): TodoItem[] | un
   return hasIncomplete ? todos : undefined;
 };
 
+export interface AskUserQuestionStepData {
+  /** Id of the prompt that produced this step. Matches the entry in `state.prompt.responses` and the prompt request's `id`. */
+  prompt_id: string;
+  /** The questions presented to the user. */
+  questions: AskUserQuestionItem[];
+  /** Undefined while the step is pending; populated on resume back-fill. */
+  answers?: AskUserQuestionAnswer[];
+}
+
+export type AskUserQuestionStep = ConversationRoundStepMixin<
+  ConversationRoundStepType.askUserQuestion,
+  AskUserQuestionStepData
+>;
+
+export const createAskUserQuestionStep = (data: AskUserQuestionStepData): AskUserQuestionStep => {
+  return {
+    type: ConversationRoundStepType.askUserQuestion,
+    ...data,
+  };
+};
+
+export const isAskUserQuestionStep = (step: ConversationRoundStep): step is AskUserQuestionStep => {
+  return step.type === ConversationRoundStepType.askUserQuestion;
+};
+
 export type ConversationRoundStep =
   | ToolCallStep
   | ReasoningStep

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -232,29 +232,6 @@ export const isTodosStep = (step: ConversationRoundStep): step is TodosStep => {
   return step.type === ConversationRoundStepType.updateTodos;
 };
 
-// ask_user_question step
-
-/**
- * Returns the (single) todos step from a list of steps, if present.
- * A round only ever has at most one todos step, which is updated in place.
- */
-export const findTodosStep = (
-  steps: ConversationRoundStep[] | undefined
-): TodosStep | undefined => {
-  return steps?.find(isTodosStep);
-};
-
-/**
- * Returns the todo list to carry over from the previous round, or undefined if nothing should carry over.
- * Carryover only happens when at least one item is still incomplete (pending / in_progress).
- * When carried over, both complete and incomplete items are included so the full plan is visible.
- */
-export const carriedOverTodos = (todos: TodoItem[] | undefined): TodoItem[] | undefined => {
-  if (!todos?.length) return undefined;
-  const hasIncomplete = todos.some((t) => t.status !== 'completed' && t.status !== 'cancelled');
-  return hasIncomplete ? todos : undefined;
-};
-
 export interface AskUserQuestionStepData {
   /** Id of the prompt that produced this step. Matches the entry in `state.prompt.responses` and the prompt request's `id`. */
   prompt_id: string;
@@ -278,6 +255,27 @@ export const createAskUserQuestionStep = (data: AskUserQuestionStepData): AskUse
 
 export const isAskUserQuestionStep = (step: ConversationRoundStep): step is AskUserQuestionStep => {
   return step.type === ConversationRoundStepType.askUserQuestion;
+};
+
+/**
+ * Returns the (single) todos step from a list of steps, if present.
+ * A round only ever has at most one todos step, which is updated in place.
+ */
+export const findTodosStep = (
+  steps: ConversationRoundStep[] | undefined
+): TodosStep | undefined => {
+  return steps?.find(isTodosStep);
+};
+
+/**
+ * Returns the todo list to carry over from the previous round, or undefined if nothing should carry over.
+ * Carryover only happens when at least one item is still incomplete (pending / in_progress).
+ * When carried over, both complete and incomplete items are included so the full plan is visible.
+ */
+export const carriedOverTodos = (todos: TodoItem[] | undefined): TodoItem[] | undefined => {
+  if (!todos?.length) return undefined;
+  const hasIncomplete = todos.some((t) => t.status !== 'completed' && t.status !== 'cancelled');
+  return hasIncomplete ? todos : undefined;
 };
 
 export type ConversationRoundStep =

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -234,31 +234,6 @@ export const isTodosStep = (step: ConversationRoundStep): step is TodosStep => {
 
 // ask_user_question step
 
-export interface AskUserQuestionStepData {
-  /** Id of the prompt that produced this step. Matches the entry in `state.prompt.responses` and the prompt request's `id`. */
-  prompt_id: string;
-  /** The questions presented to the user. */
-  questions: AskUserQuestionItem[];
-  /** Undefined while the step is pending; populated on resume back-fill. */
-  answers?: AskUserQuestionAnswer[];
-}
-
-export type AskUserQuestionStep = ConversationRoundStepMixin<
-  ConversationRoundStepType.askUserQuestion,
-  AskUserQuestionStepData
->;
-
-export const createAskUserQuestionStep = (data: AskUserQuestionStepData): AskUserQuestionStep => {
-  return {
-    type: ConversationRoundStepType.askUserQuestion,
-    ...data,
-  };
-};
-
-export const isAskUserQuestionStep = (step: ConversationRoundStep): step is AskUserQuestionStep => {
-  return step.type === ConversationRoundStepType.askUserQuestion;
-};
-
 /**
  * Returns the (single) todos step from a list of steps, if present.
  * A round only ever has at most one todos step, which is updated in place.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -232,6 +232,8 @@ export const isTodosStep = (step: ConversationRoundStep): step is TodosStep => {
   return step.type === ConversationRoundStepType.updateTodos;
 };
 
+// ask_user_question step
+
 export interface AskUserQuestionStepData {
   /** Id of the prompt that produced this step. Matches the entry in `state.prompt.responses` and the prompt request's `id`. */
   prompt_id: string;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
@@ -214,7 +214,9 @@ export const AskUserQuestionPrompt = ({
         direction="column"
         gutterSize="xs"
         responsive={false}
-        css={css`margin-top: ${euiTheme.size.s};`}
+        css={css`
+          margin-top: ${euiTheme.size.s};
+        `}
       >
         {currentQuestion.options.map((option, optionIndex) => {
           const inputId = `${baseId}-q${currentIndex}-opt${optionIndex}`;
@@ -304,7 +306,9 @@ export const AskUserQuestionPrompt = ({
         justifyContent="spaceBetween"
         alignItems="center"
         responsive={false}
-        css={css`margin-top: ${euiTheme.size.base};`}
+        css={css`
+          margin-top: ${euiTheme.size.base};
+        `}
       >
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
@@ -17,6 +17,7 @@ import {
   EuiIcon,
   EuiText,
   EuiTitle,
+  useEuiTheme,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -41,6 +42,7 @@ export const AskUserQuestionPrompt = ({
   isLoading = false,
   isDisabled = false,
 }: AskUserQuestionPromptProps) => {
+  const { euiTheme } = useEuiTheme();
   const totalQuestions = questions.length;
   const [currentIndex, setCurrentIndex] = useState(0);
   const [drafts, setDrafts] = useState<AnswerDraft[]>(() => questions.map(() => ({})));
@@ -168,7 +170,7 @@ export const AskUserQuestionPrompt = ({
     <EuiFlexGroup
       direction="column"
       responsive={false}
-      gutterSize="m"
+      gutterSize="none"
       css={containerStyles}
       data-test-subj="agentBuilderAskUserQuestionPrompt"
     >
@@ -208,7 +210,12 @@ export const AskUserQuestionPrompt = ({
       </EuiFlexItem>
 
       {/* Options */}
-      <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="xs"
+        responsive={false}
+        css={css`margin-top: ${euiTheme.size.s};`}
+      >
         {currentQuestion.options.map((option, optionIndex) => {
           const inputId = `${baseId}-q${currentIndex}-opt${optionIndex}`;
           const checked = (currentDraft.choice ?? []).includes(optionIndex);
@@ -297,6 +304,7 @@ export const AskUserQuestionPrompt = ({
         justifyContent="spaceBetween"
         alignItems="center"
         responsive={false}
+        css={css`margin-top: ${euiTheme.size.base};`}
       >
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt_utils.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { euiShadow } from '@elastic/eui';
 import type { UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -14,7 +13,7 @@ import type {
   AskUserQuestionPromptResponse,
   AskUserQuestionItem,
 } from '@kbn/agent-builder-common/agents';
-import { borderRadiusXlStyles } from '../../../../../common.styles';
+export { promptContainerStyles as containerStyles } from './prompt_container.styles';
 
 /** In-progress (mutable) answer for a single question, before it is mapped to the wire shape. */
 export interface AnswerDraft {
@@ -55,17 +54,6 @@ export const labels = {
   customError: i18n.translate('xpack.agentBuilder.askUserQuestionPrompt.customError', {
     defaultMessage: 'Enter a response or choose a different option.',
   }),
-};
-
-export const containerStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
-  return css`
-    background-color: ${euiTheme.colors.backgroundBasePlain};
-    ${borderRadiusXlStyles}
-    border: ${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBasePlain};
-    padding: ${euiTheme.size.base};
-    ${euiShadow(euiThemeContext, 's')};
-  `;
 };
 
 export const optionCardStyles = ({ euiTheme }: UseEuiTheme) => css`

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import { AuthorizationPrompt } from './authorization_prompt';
+
+jest.mock('@kbn/response-ops-oauth-hooks', () => ({
+  useConnectorOAuthConnect: jest.fn(() => ({
+    connect: jest.fn(),
+    cancelConnect: jest.fn(),
+    isConnecting: false,
+  })),
+  OAuthRedirectMode: { NewTab: 'new_tab' },
+}));
+
+jest.mock('../../../../hooks/use_toasts', () => ({
+  useToasts: () => ({ addErrorToast: jest.fn() }),
+}));
+
+jest.mock('../../../connectors/connector_type_icon', () => ({
+  ConnectorTypeIcon: () => <span />,
+}));
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const basePrompt = {
+  id: 'auth-prompt-id',
+  connector_id: 'connector-123',
+  connector_name: 'Slack',
+  connector_type: '.slack',
+  auth_method: 'oauth_authorization_code' as const,
+};
+
+describe('AuthorizationPrompt', () => {
+  it('shows Declined on the cancel button when answered false', () => {
+    renderWithProviders(
+      <AuthorizationPrompt
+        prompt={basePrompt}
+        onAuthorize={jest.fn()}
+        onCancel={jest.fn()}
+        isAnswered
+        answeredValue={false}
+      />
+    );
+    expect(screen.getByTestId('agentBuilderAuthorizationPromptCancelButton')).toHaveTextContent(
+      'Declined'
+    );
+  });
+
+  it('shows Authorized on the authorize button when answered true', () => {
+    renderWithProviders(
+      <AuthorizationPrompt
+        prompt={basePrompt}
+        onAuthorize={jest.fn()}
+        onCancel={jest.fn()}
+        isAnswered
+        answeredValue
+      />
+    );
+    expect(screen.getByTestId('agentBuilderAuthorizationPromptAuthorizeButton')).toHaveTextContent(
+      'Authorized'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiButton, EuiButtonEmpty, EuiFlexGroup, EuiText, euiShadow } from '@elastic/eui';
+import { EuiButton, EuiButtonEmpty, EuiFlexGroup, EuiText } from '@elastic/eui';
 import type { UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -16,19 +16,16 @@ import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { getEbtProps } from '@kbn/ebt-click';
 import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
 import { OAuthRedirectMode, useConnectorOAuthConnect } from '@kbn/response-ops-oauth-hooks';
-import { borderRadiusXlStyles } from '../../../../../common.styles';
+import { promptContainerStyles } from './prompt_container.styles';
 import { useToasts } from '../../../../hooks/use_toasts';
 import { ConnectorTypeIcon } from '../../../connectors/connector_type_icon';
 
 const labels = {
-  title: i18n.translate('xpack.agentBuilder.authorizationPrompt.title', {
-    defaultMessage: 'Authorization required',
+  deny: i18n.translate('xpack.agentBuilder.authorizationPrompt.deny', {
+    defaultMessage: 'Deny',
   }),
   authorize: i18n.translate('xpack.agentBuilder.authorizationPrompt.authorize', {
     defaultMessage: 'Authorize',
-  }),
-  cancel: i18n.translate('xpack.agentBuilder.authorizationPrompt.cancel', {
-    defaultMessage: 'Cancel',
   }),
   authorized: i18n.translate('xpack.agentBuilder.authorizationPrompt.authorized', {
     defaultMessage: 'Authorized',
@@ -40,22 +37,6 @@ const labels = {
     defaultMessage: 'Authorization failed',
   }),
 };
-
-const containerStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
-  return css`
-    background-color: ${euiTheme.colors.backgroundBasePlain};
-    ${borderRadiusXlStyles}
-    border: 1px solid ${euiTheme.colors.borderStrongWarning};
-    padding: ${euiTheme.size.base};
-    ${euiShadow(euiThemeContext, 's')};
-  `;
-};
-
-const headerStyles = ({ euiTheme }: UseEuiTheme) => css`
-  padding-block-end: ${euiTheme.size.m};
-  border-block-end: 1px solid ${euiTheme.colors.lightShade};
-`;
 
 const titleStyles = ({ euiTheme }: UseEuiTheme) => css`
   font-weight: ${euiTheme.font.weight.semiBold};
@@ -111,26 +92,24 @@ export const AuthorizationPrompt = ({
       direction="column"
       responsive={false}
       gutterSize="m"
-      css={containerStyles}
+      css={promptContainerStyles}
       data-test-subj="agentBuilderAuthorizationPrompt"
     >
-      <EuiFlexGroup
-        direction="row"
-        alignItems="center"
-        gutterSize="s"
-        responsive={false}
-        css={headerStyles}
-      >
-        <ConnectorTypeIcon actionTypeId={prompt.connector_type} size="l" />
-        <EuiText component="span" css={titleStyles}>
-          {labels.title}
-        </EuiText>
-      </EuiFlexGroup>
+      <EuiText component="span" css={titleStyles}>
+        <FormattedMessage
+          id="xpack.agentBuilder.authorizationPrompt.title"
+          defaultMessage="Authorize {connectorIcon} {connectorName}?"
+          values={{
+            connectorIcon: <ConnectorTypeIcon actionTypeId={prompt.connector_type} size="s" />,
+            connectorName: prompt.connector_name,
+          }}
+        />
+      </EuiText>
 
       <EuiText component="p" size="s">
         <FormattedMessage
           id="xpack.agentBuilder.authorizationPrompt.message"
-          defaultMessage="You need to authorize the {connectorName} connector to continue."
+          defaultMessage="The agent paused because it needs access to {connectorName} to continue."
           values={{
             connectorName: <strong>{prompt.connector_name}</strong>,
           }}
@@ -142,6 +121,7 @@ export const AuthorizationPrompt = ({
           onClick={handleCancel}
           disabled={isInteractionDisabled}
           size="s"
+          iconType="cross"
           color={isAnswered && answeredValue === false ? 'danger' : 'text'}
           data-test-subj="agentBuilderAuthorizationPromptCancelButton"
           {...getEbtProps({
@@ -150,7 +130,7 @@ export const AuthorizationPrompt = ({
             detail: 'conversation',
           })}
         >
-          {isAnswered && answeredValue === false ? labels.declined : labels.cancel}
+          {isAnswered && answeredValue === false ? labels.declined : labels.deny}
         </EuiButtonEmpty>
         <EuiButton
           onClick={handleAuthorize}
@@ -158,7 +138,8 @@ export const AuthorizationPrompt = ({
           disabled={isInteractionDisabled}
           fill={!isAnswered || answeredValue === true}
           size="s"
-          color={isAnswered && answeredValue === true ? 'success' : 'warning'}
+          iconType="check"
+          color={isAnswered && answeredValue === true ? 'success' : 'primary'}
           data-test-subj="agentBuilderAuthorizationPromptAuthorizeButton"
           {...getEbtProps({
             element: AGENT_BUILDER_UI_EBT.element.pageContent,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
@@ -42,6 +42,14 @@ const titleStyles = ({ euiTheme }: UseEuiTheme) => css`
   font-weight: ${euiTheme.font.weight.semiBold};
 `;
 
+const descriptionStyles = ({ euiTheme }: UseEuiTheme) => css`
+  margin-top: ${euiTheme.size.s};
+`;
+
+const buttonsRowStyles = ({ euiTheme }: UseEuiTheme) => css`
+  margin-top: ${euiTheme.size.base};
+`;
+
 export interface AuthorizationPromptProps {
   prompt: AuthorizationPromptDefinition;
   onAuthorize: () => void;
@@ -91,7 +99,7 @@ export const AuthorizationPrompt = ({
     <EuiFlexGroup
       direction="column"
       responsive={false}
-      gutterSize="m"
+      gutterSize="none"
       css={promptContainerStyles}
       data-test-subj="agentBuilderAuthorizationPrompt"
     >
@@ -106,7 +114,7 @@ export const AuthorizationPrompt = ({
         />
       </EuiText>
 
-      <EuiText component="p" size="s" color="subdued">
+      <EuiText component="p" size="s" color="subdued" css={descriptionStyles}>
         <FormattedMessage
           id="xpack.agentBuilder.authorizationPrompt.message"
           defaultMessage="The agent paused because it needs access to {connectorName} to continue."
@@ -116,7 +124,7 @@ export const AuthorizationPrompt = ({
         />
       </EuiText>
 
-      <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
+      <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false} css={buttonsRowStyles}>
         <EuiButton
           onClick={handleCancel}
           disabled={isInteractionDisabled}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiButton, EuiButtonEmpty, EuiFlexGroup, EuiText } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiText } from '@elastic/eui';
 import type { UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -98,7 +98,7 @@ export const AuthorizationPrompt = ({
       <EuiText component="span" css={titleStyles}>
         <FormattedMessage
           id="xpack.agentBuilder.authorizationPrompt.title"
-          defaultMessage="Authorize {connectorIcon} {connectorName}?"
+          defaultMessage="Reauthorize {connectorIcon} {connectorName}?"
           values={{
             connectorIcon: <ConnectorTypeIcon actionTypeId={prompt.connector_type} size="s" />,
             connectorName: prompt.connector_name,
@@ -106,7 +106,7 @@ export const AuthorizationPrompt = ({
         />
       </EuiText>
 
-      <EuiText component="p" size="s">
+      <EuiText component="p" size="s" color="subdued">
         <FormattedMessage
           id="xpack.agentBuilder.authorizationPrompt.message"
           defaultMessage="The agent paused because it needs access to {connectorName} to continue."
@@ -117,7 +117,7 @@ export const AuthorizationPrompt = ({
       </EuiText>
 
       <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
-        <EuiButtonEmpty
+        <EuiButton
           onClick={handleCancel}
           disabled={isInteractionDisabled}
           size="s"
@@ -131,7 +131,7 @@ export const AuthorizationPrompt = ({
           })}
         >
           {isAnswered && answeredValue === false ? labels.declined : labels.deny}
-        </EuiButtonEmpty>
+        </EuiButton>
         <EuiButton
           onClick={handleAuthorize}
           isLoading={isLoading || isConnecting}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/authorization_prompt.tsx
@@ -124,7 +124,12 @@ export const AuthorizationPrompt = ({
         />
       </EuiText>
 
-      <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false} css={buttonsRowStyles}>
+      <EuiFlexGroup
+        gutterSize="s"
+        justifyContent="flexEnd"
+        responsive={false}
+        css={buttonsRowStyles}
+      >
         <EuiButton
           onClick={handleCancel}
           disabled={isInteractionDisabled}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import { ConfirmationPrompt } from './confirmation_prompt';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const basePrompt = { id: 'test-id' };
+
+describe('ConfirmationPrompt', () => {
+  it('renders markdown in title — backtick content becomes a code element', () => {
+    renderWithProviders(
+      <ConfirmationPrompt
+        prompt={{ ...basePrompt, title: 'Allow `platform.core.list_indices` to run?' }}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('code')).toHaveTextContent('platform.core.list_indices');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
@@ -13,15 +13,13 @@ import {
   EuiFlexItem,
   EuiMarkdownFormat,
   useEuiTheme,
-  useEuiShadow,
 } from '@elastic/eui';
-import type { EuiThemeComputed } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { ConfirmPromptDefinition, ConfirmPromptColor } from '@kbn/agent-builder-common/agents';
+import type { ConfirmPromptDefinition } from '@kbn/agent-builder-common/agents';
 import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { getEbtProps } from '@kbn/ebt-click';
-import { borderRadiusXlStyles } from '../../../../../common.styles';
+import { promptContainerStyles } from './prompt_container.styles';
 
 const defaultLabels = {
   title: i18n.translate('xpack.agentBuilder.confirmationPrompt.defaultTitle', {
@@ -31,20 +29,11 @@ const defaultLabels = {
     defaultMessage: 'Do you want to proceed with this action?',
   }),
   confirmText: i18n.translate('xpack.agentBuilder.confirmationPrompt.confirm', {
-    defaultMessage: 'Confirm',
+    defaultMessage: 'Approve',
   }),
   cancelText: i18n.translate('xpack.agentBuilder.confirmationPrompt.cancel', {
-    defaultMessage: 'Cancel',
+    defaultMessage: 'Deny',
   }),
-};
-
-const getBorderColor = (euiTheme: EuiThemeComputed, color: ConfirmPromptColor): string => {
-  const borderColors: Record<ConfirmPromptColor, string> = {
-    primary: euiTheme.colors.borderStrongPrimary,
-    warning: euiTheme.colors.borderStrongWarning,
-    danger: euiTheme.colors.borderStrongDanger,
-  };
-  return borderColors[color];
 };
 
 export interface ConfirmationPromptProps {
@@ -67,33 +56,24 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
   answeredValue,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const color = prompt.color ?? 'warning';
-  const borderColor = getBorderColor(euiTheme, color);
+  const color = prompt.color ?? 'primary';
 
   const title = prompt.title ?? defaultLabels.title;
   const confirmText = prompt.confirm_text ?? defaultLabels.confirmText;
   const cancelText = prompt.cancel_text ?? defaultLabels.cancelText;
-
   const body = prompt.message ?? defaultLabels.message;
-
-  const containerStyles = css`
-    background-color: ${euiTheme.colors.backgroundBasePlain};
-    ${borderRadiusXlStyles}
-    border: 1px solid ${borderColor};
-    padding: ${euiTheme.size.base};
-    ${useEuiShadow('s')};
-  `;
 
   const headerStyles = css`
     padding-bottom: ${euiTheme.size.m};
-    border-bottom: 1px solid ${euiTheme.colors.lightShade};
-    margin-bottom: ${euiTheme.size.m};
   `;
 
   const titleStyles = css`
     font-weight: ${euiTheme.font.weight.semiBold};
     font-size: ${euiTheme.size.base};
     color: ${euiTheme.colors.textParagraph};
+    p {
+      margin-block: 0;
+    }
   `;
 
   const footerStyles = css`
@@ -104,13 +84,13 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
     <EuiFlexGroup
       direction="column"
       responsive={false}
-      css={containerStyles}
+      css={promptContainerStyles}
       gutterSize="none"
       data-test-subj="agentBuilderConfirmationPrompt"
     >
       {/* Header */}
       <EuiFlexItem grow={false} css={headerStyles}>
-        <span css={titleStyles}>{title}</span>
+        <EuiMarkdownFormat css={titleStyles}>{title}</EuiMarkdownFormat>
       </EuiFlexItem>
 
       {/* Body */}
@@ -126,6 +106,7 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
               onClick={onCancel}
               disabled={isDisabled || isLoading || isAnswered}
               size="s"
+              iconType="cross"
               color={isAnswered && answeredValue === false ? 'danger' : 'text'}
               data-test-subj="agentBuilderConfirmationPromptCancelButton"
               {...getEbtProps({
@@ -144,6 +125,7 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
               disabled={isDisabled || isAnswered}
               fill={!isAnswered || answeredValue === true}
               size="s"
+              iconType="check"
               color={isAnswered && answeredValue === true ? 'success' : color}
               data-test-subj="agentBuilderConfirmationPromptConfirmButton"
               {...getEbtProps({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
@@ -6,13 +6,7 @@
  */
 
 import React from 'react';
-import {
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiMarkdownFormat,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiMarkdownFormat, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import type { ConfirmPromptDefinition } from '@kbn/agent-builder-common/agents';
@@ -94,7 +88,14 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
 
       {/* Body */}
       <EuiFlexItem grow={false}>
-        <EuiMarkdownFormat textSize="s" css={css`color: ${euiTheme.colors.textSubdued};`}>{body}</EuiMarkdownFormat>
+        <EuiMarkdownFormat
+          textSize="s"
+          css={css`
+            color: ${euiTheme.colors.textSubdued};
+          `}
+        >
+          {body}
+        </EuiMarkdownFormat>
       </EuiFlexItem>
 
       {/* Action buttons */}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import {
   EuiButton,
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiMarkdownFormat,
@@ -95,14 +94,14 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
 
       {/* Body */}
       <EuiFlexItem grow={false}>
-        <EuiMarkdownFormat textSize="s">{body}</EuiMarkdownFormat>
+        <EuiMarkdownFormat textSize="s" css={css`color: ${euiTheme.colors.textSubdued};`}>{body}</EuiMarkdownFormat>
       </EuiFlexItem>
 
       {/* Action buttons */}
       <EuiFlexItem grow={false} css={footerStyles}>
         <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
+            <EuiButton
               onClick={onCancel}
               disabled={isDisabled || isLoading || isAnswered}
               size="s"
@@ -116,7 +115,7 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
               })}
             >
               {cancelText}
-            </EuiButtonEmpty>
+            </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/confirmation_prompt.tsx
@@ -57,7 +57,7 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
   const body = prompt.message ?? defaultLabels.message;
 
   const headerStyles = css`
-    padding-bottom: ${euiTheme.size.m};
+    padding-bottom: ${euiTheme.size.s};
   `;
 
   const titleStyles = css`
@@ -70,7 +70,7 @@ export const ConfirmationPrompt: React.FC<ConfirmationPromptProps> = ({
   `;
 
   const footerStyles = css`
-    margin-top: ${euiTheme.size.m};
+    margin-top: ${euiTheme.size.base};
   `;
 
   return (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/prompt_container.styles.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/prompt_container.styles.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { euiShadow } from '@elastic/eui';
+import type { UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { borderRadiusXlStyles } from '../../../../../common.styles';
+
+export const promptContainerStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+  return css`
+    background-color: ${euiTheme.colors.backgroundBasePlain};
+    ${borderRadiusXlStyles}
+    border: ${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBasePlain};
+    padding: ${euiTheme.size.base};
+    ${euiShadow(euiThemeContext, 's')};
+  `;
+};


### PR DESCRIPTION
## Summary

Unifies the visual style and copy across all HITL prompt types (confirmation, authorization, ask-user-question): shared container styles, consistent button labels (Deny/Approve), icons, and neutral borders.

<img width="1355" height="215" alt="image" src="https://github.com/user-attachments/assets/d5da4a0d-ae96-4a2d-8339-bf4dfc875d4e" />

<img width="1315" height="209" alt="image" src="https://github.com/user-attachments/assets/ca73f3d8-ef71-4d32-b85d-1b86583e18f7" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

None

Closes https://github.com/elastic/search-team/issues/14958