### PR TITLE
[Flaky] Fix creation.cy.ts (fixes #270440)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
@@ -21,7 +21,11 @@ import {
 } from '../../../screens/timeline';
 import { LOADING_INDICATOR } from '../../../screens/security_header';
 import { ROWS } from '../../../screens/timelines';
-import { createTimelineTemplate, deleteTimelines } from '../../../tasks/api_calls/timelines';
+import {
+  createTimelineTemplate,
+  deleteTimelines,
+  deleteTimelineTemplates,
+} from '../../../tasks/api_calls/timelines';
 
 import { login } from '../../../tasks/login';
 import { visit, visitWithTimeRange } from '../../../tasks/navigation';
@@ -47,6 +51,7 @@ const mockTimeline = getTimeline();
 describe('Timelines', { tags: ['@ess', '@serverless'] }, (): void => {
   beforeEach(() => {
     deleteTimelines();
+    deleteTimelineTemplates();
   });
 
   it('should create a timeline from a template and should have the same query and open the timeline modal', () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/timelines.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/timelines.ts
@@ -164,6 +164,12 @@ export const getAllTimelines = () =>
     url: 'api/timelines?page_size=100&page_index=1&sort_field=updated&sort_order=desc&timeline_type=default',
   });
 
+const getAllCustomTimelineTemplates = () =>
+  rootRequest<GetTimelinesResponse>({
+    method: 'GET',
+    url: 'api/timelines?page_size=100&page_index=1&sort_field=updated&sort_order=desc&timeline_type=template&status=active',
+  });
+
 export const deleteTimelines = () => {
   getAllTimelines().then(($timelines) => {
     const savedObjectIds = $timelines.body.timeline.map((timeline) => timeline.savedObjectId);
@@ -174,5 +180,22 @@ export const deleteTimelines = () => {
         savedObjectIds,
       },
     });
+  });
+};
+
+export const deleteTimelineTemplates = () => {
+  getAllCustomTimelineTemplates().then(($timelines) => {
+    const savedObjectIds = $timelines.body.timeline
+      .map((timeline) => timeline.savedObjectId)
+      .filter((id): id is string => id != null);
+    if (savedObjectIds.length > 0) {
+      rootRequest({
+        method: 'DELETE',
+        url: 'api/timeline',
+        body: {
+          savedObjectIds,
+        },
+      });
+    }
   });
 };


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test failed with "Too many elements found. Found '3', expected '1'" at the `cy.get(ROWS).should('have.length', '1')` assertion in `selectCustomTemplates` (tasks/templates.ts:14), which runs after clicking the "Custom templates" filter button on the timeline templates page. The root cause was that the `beforeEach` cleanup only called `deleteTimelines()`, which fetches timelines with `timeline_type=default` (regular timelines) and does not touch template timelines at all. Each test run that called `createTimelineTemplate()` left behind a custom template that was never cleaned up. After multiple runs (or in a dirty CI environment with leftover templates), the "Custom templates" filter would show 2 or 3 accumulated custom templates instead of the expected 1, causing the `have.length '1'` assertion to consistently fail for the full 150-second timeout. The fix adds a `deleteTimelineTemplates()` helper function to `tasks/api_calls/timelines.ts` that fetches all custom (non-immutable) timeline templates via `GET /api/timelines?timeline_type=template&status=active` and deletes them, then calls this new function in the `beforeEach` of `creation.cy.ts` alongside the existing `deleteTimelines()`.

**Changes**

- 80270dcf7b59 fix(test): clean up template timelines in beforeEach to prevent accumulation

Fixes #270440




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->