### PR TITLE
[9.3] Fix alert recovery targeting wrong document when multiple lifec…

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -117,7 +117,7 @@ steps:
     agents:
       machineType: n2-standard-2
       diskSizeGb: 115
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -124,8 +124,46 @@ set_git_merge_base() {
   GITHUB_PR_MERGE_BASE="$(buildkite-agent meta-data get merge-base --default '')"
 
   if [[ ! "$GITHUB_PR_MERGE_BASE" ]]; then
-    git fetch origin "$GITHUB_PR_TARGET_BRANCH"
-    GITHUB_PR_MERGE_BASE="$(git merge-base HEAD FETCH_HEAD)"
+    if git fetch origin "$GITHUB_PR_TARGET_BRANCH" 2>/dev/null; then
+      GITHUB_PR_MERGE_BASE="$(git merge-base HEAD FETCH_HEAD 2>/dev/null || true)"
+    fi
+
+    if [[ ! "$GITHUB_PR_MERGE_BASE" ]]; then
+      local compare_target="${GITHUB_PR_HEAD_SHA:-}"
+      local github_token="${GITHUB_TOKEN:-${VAULT_GITHUB_TOKEN:-}}"
+      local compare_ref
+
+      if [[ ! "$compare_target" && "${GITHUB_PR_OWNER:-}" && "${GITHUB_PR_BRANCH:-}" ]]; then
+        compare_target="${GITHUB_PR_OWNER}:${GITHUB_PR_BRANCH}"
+      fi
+
+      if [[ ! "$compare_target" ]]; then
+        echo "Failed to resolve PR merge base: PR head ref is not available for gh api fallback" >&2
+        return 1
+      fi
+
+      echo "Falling back to GitHub compare API for PR merge-base"
+      compare_ref="$(
+        jq -rn \
+          --arg base "$GITHUB_PR_TARGET_BRANCH" \
+          --arg head "$compare_target" \
+          '$base + "..." + $head | @uri'
+      )"
+
+      GITHUB_PR_MERGE_BASE="$(
+        curl -fsSL \
+          -H 'Accept: application/vnd.github+json' \
+          -H "Authorization: Bearer ${github_token}" \
+          "https://api.github.com/repos/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}/compare/${compare_ref}" |
+          jq -r '.merge_base_commit.sha // empty' || true
+      )"
+    fi
+
+    if [[ ! "$GITHUB_PR_MERGE_BASE" ]]; then
+      echo "Failed to resolve PR merge base" >&2
+      return 1
+    fi
+
     buildkite-agent meta-data set merge-base "$GITHUB_PR_MERGE_BASE"
   fi
 

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -14,7 +14,7 @@ ts-node "$(dirname "${0}")/ci_stats_start.ts"
 # We resolve the latest manifest URL at the beginning of the build to ensure that all steps in the build will use the same manifest
 # Otherwise, the manifest could change if a step is running around the time that a new one is promoted
 if [[ ! "${ES_SNAPSHOT_MANIFEST:-}" ]]; then
-  BUCKET=$(curl -s "https://storage.googleapis.com/kibana-ci-es-snapshots-daily/$(cat package.json | jq -r .version)/manifest-latest-verified.json" | jq -r .bucket)
+  BUCKET=$(curl -s "https://storage.googleapis.com/kibana-ci-es-snapshots-permanent/$(cat package.json | jq -r .version)/manifest.json" | jq -r .bucket)
   ES_SNAPSHOT_MANIFEST_DEFAULT="https://storage.googleapis.com/$BUCKET/manifest.json"
   buildkite-agent meta-data set ES_SNAPSHOT_MANIFEST_DEFAULT "$ES_SNAPSHOT_MANIFEST_DEFAULT"
 fi

