### PR TITLE
[8.19] feat(eslint): forbid new js-yaml imports in favor of yaml package (#269431)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2512,9 +2512,11 @@ module.exports = {
       // as consumers migrate to the native `fetch` API. Placed last so it wins
       // over any earlier override that re-applies RESTRICTED_IMPORTS (e.g. the
       // security_solution and workflows_management blocks). The trade-off: the
-      // 35 allowlisted files that overlap with those blocks lose their
-      // `*legacy*` pattern check; verified that none of them currently import
-      // any path matching `*legacy*`.
+      // allowlisted files that overlap with those blocks lose their `*legacy*`
+      // pattern check; verified that none of them currently import any path
+      // matching `*legacy*`. The js-yaml freeze is handled separately via
+      // @kbn/eslint/module_migration in packages/kbn-eslint-config/.eslintrc.js
+      // so it does not interact with this override.
       files: AXIOS_LEGACY_CONSUMERS,
       rules: {
         'no-restricted-imports': [

--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -19,6 +19,69 @@
 
 const { USES_STYLED_COMPONENTS } = require('@kbn/babel-preset/styled_components_files');
 
+/**
+ * Files that already import js-yaml. New js-yaml imports must not be added here;
+ * this list is expected to shrink as consumers migrate to the `yaml` package.
+ * Each entry is an anchored regex tested against the kibana-root-relative file path.
+ * The `module_migration` rule evaluates each mapping independently, so this list
+ * does not interact with other allowlists (e.g. AXIOS_LEGACY_CONSUMERS in .eslintrc.js).
+ */
+const JS_YAML_LEGACY_CONSUMERS = [
+  /^\.buildkite[\/\\]/,
+  /^oas_docs[\/\\]scripts[\/\\]/,
+  /^packages[\/\\]kbn-api-contracts[\/\\]/,
+  /^packages[\/\\]kbn-docs-utils[\/\\]/,
+  /^packages[\/\\]kbn-moon[\/\\]/,
+  /^packages[\/\\]kbn-optimizer[\/\\]/,
+  /^packages[\/\\]kbn-rspack-optimizer[\/\\]/,
+  /^scripts[\/\\]/,
+  /^src[\/\\]cli[\/\\]/,
+  /^src[\/\\]dev[\/\\]/,
+  /^src[\/\\]platform[\/\\]kbn-ui[\/\\]_tooling[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]private[\/\\]kbn-apm-config-loader[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]private[\/\\]kbn-gen-ai-functional-testing[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]private[\/\\]kbn-validate-oas[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-config[\/\\]src[\/\\]raw[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-connector-cli[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-edot-collector[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-es[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-openapi-bundler[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-otel-demo[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-otel-semantic-conventions[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-scout[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-synthtrace[\/\\]src[\/\\]cli[\/\\]/,
+  /^src[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-test[\/\\]src[\/\\]functional_test_runner[\/\\]/,
+  /^src[\/\\]platform[\/\\]plugins[\/\\]private[\/\\]interactive_setup[\/\\]server[\/\\]/,
+  /^src[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]telemetry[\/\\]server[\/\\]collectors[\/\\]/,
+  /^x-pack[\/\\]packages[\/\\]kbn-synthetics-private-location[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-data-forge[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-evals[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]kbn-inference-cli[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]packages[\/\\]shared[\/\\]response-ops[\/\\]alerting-v2-rule-form[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]agent_builder[\/\\]server[\/\\]services[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]automatic_import[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]automatic_import_v2[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]cases[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]fleet[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]inference[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]osquery[\/\\]cypress[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]rule_registry[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]streams[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]test[\/\\]cases_api_integration[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]packages[\/\\]synthetics-test-data[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]apm[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]apm[\/\\]server[\/\\]routes[\/\\]fleet[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]observability_ai_assistant_app[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]observability_onboarding[\/\\]server[\/\\]routes[\/\\]flow[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]synthetics[\/\\]public[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]packages[\/\\]test-api-clients[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]cloud_defend[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]elastic_assistant[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]server[\/\\]assistant[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]test[\/\\]security_solution_cypress[\/\\]cypress[\/\\]support[\/\\]/,
+];
+
 module.exports = {
   extends: ['./javascript.js', './typescript.js', './jest.js', './react.js'],
 
@@ -186,6 +249,14 @@ module.exports = {
           exact: true,
           disallowedMessage:
             'Use `@kbn/react-query` instead of `@tanstack/react-query`, as it defaults to networkMode="always"',
+        },
+        {
+          from: 'js-yaml',
+          to: false,
+          exclude: JS_YAML_LEGACY_CONSUMERS,
+          disallowedMessage:
+            "Do not introduce new js-yaml usage. Use the `yaml` package instead (e.g. `import yaml from 'yaml'`). " +
+            'Existing consumers are being migrated incrementally; the allowlist in JS_YAML_LEGACY_CONSUMERS will shrink over time.',
         },
       ],
     ],

--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -67,6 +67,7 @@ const JS_YAML_LEGACY_CONSUMERS = [
   /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]osquery[\/\\]cypress[\/\\]/,
   /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]rule_registry[\/\\]scripts[\/\\]/,
   /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]streams[\/\\]scripts[\/\\]/,
+  /^x-pack[\/\\]platform[\/\\]plugins[\/\\]shared[\/\\]integration_assistant[\/\\]server[\/\\]/,
   /^x-pack[\/\\]platform[\/\\]test[\/\\]cases_api_integration[\/\\]/,
   /^x-pack[\/\\]solutions[\/\\]observability[\/\\]packages[\/\\]synthetics-test-data[\/\\]/,
   /^x-pack[\/\\]solutions[\/\\]observability[\/\\]plugins[\/\\]apm[\/\\]scripts[\/\\]/,

--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -81,6 +81,7 @@ const JS_YAML_LEGACY_CONSUMERS = [
   /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]scripts[\/\\]/,
   /^x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]server[\/\\]assistant[\/\\]/,
   /^x-pack[\/\\]solutions[\/\\]security[\/\\]test[\/\\]security_solution_cypress[\/\\]cypress[\/\\]support[\/\\]/,
+  /^x-pack[\/\\]solutions[\/\\]security[\/\\]test[\/\\]security_solution_playwright[\/\\]api_utils[\/\\]/,
 ];
 
 module.exports = {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [feat(eslint): forbid new js-yaml imports in favor of yaml package (#269431)](https://github.com/elastic/kibana/pull/269431)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-06-23T14:44:30Z","message":"feat(eslint): forbid new js-yaml imports in favor of yaml package (#269431)\n\nCloses #269433\n\n## Summary\n\nFreezes new `js-yaml` imports across the codebase and directs developers\nto use the `yaml` package instead.\n\n**Changes:**\n- Adds `JS_YAML_LEGACY_CONSUMERS` — 52 anchored-regex patterns covering\nall existing `js-yaml` call sites — to\n`packages/kbn-eslint-config/.eslintrc.js`\n- Enforces the freeze via `@kbn/eslint/module_migration` (`to: false`,\n`exclude: JS_YAML_LEGACY_CONSUMERS`), the same mechanism used for\n`elastic-apm-node` and `styled-components`\n\n**Why `module_migration` instead of `no-restricted-imports`?**\n\nESLint replaces (not merges) `no-restricted-imports` options from the\nlast matching override. A `no-restricted-imports`-based allowlist\noverride for js-yaml would clobber the existing axios allowlist override\nfor the 800+ files matched by both lists' broad globs (`.buildkite/**`,\n`src/dev/**`, `fleet/**`, …), re-introducing axios lint errors across\nthose files. `@kbn/eslint/module_migration` evaluates each module\nrestriction independently per file, so the js-yaml and axios allowlists\ncannot interact. It also catches `require('js-yaml')` (via its\n`CallExpression` handler), which `no-restricted-imports` does not.\n\nAny new `import ... from 'js-yaml'` or `require('js-yaml')` outside the\nallowlist will now produce:\n\n> Do not introduce new js-yaml usage. Use the \\`yaml\\` package instead\n(e.g. \\`import yaml from 'yaml'\\`). Existing consumers are being\nmigrated incrementally; the allowlist in JS_YAML_LEGACY_CONSUMERS will\nshrink over time.\n\nThe `JS_YAML_LEGACY_CONSUMERS` allowlist is expected to shrink over time\nas teams migrate their existing usage.\n\n## Test plan\n\n- [ ] Verify ESLint passes on a file already importing `js-yaml`\n(covered by the allowlist)\n- [ ] Verify ESLint errors on a new file importing `js-yaml` outside the\nallowlist\n- [ ] Verify ESLint errors on a new file using `require('js-yaml')`\noutside the allowlist\n- [ ] CI lint check passes\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cbb6b0a45b7845a96f04cfd1900ec5c6bc2504d6","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0"],"title":"feat(eslint): forbid new js-yaml imports in favor of yaml package","number":269431,"url":"https://github.com/elastic/kibana/pull/269431","mergeCommit":{"message":"feat(eslint): forbid new js-yaml imports in favor of yaml package (#269431)\n\nCloses #269433\n\n## Summary\n\nFreezes new `js-yaml` imports across the codebase and directs developers\nto use the `yaml` package instead.\n\n**Changes:**\n- Adds `JS_YAML_LEGACY_CONSUMERS` — 52 anchored-regex patterns covering\nall existing `js-yaml` call sites — to\n`packages/kbn-eslint-config/.eslintrc.js`\n- Enforces the freeze via `@kbn/eslint/module_migration` (`to: false`,\n`exclude: JS_YAML_LEGACY_CONSUMERS`), the same mechanism used for\n`elastic-apm-node` and `styled-components`\n\n**Why `module_migration` instead of `no-restricted-imports`?**\n\nESLint replaces (not merges) `no-restricted-imports` options from the\nlast matching override. A `no-restricted-imports`-based allowlist\noverride for js-yaml would clobber the existing axios allowlist override\nfor the 800+ files matched by both lists' broad globs (`.buildkite/**`,\n`src/dev/**`, `fleet/**`, …), re-introducing axios lint errors across\nthose files. `@kbn/eslint/module_migration` evaluates each module\nrestriction independently per file, so the js-yaml and axios allowlists\ncannot interact. It also catches `require('js-yaml')` (via its\n`CallExpression` handler), which `no-restricted-imports` does not.\n\nAny new `import ... from 'js-yaml'` or `require('js-yaml')` outside the\nallowlist will now produce:\n\n> Do not introduce new js-yaml usage. Use the \\`yaml\\` package instead\n(e.g. \\`import yaml from 'yaml'\\`). Existing consumers are being\nmigrated incrementally; the allowlist in JS_YAML_LEGACY_CONSUMERS will\nshrink over time.\n\nThe `JS_YAML_LEGACY_CONSUMERS` allowlist is expected to shrink over time\nas teams migrate their existing usage.\n\n## Test plan\n\n- [ ] Verify ESLint passes on a file already importing `js-yaml`\n(covered by the allowlist)\n- [ ] Verify ESLint errors on a new file importing `js-yaml` outside the\nallowlist\n- [ ] Verify ESLint errors on a new file using `require('js-yaml')`\noutside the allowlist\n- [ ] CI lint check passes\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cbb6b0a45b7845a96f04cfd1900ec5c6bc2504d6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269431","number":269431,"mergeCommit":{"message":"feat(eslint): forbid new js-yaml imports in favor of yaml package (#269431)\n\nCloses #269433\n\n## Summary\n\nFreezes new `js-yaml` imports across the codebase and directs developers\nto use the `yaml` package instead.\n\n**Changes:**\n- Adds `JS_YAML_LEGACY_CONSUMERS` — 52 anchored-regex patterns covering\nall existing `js-yaml` call sites — to\n`packages/kbn-eslint-config/.eslintrc.js`\n- Enforces the freeze via `@kbn/eslint/module_migration` (`to: false`,\n`exclude: JS_YAML_LEGACY_CONSUMERS`), the same mechanism used for\n`elastic-apm-node` and `styled-components`\n\n**Why `module_migration` instead of `no-restricted-imports`?**\n\nESLint replaces (not merges) `no-restricted-imports` options from the\nlast matching override. A `no-restricted-imports`-based allowlist\noverride for js-yaml would clobber the existing axios allowlist override\nfor the 800+ files matched by both lists' broad globs (`.buildkite/**`,\n`src/dev/**`, `fleet/**`, …), re-introducing axios lint errors across\nthose files. `@kbn/eslint/module_migration` evaluates each module\nrestriction independently per file, so the js-yaml and axios allowlists\ncannot interact. It also catches `require('js-yaml')` (via its\n`CallExpression` handler), which `no-restricted-imports` does not.\n\nAny new `import ... from 'js-yaml'` or `require('js-yaml')` outside the\nallowlist will now produce:\n\n> Do not introduce new js-yaml usage. Use the \\`yaml\\` package instead\n(e.g. \\`import yaml from 'yaml'\\`). Existing consumers are being\nmigrated incrementally; the allowlist in JS_YAML_LEGACY_CONSUMERS will\nshrink over time.\n\nThe `JS_YAML_LEGACY_CONSUMERS` allowlist is expected to shrink over time\nas teams migrate their existing usage.\n\n## Test plan\n\n- [ ] Verify ESLint passes on a file already importing `js-yaml`\n(covered by the allowlist)\n- [ ] Verify ESLint errors on a new file importing `js-yaml` outside the\nallowlist\n- [ ] Verify ESLint errors on a new file using `require('js-yaml')`\noutside the allowlist\n- [ ] CI lint check passes\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"cbb6b0a45b7845a96f04cfd1900ec5c6bc2504d6"}},{"url":"https://github.com/elastic/kibana/pull/274602","number":274602,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/274603","number":274603,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->