### PR TITLE
[Fleet] Move Integrations search bar to separate row

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
@@ -643,10 +643,15 @@ export const SearchAndFiltersBar: React.FC<SearchAndFiltersBarProps> = ({
 
   return (
     <StickyFlexItem>
-      <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
+      <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={true}>
           <SearchBar categories={categories} availableSubCategories={availableSubCategories} />
         </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
         <EuiFlexItem grow={false}>
           <EuiFilterGroup compressed>
             <SetupMethodFilter


### PR DESCRIPTION
Relates https://github.com/elastic/kibana/issues/274811

Since adding more filters, the Search bar became quite small.
Moving the search bar and selected categories to a separate row.

<img width="2550" height="2064" alt="image" src="https://github.com/user-attachments/assets/19bfea0b-ee75-47a1-9f0a-7d6d3acabbbd" />
