### PR TITLE
[RSPack] Enable Emotion component selectors via @swc/plugin-emotion

### DIFF
--- a/.buildkite/scripts/steps/security/third_party_packages.txt
+++ b/.buildkite/scripts/steps/security/third_party_packages.txt
@@ -56,3 +56,4 @@ redux-thunk-v2
 redux-toolkit-v1
 redux-v4
 reselect-v4
+@swc/plugin-emotion

--- a/package.json
+++ b/package.json
@@ -1978,6 +1978,7 @@
     "@storybook/types": "8.6.17",
     "@swc/core": "1.15.18",
     "@swc/helpers": "0.5.19",
+    "@swc/plugin-emotion": "14.7.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/packages/kbn-rspack-optimizer/src/config/shared_config.ts
+++ b/packages/kbn-rspack-optimizer/src/config/shared_config.ts
@@ -87,9 +87,12 @@ export function getSharedResolveFallback(): Record<string, false> {
  * This is faster than the webpack `swc-loader` because it's implemented
  * in Rust and integrated directly into RSPack.
  *
- * Uses @swc/plugin-emotion for CSS-in-JS. styled-components files
- * will still work at runtime - we just won't have build-time optimizations
- * like better debugging labels for styled-components.
+ * Emotion CSS-in-JS is handled in two parts: the `css` prop via Emotion's JSX
+ * runtime (`importSource: '@emotion/react'`), and styled-component labels +
+ * component-selector `target`s via the `@swc/plugin-emotion` WASM plugin
+ * (mirrors `@emotion/babel-plugin` on the webpack path). styled-components files
+ * still work at runtime without a build plugin - we just won't have build-time
+ * optimizations like better debugging labels for styled-components.
  *
  * This is acceptable because:
  * 1. Kibana is migrating from styled-components to Emotion
@@ -128,7 +131,35 @@ function getSwcOptions(dist: boolean, hmr: boolean = false) {
           importSource: '@emotion/react',
         },
       },
-      // No plugins needed - Emotion's JSX runtime handles css prop directly
+      // The JSX runtime above only handles the css prop. Emotion *component
+      // selectors* (interpolating a styled component as a CSS selector, e.g.
+      // `${NodeShapeContainer}:hover`) additionally require a build transform
+      // that injects a stable `target` into each styled component. The webpack
+      // optimizer gets this from `@emotion/babel-plugin` (via
+      // `@emotion/babel-preset-css-prop`); under SWC we run the equivalent
+      // `@swc/plugin-emotion` WASM plugin so component selectors don't throw at
+      // runtime. labelFormat is shared with the Babel path via
+      // `@kbn/transpiler-config` to keep generated class names consistent.
+      //
+      // NOTE: `@swc/plugin-emotion` is a WebAssembly plugin whose ABI is locked
+      // to the `swc_core` version that RSPack's bundled SWC was built against.
+      // RSPack 1.7.11 reports `swc_core` 59.0.1; `@swc/plugin-emotion@14.7.0` is
+      // built against `swc_core` 58.0.1 (the closest release at/below the host —
+      // there is no release targeting 59/60, it jumps to 61.0.1 in 14.8.0). The
+      // pinned version must be re-checked whenever `@rspack/core` is bumped, or
+      // the build will panic on a plugin ABI mismatch.
+      experimental: {
+        plugins: [
+          [
+            require.resolve('@swc/plugin-emotion'),
+            {
+              autoLabel: dist ? 'never' : 'dev-only',
+              labelFormat: sharedConfig.emotion.labelFormat,
+              sourceMap: !dist,
+            },
+          ],
+        ],
+      },
       // Target ES2020 for browser builds (matches Kibana's browserslist)
       target: 'es2020',
       // Keep class names for debugging and error messages

--- a/packages/kbn-swc-config/src/browser.js
+++ b/packages/kbn-swc-config/src/browser.js
@@ -18,7 +18,8 @@ const { getSharedConfig } = require('@kbn/transpiler-config');
  * Key features:
  * - TypeScript with decorators (legacy mode)
  * - React automatic runtime with Emotion's JSX (importSource: '@emotion/react')
- * - Emotion CSS-in-JS support via the JSX runtime (no plugin needed)
+ * - Emotion css prop via the JSX runtime, plus styled-component labels and
+ *   component-selector `target`s via the @swc/plugin-emotion WASM plugin
  *
  * Note: styled-components files work without a build plugin - they just
  * won't have build-time optimizations. This is acceptable as Kibana is
@@ -49,7 +50,23 @@ function getBrowserSwcConfig(options = {}) {
           importSource: '@emotion/react',
         },
       },
-      // No plugins needed - Emotion's JSX runtime handles css prop directly
+      // The JSX runtime only handles the css prop. Emotion component selectors
+      // (interpolating a styled component as a CSS selector) additionally need a
+      // build transform that injects a stable `target` into each styled
+      // component, so we run `@swc/plugin-emotion` (the SWC equivalent of
+      // `@emotion/babel-plugin` used on the webpack path).
+      experimental: {
+        plugins: [
+          [
+            require.resolve('@swc/plugin-emotion'),
+            {
+              autoLabel: production ? 'never' : 'dev-only',
+              labelFormat: sharedConfig.emotion.labelFormat,
+              sourceMap: !production,
+            },
+          ],
+        ],
+      },
       // Target ES2020 for browser builds (matches Kibana's browserslist)
       target: 'es2020',
       // Keep class names for debugging and error messages

