### PR TITLE
[8.19] Upgrade protobufjs to 7.6.4 (#273724)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10759,28 +10759,22 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
   integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
 
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
-  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
-  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
   integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
-
-"@protobufjs/inquire@^1.1.0", "@protobufjs/inquire@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.1.tgz#6cb936f4ac50965230af1e9d0bbfd57ea3675aa4"
-  integrity sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
@@ -24797,7 +24791,7 @@ loglevel@^1.6.0:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.1.tgz#d63976ac9bcd03c7c873116d41c2a85bafff1be7"
   integrity sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==
 
-long@^5.0.0, long@^5.2.0:
+long@^5.0.0, long@^5.2.0, long@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
@@ -28069,22 +28063,21 @@ property-information@^5.0.0, property-information@^5.0.1, property-information@^
     xtend "^4.0.0"
 
 protobufjs@^7.0.0, protobufjs@^7.5.3:
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.8.tgz#51b153a06da6e47153a1aa6800cb1253bc502436"
-  integrity sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.4.tgz#8bb000300026efd63eb7951d26e5dbb38f5658f2"
+  integrity sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
     "@protobufjs/codegen" "^2.0.5"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
     "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.1"
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.1"
     "@types/node" ">=13.7.0"
-    long "^5.0.0"
+    long "^5.3.2"
 
 protocol-buffers-schema@^3.3.1:
   version "3.6.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Upgrade protobufjs to 7.6.4 (#273724)](https://github.com/elastic/kibana/pull/273724)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2026-06-23T08:28:34Z","message":"Upgrade protobufjs to 7.6.4 (#273724)\n\n## Summary\n\nUpgrades the transitive `protobufjs` resolution to `7.6.4` and refreshes\n`yarn.lock`.\n\n### Checklist\n\n- [x] No user-facing text changes\n- [x] No documentation required for this dependency-only security update\n- [x] No unit or functional tests added; dependency resolution only\n- [x] No plugin configuration or HTTP API changes\n- [x] `release_note:skip` and `backport:skip` labels applied\n\n### Identify risks\n\nLow risk. This pins an existing transitive dependency to a patched\nversion.\n\nValidation:\n\n- `yarn kbn bootstrap`\n- `node scripts/check.js --scope=local`\n- `yarn list --pattern protobufjs`\n- `git diff --check`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"374bbe91b8efd65427ee458c4290c0a771d77eb5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.5.0","v9.4.3","v9.3.6"],"title":"Upgrade protobufjs to 7.6.4","number":273724,"url":"https://github.com/elastic/kibana/pull/273724","mergeCommit":{"message":"Upgrade protobufjs to 7.6.4 (#273724)\n\n## Summary\n\nUpgrades the transitive `protobufjs` resolution to `7.6.4` and refreshes\n`yarn.lock`.\n\n### Checklist\n\n- [x] No user-facing text changes\n- [x] No documentation required for this dependency-only security update\n- [x] No unit or functional tests added; dependency resolution only\n- [x] No plugin configuration or HTTP API changes\n- [x] `release_note:skip` and `backport:skip` labels applied\n\n### Identify risks\n\nLow risk. This pins an existing transitive dependency to a patched\nversion.\n\nValidation:\n\n- `yarn kbn bootstrap`\n- `node scripts/check.js --scope=local`\n- `yarn list --pattern protobufjs`\n- `git diff --check`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"374bbe91b8efd65427ee458c4290c0a771d77eb5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273724","number":273724,"mergeCommit":{"message":"Upgrade protobufjs to 7.6.4 (#273724)\n\n## Summary\n\nUpgrades the transitive `protobufjs` resolution to `7.6.4` and refreshes\n`yarn.lock`.\n\n### Checklist\n\n- [x] No user-facing text changes\n- [x] No documentation required for this dependency-only security update\n- [x] No unit or functional tests added; dependency resolution only\n- [x] No plugin configuration or HTTP API changes\n- [x] `release_note:skip` and `backport:skip` labels applied\n\n### Identify risks\n\nLow risk. This pins an existing transitive dependency to a patched\nversion.\n\nValidation:\n\n- `yarn kbn bootstrap`\n- `node scripts/check.js --scope=local`\n- `yarn list --pattern protobufjs`\n- `git diff --check`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"374bbe91b8efd65427ee458c4290c0a771d77eb5"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/274494","number":274494,"state":"MERGED","mergeCommit":{"sha":"29c07fa7671c4f31a33c59a41d04d58e5dcd746f","message":"[9.4] Upgrade protobufjs to 7.6.4 (#273724) (#274494)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Upgrade protobufjs to 7.6.4\n(#273724)](https://github.com/elastic/kibana/pull/273724)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jean-Louis Leysens <jeanlouis.leysens@elastic.co>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}},{"branch":"9.3","label":"v9.3.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/274492","number":274492,"state":"MERGED","mergeCommit":{"sha":"0c5df341980f9715eb144ce9379e58091acfe55c","message":"[9.3] Upgrade protobufjs to 7.6.4 (#273724) (#274492)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Upgrade protobufjs to 7.6.4\n(#273724)](https://github.com/elastic/kibana/pull/273724)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jean-Louis Leysens <jeanlouis.leysens@elastic.co>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}}]}] BACKPORT-->