### PR TITLE
[Streams/Index Management] Promote frozen-phase callouts to shared package

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/README.md
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/README.md
@@ -163,6 +163,34 @@ The primary action is intentionally callback-based through `onPrimaryAction` bec
 
 The “Review subscription features” link is controlled by the required `subscriptionFeaturesUrl` prop. Consumers must provide it explicitly (for example, `https://www.elastic.co/subscriptions/cloud` for Cloud or `https://www.elastic.co/subscriptions` for self-managed).
 
+### `FrozenEnterpriseRequiredCallout`
+
+A warning callout shown when the current subscription tier does not support the frozen phase. The optional `onUpgradeEnterprise` callback renders an "Upgrade to enterprise" action; when omitted, the callout is informational only.
+
+```typescript
+import { FrozenEnterpriseRequiredCallout } from '@kbn/data-lifecycle-phases';
+
+<FrozenEnterpriseRequiredCallout
+  onUpgradeEnterprise={openUpgradeFlow}
+  calloutTestSubj="frozenEnterpriseRequiredCallout"
+  upgradeButtonTestSubj="frozenEnterpriseUpgradeButton"
+/>
+```
+
+### `FrozenDefaultRepositoryRequiredCallout`
+
+A warning callout shown when the previously assigned default searchable snapshot repository is no longer available. Renders an `EuiSplitButton` whose primary action creates a default repository (`onCreateDefaultRepository`) and whose secondary action refreshes the panel (`onRefresh`, with `isRefreshing` for the loading state). When neither callback is provided, the callout is informational only.
+
+```typescript
+import { FrozenDefaultRepositoryRequiredCallout } from '@kbn/data-lifecycle-phases';
+
+<FrozenDefaultRepositoryRequiredCallout
+  onCreateDefaultRepository={openCreateRepositoryFlow}
+  onRefresh={refetchRepositories}
+  isRefreshing={isLoading}
+/>
+```
+
 ## Development
 
 ### Storybook

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/index.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/index.ts
@@ -16,3 +16,4 @@ export * from './src/default_snapshot_repository_required_modal';
 export * from './src/edit_failed_data_lifecycle_flyout';
 export * from './src/phase_requirement_badges';
 export * from './src/searchable_snapshot_repository_info';
