### PR TITLE
test(alerting-v2): add Scout UI tests for threshold rule builder

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -49,6 +49,7 @@ import { QuerySandboxFlyout } from './query_sandbox_flyout';
 import { isAlertTabDisabled } from './compose_discover_tabs';
 import { RULE_BUILDER_REGISTRY, BuilderStateProvider, type BuilderState } from './rule_builder';
 import type { ComposeDiscoverMode, QueryTab, RecoveryType } from './types';
+import { isBuilderConditionStepId } from './types';
 import { getSandboxTabs, useComposeDiscoverState } from './use_compose_discover_state';
 import { useEsqlAutocomplete } from './use_esql_providers';
 import {
@@ -249,7 +250,6 @@ export function ComposeDiscoverFlyout({
     mode: mode === 'clone' ? 'edit' : mode,
     initialKind,
     initialRecoveryType: hasInitialCustomRecovery ? 'custom' : 'default',
-    isBuilderMode,
     isQueryPrePopulated: isDiscoverQueryComplete,
     forceYamlMode,
   });
@@ -792,13 +792,14 @@ export function ComposeDiscoverFlyout({
       const valid = await currentStep.validate(methods, uiState, baseServices, builderState);
       if (!valid) return;
     }
-    dispatch({ type: 'GO_NEXT', isAlert });
+    dispatch({ type: 'GO_NEXT', isAlert, isBuilderMode });
   }, [
     hasValidationErrors,
     currentStep,
     methods,
     uiState,
     isAlert,
+    isBuilderMode,
     dispatch,
     baseServices,
     builderState,
@@ -822,6 +823,13 @@ export function ComposeDiscoverFlyout({
     handleSubmit,
     hasValidationErrors,
   ]);
+
+  // Builder step validate is always synchronous (wraps definition.validate which returns boolean).
+  const isBuilderStepValid = useMemo(() => {
+    if (!currentStep || !isBuilderConditionStepId(currentStep.id) || !currentStep.validate)
+      return true;
+    return currentStep.validate(methods, uiState, baseServices, builderState) as boolean;
+  }, [currentStep, methods, uiState, baseServices, builderState]);
 
   const validationCallout = hasValidationErrors ? (
     <>
@@ -1029,6 +1037,8 @@ export function ComposeDiscoverFlyout({
               isCreate={isCreate}
               hasValidationErrors={hasValidationErrors}
               yamlHasErrors={yamlHasErrors}
+              isBuilderMode={isBuilderMode}
+              isBuilderStepValid={isBuilderStepValid}
               isSaving={isSaving}
               onNext={handleNext}
               onFinalSubmit={handleFinalSubmit}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.test.tsx
@@ -20,6 +20,12 @@ const ALERT_CONDITION_STEP: StepDefinition = {
   render: () => null,
 };
 
+const BUILDER_CONDITION_STEP: StepDefinition = {
+  id: 'builderCondition',
+  title: 'Alert Condition',
+  render: () => null,
+};
+
 const DETAILS_STEP: StepDefinition = {
   id: 'details',
   title: 'Details & Artifacts',
@@ -81,6 +87,8 @@ const renderFooter = ({
     isCreate: true,
     hasValidationErrors: false,
     yamlHasErrors: false,
+    isBuilderMode: false,
+    isBuilderStepValid: true,
     isSaving: false,
     onNext,
     onFinalSubmit,
@@ -159,7 +167,7 @@ describe('ComposeDiscoverFooter', () => {
     it('dispatches GO_BACK when Back is clicked', () => {
       const { dispatch } = renderFooter({ stateOverrides: { step: 1 } });
       fireEvent.click(screen.getByTestId('composeDiscoverBack'));
-      expect(dispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'GO_BACK', isBuilderMode: false });
     });
   });
 
@@ -349,6 +357,42 @@ describe('ComposeDiscoverFooter', () => {
     it('disables Back when child flyout is open', () => {
       renderFooter({ stateOverrides: { step: 1, childOpen: true } });
       expect(screen.getByTestId('composeDiscoverBack')).toBeDisabled();
+    });
+  });
+
+  describe('Builder mode validation', () => {
+    it('disables Next when isBuilderStepValid is false', () => {
+      renderFooter({
+        propsOverrides: {
+          currentStep: BUILDER_CONDITION_STEP,
+          isBuilderMode: true,
+          isBuilderStepValid: false,
+        },
+      });
+      expect(screen.getByTestId('composeDiscoverNext')).toBeDisabled();
+    });
+
+    it('enables Next when isBuilderStepValid is true', () => {
+      renderFooter({
+        propsOverrides: {
+          currentStep: BUILDER_CONDITION_STEP,
+          isBuilderMode: true,
+          isBuilderStepValid: true,
+        },
+      });
+      expect(screen.getByTestId('composeDiscoverNext')).not.toBeDisabled();
+    });
+
+    it('does not block Next due to childOpen in builder mode', () => {
+      renderFooter({
+        stateOverrides: { childOpen: true },
+        propsOverrides: {
+          currentStep: BUILDER_CONDITION_STEP,
+          isBuilderMode: true,
+          isBuilderStepValid: true,
+        },
+      });
+      expect(screen.getByTestId('composeDiscoverNext')).not.toBeDisabled();
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.tsx
@@ -17,7 +17,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { useWatch } from 'react-hook-form';
 import type { ComposeDiscoverAction, ComposeDiscoverState, StepDefinition } from './types';
-import { isAlertConditionStepId } from './types';
+import { isAlertConditionStepId, isBuilderConditionStepId } from './types';
 import type { ComposeFormValues } from './compose_form_types';
 import { getBreachQuery } from './compose_form_types';
 import { getEsqlSummaryState } from './compose_discover_form/esql_query_summary_section';
@@ -78,6 +78,8 @@ export interface ComposeDiscoverFooterProps {
   isCreate: boolean;
   hasValidationErrors: boolean;
   yamlHasErrors: boolean;
+  isBuilderMode: boolean;
+  isBuilderStepValid: boolean;
   isSaving: boolean;
   onNext: () => void;
   onFinalSubmit: () => void;
@@ -94,6 +96,8 @@ export const ComposeDiscoverFooter = ({
   isCreate,
   hasValidationErrors,
   yamlHasErrors,
+  isBuilderMode,
+  isBuilderStepValid,
   isSaving,
   onNext,
   onFinalSubmit,
@@ -104,6 +108,7 @@ export const ComposeDiscoverFooter = ({
   const isAlert = useWatch<ComposeFormValues, 'kind'>({ name: 'kind' }) === 'alert';
   const watchedQuery = useWatch<ComposeFormValues, 'query'>({ name: 'query' });
 
+  const isBuilderStep = currentStep ? isBuilderConditionStepId(currentStep.id) : false;
   const isConditionStep = currentStep ? isAlertConditionStepId(currentStep.id) : false;
 
   /*
@@ -126,9 +131,10 @@ export const ComposeDiscoverFooter = ({
     alertConditionState !== undefined && alertConditionState !== 'success';
 
   const nextDisabled =
-    uiState.childOpen ||
+    (!isBuilderMode && uiState.childOpen) ||
     hasValidationErrors ||
-    (isConditionStep && !uiState.queryCommitted) ||
+    (isConditionStep && !isBuilderStep && !uiState.queryCommitted) ||
+    (isBuilderStep && !isBuilderStepValid) ||
     invalidAlertCondition;
 
   const getNextTooltip = (): string | undefined => {
@@ -206,8 +212,8 @@ export const ComposeDiscoverFooter = ({
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
                   iconType="arrowLeft"
-                  isDisabled={uiState.childOpen}
-                  onClick={() => dispatch({ type: 'GO_BACK' })}
+                  isDisabled={!isBuilderMode && uiState.childOpen}
+                  onClick={() => dispatch({ type: 'GO_BACK', isBuilderMode })}
                   data-test-subj="composeDiscoverBack"
                 >
                   {BACK_BUTTON_LABEL}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx
@@ -404,4 +404,27 @@ describe('shell shared fields', () => {
 
     expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
   });
+
+  it('disables ModeSelect in edit mode', () => {
+    const services = { ...createMockServices(), dashboard: mockDashboard };
+    render(
+      <ComposeDiscoverForm
+        state={createState({ queryCommitted: true, step: 0 })}
+        dispatch={jest.fn()}
+        services={services}
+        onRecoveryTypeChange={jest.fn()}
+        onKindChange={jest.fn()}
+        isEditing={true}
+      />,
+      { wrapper: createComposeFormWrapper({ ...BASE_COMPOSE_VALUES }, services) }
+    );
+
+    expect(screen.getByTestId('composeDiscoverModeSelect')).toBeDisabled();
+  });
+
+  it('enables ModeSelect in create mode when query is committed', () => {
+    renderShell({ step: 0, queryCommitted: true });
+
+    expect(screen.getByTestId('composeDiscoverModeSelect')).not.toBeDisabled();
+  });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.test.tsx
@@ -247,4 +247,284 @@ describe('RuleBuilderAlertConditionStep', () => {
 
     expect(screen.getByText('Field is required.')).toBeInTheDocument();
   });
+
+  it('adds a second stat and shows remove buttons for both', () => {
+    let builderState = makeBuilderState();
+    const onBuilderStateChange = jest.fn((next: ThresholdFormValues) => {
+      builderState = next;
+    });
+
+    const { rerender } = render(
+      <Wrapper builderState={builderState} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderStatAgg-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('ruleBuilderStatAgg-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ruleBuilderRemoveStat-0')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ruleBuilderAddStat'));
+    const afterAdd = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+    expect(afterAdd.stats).toHaveLength(2);
+
+    rerender(
+      <Wrapper builderState={afterAdd} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderStatAgg-1')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleBuilderRemoveStat-0')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleBuilderRemoveStat-1')).toBeInTheDocument();
+  });
+
+  it('adds and removes alert conditions with operator toggle', () => {
+    let builderState = makeBuilderState();
+    const onBuilderStateChange = jest.fn((next: ThresholdFormValues) => {
+      builderState = next;
+    });
+
+    const { rerender } = render(
+      <Wrapper builderState={builderState} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderConditionMetric-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('ruleBuilderConditionMetric-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ruleBuilderConditionOperator')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ruleBuilderAddCondition'));
+    const afterAdd = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+    expect(afterAdd.alertConditions).toHaveLength(2);
+
+    rerender(
+      <Wrapper builderState={afterAdd} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderConditionMetric-1')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleBuilderConditionOperator')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ruleBuilderRemoveCondition-1'));
+    const afterRemove = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+    expect(afterRemove.alertConditions).toHaveLength(1);
+
+    rerender(
+      <Wrapper builderState={afterRemove} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('ruleBuilderConditionOperator')).not.toBeInTheDocument();
+  });
+
+  it('adds and removes evaluations and reflects label in condition metric dropdown', () => {
+    let builderState = makeBuilderState();
+    const onBuilderStateChange = jest.fn((next: ThresholdFormValues) => {
+      builderState = next;
+    });
+
+    const { rerender } = render(
+      <Wrapper builderState={builderState} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('ruleBuilderEvalLabel-0')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ruleBuilderAddEvaluation'));
+    const afterAdd = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+    expect(afterAdd.evaluations).toHaveLength(1);
+
+    rerender(
+      <Wrapper builderState={afterAdd} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderEvalLabel-0')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleBuilderEvalExpression-0')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('ruleBuilderEvalLabel-0'), {
+      target: { value: 'error_rate' },
+    });
+    const afterLabel = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+
+    rerender(
+      <Wrapper builderState={afterLabel} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    const metricSelect = screen.getByTestId('ruleBuilderConditionMetric-0');
+    const options = Array.from(metricSelect.querySelectorAll('option'));
+    expect(options.some((o) => o.textContent === 'error_rate')).toBe(true);
+
+    fireEvent.click(screen.getByTestId('ruleBuilderRemoveEval-0'));
+    const afterRemove = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+    expect(afterRemove.evaluations).toHaveLength(0);
+  });
+
+  it('sets and displays filter input value', () => {
+    const onBuilderStateChange = jest.fn();
+    const builderState = makeBuilderState();
+
+    render(
+      <Wrapper builderState={builderState} onBuilderStateChange={onBuilderStateChange}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    const filterInput = screen.getByTestId('ruleBuilderFilter');
+    fireEvent.change(filterInput, { target: { value: 'host.name == "api"' } });
+
+    expect(onBuilderStateChange).toHaveBeenCalled();
+    const call = onBuilderStateChange.mock.calls.at(-1)?.[0] as ThresholdFormValues;
+    expect(call.filterQuery).toBe('host.name == "api"');
+  });
+
+  it('shows stat field combo box when aggregation requires a field', () => {
+    const builderState = makeBuilderState({
+      stats: [
+        { id: 'stat-1', label: 'avg_latency', aggregation: Aggregation.AVG, field: undefined },
+      ],
+    });
+
+    render(
+      <Wrapper builderState={builderState} onBuilderStateChange={jest.fn()}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderStatField-0')).toBeInTheDocument();
+  });
+
+  it('hides stat field combo box for COUNT aggregation', () => {
+    const builderState = makeBuilderState();
+
+    render(
+      <Wrapper builderState={builderState} onBuilderStateChange={jest.fn()}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('ruleBuilderStatField-0')).not.toBeInTheDocument();
+  });
+
+  it('shows second threshold input for between comparator and hides it for single comparator', () => {
+    const builderState = makeBuilderState({
+      alertConditions: [
+        { id: 'cond-1', metric: 'count', comparator: Comparator.BETWEEN, threshold: [10, 50] },
+      ],
+    });
+
+    const { rerender } = render(
+      <Wrapper builderState={builderState} onBuilderStateChange={jest.fn()}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderConditionThresholdTo-0')).toBeInTheDocument();
+
+    const singleComparator = makeBuilderState({
+      alertConditions: [
+        { id: 'cond-1', metric: 'count', comparator: Comparator.GT, threshold: [100] },
+      ],
+    });
+
+    rerender(
+      <Wrapper builderState={singleComparator} onBuilderStateChange={jest.fn()}>
+        <RuleBuilderAlertConditionStep
+          state={createState()}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('ruleBuilderConditionThresholdTo-0')).not.toBeInTheDocument();
+  });
+
+  it('disables preview button when childOpen is true', () => {
+    const builderState = makeBuilderState();
+
+    render(
+      <Wrapper builderState={builderState} onBuilderStateChange={jest.fn()}>
+        <RuleBuilderAlertConditionStep
+          state={createState({ childOpen: true })}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderOpenPreview')).toBeDisabled();
+  });
+
+  it('enables preview button when childOpen is false', () => {
+    const builderState = makeBuilderState();
+
+    render(
+      <Wrapper builderState={builderState} onBuilderStateChange={jest.fn()}>
+        <RuleBuilderAlertConditionStep
+          state={createState({ childOpen: false })}
+          dispatch={dispatch}
+          services={createMockServices()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('ruleBuilderOpenPreview')).not.toBeDisabled();
+  });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
@@ -27,6 +27,8 @@ export type StepId =
 export const isAlertConditionStepId = (id: StepId): boolean =>
   id === 'alertCondition' || id === 'builderCondition';
 
+export const isBuilderConditionStepId = (id: StepId): boolean => id === 'builderCondition';
+
 export interface CustomRecoveryRenderProps {
   state: ComposeDiscoverState;
   dispatch: React.Dispatch<ComposeDiscoverAction>;
@@ -81,8 +83,8 @@ export type ComposeDiscoverAction =
   | { type: 'KIND_CHANGE'; kind: 'signal' | 'alert' }
   | { type: 'SET_TAB'; tab: QueryTab }
   | { type: 'SET_STEP'; step: number }
-  | { type: 'GO_NEXT'; isAlert: boolean }
-  | { type: 'GO_BACK' }
+  | { type: 'GO_NEXT'; isAlert: boolean; isBuilderMode?: boolean }
+  | { type: 'GO_BACK'; isBuilderMode?: boolean }
   | { type: 'OPEN_CHILD'; isAlert: boolean }
   | { type: 'OPEN_CHILD_FOR_STEP'; step: number; isAlert: boolean }
   | { type: 'CLOSE_CHILD' }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
@@ -72,8 +72,8 @@ describe('createInitialState', () => {
     expect(withSignal.recoveryType).toBe('default');
   });
 
-  it('opens the query preview in builder create mode', () => {
-    const state = createInitialState({ mode: 'create', isBuilderMode: true });
+  it('opens the query preview in create mode', () => {
+    const state = createInitialState({ mode: 'create' });
 
     expect(state.childOpen).toBe(true);
     expect(state.queryCommitted).toBe(false);
@@ -194,6 +194,50 @@ describe('reducer', () => {
 
       expect(next.yamlMode).toBe(false);
       expect(next.childOpen).toBe(false);
+    });
+  });
+
+  describe('GO_NEXT', () => {
+    it('closes preview when advancing in non-builder mode', () => {
+      const state = createState({ step: 0, childOpen: true });
+      const next = reducer(state, { type: 'GO_NEXT', isAlert: true });
+
+      expect(next.step).toBe(1);
+      expect(next.childOpen).toBe(false);
+    });
+
+    it('preserves preview state when advancing in builder mode', () => {
+      const state = createState({ step: 0, childOpen: true });
+      const next = reducer(state, { type: 'GO_NEXT', isAlert: true, isBuilderMode: true });
+
+      expect(next.step).toBe(1);
+      expect(next.childOpen).toBe(true);
+    });
+
+    it('keeps preview closed if user closed it in builder mode', () => {
+      const state = createState({ step: 0, childOpen: false });
+      const next = reducer(state, { type: 'GO_NEXT', isAlert: true, isBuilderMode: true });
+
+      expect(next.step).toBe(1);
+      expect(next.childOpen).toBe(false);
+    });
+  });
+
+  describe('GO_BACK', () => {
+    it('closes preview when going back in non-builder mode', () => {
+      const state = createState({ step: 2, childOpen: true });
+      const next = reducer(state, { type: 'GO_BACK' });
+
+      expect(next.step).toBe(1);
+      expect(next.childOpen).toBe(false);
+    });
+
+    it('preserves preview state when going back in builder mode', () => {
+      const state = createState({ step: 2, childOpen: true });
+      const next = reducer(state, { type: 'GO_BACK', isBuilderMode: true });
+
+      expect(next.step).toBe(1);
+      expect(next.childOpen).toBe(true);
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
@@ -30,7 +30,6 @@ export interface InitialStateConfig {
   mode: ComposeDiscoverMode;
   initialKind?: RuleKind;
   initialRecoveryType?: RecoveryType;
-  isBuilderMode?: boolean;
   /** When true, the query is already populated (e.g. from Discover) and the sandbox gate is skipped. */
   isQueryPrePopulated?: boolean;
   /** When true, the flyout opens directly in YAML mode with the sandbox open. */
@@ -41,7 +40,6 @@ export const createInitialState = ({
   mode,
   initialKind = 'alert',
   initialRecoveryType = 'default',
-  isBuilderMode = false,
   isQueryPrePopulated = false,
   forceYamlMode = false,
 }: InitialStateConfig): ComposeDiscoverState => {
@@ -116,13 +114,23 @@ export function reducer(
     case 'SET_STEP':
       return { ...state, step: action.step };
     case 'GO_NEXT': {
-      const stepCount = getStepIds(action.isAlert).length;
+      const stepCount = (
+        action.isBuilderMode ? getBuilderStepIds(action.isAlert) : getStepIds(action.isAlert)
+      ).length;
       const nextStep = Math.min(state.step + 1, stepCount - 1);
-      return { ...state, step: nextStep, childOpen: false };
+      return {
+        ...state,
+        step: nextStep,
+        childOpen: action.isBuilderMode ? state.childOpen : false,
+      };
     }
     case 'GO_BACK': {
       const prevStep = Math.max(state.step - 1, 0);
-      return { ...state, step: prevStep, childOpen: false };
+      return {
+        ...state,
+        step: prevStep,
+        childOpen: action.isBuilderMode ? state.childOpen : false,
+      };
     }
     case 'OPEN_CHILD':
       return {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Locator, ScoutPage } from '@kbn/scout';
-import { EuiSuperSelectWrapper, KibanaCodeEditorWrapper } from '@kbn/scout';
+import { KibanaCodeEditorWrapper } from '@kbn/scout';
 
 export class ComposeDiscoverPage {
   public readonly flyout: Locator;
@@ -30,7 +30,6 @@ export class ComposeDiscoverPage {
    * create now uses a single unified editor and the heuristic split runs on Apply.
    */
   public readonly alertSummaryEditorButton: Locator;
-  public readonly sandboxPanel: Locator;
   public readonly sandboxCloseButton: Locator;
   public readonly sandboxSearchButton: Locator;
   public readonly sandboxApplyButton: Locator;
@@ -44,7 +43,6 @@ export class ComposeDiscoverPage {
   /** "Create ES|QL rule" card in the empty-state panel (shown when no rules exist). */
   public readonly createEsqlRuleCard: Locator;
   public readonly modeSelect: Locator;
-  public readonly modeSelector: EuiSuperSelectWrapper;
   public readonly cancelButton: Locator;
   /**
    * Callout shown after Apply when the query has a base but no alert condition
@@ -66,7 +64,6 @@ export class ComposeDiscoverPage {
     this.openEditorButton = this.page.testSubj.locator('composeDiscoverOpenEditor');
     this.editQueryButton = this.page.testSubj.locator('composeDiscoverEditQuery');
     this.alertSummaryEditorButton = this.page.testSubj.locator('esqlSummaryOpenEditor');
-    this.sandboxPanel = this.page.testSubj.locator('querySandbox');
     this.sandboxCloseButton = this.page.testSubj.locator('querySandboxClose');
     this.sandboxSearchButton = this.page.testSubj.locator('composeDiscoverRunQuery');
     this.sandboxApplyButton = this.page.testSubj.locator('querySandboxApply');
@@ -78,7 +75,6 @@ export class ComposeDiscoverPage {
       'input[placeholder="Link related dashboards for investigation"]'
     );
     this.modeSelect = this.page.testSubj.locator('composeDiscoverModeSelect');
-    this.modeSelector = new EuiSuperSelectWrapper(page, 'composeDiscoverModeSelect');
     this.createRulePopoverButton = this.page.testSubj.locator('createRulePopoverButton');
     this.createEsqlRuleButton = this.page.testSubj.locator('createEsqlRuleButton');
     this.createEsqlRuleCard = this.page.testSubj.locator('createEsqlRuleCard');

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/compose_discover_page.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Locator, ScoutPage } from '@kbn/scout';
-import { KibanaCodeEditorWrapper } from '@kbn/scout';
+import { EuiSuperSelectWrapper, KibanaCodeEditorWrapper } from '@kbn/scout';
 
 export class ComposeDiscoverPage {
   public readonly flyout: Locator;
@@ -30,6 +30,7 @@ export class ComposeDiscoverPage {
    * create now uses a single unified editor and the heuristic split runs on Apply.
    */
   public readonly alertSummaryEditorButton: Locator;
+  public readonly sandboxPanel: Locator;
   public readonly sandboxCloseButton: Locator;
   public readonly sandboxSearchButton: Locator;
   public readonly sandboxApplyButton: Locator;
@@ -42,6 +43,8 @@ export class ComposeDiscoverPage {
   public readonly createEsqlRuleButton: Locator;
   /** "Create ES|QL rule" card in the empty-state panel (shown when no rules exist). */
   public readonly createEsqlRuleCard: Locator;
+  public readonly modeSelect: Locator;
+  public readonly modeSelector: EuiSuperSelectWrapper;
   public readonly cancelButton: Locator;
   /**
    * Callout shown after Apply when the query has a base but no alert condition
@@ -63,6 +66,7 @@ export class ComposeDiscoverPage {
     this.openEditorButton = this.page.testSubj.locator('composeDiscoverOpenEditor');
     this.editQueryButton = this.page.testSubj.locator('composeDiscoverEditQuery');
     this.alertSummaryEditorButton = this.page.testSubj.locator('esqlSummaryOpenEditor');
+    this.sandboxPanel = this.page.testSubj.locator('querySandbox');
     this.sandboxCloseButton = this.page.testSubj.locator('querySandboxClose');
     this.sandboxSearchButton = this.page.testSubj.locator('composeDiscoverRunQuery');
     this.sandboxApplyButton = this.page.testSubj.locator('querySandboxApply');
@@ -73,6 +77,8 @@ export class ComposeDiscoverPage {
     this.relatedDashboardsInput = this.flyout.locator(
       'input[placeholder="Link related dashboards for investigation"]'
     );
+    this.modeSelect = this.page.testSubj.locator('composeDiscoverModeSelect');
+    this.modeSelector = new EuiSuperSelectWrapper(page, 'composeDiscoverModeSelect');
     this.createRulePopoverButton = this.page.testSubj.locator('createRulePopoverButton');
     this.createEsqlRuleButton = this.page.testSubj.locator('createEsqlRuleButton');
     this.createEsqlRuleCard = this.page.testSubj.locator('createEsqlRuleCard');

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/index.ts
@@ -10,21 +10,27 @@ import { createLazyPageObject } from '@kbn/scout';
 import { ComposeDiscoverPage } from './compose_discover_page';
 import { DiscoverAppMenu } from './discover_app_menu';
 import { ExecutionHistoryPage } from './execution_history_page';
+import { RuleBuilderPage } from './rule_builder_page';
 import { RuleFormPage } from './rule_form_page';
 import { RulesListPage } from './rules_list_page';
+import { ThresholdBuilderPage } from './threshold_builder_page';
 
 export { ComposeDiscoverPage } from './compose_discover_page';
 export { DiscoverAppMenu } from './discover_app_menu';
 export { ExecutionHistoryPage } from './execution_history_page';
+export { RuleBuilderPage } from './rule_builder_page';
 export { RuleFormPage } from './rule_form_page';
 export { RulesListPage } from './rules_list_page';
+export { ThresholdBuilderPage } from './threshold_builder_page';
 
 export type AlertingPageObjects = PageObjects & {
   composeDiscover: ComposeDiscoverPage;
   discoverAppMenu: DiscoverAppMenu;
   executionHistory: ExecutionHistoryPage;
+  ruleBuilder: RuleBuilderPage;
   ruleForm: RuleFormPage;
   rulesList: RulesListPage;
+  thresholdBuilder: ThresholdBuilderPage;
 };
 
 export const extendPageObjects = (
@@ -38,7 +44,9 @@ export const extendPageObjects = (
     composeDiscover: createLazyPageObject(ComposeDiscoverPage, page),
     discoverAppMenu,
     executionHistory: createLazyPageObject(ExecutionHistoryPage, page),
+    ruleBuilder: createLazyPageObject(RuleBuilderPage, page),
     ruleForm: createLazyPageObject(RuleFormPage, page, discoverAppMenu),
     rulesList: createLazyPageObject(RulesListPage, page),
+    thresholdBuilder: createLazyPageObject(ThresholdBuilderPage, page),
   };
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_builder_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_builder_page.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+const BUILDER_CARDS: Record<string, { testSubj: string; buttonName: RegExp }> = {
+  threshold: {
+    testSubj: 'createThresholdAlertCard',
+    buttonName: /threshold alert/i,
+  },
+};
+
+export class RuleBuilderPage {
+  public readonly createRulePopoverButton: Locator;
+  private readonly createRuleButton: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.createRulePopoverButton = this.page.testSubj.locator('createRulePopoverButton');
+    this.createRuleButton = this.page.testSubj.locator('createRuleButton');
+  }
+
+  private builderCard(type: string): Locator {
+    const config = BUILDER_CARDS[type];
+    if (!config) {
+      throw new Error(`Unknown builder type "${type}". Register it in BUILDER_CARDS.`);
+    }
+    return this.page.testSubj.locator(config.testSubj);
+  }
+
+  async openCreateBuilderFlyout(type: string) {
+    const config = BUILDER_CARDS[type];
+    if (!config) {
+      throw new Error(`Unknown builder type "${type}". Register it in BUILDER_CARDS.`);
+    }
+
+    const card = this.builderCard(type);
+    await this.createRuleButton.or(card).waitFor({ state: 'visible' });
+
+    if (await this.createRuleButton.isVisible()) {
+      await this.createRuleButton.click();
+      const optionsFlyout = this.page.testSubj.locator('ruleCreateOptionsFlyout');
+      await optionsFlyout.waitFor({ state: 'visible' });
+      const builderButton = optionsFlyout.getByRole('button', { name: config.buttonName });
+      await builderButton.click();
+    } else {
+      await card.click();
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_builder_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_builder_page.ts
@@ -15,11 +15,9 @@ const BUILDER_CARDS: Record<string, { testSubj: string; buttonName: RegExp }> = 
 };
 
 export class RuleBuilderPage {
-  public readonly createRulePopoverButton: Locator;
   private readonly createRuleButton: Locator;
 
   constructor(private readonly page: ScoutPage) {
-    this.createRulePopoverButton = this.page.testSubj.locator('createRulePopoverButton');
     this.createRuleButton = this.page.testSubj.locator('createRuleButton');
   }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/threshold_builder_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/threshold_builder_page.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { EuiComboBoxWrapper } from '@kbn/scout';
+
+export class ThresholdBuilderPage {
+  public readonly timeFieldSelect: Locator;
+  public readonly addStatButton: Locator;
+
+  private readonly indexComboBox: EuiComboBoxWrapper;
+
+  constructor(private readonly page: ScoutPage) {
+    this.timeFieldSelect = this.page.testSubj.locator('ruleBuilderTimeField');
+    this.addStatButton = this.page.testSubj.locator('ruleBuilderAddStat');
+    this.indexComboBox = new EuiComboBoxWrapper(page, 'ruleBuilderIndexField');
+  }
+
+  async setIndex(pattern: string) {
+    await this.indexComboBox.setCustomSingleOption(pattern, { settleTimeoutMs: 10_000 });
+  }
+
+  statAggSelect(idx: number): Locator {
+    return this.page.testSubj.locator(`ruleBuilderStatAgg-${idx}`);
+  }
+
+  conditionThresholdInput(idx: number): Locator {
+    return this.page.testSubj.locator(`ruleBuilderConditionThreshold-${idx}`);
+  }
+
+  async setConditionThreshold(idx: number, value: string) {
+    await this.conditionThresholdInput(idx).fill(value);
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
@@ -57,7 +57,6 @@ test.describe(
     });
 
     test('create flow: configure threshold builder and submit', async ({
-      page,
       pageObjects,
       apiServices,
     }) => {
@@ -99,7 +98,7 @@ test.describe(
 
       await test.step('advance to Details step', async () => {
         await pageObjects.composeDiscover.clickNext();
-        await expect(page.testSubj.locator('ruleNameInput')).toBeVisible();
+        await expect(pageObjects.composeDiscover.ruleNameInput).toBeVisible();
       });
 
       await test.step('fill rule name', async () => {
@@ -198,7 +197,7 @@ test.describe(
       });
 
       await test.step('create rule button is not visible', async () => {
-        await expect(pageObjects.ruleBuilder.createRulePopoverButton).toBeHidden();
+        await expect(pageObjects.composeDiscover.createRulePopoverButton).toBeHidden();
       });
     });
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { buildCreateRuleData, test } from '../fixtures';
+
+const TEST_INDEX = 'test-rule-builder';
+const RULE_NAME = 'scout-rule-builder-create';
+const EDIT_RULE_NAME = 'scout-rule-builder-edit';
+const EDITED_RULE_NAME = 'scout-rule-builder-edited';
+
+test.describe(
+  'Rule Builder — threshold create and edit flows',
+  { tag: '@local-stateful-classic' },
+  () => {
+    test.beforeAll(async ({ esClient, apiServices }) => {
+      await apiServices.alertingV2.rules.cleanUp();
+      await esClient.indices.create(
+        {
+          index: TEST_INDEX,
+          mappings: {
+            properties: {
+              '@timestamp': { type: 'date' },
+              message: { type: 'text' },
+              latency: { type: 'float' },
+              'host.name': { type: 'keyword' },
+            },
+          },
+        },
+        { ignore: [400] }
+      );
+      await esClient.index({
+        index: TEST_INDEX,
+        document: {
+          '@timestamp': new Date().toISOString(),
+          message: 'test event',
+          latency: 42.5,
+          'host.name': 'host-1',
+        },
+        refresh: 'wait_for',
+      });
+    });
+
+    test.beforeEach(async ({ browserAuth, page, pageObjects }) => {
+      await browserAuth.loginAsAlertingV2Editor();
+      await pageObjects.rulesList.goto();
+      await expect(page.testSubj.locator('rulesListLoading')).toBeHidden({ timeout: 60_000 });
+    });
+
+    test.afterAll(async ({ esClient, apiServices }) => {
+      await apiServices.alertingV2.rules.cleanUp();
+      await esClient.indices.delete({ index: TEST_INDEX }, { ignore: [404] });
+    });
+
+    test('create flow: configure threshold builder and submit', async ({
+      page,
+      pageObjects,
+      apiServices,
+    }) => {
+      await test.step('open threshold builder flyout', async () => {
+        await pageObjects.ruleBuilder.openCreateBuilderFlyout('threshold');
+        await expect(pageObjects.composeDiscover.flyout).toBeVisible();
+      });
+
+      await test.step('builder form is visible with default stat', async () => {
+        await expect(pageObjects.composeDiscover.modeSelect).toBeVisible();
+        await expect(pageObjects.thresholdBuilder.addStatButton).toBeVisible();
+        await expect(pageObjects.thresholdBuilder.statAggSelect(0)).toBeVisible();
+      });
+
+      await test.step('select index pattern', async () => {
+        await pageObjects.thresholdBuilder.setIndex(TEST_INDEX);
+      });
+
+      await test.step('time field is auto-populated', async () => {
+        await expect(pageObjects.thresholdBuilder.timeFieldSelect).toBeVisible();
+      });
+
+      await test.step('set threshold condition value', async () => {
+        await pageObjects.thresholdBuilder.setConditionThreshold(0, '5');
+      });
+
+      await test.step('Next is enabled after builder form is valid', async () => {
+        await expect(pageObjects.composeDiscover.nextButton).toBeEnabled();
+      });
+
+      await test.step('advance through Recovery Condition step', async () => {
+        await pageObjects.composeDiscover.clickNext();
+      });
+
+      await test.step('advance to Details step', async () => {
+        await pageObjects.composeDiscover.clickNext();
+        await expect(page.testSubj.locator('ruleNameInput')).toBeVisible();
+      });
+
+      await test.step('fill rule name', async () => {
+        await pageObjects.composeDiscover.setRuleName(RULE_NAME);
+      });
+
+      await test.step('advance to Actions step and submit', async () => {
+        await pageObjects.composeDiscover.clickNext();
+        await expect(pageObjects.composeDiscover.submitButton).toBeVisible();
+        await pageObjects.composeDiscover.clickSubmit();
+        await expect(pageObjects.composeDiscover.flyout).toBeHidden({ timeout: 30_000 });
+      });
+
+      await test.step('verify rule created with builder_type metadata', async () => {
+        await expect
+          .poll(
+            async () => {
+              const { items } = await apiServices.alertingV2.rules.find({
+                search: RULE_NAME,
+              });
+              return items[0]?.metadata?.builder_type;
+            },
+            { timeout: 30_000 }
+          )
+          .toBe('threshold');
+      });
+    });
+
+    test('edit flow: open builder-created rule and modify', async ({
+      pageObjects,
+      apiServices,
+    }) => {
+      let ruleId: string;
+
+      await test.step('seed a builder rule via API', async () => {
+        const rule = await apiServices.alertingV2.rules.create(
+          buildCreateRuleData({
+            metadata: { name: EDIT_RULE_NAME, builder_type: 'threshold' },
+            query: {
+              format: 'composed',
+              base: `FROM ${TEST_INDEX} | STATS count = COUNT(*)`,
+              breach: { segment: '| WHERE count > 5' },
+            },
+            time_field: '@timestamp',
+          })
+        );
+        ruleId = rule.id;
+      });
+
+      await test.step('refresh rules list', async () => {
+        await pageObjects.rulesList.goto();
+        await expect(pageObjects.rulesList.rulesListTable).toBeVisible({ timeout: 60_000 });
+      });
+
+      await test.step('open edit flyout', async () => {
+        await pageObjects.composeDiscover.openEditFlyout(ruleId!);
+        await expect(pageObjects.composeDiscover.flyout).toBeVisible();
+      });
+
+      await test.step('builder form is displayed in edit mode', async () => {
+        await expect(pageObjects.thresholdBuilder.addStatButton).toBeVisible();
+      });
+
+      await test.step('navigate to Details step and modify name', async () => {
+        await pageObjects.composeDiscover.clickNext();
+        await pageObjects.composeDiscover.clickNext();
+        await pageObjects.composeDiscover.ruleNameInput.clear();
+        await pageObjects.composeDiscover.setRuleName(EDITED_RULE_NAME);
+      });
+
+      await test.step('advance to Actions step and submit', async () => {
+        await pageObjects.composeDiscover.clickNext();
+        await expect(pageObjects.composeDiscover.submitButton).toBeVisible();
+        await pageObjects.composeDiscover.clickSubmit();
+        await expect(pageObjects.composeDiscover.flyout).toBeHidden({ timeout: 30_000 });
+      });
+
+      await test.step('verify rule updated', async () => {
+        await expect
+          .poll(async () => (await apiServices.alertingV2.rules.get(ruleId!)).metadata.name, {
+            timeout: 30_000,
+          })
+          .toBe(EDITED_RULE_NAME);
+      });
+    });
+
+    test('permissions: viewer role cannot access create flow', async ({
+      browserAuth,
+      page,
+      pageObjects,
+    }) => {
+      await test.step('login as viewer', async () => {
+        await browserAuth.loginAsAlertingV2Viewer();
+        await pageObjects.rulesList.goto();
+        await expect(page.testSubj.locator('rulesListLoading')).toBeHidden({ timeout: 60_000 });
+      });
+
+      await test.step('create rule button is not visible', async () => {
+        await expect(pageObjects.ruleBuilder.createRulePopoverButton).toBeHidden();
+      });
+    });
+  }
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
@@ -71,6 +71,10 @@ test.describe(
         await expect(pageObjects.thresholdBuilder.statAggSelect(0)).toBeVisible();
       });
 
+      await test.step('Next is disabled before index is selected', async () => {
+        await expect(pageObjects.composeDiscover.nextButton).toBeDisabled();
+      });
+
       await test.step('select index pattern', async () => {
         await pageObjects.thresholdBuilder.setIndex(TEST_INDEX);
       });
@@ -78,10 +82,6 @@ test.describe(
       await test.step('time field is auto-populated', async () => {
         await expect(pageObjects.thresholdBuilder.timeFieldSelect).toBeVisible();
         await expect(pageObjects.thresholdBuilder.timeFieldSelect).toHaveValue('@timestamp');
-      });
-
-      await test.step('Next is disabled before builder form is valid', async () => {
-        await expect(pageObjects.composeDiscover.nextButton).toBeDisabled();
       });
 
       await test.step('set threshold condition value', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
@@ -78,6 +78,11 @@ test.describe(
 
       await test.step('time field is auto-populated', async () => {
         await expect(pageObjects.thresholdBuilder.timeFieldSelect).toBeVisible();
+        await expect(pageObjects.thresholdBuilder.timeFieldSelect).toHaveValue('@timestamp');
+      });
+
+      await test.step('Next is disabled before builder form is valid', async () => {
+        await expect(pageObjects.composeDiscover.nextButton).toBeDisabled();
       });
 
       await test.step('set threshold condition value', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts
@@ -143,6 +143,7 @@ test.describe(
               breach: { segment: '| WHERE count > 5' },
             },
             time_field: '@timestamp',
+            recovery_strategy: undefined,
           })
         );
         ruleId = rule.id;


### PR DESCRIPTION
## Summary

Adds Scout UI integration tests and RTL/Jest unit tests for the threshold rule builder, along with behavior fixes required for tests to pass.

### Scout UI tests (3 full-stack integration)

- **Create flow**: configure builder, advance through steps, submit, verify rule created via API with `builder_type: threshold`
- **Edit flow**: seed rule via API, modify name through UI, submit, verify update via API
- **Permissions**: viewer role cannot access the create flow

### RTL/Jest unit tests (14 component-level)

Moved from Scout to RTL per [review feedback](https://github.com/elastic/kibana/pull/274577#discussion_r3460874289) — these test form-state and rendering logic that doesn't require a full Kibana + ES + browser stack:

- Add/remove stats with remove button visibility
- Add/remove alert conditions with operator toggle
- Evaluations lifecycle and metric dropdown reflection
- Filter input value propagation
- Stat field combo box visibility by aggregation type (COUNT vs AVG)
- Between comparator second threshold input appears/disappears
- Preview button disabled state based on `childOpen`
- Builder mode validation gating in footer (`isBuilderStepValid`)
- ModeSelect enabled on create, disabled on edit

### New page objects

- `RuleBuilderPage` — shared entry-point for opening any builder flyout (extensible via `BUILDER_CARDS` registry)
- `ThresholdBuilderPage` — threshold-specific locators (trimmed to only members used by tests)

### Behavior fixes (included so tests pass)

> **Note**: These fixes are also in #274576 which should merge first. After merge, this PR can be rebased to contain only test changes.

- Open preview sandbox by default in create mode; preview stays open across all builder steps unless explicitly closed by the user
- Fix footer Next/Back buttons to not be blocked by `childOpen` in builder mode; gate Next on builder step validation instead
- Add `isBuilderConditionStepId` helper for consistent step ID checks
- Use correct builder step count in `GO_NEXT` reducer

## Test plan

- [x] 3 Scout UI tests pass: `node scripts/scout run-tests --arch stateful --domain classic --testFiles x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/rule_builder_threshold.spec.ts`
- [x] RTL tests pass: `node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/rule_builder/threshold/alert_condition_step.test.tsx`
- [x] Footer tests pass: `node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_footer.test.tsx`
- [x] Form tests pass: `node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/compose_discover_form.test.tsx`
- [x] CI green (flaky failures unrelated to this PR)