### PR TITLE
[8.19] chore(deps,oas_docs): bump `brace-expansion` to `2.1.1` and `5.0.6` (#274525)

### DIFF
--- a/oas_docs/package-lock.json
+++ b/oas_docs/package-lock.json
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps,oas_docs): bump `brace-expansion` to `2.1.1` and `5.0.6` (#274525)](https://github.com/elastic/kibana/pull/274525)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-06-23T11:19:08Z","message":"chore(deps,oas_docs): bump `brace-expansion` to `2.1.1` and `5.0.6` (#274525)\n\n## Summary\n\nBump `brace-expansion` to `2.1.1` and `5.0.6` in `oas_docs`","sha":"02a4b67979e7b81c3cfa309b02b9228d7816df6d","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"chore(deps,oas_docs): bump `brace-expansion` to `2.1.1` and `5.0.6`","number":274525,"url":"https://github.com/elastic/kibana/pull/274525","mergeCommit":{"message":"chore(deps,oas_docs): bump `brace-expansion` to `2.1.1` and `5.0.6` (#274525)\n\n## Summary\n\nBump `brace-expansion` to `2.1.1` and `5.0.6` in `oas_docs`","sha":"02a4b67979e7b81c3cfa309b02b9228d7816df6d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274525","number":274525,"mergeCommit":{"message":"chore(deps,oas_docs): bump `brace-expansion` to `2.1.1` and `5.0.6` (#274525)\n\n## Summary\n\nBump `brace-expansion` to `2.1.1` and `5.0.6` in `oas_docs`","sha":"02a4b67979e7b81c3cfa309b02b9228d7816df6d"}}]}] BACKPORT-->