+export * from './src/frozen_phase_callouts';

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/__stories__/frozen_phase_callouts.stories.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/__stories__/frozen_phase_callouts.stories.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { EuiPanel } from '@elastic/eui';
+import { FrozenDefaultRepositoryRequiredCallout } from '../frozen_default_repository_required_callout';
+import { FrozenEnterpriseRequiredCallout } from '../frozen_enterprise_required_callout';
+
+const meta: Meta = {
+  title: 'Data Lifecycle Phases / Frozen phase callouts',
+};
+
+export default meta;
+type Story = StoryObj;
+
+const Container = ({ children }: { children: React.ReactNode }) => (
+  <EuiPanel hasBorder hasShadow={false} paddingSize="m" css={{ maxWidth: 520 }}>
+    {children}
+  </EuiPanel>
+);
+
+export const EnterpriseRequiredWithUpgrade: Story = {
+  name: 'Enterprise required — with upgrade action',
+  render: () => (
+    <Container>
+      <FrozenEnterpriseRequiredCallout
+        onUpgradeEnterprise={() => action('onUpgradeEnterprise')()}
+      />
+    </Container>
+  ),
+};
+
+export const EnterpriseRequiredNoAction: Story = {
+  name: 'Enterprise required — no action',
+  render: () => (
+    <Container>
+      <FrozenEnterpriseRequiredCallout />
+    </Container>
+  ),
+};
+
+export const DefaultRepositoryRequiredWithActions: Story = {
+  name: 'Default repository required — with actions',
+  render: () => (
+    <Container>
+      <FrozenDefaultRepositoryRequiredCallout
+        onCreateDefaultRepository={() => action('onCreateDefaultRepository')()}
+        onRefresh={() => action('onRefresh')()}
+      />
+    </Container>
+  ),
+};
+
+export const DefaultRepositoryRequiredRefreshing: Story = {
+  name: 'Default repository required — refreshing',
+  render: () => (
+    <Container>
+      <FrozenDefaultRepositoryRequiredCallout
+        onCreateDefaultRepository={() => action('onCreateDefaultRepository')()}
+        onRefresh={() => action('onRefresh')()}
+        isRefreshing
+      />
+    </Container>
+  ),
+};
+
+export const DefaultRepositoryRequiredNoActions: Story = {
+  name: 'Default repository required — no actions',
+  render: () => (
+    <Container>
+      <FrozenDefaultRepositoryRequiredCallout />
+    </Container>
+  ),
+};

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_default_repository_required_callout.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_default_repository_required_callout.test.tsx
@@ -47,10 +47,7 @@ describe('FrozenDefaultRepositoryRequiredCallout', () => {
 
   it('disables the create button when onCreateDefaultRepository is not provided', () => {
     renderWithI18n(
-      <FrozenDefaultRepositoryRequiredCallout
-        onRefresh={() => {}}
-        createButtonTestSubj="create"
-      />
+      <FrozenDefaultRepositoryRequiredCallout onRefresh={() => {}} createButtonTestSubj="create" />
     );
 
     expect(screen.getByTestId('create')).toBeDisabled();

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_default_repository_required_callout.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_default_repository_required_callout.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { FrozenDefaultRepositoryRequiredCallout } from './frozen_default_repository_required_callout';
+
+describe('FrozenDefaultRepositoryRequiredCallout', () => {
+  it('renders the callout title and body', () => {
+    renderWithI18n(<FrozenDefaultRepositoryRequiredCallout calloutTestSubj="callout" />);
+
+    expect(screen.getByTestId('callout')).toBeInTheDocument();
+    expect(screen.getByText('Default snapshot repository required')).toBeInTheDocument();
+  });
+
+  it('does not render the action buttons when no handlers are provided', () => {
+    renderWithI18n(
+      <FrozenDefaultRepositoryRequiredCallout
+        createButtonTestSubj="create"
+        refreshButtonTestSubj="refresh"
+      />
+    );
+
+    expect(screen.queryByTestId('create')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('refresh')).not.toBeInTheDocument();
+  });
+
+  it('calls onCreateDefaultRepository when the create button is clicked', () => {
+    const onCreateDefaultRepository = jest.fn();
+
+    renderWithI18n(
+      <FrozenDefaultRepositoryRequiredCallout
+        onCreateDefaultRepository={onCreateDefaultRepository}
+        createButtonTestSubj="create"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('create'));
+    expect(onCreateDefaultRepository).toHaveBeenCalled();
+  });
+
+  it('disables the create button when onCreateDefaultRepository is not provided', () => {
+    renderWithI18n(
+      <FrozenDefaultRepositoryRequiredCallout
+        onRefresh={() => {}}
+        createButtonTestSubj="create"
+      />
+    );
+
+    expect(screen.getByTestId('create')).toBeDisabled();
+  });
+
+  it('calls onRefresh when the refresh button is clicked', () => {
+    const onRefresh = jest.fn();
+
+    renderWithI18n(
+      <FrozenDefaultRepositoryRequiredCallout
+        onRefresh={onRefresh}
+        refreshButtonTestSubj="refresh"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('refresh'));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('disables refresh while refreshing', () => {
+    const onRefresh = jest.fn();
+
+    renderWithI18n(
+      <FrozenDefaultRepositoryRequiredCallout
+        onRefresh={onRefresh}
+        isRefreshing={true}
+        refreshButtonTestSubj="refresh"
+      />
+    );
+
+    const refreshButton = screen.getByTestId('refresh');
+    expect(refreshButton).toBeDisabled();
+
+    fireEvent.click(refreshButton);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_default_repository_required_callout.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_default_repository_required_callout.tsx
@@ -32,7 +32,7 @@ export const FrozenDefaultRepositoryRequiredCallout = ({
       color="warning"
       announceOnMount={false}
       title={i18n.translate(
-        'xpack.streams.streamDetailLifecycle.frozen.defaultRepositoryRequiredCallout.title',
+        'xpack.dataLifecyclePhases.frozen.defaultRepositoryRequiredCallout.title',
         {
           defaultMessage: 'Default snapshot repository required',
         }
@@ -40,26 +40,23 @@ export const FrozenDefaultRepositoryRequiredCallout = ({
       data-test-subj={calloutTestSubj}
     >
       <EuiText size="s" color="subdued">
-        {i18n.translate(
-          'xpack.streams.streamDetailLifecycle.frozen.defaultRepositoryRequiredCallout.body',
-          {
-            defaultMessage:
-              'The previously assigned default searchable snapshot repository is no longer available. This phase will be ignored until you assign a new default repository, then refresh this panel.',
-          }
-        )}
+        {i18n.translate('xpack.dataLifecyclePhases.frozen.defaultRepositoryRequiredCallout.body', {
+          defaultMessage:
+            'The previously assigned default searchable snapshot repository is no longer available. This phase will be ignored until you assign a new default repository, then refresh this panel.',
+        })}
       </EuiText>
 
       {(onCreateDefaultRepository || onRefresh) && (
         <>
           <EuiSpacer size="m" />
-          <EuiSplitButton fill size="s" color="warning">
+          <EuiSplitButton size="s" color="warning">
             <EuiSplitButton.ActionPrimary
               data-test-subj={createButtonTestSubj}
               isDisabled={!onCreateDefaultRepository}
               onClick={onCreateDefaultRepository}
             >
               {i18n.translate(
-                'xpack.streams.streamDetailLifecycle.frozen.defaultRepositoryRequiredCallout.createButton',
+                'xpack.dataLifecyclePhases.frozen.defaultRepositoryRequiredCallout.createButton',
                 { defaultMessage: 'Create default repository' }
               )}
             </EuiSplitButton.ActionPrimary>
@@ -68,7 +65,7 @@ export const FrozenDefaultRepositoryRequiredCallout = ({
               isLoading={Boolean(isRefreshing)}
               disabled={Boolean(isRefreshing) || !onRefresh}
               aria-label={i18n.translate(
-                'xpack.streams.streamDetailLifecycle.frozen.defaultRepositoryRequiredCallout.refreshButtonAriaLabel',
+                'xpack.dataLifecyclePhases.frozen.defaultRepositoryRequiredCallout.refreshButtonAriaLabel',
                 { defaultMessage: 'Refresh panel' }
               )}
               data-test-subj={refreshButtonTestSubj}

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_enterprise_required_callout.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_enterprise_required_callout.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { FrozenEnterpriseRequiredCallout } from './frozen_enterprise_required_callout';
+
+describe('FrozenEnterpriseRequiredCallout', () => {
+  it('renders the callout title and body', () => {
+    renderWithI18n(<FrozenEnterpriseRequiredCallout calloutTestSubj="callout" />);
+
+    expect(screen.getByTestId('callout')).toBeInTheDocument();
+    expect(screen.getByText('Enterprise license required for frozen phase')).toBeInTheDocument();
+  });
+
+  it('does not render the upgrade button when onUpgradeEnterprise is not provided', () => {
+    renderWithI18n(<FrozenEnterpriseRequiredCallout upgradeButtonTestSubj="upgrade" />);
+
+    expect(screen.queryByTestId('upgrade')).not.toBeInTheDocument();
+  });
+
+  it('renders the upgrade button and calls onUpgradeEnterprise when clicked', () => {
+    const onUpgradeEnterprise = jest.fn();
+
+    renderWithI18n(
+      <FrozenEnterpriseRequiredCallout
+        onUpgradeEnterprise={onUpgradeEnterprise}
+        upgradeButtonTestSubj="upgrade"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('upgrade'));
+    expect(onUpgradeEnterprise).toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_enterprise_required_callout.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/frozen_enterprise_required_callout.tsx
@@ -27,23 +27,17 @@ export const FrozenEnterpriseRequiredCallout = ({
       size="s"
       color="warning"
       announceOnMount={false}
-      title={i18n.translate(
-        'xpack.streams.streamDetailLifecycle.frozen.enterpriseRequiredCallout.title',
-        {
-          defaultMessage: 'Enterprise license required for frozen phase',
-        }
-      )}
+      title={i18n.translate('xpack.dataLifecyclePhases.frozen.enterpriseRequiredCallout.title', {
+        defaultMessage: 'Enterprise license required for frozen phase',
+      })}
       data-test-subj={calloutTestSubj}
       css={calloutCss}
     >
       <EuiText size="s" color="subdued">
-        {i18n.translate(
-          'xpack.streams.streamDetailLifecycle.frozen.enterpriseRequiredCallout.body',
-          {
-            defaultMessage:
-              'Your current subscription tier does not support the frozen phase. This phase will be ignored until you remove it or upgrade your license.',
-          }
-        )}
+        {i18n.translate('xpack.dataLifecyclePhases.frozen.enterpriseRequiredCallout.body', {
+          defaultMessage:
+            'Your current subscription tier does not support the frozen phase. This phase will be ignored until you remove it or upgrade your license.',
+        })}
       </EuiText>
 
       {onUpgradeEnterprise && (
@@ -51,13 +45,12 @@ export const FrozenEnterpriseRequiredCallout = ({
           <EuiSpacer size="m" />
           <EuiButton
             size="s"
-            fill
             color="warning"
             onClick={onUpgradeEnterprise}
             data-test-subj={upgradeButtonTestSubj}
           >
             {i18n.translate(
-              'xpack.streams.streamDetailLifecycle.frozen.enterpriseRequiredCallout.upgradeButton',
+              'xpack.dataLifecyclePhases.frozen.enterpriseRequiredCallout.upgradeButton',
               {
                 defaultMessage: 'Upgrade to enterprise',
               }

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/index.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/frozen_phase_callouts/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './frozen_default_repository_required_callout';
+export * from './frozen_enterprise_required_callout';

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/README.md
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/README.md
@@ -97,15 +97,21 @@ Note: this component uses `@kbn/i18n-react`. In Jest/component tests wrap with `
 
 - **`FrozenPhaseCard`** (`dlm_phases_selector/frozen_phase_card.tsx`)
   - **Purpose**: optional **Frozen** phase configuration (move-to-frozen after a duration).
-  - **Gating/disable behavior**:
-    - The parent selector computes a `disabledReason` when either:
-      - **No Enterprise license** → badge label "Enterprise required" with `iconType: 'lock'`.
-      - **No default snapshot repository** → badge label "Default repository required" with `iconType: 'warning'`.
-    - When a `disabledReason` is present, the card is disabled and the config UI is hidden even if `duration.enabled` is true.
+  - **Self-contained gating**: the card receives the raw requirement booleans (`hasEnterpriseLicense`, `hasDefaultSnapshotRepository`) plus the data needed to act on them (`canCreateDefaultSnapshotRepository`, `createDefaultRepositoryUrl`, `enterprise`, `onRefreshDefaultSnapshotRepository`), and derives the gating/grace behavior internally. The card also **owns and renders the gating modals** (`EnterpriseGatingModal` and `DefaultSnapshotRepositoryRequiredModal`): both the disabled-state badge and the grace-state callout open the same modal, so the parent no longer manages modal state. The card also captures whether the phase was active on first render to decide the grace state.
+  - **Disabled + badge behavior** (phase **not** active and a requirement is missing):
+    - **No Enterprise license** → "Enterprise required" badge (clicking it opens the `EnterpriseGatingModal`).
+    - **No default snapshot repository** → "Default repository required" badge (clicking it opens the `DefaultSnapshotRepositoryRequiredModal`). Enterprise takes precedence when both are missing.
+    - The card is disabled and the config UI is hidden even if `duration.enabled` is true.
+  - **Grace state (existing template with frozen already active)**:
+    - When the card mounts with `duration.enabled === true` (e.g. editing an existing template) but a requirement is missing, it keeps the phase **enabled** and renders warning callouts instead of a badge, matching the order used by the Streams DLM frozen configuration flyout:
+      - `FrozenEnterpriseRequiredCallout` renders **above** the configuration when the Enterprise license is missing; its "Upgrade to enterprise" button opens the same `EnterpriseGatingModal` as the badge.
+      - `FrozenDefaultRepositoryRequiredCallout` renders **inside the Searchable snapshot section** when the default repository is missing; its "Create default repository" button opens the same `DefaultSnapshotRepositoryRequiredModal` as the badge (disabled when `canCreateDefaultSnapshotRepository` is false), and its refresh button revalidates via `onRefreshDefaultSnapshotRepository`.
+    - While a warning callout is shown the phase configuration inputs (move-after duration) are **disabled** until the warning is resolved or the phase is turned off.
+    - The user can resolve the warning or **uncheck** the phase. Once unchecked while a requirement is missing, the card collapses back to the disabled + badge state (and the badge/modal for the situation). It can't be re-enabled until the requirement is satisfied.
   - **What it renders when enabled**:
     - `DurationFields` labeled "Move after …"
-    - A "Searchable snapshot" info row plus `SearchableSnapshotRepositoryInfo` when `defaultSnapshotRepository` is provided.
-  - **Props**: `duration`/`durationError`/`helpText`/`onChange`, `disabled` + optional `disabledReason`, `isFormDisabled`, plus `defaultSnapshotRepository` and `manageRepositoriesHref`.
+    - A "Searchable snapshot" info row plus `SearchableSnapshotRepositoryInfo` when `defaultSnapshotRepository` is provided (or the default-repository warning callout in the grace state).
+  - **Props**: `duration`/`durationError`/`helpText`/`onChange`, `isFormDisabled`, `defaultSnapshotRepository`, `manageRepositoriesHref`, the requirement booleans `hasEnterpriseLicense`/`hasDefaultSnapshotRepository`, and the data the card needs to drive its own modals: `canCreateDefaultSnapshotRepository`, `createDefaultRepositoryUrl`, `enterprise` (all required), plus the optional `onRefreshDefaultSnapshotRepository` callback.
 
 - **`DeletePhaseCard`** (`dlm_phases_selector/delete_phase_card.tsx`)
   - **Purpose**: optional **Delete** phase configuration (delete after a duration).

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/__stories__/frozen.stories.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/__stories__/frozen.stories.tsx
@@ -9,13 +9,17 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { usePhaseColors } from '@kbn/data-lifecycle-phases';
-import { FrozenPhaseCard, type FrozenDisabledReason } from '../components/frozen_phase_card';
+import { FrozenPhaseCard } from '../components/frozen_phase_card';
 import type { DlmPhaseDuration } from '../types';
 
-const FrozenCard = (args: { disabled: boolean; disabledReason?: FrozenDisabledReason }) => {
+const FrozenCard = (args: {
+  hasEnterpriseLicense: boolean;
+  hasDefaultSnapshotRepository: boolean;
+  initiallyEnabled?: boolean;
+}) => {
   const phaseColors = usePhaseColors();
   const [duration, setDuration] = useState<DlmPhaseDuration>({
-    enabled: true,
+    enabled: args.initiallyEnabled ?? true,
     value: '30',
     unit: 'd',
   });
@@ -25,13 +29,23 @@ const FrozenCard = (args: { disabled: boolean; disabledReason?: FrozenDisabledRe
       id="storybookFrozenPhase"
       color={phaseColors.frozen}
       duration={duration}
-      disabled={args.disabled}
-      disabledReason={args.disabledReason}
       durationError={undefined}
       helpText={undefined}
       isFormDisabled={false}
       defaultSnapshotRepository="found-snapshots"
       manageRepositoriesHref="/app/management/data/snapshot_restore/repositories"
+      hasEnterpriseLicense={args.hasEnterpriseLicense}
+      hasDefaultSnapshotRepository={args.hasDefaultSnapshotRepository}
+      canCreateDefaultSnapshotRepository={true}
+      createDefaultRepositoryUrl="/app/management/data/snapshot_restore/add_repository"
+      enterprise={{
+        isCloudEnabled: true,
+        canManageLicense: true,
+        trialDaysLeft: undefined,
+        onUpgrade: action('enterprise.onUpgrade'),
+        subscriptionFeaturesUrl: 'https://www.elastic.co/subscriptions/cloud',
+      }}
+      onRefreshDefaultSnapshotRepository={action('onRefreshDefaultSnapshotRepository')}
       onChange={setDuration}
     />
   );
@@ -41,7 +55,9 @@ const meta: Meta<typeof FrozenCard> = {
   component: FrozenCard,
   title: 'DLM Phases Selector/Cards/Frozen',
   args: {
-    disabled: false,
+    hasEnterpriseLicense: true,
+    hasDefaultSnapshotRepository: true,
+    initiallyEnabled: true,
   },
 };
 
@@ -53,20 +69,28 @@ export const Card: Story = {};
 
 export const CardEnterpriseRequired: Story = {
   args: {
-    disabled: true,
-    disabledReason: {
-      type: 'enterprise',
-      onClick: action('onOpenSubscriptionUpgradeModal'),
-    },
+    hasEnterpriseLicense: false,
+    initiallyEnabled: false,
   },
 };
 
 export const CardDefaultRepositoryRequired: Story = {
   args: {
-    disabled: true,
-    disabledReason: {
-      type: 'defaultRepository',
-      onClick: action('onOpenCreateDefaultRepositoryModal'),
-    },
+    hasDefaultSnapshotRepository: false,
+    initiallyEnabled: false,
+  },
+};
+
+export const CardActiveWithEnterpriseWarning: Story = {
+  args: {
+    hasEnterpriseLicense: false,
+    initiallyEnabled: true,
+  },
+};
+
+export const CardActiveWithDefaultRepositoryWarning: Story = {
+  args: {
+    hasDefaultSnapshotRepository: false,
+    initiallyEnabled: true,
   },
 };

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/__stories__/implementation_examples.stories.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/__stories__/implementation_examples.stories.tsx
@@ -100,3 +100,27 @@ export const FrozenOmittedWithoutRepositoryPermission: Story = {
   },
   render: (args) => <DlmPhasesSelector {...args} />,
 };
+
+export const ExistingFrozenActiveMissingEnterprise: Story = {
+  name: 'Existing template — frozen active, enterprise missing',
+  args: {
+    hasEnterpriseLicense: false,
+    defaultValue: {
+      frozen: { enabled: true, value: '30', unit: 'd' },
+      delete: { enabled: true, value: '60', unit: 'd' },
+    },
+  },
+  render: (args) => <DlmPhasesSelector {...args} />,
+};
+
+export const ExistingFrozenActiveMissingRepository: Story = {
+  name: 'Existing template — frozen active, repository missing',
+  args: {
+    hasDefaultSnapshotRepository: false,
+    defaultValue: {
+      frozen: { enabled: true, value: '30', unit: 'd' },
+      delete: { enabled: true, value: '60', unit: 'd' },
+    },
+  },
+  render: (args) => <DlmPhasesSelector {...args} />,
+};

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.test.tsx
@@ -13,6 +13,14 @@ import { FrozenPhaseCard } from './frozen_phase_card';
 
 const defaultDuration = { enabled: true, value: '30', unit: 'd' };
 
+const enterpriseConfig = {
+  isCloudEnabled: true,
+  canManageLicense: true,
+  trialDaysLeft: undefined,
+  onUpgrade: jest.fn(),
+  subscriptionFeaturesUrl: 'https://www.elastic.co/subscriptions/cloud',
+};
+
 const renderFrozenPhaseCard = (props?: Partial<React.ComponentProps<typeof FrozenPhaseCard>>) => {
   const onChange = jest.fn();
 
@@ -22,8 +30,12 @@ const renderFrozenPhaseCard = (props?: Partial<React.ComponentProps<typeof Froze
         id="frozenPhase"
         color="#006bb4"
         duration={defaultDuration}
-        disabled={false}
         isFormDisabled={false}
+        hasEnterpriseLicense={true}
+        hasDefaultSnapshotRepository={true}
+        canCreateDefaultSnapshotRepository={true}
+        createDefaultRepositoryUrl="/app/management/data/snapshot_restore/add_repository"
+        enterprise={enterpriseConfig}
         onChange={onChange}
         {...props}
       />
@@ -47,17 +59,15 @@ describe('FrozenPhaseCard', () => {
     expect(queryByTestId('frozenSearchableSnapshotLabel')).not.toBeInTheDocument();
   });
 
-  it('hides configuration when a disabled reason is present', () => {
+  it('hides configuration and shows a badge when a requirement is missing and the phase was not active', () => {
     const { queryByTestId } = renderFrozenPhaseCard({
-      disabled: true,
-      disabledReason: {
-        type: 'enterprise',
-        onClick: jest.fn(),
-      },
+      duration: { ...defaultDuration, enabled: false },
+      hasEnterpriseLicense: false,
     });
 
     expect(queryByTestId('frozenDurationValue')).not.toBeInTheDocument();
     expect(queryByTestId('frozenSearchableSnapshotLabel')).not.toBeInTheDocument();
+    expect(queryByTestId('enterpriseLicenseRequiredBadge')).toBeInTheDocument();
   });
 
   it('renders searchable snapshot info with repository name and manage link', () => {
@@ -97,18 +107,125 @@ describe('FrozenPhaseCard', () => {
     });
   });
 
-  it('invokes disabled reason onClick from the badge', () => {
-    const onDisabledReasonClick = jest.fn();
-    const { getByTestId } = renderFrozenPhaseCard({
-      disabled: true,
-      disabledReason: {
-        type: 'enterprise',
-        onClick: onDisabledReasonClick,
-      },
+  it('opens the enterprise gating modal from the enterprise badge', () => {
+    const { getByTestId, getByText } = renderFrozenPhaseCard({
+      duration: { ...defaultDuration, enabled: false },
+      hasEnterpriseLicense: false,
     });
 
     fireEvent.click(getByTestId('enterpriseLicenseRequiredBadge'));
 
-    expect(onDisabledReasonClick).toHaveBeenCalledTimes(1);
+    expect(getByText('Unlock the frozen data phase by upgrading to Enterprise')).toBeInTheDocument();
+  });
+
+  it('opens the default repository modal from the default repository badge', () => {
+    const { getByTestId, getByRole } = renderFrozenPhaseCard({
+      duration: { ...defaultDuration, enabled: false },
+      hasDefaultSnapshotRepository: false,
+    });
+
+    fireEvent.click(getByTestId('defaultRepositoryRequiredBadge'));
+
+    // The modal (not the callout) exposes a "Refresh snapshot repositories" button.
+    expect(getByRole('button', { name: 'Refresh snapshot repositories' })).toBeInTheDocument();
+  });
+
+  it('shows the default repository badge (not enterprise) when only the repository is missing', () => {
+    const { getByTestId, queryByTestId } = renderFrozenPhaseCard({
+      duration: { ...defaultDuration, enabled: false },
+      hasDefaultSnapshotRepository: false,
+    });
+
+    expect(getByTestId('defaultRepositoryRequiredBadge')).toBeInTheDocument();
+    expect(queryByTestId('enterpriseLicenseRequiredBadge')).not.toBeInTheDocument();
+  });
+
+  describe('grace state (phase active on mount with a missing requirement)', () => {
+    it('renders the enterprise callout above the configuration and opens the upgrade modal', () => {
+      const { getByTestId, getByText } = renderFrozenPhaseCard({
+        hasEnterpriseLicense: false,
+      });
+
+      expect(getByTestId('frozenEnterpriseRequiredCallout')).toBeInTheDocument();
+      expect(getByTestId('frozenDurationValue')).toBeInTheDocument();
+
+      fireEvent.click(getByTestId('frozenUpgradeEnterpriseButton'));
+      expect(getByText('Unlock the frozen data phase by upgrading to Enterprise')).toBeInTheDocument();
+    });
+
+    it('renders the default repository callout and opens the create-repository modal', () => {
+      const { getByTestId, queryByTestId, getByRole } = renderFrozenPhaseCard({
+        hasDefaultSnapshotRepository: false,
+        defaultSnapshotRepository: 'my-repo',
+      });
+
+      expect(getByTestId('frozenDefaultRepositoryRequiredCallout')).toBeInTheDocument();
+      expect(queryByTestId('frozenSearchableSnapshotInfo')).not.toBeInTheDocument();
+
+      fireEvent.click(getByTestId('frozenCreateDefaultRepositoryButton'));
+      // The modal (not the callout) exposes a "Refresh snapshot repositories" button.
+      expect(getByRole('button', { name: 'Refresh snapshot repositories' })).toBeInTheDocument();
+    });
+
+    it('disables the create repository action when the user cannot create one', () => {
+      const { getByTestId } = renderFrozenPhaseCard({
+        hasDefaultSnapshotRepository: false,
+        canCreateDefaultSnapshotRepository: false,
+      });
+
+      expect(getByTestId('frozenCreateDefaultRepositoryButton')).toBeDisabled();
+    });
+
+    it('renders both callouts when both requirements are missing', () => {
+      const { getByTestId } = renderFrozenPhaseCard({
+        hasEnterpriseLicense: false,
+        hasDefaultSnapshotRepository: false,
+      });
+
+      expect(getByTestId('frozenEnterpriseRequiredCallout')).toBeInTheDocument();
+      expect(getByTestId('frozenDefaultRepositoryRequiredCallout')).toBeInTheDocument();
+    });
+
+    it('disables the duration inputs while a warning callout is active', () => {
+      const { getByTestId } = renderFrozenPhaseCard({
+        hasEnterpriseLicense: false,
+      });
+
+      expect(getByTestId('frozenDurationValue')).toBeDisabled();
+      expect(getByTestId('frozenDurationUnit')).toBeDisabled();
+    });
+
+    it('collapses to the disabled badge state after the user unchecks the phase', () => {
+      const { getByTestId, queryByTestId, rerender, onChange } = renderFrozenPhaseCard({
+        hasEnterpriseLicense: false,
+      });
+
+      // Initially in the grace state.
+      expect(getByTestId('frozenEnterpriseRequiredCallout')).toBeInTheDocument();
+
+      fireEvent.click(getByTestId('dlmPhasesSelectorFrozenPhaseCard'));
+      expect(onChange).toHaveBeenCalledWith({ enabled: false, value: '30', unit: 'd' });
+
+      // Simulate the parent updating the duration to disabled.
+      rerender(
+        <IntlProvider>
+          <FrozenPhaseCard
+            id="frozenPhase"
+            color="#006bb4"
+            duration={{ ...defaultDuration, enabled: false }}
+            isFormDisabled={false}
+            hasEnterpriseLicense={false}
+            hasDefaultSnapshotRepository={true}
+            canCreateDefaultSnapshotRepository={true}
+            createDefaultRepositoryUrl="/app/management/data/snapshot_restore/add_repository"
+            enterprise={enterpriseConfig}
+            onChange={onChange}
+          />
+        </IntlProvider>
+      );
+
+      expect(queryByTestId('frozenEnterpriseRequiredCallout')).not.toBeInTheDocument();
+      expect(getByTestId('enterpriseLicenseRequiredBadge')).toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.test.tsx
@@ -115,7 +115,9 @@ describe('FrozenPhaseCard', () => {
 
     fireEvent.click(getByTestId('enterpriseLicenseRequiredBadge'));
 
-    expect(getByText('Unlock the frozen data phase by upgrading to Enterprise')).toBeInTheDocument();
+    expect(
+      getByText('Unlock the frozen data phase by upgrading to Enterprise')
+    ).toBeInTheDocument();
   });
 
   it('opens the default repository modal from the default repository badge', () => {
@@ -150,7 +152,9 @@ describe('FrozenPhaseCard', () => {
       expect(getByTestId('frozenDurationValue')).toBeInTheDocument();
 
       fireEvent.click(getByTestId('frozenUpgradeEnterpriseButton'));
-      expect(getByText('Unlock the frozen data phase by upgrading to Enterprise')).toBeInTheDocument();
+      expect(
+        getByText('Unlock the frozen data phase by upgrading to Enterprise')
+      ).toBeInTheDocument();
     });
 
     it('renders the default repository callout and opens the create-repository modal', () => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/components/frozen_phase_card.tsx
@@ -5,109 +5,207 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { EuiIcon, EuiIconTip, EuiSpacer, EuiText } from '@elastic/eui';
 import {
   DefaultRepositoryRequiredBadge,
+  DefaultSnapshotRepositoryRequiredModal,
+  EnterpriseGatingModal,
   EnterpriseLicenseRequiredBadge,
+  FrozenDefaultRepositoryRequiredCallout,
+  FrozenEnterpriseRequiredCallout,
   SearchableSnapshotRepositoryInfo,
 } from '@kbn/data-lifecycle-phases';
 import { dlmPhasesSelectorStrings as strings } from '../strings';
-import type { DlmPhaseDuration } from '../types';
+import type { DlmPhaseDuration, DlmPhasesSelectorEnterpriseConfig } from '../types';
 import { DurationFields } from './duration_fields';
 import { PhaseCard } from './phase_card';
-
-export type FrozenDisabledReason =
-  | { type: 'enterprise'; onClick?: () => void }
-  | { type: 'defaultRepository'; onClick?: () => void };
 
 export interface FrozenPhaseCardProps {
   id: string;
   color: string;
   duration: DlmPhaseDuration;
-  disabled: boolean;
-  disabledReason?: FrozenDisabledReason;
   durationError?: string;
   helpText?: React.ReactNode;
   isFormDisabled: boolean;
   defaultSnapshotRepository?: string;
   manageRepositoriesHref?: string;
+  hasEnterpriseLicense: boolean;
+  hasDefaultSnapshotRepository: boolean;
+  canCreateDefaultSnapshotRepository: boolean;
+  createDefaultRepositoryUrl: string;
+  enterprise: DlmPhasesSelectorEnterpriseConfig;
+  onRefreshDefaultSnapshotRepository?: () => void | Promise<void>;
   onChange: (duration: DlmPhaseDuration) => void;
 }
-
-const DisabledReasonBadge = ({ disabledReason }: { disabledReason: FrozenDisabledReason }) => {
-  if (disabledReason.type === 'enterprise') {
-    return <EnterpriseLicenseRequiredBadge onClick={disabledReason.onClick} />;
-  }
-
-  return <DefaultRepositoryRequiredBadge onClick={disabledReason.onClick} />;
-};
 
 export const FrozenPhaseCard = ({
   id,
   color,
   duration,
-  disabled,
-  disabledReason,
   durationError,
   helpText,
   isFormDisabled,
   defaultSnapshotRepository,
   manageRepositoriesHref,
+  hasEnterpriseLicense,
+  hasDefaultSnapshotRepository,
+  canCreateDefaultSnapshotRepository,
+  createDefaultRepositoryUrl,
+  enterprise,
+  onRefreshDefaultSnapshotRepository,
   onChange,
 }: FrozenPhaseCardProps) => {
-  const isDurationFieldsDisabled = isFormDisabled || disabled;
-  const showConfig = !disabledReason;
+  const wasInitiallyActiveRef = useRef(duration.enabled);
+  const isRequirementMissing = !hasEnterpriseLicense || !hasDefaultSnapshotRepository;
+  const isGraceActive = wasInitiallyActiveRef.current && duration.enabled && isRequirementMissing;
+  const showEnterpriseCallout = isGraceActive && !hasEnterpriseLicense;
+  const showDefaultRepositoryCallout = isGraceActive && !hasDefaultSnapshotRepository;
+  const hasActiveCallout = showEnterpriseCallout || showDefaultRepositoryCallout;
+
+  const [openModal, setOpenModal] = useState<'enterprise' | 'defaultRepository' | undefined>();
+  const [isRefreshingDefaultRepository, setIsRefreshingDefaultRepository] = useState(false);
+
+  const closeModal = useCallback(() => setOpenModal(undefined), []);
+
+  useEffect(() => {
+    if (hasDefaultSnapshotRepository && openModal === 'defaultRepository') {
+      closeModal();
+    }
+  }, [closeModal, hasDefaultSnapshotRepository, openModal]);
+
+  const openEnterpriseModal = useCallback(() => setOpenModal('enterprise'), []);
+  const openCreateDefaultRepositoryModal = canCreateDefaultSnapshotRepository
+    ? () => setOpenModal('defaultRepository')
+    : undefined;
+
+  const refreshDefaultRepository = useCallback(async () => {
+    if (!onRefreshDefaultSnapshotRepository) {
+      return;
+    }
+
+    setIsRefreshingDefaultRepository(true);
+
+    try {
+      await onRefreshDefaultSnapshotRepository();
+    } finally {
+      setIsRefreshingDefaultRepository(false);
+    }
+  }, [onRefreshDefaultSnapshotRepository]);
+
+  const disabledBadge =
+    isGraceActive || !isRequirementMissing ? undefined : !hasEnterpriseLicense ? (
+      <EnterpriseLicenseRequiredBadge onClick={openEnterpriseModal} />
+    ) : (
+      <DefaultRepositoryRequiredBadge onClick={openCreateDefaultRepositoryModal} />
+    );
+  const isCardDisabled = isFormDisabled || Boolean(disabledBadge);
+  const isDurationFieldsDisabled = isCardDisabled || hasActiveCallout;
+  const showConfig = !disabledBadge;
 
   return (
-    <PhaseCard
-      id={id}
-      checked={duration.enabled}
-      dataTestSubj="dlmPhasesSelectorFrozenPhaseCard"
-      disabled={disabled}
-      checkboxAriaLabel={strings.frozenPhaseCheckboxAriaLabel}
-      title={strings.frozenPhaseLabel}
-      description={strings.frozenPhaseDescription}
-      icon={<EuiIcon type="dot" color={color} size="m" aria-hidden />}
-      badges={disabledReason ? <DisabledReasonBadge disabledReason={disabledReason} /> : undefined}
-      onChange={(checked) => onChange({ ...duration, enabled: checked })}
-    >
-      {showConfig && (
-        <>
-          <DurationFields
-            label={strings.moveAfterLabel}
-            phaseLabel={strings.frozenPhaseLabel}
-            testSubjectPrefix="frozen"
-            duration={duration}
-            error={durationError}
-            helpText={helpText}
-            disabled={isDurationFieldsDisabled}
-            onChange={onChange}
-          />
-
-          <EuiSpacer size="m" />
-
-          <EuiText size="s" data-test-subj="frozenSearchableSnapshotLabel">
-            <strong>
-              {strings.searchableSnapshotLabel}{' '}
-              <EuiIconTip content={strings.searchableSnapshotTooltip} type="info" color="subdued" />
-            </strong>
-          </EuiText>
-
-          {defaultSnapshotRepository && (
-            <>
-              <EuiSpacer size="xs" />
-
-              <EuiText size="s" color="subdued" data-test-subj="frozenSearchableSnapshotInfo">
-                <SearchableSnapshotRepositoryInfo
-                  defaultRepository={defaultSnapshotRepository}
-                  manageRepositoriesHref={manageRepositoriesHref}
+    <>
+      <PhaseCard
+        id={id}
+        checked={duration.enabled}
+        dataTestSubj="dlmPhasesSelectorFrozenPhaseCard"
+        disabled={isCardDisabled}
+        checkboxAriaLabel={strings.frozenPhaseCheckboxAriaLabel}
+        title={strings.frozenPhaseLabel}
+        description={strings.frozenPhaseDescription}
+        icon={<EuiIcon type="dot" color={color} size="m" aria-hidden />}
+        badges={disabledBadge}
+        onChange={(checked) => onChange({ ...duration, enabled: checked })}
+      >
+        {showConfig && (
+          <>
+            {showEnterpriseCallout && (
+              <>
+                <FrozenEnterpriseRequiredCallout
+                  onUpgradeEnterprise={openEnterpriseModal}
+                  calloutTestSubj="frozenEnterpriseRequiredCallout"
+                  upgradeButtonTestSubj="frozenUpgradeEnterpriseButton"
                 />
-              </EuiText>
-            </>
-          )}
-        </>
+                <EuiSpacer size="m" />
+              </>
+            )}
+
+            <DurationFields
+              label={strings.moveAfterLabel}
+              phaseLabel={strings.frozenPhaseLabel}
+              testSubjectPrefix="frozen"
+              duration={duration}
+              error={durationError}
+              helpText={helpText}
+              disabled={isDurationFieldsDisabled}
+              onChange={onChange}
+            />
+
+            <EuiSpacer size="m" />
+
+            <EuiText size="s" data-test-subj="frozenSearchableSnapshotLabel">
+              <strong>
+                {strings.searchableSnapshotLabel}{' '}
+                <EuiIconTip
+                  content={strings.searchableSnapshotTooltip}
+                  type="info"
+                  color="subdued"
+                />
+              </strong>
+            </EuiText>
+
+            {showDefaultRepositoryCallout ? (
+              <>
+                <EuiSpacer size="s" />
+
+                <FrozenDefaultRepositoryRequiredCallout
+                  onCreateDefaultRepository={openCreateDefaultRepositoryModal}
+                  onRefresh={refreshDefaultRepository}
+                  isRefreshing={isRefreshingDefaultRepository}
+                  calloutTestSubj="frozenDefaultRepositoryRequiredCallout"
+                  createButtonTestSubj="frozenCreateDefaultRepositoryButton"
+                  refreshButtonTestSubj="frozenRefreshDefaultRepositoryButton"
+                />
+              </>
+            ) : (
+              defaultSnapshotRepository && (
+                <>
+                  <EuiSpacer size="xs" />
+
+                  <EuiText size="s" color="subdued" data-test-subj="frozenSearchableSnapshotInfo">
+                    <SearchableSnapshotRepositoryInfo
+                      defaultRepository={defaultSnapshotRepository}
+                      manageRepositoriesHref={manageRepositoriesHref}
+                    />
+                  </EuiText>
+                </>
+              )
+            )}
+          </>
+        )}
+      </PhaseCard>
+
+      {openModal === 'enterprise' && (
+        <EnterpriseGatingModal
+          environment={enterprise.isCloudEnabled ? 'cloud' : 'selfManaged'}
+          hasManageSubscriptionPermission={
+            enterprise.isCloudEnabled ? true : enterprise.canManageLicense
+          }
+          trialStatus={enterprise.trialDaysLeft === 0 ? 'expired' : 'notStarted'}
+          subscriptionFeaturesUrl={enterprise.subscriptionFeaturesUrl}
+          onPrimaryAction={enterprise.onUpgrade}
+          onCancel={closeModal}
+        />
       )}
-    </PhaseCard>
+
+      {openModal === 'defaultRepository' && (
+        <DefaultSnapshotRepositoryRequiredModal
+          createDefaultRepositoryUrl={createDefaultRepositoryUrl}
+          isRefreshing={isRefreshingDefaultRepository}
+          onCancel={closeModal}
+          onRefresh={refreshDefaultRepository}
+        />
+      )}
+    </>
   );
 };

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/dlm_phases_selector.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/dlm_phases_selector.test.tsx
@@ -185,6 +185,73 @@ describe('DlmPhasesSelector', () => {
     expect(queryByTestId('dlmPhasesSelectorFrozenPhaseCard')).not.toBeInTheDocument();
   });
 
+  describe('existing template with frozen phase already active (grace state)', () => {
+    const GRACE_DEFAULT_VALUE = {
+      frozen: { enabled: true, value: '30', unit: 'd' },
+      delete: { enabled: true, value: '60', unit: 'd' },
+    };
+
+    it('keeps frozen enabled with the enterprise warning callout when the license is missing', () => {
+      const { getByLabelText, getByTestId, getByText, queryByText } = renderSelector({
+        hasEnterpriseLicense: false,
+        defaultValue: GRACE_DEFAULT_VALUE,
+      });
+
+      expect(getByLabelText('Enable frozen phase')).not.toBeDisabled();
+      expect(getByLabelText('Enable frozen phase')).toBeChecked();
+      expect(getByTestId('frozenEnterpriseRequiredCallout')).toBeInTheDocument();
+      expect(getByText('Move after')).toBeInTheDocument();
+      expect(queryByText('Enterprise required')).not.toBeInTheDocument();
+    });
+
+    it('keeps frozen enabled with the default repository warning callout when the repository is missing', () => {
+      const { getByLabelText, getByTestId, queryByText } = renderSelector({
+        hasDefaultSnapshotRepository: false,
+        defaultValue: GRACE_DEFAULT_VALUE,
+      });
+
+      expect(getByLabelText('Enable frozen phase')).not.toBeDisabled();
+      expect(getByTestId('frozenDefaultRepositoryRequiredCallout')).toBeInTheDocument();
+      expect(queryByText('Default repository required')).not.toBeInTheDocument();
+    });
+
+    it('shows both warning callouts when both requirements are missing', () => {
+      const { getByTestId } = renderSelector({
+        hasEnterpriseLicense: false,
+        hasDefaultSnapshotRepository: false,
+        defaultValue: GRACE_DEFAULT_VALUE,
+      });
+
+      expect(getByTestId('frozenEnterpriseRequiredCallout')).toBeInTheDocument();
+      expect(getByTestId('frozenDefaultRepositoryRequiredCallout')).toBeInTheDocument();
+    });
+
+    it('collapses to the disabled badge state after the user unchecks the phase', () => {
+      const { getByLabelText, getByText, queryByTestId } = renderSelector({
+        hasEnterpriseLicense: false,
+        defaultValue: GRACE_DEFAULT_VALUE,
+      });
+
+      fireEvent.click(getByLabelText('Enable frozen phase'));
+
+      expect(getByText('Enterprise required')).toBeInTheDocument();
+      expect(getByLabelText('Enable frozen phase')).toBeDisabled();
+      expect(queryByTestId('frozenEnterpriseRequiredCallout')).not.toBeInTheDocument();
+    });
+
+    it('keeps the frozen phase visible in the grace state even without create permission', () => {
+      const { getByTestId } = renderSelector({
+        hasDefaultSnapshotRepository: false,
+        canCreateDefaultSnapshotRepository: false,
+        defaultValue: GRACE_DEFAULT_VALUE,
+      });
+
+      expect(getByTestId('dlmPhasesSelectorFrozenPhaseCard')).toBeInTheDocument();
+      expect(getByTestId('frozenDefaultRepositoryRequiredCallout')).toBeInTheDocument();
+      expect(getByTestId('frozenCreateDefaultRepositoryButton')).toBeDisabled();
+    });
+  });
+
   it('disables phase configuration fields when the selector is disabled', () => {
     const { getByText, getByTestId } = renderSelector({
       isDisabled: true,

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/dlm_phases_selector.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector/dlm_phases_selector.tsx
@@ -5,13 +5,9 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, useGeneratedHtmlId } from '@elastic/eui';
-import {
-  DefaultSnapshotRepositoryRequiredModal,
-  EnterpriseGatingModal,
-  usePhaseColors,
-} from '@kbn/data-lifecycle-phases';
+import { usePhaseColors } from '@kbn/data-lifecycle-phases';
 import {
   getDurationLabel,
   mergeDefaultValue,
@@ -23,7 +19,6 @@ import { FrozenPhaseCard } from './components/frozen_phase_card';
 import { HotPhaseCard } from './components/hot_phase_card';
 import { dlmPhasesSelectorStrings as strings } from './strings';
 import type { DlmPhaseDuration, DlmPhasesSelectorProps, DlmPhasesSelectorValue } from './types';
-import type { FrozenDisabledReason } from './components/frozen_phase_card';
 
 export type {
   DlmPhaseDuration,
@@ -53,43 +48,15 @@ export const DlmPhasesSelector = ({
   const phaseColors = usePhaseColors();
 
   const [value, setValue] = useState<DlmPhasesSelectorValue>(() => mergeDefaultValue(defaultValue));
-  const [openModal, setOpenModal] = useState<'enterprise' | 'defaultRepository' | undefined>();
-  const [isRefreshingDefaultSnapshotRepository, setIsRefreshingDefaultSnapshotRepository] =
-    useState(false);
 
-  const closeModal = useCallback(() => {
-    setOpenModal(undefined);
-  }, []);
+  const frozenInitiallyActiveRef = useRef(value.frozen.enabled);
 
-  useEffect(() => {
-    if (hasDefaultSnapshotRepository && openModal === 'defaultRepository') {
-      closeModal();
-    }
-  }, [closeModal, hasDefaultSnapshotRepository, openModal]);
-
-  const refreshDefaultSnapshotRepository = useCallback(async () => {
-    if (!onRefreshDefaultSnapshotRepository) {
-      return;
-    }
-
-    setIsRefreshingDefaultSnapshotRepository(true);
-
-    try {
-      await onRefreshDefaultSnapshotRepository();
-    } finally {
-      setIsRefreshingDefaultSnapshotRepository(false);
-    }
-  }, [onRefreshDefaultSnapshotRepository]);
-
-  const frozenDisabledReason: FrozenDisabledReason | undefined = !hasEnterpriseLicense
-    ? { type: 'enterprise', onClick: () => setOpenModal('enterprise') }
-    : !hasDefaultSnapshotRepository
-    ? { type: 'defaultRepository', onClick: () => setOpenModal('defaultRepository') }
-    : undefined;
-
+  const isFrozenStillActiveFromExisting = frozenInitiallyActiveRef.current && value.frozen.enabled;
   const shouldShowFrozenPhase =
-    !serverless && (hasDefaultSnapshotRepository || canCreateDefaultSnapshotRepository);
-  const frozenDisabled = isDisabled || Boolean(frozenDisabledReason);
+    !serverless &&
+    (hasDefaultSnapshotRepository ||
+      canCreateDefaultSnapshotRepository ||
+      isFrozenStillActiveFromExisting);
   const validation = validateDurations(value);
 
   const updateValue = useCallback(
@@ -126,66 +93,46 @@ export const DlmPhasesSelector = ({
       : undefined;
 
   return (
-    <>
-      <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
-        {!serverless && (
-          <EuiFlexItem grow={false}>
-            <HotPhaseCard id={hotCheckboxId} color={phaseColors.hot} />
-          </EuiFlexItem>
-        )}
-
-        {shouldShowFrozenPhase && (
-          <EuiFlexItem grow={false}>
-            <FrozenPhaseCard
-              id={frozenCheckboxId}
-              color={phaseColors.frozen}
-              duration={value.frozen}
-              disabled={frozenDisabled}
-              disabledReason={frozenDisabledReason}
-              durationError={validation.frozenError}
-              helpText={frozenHelpText}
-              isFormDisabled={isDisabled}
-              defaultSnapshotRepository={defaultSnapshotRepository}
-              manageRepositoriesHref={manageRepositoriesUrl}
-              onChange={updateFrozen}
-            />
-          </EuiFlexItem>
-        )}
-
+    <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+      {!serverless && (
         <EuiFlexItem grow={false}>
-          <DeletePhaseCard
-            id={deleteCheckboxId}
-            duration={value.delete}
-            isCardDisabled={isDisabled}
-            durationError={validation.deleteError}
-            helpText={deleteHelpText}
+          <HotPhaseCard id={hotCheckboxId} color={phaseColors.hot} />
+        </EuiFlexItem>
+      )}
+
+      {shouldShowFrozenPhase && (
+        <EuiFlexItem grow={false}>
+          <FrozenPhaseCard
+            id={frozenCheckboxId}
+            color={phaseColors.frozen}
+            duration={value.frozen}
+            durationError={validation.frozenError}
+            helpText={frozenHelpText}
             isFormDisabled={isDisabled}
-            onChange={updateDelete}
+            defaultSnapshotRepository={defaultSnapshotRepository}
+            manageRepositoriesHref={manageRepositoriesUrl}
+            hasEnterpriseLicense={hasEnterpriseLicense}
+            hasDefaultSnapshotRepository={hasDefaultSnapshotRepository}
+            canCreateDefaultSnapshotRepository={canCreateDefaultSnapshotRepository}
+            createDefaultRepositoryUrl={createDefaultRepositoryUrl}
+            enterprise={enterprise}
+            onRefreshDefaultSnapshotRepository={onRefreshDefaultSnapshotRepository}
+            onChange={updateFrozen}
           />
         </EuiFlexItem>
-      </EuiFlexGroup>
-
-      {openModal === 'enterprise' && (
-        <EnterpriseGatingModal
-          environment={enterprise.isCloudEnabled ? 'cloud' : 'selfManaged'}
-          hasManageSubscriptionPermission={
-            enterprise.isCloudEnabled ? true : enterprise.canManageLicense
-          }
-          trialStatus={enterprise.trialDaysLeft === 0 ? 'expired' : 'notStarted'}
-          subscriptionFeaturesUrl={enterprise.subscriptionFeaturesUrl}
-          onPrimaryAction={enterprise.onUpgrade}
-          onCancel={closeModal}
-        />
       )}
 
-      {openModal === 'defaultRepository' && (
-        <DefaultSnapshotRepositoryRequiredModal
-          createDefaultRepositoryUrl={createDefaultRepositoryUrl}
-          isRefreshing={isRefreshingDefaultSnapshotRepository}
-          onCancel={closeModal}
-          onRefresh={refreshDefaultSnapshotRepository}
+      <EuiFlexItem grow={false}>
+        <DeletePhaseCard
+          id={deleteCheckboxId}
+          duration={value.delete}
+          isCardDisabled={isDisabled}
+          durationError={validation.deleteError}
+          helpText={deleteHelpText}
+          isFormDisabled={isDisabled}
+          onChange={updateDelete}
         />
-      )}
-    </>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase.tsx
@@ -24,12 +24,14 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { capitalize } from 'lodash';
-import { usePhaseColors } from '@kbn/data-lifecycle-phases';
+import {
+  FrozenDefaultRepositoryRequiredCallout,
+  FrozenEnterpriseRequiredCallout,
+  usePhaseColors,
+} from '@kbn/data-lifecycle-phases';
 import { formatBytes } from '../../helpers/format_bytes';
 import { LifecyclePhaseButton } from './lifecycle_phase_button';
 import { isZeroAge } from '../../../../../../util/format_size_units';
-import { FrozenEnterpriseRequiredCallout } from './frozen_enterprise_required_callout';
-import { FrozenDefaultRepositoryRequiredCallout } from './frozen_default_repository_required_callout';
 
 interface BaseLifecyclePhaseProps {
   color?: string;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dlm_phases_flyout/edit_dlm_phases_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dlm_phases_flyout/edit_dlm_phases_flyout.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 import { FormProvider, useForm, useFormState, useWatch } from 'react-hook-form';
 
+import { FrozenEnterpriseRequiredCallout } from '@kbn/data-lifecycle-phases';
 import type { EditDlmPhasesFlyoutProps } from './types';
 import type { EditDataPhasesFlyoutChangeMeta } from '../shared';
 import { DlmSearchableSnapshotInfoSection } from './sections/dlm_searchable_snapshot_info_section';
@@ -29,7 +30,6 @@ import { AfterField, getDlmPhasesFlyoutFormSchema, type DlmPhasesFlyoutFormInter
 import { DEFAULT_NEW_PHASE_MIN_AGE, TIME_UNIT_OPTIONS } from '../edit_ilm_phases_flyout/constants';
 import { PhaseTabsRow } from '../shared';
 import { useDataPhasesFlyoutStyles } from '../shared';
-import { FrozenEnterpriseRequiredCallout } from '../../common/data_lifecycle/frozen_enterprise_required_callout';
 import { useIlmPhasesColorAndDescription } from '../../hooks/use_ilm_phases_color_and_description';
 import {
   formatDuration,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dlm_phases_flyout/sections/dlm_searchable_snapshot_info_section.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dlm_phases_flyout/sections/dlm_searchable_snapshot_info_section.tsx
@@ -8,8 +8,10 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { SearchableSnapshotRepositoryInfo } from '@kbn/data-lifecycle-phases';
-import { FrozenDefaultRepositoryRequiredCallout } from '../../../common/data_lifecycle/frozen_default_repository_required_callout';
+import {
+    FrozenDefaultRepositoryRequiredCallout,
+    SearchableSnapshotRepositoryInfo,
+} from '@kbn/data-lifecycle-phases';
 
 export interface DlmSearchableSnapshotInfoSectionProps {
   dataTestSubj: string;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dlm_phases_flyout/sections/dlm_searchable_snapshot_info_section.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/edit_dlm_phases_flyout/sections/dlm_searchable_snapshot_info_section.tsx
@@ -9,8 +9,8 @@ import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
-    FrozenDefaultRepositoryRequiredCallout,
-    SearchableSnapshotRepositoryInfo,
+  FrozenDefaultRepositoryRequiredCallout,
+  SearchableSnapshotRepositoryInfo,
 } from '@kbn/data-lifecycle-phases';
 
 export interface DlmSearchableSnapshotInfoSectionProps {


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/266068

## Summary

Prework for the Index Templates "Data lifecycle" layout changes. The frozen-phase warning callouts that already existed locally in Streams (`FrozenEnterpriseRequiredCallout` and `FrozenDefaultRepositoryRequiredCallout`) are promoted into the shared `@kbn/data-lifecycle-phases` package so both Streams and Index Management can reuse them. The Index Management `FrozenPhaseCard` is then refactored to consume these shared callouts and own its own gating behavior.

- Move `FrozenEnterpriseRequiredCallout` and `FrozenDefaultRepositoryRequiredCallout` from `streams_app` into `@kbn/data-lifecycle-phases` (new `frozen_phase_callouts` module, exported from the package entry), re-pointing i18n ids from `xpack.streams.streamDetailLifecycle.frozen.*` to `xpack.dataLifecyclePhases.frozen.*` and dropping the `fill` styling so the buttons match the new design.
- Update Streams consumers (`lifecycle_phase.tsx`, `edit_dlm_phases_flyout.tsx`, `dlm_searchable_snapshot_info_section.tsx`) to import the callouts from the shared package.
- Make `FrozenPhaseCard` self-contained: it now receives the raw requirement booleans (`hasEnterpriseLicense`, `hasDefaultSnapshotRepository`) plus the data needed to act on them, derives its own disabled/grace state, owns the `EnterpriseGatingModal` / `DefaultSnapshotRepositoryRequiredModal`, and renders the shared warning callouts in the "grace" state (existing template with frozen already active but a requirement now missing). The `DlmPhasesSelector` no longer manages this modal state and the old `FrozenDisabledReason` type is removed.
- Add Storybook stories for the shared callouts and for the new grace-state scenarios; update existing stories, READMEs, and tests accordingly.

### Test plan

- Automated: updated `frozen_phase_card.test.tsx` and `dlm_phases_selector.test.tsx` with coverage for the disabled + badge states, modal opening from badges, and the new grace-state behavior (callouts shown, duration inputs disabled, create-repository permission, collapse-on-uncheck). Run: - `node scripts/jest x-pack/platform/plugins/shared/index_management/public/application/components/data_lifecycle/dlm_phases_selector` - `node scripts/type_check --project x-pack/platform/packages/shared/kbn-data-lifecycle-phases/tsconfig.json` - `node scripts/i18n_check` (i18n ids moved from `xpack.streams.*` to `xpack.dataLifecyclePhases.*`)
- Manual (Storybook — shared package / Index Management): - "Data Lifecycle Phases / Frozen phase callouts" stories render the moved callouts. - "DLM Phases Selector/Cards/Frozen" → `CardEnterpriseRequired` / `CardDefaultRepositoryRequired`   show the disabled card with the correct badge + modal on click. - `CardActiveWithEnterpriseWarning` / `CardActiveWithDefaultRepositoryWarning` show the   grace state (phase stays checked, warning callout shown, duration inputs disabled).
- Manual (Storybook — Streams): in the `LifecyclePhase` stories (`lifecycle_phase.stories.tsx`), verify `FrozenPhaseEnterpriseCallout` and `FrozenPhaseDefaultRepositoryCallout` still render both callouts unchanged after the import path / i18n id move (no behavior change).

### Evidence

https://github.com/user-attachments/assets/d2d7b517-f14e-461f-a968-720102345da4