--- a/src/dev/build/tasks/os_packages/run_fpm.ts
+++ b/src/dev/build/tasks/os_packages/run_fpm.ts
@@ -60,6 +60,8 @@ export async function runFpm(
     'Explore and visualize your Elasticsearch data',
     '--version',
     version,
+    '--iteration',
+    '2',
     '--url',
     'https://www.elastic.co',
     '--vendor',

--- a/src/platform/packages/private/kbn-journeys/journey/journey_ftr_config.ts
+++ b/src/platform/packages/private/kbn-journeys/journey/journey_ftr_config.ts
@@ -93,7 +93,15 @@ export function makeFtrConfigProvider(
     const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
 
     const packageRegistryConfig = path.join(__dirname, '../fixtures/package_registry_config.yml');
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+    // EPR_REQUIRE_PACKAGE_SIGNATURES=false: the `:lite` distribution ships some
+    // packages without `.sig` files, so opt out of upstream signature enforcement
+    // (added in elastic/package-registry#1646).
+    const dockerArgs: string[] = [
+      '-v',
+      `${packageRegistryConfig}:/package-registry/config.yml`,
+      '-e',
+      'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+    ];
 
     return {
       ...baseConfig,

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/serverless/serverless.base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/serverless/serverless.base.config.ts
@@ -27,7 +27,15 @@ import type { ScoutServerConfig } from '../../../../../types';
 import { SAML_IDP_PLUGIN_PATH, SERVERLESS_IDP_METADATA_PATH, JWKS_PATH } from '../../../constants';
 
 const packageRegistryConfig = join(__dirname, './package_registry_config.yml');
-const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+// EPR_REQUIRE_PACKAGE_SIGNATURES=false: the `:lite` distribution ships some
+// packages without `.sig` files, so opt out of upstream signature enforcement
+// (added in elastic/package-registry#1646).
+const dockerArgs: string[] = [
+  '-v',
+  `${packageRegistryConfig}:/package-registry/config.yml`,
+  '-e',
+  'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+];
 
 /**
  * This is used by CI to set the docker registry port

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts
@@ -28,7 +28,15 @@ import type { ScoutServerConfig } from '../../../../../types';
 import { SAML_IDP_PLUGIN_PATH, STATEFUL_IDP_METADATA_PATH } from '../../../constants';
 
 const packageRegistryConfig = join(__dirname, './package_registry_config.yml');
-const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+// EPR_REQUIRE_PACKAGE_SIGNATURES=false: the `:lite` distribution ships some
+// packages without `.sig` files, so opt out of upstream signature enforcement
+// (added in elastic/package-registry#1646).
+const dockerArgs: string[] = [
+  '-v',
+  `${packageRegistryConfig}:/package-registry/config.yml`,
+  '-e',
+  'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+];
 
 /**
  * This is used by CI to set the docker registry port

--- a/src/platform/packages/shared/kbn-test-docker-servers/src/package_registry/index.ts
+++ b/src/platform/packages/shared/kbn-test-docker-servers/src/package_registry/index.ts
@@ -17,7 +17,15 @@ export const fleetPackageRegistryDockerImage =
   'docker.elastic.co/kibana-ci/package-registry-distribution:lite';
 
 const packageRegistryConfig = join(__dirname, './package_registry_config.yml');
-const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+// EPR_REQUIRE_PACKAGE_SIGNATURES=false: opt out of upstream signature enforcement
+// added in elastic/package-registry#1646; the throwaway test registry serves the
+// `:lite` distribution which ships some packages without `.sig` files.
+const dockerArgs: string[] = [
+  '-v',
+  `${packageRegistryConfig}:/package-registry/config.yml`,
+  '-e',
+  'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+];
 
 /**
  * This is used by CI to set the docker registry port

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.test.ts
@@ -120,10 +120,31 @@ describe('get_tracked_alerts', () => {
       const mockAlert = {
         [ALERT_UUID]: 'uuid-1',
         [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
       } as unknown as TestAlertDoc;
       tracked.all['uuid-1'] = mockAlert;
+      tracked.active['uuid-1'] = mockAlert;
       expect(tracked.getById('id-1')).toBe(mockAlert);
       expect(tracked.getById('nonexistent')).toBeUndefined();
+    });
+
+    it('getById prefers active over recovered when same instance id exists in both', () => {
+      const tracked = createEmptyTrackedAlerts<{}>();
+      const recoveredAlert = {
+        [ALERT_UUID]: 'uuid-old',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_RECOVERED,
+      } as unknown as TestAlertDoc;
+      const activeAlert = {
+        [ALERT_UUID]: 'uuid-new',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
+      } as unknown as TestAlertDoc;
+      tracked.all['uuid-old'] = recoveredAlert;
+      tracked.recovered['uuid-old'] = recoveredAlert;
+      tracked.all['uuid-new'] = activeAlert;
+      tracked.active['uuid-new'] = activeAlert;
+      expect(tracked.getById('id-1')).toBe(activeAlert);
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.ts
@@ -101,7 +101,10 @@ export function createEmptyTrackedAlerts<
       return this.all[uuid];
     },
     getById(id: string) {
-      return Object.values(this.all).find((alert) => get(alert, ALERT_INSTANCE_ID) === id);
+      return (
+        Object.values(this.active).find((alert) => get(alert, ALERT_INSTANCE_ID) === id) ??
+        Object.values(this.recovered).find((alert) => get(alert, ALERT_INSTANCE_ID) === id)
+      );
     },
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -76,7 +76,15 @@ export function useDockerRegistry() {
 
   let dockerProcess: ChildProcess | undefined;
   async function startDockerRegistryServer() {
-    const args = ['run', '--rm', '-p', `${packageRegistryPort}:8080`, DOCKER_IMAGE];
+    const args = [
+      'run',
+      '--rm',
+      '-p',
+      `${packageRegistryPort}:8080`,
+      '-e',
+      'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+      DOCKER_IMAGE,
+    ];
 
     dockerProcess = execa('docker', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/x-pack/platform/test/fleet_api_integration/config.base.ts
+++ b/x-pack/platform/test/fleet_api_integration/config.base.ts
@@ -40,6 +40,8 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
     `${getFullPath(src)}:${dest}`,
   ]);
 
+  dockerArgs.push('-e', 'EPR_REQUIRE_PACKAGE_SIGNATURES=false');
+
   const dockerServers = !skipRunningDockerRegistry
     ? defineDockerServersConfig({
         registry: {

--- a/x-pack/platform/test/serverless/shared/config.base.ts
+++ b/x-pack/platform/test/serverless/shared/config.base.ts
@@ -24,7 +24,15 @@ import { services as svlServices } from './services';
 
 export default async () => {
   const packageRegistryConfig = path.join(__dirname, './common/package_registry_config.yml');
-  const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+  // EPR_REQUIRE_PACKAGE_SIGNATURES=false: the `:lite` distribution ships some
+  // packages without `.sig` files, so opt out of upstream signature enforcement
+  // (added in elastic/package-registry#1646).
+  const dockerArgs: string[] = [
+    '-v',
+    `${packageRegistryConfig}:/package-registry/config.yml`,
+    '-e',
+    'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+  ];
 
   /**
    * This is used by CI to set the docker registry port

--- a/x-pack/solutions/observability/test/apm_api_integration/common/config.ts
+++ b/x-pack/solutions/observability/test/apm_api_integration/common/config.ts
@@ -108,7 +108,15 @@ export function createTestConfig(
     const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
 
     const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+    // EPR_REQUIRE_PACKAGE_SIGNATURES=false: the `:lite` distribution ships some
+    // packages without `.sig` files, so opt out of upstream signature enforcement
+    // (added in elastic/package-registry#1646).
+    const dockerArgs: string[] = [
+      '-v',
+      `${packageRegistryConfig}:/package-registry/config.yml`,
+      '-e',
+      'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
+    ];
 
     return {
       testConfigCategory: ScoutTestRunConfigCategory.API_TEST,

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/common/endpoint_registry_helpers.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/common/endpoint_registry_helpers.ts
@@ -60,6 +60,8 @@ export function SecuritySolutionEndpointRegistryHelpers() {
       const args: string[] = [
         '-v',
         `${packageRegistryConfig}:/package-registry/config.yml`,
+        '-e',
+        'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
         ...dockerArgs,
       ];
       return defineDockerServersConfig({

--- a/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_registry_helpers.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/services/endpoint_registry_helpers.ts
@@ -60,6 +60,8 @@ export function SecuritySolutionEndpointRegistryHelpers() {
       const args: string[] = [
         '-v',
         `${packageRegistryConfig}:/package-registry/config.yml`,
+        '-e',
+        'EPR_REQUIRE_PACKAGE_SIGNATURES=false',
         ...dockerArgs,
       ];
       return defineDockerServersConfig({


### PR DESCRIPTION
Cherrypick of #261033 to `9.3.3-2`

# Backport

This will backport the following commits from `main` to `9.3`:
- [Fix alert recovery targeting wrong document when multiple lifecycles exist for same instance ID
(#261012)](https://github.com/elastic/kibana/pull/261012)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool
documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin
Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-02T21:24:48Z","message":"Fix alert recovery targeting wrong document when multiple lifecycles exist for same instance ID (#261012)\n\n## Summary\n\n- Fix a bug in `getById` where `buildRecoveredAlerts()` could target a\nstale document from a previous alert lifecycle instead of the current\nactive one, leaving the active alert stuck in \"active\" status\npermanently\n- The root cause was `Object.values(this.all).find()` returning\nwhichever document appeared first in ES query results —\nnon-deterministic when multiple documents share the same\n`kibana.alert.instance.id`\n- The fix changes `getById` to search status-specific dictionaries in\npriority order: active, then recovered, then delayed\n\n### Problem\n\nWhen an alert instance goes through multiple fire/recover cycles, the\n`.alerts-*` data stream accumulates multiple documents for the same\n`kibana.alert.instance.id` (each with a unique `kibana.alert.uuid`).\nDuring `initializeExecution`, `getTrackedAlerts` fetches documents from\nrecent executions and populates `trackedAlerts.all` with both the old\nrecovered document and the current active document.\n\nWhen recovery runs,
`AlertBuilder.buildRecoveredAlerts()`
calls\n`trackedAlerts.getById(instanceId)` to find the document to update. The\nprevious implementation used
`Object.values(this.all).find()`, which\nreturned the first match by insertion order. If the old recovered\ndocument was returned first (e.g., because it resided in an earlier\nbacking index), the recovery update targeted the wrong document —\nupdating the already-recovered document again while leaving the current\nactive document untouched.\n\nThis caused:\n- The active alert document remaining permanently stuck with\n`kibana.alert.status: active`\n- The event log recording the recovery for the correct UUID (from task\nstate), creating a divergence between the alert index and event log\n- UI showing conflicting statuses depending on which data source was\nqueried\n\n### Fix\n\nChanged `getById` to search `active`, `recovered`, and `delayed`\ndictionaries in priority order instead of scanning the unordered `all`\ndictionary. Since `populateTrackedAlerts` already categorizes documents\nby status, this ensures recovery always targets the active document\nfirst.\n\n## Manual verification with pattern firing rule:\n\n1. To reproduce the bug, temporarily change `getById` priority to\n`recovered → active → delayed`:\n ```typescript\n Object.values(this.recovered).find(...) ??\n
Object.values(this.active).find(...) ??\n
Object.values(this.delayed).find(...)\n ```\n2. Create a Pattern Firing AAD rule with pattern `(a - a -)`\n3. Run the rule 4 times\n4. Observe: 1 active alert + 1 recovered alert — the active alert is\nstuck and never recovers (bug confirmed)\n5. Revert to the fix (active → recovered → delayed priority)\n6. Create the rule again with the same pattern `(a
- a -)` and run 4\ntimes\n7. Observe: 2 recovered alerts — both lifecycles recover
correctly","sha":"1cc65442a7577db35fab769a615b4342d9547665","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:all-open","v9.4.0"],"title":"Fix alert recovery targeting wrong document when multiple lifecycles exist for same instance
ID","number":261012,"url":"https://github.com/elastic/kibana/pull/261012","mergeCommit":{"message":"Fix alert recovery targeting wrong document when multiple lifecycles exist for same instance ID (#261012)\n\n## Summary\n\n- Fix a bug in `getById` where `buildRecoveredAlerts()` could target a\nstale document from a previous alert lifecycle instead of the current\nactive one, leaving the active alert stuck in \"active\" status\npermanently\n- The root cause was `Object.values(this.all).find()` returning\nwhichever document appeared first in ES query results —\nnon-deterministic when multiple documents share the same\n`kibana.alert.instance.id`\n- The fix changes `getById` to search status-specific dictionaries in\npriority order: active, then recovered, then delayed\n\n### Problem\n\nWhen an alert instance goes through multiple fire/recover cycles, the\n`.alerts-*` data stream accumulates multiple documents for the same\n`kibana.alert.instance.id` (each with a unique `kibana.alert.uuid`).\nDuring `initializeExecution`, `getTrackedAlerts` fetches documents from\nrecent executions and populates `trackedAlerts.all` with both the old\nrecovered document and the current active document.\n\nWhen recovery runs,
`AlertBuilder.buildRecoveredAlerts()`
calls\n`trackedAlerts.getById(instanceId)` to find the document to update. The\nprevious implementation used
`Object.values(this.all).find()`, which\nreturned the first match by insertion order. If the old recovered\ndocument was returned first (e.g., because it resided in an earlier\nbacking index), the recovery update targeted the wrong document —\nupdating the already-recovered document again while leaving the current\nactive document untouched.\n\nThis caused:\n- The active alert document remaining permanently stuck with\n`kibana.alert.status: active`\n- The event log recording the recovery for the correct UUID (from task\nstate), creating a divergence between the alert index and event log\n- UI showing conflicting statuses depending on which data source was\nqueried\n\n### Fix\n\nChanged `getById` to search `active`, `recovered`, and `delayed`\ndictionaries in priority order instead of scanning the unordered `all`\ndictionary. Since `populateTrackedAlerts` already categorizes documents\nby status, this ensures recovery always targets the active document\nfirst.\n\n## Manual verification with pattern firing rule:\n\n1. To reproduce the bug, temporarily change `getById` priority to\n`recovered → active → delayed`:\n ```typescript\n Object.values(this.recovered).find(...) ??\n
Object.values(this.active).find(...) ??\n
Object.values(this.delayed).find(...)\n ```\n2. Create a Pattern Firing AAD rule with pattern `(a - a -)`\n3. Run the rule 4 times\n4. Observe: 1 active alert + 1 recovered alert — the active alert is\nstuck and never recovers (bug confirmed)\n5. Revert to the fix (active → recovered → delayed priority)\n6. Create the rule again with the same pattern `(a
- a -)` and run 4\ntimes\n7. Observe: 2 recovered alerts — both lifecycles recover
correctly","sha":"1cc65442a7577db35fab769a615b4342d9547665"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261012","number":261012,"mergeCommit":{"message":"Fix alert recovery targeting wrong document when multiple lifecycles exist for same instance ID (#261012)\n\n## Summary\n\n- Fix a bug in `getById` where `buildRecoveredAlerts()` could target a\nstale document from a previous alert lifecycle instead of the current\nactive one, leaving the active alert stuck in \"active\" status\npermanently\n- The root cause was `Object.values(this.all).find()` returning\nwhichever document appeared first in ES query results —\nnon-deterministic when multiple documents share the same\n`kibana.alert.instance.id`\n- The fix changes `getById` to search status-specific dictionaries in\npriority order: active, then recovered, then delayed\n\n### Problem\n\nWhen an alert instance goes through multiple fire/recover cycles, the\n`.alerts-*` data stream accumulates multiple documents for the same\n`kibana.alert.instance.id` (each with a unique `kibana.alert.uuid`).\nDuring `initializeExecution`, `getTrackedAlerts` fetches documents from\nrecent executions and populates `trackedAlerts.all` with both the old\nrecovered document and the current active document.\n\nWhen recovery runs,
`AlertBuilder.buildRecoveredAlerts()`
calls\n`trackedAlerts.getById(instanceId)` to find the document to update. The\nprevious implementation used
`Object.values(this.all).find()`, which\nreturned the first match by insertion order. If the old recovered\ndocument was returned first (e.g., because it resided in an earlier\nbacking index), the recovery update targeted the wrong document —\nupdating the already-recovered document again while leaving the current\nactive document untouched.\n\nThis caused:\n- The active alert document remaining permanently stuck with\n`kibana.alert.status: active`\n- The event log recording the recovery for the correct UUID (from task\nstate), creating a divergence between the alert index and event log\n- UI showing conflicting statuses depending on which data source was\nqueried\n\n### Fix\n\nChanged `getById` to search `active`, `recovered`, and `delayed`\ndictionaries in priority order instead of scanning the unordered `all`\ndictionary. Since `populateTrackedAlerts` already categorizes documents\nby status, this ensures recovery always targets the active document\nfirst.\n\n## Manual verification with pattern firing rule:\n\n1. To reproduce the bug, temporarily change `getById` priority to\n`recovered → active → delayed`:\n ```typescript\n Object.values(this.recovered).find(...) ??\n
Object.values(this.active).find(...) ??\n
Object.values(this.delayed).find(...)\n ```\n2. Create a Pattern Firing AAD rule with pattern `(a - a -)`\n3. Run the rule 4 times\n4. Observe: 1 active alert + 1 recovered alert — the active alert is\nstuck and never recovers (bug confirmed)\n5. Revert to the fix (active → recovered → delayed priority)\n6. Create the rule again with the same pattern `(a
- a -)` and run 4\ntimes\n7. Observe: 2 recovered alerts — both lifecycles recover
correctly","sha":"1cc65442a7577db35fab769a615b4342d9547665"}}]}] BACKPORT-->

---------



