### PR TITLE
[One Workflow] Fix Slack API workflow schemas

### DIFF
--- a/docs/reference/connectors-kibana/slack-action-type.md
+++ b/docs/reference/connectors-kibana/slack-action-type.md
@@ -35,22 +35,6 @@ If you use the latter method, you must provide a valid list of Slack channels. D
 
 When you create a rule, each action can communicate with one of the specified channels. For Slack setup details, go to [Configure a Slack account](#configuring-slack).
 
-### Connector configuration [slack-connector-configuration]
-
-Slack connectors have the following configuration properties:
-
-Webhook URL
-:   The incoming webhook URL. This is required for webhook-based Slack connectors.
-
-Bot User OAuth Token
-:   The Slack bot user OAuth token. This is required for Web API Slack connectors.
-
-Allowed channel names
-:   {applies_to}`stack: ga 9.3+` The Slack channel names that the Web API connector can send messages to. Channel names must start with `#`, for example `#alert-notifications`. If you don't specify allowed channels, the connector can send messages to any channel name.
-
-Channel IDs
-:   {applies_to}`stack: ga 9.0-9.2` The Slack channel IDs that the Web API connector can send messages to.
-
 ## Test connectors [slack-action-configuration]
 
 You can test connectors as you're creating or editing the connector in {{kib}}. For the webhook type of connector, its message text cannot contain Markdown, images, or other advanced formatting:
@@ -96,9 +80,7 @@ Validate channel ID
 :   Validate whether a Slack channel ID can be used by the connector.
     - `channelId` (optional): Slack channel ID to validate.
 
-## Workflow examples [slack-workflow-examples]
-
-In workflow YAML, the Slack Web API action is part of the step `type`. Put the action parameters directly under `with`; don't add `subAction` or `subActionParams`.
+## Workflows examples [slack-workflow-examples]
 
 Send a plain text message:
 

--- a/docs/reference/connectors-kibana/slack-action-type.md
+++ b/docs/reference/connectors-kibana/slack-action-type.md
@@ -31,9 +31,25 @@ If you use the latter method, you must provide a valid list of Slack channels. D
 
 - {applies_to}`stack: ga 9.3+` In the **Allowed channel names** field, you can enter up to 500 channels. Channel names must include a `#` at the front, for example: `#alert-notifications`. If you don't specify allowed channels, you can enter any channel name when configuring the Slack action for a rule.
 
-- {applies_to}`stack: ga 9.0-9.2`: In the **Channel IDs** field, enter the names of the Slack channels you want to message.
+- {applies_to}`stack: ga 9.0-9.2`: In the **Channel IDs** field, enter the IDs of the Slack channels you want to message.
 
 When you create a rule, each action can communicate with one of the specified channels. For Slack setup details, go to [Configure a Slack account](#configuring-slack).
+
+### Connector configuration [slack-connector-configuration]
+
+Slack connectors have the following configuration properties:
+
+Webhook URL
+:   The incoming webhook URL. This is required for webhook-based Slack connectors.
+
+Bot User OAuth Token
+:   The Slack bot user OAuth token. This is required for Web API Slack connectors.
+
+Allowed channel names
+:   {applies_to}`stack: ga 9.3+` The Slack channel names that the Web API connector can send messages to. Channel names must start with `#`, for example `#alert-notifications`. If you don't specify allowed channels, the connector can send messages to any channel name.
+
+Channel IDs
+:   {applies_to}`stack: ga 9.0-9.2` The Slack channel IDs that the Web API connector can send messages to.
 
 ## Test connectors [slack-action-configuration]
 
@@ -44,14 +60,90 @@ You can test connectors as you're creating or editing the connector in {{kib}}. 
 :screenshot:
 :::
 
-For the web API type of connector, you must choose one of the channel IDs. You can then test either plain text or block kit messages:
+For the Web API type of connector, you must choose one of the channel IDs or names. You can then test either plain text or Block Kit messages:
 
 :::{image} ../images/slack-api-connector-test.png
 :alt: Slack web API connector test
 :screenshot:
 :::
 
-After you add block kit messages you can click a link to preview them in the Slack block kit builder.
+After you add Block Kit messages, you can click a link to preview them in the Slack Block Kit Builder.
+
+## Action parameters [slack-action-parameters]
+
+Webhook Slack connectors have the following action parameter:
+
+Message
+:   The text to send to the connector's webhook channel.
+
+Web API Slack connectors have the following actions:
+
+Post message
+:   Send a plain text message to a Slack channel.
+    - `channelNames` (optional): Slack channel names. Channel names must start with `#`, for example `#alerts`. Only one channel is supported. Takes priority over `channelIds` and `channels`.
+    - `channelIds` (optional): Slack channel IDs, for example `C123ABC456`. Only one channel is supported.
+    - `channels` (optional, deprecated): Legacy channel values. Use `channelNames` or `channelIds` instead.
+    - `text` (required): Message text.
+
+Post Block Kit
+:   Send a Slack [Block Kit](https://api.slack.com/block-kit) message to a Slack channel.
+    - `channelNames` (optional): Slack channel names. Channel names must start with `#`, for example `#alerts`. Only one channel is supported. Takes priority over `channelIds` and `channels`.
+    - `channelIds` (optional): Slack channel IDs, for example `C123ABC456`. Only one channel is supported.
+    - `channels` (optional, deprecated): Legacy channel values. Use `channelNames` or `channelIds` instead.
+    - `text` (required): A JSON string that contains the Block Kit payload. The JSON object must include a top-level `blocks` property. In workflow YAML, use a block scalar (`|`) when the payload spans multiple lines.
+
+Validate channel ID
+:   Validate whether a Slack channel ID can be used by the connector.
+    - `channelId` (optional): Slack channel ID to validate.
+
+## Workflow examples [slack-workflow-examples]
+
+In workflow YAML, the Slack Web API action is part of the step `type`. Put the action parameters directly under `with`; don't add `subAction` or `subActionParams`.
+
+Send a plain text message:
+
+```yaml
+steps:
+  - name: post_message_to_slack
+    type: slack_api.postMessage
+    connector-id: <connector-id>
+    with:
+      channelNames:
+        - '#alerts'
+      text: 'Workflow finished successfully'
+```
+
+Send a Block Kit message. The `text` field is a JSON string that contains the Slack `blocks` payload:
+
+```yaml
+steps:
+  - name: post_digest_to_slack
+    type: slack_api.postBlockkit
+    connector-id: <connector-id>
+    with:
+      channelIds:
+        - C123ABC456
+      text: |
+        {
+          "blocks": [
+            {
+              "type": "header",
+              "text": {
+                "type": "plain_text",
+                "text": "Daily report",
+                "emoji": true
+              }
+            },
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "*Summary*"
+              }
+            }
+          ]
+        }
+```
 
 ## Connector networking configuration [slack-connector-networking-configuration]
 

--- a/src/platform/packages/shared/kbn-connector-schemas/slack_api/constants.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/slack_api/constants.ts
@@ -14,3 +14,9 @@ export const CONNECTOR_NAME = i18n.translate('connectors.slackApi.title', {
 });
 
 export const SLACK_URL = 'https://slack.com/api/';
+
+export enum SUB_ACTION {
+  VALID_CHANNEL_ID = 'validChannelId',
+  POST_MESSAGE = 'postMessage',
+  POST_BLOCKKIT = 'postBlockkit',
+}

--- a/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
@@ -8,6 +8,11 @@
  */
 
 import {
+  PostBlockkitSubActionParamsSchema as SlackApiPostBlockkitParamsSchema,
+  PostMessageSubActionParamsSchema as SlackApiPostMessageParamsSchema,
+  ValidChannelIdSubActionParamsSchema as SlackApiValidChannelIdParamsSchema,
+} from '@kbn/connector-schemas/slack_api';
+import {
   XSOARPlaybooksActionResponseSchema,
   XSOARRunActionParamsSchema,
   XSOARRunActionResponseSchema,
@@ -100,9 +105,6 @@ import {
   ServiceNowGetIncidentParamsSchema,
   ServiceNowIncidentResponseSchema,
   ServiceNowUpdateIncidentParamsSchema,
-  SlackApiGetChannelsParamsSchema,
-  SlackApiGetUsersParamsSchema,
-  SlackApiPostMessageParamsSchema,
   SlackApiResponseSchema,
   SlackParamsSchema,
   SlackResponseSchema,
@@ -236,9 +238,9 @@ export const ConnectorActionInputSchemas = new Map<string, Record<string, z.ZodS
   [
     '.slack_api',
     {
+      validChannelId: SlackApiValidChannelIdParamsSchema,
       postMessage: SlackApiPostMessageParamsSchema,
-      getChannels: SlackApiGetChannelsParamsSchema,
-      getUsers: SlackApiGetUsersParamsSchema,
+      postBlockkit: SlackApiPostBlockkitParamsSchema,
     },
   ],
   [
@@ -401,9 +403,9 @@ export const ConnectorActionOutputSchemas = new Map<string, Record<string, z.Zod
   [
     '.slack_api',
     {
+      validChannelId: SlackApiResponseSchema,
       postMessage: SlackApiResponseSchema,
-      getChannels: SlackApiResponseSchema,
-      getUsers: SlackApiResponseSchema,
+      postBlockkit: SlackApiResponseSchema,
     },
   ],
   [

--- a/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
@@ -40,6 +40,10 @@ import {
   SUB_ACTION as OpsgenieSubActions,
 } from '@kbn/connector-schemas/opsgenie/constants';
 import {
+  CONNECTOR_ID as SLACK_API_CONNECTOR_ID,
+  SUB_ACTION as SLACK_API_SUB_ACTION,
+} from '@kbn/connector-schemas/slack_api/constants';
+import {
   CONNECTOR_ID as THEHIVE_CONNECTOR_ID,
   SUB_ACTION as THEHIVE_SUB_ACTION,
 } from '@kbn/connector-schemas/thehive/constants';
@@ -125,6 +129,7 @@ function createSubActionsMapping() {
     { id: JIRA_SERVICE_MANAGEMENT_CONNECTOR_TYPE_ID, actions: JiraServiceManagementSubActions },
     { id: OpsgenieConnectorTypeId, actions: OpsgenieSubActions },
     { id: MCP_CONNECTOR_ID, actions: MCP_SUB_ACTION },
+    { id: SLACK_API_CONNECTOR_ID, actions: SLACK_API_SUB_ACTION },
     // Legacy connectors (using older ActionType pattern)
     { id: '.jira', actions: JIRA_SUB_ACTIONS },
     { id: '.servicenow-itsm', actions: SERVICENOW_ITSM_SUB_ACTIONS },

--- a/src/platform/plugins/shared/workflows_management/common/schema_additional.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema_additional.test.ts
@@ -9,6 +9,7 @@
 
 import { getWorkflowJsonSchema, isDynamicConnector, StepCategory } from '@kbn/workflows';
 import { z } from '@kbn/zod/v4';
+import { CONNECTOR_SUB_ACTIONS_MAP } from './connector_sub_actions_map';
 import {
   createMockConnectorInstance,
   createMockConnectorTypeInfo,
@@ -361,6 +362,43 @@ describe('schema - additional coverage', () => {
         isRuleSeverity: false,
         body: null,
       });
+    });
+
+    it('should create Slack API sub-action contracts that accept flat workflow params', () => {
+      const types = {
+        '.slack_api': createMockConnectorTypeInfo({
+          actionTypeId: '.slack_api',
+          displayName: 'Slack API',
+          subActions: CONNECTOR_SUB_ACTIONS_MAP['.slack_api'],
+        }),
+      };
+
+      const contracts = convertDynamicConnectorsToContracts(types);
+
+      expect(contracts.map((contract) => contract.type)).toEqual([
+        'slack_api.validChannelId',
+        'slack_api.postMessage',
+        'slack_api.postBlockkit',
+      ]);
+
+      const schema = getWorkflowZodSchema(types);
+      expect(() =>
+        schema.parse({
+          name: 'slack api workflow',
+          triggers: [{ type: 'manual' }],
+          steps: [
+            {
+              name: 'post_digest_to_slack',
+              type: 'slack_api.postBlockkit',
+              'connector-id': 'slackybot',
+              with: {
+                channelNames: ['#triage'],
+                text: JSON.stringify({ blocks: [] }),
+              },
+            },
+          ],
+        })
+      ).not.toThrow();
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/index.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/index.ts
@@ -114,12 +114,7 @@ export {
 } from './cases_webhook';
 
 // Slack API connector schemas
-export {
-  SlackApiPostMessageParamsSchema,
-  SlackApiGetChannelsParamsSchema,
-  SlackApiGetUsersParamsSchema,
-  SlackApiResponseSchema,
-} from './slack_api';
+export { SlackApiResponseSchema } from './slack_api';
 
 // Tines connector schemas
 export {

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/slack_api.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/slack_api.ts
@@ -14,27 +14,6 @@
 
 import { z } from '@kbn/zod/v4';
 
-// Slack API connector parameter schemas for different sub-actions
-export const SlackApiPostMessageParamsSchema = z.object({
-  channels: z.array(z.string()),
-  text: z.string(),
-  blocks: z.array(z.any()).optional(),
-  attachments: z.array(z.any()).optional(),
-  thread_ts: z.string().optional(),
-  unfurl_links: z.boolean().optional(),
-  unfurl_media: z.boolean().optional(),
-});
-
-export const SlackApiGetChannelsParamsSchema = z.object({
-  types: z.string().optional(),
-  exclude_archived: z.boolean().optional(),
-  limit: z.number().optional(),
-});
-
-export const SlackApiGetUsersParamsSchema = z.object({
-  limit: z.number().optional(),
-});
-
 // Slack API connector response schema
 export const SlackApiResponseSchema = z.object({
   ok: z.boolean(),


### PR DESCRIPTION
TL;DR: Fix Slack API workflow steps to use flat `with` params for sub-actions and document the workflow shape.

Why it was broken: Slack API was missing from the workflows sub-action mapping, so workflows exposed the raw connector params (`subAction` and `subActionParams`) instead of `slack_api.postMessage` / `slack_api.postBlockkit` step types.

Made with [Cursor](https://cursor.com)