--- a/renovate.json
+++ b/renovate.json
@@ -2494,7 +2494,7 @@
     },
     {
       "groupName": "@swc",
-      "matchDepNames": ["@swc/core", "@swc/helpers"],
+      "matchDepNames": ["@swc/core", "@swc/helpers", "@swc/plugin-emotion"],
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "addLabels": ["Team:Operations"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -14273,6 +14273,13 @@
   dependencies:
     tslib "^2.8.0"
 
+"@swc/plugin-emotion@14.7.0":
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/@swc/plugin-emotion/-/plugin-emotion-14.7.0.tgz#f74096282e8746bdda66e7fb1049764a4a752f01"
+  integrity sha512-RwYrsxia8GKh2qLHWwymcfCeP6C5gAkssB2YtBRhP/qlKCxXYfv808buEXkCYvyGIY+bN3XziKXCuAi+waA5pQ==
+  dependencies:
+    "@swc/counter" "^0.1.3"
+
 "@swc/types@^0.1.25":
   version "0.1.25"
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.25.tgz#b517b2a60feb37dd933e542d93093719e4cf1078"


### PR DESCRIPTION
## Summary

Emotion **component selectors** — interpolating a styled component as a CSS
selector, e.g. `` styled.div`${NodeShapeContainer}:hover & { ... }` `` — throw at
runtime when Kibana is bundled with the **RSPack** optimizer
(`KBN_USE_RSPACK=true`), while working fine under the Webpack optimizer:

```
Error: Component selectors can only be used in conjunction with
@emotion/babel-plugin, the swc Emotion plugin, or another Emotion-aware
compiler transform.
```

This PR makes the RSPack/SWC build apply an Emotion transform equivalent to the
Webpack path so component selectors work under both bundlers.

### Issue with loading the flyout graph component

While migrating the Security Solution graph visualization, the app crashed at
render under RSPack with the error above. The same code rendered fine under the
default Webpack optimizer (`yarn start`) — the crash only happened with
`KBN_USE_RSPACK=true yarn start`. That bundler split was the key clue.

https://github.com/user-attachments/assets/1e9830ee-8362-448a-b641-a49c20a3bea8

### Investigation

- **The error mechanism.** `@emotion/styled` only knows how to resolve
  `${Component}` to a selector if a build transform injected a stable `target`
  into that styled component. Without it, the component's `toString()` throws the
  message above. So the error means "no Emotion build transform ran on this file."
- **Webpack path** — `@kbn/optimizer` → `@kbn/babel-preset/webpack_preset` applies
  `@emotion/babel-preset-css-prop`, which bundles **`@emotion/babel-plugin`**. That
  injects the `target`, so component selectors work.
- **RSPack path** — `@kbn/rspack-optimizer` transpiles with `builtin:swc-loader`
  and only wired Emotion's **JSX runtime** (`importSource: '@emotion/react'`),
  which handles the **`css` prop only**. No transform injected styled-component
  `target`s — the SWC config explicitly carried a "No plugins needed" note. Hence
  the `css` prop and basic `styled` worked, but component selectors did not.
- This explained every symptom: works under Webpack, fails under RSPack; ships
  fine in CI (Webpack); not a cache issue.

### The fix

Add the `@swc/plugin-emotion` WASM plugin to the SWC loader options, mirroring
`@emotion/babel-plugin` on the Webpack path, in both:

- `packages/kbn-rspack-optimizer/src/config/shared_config.ts` (`getSwcOptions`) —
  the main Kibana build.
- `packages/kbn-swc-config/src/browser.js` (`getBrowserSwcConfig`) — external
  plugin builds.

It reuses the shared `emotion.labelFormat` from `@kbn/transpiler-config` so
generated class names stay consistent with the Babel path. The existing
`importSource: '@emotion/react'` JSX runtime still handles the `css` prop; the
plugin adds the styled labels + component-selector `target`s on top — the same
two-part arrangement `@emotion/babel-preset-css-prop` uses on Webpack.

https://github.com/user-attachments/assets/64beb857-d1bd-495b-9f56-60a97ab52ac6

### Maintenance note

`@swc/plugin-emotion` is a **WebAssembly plugin whose ABI is locked to the
`swc_core` version that RSPack's bundled SWC was built against**, not to the
repo's `@swc/core`. RSPack `1.7.11` reports `swc_core` **59.0.1**.

There is **no `@swc/plugin-emotion` release built for `swc_core` 59 or 60** — the
releases jump from `58.0.1` (`14.7.0`) to `61.0.1` (`14.8.0`). We pinned
**`14.7.0`** (built for `58.0.1`, the closest release at/below the host); SWC's
plugin ABI is backward-tolerant, so a host at 59 loads a plugin built for 58, and
this is verified working locally.

**This pin must be re-checked on every `@rspack/core` bump** — a mismatched
`swc_core` makes the build *panic* (not degrade gracefully). See
https://rspack.rs/errors/swc-plugin-version for selecting versions. It would be
worth deciding whether this coupling is acceptable long-term, or whether a CI
guard should assert the plugin↔rspack `swc_core` compatibility.

## How to test

- `KBN_USE_RSPACK=true yarn start --no-base-path` — graph renders without the
  component-selector error (verified after a full `yarn kbn reset` + bootstrap).
- Webpack path (`yarn start`) — unchanged.

🤖 Generated with Claude Code and Cursor
