### PR TITLE
[APM] Show quick-filters and minimap on maximized service map dashboard panel

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -106,6 +106,11 @@ interface GraphProps {
   fullMapHref?: string;
   /** When true, hides minimap, options panel, and navigation actions that don't apply in dashboard embeds. */
   isEmbedded?: boolean;
+  /**
+   * When true, shows the quick-filters toggle/menu and minimap even in embedded mode.
+   * Used by the dashboard embeddable when the panel is maximized in view mode.
+   */
+  showEmbeddedControls?: boolean;
   /** Override for the popover's Focus map button visibility. Defaults to `!isEmbedded`. */
   showFocusMap?: boolean;
   /** Focus button always navigates, even for the currently focused service. */
@@ -150,6 +155,7 @@ function GraphInner({
   onToggleFullscreen,
   fullMapHref,
   isEmbedded = false,
+  showEmbeddedControls = false,
   showFocusMap,
   alwaysNavigateOnPopoverFocus,
   clearKueryOnPopoverNavigation,
@@ -213,6 +219,9 @@ function GraphInner({
     viewFilters.anomalySeverityFilter.length > 0 ||
     searchQuery.trim().length > 0;
   const [panelExpanded, setPanelExpanded] = useState(!isEmbedded);
+  // When the panel is maximized in a dashboard (view mode), we show the quick-filters and minimap
+  // even though we're embedded. In all other embedded states they stay hidden.
+  const showControls = !isEmbedded || showEmbeddedControls;
   const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
     controlledOrientation ?? 'horizontal'
   );
@@ -705,7 +714,7 @@ function GraphInner({
             )}
             <Panel position="top-left" css={topLeftToolbarStyles}>
               <div css={topLeftToolbarColumnStyles}>
-                {!isEmbedded && (
+                {showControls && (
                   <ServiceMapOptionsPanelToggle
                     isExpanded={panelExpanded}
                     onExpandedChange={setPanelExpanded}
@@ -805,7 +814,7 @@ function GraphInner({
                   <ServiceMapLegend controlIconCss={mapToolbarControlIconCss} />
                 </EuiPanel>
               </div>
-              {!isEmbedded && panelExpanded && (
+              {showControls && panelExpanded && (
                 <ServiceMapOptionsPanel
                   nodes={nodesAfterFilters}
                   filterOptionCounts={filterOptionCounts}
@@ -857,7 +866,7 @@ function GraphInner({
                 </EuiPanel>
               </Panel>
             )}
-            {!isEmbedded && <ServiceMapMinimap />}
+            {showControls && <ServiceMapMinimap />}
           </ReactFlow>
           <MapPopover
             selectedNode={selectedNodeForPopover}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -222,6 +222,13 @@ function GraphInner({
   // When the panel is maximized in a dashboard (view mode), we show the quick-filters and minimap
   // even though we're embedded. In all other embedded states they stay hidden.
   const showControls = !isEmbedded || showEmbeddedControls;
+  // Auto-open the quick-filters panel the moment the dashboard panel is maximized so users
+  // immediately discover the controls. The user can still close it manually mid-session.
+  useEffect(() => {
+    if (showEmbeddedControls) {
+      setPanelExpanded(true);
+    }
+  }, [showEmbeddedControls]);
   const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
     controlledOrientation ?? 'horizontal'
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx
@@ -256,6 +256,18 @@ describe('ServiceMapGraph - MiniMap', () => {
       expect(screen.getByTestId('serviceMapMinimap')).toBeInTheDocument();
       expect(screen.getByTestId('serviceMapOptionsPanelToggle')).toBeInTheDocument();
     });
+
+    it('auto-expands the quick-filters panel when maximized so users immediately see the controls', () => {
+      render(
+        <ReactFlowProvider>
+          <ServiceMapGraph {...defaultProps} isEmbedded showEmbeddedControls />
+        </ReactFlowProvider>
+      );
+
+      // The options panel itself (not just the toggle) should be visible without the user
+      // having to click anything.
+      expect(screen.getByTestId('serviceMapOptionsPanel')).toBeInTheDocument();
+    });
   });
 
   describe('nodeColor', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx
@@ -234,6 +234,30 @@ describe('ServiceMapGraph - MiniMap', () => {
     expect(reactFlow).toContainElement(background);
   });
 
+  describe('when isEmbedded', () => {
+    it('hides the minimap and options toggle in a normal embedded panel', () => {
+      render(
+        <ReactFlowProvider>
+          <ServiceMapGraph {...defaultProps} isEmbedded />
+        </ReactFlowProvider>
+      );
+
+      expect(screen.queryByTestId('serviceMapMinimap')).toBeNull();
+      expect(screen.queryByTestId('serviceMapOptionsPanelToggle')).toBeNull();
+    });
+
+    it('shows the minimap and options toggle when the panel is maximized (showEmbeddedControls)', () => {
+      render(
+        <ReactFlowProvider>
+          <ServiceMapGraph {...defaultProps} isEmbedded showEmbeddedControls />
+        </ReactFlowProvider>
+      );
+
+      expect(screen.getByTestId('serviceMapMinimap')).toBeInTheDocument();
+      expect(screen.getByTestId('serviceMapOptionsPanelToggle')).toBeInTheDocument();
+    });
+  });
+
   describe('nodeColor', () => {
     it('returns primary color for service nodes without anomaly stats', () => {
       render(

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
@@ -63,6 +63,11 @@ export interface ServiceMapEmbeddableProps {
   parentQuery?: Query | AggregateQuery;
   viewFilters?: ServiceMapViewFilters;
   onViewFiltersChange?: (next: ServiceMapViewFilters) => void;
+  /**
+   * When true, shows the quick-filters toggle/menu and minimap even though this is an embed.
+   * Set by the dashboard embeddable factory when the panel is maximized in view mode.
+   */
+  showEmbeddedControls?: boolean;
 }
 
 function LoadingSpinner() {
@@ -98,6 +103,7 @@ export function ServiceMapEmbeddable({
   parentQuery,
   viewFilters,
   onViewFiltersChange,
+  showEmbeddedControls,
 }: ServiceMapEmbeddableProps) {
   const license = useLicenseContext();
   const { config } = useApmPluginContext();
@@ -338,6 +344,7 @@ export function ServiceMapEmbeddable({
           isFullscreen={false}
           fullMapHref={fullMapHref}
           isEmbedded
+          showEmbeddedControls={showEmbeddedControls}
           showFocusMap={showFocusMapInPopover}
           alwaysNavigateOnPopoverFocus={alwaysNavigateOnPopoverFocus}
           clearKueryOnPopoverNavigation={clearKueryOnPopoverNavigation}

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { BehaviorSubject, Subject } from 'rxjs';
 import {
   ENVIRONMENT_ALL,
@@ -36,6 +36,11 @@ jest.mock('@kbn/presentation-publishing', () => ({
   timeRangeComparators: { time_range: 'deepEquality' },
   useBatchedPublishingSubjects: (...args: unknown[]) => mockUseBatchedPublishingSubjects(...args),
   useFetchContext: (...args: unknown[]) => mockUseFetchContext(...args),
+  apiHasParentApi: (api: unknown) =>
+    Boolean((api as { parentApi?: unknown } | null)?.parentApi !== undefined),
+  apiCanExpandPanels: (api: unknown) =>
+    Boolean((api as { expandPanel?: unknown } | null)?.expandPanel !== undefined),
+  getViewModeSubject: (api: unknown) => (api as { viewMode$?: unknown } | null)?.viewMode$,
 }));
 
 jest.mock('../embeddable_context', () => ({
@@ -517,6 +522,138 @@ describe('getServiceMapEmbeddableFactory', () => {
       const api = await buildEmbeddableWithApi({});
 
       expect(api.filters$.getValue()).toHaveLength(0);
+    });
+  });
+
+  describe('showEmbeddedControls', () => {
+    function buildWithExpandableParent(uuid: string, viewMode: 'view' | 'edit' = 'view') {
+      const expandedPanelId$ = new BehaviorSubject<string | undefined>(undefined);
+      const viewMode$ = new BehaviorSubject<string>(viewMode);
+      const parentApi = {
+        query$: new BehaviorSubject({ query: '' }),
+        expandPanel: jest.fn(),
+        expandedPanelId$,
+        viewMode$,
+      };
+      const finalizeApi = jest.fn((apiRegistration: Record<string, unknown>) => ({
+        ...apiRegistration,
+        parentApi,
+      }));
+      const factory = getServiceMapEmbeddableFactory({
+        coreStart: {},
+      } as unknown as EmbeddableDeps);
+
+      return { expandedPanelId$, factory, finalizeApi, parentApi, uuid };
+    }
+
+    it('is false when the panel is not expanded', async () => {
+      const uuid = 'panel-not-expanded';
+      const {
+        expandedPanelId$: _,
+        factory,
+        finalizeApi,
+        parentApi,
+      } = buildWithExpandableParent(uuid);
+
+      const embeddable = await factory.buildEmbeddable({
+        initialState: {},
+        finalizeApi,
+        uuid,
+        parentApi,
+        initializeDrilldownsManager: jest.fn(),
+      } as never);
+
+      render(<embeddable.Component />);
+
+      expect(mockServiceMapEmbeddable).toHaveBeenCalledWith(
+        expect.objectContaining({ showEmbeddedControls: false })
+      );
+    });
+
+    it('becomes true when expandedPanelId$ emits this panel uuid in view mode', async () => {
+      const uuid = 'panel-maximize-view';
+      const { expandedPanelId$, factory, finalizeApi, parentApi } = buildWithExpandableParent(
+        uuid,
+        'view'
+      );
+
+      const embeddable = await factory.buildEmbeddable({
+        initialState: {},
+        finalizeApi,
+        uuid,
+        parentApi,
+        initializeDrilldownsManager: jest.fn(),
+      } as never);
+
+      render(<embeddable.Component />);
+
+      act(() => {
+        expandedPanelId$.next(uuid);
+      });
+
+      expect(mockServiceMapEmbeddable).toHaveBeenLastCalledWith(
+        expect.objectContaining({ showEmbeddedControls: true })
+      );
+    });
+
+    it('stays false when panel is expanded but dashboard is in edit mode', async () => {
+      const uuid = 'panel-maximize-edit';
+      const { expandedPanelId$, factory, finalizeApi, parentApi } = buildWithExpandableParent(
+        uuid,
+        'edit'
+      );
+
+      const embeddable = await factory.buildEmbeddable({
+        initialState: {},
+        finalizeApi,
+        uuid,
+        parentApi,
+        initializeDrilldownsManager: jest.fn(),
+      } as never);
+
+      render(<embeddable.Component />);
+
+      act(() => {
+        expandedPanelId$.next(uuid);
+      });
+
+      expect(mockServiceMapEmbeddable).toHaveBeenLastCalledWith(
+        expect.objectContaining({ showEmbeddedControls: false })
+      );
+    });
+
+    it('resets to false when panel collapses again', async () => {
+      const uuid = 'panel-collapse';
+      const { expandedPanelId$, factory, finalizeApi, parentApi } = buildWithExpandableParent(
+        uuid,
+        'view'
+      );
+
+      const embeddable = await factory.buildEmbeddable({
+        initialState: {},
+        finalizeApi,
+        uuid,
+        parentApi,
+        initializeDrilldownsManager: jest.fn(),
+      } as never);
+
+      render(<embeddable.Component />);
+
+      act(() => {
+        expandedPanelId$.next(uuid);
+      });
+
+      expect(mockServiceMapEmbeddable).toHaveBeenLastCalledWith(
+        expect.objectContaining({ showEmbeddedControls: true })
+      );
+
+      act(() => {
+        expandedPanelId$.next(undefined);
+      });
+
+      expect(mockServiceMapEmbeddable).toHaveBeenLastCalledWith(
+        expect.objectContaining({ showEmbeddedControls: false })
+      );
     });
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -5,17 +5,22 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
 import type { EmbeddablePublicDefinition } from '@kbn/embeddable-plugin/public';
 import type {
+  CanExpandPanels,
   HasEditCapabilities,
   PublishesBlockingError,
   PublishesUnifiedSearch,
+  ViewMode,
 } from '@kbn/presentation-publishing';
 import {
+  apiCanExpandPanels,
+  apiHasParentApi,
+  getViewModeSubject,
   initializeStateManager,
   initializeTimeRangeManager,
   initializeTitleManager,
@@ -119,6 +124,9 @@ function buildQueryFromKuery(kuery: string | undefined): Query | undefined {
   }
   return { query: trimmed, language: 'kuery' };
 }
+
+const NO_EXPANDED_PANEL$ = new BehaviorSubject<string | undefined>(undefined);
+const DEFAULT_VIEW_MODE$ = new BehaviorSubject<ViewMode>('view');
 
 export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
   const factory: EmbeddablePublicDefinition<ServiceMapEmbeddableState, ServiceMapEmbeddableApi> = {
@@ -242,6 +250,13 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
         },
       });
 
+      // Precompute stable subject references for panel-maximized and view-mode detection.
+      const expandedPanelIdSubject =
+        apiHasParentApi(api) && apiCanExpandPanels(api.parentApi)
+          ? (api.parentApi as CanExpandPanels).expandedPanelId$
+          : NO_EXPANDED_PANEL$;
+      const viewModeSubject = getViewModeSubject(api.parentApi) ?? DEFAULT_VIEW_MODE$;
+
       return {
         api,
         Component: () => {
@@ -284,6 +299,20 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
             customStateManager.api.connectionFilter$,
             customStateManager.api.anomalySeverityFilter$
           );
+
+          const [showEmbeddedControls, setShowEmbeddedControls] = useState(
+            () =>
+              expandedPanelIdSubject.getValue() === uuid && viewModeSubject.getValue() !== 'edit'
+          );
+
+          useEffect(() => {
+            const sub = combineLatest([expandedPanelIdSubject, viewModeSubject]).subscribe(
+              ([expandedId, vm]) => {
+                setShowEmbeddedControls(expandedId === uuid && vm !== 'edit');
+              }
+            );
+            return () => sub.unsubscribe();
+          }, []);
 
           const viewFilters = useMemo(
             () =>
@@ -356,6 +385,7 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                   parentQuery={parentQuery}
                   viewFilters={viewFilters}
                   onViewFiltersChange={onViewFiltersChange}
+                  showEmbeddedControls={showEmbeddedControls}
                 />
               </ApmEmbeddableContext>
             </div>


### PR DESCRIPTION
## Summary

- When the APM service map dashboard panel is **maximized** (expanded) and the dashboard is in **view mode**, the quick-filters toggle/menu and minimap are now shown — the same controls available on the full service map page.
- In all other embedded contexts (normal panel size, or edit mode) behaviour is unchanged: controls remain hidden.
- The in-app fullscreen toggle and "Add to dashboard" button stay hidden in all embedded contexts (out of scope).

**How detection works:** the factory subscribes to `expandedPanelId$` and `viewMode$` from the dashboard parent API via a `combineLatest` + `useEffect`. When the emitted panel ID matches the embeddable's own `uuid` and the view mode is not `'edit'`, a `showEmbeddedControls` flag is set and forwarded through `ServiceMapEmbeddable` → `ServiceMapGraph`.

Note: `getViewModeSubject(api.parentApi)` is used (not `api`) because the embeddable registers `onEdit`, which makes `api.viewMode$` always report `'edit'`.

<img width="1917" height="968" alt="image" src="https://github.com/user-attachments/assets/8f3de3fc-288f-45ea-98e7-89f83167c17a" />
<img width="1912" height="718" alt="image" src="https://github.com/user-attachments/assets/4bedc586-982d-4c28-ad0f-1e173999097e" />
<img width="1913" height="728" alt="image" src="https://github.com/user-attachments/assets/b16374d1-0c5d-47a1-8606-a0e83d604565" />
<img width="1918" height="969" alt="image" src="https://github.com/user-attachments/assets/702af2a2-5687-4b42-9c8f-4c476eb0e7d8" />


## Testing

1. Open a dashboard containing the APM Service Map panel in **view mode**.
2. Click the maximize (expand) icon on the panel — the quick-filters toggle button and minimap should appear.
3. Click minimize — both controls should disappear again.
4. Switch the dashboard to **edit mode** and maximize the panel — controls should remain hidden (edit mode guard working correctly).


https://github.com/user-attachments/assets/eaf3b4dd-fab2-4223-9c0e-13c09f8cf62b



## References

Closes #274509