### PR TITLE
Fix YAML validation errors in memory managed workflows

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_memory/conversation_scraper.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_memory/conversation_scraper.yaml
@@ -22,6 +22,13 @@ triggers:
   - type: scheduled
     with:
       every: "4h"
+  - type: manual
+    inputs:
+      - name: connectorId
+        type: string
+        default: ".anthropic-claude-4.6-sonnet-chat_completion"
+        required: false
+        description: "AI connector ID to use for the extraction agent."
 
 consts:
   CONVERSATIONS_LOOKBACK: "now-8h"
@@ -65,10 +72,10 @@ steps:
     steps:
       - name: extract_knowledge
         type: ai.agent
-        connector-id: ".anthropic-claude-4.6-sonnet-chat_completion"
+        connector-id: "${{ inputs.connectorId }}"
         create-conversation: true
+        timeout: 1800s
         with:
-          timeout: 1800s
           message: |
             First, call the load_skill tool with skill path skills/platform/streams/streams-conversation-scraper.
             Wait for the skill to load before calling any other tools.

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_memory/memory_consolidation.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_memory/memory_consolidation.yaml
@@ -23,14 +23,21 @@ triggers:
   - type: scheduled
     with:
       every: "24h"
+  - type: manual
+    inputs:
+      - name: connectorId
+        type: string
+        default: ".anthropic-claude-4.6-sonnet-chat_completion"
+        required: false
+        description: "AI connector ID to use for the consolidation agent."
 
 steps:
   - name: consolidate_memory
     type: ai.agent
-    connector-id: ".anthropic-claude-4.6-sonnet-chat_completion"
+    connector-id: "${{ inputs.connectorId }}"
     create-conversation: true
+    timeout: 1800s
     with:
-      timeout: 1800s
       message: |
         First, call the load_skill tool with skill path skills/platform/streams/streams-memory-consolidation.
         Wait for the skill to load before calling any other tools.

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_memory/memory_synthesis.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_memory/memory_synthesis.yaml
@@ -20,14 +20,20 @@ tags:
 
 triggers:
   - type: manual
+    inputs:
+      - name: connectorId
+        type: string
+        default: ".anthropic-claude-4.6-sonnet-chat_completion"
+        required: false
+        description: "AI connector ID to use for the synthesis agent."
 
 steps:
   - name: synthesize_memory
     type: ai.agent
-    connector-id: ".anthropic-claude-4.6-sonnet-chat_completion"
+    connector-id: "${{ inputs.connectorId }}"
     create-conversation: true
+    timeout: 1800s
     with:
-      timeout: 1800s
       message: |
         First, call the load_skill tool with skill path skills/platform/streams/streams-memory-synthesis.
         Wait for the skill to load before calling any other tools.

--- a/src/platform/test/moon.yml
+++ b/src/platform/test/moon.yml
@@ -16,6 +16,7 @@ project:
   sourceRoot: src/platform/test
 dependsOn:
   - '@kbn/core'
+  - '@kbn/content-list-common'
   - '@kbn/dashboard-plugin'
   - '@kbn/expressions-plugin'
   - '@kbn/saved-objects-management-plugin'

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/moon.yml
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/moon.yml
@@ -19,6 +19,8 @@ project:
 dependsOn:
   - '@kbn/core'
   - '@kbn/scout'
+  - '@kbn/content-list-common'
+  - '@kbn/content-list-scout'
   - '@kbn/usage-collection-plugin'
   - '@kbn/management-plugin'
   - '@kbn/saved-objects-tagging-oss-plugin'

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/workflows/managed_workflows.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/workflows/managed_workflows.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import { tags } from '@kbn/scout';
+import {
+  STREAMS_MEMORY_SYNTHESIS_WORKFLOW_ID,
+  STREAMS_MEMORY_CONSOLIDATION_WORKFLOW_ID,
+  STREAMS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
+} from '@kbn/workflows/managed';
+import { streamsApiTest as apiTest } from '../../fixtures';
+import { PUBLIC_API_HEADERS } from '../../fixtures/constants';
+
+const MEMORY_WORKFLOW_IDS = [
+  STREAMS_MEMORY_SYNTHESIS_WORKFLOW_ID,
+  STREAMS_MEMORY_CONSOLIDATION_WORKFLOW_ID,
+  STREAMS_MEMORY_CONVERSATION_SCRAPER_WORKFLOW_ID,
+];
+
+/**
+ * Verifies that all three memory managed workflows are installed and marked as valid
+ * after the feature flag is enabled. Polls until each workflow appears, since
+ * installation is asynchronous (triggered by a reactive observable in plugin start).
+ */
+apiTest.describe(
+  'Memory managed workflows',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    apiTest.beforeAll(async ({ apiServices }) => {
+      await apiServices.streamsTest.enableMemory();
+    });
+
+    apiTest.afterAll(async ({ apiServices }) => {
+      await apiServices.streamsTest.disableMemory();
+    });
+
+    for (const workflowId of MEMORY_WORKFLOW_IDS) {
+      apiTest(`${workflowId}: is installed and valid`, async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const headers = { ...PUBLIC_API_HEADERS, ...cookieHeader };
+
+        await expect
+          .poll(
+            async () => {
+              const response = await apiClient.get(`api/workflows/workflow/${workflowId}`, {
+                headers,
+                responseType: 'json',
+              });
+              return response.statusCode === 200 ? response.body.valid : false;
+            },
+            { timeout: 20_000, intervals: [1_000] }
+          )
+          .toBe(true);
+      });
+    }
+  }
+);


### PR DESCRIPTION
## Summary

Built-in memory workflows showed validation errors in the workflow editor that prevented admins from enabling them.

**Two bugs fixed (all three `streams_memory` workflows):**

- `timeout` was nested inside the `with:` block of `ai.agent` steps. The schema only allows `timeout` as a sibling of `with:` at the step level. Fixed in all three workflows.

- Hardcoded connector IDs (e.g. `.anthropic-claude-4.6-sonnet-chat_completion`) are not valid on user instances and failed the UI's connector-exists check, blocking the workflows from being enabled. A `connectorId` input (defaulting to the previous hardcoded value) was added to the manual trigger and `connector-id` was switched to `${{ inputs.connectorId }}`. The UI validator skips existence checks for template references, so the error disappears and admins can supply their own connector at trigger time.

**Also:** `conversation_scraper` and `memory_consolidation` were scheduled-only; a manual trigger with the same `connectorId` input was added so they can be run on demand too. When triggered by the scheduler, `connectorId` resolves to the default value.

## Test plan

- [ ] Open the Workflows UI as an admin — the memory workflows should no longer show `Property timeout is not allowed` or `connector UUID not found` errors
- [ ] Enable Memory Synthesis from the UI — the `connectorId` input should appear in the trigger form
- [ ] Run the Scout integration test: `node scripts/scout run-tests --arch stateful --domain classic --testFiles x-pack/platform/plugins/shared/streams/test/scout/api/tests/workflows/managed_workflows.spec.ts`
- [ ] After manually enabling the workflows, it should be possible to trigger them from the sigevents memory tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)