### PR TITLE
[Flaky] Fix creation.cy.ts (fixes #270438)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
@@ -102,9 +102,8 @@ describe('Timelines', { tags: ['@ess', '@serverless'] }, (): void => {
     // Saved
     cy.get(TIMELINE_STATUS).should('not.exist');
 
-    // Offsetting the extra save that is happening in the background
-    // for the saved search object.
-    cy.get(LOADING_INDICATOR).should('be.visible');
+    // Wait for any background saves (e.g. saved search object) to settle
+    // before typing in the KQL bar to avoid interfering with in-flight requests.
     cy.get(LOADING_INDICATOR).should('not.exist');
 
     executeTimelineKQL('agent.name : *');
@@ -124,9 +123,7 @@ describe('Timelines', { tags: ['@ess', '@serverless'] }, (): void => {
     openTimelineUsingToggle();
     addNameToTimelineAndSave('First');
 
-    // Offsetting the extra save that is happening in the background
-    // for the saved search object.
-    cy.get(LOADING_INDICATOR).should('be.visible');
+    // Wait for any background saves (e.g. saved search object) to settle.
     cy.get(LOADING_INDICATOR).should('not.exist');
 
     addNameToTimelineAndSaveAsNew('Second');

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
@@ -19,7 +19,6 @@ import {
   SAVE_TIMELINE_ACTION_BTN,
   SAVE_TIMELINE_TOOLTIP,
 } from '../../../screens/timeline';
-import { LOADING_INDICATOR } from '../../../screens/security_header';
 import { ROWS } from '../../../screens/timelines';
 import { createTimelineTemplate, deleteTimelines } from '../../../tasks/api_calls/timelines';
 
@@ -102,10 +101,6 @@ describe('Timelines', { tags: ['@ess', '@serverless'] }, (): void => {
     // Saved
     cy.get(TIMELINE_STATUS).should('not.exist');
 
-    // Wait for any background saves (e.g. saved search object) to settle
-    // before typing in the KQL bar to avoid interfering with in-flight requests.
-    cy.get(LOADING_INDICATOR).should('not.exist');
-
     executeTimelineKQL('agent.name : *');
 
     // Saved but has unsaved changes
@@ -122,9 +117,6 @@ describe('Timelines', { tags: ['@ess', '@serverless'] }, (): void => {
 
     openTimelineUsingToggle();
     addNameToTimelineAndSave('First');
-
-    // Wait for any background saves (e.g. saved search object) to settle.
-    cy.get(LOADING_INDICATOR).should('not.exist');
 
     addNameToTimelineAndSaveAsNew('Second');
     closeTimeline();


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test "should show the different timeline states" failed at line 108 with:
`Expected <span.euiLoadingSpinner…> not to exist in the DOM, but it was continuously found.`
— after a 150 000 ms timeout.

The root cause is a fragile two-step pattern used to synchronise against a background
save of the saved-search object after a timeline is persisted:

```javascript
cy.get(LOADING_INDICATOR).should('be.visible');   // line 107 — REQUIRES indicator to appear
cy.get(LOADING_INDICATOR).should('not.exist');    // line 108 — FAILS if it never disappears
```

When Cypress retries `should('be.visible')` it may pick up the loading indicator from a
*different* in-flight request (notes fetch triggered by `fetchNotesBySavedObjectIds` when
`isTimelineSaved` first becomes true; or the `GET /api/timelines` refresh triggered by
`refreshTimelines` inside the save middleware; or a `dataViews.contract.get()` call from
the data-view manager). Once that second indicator is caught, `should('not.exist')` may
never pass because that unrelated request either hangs or is continuously restarted (e.g.
a polling data-view check introduced after the `newDataViewPickerEnabled` feature-flag
was removed in #238549).

The fix drops the `should('be.visible')` precondition and keeps only `should('not.exist')`:
if no indicator is present the assertion passes immediately (save was already fast); if
any indicator is present for *any* reason the test waits for it to clear — which is the
actual intent. The same pattern was also corrected in the `should save timelines as new`
test in the same file to prevent a future recurrence.

**Changes**

- 1b14c9b6b8d3 fix(test): remove fragile loading-indicator visibility check in timeline creation tests

Fixes #270438




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->