### PR TITLE
[Flaky] Fix index.test.ts (fixes #274574)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -63,6 +63,13 @@ jest.mock('../../common/hooks/is_in_security_app', () => ({
   useIsInSecurityApp: jest.fn(),
 }));
 
+// EntityStoreEuidApiProvider uses a dynamic import('./euid_browser') in a useEffect.
+// That async import causes react-test-renderer's act() to wait indefinitely when
+// the component tree is inspected via TestRenderer. Mock it out to avoid the hang.
+jest.mock('@kbn/entity-store/public', () => ({
+  EntityStoreEuidApiProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 describe('AlertFlyoutHeader', () => {
   const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
 
@@ -92,12 +99,8 @@ describe('AlertFlyoutHeader', () => {
     } as unknown as DataTableRecord;
     const store = createStore(() => ({}));
     const storePromise = Promise.resolve(store as never);
+    const servicesPromise = Promise.resolve(servicesMock);
     const history = createMemoryHistory({ initialEntries: ['/discover'] });
-
-    let resolveServices: (services: StartServices) => void;
-    const servicesPromise = new Promise<StartServices>((resolve) => {
-      resolveServices = resolve;
-    });
 
     let tree!: TestRenderer.ReactTestRenderer;
     await act(async () => {
@@ -114,7 +117,6 @@ describe('AlertFlyoutHeader', () => {
     });
 
     await act(async () => {
-      resolveServices(servicesMock);
       await servicesPromise;
       await storePromise;
     });


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test `AlertFlyoutHeader wraps the header in KibanaContextProvider and ReactQueryClientProvider` was timing out (5000ms Jest default) because of two compounding issues. First, `EntityStoreEuidApiProvider` (from `@kbn/entity-store/public`, used inside `flyoutProviders`) has a `useEffect` that calls `import('./euid_browser')` — a dynamic import that is an async Promise. When the component renders inside `react-test-renderer`'s `await act(async () => {...})`, React's `act()` tries to flush ALL pending state updates and async work before exiting, including waiting for any Promises that trigger state changes. The dynamic import eventually calls `setApi({...})`, which `act()` tracks and waits for. Under CI load, or due to a bug in how `react-test-renderer`'s `act()` handles microtask chains from dynamic imports, this wait never completed within 5s. Second, the test used a manually-controlled `servicesPromise` (resolved inside the second `act()` block), which created a fragile sequence: `resolveServices()` → `Promise.all` in `useEffect` resolves → `setServices`/`setStore` → component re-renders with `flyoutProviders` → `EntityStoreEuidApiProvider` mounts → dynamic import fires — all within `act()`, which then hung. The fix mocks `@kbn/entity-store/public`'s `EntityStoreEuidApiProvider` (consistent with how `CaseProvider`, `AssistantProvider`, and `DiscoverInTimelineContextProvider` are already mocked in the same file) to prevent the dynamic import from running, and replaces the manually-controlled promise with `Promise.resolve(servicesMock)` to eliminate the fragile two-phase act pattern. All 11 tests in the file pass after the fix.

**Changes**

- ae955b3fc657 fix(test): prevent dynamic import timeout in AlertFlyoutHeader provider test

Fixes #274574




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`