### PR TITLE
[SideNav] Add eslint rule for formatting side navigation labels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3099,6 +3099,19 @@ module.exports = {
 };
 
 /**
+ * Navigation title sentence-case rule. Self-scoping (no globs needed): it checks
+ * nav trees (files importing @kbn/core-chrome-browser), navigation modules, and
+ * `registerApp` / `deepLinks` titles detected by AST context in any file.
+ */
+module.exports.overrides.push({
+  files: ['**/*.{ts,tsx}'],
+  excludedFiles: ['**/*.{test,spec}.{ts,tsx}', '**/*.stories.{ts,tsx}'],
+  rules: {
+    '@kbn/i18n/nav_link_should_use_sentence_case': 'warn',
+  },
+});
+
+/**
  * Prettier disables all conflicting rules, listing as last override so it takes precedence
  * people kept ignoring that this was last so it's now defined outside of the overrides list
  */

--- a/packages/kbn-eslint-plugin-i18n/index.ts
+++ b/packages/kbn-eslint-plugin-i18n/index.ts
@@ -11,6 +11,7 @@ import { StringsShouldBeTranslatedWithI18n } from './rules/strings_should_be_tra
 import { StringsShouldBeTranslatedWithFormattedMessage } from './rules/strings_should_be_translated_with_formatted_message';
 import { I18nTranslateShouldStartWithTheRightId } from './rules/i18n_translate_should_start_with_the_right_id';
 import { FormattedMessageShouldStartWithTheRightId } from './rules/formatted_message_should_start_with_the_right_id';
