### PR TITLE
[ES|QL] Uses code-editor instead of monaco at the utils package

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-esql-utils/moon.yml
@@ -29,7 +29,7 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/datemath'
   - '@kbn/es-query'
-  - '@kbn/monaco'
+  - '@kbn/code-editor'
   - '@kbn/core'
   - '@kbn/index-management-shared-types'
   - '@kbn/licensing-types'

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import type { ESQLColumn } from '@elastic/esql/types';
 import { Parser, walk } from '@elastic/esql';
 import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -36,7 +36,7 @@ import type {
 } from '@elastic/esql/types';
 import { type ESQLControlVariable, ESQLVariableType } from '@kbn/esql-types';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 
 const DEFAULT_ESQL_LIMIT = 1000;
 

--- a/src/platform/packages/shared/kbn-esql-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-esql-utils/tsconfig.json
@@ -28,7 +28,7 @@
     "@kbn/i18n",
     "@kbn/datemath",
     "@kbn/es-query",
-    "@kbn/monaco",
+    "@kbn/code-editor",
     "@kbn/core",
     "@kbn/index-management-shared-types",
     "@kbn/licensing-types",


### PR DESCRIPTION
## Summary

A small cleanup as the IDE complains



