### PR TITLE
[Fleet] Add config value to disable knowledge base

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -8,6 +8,7 @@ xpack.osquery.enabled: false
 
 # Enable fleet on search projects for agentless features
 xpack.fleet.enabled: true
+xpack.fleet.installIntegrationsKnowledge: false
 xpack.fleet.packages:
   # fleet_server package installed to publish agent metrics
   - name: fleet_server

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -62,6 +62,7 @@ export const config: PluginConfigDescriptor = {
     prereleaseEnabledByDefault: true,
     hideDashboards: true,
     isAirGapped: true,
+    installIntegrationsKnowledge: true,
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
     // Unused settings before Fleet server exists
@@ -446,6 +447,7 @@ export const config: PluginConfigDescriptor = {
       integrationsHomeOverride: schema.maybe(schema.string()),
       prereleaseEnabledByDefault: schema.boolean({ defaultValue: false }),
       hideDashboards: schema.boolean({ defaultValue: false }),
+      installIntegrationsKnowledge: schema.maybe(schema.boolean()),
       integrationRollbackTTL: schema.maybe(schema.string()),
     },
     {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_integration_knowledge_setting.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_integration_knowledge_setting.test.ts
@@ -56,7 +56,50 @@ describe('getIntegrationKnowledgeSetting', () => {
     expect(result).toBe(false);
   });
 
-  it('should return true if config is disabled and user setting is enabled', async () => {
+  it('should return false if experimental feature flag is disabled and user setting is enabled', async () => {
+    (appContextService.getConfig as jest.Mock).mockReturnValue(null);
+    (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+      installIntegrationsKnowledge: false,
+    });
+    (getSettings as jest.Mock).mockResolvedValue({
+      integration_knowledge_enabled: true,
+    });
+
+    const result = await getIntegrationKnowledgeSetting(mockSoClient);
+    expect(result).toBe(false);
+  });
+
+  it('should return false if top-level installIntegrationsKnowledge is false and user setting is enabled', async () => {
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      installIntegrationsKnowledge: false,
+    });
+    (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+      installIntegrationsKnowledge: true,
+    });
+    (getSettings as jest.Mock).mockResolvedValue({
+      integration_knowledge_enabled: true,
+    });
+
+    const result = await getIntegrationKnowledgeSetting(mockSoClient);
+    expect(result).toBe(false);
+  });
+
+  it('should return true if top-level installIntegrationsKnowledge is true and user setting is enabled', async () => {
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      installIntegrationsKnowledge: true,
+    });
+    (appContextService.getExperimentalFeatures as jest.Mock).mockReturnValue({
+      installIntegrationsKnowledge: true,
+    });
+    (getSettings as jest.Mock).mockResolvedValue({
+      integration_knowledge_enabled: true,
+    });
+
+    const result = await getIntegrationKnowledgeSetting(mockSoClient);
+    expect(result).toBe(true);
+  });
+
+  it('should return false if config is disabled and user setting is enabled', async () => {
     (appContextService.getConfig as jest.Mock).mockReturnValue({
       experimentalFeatures: {
         integrationKnowledge: false,
@@ -70,6 +113,6 @@ describe('getIntegrationKnowledgeSetting', () => {
     });
 
     const result = await getIntegrationKnowledgeSetting(mockSoClient);
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_integration_knowledge_setting.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_integration_knowledge_setting.ts
@@ -16,8 +16,14 @@ export async function getIntegrationKnowledgeSetting(
   const config = appContextService.getConfig();
 
   const integrationKnowledgeConfig: boolean =
+    config?.installIntegrationsKnowledge ??
     config?.experimentalFeatures?.integrationKnowledge ??
     appContextService.getExperimentalFeatures().installIntegrationsKnowledge;
+
+  if (!integrationKnowledgeConfig) {
+    return false;
+  }
+
   try {
     const { integration_knowledge_enabled: integrationKnowledgeEnabled } = await getSettings(
       savedObjectsClient

--- a/x-pack/platform/plugins/shared/fleet/server/services/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/settings.ts
@@ -87,7 +87,8 @@ export async function settingsSetup(soClient: SavedObjectsClientContract) {
       updatedSettings.prerelease_integrations_enabled = config?.prereleaseEnabledByDefault;
     }
     if (
-      (config?.experimentalFeatures?.integrationKnowledge ??
+      (config?.installIntegrationsKnowledge ??
+        config?.experimentalFeatures?.integrationKnowledge ??
         appContextService.getExperimentalFeatures().installIntegrationsKnowledge) &&
       settings.integration_knowledge_enabled === undefined
     ) {


### PR DESCRIPTION
## Summary

Hotfix to disable knowledge base integrations on Fleet.