### PR TITLE
[streams] Add semantic search to sigevents memory

### DIFF
--- a/x-pack/platform/plugins/shared/streams/common/queries.ts
+++ b/x-pack/platform/plugins/shared/streams/common/queries.ts
@@ -12,7 +12,7 @@ export type { QueryLink };
 export const QUERY_STATUSES = ['active', 'draft'] as const;
 export type QueryStatus = (typeof QUERY_STATUSES)[number];
 
-export const SEARCH_MODES = ['keyword', 'semantic', 'hybrid'] as const;
+export const SEARCH_MODES = ['keyword', 'hybrid'] as const;
 export type SearchMode = (typeof SEARCH_MODES)[number];
 
 const DEFAULT_SEARCH_MODE: SearchMode = 'hybrid';

--- a/x-pack/platform/plugins/shared/streams/common/queries.ts
+++ b/x-pack/platform/plugins/shared/streams/common/queries.ts
@@ -12,7 +12,7 @@ export type { QueryLink };
 export const QUERY_STATUSES = ['active', 'draft'] as const;
 export type QueryStatus = (typeof QUERY_STATUSES)[number];
 
-export const SEARCH_MODES = ['keyword', 'hybrid'] as const;
+export const SEARCH_MODES = ['keyword', 'semantic', 'hybrid'] as const;
 export type SearchMode = (typeof SEARCH_MODES)[number];
 
 const DEFAULT_SEARCH_MODE: SearchMode = 'hybrid';

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
@@ -48,7 +48,8 @@ const memorySearchSchema = z.object({
       'Search mode — omit for the default "hybrid" behaviour, which combines keyword and semantic ' +
         'matching and finds pages that are thematically related even when they share no keywords with the query. ' +
         '"keyword": fast fuzzy/wildcard match only — use when you know the exact name, tag, or category and want ' +
-        'to avoid false positives from semantic drift.'
+        'to avoid false positives from semantic drift. ' +
+        '"semantic": vector-similarity only — rarely the right choice because it ignores exact matches; prefer hybrid.'
     ),
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
@@ -48,8 +48,7 @@ const memorySearchSchema = z.object({
       'Search mode — omit for the default "hybrid" behaviour, which combines keyword and semantic ' +
         'matching and finds pages that are thematically related even when they share no keywords with the query. ' +
         '"keyword": fast fuzzy/wildcard match only — use when you know the exact name, tag, or category and want ' +
-        'to avoid false positives from semantic drift. ' +
-        '"semantic": vector-similarity only — rarely the right choice because it ignores exact matches; prefer hybrid.'
+        'to avoid false positives from semantic drift.'
     ),
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
@@ -10,6 +10,7 @@ import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { getToolResultId, createErrorResult } from '@kbn/agent-builder-server';
+import { SEARCH_MODES } from '../../../../common/queries';
 import { platformStreamsMemoryTools } from './tool_ids';
 import type { MemoryToolsOptions } from './types';
 
@@ -40,6 +41,14 @@ const memorySearchSchema = z.object({
     .max(50)
     .optional()
     .describe('Maximum number of results to return (defaults to 10).'),
+  mode: z
+    .enum(SEARCH_MODES)
+    .optional()
+    .describe(
+      'Search mode: "hybrid" (default) combines keyword and semantic matching for best recall, ' +
+        '"semantic" uses vector similarity only, "keyword" uses fuzzy text matching only. ' +
+        'Use "semantic" or "hybrid" when looking for conceptually related pages rather than exact keyword matches.'
+    ),
 });
 
 export const createMemorySearchTool = ({
@@ -53,7 +62,7 @@ export const createMemorySearchTool = ({
     'Memory contains persistent knowledge accumulated across conversations.',
   schema: memorySearchSchema,
   tags: ['memory'],
-  handler: async ({ query, tags, categories, references, size }, context) => {
+  handler: async ({ query, tags, categories, references, size, mode }, context) => {
     const memoryService = getMemoryService(context.esClient.asCurrentUser);
 
     try {
@@ -63,6 +72,7 @@ export const createMemorySearchTool = ({
         categories,
         references,
         size,
+        mode,
       });
 
       if (results.length === 0) {

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/memory/memory_search.ts
@@ -45,9 +45,11 @@ const memorySearchSchema = z.object({
     .enum(SEARCH_MODES)
     .optional()
     .describe(
-      'Search mode: "hybrid" (default) combines keyword and semantic matching for best recall, ' +
-        '"semantic" uses vector similarity only, "keyword" uses fuzzy text matching only. ' +
-        'Use "semantic" or "hybrid" when looking for conceptually related pages rather than exact keyword matches.'
+      'Search mode — omit for the default "hybrid" behaviour, which combines keyword and semantic ' +
+        'matching and finds pages that are thematically related even when they share no keywords with the query. ' +
+        '"keyword": fast fuzzy/wildcard match only — use when you know the exact name, tag, or category and want ' +
+        'to avoid false positives from semantic drift. ' +
+        '"semantic": vector-similarity only — rarely the right choice because it ignores exact matches; prefer hybrid.'
     ),
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
@@ -19,7 +19,7 @@ export const memoriesMappings = {
     name: mappings.keyword(),
     title: mappings.text({ fields: { keyword: { type: 'keyword', ignore_above: 512 } } }),
     content: mappings.text(),
-    // Semantic embedding — populated on write, queried via 'semantic' or 'hybrid' search mode
+    // Vector embedding — populated on write, queried via 'hybrid' search mode
     search_embedding: mappings.semanticText(),
     // Classification
     categories: mappings.keyword(),

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
@@ -19,7 +19,7 @@ export const memoriesMappings = {
     name: mappings.keyword(),
     title: mappings.text({ fields: { keyword: { type: 'keyword', ignore_above: 512 } } }),
     content: mappings.text(),
-    // Vector embedding — populated on write, queried via 'hybrid' search mode
+    // Semantic embedding — populated on write, queried via 'semantic' or 'hybrid' search mode
     search_embedding: mappings.semanticText(),
     // Classification
     categories: mappings.keyword(),

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/data_stream.ts
@@ -19,6 +19,8 @@ export const memoriesMappings = {
     name: mappings.keyword(),
     title: mappings.text({ fields: { keyword: { type: 'keyword', ignore_above: 512 } } }),
     content: mappings.text(),
+    // Semantic embedding — populated on write, queried via 'semantic' or 'hybrid' search mode
+    search_embedding: mappings.semanticText(),
     // Classification
     categories: mappings.keyword(),
     tags: mappings.keyword(),
@@ -38,7 +40,7 @@ export type StoredMemoryPage = GetFieldsOf<typeof memoriesMappings>;
 
 export const memoriesDataStream: DataStreamDefinition<typeof memoriesMappings, StoredMemoryPage> = {
   name: MEMORIES_DATA_STREAM,
-  version: 1,
+  version: 2,
   hidden: true,
   template: {
     priority: 500,

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
@@ -146,7 +146,7 @@ const createInMemoryEsClient = () => {
       return { hits: { hits: [], total: { value: 0 } } } as never;
     }
 
-    // Retriever-based queries (semantic/hybrid) embed the ids filter inside the retriever.
+    // Retriever-based queries (hybrid) embed the ids filter inside the retriever.
     // Extract it so the mock can apply the same correctness invariant as a plain query.
     const effectiveQuery = request.query ?? extractRetrieverFilter(request.retriever!);
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
@@ -463,6 +463,68 @@ describe('MemoryServiceImpl', () => {
     await expect(service.listByCategory({ category: 'services' })).resolves.toEqual([]);
   });
 
+  describe('search mode behaviour', () => {
+    it('mode: keyword does not widen Phase 1 to match-all — no retriever is issued', async () => {
+      mockedUuidV4.mockReturnValueOnce('k-entry').mockReturnValueOnce('k-hist');
+      const { service, esClient } = createService();
+
+      await service.create({ name: 'page', title: 'Page', content: 'content', user });
+
+      // Override: throw if a retriever-based request is ever issued
+      const base = esClient.search.getMockImplementation()!;
+      esClient.search.mockImplementation(async (params) => {
+        if ((params as { retriever?: unknown }).retriever) {
+          throw new Error('retriever must not be used in keyword mode');
+        }
+        return base(params as never);
+      });
+
+      await expect(service.search({ query: 'page', mode: 'keyword' })).resolves.toHaveLength(1);
+    });
+
+    it('auto-resolved hybrid falls back to keyword and warns when retriever search throws', async () => {
+      mockedUuidV4.mockReturnValueOnce('fb-entry').mockReturnValueOnce('fb-hist');
+      const { service, esClient } = createService();
+
+      await service.create({ name: 'fallback-page', title: 'Fallback', content: 'content', user });
+
+      const base = esClient.search.getMockImplementation()!;
+      esClient.search.mockImplementation(async (params) => {
+        if ((params as { retriever?: unknown }).retriever) {
+          throw new Error('inference_service_not_found: model still loading');
+        }
+        return base(params as never);
+      });
+
+      // No explicit mode → auto-resolves to hybrid → falls back to keyword on error
+      const results = await service.search({ query: 'fallback-page' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({ name: 'fallback-page' });
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('falling back to keyword'));
+    });
+
+    it('explicit hybrid mode propagates retriever errors without fallback', async () => {
+      mockedUuidV4.mockReturnValueOnce('ex-entry').mockReturnValueOnce('ex-hist');
+      const { service, esClient } = createService();
+
+      await service.create({ name: 'explicit-page', title: 'Explicit', content: 'content', user });
+
+      const base = esClient.search.getMockImplementation()!;
+      esClient.search.mockImplementation(async (params) => {
+        if ((params as { retriever?: unknown }).retriever) {
+          throw new Error('inference endpoint unavailable');
+        }
+        return base(params as never);
+      });
+
+      // Explicit mode → no fallback → error propagates
+      await expect(service.search({ query: 'explicit-page', mode: 'hybrid' })).rejects.toThrow(
+        'inference endpoint unavailable'
+      );
+    });
+  });
+
   it('getBacklinks does not return a page whose latest version dropped the reference', async () => {
     mockedUuidV4
       .mockReturnValueOnce('target-uuid')

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
@@ -95,8 +95,12 @@ const extractRetrieverFilter = (retriever: Record<string, unknown>): Record<stri
   const rrf = retriever.rrf as { filter?: Record<string, unknown> } | undefined;
   if (rrf?.filter) return rrf.filter;
 
-  type InnerStandard = { retriever?: { standard?: { filter?: Record<string, unknown> } } };
-  type LinearRetriever = { retrievers?: InnerStandard[] };
+  interface InnerStandard {
+    retriever?: { standard?: { filter?: Record<string, unknown> } };
+  }
+  interface LinearRetriever {
+    retrievers?: InnerStandard[];
+  }
   const linear = retriever.linear as LinearRetriever | undefined;
   const innerFilter = linear?.retrievers?.[0]?.retriever?.standard?.filter;
   if (innerFilter) return innerFilter;

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
@@ -146,7 +146,7 @@ const createInMemoryEsClient = () => {
       return { hits: { hits: [], total: { value: 0 } } } as never;
     }
 
-    // Retriever-based queries (hybrid) embed the ids filter inside the retriever.
+    // Retriever-based queries (semantic/hybrid) embed the ids filter inside the retriever.
     // Extract it so the mock can apply the same correctness invariant as a plain query.
     const effectiveQuery = request.query ?? extractRetrieverFilter(request.retriever!);
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.test.ts
@@ -89,6 +89,21 @@ const collapseDocuments = (
     .slice(0, size);
 };
 
+// For retriever-based queries (semantic/hybrid), extract the effective filter so the mock can
+// apply the same ids-based correctness invariant as a plain bool query.
+const extractRetrieverFilter = (retriever: Record<string, unknown>): Record<string, unknown> => {
+  const rrf = retriever.rrf as { filter?: Record<string, unknown> } | undefined;
+  if (rrf?.filter) return rrf.filter;
+
+  type InnerStandard = { retriever?: { standard?: { filter?: Record<string, unknown> } } };
+  type LinearRetriever = { retrievers?: InnerStandard[] };
+  const linear = retriever.linear as LinearRetriever | undefined;
+  const innerFilter = linear?.retrievers?.[0]?.retriever?.standard?.filter;
+  if (innerFilter) return innerFilter;
+
+  return { match_all: {} };
+};
+
 const createInMemoryEsClient = () => {
   const memoryDocs: MemoryDocument[] = [];
   let docCounter = 0;
@@ -116,17 +131,22 @@ const createInMemoryEsClient = () => {
     const request = params as {
       index?: string;
       query?: Record<string, unknown>;
+      retriever?: Record<string, unknown>;
       collapse?: { field?: string };
       size?: number;
       _source?: boolean;
       fields?: string[];
     };
 
-    if (request.index !== MEMORIES_DATA_STREAM || !request.query) {
+    if (request.index !== MEMORIES_DATA_STREAM || (!request.query && !request.retriever)) {
       return { hits: { hits: [], total: { value: 0 } } } as never;
     }
 
-    const filtered = filterByQuery(memoryDocs, request.query);
+    // Retriever-based queries (semantic/hybrid) embed the ids filter inside the retriever.
+    // Extract it so the mock can apply the same correctness invariant as a plain query.
+    const effectiveQuery = request.query ?? extractRetrieverFilter(request.retriever!);
+
+    const filtered = filterByQuery(memoryDocs, effectiveQuery);
     const collapseField = request.collapse?.field as keyof MemoryDocument | undefined;
     const size = request.size ?? filtered.length;
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -7,7 +7,10 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import type { Logger, ElasticsearchClient } from '@kbn/core/server';
-import type { QueryDslQueryContainer, RetrieverContainer } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  QueryDslQueryContainer,
+  RetrieverContainer,
+} from '@elastic/elasticsearch/lib/api/types';
 import { badRequest, notFound } from '@hapi/boom';
 import { DataStreamClient } from '@kbn/data-streams';
 import type { IDataStreamClient } from '@kbn/data-streams';
@@ -16,6 +19,7 @@ import { memoriesDataStream, type memoriesMappings, type StoredMemoryPage } from
 import { MEMORIES_DATA_STREAM } from '../../../common/constants';
 import { resolveSearchMode, type SearchMode } from '../../../common/queries';
 import { DEFAULT_SIG_EVENTS_TUNING_CONFIG } from '../../../common/sig_events_tuning_config';
+import { bulkCreateWithInferenceFallback } from '../streams/ki/knowledge_indicator_client/bulk_with_inference_fallback';
 import type {
   MemoryEntry,
   MemoryVersionRecord,
@@ -81,37 +85,32 @@ export class MemoryServiceImpl implements MemoryService {
    * entry, defaulting to `false` for live writes.
    */
   private async _indexPage(entry: MemoryEntry): Promise<void> {
-    const document: StoredMemoryPage = {
-      '@timestamp': entry.updated_at,
-      id: entry.id,
-      name: entry.name,
-      title: entry.title,
-      content: entry.content,
-      // Populate search_embedding for live pages so semantic/hybrid search can rank them.
-      // Tombstones omit it — there is no value in embedding a soft-delete marker.
-      ...(!entry.is_deleted && { search_embedding: `${entry.title}\n\n${entry.content}` }),
-      categories: entry.categories,
-      tags: entry.tags,
-      references: entry.references,
-      version: entry.version,
-      created_at: entry.created_at,
-      updated_at: entry.updated_at,
-      created_by: entry.created_by,
-      updated_by: entry.updated_by,
-      is_deleted: entry.is_deleted ?? false,
-    };
-
-    const response = await this.dataStreamClient.create({
-      documents: [document],
-      refresh: 'wait_for',
+    await bulkCreateWithInferenceFallback(this.logger, ({ includeEmbedding }) => {
+      const document: StoredMemoryPage = {
+        '@timestamp': entry.updated_at,
+        id: entry.id,
+        name: entry.name,
+        title: entry.title,
+        content: entry.content,
+        // Populate search_embedding for live pages so semantic/hybrid search can rank them.
+        // Omit it on tombstones (no value in embedding a soft-delete marker) and on the
+        // final fallback attempt when the inference endpoint is unavailable.
+        ...(includeEmbedding &&
+          !entry.is_deleted && {
+            search_embedding: `${entry.title}\n\n${entry.content}`,
+          }),
+        categories: entry.categories,
+        tags: entry.tags,
+        references: entry.references,
+        version: entry.version,
+        created_at: entry.created_at,
+        updated_at: entry.updated_at,
+        created_by: entry.created_by,
+        updated_by: entry.updated_by,
+        is_deleted: entry.is_deleted ?? false,
+      };
+      return this.dataStreamClient.create({ documents: [document], refresh: 'wait_for' });
     });
-
-    if (response.errors) {
-      const failure = response.items.find((item) => item.create?.error)?.create?.error;
-      throw new Error(
-        `Failed to index memory page '${entry.id}': ${failure?.reason ?? 'unknown bulk error'}`
-      );
-    }
   }
 
   // ── Reads: field collapse to resolve latest version ──
@@ -510,7 +509,11 @@ export class MemoryServiceImpl implements MemoryService {
     const phase1Query: QueryDslQueryContainer =
       mode === 'keyword'
         ? { bool: { filter: structuredFilters, must: [fuzzyMatch] } }
-        : { bool: structuredFilters.length ? { filter: structuredFilters } : { must: [{ match_all: {} }] } };
+        : {
+            bool: structuredFilters.length
+              ? { filter: structuredFilters }
+              : { must: [{ match_all: {} }] },
+          };
 
     let candidateIds: string[];
     try {
@@ -541,7 +544,15 @@ export class MemoryServiceImpl implements MemoryService {
     // a page whose current version satisfies both the structural filters and the text query.
     // Semantic and hybrid modes use a retriever instead of a plain query so ES can apply
     // vector scoring; keyword mode keeps the original bool query path.
-    const response = await this._executePhase3(mode, params.mode, query, latestLiveIds, structuredFilters, fuzzyMatch, size);
+    const response = await this._executePhase3(
+      mode,
+      params.mode,
+      query,
+      latestLiveIds,
+      structuredFilters,
+      fuzzyMatch,
+      size
+    );
     if (!response) return [];
 
     return response.hits.hits.flatMap((hit) => {
@@ -660,9 +671,7 @@ export class MemoryServiceImpl implements MemoryService {
       if (mode !== 'keyword' && !requestedMode) {
         // Auto-resolved mode failed (inference endpoint unavailable) — fall back to keyword.
         this.logger.warn(
-          `Memory search mode "${mode}" failed, falling back to keyword: ${
-            (err as Error).message
-          }`
+          `Memory search mode "${mode}" failed, falling back to keyword: ${(err as Error).message}`
         );
         return this.esClient.search<MemoryEntry>({
           index: MEMORIES_DATA_STREAM,

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -7,13 +7,15 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import type { Logger, ElasticsearchClient } from '@kbn/core/server';
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { QueryDslQueryContainer, RetrieverContainer } from '@elastic/elasticsearch/lib/api/types';
 import { badRequest, notFound } from '@hapi/boom';
 import { DataStreamClient } from '@kbn/data-streams';
 import type { IDataStreamClient } from '@kbn/data-streams';
 import { createMemoryHistoryStorage } from './history_storage';
 import { memoriesDataStream, type memoriesMappings, type StoredMemoryPage } from './data_stream';
 import { MEMORIES_DATA_STREAM } from '../../../common/constants';
+import { resolveSearchMode, type SearchMode } from '../../../common/queries';
+import { DEFAULT_SIG_EVENTS_TUNING_CONFIG } from '../../../common/sig_events_tuning_config';
 import type {
   MemoryEntry,
   MemoryVersionRecord,
@@ -85,6 +87,9 @@ export class MemoryServiceImpl implements MemoryService {
       name: entry.name,
       title: entry.title,
       content: entry.content,
+      // Populate search_embedding for live pages so semantic/hybrid search can rank them.
+      // Tombstones omit it — there is no value in embedding a soft-delete marker.
+      ...(!entry.is_deleted && { search_embedding: `${entry.title}\n\n${entry.content}` }),
       categories: entry.categories,
       tags: entry.tags,
       references: entry.references,
@@ -470,6 +475,7 @@ export class MemoryServiceImpl implements MemoryService {
 
   async search(params: SearchMemoryParams): Promise<MemorySearchResult[]> {
     const { query, tags, categories, references, size = 10 } = params;
+    const mode = resolveSearchMode(params.mode);
     const escapedQuery = query.toLowerCase().replace(/[\\*?]/g, '\\$&');
 
     const structuredFilters: QueryDslQueryContainer[] = [];
@@ -496,18 +502,23 @@ export class MemoryServiceImpl implements MemoryService {
       },
     };
 
-    // Phase 1: collect the id of every page that has ANY version matching the query (ids only, so
-    // this stays cheap even when widened). The matched version may be stale; we only keep the page
-    // ids here and re-validate each page's latest version in phases 2-3. Fetching all matching pages
-    // (up to MAX_PAGES) — rather than a relevance-capped window — means a page whose latest matches
-    // can never be dropped before it reaches the authoritative phase 3 ranking.
+    // Phase 1: collect the id of every page that might be relevant (ids only, cheap).
+    // For keyword mode: narrow by the text query so the candidate set stays small.
+    // For semantic/hybrid: use only structural filters (or match_all) so Phase 3's
+    // retriever handles text relevance — a keyword-only Phase 1 would silently drop
+    // pages that are semantically relevant but don't keyword-match any version.
+    const phase1Query: QueryDslQueryContainer =
+      mode === 'keyword'
+        ? { bool: { filter: structuredFilters, must: [fuzzyMatch] } }
+        : { bool: structuredFilters.length ? { filter: structuredFilters } : { must: [{ match_all: {} }] } };
+
     let candidateIds: string[];
     try {
       const candidateResponse = await this.esClient.search({
         index: MEMORIES_DATA_STREAM,
         track_total_hits: false,
         collapse: { field: 'id' },
-        query: { bool: { filter: structuredFilters, must: [fuzzyMatch] } },
+        query: phase1Query,
         size: MAX_PAGES,
         _source: false,
         fields: ['id'],
@@ -526,30 +537,12 @@ export class MemoryServiceImpl implements MemoryService {
     const latestLiveIds = (await this._resolveLatestByIds(candidateIds)).map((hit) => hit._id);
     if (latestLiveIds.length === 0) return [];
 
-    // Phase 3: re-run the query against ONLY those latest documents (via an `ids` filter), so a
-    // result can come only from a page whose LATEST version satisfies the filters and the text
-    // query — a stale older version that once matched, or a soft-deleted page, can never surface.
-    let response;
-    try {
-      response = await this.esClient.search<MemoryEntry>({
-        index: MEMORIES_DATA_STREAM,
-        track_total_hits: false,
-        query: {
-          bool: {
-            filter: [{ ids: { values: latestLiveIds } }, ...structuredFilters],
-            must: [fuzzyMatch],
-          },
-        },
-        sort: [{ _score: { order: 'desc' } }],
-        size,
-        highlight: {
-          fields: { content: { fragment_size: 200, number_of_fragments: 1 }, title: {} },
-        },
-      });
-    } catch (err) {
-      if (isIndexNotFoundError(err)) return [];
-      throw err;
-    }
+    // Phase 3: re-run against ONLY the latest live documents so a result can only come from
+    // a page whose current version satisfies both the structural filters and the text query.
+    // Semantic and hybrid modes use a retriever instead of a plain query so ES can apply
+    // vector scoring; keyword mode keeps the original bool query path.
+    const response = await this._executePhase3(mode, params.mode, query, latestLiveIds, structuredFilters, fuzzyMatch, size);
+    if (!response) return [];
 
     return response.hits.hits.flatMap((hit) => {
       const source = hit._source;
@@ -568,6 +561,123 @@ export class MemoryServiceImpl implements MemoryService {
         },
       ];
     });
+  }
+
+  private async _executePhase3(
+    mode: SearchMode,
+    requestedMode: SearchMode | undefined,
+    query: string,
+    latestLiveIds: string[],
+    structuredFilters: QueryDslQueryContainer[],
+    fuzzyMatch: QueryDslQueryContainer,
+    size: number
+  ) {
+    const { semantic_min_score: minScore, rrf_rank_constant: rankConstant } =
+      DEFAULT_SIG_EVENTS_TUNING_CONFIG;
+    const idsFilter: QueryDslQueryContainer = { ids: { values: latestLiveIds } };
+    const allFilters = [idsFilter, ...structuredFilters];
+
+    let retriever: RetrieverContainer | undefined;
+
+    if (mode === 'semantic') {
+      retriever = {
+        linear: {
+          retrievers: [
+            {
+              retriever: {
+                standard: {
+                  query: { match: { search_embedding: query } },
+                  filter: { bool: { filter: allFilters } },
+                },
+              },
+              weight: 1,
+              normalizer: 'minmax',
+            },
+          ],
+          rank_window_size: size,
+          min_score: minScore,
+        },
+      };
+    } else if (mode === 'hybrid') {
+      retriever = {
+        rrf: {
+          retrievers: [
+            {
+              standard: {
+                query: { bool: { must: [fuzzyMatch] } },
+              },
+            },
+            {
+              linear: {
+                retrievers: [
+                  {
+                    retriever: {
+                      standard: {
+                        query: { match: { search_embedding: query } },
+                      },
+                    },
+                    weight: 1,
+                    normalizer: 'minmax',
+                  },
+                ],
+                rank_window_size: size,
+                min_score: minScore,
+              },
+            },
+          ],
+          filter: { bool: { filter: allFilters } },
+          rank_window_size: size,
+          rank_constant: rankConstant,
+        },
+      };
+    }
+
+    try {
+      if (retriever) {
+        return await this.esClient.search<MemoryEntry>({
+          index: MEMORIES_DATA_STREAM,
+          track_total_hits: false,
+          retriever,
+          size,
+          highlight: {
+            fields: { content: { fragment_size: 200, number_of_fragments: 1 }, title: {} },
+          },
+        });
+      }
+
+      // keyword mode: plain bool query, no retriever
+      return await this.esClient.search<MemoryEntry>({
+        index: MEMORIES_DATA_STREAM,
+        track_total_hits: false,
+        query: { bool: { filter: allFilters, must: [fuzzyMatch] } },
+        sort: [{ _score: { order: 'desc' } }],
+        size,
+        highlight: {
+          fields: { content: { fragment_size: 200, number_of_fragments: 1 }, title: {} },
+        },
+      });
+    } catch (err) {
+      if (mode !== 'keyword' && !requestedMode) {
+        // Auto-resolved mode failed (inference endpoint unavailable) — fall back to keyword.
+        this.logger.warn(
+          `Memory search mode "${mode}" failed, falling back to keyword: ${
+            (err as Error).message
+          }`
+        );
+        return this.esClient.search<MemoryEntry>({
+          index: MEMORIES_DATA_STREAM,
+          track_total_hits: false,
+          query: { bool: { filter: allFilters, must: [fuzzyMatch] } },
+          sort: [{ _score: { order: 'desc' } }],
+          size,
+          highlight: {
+            fields: { content: { fragment_size: 200, number_of_fragments: 1 }, title: {} },
+          },
+        });
+      }
+      if (isIndexNotFoundError(err)) return null;
+      throw err;
+    }
   }
 
   async listAll(): Promise<MemoryEntry[]> {

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -194,6 +194,23 @@ export class MemoryServiceImpl implements MemoryService {
   }
 
   /**
+   * Resolve the current latest version of each given page id (filtering on `id` is safe — it is
+   * invariant), dropping any that are tombstoned. Used as phase two of reads that match on mutable
+   * fields, so callers see each page's true latest state rather than the version that matched.
+   */
+  private async _resolveLatestByIds(
+    ids: string[]
+  ): Promise<Array<{ _id: string; _source: MemoryEntry }>> {
+    if (ids.length === 0) return [];
+    const hits = await this._searchLatest({
+      query: { bool: { filter: [{ terms: { id: ids } }] } },
+      collapseField: 'id',
+      size: ids.length,
+    });
+    return hits.filter((hit) => hit._source.is_deleted !== true);
+  }
+
+  /**
    * Phase one of a mutable-field read: collect the distinct page ids of documents matching `query`,
    * without fetching `_source` (only the `id` field). The matched versions may be stale, so callers
    * must re-resolve the current latest via {@link _resolveLatestByIds}.
@@ -216,23 +233,6 @@ export class MemoryServiceImpl implements MemoryService {
       if (isIndexNotFoundError(err)) return [];
       throw err;
     }
-  }
-
-  /**
-   * Resolve the current latest version of each given page id (filtering on `id` is safe — it is
-   * invariant), dropping any that are tombstoned. Used as phase two of reads that match on mutable
-   * fields, so callers see each page's true latest state rather than the version that matched.
-   */
-  private async _resolveLatestByIds(
-    ids: string[]
-  ): Promise<Array<{ _id: string; _source: MemoryEntry }>> {
-    if (ids.length === 0) return [];
-    const hits = await this._searchLatest({
-      query: { bool: { filter: [{ terms: { id: ids } }] } },
-      collapseField: 'id',
-      size: ids.length,
-    });
-    return hits.filter((hit) => hit._source.is_deleted !== true);
   }
 
   // ── Public API ──
@@ -503,9 +503,9 @@ export class MemoryServiceImpl implements MemoryService {
 
     // Phase 1: collect the id of every page that might be relevant (ids only, cheap).
     // For keyword mode: narrow by the text query so the candidate set stays small.
-    // For semantic/hybrid: use only structural filters (or match_all) so Phase 3's
-    // retriever handles text relevance — a keyword-only Phase 1 would silently drop
-    // pages that are semantically relevant but don't keyword-match any version.
+    // For hybrid: use only structural filters (or match_all) so Phase 3's retriever
+    // handles text relevance — a keyword-only Phase 1 would silently drop pages that
+    // are semantically relevant but don't keyword-match any version.
     const phase1Query: QueryDslQueryContainer =
       mode === 'keyword'
         ? { bool: { filter: structuredFilters, must: [fuzzyMatch] } }
@@ -590,26 +590,7 @@ export class MemoryServiceImpl implements MemoryService {
 
     let retriever: RetrieverContainer | undefined;
 
-    if (mode === 'semantic') {
-      retriever = {
-        linear: {
-          retrievers: [
-            {
-              retriever: {
-                standard: {
-                  query: { match: { search_embedding: query } },
-                  filter: { bool: { filter: allFilters } },
-                },
-              },
-              weight: 1,
-              normalizer: 'minmax',
-            },
-          ],
-          rank_window_size: size,
-          min_score: minScore,
-        },
-      };
-    } else if (mode === 'hybrid') {
+    if (mode === 'hybrid') {
       retriever = {
         rrf: {
           retrievers: [

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -194,23 +194,6 @@ export class MemoryServiceImpl implements MemoryService {
   }
 
   /**
-   * Resolve the current latest version of each given page id (filtering on `id` is safe — it is
-   * invariant), dropping any that are tombstoned. Used as phase two of reads that match on mutable
-   * fields, so callers see each page's true latest state rather than the version that matched.
-   */
-  private async _resolveLatestByIds(
-    ids: string[]
-  ): Promise<Array<{ _id: string; _source: MemoryEntry }>> {
-    if (ids.length === 0) return [];
-    const hits = await this._searchLatest({
-      query: { bool: { filter: [{ terms: { id: ids } }] } },
-      collapseField: 'id',
-      size: ids.length,
-    });
-    return hits.filter((hit) => hit._source.is_deleted !== true);
-  }
-
-  /**
    * Phase one of a mutable-field read: collect the distinct page ids of documents matching `query`,
    * without fetching `_source` (only the `id` field). The matched versions may be stale, so callers
    * must re-resolve the current latest via {@link _resolveLatestByIds}.
@@ -233,6 +216,23 @@ export class MemoryServiceImpl implements MemoryService {
       if (isIndexNotFoundError(err)) return [];
       throw err;
     }
+  }
+
+  /**
+   * Resolve the current latest version of each given page id (filtering on `id` is safe — it is
+   * invariant), dropping any that are tombstoned. Used as phase two of reads that match on mutable
+   * fields, so callers see each page's true latest state rather than the version that matched.
+   */
+  private async _resolveLatestByIds(
+    ids: string[]
+  ): Promise<Array<{ _id: string; _source: MemoryEntry }>> {
+    if (ids.length === 0) return [];
+    const hits = await this._searchLatest({
+      query: { bool: { filter: [{ terms: { id: ids } }] } },
+      collapseField: 'id',
+      size: ids.length,
+    });
+    return hits.filter((hit) => hit._source.is_deleted !== true);
   }
 
   // ── Public API ──
@@ -503,9 +503,9 @@ export class MemoryServiceImpl implements MemoryService {
 
     // Phase 1: collect the id of every page that might be relevant (ids only, cheap).
     // For keyword mode: narrow by the text query so the candidate set stays small.
-    // For hybrid: use only structural filters (or match_all) so Phase 3's retriever
-    // handles text relevance — a keyword-only Phase 1 would silently drop pages that
-    // are semantically relevant but don't keyword-match any version.
+    // For semantic/hybrid: use only structural filters (or match_all) so Phase 3's
+    // retriever handles text relevance — a keyword-only Phase 1 would silently drop
+    // pages that are semantically relevant but don't keyword-match any version.
     const phase1Query: QueryDslQueryContainer =
       mode === 'keyword'
         ? { bool: { filter: structuredFilters, must: [fuzzyMatch] } }
@@ -590,7 +590,26 @@ export class MemoryServiceImpl implements MemoryService {
 
     let retriever: RetrieverContainer | undefined;
 
-    if (mode === 'hybrid') {
+    if (mode === 'semantic') {
+      retriever = {
+        linear: {
+          retrievers: [
+            {
+              retriever: {
+                standard: {
+                  query: { match: { search_embedding: query } },
+                  filter: { bool: { filter: allFilters } },
+                },
+              },
+              weight: 1,
+              normalizer: 'minmax',
+            },
+          ],
+          rank_window_size: size,
+          min_score: minScore,
+        },
+      };
+    } else if (mode === 'hybrid') {
       retriever = {
         rrf: {
           retrievers: [

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/types.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
+import type { SearchMode } from '../../../common/queries';
 
 /**
  * A memory page as stored in the main memory index.
@@ -117,6 +118,7 @@ export interface SearchMemoryParams {
   categories?: string[];
   references?: string[];
   size?: number;
+  mode?: SearchMode;
 }
 
 /** Dependencies for the memory service */

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/indicator_searcher.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/indicator_searcher.ts
@@ -146,6 +146,25 @@ export class IndicatorSearcher {
           query: this.buildKeywordQuery(queryText, filter, options.types),
         },
       };
+    } else if (mode === 'semantic') {
+      retriever = {
+        linear: {
+          retrievers: [
+            {
+              retriever: {
+                standard: {
+                  query: { match: { search_embedding: queryText } },
+                  filter: { bool: { filter } },
+                },
+              },
+              weight: 1,
+              normalizer: 'minmax',
+            },
+          ],
+          rank_window_size: limit,
+          min_score: this.config.semantic_min_score,
+        },
+      };
     } else {
       retriever = {
         rrf: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/indicator_searcher.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ki/knowledge_indicator_client/indicator_searcher.ts
@@ -146,25 +146,6 @@ export class IndicatorSearcher {
           query: this.buildKeywordQuery(queryText, filter, options.types),
         },
       };
-    } else if (mode === 'semantic') {
-      retriever = {
-        linear: {
-          retrievers: [
-            {
-              retriever: {
-                standard: {
-                  query: { match: { search_embedding: queryText } },
-                  filter: { bool: { filter } },
-                },
-              },
-              weight: 1,
-              normalizer: 'minmax',
-            },
-          ],
-          rank_window_size: limit,
-          min_score: this.config.semantic_min_score,
-        },
-      };
     } else {
       retriever = {
         rrf: {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/nightshift-program/issues/342

Adds `semantic_text`-backed vector search to the sigevents memory store (`.significant_events-memories`), following the same pattern already used by knowledge indicators.

- **Mapping** (`data_stream.ts`): adds `search_embedding: mappings.semanticText()` (platform default inference endpoint — same as KI), bumps template version to 2
- **Write path** (`memory_service.ts`): populates `search_embedding` with `title + "\n\n" + content` on every live write; tombstones omit it
- **Search** (`memory_service.ts`): adds `_executePhase3` with `keyword` / `semantic` / `hybrid` retriever support — RRF retriever for hybrid, linear+minmax for semantic; Phase 1 widens to match-all (or structural-filters only) for semantic/hybrid so semantically-relevant pages are never dropped before Phase 3 ranking; auto-falls back to keyword when inference endpoint is unavailable
- **Types** (`types.ts`): adds optional `mode?: SearchMode` to `SearchMemoryParams`
- **Agent tool** (`memory_search.ts`): exposes `mode` parameter; `hybrid` is the effective default via `resolveSearchMode`
- **Tests** (`memory_service.test.ts`): extends the in-memory ES mock to handle retriever-based Phase 3 requests (rrf/linear) by extracting the ids filter

## How to test

1. Start Kibana with an ELSER inference endpoint available (or use the platform default)
2. Create a few memory pages via the agent tool or API
3. Search with `mode: "hybrid"` — pages should be findable by meaning, not just exact keywords

## Test plan

- [x] Jest: all 9 existing `MemoryServiceImpl` tests pass with hybrid as default mode
- [x] TypeScript: no new type errors
- [x] ESLint: no new lint errors
- [ ] Integration: manual test with real inference endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)