### PR TITLE
[Flaky] Fix bulk_add_to_timeline.cy.ts (fixes #274536)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -61,7 +61,7 @@ import {
   TIMELINE_CONTEXT_MENU_BTN,
   TOOLTIP,
 } from '../screens/alerts';
-import { REFRESH_BUTTON } from '../screens/security_header';
+import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
 import {
   ENRICHMENT_QUERY_END_INPUT,
   ENRICHMENT_QUERY_RANGE_PICKER,
@@ -454,9 +454,10 @@ export const showTopNAlertProperty = (propertySelector: string, rowIndex: number
 export const waitForAlerts = () => {
   waitForPageFilters();
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
-  cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
+  cy.get(LOADING_INDICATOR).should('not.exist');
+  cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -61,7 +61,7 @@ import {
   TIMELINE_CONTEXT_MENU_BTN,
   TOOLTIP,
 } from '../screens/alerts';
-import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
+import { REFRESH_BUTTON } from '../screens/security_header';
 import {
   ENRICHMENT_QUERY_END_INPUT,
   ENRICHMENT_QUERY_RANGE_PICKER,
@@ -456,7 +456,6 @@ export const waitForAlerts = () => {
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
-  cy.get(LOADING_INDICATOR).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };
 


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

Tests failing with:
\`\`\`
AssertionError: Timed out retrying after 150000ms: Expected <span.euiLoadingSpinner> not to exist in the DOM, but it was continuously found.
    at waitForAlerts (webpack:///./tasks/alerts.ts:460:28)
    at waitForAlertsToPopulate (webpack:///./tasks/create_new_rule.ts:919:16)
\`\`\`

The \`globalLoadingIndicator\` element (rendered by Kibana's chrome loading indicator component) tracks **all** \`core.http.fetch()\` calls app-wide — telemetry, capabilities, session pings, entity analytics polls, etc. — not just the alerts search. Waiting for it to disappear with a 150s timeout causes intermittent failures whenever unrelated background HTTP traffic keeps it continuously active in CI.

**Root cause path:**
1. PR #271280 moved \`cy.waitForNetworkIdle\` for the specific alerts endpoint to **before** the loading indicator check, reasoning that a settled network guarantees the spinner is gone. This created a new race: after the 500ms idle window for the specific endpoint, a background request from entity analytics or similar would immediately start — keeping the indicator active for 150+ seconds.
2. Commit \`875720710f50\` (first commit on this branch) reversed that order back to the canonical \`kbn-cypress-test-helper\` ordering (loading indicator before networkIdle). This reduced the failure rate from consistent to ~4% (48/50 in the flaky runner), but did not eliminate it — heavy CI background traffic still hits the 150s retry window.
3. The fix: **remove the loading indicator check entirely.** The remaining checks in \`waitForAlerts\` already ensure the alerts table is fully settled:
   - \`waitForPageFilters\`: filter group and option lists loaded
   - \`REFRESH_BUTTON\`: no pending refresh
   - \`DATAGRID_CHANGES_IN_PROGRESS\`: data grid idle
   - \`EVENT_CONTAINER_TABLE_LOADING\`: alerts container gone
   - \`waitForNetworkIdle\` on the specific alerts endpoint (500ms idle)

The global spinner is redundant for these purposes and harmful because it fails on unrelated HTTP traffic.

**Changes**

- \`875720710f50\` – reorder networkIdle to after loading indicator check (partial fix, reduces but doesn't eliminate flakiness)
- \`HEAD\` – remove redundant \`globalLoadingIndicator\` check and its import from \`waitForAlerts\`

Fixes #274536
Fixes #272791

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The \`release_note:breaking\` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct \`release_note:*\` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable \`backport:*\` labels.

### Identify risks

- **Shared utility change (LOW):** \`waitForAlerts\` is used by ~134 Cypress tests. The global spinner check is removed; the alerts-specific network idle and DOM checks remain. Any test that was relying solely on the global spinner to detect page readiness will now rely on the more specific checks — which is strictly more correct behavior.
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** \`release_note:skip\`