### PR TITLE
[9.3] [ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup (#272749)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/services/referenced_panel_manager.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/referenced_panel_manager.ts
@@ -8,7 +8,26 @@
 import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
 import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { Reference } from '@kbn/content-management-utils';
+import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
 import type { ReferencedPanelAttributes, ReferencedPanelAttributesWithReferences } from './helpers';
+
+// Dashboard panels carry an embeddable `type` while the entries in
+// `dashboard.references` carry the underlying saved object content type. They
+// happened to be the same string before the Lens / Visualize embeddable rename
+// (https://github.com/elastic/kibana/pull/260040), but after that change the
+// embeddable type for Lens became `vis` while the saved object content type
+// stayed as `lens` (see `LENS_CONTENT_TYPE` in `@kbn/lens-common`). The same
+// pattern applies to the legacy visualization embeddable (`legacy_vis`
+// embeddable, `visualization` saved object). This map translates an embeddable
+// type into the saved object type used inside dashboard references so we can
+// look up the right entry in `dashboard.references` and call `bulkGet` with a
+// valid saved object type.
+const EMBEDDABLE_TYPE_TO_SAVED_OBJECT_TYPE: Readonly<Record<string, string>> = {
+  [LENS_EMBEDDABLE_TYPE]: 'lens',
+};
+
+const toReferenceSavedObjectType = (embeddableType: string): string =>
+  EMBEDDABLE_TYPE_TO_SAVED_OBJECT_TYPE[embeddableType] ?? embeddableType;
 
 export class ReferencedPanelManager {
   // The uid refers to the ID of the saved object reference, while the panelId refers to the ID of the saved object itself (the panel).
@@ -59,12 +78,27 @@ export class ReferencedPanelManager {
     const { uid, type } = panel;
     if (!uid) return;
 
-    const panelReference = references.find((r) => r.name.includes(uid) && r.type === type);
-    // A reference of the panel was not found
+    const savedObjectType = toReferenceSavedObjectType(type);
+    const panelReference = references.find(
+      (r) => r.name.includes(uid) && r.type === savedObjectType
+    );
+    // A reference of the panel was not found.
+    //
+    // This is a recoverable condition: the panel is silently skipped from
+    // suggested-dashboards scoring and the endpoint still returns
+    // successfully. We log at `warn` (not `error`) to avoid inflating the
+    // server error metric, and we keep panel/dashboard identifiers out of
+    // the message string so the log can be aggregated by message without
+    // exploding cardinality. The identifiers stay searchable via `labels`.
     if (!panelReference) {
-      this.logger.error(
-        `Reference for panel of type ${type} and uid ${uid} was not found in dashboard with id ${dashboardId}`
-      );
+      this.logger.warn(`Reference for dashboard panel not found in dashboard.references`, {
+        labels: {
+          panel_embeddable_type: type,
+          panel_saved_object_type: savedObjectType,
+          panel_uid: uid,
+          dashboard_id: dashboardId,
+        },
+      });
       return;
     }
 
@@ -73,7 +107,7 @@ export class ReferencedPanelManager {
     this.panelUidToId.set(uid, panelId);
 
     if (!this.panelsTypeById.has(panelId)) {
-      this.panelsTypeById.set(panelId, panel.type);
+      this.panelsTypeById.set(panelId, savedObjectType);
     }
   }
 }

--- a/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts
@@ -12,6 +12,7 @@ import type { AlertData } from './alert_data';
 import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/rule-data-utils';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { ReferencedPanelManager } from './referenced_panel_manager';
+import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
 
 describe('RelatedDashboardsClient', () => {
   const mockGetDashboard = jest.fn();
@@ -313,7 +314,8 @@ describe('RelatedDashboardsClient', () => {
 
     it('should fetch referenced panels when fetching dashboards', async () => {
       const PANEL_SO_ID = 'panelSOId';
-      const PANEL_TYPE = 'lens';
+      const PANEL_EMBEDDABLE_TYPE = LENS_EMBEDDABLE_TYPE;
+      const PANEL_SO_TYPE = 'lens'; // saved object content type for Lens
       const PANEL_UID = 'panelUid';
       const PANEL_SO_ATTRIBUTES = { title: 'Panel 1' };
       mockScanDashboards.mockResolvedValue({
@@ -321,8 +323,8 @@ describe('RelatedDashboardsClient', () => {
           {
             id: 'dashboard1',
             title: 'Dashboard 1',
-            panels: [{ config: {}, uid: PANEL_UID, type: PANEL_TYPE }],
-            references: [{ name: PANEL_UID, type: PANEL_TYPE, id: PANEL_SO_ID }],
+            panels: [{ config: {}, id: PANEL_UID, type: PANEL_EMBEDDABLE_TYPE }],
+            references: [{ name: PANEL_UID, type: PANEL_SO_TYPE, id: PANEL_SO_ID }],
           },
         ],
         total: 1,
@@ -330,13 +332,13 @@ describe('RelatedDashboardsClient', () => {
 
       soClientMock.bulkGet.mockResolvedValueOnce({
         saved_objects: [
-          { attributes: PANEL_SO_ATTRIBUTES, type: PANEL_TYPE, id: PANEL_SO_ID, references: [] },
+          { attributes: PANEL_SO_ATTRIBUTES, type: PANEL_SO_TYPE, id: PANEL_SO_ID, references: [] },
         ],
       });
 
       // @ts-ignore next-line
       await client.fetchDashboards({ page: 1 });
-      expect(soClientMock.bulkGet).toHaveBeenCalledWith([{ id: PANEL_SO_ID, type: PANEL_TYPE }]);
+      expect(soClientMock.bulkGet).toHaveBeenCalledWith([{ id: PANEL_SO_ID, type: PANEL_SO_TYPE }]);
       // @ts-ignore next-line
       expect(client.referencedPanelManager.getByUid(PANEL_UID)).toStrictEqual({
         ...PANEL_SO_ATTRIBUTES,
@@ -346,7 +348,8 @@ describe('RelatedDashboardsClient', () => {
 
     it('should not refetch a referenced panel if it was fetched before', async () => {
       const PANEL_SO_ID = 'panelSOId';
-      const PANEL_TYPE = 'lens';
+      const PANEL_EMBEDDABLE_TYPE = LENS_EMBEDDABLE_TYPE;
+      const PANEL_SO_TYPE = 'lens'; // saved object content type for Lens
       const PANEL_UID = 'panelUid';
       const OTHER_PANEL_UID = 'otherPanelUid';
       const PANEL_SO_ATTRIBUTES = { title: 'Panel 1' };
@@ -356,12 +359,12 @@ describe('RelatedDashboardsClient', () => {
             id: 'dashboard1',
             title: 'Dashboard 1',
             panels: [
-              { config: {}, uid: PANEL_UID, type: PANEL_TYPE },
-              { config: {}, uid: OTHER_PANEL_UID, type: PANEL_TYPE },
+              { config: {}, id: PANEL_UID, type: PANEL_EMBEDDABLE_TYPE },
+              { config: {}, id: OTHER_PANEL_UID, type: PANEL_EMBEDDABLE_TYPE },
             ],
             references: [
-              { name: PANEL_UID, type: PANEL_TYPE, id: PANEL_SO_ID },
-              { name: OTHER_PANEL_UID, type: PANEL_TYPE, id: PANEL_SO_ID },
+              { name: PANEL_UID, type: PANEL_SO_TYPE, id: PANEL_SO_ID },
+              { name: OTHER_PANEL_UID, type: PANEL_SO_TYPE, id: PANEL_SO_ID },
             ],
           },
         ],
@@ -370,7 +373,7 @@ describe('RelatedDashboardsClient', () => {
 
       soClientMock.bulkGet.mockResolvedValueOnce({
         saved_objects: [
-          { attributes: PANEL_SO_ATTRIBUTES, type: PANEL_TYPE, id: PANEL_SO_ID, references: [] },
+          { attributes: PANEL_SO_ATTRIBUTES, type: PANEL_SO_TYPE, id: PANEL_SO_ID, references: [] },
         ],
       });
 

--- a/x-pack/solutions/observability/plugins/observability/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability/tsconfig.json
@@ -145,7 +145,8 @@
     "@kbn/management-settings-ids",
     "@kbn/onechat-plugin",
     "@kbn/observability-agent-builder-plugin",
-    "@kbn/fleet-plugin"
+    "@kbn/fleet-plugin",
+    "@kbn/lens-common"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup (#272749)](https://github.com/elastic/kibana/pull/272749)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miguel Martín","email":"miguel.martin@elastic.co"},"sourceCommit":{"committedDate":"2026-06-15T15:44:05Z","message":"[ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup (#272749)\n\n## Summary\n\n`ReferencedPanelManager.addReferencedPanel` compared `panel.type`\n(embeddable type) against `reference.type` (saved object content type).\nAfter [#260040](https://github.com/elastic/kibana/pull/260040) renamed\n`LENS_EMBEDDABLE_TYPE` from `lens` to `vis` while leaving the saved\nobject content type as `lens`, the comparison fails for every Lens\nby-reference panel, dropping them from suggested-dashboards scoring and\nproducing log spam.\n\nMap embeddable type to saved object type before searching\n`dashboard.references` and before calling `bulkGet`. Also downgrade the\n\"reference not found\" log to `warn` and move identifiers from the\nmessage into structured `labels` so the log can be aggregated by message\nwithout high cardinality.\n\n## Test plan\n\n- [ ] `node scripts/jest\nx-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts`\n- [ ] Manual: trigger a Custom Threshold alert against a dashboard with\na Lens by-reference panel and verify the dashboard is suggested and no\nwarn log fires.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bb70789bd3638405263b10836f8ac79f1484fb70","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","author:actionable-obs","v9.5.0","v9.4.3","v9.3.6"],"title":"[ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup","number":272749,"url":"https://github.com/elastic/kibana/pull/272749","mergeCommit":{"message":"[ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup (#272749)\n\n## Summary\n\n`ReferencedPanelManager.addReferencedPanel` compared `panel.type`\n(embeddable type) against `reference.type` (saved object content type).\nAfter [#260040](https://github.com/elastic/kibana/pull/260040) renamed\n`LENS_EMBEDDABLE_TYPE` from `lens` to `vis` while leaving the saved\nobject content type as `lens`, the comparison fails for every Lens\nby-reference panel, dropping them from suggested-dashboards scoring and\nproducing log spam.\n\nMap embeddable type to saved object type before searching\n`dashboard.references` and before calling `bulkGet`. Also downgrade the\n\"reference not found\" log to `warn` and move identifiers from the\nmessage into structured `labels` so the log can be aggregated by message\nwithout high cardinality.\n\n## Test plan\n\n- [ ] `node scripts/jest\nx-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts`\n- [ ] Manual: trigger a Custom Threshold alert against a dashboard with\na Lens by-reference panel and verify the dashboard is suggested and no\nwarn log fires.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bb70789bd3638405263b10836f8ac79f1484fb70"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/272749","number":272749,"mergeCommit":{"message":"[ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup (#272749)\n\n## Summary\n\n`ReferencedPanelManager.addReferencedPanel` compared `panel.type`\n(embeddable type) against `reference.type` (saved object content type).\nAfter [#260040](https://github.com/elastic/kibana/pull/260040) renamed\n`LENS_EMBEDDABLE_TYPE` from `lens` to `vis` while leaving the saved\nobject content type as `lens`, the comparison fails for every Lens\nby-reference panel, dropping them from suggested-dashboards scoring and\nproducing log spam.\n\nMap embeddable type to saved object type before searching\n`dashboard.references` and before calling `bulkGet`. Also downgrade the\n\"reference not found\" log to `warn` and move identifiers from the\nmessage into structured `labels` so the log can be aggregated by message\nwithout high cardinality.\n\n## Test plan\n\n- [ ] `node scripts/jest\nx-pack/solutions/observability/plugins/observability/server/services/related_dashboards_client.test.ts`\n- [ ] Manual: trigger a Custom Threshold alert against a dashboard with\na Lens by-reference panel and verify the dashboard is suggested and no\nwarn log fires.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bb70789bd3638405263b10836f8ac79f1484fb70"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/273397","number":273397,"state":"MERGED","mergeCommit":{"sha":"7aabb07665303d3b3cb43cb460b0018d0da1b57e","message":"[9.4] [ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel reference lookup (#272749) (#273397)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[ObsUX][RelatedDashboards] Fix Lens embeddable type mismatch in panel\nreference lookup\n(#272749)](https://github.com/elastic/kibana/pull/272749)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Miguel Martín <miguel.martin@elastic.co>"}},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->