### PR TITLE
[Agent Builder] add generate_esql and execute_esql as default tools

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
@@ -112,6 +112,8 @@ export const defaultAgentToolIds = [
   platformCoreTools.search,
   platformCoreTools.listIndices,
   platformCoreTools.getIndexMapping,
+  platformCoreTools.generateEsql,
+  platformCoreTools.executeEsql,
   platformCoreTools.getDocumentById,
   platformCoreTools.getWorkflowExecutionStatus,
   platformCoreTools.resumeWorkflowExecution,


### PR DESCRIPTION
## Summary

Add the following tools in the default preset:
- `platform.core.generate_esql`
- `platform.core.execute_esql`