+import { NavLinkShouldUseSentenceCase } from './rules/nav_link_should_use_sentence_case';
 
 /**
  * Custom ESLint rules, add `'@kbn/eslint-plugin-i18n'` to your eslint config to use them
@@ -22,4 +23,5 @@ export const rules = {
     StringsShouldBeTranslatedWithFormattedMessage,
   i18n_translate_should_start_with_the_right_id: I18nTranslateShouldStartWithTheRightId,
   formatted_message_should_start_with_the_right_id: FormattedMessageShouldStartWithTheRightId,
+  nav_link_should_use_sentence_case: NavLinkShouldUseSentenceCase,
 };

--- a/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
@@ -34,9 +34,9 @@ const SECURITY_LINKS_FILE =
   '/x-pack/solutions/security/plugins/security_solution/public/rules/links.ts';
 
 const wrap = (code: string) =>
-  `import { i18n } from '@kbn/i18n';\nimport type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';\n${code}`;
+  `import type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';\n${code}`;
 
-const plain = (code: string) => `import { i18n } from '@kbn/i18n';\n${code}`;
+const plain = (code: string) => code;
 
 const invalid: RuleTester.InvalidTestCase[] = [
   // Canonical term with wrong casing → brandMismatch (literal + i18n.translate)
@@ -109,21 +109,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     ],
   },
   {
-    name: 'Multiple Title Case words reports the first offender',
-    filename: NAV_FILE,
-    code: wrap(`const node = { title: 'Data Management Panel' };`),
-    errors: [
-      {
-        messageId: 'sentenceCase',
-        data: {
-          message: 'Data Management Panel',
-          suggestion: 'Data management panel',
-          word: 'Management',
-        },
-      },
-    ],
-  },
-  {
     name: 'label wrapping i18n.translate in a nav-tree file warns',
     filename: NAV_FILE,
     code: wrap(
@@ -137,7 +122,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     ],
   },
 
-  // registerApp titles (any file, no core-chrome import) — literal + i18n.translate
+  // registerApp titles (any file, no core-chrome import) — literal
   {
     name: 'registerApp title literal in a plugin file warns',
     filename: PLUGIN_FILE,
@@ -148,19 +133,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
       {
         messageId: 'sentenceCase',
         data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
-      },
-    ],
-  },
-  {
-    name: 'registerApp title wrapping i18n.translate in a plugin file warns',
-    filename: PLUGIN_FILE,
-    code: plain(
-      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Machine learning' }) });`
-    ),
-    errors: [
-      {
-        messageId: 'brandMismatch',
-        data: { message: 'Machine learning', expected: 'Machine Learning' },
       },
     ],
   },
@@ -326,11 +298,6 @@ const valid: RuleTester.ValidTestCase[] = [
       `const node = { title: i18n.translate('foo.nav.soc', { defaultMessage: 'Elastic AI SOC Engine' }) };`
     ),
   },
-  {
-    name: 'Machine Learning Kibana app title — allowed',
-    filename: NAV_FILE,
-    code: wrap(`const node = { title: 'Machine Learning' };`),
-  },
 
   // Sentence case — no violation
   {
@@ -354,11 +321,6 @@ const valid: RuleTester.ValidTestCase[] = [
     filename: NAV_FILE,
     code: wrap(`const node = { title: 'macOS agents' };`),
   },
-  {
-    name: 'Single word title — allowed',
-    filename: NAV_FILE,
-    code: wrap(`const node = { title: 'Discover' };`),
-  },
 
   // Not a nav title → ignored
   {
@@ -374,11 +336,6 @@ const valid: RuleTester.ValidTestCase[] = [
     code: wrap(
       `const NAV_TITLE = i18n.translate('foo.nav.x', { defaultMessage: 'Some Custom Thing' });`
     ),
-  },
-  {
-    name: 'Non-i18n.translate call — ignored',
-    filename: NAV_FILE,
-    code: wrap(`const t = someOtherFn('foo', { defaultMessage: 'Not A Nav Link' });`),
   },
 
   // Out of scope: not a nav file and not a registration context
@@ -412,14 +369,6 @@ const valid: RuleTester.ValidTestCase[] = [
     filename: PLUGIN_FILE,
     code: plain(
       `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: ['globalSearch'] }] });`
-    ),
-  },
-  // Correct casing in a registration context — allowed
-  {
-    name: 'registerApp canonical title — allowed',
-    filename: PLUGIN_FILE,
-    code: plain(
-      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Machine Learning' }) });`
     ),
   },
   // Navigation-module file only checks title/label — other strings ignored
@@ -471,9 +420,7 @@ const valid: RuleTester.ValidTestCase[] = [
   },
 ];
 
-for (const [, tester] of [tsTester]) {
-  tester.run('nav_link_should_use_sentence_case', NavLinkShouldUseSentenceCase, {
-    valid,
-    invalid,
-  });
-}
+tsTester[1].run('nav_link_should_use_sentence_case', NavLinkShouldUseSentenceCase, {
+  valid,
+  invalid,
+});

--- a/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
@@ -27,32 +27,40 @@ const PLUGIN_FILE = '/x-pack/platform/plugins/shared/some_plugin/public/plugin.t
 // A file inside a navigation module — checked in full without the import.
 const NAV_PATH_FILE = '/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts';
 
+// security_solution nav title definition files (hard-coded paths, see rule for rationale).
+const SECURITY_TRANSLATIONS_FILE =
+  '/x-pack/solutions/security/plugins/security_solution/public/app/translations.ts';
+const SECURITY_LINKS_FILE =
+  '/x-pack/solutions/security/plugins/security_solution/public/rules/links.ts';
+
 const wrap = (code: string) =>
   `import { i18n } from '@kbn/i18n';\nimport type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';\n${code}`;
 
 const plain = (code: string) => `import { i18n } from '@kbn/i18n';\n${code}`;
 
 const invalid: RuleTester.InvalidTestCase[] = [
-  // Canonical term with wrong casing → brandMismatch
+  // Canonical term with wrong casing → brandMismatch (literal + i18n.translate)
   {
-    name: 'Brand term partially wrong casing',
+    name: 'Canonical term wrong casing (literal) warns with expected form',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.inf', { defaultMessage: 'Elastic inference' });`),
-    errors: [
-      {
-        messageId: 'brandMismatch',
-        data: { message: 'Elastic inference', expected: 'Elastic Inference' },
-      },
-    ],
-  },
-  {
-    name: 'Machine learning wrong casing warns with expected form',
-    filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.ml', { defaultMessage: 'Machine learning' });`),
+    code: wrap(`const node = { title: 'Machine learning' };`),
     errors: [
       {
         messageId: 'brandMismatch',
         data: { message: 'Machine learning', expected: 'Machine Learning' },
+      },
+    ],
+  },
+  {
+    name: 'Canonical term wrong casing (i18n.translate) warns with expected form',
+    filename: NAV_FILE,
+    code: wrap(
+      `const node = { title: i18n.translate('foo.nav.inf', { defaultMessage: 'Elastic inference' }) };`
+    ),
+    errors: [
+      {
+        messageId: 'brandMismatch',
+        data: { message: 'Elastic inference', expected: 'Elastic Inference' },
       },
     ],
   },
@@ -61,7 +69,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
   {
     name: 'Former Title Case management label now warns (not a brand proper noun)',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.idx', { defaultMessage: 'Index Management' });`),
+    code: wrap(`const node = { title: 'Index Management' };`),
     errors: [
       {
         messageId: 'sentenceCase',
@@ -74,42 +82,36 @@ const invalid: RuleTester.InvalidTestCase[] = [
   {
     name: 'Lowercase single-word title warns to capitalise',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.wf', { defaultMessage: 'workflows' });`),
+    code: wrap(`const node = { title: 'workflows' };`),
     errors: [
       { messageId: 'capitalizeFirst', data: { message: 'workflows', suggestion: 'Workflows' } },
     ],
   },
   {
-    name: 'Lowercase first word warns to capitalise',
+    name: 'Lowercase first word (label) warns to capitalise',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.dv', { defaultMessage: 'data views' });`),
+    code: wrap(`const node = { label: 'data views' };`),
     errors: [
       { messageId: 'capitalizeFirst', data: { message: 'data views', suggestion: 'Data views' } },
     ],
   },
 
-  // Sentence case violation on a new (non-glossary) term
+  // Sentence case violations on a new (non-glossary) term
   {
     name: 'New Title Case term warns with sentence case suggestion',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' });`),
+    code: wrap(`const node = { title: 'My Custom Section' };`),
     errors: [
       {
         messageId: 'sentenceCase',
-        data: {
-          message: 'My Custom Section',
-          suggestion: 'My custom section',
-          word: 'Custom',
-        },
+        data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
       },
     ],
   },
   {
-    name: 'Multiple Title Case words on a new term',
+    name: 'Multiple Title Case words reports the first offender',
     filename: NAV_FILE,
-    code: wrap(
-      `const t = i18n.translate('foo.nav.data', { defaultMessage: 'Data Management Panel' });`
-    ),
+    code: wrap(`const node = { title: 'Data Management Panel' };`),
     errors: [
       {
         messageId: 'sentenceCase',
@@ -121,8 +123,21 @@ const invalid: RuleTester.InvalidTestCase[] = [
       },
     ],
   },
+  {
+    name: 'label wrapping i18n.translate in a nav-tree file warns',
+    filename: NAV_FILE,
+    code: wrap(
+      `const node = { label: i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' }) };`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
+      },
+    ],
+  },
 
-  // Management section registration in a file WITHOUT the core-chrome import
+  // registerApp titles (any file, no core-chrome import) — literal + i18n.translate
   {
     name: 'registerApp title literal in a plugin file warns',
     filename: PLUGIN_FILE,
@@ -140,16 +155,16 @@ const invalid: RuleTester.InvalidTestCase[] = [
     name: 'registerApp title wrapping i18n.translate in a plugin file warns',
     filename: PLUGIN_FILE,
     code: plain(
-      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Stack monitoring' }) });`
+      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Machine learning' }) });`
     ),
     errors: [
       {
         messageId: 'brandMismatch',
-        data: { message: 'Stack monitoring', expected: 'Stack Monitoring' },
+        data: { message: 'Machine learning', expected: 'Machine Learning' },
       },
     ],
   },
-  // Deep link title in a file WITHOUT the core-chrome import
+  // Deep link title (any file)
   {
     name: 'deepLinks title in a plugin file warns',
     filename: PLUGIN_FILE,
@@ -163,7 +178,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
       },
     ],
   },
-  // A title in a nav-module file is checked even without the core-chrome import
+  // Title in a navigation-module file (no core-chrome import needed)
   {
     name: 'title in a navigation-module file warns',
     filename: NAV_PATH_FILE,
@@ -177,13 +192,53 @@ const invalid: RuleTester.InvalidTestCase[] = [
       },
     ],
   },
-  // title wrapping i18n.translate inside a core-chrome nav tree is still checked
+
+  // visibleIn containing a sidenav context → still in the sidenav, must be checked
   {
-    name: 'title wrapping i18n.translate in a nav-tree file warns',
-    filename: NAV_FILE,
-    code: wrap(
-      `const node = { title: i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' }) };`
+    name: 'deepLink with visibleIn containing classicSideNav warns',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: ['classicSideNav'] }] });`
     ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Hidden Page', suggestion: 'My hidden page', word: 'Hidden' },
+      },
+    ],
+  },
+  {
+    name: 'deepLink with visibleIn containing projectSideNav warns',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: ['globalSearch', 'projectSideNav'] }] });`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Hidden Page', suggestion: 'My hidden page', word: 'Hidden' },
+      },
+    ],
+  },
+
+  // Template literal titles are checked
+  {
+    name: 'template literal title warns',
+    filename: NAV_FILE,
+    code: wrap('const node = { title: `My Custom Section` };'),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
+      },
+    ],
+  },
+
+  // Same-file const resolution
+  {
+    name: 'same-file const title warns',
+    filename: NAV_FILE,
+    code: wrap(`const MY_TITLE = 'My Custom Section'; const node = { title: MY_TITLE };`),
     errors: [
       {
         messageId: 'sentenceCase',
@@ -192,124 +247,151 @@ const invalid: RuleTester.InvalidTestCase[] = [
     ],
   },
   {
-    name: 'label wrapping i18n.translate in a nav-tree file warns',
+    name: 'same-file i18n.translate const title warns',
     filename: NAV_FILE,
     code: wrap(
-      `const node = { label: i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' }) };`
+      `const MY_TITLE = i18n.translate('foo', { defaultMessage: 'My Custom Section' }); const node = { title: MY_TITLE };`
     ),
     errors: [
       {
         messageId: 'sentenceCase',
         data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
+      },
+    ],
+  },
+
+  // security_solution app/translations.ts — every export is a nav title, all are checked
+  {
+    name: 'security translations: title-case export warns',
+    filename: SECURITY_TRANSLATIONS_FILE,
+    code: plain(
+      `export const DATA_QUALITY = i18n.translate('xpack.securitySolution.navigation.ecsDataQualityDashboard', { defaultMessage: 'Data Quality' });`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'Data Quality', suggestion: 'Data quality', word: 'Quality' },
+      },
+    ],
+  },
+  {
+    name: 'security translations: MITRE coverage warns on Coverage',
+    filename: SECURITY_TRANSLATIONS_FILE,
+    code: plain(
+      `export const COVERAGE_OVERVIEW = i18n.translate('xpack.securitySolution.navigation.coverageOverviewDashboard', { defaultMessage: 'MITRE ATT&CK® Coverage' });`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: {
+          message: 'MITRE ATT&CK® Coverage',
+          suggestion: 'MITRE ATT&CK® coverage',
+          word: 'Coverage',
+        },
+      },
+    ],
+  },
+
+  // security_solution links.ts — inline title: i18n.translate is checked
+  {
+    name: 'security links: title-case inline title warns',
+    filename: SECURITY_LINKS_FILE,
+    code: plain(
+      `const link = { id: 'x', title: i18n.translate('foo', { defaultMessage: 'Uncommon Processes' }), path: '/hosts/uncommon' };`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: {
+          message: 'Uncommon Processes',
+          suggestion: 'Uncommon processes',
+          word: 'Processes',
+        },
       },
     ],
   },
 ];
 
 const valid: RuleTester.ValidTestCase[] = [
-  // Brand/canonical terms with correct casing — no warning
+  // Canonical / brand terms with exact casing — no warning
+  {
+    name: 'Canonical term Machine Learning — no warning',
+    filename: NAV_FILE,
+    code: wrap(`const node = { title: 'Machine Learning' };`),
+  },
   {
     name: 'Product name Elastic AI SOC Engine — allowed',
     filename: NAV_FILE,
     code: wrap(
-      `const t = i18n.translate('foo.nav.soc', { defaultMessage: 'Elastic AI SOC Engine' });`
-    ),
-  },
-  // Hidden deep link (visibleIn: []) is not a nav item — ignored
-  {
-    name: 'deepLink title with visibleIn: [] — ignored',
-    filename: PLUGIN_FILE,
-    code: plain(
-      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: [] }] });`
-    ),
-  },
-
-  // Canonical term with exact casing — no warning
-  {
-    name: 'Canonical term Stack Monitoring — no warning',
-    filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.mon', { defaultMessage: 'Stack Monitoring' });`),
-  },
-
-  // Sentence case — no violation
-  {
-    name: 'Sentence case new term — allowed',
-    filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.data', { defaultMessage: 'Data management' });`),
-  },
-  {
-    name: 'Sentence case label in a nav-tree object — allowed',
-    filename: NAV_FILE,
-    code: wrap(
-      `const node = { label: i18n.translate('foo.nav.data', { defaultMessage: 'Data management' }) };`
+      `const node = { title: i18n.translate('foo.nav.soc', { defaultMessage: 'Elastic AI SOC Engine' }) };`
     ),
   },
   {
     name: 'Machine Learning Kibana app title — allowed',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.ml', { defaultMessage: 'Machine Learning' });`),
+    code: wrap(`const node = { title: 'Machine Learning' };`),
   },
-  // Acronyms — always allowed mid-title
+
+  // Sentence case — no violation
+  {
+    name: 'Sentence case title — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const node = { title: 'Data management' };`),
+  },
+  // Acronyms / mixed-case brand tokens are not plain Title Case — allowed
   {
     name: 'Pure acronym mid-title — allowed',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.api', { defaultMessage: 'Manage API keys' });`),
+    code: wrap(`const node = { title: 'Manage API keys' };`),
   },
-  // Mixed-case brand token mid-title is not plain Title Case — allowed
   {
     name: 'Mixed-case token (OpenAI) mid-title — allowed',
     filename: NAV_FILE,
-    code: wrap(
-      `const t = i18n.translate('foo.nav.oai', { defaultMessage: 'Manage OpenAI connectors' });`
-    ),
+    code: wrap(`const node = { title: 'Manage OpenAI connectors' };`),
   },
-  // Lowercase-first token that is a legit mixed-case/symbol brand — allowed
   {
     name: 'Lowercase-first mixed-case token (macOS) — allowed',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.mac', { defaultMessage: 'macOS agents' });`),
+    code: wrap(`const node = { title: 'macOS agents' };`),
   },
-  // Non-title property value (description) in a nav-tree file — ignored
-  {
-    name: 'description property (i18n.translate) in a nav-tree file — ignored',
-    filename: NAV_FILE,
-    code: wrap(
-      `const x = { description: i18n.translate('foo.desc', { defaultMessage: 'View Custom Stuff' }) };`
-    ),
-  },
-
-  // Single word — nothing to check
   {
     name: 'Single word title — allowed',
     filename: NAV_FILE,
-    code: wrap(`const t = i18n.translate('foo.nav.discover', { defaultMessage: 'Discover' });`),
+    code: wrap(`const node = { title: 'Discover' };`),
   },
 
-  // Non-i18n.translate — ignored
+  // Not a nav title → ignored
+  {
+    name: 'Non-title property (description) in a nav-tree file — ignored',
+    filename: NAV_FILE,
+    code: wrap(
+      `const node = { description: i18n.translate('foo.desc', { defaultMessage: 'View Custom Stuff' }) };`
+    ),
+  },
+  {
+    name: 'Standalone i18n.translate const in a nav-tree file — ignored',
+    filename: NAV_FILE,
+    code: wrap(
+      `const NAV_TITLE = i18n.translate('foo.nav.x', { defaultMessage: 'Some Custom Thing' });`
+    ),
+  },
   {
     name: 'Non-i18n.translate call — ignored',
     filename: NAV_FILE,
     code: wrap(`const t = someOtherFn('foo', { defaultMessage: 'Not A Nav Link' });`),
   },
 
-  // A title/label outside a nav file and outside a registration context is ignored
+  // Out of scope: not a nav file and not a registration context
   {
     name: 'Title literal in a non-nav, non-registration object — ignored',
     filename: PLUGIN_FILE,
     code: plain(`const config = { title: 'Some Arbitrary Title' };`),
   },
   {
-    name: 'i18n.translate outside a nav file and registration — ignored',
-    filename: PLUGIN_FILE,
-    code: plain(`const t = i18n.translate('foo.button', { defaultMessage: 'Create New Thing' });`),
-  },
-  // A non-application .register(...) is not treated as a nav registration
-  {
     name: 'Non-application register title — ignored',
     filename: PLUGIN_FILE,
     code: plain(`expressions.register({ id: 'x', title: 'Some Expression Thing' });`),
   },
-  // A bare application.register title is the app title, not a nav item — ignored
   {
     name: 'application.register title (chromeless/setup apps) — ignored',
     filename: PLUGIN_FILE,
@@ -317,20 +399,74 @@ const valid: RuleTester.ValidTestCase[] = [
       `core.application.register({ id: 'x', title: 'Configure Elastic To Get Started', chromeless: true });`
     ),
   },
-  // Correct casing in registration contexts — allowed
+  // visibleIn without a sidenav context → not a nav item, ignored
+  {
+    name: 'deepLink with visibleIn: [] — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: [] }] });`
+    ),
+  },
+  {
+    name: 'deepLink with visibleIn: [globalSearch only] — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: ['globalSearch'] }] });`
+    ),
+  },
+  // Correct casing in a registration context — allowed
   {
     name: 'registerApp canonical title — allowed',
     filename: PLUGIN_FILE,
     code: plain(
-      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Stack Monitoring' }) });`
+      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Machine Learning' }) });`
     ),
   },
-  // Descriptions / callouts / aria labels in a nav-module file are NOT titles
+  // Navigation-module file only checks title/label — other strings ignored
   {
     name: 'standalone description const in a nav-module file — ignored',
     filename: NAV_PATH_FILE,
     code: plain(
       `export const CALLOUT = i18n.translate('sec.nav.callout', { defaultMessage: 'Powered by Elastic AI' });`
+    ),
+  },
+
+  // security_solution app/translations.ts — sentence case titles are allowed
+  {
+    name: 'security translations: sentence case export — allowed',
+    filename: SECURITY_TRANSLATIONS_FILE,
+    code: plain(
+      `export const HOSTS = i18n.translate('xpack.securitySolution.navigation.hosts', { defaultMessage: 'Hosts' });`
+    ),
+  },
+  {
+    name: 'security translations: acronym mid-title export — allowed',
+    filename: SECURITY_TRANSLATIONS_FILE,
+    code: plain(
+      `export const RULES = i18n.translate('xpack.securitySolution.navigation.rules', { defaultMessage: 'Detection rules (SIEM)' });`
+    ),
+  },
+
+  // Same-file const — correct casing is allowed
+  {
+    name: 'same-file const with sentence case title — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const MY_TITLE = 'Data management'; const node = { title: MY_TITLE };`),
+  },
+
+  // security_solution links.ts — sentence case title: is allowed, description: is not checked
+  {
+    name: 'security links: sentence case inline title — allowed',
+    filename: SECURITY_LINKS_FILE,
+    code: plain(
+      `const link = { id: 'x', title: i18n.translate('foo', { defaultMessage: 'All hosts' }), path: '/hosts' };`
+    ),
+  },
+  {
+    name: 'security links: description with title case is not checked',
+    filename: SECURITY_LINKS_FILE,
+    code: plain(
+      `const link = { id: 'x', title: i18n.translate('foo', { defaultMessage: 'Hosts' }), description: i18n.translate('bar', { defaultMessage: 'View All Hosts Here' }), path: '/hosts' };`
     ),
   },
 ];

--- a/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
@@ -1,0 +1,343 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { RuleTester } from 'eslint';
+import { NavLinkShouldUseSentenceCase } from './nav_link_should_use_sentence_case';
+
+const tsTester = [
+  '@typescript-eslint/parser',
+  new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: { sourceType: 'module', ecmaVersion: 2018 },
+  }),
+] as const;
+
+const NAV_FILE = '/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts';
+
+// A file that does NOT import @kbn/core-chrome-browser — used to prove that
+// registration / deep-link titles are detected by AST context alone.
+const PLUGIN_FILE = '/x-pack/platform/plugins/shared/some_plugin/public/plugin.ts';
+
+// A file inside a navigation module — checked in full without the import.
+const NAV_PATH_FILE = '/x-pack/solutions/security/packages/navigation/src/i18n_strings.ts';
+
+const wrap = (code: string) =>
+  `import { i18n } from '@kbn/i18n';\nimport type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';\n${code}`;
+
+const plain = (code: string) => `import { i18n } from '@kbn/i18n';\n${code}`;
+
+const invalid: RuleTester.InvalidTestCase[] = [
+  // Canonical term with wrong casing → brandMismatch
+  {
+    name: 'Brand term partially wrong casing',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.inf', { defaultMessage: 'Elastic inference' });`),
+    errors: [
+      {
+        messageId: 'brandMismatch',
+        data: { message: 'Elastic inference', expected: 'Elastic Inference' },
+      },
+    ],
+  },
+  {
+    name: 'Machine learning wrong casing warns with expected form',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.ml', { defaultMessage: 'Machine learning' });`),
+    errors: [
+      {
+        messageId: 'brandMismatch',
+        data: { message: 'Machine learning', expected: 'Machine Learning' },
+      },
+    ],
+  },
+
+  // Management page titles are NOT canonical proper nouns — sentence case applies
+  {
+    name: 'Former Title Case management label now warns (not a brand proper noun)',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.idx', { defaultMessage: 'Index Management' });`),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'Index Management', suggestion: 'Index management', word: 'Management' },
+      },
+    ],
+  },
+
+  // First word must be capitalised
+  {
+    name: 'Lowercase single-word title warns to capitalise',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.wf', { defaultMessage: 'workflows' });`),
+    errors: [
+      { messageId: 'capitalizeFirst', data: { message: 'workflows', suggestion: 'Workflows' } },
+    ],
+  },
+  {
+    name: 'Lowercase first word warns to capitalise',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.dv', { defaultMessage: 'data views' });`),
+    errors: [
+      { messageId: 'capitalizeFirst', data: { message: 'data views', suggestion: 'Data views' } },
+    ],
+  },
+
+  // Sentence case violation on a new (non-glossary) term
+  {
+    name: 'New Title Case term warns with sentence case suggestion',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' });`),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: {
+          message: 'My Custom Section',
+          suggestion: 'My custom section',
+          word: 'Custom',
+        },
+      },
+    ],
+  },
+  {
+    name: 'Multiple Title Case words on a new term',
+    filename: NAV_FILE,
+    code: wrap(
+      `const t = i18n.translate('foo.nav.data', { defaultMessage: 'Data Management Panel' });`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: {
+          message: 'Data Management Panel',
+          suggestion: 'Data management panel',
+          word: 'Management',
+        },
+      },
+    ],
+  },
+
+  // Management section registration in a file WITHOUT the core-chrome import
+  {
+    name: 'registerApp title literal in a plugin file warns',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `management.sections.section.data.registerApp({ id: 'x', title: 'My Custom Section' });`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
+      },
+    ],
+  },
+  {
+    name: 'registerApp title wrapping i18n.translate in a plugin file warns',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Stack monitoring' }) });`
+    ),
+    errors: [
+      {
+        messageId: 'brandMismatch',
+        data: { message: 'Stack monitoring', expected: 'Stack Monitoring' },
+      },
+    ],
+  },
+  // Deep link title in a file WITHOUT the core-chrome import
+  {
+    name: 'deepLinks title in a plugin file warns',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Deep Link' }] });`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Deep Link', suggestion: 'My deep link', word: 'Deep' },
+      },
+    ],
+  },
+  // A title in a nav-module file is checked even without the core-chrome import
+  {
+    name: 'title in a navigation-module file warns',
+    filename: NAV_PATH_FILE,
+    code: plain(
+      `export const s = { ml: { title: i18n.translate('sec.nav.ml', { defaultMessage: 'Machine learning' }) } };`
+    ),
+    errors: [
+      {
+        messageId: 'brandMismatch',
+        data: { message: 'Machine learning', expected: 'Machine Learning' },
+      },
+    ],
+  },
+  // title wrapping i18n.translate inside a core-chrome nav tree is still checked
+  {
+    name: 'title wrapping i18n.translate in a nav-tree file warns',
+    filename: NAV_FILE,
+    code: wrap(
+      `const node = { title: i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' }) };`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
+      },
+    ],
+  },
+  {
+    name: 'label wrapping i18n.translate in a nav-tree file warns',
+    filename: NAV_FILE,
+    code: wrap(
+      `const node = { label: i18n.translate('foo.nav.sec', { defaultMessage: 'My Custom Section' }) };`
+    ),
+    errors: [
+      {
+        messageId: 'sentenceCase',
+        data: { message: 'My Custom Section', suggestion: 'My custom section', word: 'Custom' },
+      },
+    ],
+  },
+];
+
+const valid: RuleTester.ValidTestCase[] = [
+  // Brand/canonical terms with correct casing — no warning
+  {
+    name: 'Product name Elastic AI SOC Engine — allowed',
+    filename: NAV_FILE,
+    code: wrap(
+      `const t = i18n.translate('foo.nav.soc', { defaultMessage: 'Elastic AI SOC Engine' });`
+    ),
+  },
+  // Hidden deep link (visibleIn: []) is not a nav item — ignored
+  {
+    name: 'deepLink title with visibleIn: [] — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Streams', deepLinks: [{ id: 'y', title: 'My Hidden Page', visibleIn: [] }] });`
+    ),
+  },
+
+  // Canonical term with exact casing — no warning
+  {
+    name: 'Canonical term Stack Monitoring — no warning',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.mon', { defaultMessage: 'Stack Monitoring' });`),
+  },
+
+  // Sentence case — no violation
+  {
+    name: 'Sentence case new term — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.data', { defaultMessage: 'Data management' });`),
+  },
+  {
+    name: 'Sentence case label in a nav-tree object — allowed',
+    filename: NAV_FILE,
+    code: wrap(
+      `const node = { label: i18n.translate('foo.nav.data', { defaultMessage: 'Data management' }) };`
+    ),
+  },
+  {
+    name: 'Machine Learning Kibana app title — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.ml', { defaultMessage: 'Machine Learning' });`),
+  },
+  // Acronyms — always allowed mid-title
+  {
+    name: 'Pure acronym mid-title — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.api', { defaultMessage: 'Manage API keys' });`),
+  },
+  // Mixed-case brand token mid-title is not plain Title Case — allowed
+  {
+    name: 'Mixed-case token (OpenAI) mid-title — allowed',
+    filename: NAV_FILE,
+    code: wrap(
+      `const t = i18n.translate('foo.nav.oai', { defaultMessage: 'Manage OpenAI connectors' });`
+    ),
+  },
+  // Lowercase-first token that is a legit mixed-case/symbol brand — allowed
+  {
+    name: 'Lowercase-first mixed-case token (macOS) — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.mac', { defaultMessage: 'macOS agents' });`),
+  },
+  // Non-title property value (description) in a nav-tree file — ignored
+  {
+    name: 'description property (i18n.translate) in a nav-tree file — ignored',
+    filename: NAV_FILE,
+    code: wrap(
+      `const x = { description: i18n.translate('foo.desc', { defaultMessage: 'View Custom Stuff' }) };`
+    ),
+  },
+
+  // Single word — nothing to check
+  {
+    name: 'Single word title — allowed',
+    filename: NAV_FILE,
+    code: wrap(`const t = i18n.translate('foo.nav.discover', { defaultMessage: 'Discover' });`),
+  },
+
+  // Non-i18n.translate — ignored
+  {
+    name: 'Non-i18n.translate call — ignored',
+    filename: NAV_FILE,
+    code: wrap(`const t = someOtherFn('foo', { defaultMessage: 'Not A Nav Link' });`),
+  },
+
+  // A title/label outside a nav file and outside a registration context is ignored
+  {
+    name: 'Title literal in a non-nav, non-registration object — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(`const config = { title: 'Some Arbitrary Title' };`),
+  },
+  {
+    name: 'i18n.translate outside a nav file and registration — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(`const t = i18n.translate('foo.button', { defaultMessage: 'Create New Thing' });`),
+  },
+  // A non-application .register(...) is not treated as a nav registration
+  {
+    name: 'Non-application register title — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(`expressions.register({ id: 'x', title: 'Some Expression Thing' });`),
+  },
+  // A bare application.register title is the app title, not a nav item — ignored
+  {
+    name: 'application.register title (chromeless/setup apps) — ignored',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `core.application.register({ id: 'x', title: 'Configure Elastic To Get Started', chromeless: true });`
+    ),
+  },
+  // Correct casing in registration contexts — allowed
+  {
+    name: 'registerApp canonical title — allowed',
+    filename: PLUGIN_FILE,
+    code: plain(
+      `management.sections.section.data.registerApp({ id: 'x', title: i18n.translate('foo.mon', { defaultMessage: 'Stack Monitoring' }) });`
+    ),
+  },
+  // Descriptions / callouts / aria labels in a nav-module file are NOT titles
+  {
+    name: 'standalone description const in a nav-module file — ignored',
+    filename: NAV_PATH_FILE,
+    code: plain(
+      `export const CALLOUT = i18n.translate('sec.nav.callout', { defaultMessage: 'Powered by Elastic AI' });`
+    ),
+  },
+];
+
+for (const [, tester] of [tsTester]) {
+  tester.run('nav_link_should_use_sentence_case', NavLinkShouldUseSentenceCase, {
+    valid,
+    invalid,
+  });
+}

--- a/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts
@@ -11,11 +11,7 @@ import type { TSESTree } from '@typescript-eslint/typescript-estree';
 import type { Rule } from 'eslint';
 import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
 
-/**
- * Proper nouns kept in exact casing that currently appear in nav. Unused brand
- * names are omitted; add one only when it lands in nav.
- * Everything else is sentence case; acronyms are auto-detected.
- */
+/** Proper nouns in nav with exact required casing; add only when a term lands in nav. */
 const CANONICAL_NAV_TERMS = [
   'AI Assistant',
   'AI Assistants',
@@ -64,10 +60,7 @@ function toSentenceCaseSuggestion(str: string): string {
     .join(' ');
 }
 
-/**
- * True for a label/title in a `*.registerApp(...)` object or a `deepLinks: [...]`
- * element. Bare `application.register(...)` is excluded (an app isn't nav).
- */
+/** True for a label/title inside registerApp(...) or a deepLinks:[...] element. */
 function isInNavRegistrationContext(prop: TSESTree.Property): boolean {
   const objExpr = prop.parent;
   if (!objExpr || objExpr.type !== AST_NODE_TYPES.ObjectExpression) return false;
@@ -104,11 +97,7 @@ function isInNavRegistrationContext(prop: TSESTree.Property): boolean {
 
 const SIDENAV_CONTEXTS = new Set(['classicSideNav', 'projectSideNav']);
 
-/**
- * True when the object's `visibleIn` array contains no sidenav context.
- * Skipped (returns false) if `visibleIn` is absent, non-literal, or a referenced const —
- * we only suppress checking when we can prove the item is not shown in the sidenav.
- */
+/** True when the item is provably absent from both sidenavs (visibleIn present but contains no sidenav context). */
 function isHiddenFromSideNav(prop: TSESTree.Property): boolean {
   const obj = prop.parent;
   if (!obj || obj.type !== AST_NODE_TYPES.ObjectExpression) return false;

--- a/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts
@@ -17,21 +17,27 @@ import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
  * Everything else is sentence case; acronyms are auto-detected.
  */
 const CANONICAL_NAV_TERMS = [
-  // Brand/feature names used in nav.
-  'Significant Events',
-  'Universal Profiling',
-  // Kibana UI names the brand guide capitalises.
-  'Machine Learning',
-  'Stack Monitoring',
-  'User Experience',
+  'AI Assistant',
+  'AI Assistants',
+  'Cloud Connect',
   'Elastic AI SOC Engine',
   'Elastic Inference',
+  'Machine Learning',
+  'Significant Events',
+  'Stack Monitoring',
+  'Universal Profiling',
 ] as const;
 
 const CANONICAL_NAV_TERMS_MAP = new Map(CANONICAL_NAV_TERMS.map((t) => [t.toLowerCase(), t]));
 
 /** Navigation-module files: check label/title only, for cases without the core-chrome import. */
 const NAV_PATH_SEGMENT = /[\\/]navigation[\\/]/;
+
+// security_solution nav titles live outside /navigation/: top-level consts in app/translations.ts
+// (consumed cross-file, unreachable at the usage site) and inline i18n.translate() calls in
+// public/*/links.ts. Hard-coded because this two-layer architecture is unique to this plugin.
+const SECURITY_NAV_TRANSLATIONS = /[\\/]security_solution[\\/]public[\\/]app[\\/]translations\.ts$/;
+const SECURITY_LINKS_FILE = /[\\/]security_solution[\\/]public[\\/][^/\\]+[\\/]links\.ts$/;
 
 /**
  * Excluded from sentence case: acronyms (API), mixed-case brand tokens (GenAI, macOS),
@@ -96,24 +102,46 @@ function isInNavRegistrationContext(prop: TSESTree.Property): boolean {
   return false;
 }
 
-/** True when the object has a literal `visibleIn: []` (hidden everywhere). A
- *  referenced const or spread is not resolved — only the empty-array literal. */
-function isHiddenFromNav(prop: TSESTree.Property): boolean {
+const SIDENAV_CONTEXTS = new Set(['classicSideNav', 'projectSideNav']);
+
+/**
+ * True when the object's `visibleIn` array contains no sidenav context.
+ * Skipped (returns false) if `visibleIn` is absent, non-literal, or a referenced const —
+ * we only suppress checking when we can prove the item is not shown in the sidenav.
+ */
+function isHiddenFromSideNav(prop: TSESTree.Property): boolean {
   const obj = prop.parent;
   if (!obj || obj.type !== AST_NODE_TYPES.ObjectExpression) return false;
-  return obj.properties.some(
-    (p) =>
+
+  const visibleInProp = obj.properties.find(
+    (p): p is TSESTree.Property =>
       p.type === AST_NODE_TYPES.Property &&
       p.key.type === AST_NODE_TYPES.Identifier &&
-      p.key.name === 'visibleIn' &&
-      p.value.type === AST_NODE_TYPES.ArrayExpression &&
-      p.value.elements.length === 0
+      p.key.name === 'visibleIn'
+  );
+
+  if (!visibleInProp) return false;
+  if (visibleInProp.value.type !== AST_NODE_TYPES.ArrayExpression) return false; // const ref — don't assume hidden
+
+  const elements = visibleInProp.value.elements;
+  // Empty array → hidden everywhere
+  if (elements.length === 0) return true;
+  // Non-empty → hidden from sidenav only if no sidenav context is listed
+  return !elements.some(
+    (el) =>
+      el !== null &&
+      el.type === AST_NODE_TYPES.Literal &&
+      typeof el.value === 'string' &&
+      SIDENAV_CONTEXTS.has(el.value)
   );
 }
 
-/** String value of a string literal, or null. */
+/** String value of a string literal or no-expression template literal, or null. */
 function getStaticString(node: TSESTree.Node): string | null {
-  return node.type === AST_NODE_TYPES.Literal && typeof node.value === 'string' ? node.value : null;
+  if (node.type === AST_NODE_TYPES.Literal && typeof node.value === 'string') return node.value;
+  if (node.type === AST_NODE_TYPES.TemplateLiteral && node.expressions.length === 0)
+    return node.quasis[0].value.cooked ?? null;
+  return null;
 }
 
 function getTranslateDefaultMessage(node: TSESTree.Node): string | null {
@@ -174,11 +202,13 @@ export const NavLinkShouldUseSentenceCase: Rule.RuleModule = {
   },
 
   create(context) {
-    // Where titles are checked:
-    //  - importNavFile: imports @kbn/core-chrome-browser — label/title + title consts.
-    //  - pathNavFile: inside a navigation module — label/title only.
-    //  - registration: *.registerApp / deepLinks titles in any file (not bare register).
+    // Scope triggers — each enables a different subset of checks (see visitors below):
+    //  - importNavFile: imports @kbn/core-chrome-browser
+    //  - pathNavFile: path contains /navigation/
+    //  - securityNavTranslations / securityLinksFile: security-specific hard-coded paths
     const pathNavFile = NAV_PATH_SEGMENT.test(context.filename);
+    const securityNavTranslations = SECURITY_NAV_TRANSLATIONS.test(context.filename);
+    const securityLinksFile = SECURITY_LINKS_FILE.test(context.filename);
     let importNavFile = false;
 
     function checkString(message: string, reportNode: Rule.Node) {
@@ -220,7 +250,18 @@ export const NavLinkShouldUseSentenceCase: Rule.RuleModule = {
       }
     }
 
-    // Property catches titles written inline (title:/label:); CallExpression catches titles defined as standalone i18n.translate consts.
+    // Resolves same-file `title: CONST` to its initializer. Cross-file refs are covered
+    // by the security-specific paths above.
+    function resolveSameFileConstInit(idNode: TSESTree.Identifier): TSESTree.Node | null {
+      const scope = context.sourceCode.getScope(idNode as unknown as Rule.Node);
+      const variable = scope.references.find((r) => r.identifier === idNode)?.resolved;
+      if (!variable) return null;
+      const def = variable.defs[0];
+      if (def?.type === 'Variable' && def.node.init)
+        return def.node.init as unknown as TSESTree.Node;
+      return null;
+    }
+
     return {
       ImportDeclaration(node) {
         const importNode = node as TSESTree.ImportDeclaration;
@@ -229,24 +270,15 @@ export const NavLinkShouldUseSentenceCase: Rule.RuleModule = {
         }
       },
 
-      // Title consts in nav-tree files: `const FOO_TITLE = i18n.translate(...)`.
-      // Restricted to const initializers so non-title values (description,
-      // tooltip, aria label) and inline title/label (owned by Property) are
-      // not also reported here.
+      // Every export in app/translations.ts is a nav title — check all i18n.translate() calls.
       CallExpression(node) {
-        if (!importNavFile) return;
-
+        if (!securityNavTranslations) return;
         const callNode = node as TSESTree.CallExpression;
-        if (callNode.parent?.type !== AST_NODE_TYPES.VariableDeclarator) return;
-
-        const defaultMessage = getTranslateDefaultMessage(callNode);
-        if (defaultMessage === null) return;
-
-        checkString(defaultMessage, callNode as unknown as Rule.Node);
+        const msg = getTranslateDefaultMessage(callNode);
+        if (msg !== null) checkString(msg, callNode as unknown as Rule.Node);
       },
 
-      // Checks `label`/`title` values (a string literal or an i18n.translate)
-      // in nav-tree files, navigation modules, and registerApp/deepLinks objects.
+      // Checks `label`/`title`: string literal, inline i18n.translate, or same-file const ref.
       Property(node) {
         const prop = node as TSESTree.Property;
 
@@ -258,21 +290,24 @@ export const NavLinkShouldUseSentenceCase: Rule.RuleModule = {
         }
 
         const inRegistrationContext = isInNavRegistrationContext(prop);
-        if (!importNavFile && !pathNavFile && !inRegistrationContext) return;
+        if (!importNavFile && !pathNavFile && !inRegistrationContext && !securityLinksFile) return;
 
-        if (isHiddenFromNav(prop)) return; // not rendered in nav (visibleIn: [])
+        if (isHiddenFromSideNav(prop)) return;
 
         const valueNode = prop.value;
 
-        const literal = getStaticString(valueNode);
-        if (literal !== null) {
-          checkString(literal, valueNode as unknown as Rule.Node);
+        // Direct string literal or inline i18n.translate.
+        const direct = getStaticString(valueNode) ?? getTranslateDefaultMessage(valueNode);
+        if (direct !== null) {
+          checkString(direct, valueNode as unknown as Rule.Node);
           return;
         }
 
-        const defaultMessage = getTranslateDefaultMessage(valueNode);
-        if (defaultMessage !== null) {
-          checkString(defaultMessage, valueNode as unknown as Rule.Node);
+        // `title: SOME_CONST` → resolve to its same-file const initializer.
+        if (valueNode.type === AST_NODE_TYPES.Identifier) {
+          const init = resolveSameFileConstInit(valueNode);
+          const resolved = init && (getStaticString(init) ?? getTranslateDefaultMessage(init));
+          if (resolved) checkString(resolved, init as unknown as Rule.Node);
         }
       },
     };

--- a/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TSESTree } from '@typescript-eslint/typescript-estree';
+import type { Rule } from 'eslint';
+import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
+
+/**
+ * Proper nouns kept in exact casing that currently appear in nav. Unused brand
+ * names are omitted; add one only when it lands in nav.
+ * Everything else is sentence case; acronyms are auto-detected.
+ */
+const CANONICAL_NAV_TERMS = [
+  // Brand/feature names used in nav.
+  'Significant Events',
+  'Universal Profiling',
+  // Kibana UI names the brand guide capitalises.
+  'Machine Learning',
+  'Stack Monitoring',
+  'User Experience',
+  'Elastic AI SOC Engine',
+  'Elastic Inference',
+] as const;
+
+const CANONICAL_NAV_TERMS_MAP = new Map(CANONICAL_NAV_TERMS.map((t) => [t.toLowerCase(), t]));
+
+/** Navigation-module files: check label/title only, for cases without the core-chrome import. */
+const NAV_PATH_SEGMENT = /[\\/]navigation[\\/]/;
+
+/**
+ * Excluded from sentence case: acronyms (API), mixed-case brand tokens (GenAI, macOS),
+ * and tokens with symbols (ATT&CK®, Cross-Cluster, ES|QL).
+ */
+function isTitleCasedWord(word: string): boolean {
+  return /^[A-Z][a-z]+$/.test(word);
+}
+
+/** A plain lowercase word ("workflows") — the first word must be capitalised.
+ *  Mixed-case/symbol tokens (macOS, n-gram, ES|QL) are left alone. */
+function isLowercaseWord(word: string): boolean {
+  return /^[a-z]+$/.test(word);
+}
+
+function toSentenceCaseSuggestion(str: string): string {
+  return str
+    .trim()
+    .split(/\s+/)
+    .map((word, i) => {
+      if (i === 0) return isLowercaseWord(word) ? word[0].toUpperCase() + word.slice(1) : word;
+      return isTitleCasedWord(word) ? word[0].toLowerCase() + word.slice(1) : word;
+    })
+    .join(' ');
+}
+
+/**
+ * True for a label/title in a `*.registerApp(...)` object or a `deepLinks: [...]`
+ * element. Bare `application.register(...)` is excluded (an app isn't nav).
+ */
+function isInNavRegistrationContext(prop: TSESTree.Property): boolean {
+  const objExpr = prop.parent;
+  if (!objExpr || objExpr.type !== AST_NODE_TYPES.ObjectExpression) return false;
+
+  const objParent = objExpr.parent;
+  if (!objParent) return false;
+
+  // registerApp(...) — management section apps
+  if (
+    objParent.type === AST_NODE_TYPES.CallExpression &&
+    objParent.arguments.includes(objExpr as TSESTree.CallExpressionArgument) &&
+    objParent.callee.type === AST_NODE_TYPES.MemberExpression &&
+    objParent.callee.property.type === AST_NODE_TYPES.Identifier &&
+    objParent.callee.property.name === 'registerApp'
+  ) {
+    return true;
+  }
+
+  // element of a `deepLinks: [...]` array
+  if (objParent.type === AST_NODE_TYPES.ArrayExpression) {
+    const arrParent = objParent.parent;
+    if (
+      arrParent &&
+      arrParent.type === AST_NODE_TYPES.Property &&
+      arrParent.key.type === AST_NODE_TYPES.Identifier &&
+      arrParent.key.name === 'deepLinks'
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** True when the object has a literal `visibleIn: []` (hidden everywhere). A
+ *  referenced const or spread is not resolved — only the empty-array literal. */
+function isHiddenFromNav(prop: TSESTree.Property): boolean {
+  const obj = prop.parent;
+  if (!obj || obj.type !== AST_NODE_TYPES.ObjectExpression) return false;
+  return obj.properties.some(
+    (p) =>
+      p.type === AST_NODE_TYPES.Property &&
+      p.key.type === AST_NODE_TYPES.Identifier &&
+      p.key.name === 'visibleIn' &&
+      p.value.type === AST_NODE_TYPES.ArrayExpression &&
+      p.value.elements.length === 0
+  );
+}
+
+/** String value of a string literal, or null. */
+function getStaticString(node: TSESTree.Node): string | null {
+  return node.type === AST_NODE_TYPES.Literal && typeof node.value === 'string' ? node.value : null;
+}
+
+function getTranslateDefaultMessage(node: TSESTree.Node): string | null {
+  if (node.type !== AST_NODE_TYPES.CallExpression) return null;
+
+  const { callee } = node;
+  if (
+    callee.type !== AST_NODE_TYPES.MemberExpression ||
+    callee.object.type !== AST_NODE_TYPES.Identifier ||
+    callee.property.type !== AST_NODE_TYPES.Identifier ||
+    callee.object.name !== 'i18n' ||
+    callee.property.name !== 'translate'
+  ) {
+    return null;
+  }
+
+  const optionsArg = node.arguments[1];
+  if (!optionsArg || optionsArg.type !== AST_NODE_TYPES.ObjectExpression) return null;
+
+  const defaultMessageProp = optionsArg.properties.find(
+    (p): p is TSESTree.Property =>
+      p.type === AST_NODE_TYPES.Property &&
+      p.key.type === AST_NODE_TYPES.Identifier &&
+      p.key.name === 'defaultMessage'
+  );
+
+  return defaultMessageProp ? getStaticString(defaultMessageProp.value) : null;
+}
+
+export const MESSAGES = {
+  brandMismatch:
+    '"{{message}}" is a known canonical nav term — use the exact casing "{{expected}}".',
+  capitalizeFirst:
+    'Navigation title "{{message}}" should start with a capital letter (e.g. "{{suggestion}}").',
+  sentenceCase:
+    'Navigation title "{{message}}" should use sentence case (e.g. "{{suggestion}}").' +
+    ' Only the first word, acronyms, and approved proper nouns are capitalised.' +
+    ' If "{{word}}" is a product or feature name that must keep specific casing,' +
+    ' confirm the official format in the Elastic brand writing style guide' +
+    ' (https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide) or with the brand team,' +
+    ' then add the exact name to CANONICAL_NAV_TERMS in' +
+    ' nav_link_should_use_sentence_case.ts.',
+} as const;
+
+export const NavLinkShouldUseSentenceCase: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    // Intentionally not fixable (no `meta.fixable`, no `fix`): `eslint --fix`
+    // must never auto-rewrite a shipped nav label.
+    docs: {
+      description:
+        'Navigation link titles must use sentence case. Terms in CANONICAL_NAV_TERMS' +
+        ' must match their exact canonical casing.',
+      url: 'https://github.com/elastic/kibana/blob/main/packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.ts',
+    },
+    messages: MESSAGES,
+    schema: [],
+  },
+
+  create(context) {
+    // Where titles are checked:
+    //  - importNavFile: imports @kbn/core-chrome-browser — label/title + title consts.
+    //  - pathNavFile: inside a navigation module — label/title only.
+    //  - registration: *.registerApp / deepLinks titles in any file (not bare register).
+    const pathNavFile = NAV_PATH_SEGMENT.test(context.filename);
+    let importNavFile = false;
+
+    function checkString(message: string, reportNode: Rule.Node) {
+      // Canonical term: enforce exact casing
+      const canonicalTerm = CANONICAL_NAV_TERMS_MAP.get(message.toLowerCase().trim());
+      if (canonicalTerm !== undefined) {
+        if (message !== canonicalTerm) {
+          context.report({
+            node: reportNode,
+            messageId: 'brandMismatch',
+            data: { message, expected: canonicalTerm },
+          });
+        }
+        return;
+      }
+
+      const words = message.trim().split(/\s+/);
+
+      // First word must be capitalised
+      if (isLowercaseWord(words[0])) {
+        context.report({
+          node: reportNode,
+          messageId: 'capitalizeFirst',
+          data: { message, suggestion: toSentenceCaseSuggestion(message) },
+        });
+        return;
+      }
+
+      // Later words must be lowercase (unless acronym/brand/proper noun)
+      for (let i = 1; i < words.length; i++) {
+        if (isTitleCasedWord(words[i])) {
+          context.report({
+            node: reportNode,
+            messageId: 'sentenceCase',
+            data: { message, suggestion: toSentenceCaseSuggestion(message), word: words[i] },
+          });
+          return;
+        }
+      }
+    }
+
+    // Property catches titles written inline (title:/label:); CallExpression catches titles defined as standalone i18n.translate consts.
+    return {
+      ImportDeclaration(node) {
+        const importNode = node as TSESTree.ImportDeclaration;
+        if (importNode.source.value === '@kbn/core-chrome-browser') {
+          importNavFile = true;
+        }
+      },
+
+      // Title consts in nav-tree files: `const FOO_TITLE = i18n.translate(...)`.
+      // Restricted to const initializers so non-title values (description,
+      // tooltip, aria label) and inline title/label (owned by Property) are
+      // not also reported here.
+      CallExpression(node) {
+        if (!importNavFile) return;
+
+        const callNode = node as TSESTree.CallExpression;
+        if (callNode.parent?.type !== AST_NODE_TYPES.VariableDeclarator) return;
+
+        const defaultMessage = getTranslateDefaultMessage(callNode);
+        if (defaultMessage === null) return;
+
+        checkString(defaultMessage, callNode as unknown as Rule.Node);
+      },
+
+      // Checks `label`/`title` values (a string literal or an i18n.translate)
+      // in nav-tree files, navigation modules, and registerApp/deepLinks objects.
+      Property(node) {
+        const prop = node as TSESTree.Property;
+
+        if (
+          prop.key.type !== AST_NODE_TYPES.Identifier ||
+          (prop.key.name !== 'label' && prop.key.name !== 'title')
+        ) {
+          return;
+        }
+
+        const inRegistrationContext = isInNavRegistrationContext(prop);
+        if (!importNavFile && !pathNavFile && !inRegistrationContext) return;
+
+        if (isHiddenFromNav(prop)) return; // not rendered in nav (visibleIn: [])
+
+        const valueNode = prop.value;
+
+        const literal = getStaticString(valueNode);
+        if (literal !== null) {
+          checkString(literal, valueNode as unknown as Rule.Node);
+          return;
+        }
+
+        const defaultMessage = getTranslateDefaultMessage(valueNode);
+        if (defaultMessage !== null) {
+          checkString(defaultMessage, valueNode as unknown as Rule.Node);
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Adds a custom ESLint rule — `@kbn/i18n/nav_link_should_use_sentence_case` — that enforces **sentence case** on Kibana navigation titles, per the [Elastic brand writing style guide](https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide).

Navigation labels should read like **“Stack management”**, not “Stack Management” — only the first word, acronyms, and approved proper nouns are capitalised.

This PR adds **only the rule, its tests, and the wiring to enable it**. It changes **no navigation labels** and has **no runtime/UI impact** (see _Scope_ below).

## What it checks

A `title` / `label` is checked when it is:

- in a file that imports `@kbn/core-chrome-browser` (navigation trees), or
- in a file under a `/navigation/` module path (e.g. a package’s `i18n_strings.ts`), or
- the argument of a `*.registerApp({ title })` call (Stack Management apps), or
- an element of a `deepLinks: [{ title }]` array.

It reports three situations:

| Message | Example | Suggestion |
| --- | --- | --- |
| `capitalizeFirst` | `workflows` | `Workflows` |
| `sentenceCase` | `My Custom Section` | `My custom section` |
| `brandMismatch` | `stack monitoring` | `Stack Monitoring` |

Left untouched: acronyms (`API`, `TLS`, `SIEM`), mixed-case brand tokens (`GenAI`, `macOS`, `ES|QL`), symbol tokens (`ATT&CK®`, `Cross-Cluster`), and a small `CANONICAL_NAV_TERMS` allowlist of proper nouns that currently appear in navigation.

## Not auto-fixable

The rule is intentionally **not fixable** — `eslint --fix` (and CI autofix) will never rewrite a shipped nav label. Casing changes to existing labels are deliberate and must be made by hand after confirming the official name with the brand writing style guide / brand team. The rule is registered at **`warn`** level, so it surfaces issues without breaking builds.

## Scope & follow-ups

To keep this PR reviewable and risk-free, it is limited to the lint rule. The broader cleanup ships separately:

1. **This PR** — the ESLint rule + tests (no behaviour change).
2. **Next** — fix existing navigation labels flagged by the rule.
3. **After** — remove the runtime `@kbn/shared-ux-label-formatter` (which sentence-cased labels at render time); the lint rule replaces it.

## Testing

```
node scripts/jest packages/kbn-eslint-plugin-i18n/rules/nav_link_should_use_sentence_case.test.ts
```

31 tests cover every detection path, the three message types, acronym / mixed-case / `visibleIn: []` handling, and the non-nav exclusions.
