### PR TITLE
[Cases] Support unified attachment shapes in push to connector

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.test.ts
@@ -40,6 +40,7 @@ import {
 } from './utils';
 
 import type {
+  AttachmentV2,
   CaseCustomFields,
   CustomFieldsConfiguration,
   Observable,
@@ -50,6 +51,7 @@ import {
   CaseStatuses,
   CustomFieldTypes,
   UserActionActions,
+  UserActionTypes,
   CaseSeverity,
   ConnectorTypes,
 } from '../../../common/types/domain';
@@ -58,7 +60,7 @@ import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
 import { userProfiles, userProfilesMap } from '../user_profiles.mock';
 import { mappings, mockCases } from '../../mocks';
-import type { ObservablePost } from '../../../common/types/api';
+import type { ObservablePost, CaseUserActionsDeprecatedResponse } from '../../../common/types/api';
 import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
 
 const allComments = [
@@ -477,6 +479,66 @@ describe('utils', () => {
           commentId: 'comment-user-1',
         },
       ]);
+    });
+
+    it('counts unified alert attachments toward the alerts total', async () => {
+      const unifiedAlertSingle = {
+        ...omit(commentAlert, ['alertId', 'index', 'rule']),
+        id: 'unified-alert-1',
+        type: 'security.alert',
+        attachmentId: 'alert-id-3',
+      } as unknown as AttachmentV2;
+      const unifiedAlertMulti = {
+        ...omit(commentAlert, ['alertId', 'index', 'rule']),
+        id: 'unified-alert-2',
+        type: 'security.alert',
+        attachmentId: ['alert-id-4', 'alert-id-5'],
+      } as unknown as AttachmentV2;
+
+      const res = await createIncident({
+        theCase: {
+          ...theCase,
+          // 1 legacy alert (1 id) + 2 unified alerts (1 + 2 ids) = 4 alerts total
+          comments: [commentAlert, unifiedAlertSingle, unifiedAlertMulti],
+        },
+        userActions,
+        connector,
+        alerts: [],
+        casesConnectors,
+        spaceId: 'default',
+      });
+
+      expect(res.comments).toEqual([
+        {
+          comment: 'Elastic Alerts attached to the case: 4',
+          commentId: 'mock-id-1-total-alerts',
+        },
+      ]);
+    });
+
+    it('skips the alerts summary when every alert (legacy or unified) has been pushed', async () => {
+      const pushedAt = '2019-11-25T21:55:00.177Z';
+      const unifiedAlertPushed = {
+        ...omit(commentAlert, ['alertId', 'index', 'rule']),
+        id: 'unified-alert-1',
+        type: 'security.alert',
+        attachmentId: ['alert-id-3', 'alert-id-4'],
+        pushed_at: pushedAt,
+      } as unknown as AttachmentV2;
+
+      const res = await createIncident({
+        theCase: {
+          ...theCase,
+          comments: [{ ...commentAlertMultipleIds, pushed_at: pushedAt }, unifiedAlertPushed],
+        },
+        userActions,
+        connector,
+        alerts: [],
+        casesConnectors,
+        spaceId: 'default',
+      });
+
+      expect(res.comments).toEqual([]);
     });
 
     it('adds the backlink to cases correctly', async () => {
@@ -949,6 +1011,46 @@ describe('utils', () => {
           comment:
             'Elastic Alerts attached to the case: 1\n\nFor more details, view the alerts in Kibana\nAlerts URL: https://example.com/s/test-space/app/security/cases/mock-id-1/?tabId=alerts',
           commentId: 'mock-id-1-total-alerts',
+        },
+      ]);
+    });
+
+    it('formats unified `comment` attachments using data.content', () => {
+      const unifiedComment = {
+        ...omit(commentObj, ['comment']),
+        id: 'comment-unified-1',
+        type: 'comment',
+        data: { content: 'Unified comment body' },
+      } as unknown as AttachmentV2;
+
+      const userActionsWithUnified = [
+        ...userActions,
+        {
+          ...userActions.find((action) => action.type === UserActionTypes.comment)!,
+          comment_id: unifiedComment.id,
+        },
+      ] as CaseUserActionsDeprecatedResponse;
+
+      const theCase = {
+        ...flattenCaseSavedObject({ savedObject: mockCases[0] }),
+        comments: [unifiedComment],
+        totalComments: 1,
+      };
+
+      const latestPushInfo = getLatestPushInfo('not-exists', userActionsWithUnified);
+
+      expect(
+        formatComments({
+          userActions: userActionsWithUnified,
+          theCase,
+          latestPushInfo,
+          userProfiles: userProfilesMap,
+          spaceId: 'default',
+        })
+      ).toEqual([
+        {
+          comment: 'Unified comment body\n\nAdded by elastic.',
+          commentId: 'comment-unified-1',
         },
       ]);
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/utils.ts
@@ -30,6 +30,7 @@ import type {
 import type { Template } from '../../../common/types/domain/template/latest';
 import { AttachmentType, CaseStatuses, UserActionTypes } from '../../../common/types/domain';
 import type {
+  AttachmentRequestV2,
   CasePostRequest,
   CaseRequestCustomFields,
   CaseUserActionsDeprecatedResponse,
@@ -39,10 +40,15 @@ import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { isPushedUserAction } from '../../../common/utils/user_actions';
 import type { CasesClientGetAlertsResponse } from '../alerts/types';
 import type { ExternalServiceComment, ExternalServiceIncident } from './types';
-import { getAlertIds } from '../utils';
 import type { CasesConnectorsMap } from '../../connectors';
 import { getCaseViewPath } from '../../common/utils';
-import { isLegacyAttachmentRequest } from '../../../common/utils/attachments';
+import {
+  isCommentAttachmentType,
+  isLegacyAttachmentRequest,
+  isUnifiedAlertAttachment,
+  toStringArray,
+} from '../../../common/utils/attachments';
+import { COMMENT_ATTACHMENT_TYPE } from '../../../common/constants/attachments';
 import * as i18n from './translations';
 
 interface CreateIncidentArgs {
@@ -93,33 +99,17 @@ export const getLatestPushInfo = (
 };
 
 /**
- * Builds the connector-comment string that gets posted alongside the case to
- * external incident systems (ServiceNow, Jira, Resilient, Swimlane).
- *
- * The legacy `actions` branch is intentionally absent: legacy `actions`
- * attachments are projected to the unified `security.endpoint` shape on read
- * (see `actionsAttachmentTransformer`), so they never surface here as
- * `AttachmentType.actions`. The user-facing host-isolation comment now lives
- * on the unified attachment's `data.content`, which the registry-hook
- * redesign tracked in https://github.com/elastic/kibana/issues/262574 will
- * surface to push-to-connector. Today host-isolation comments are not pushed
- * (matches existing behavior for the `externalReference` + `endpoint` shape
- * that has been in place since multi-EDR support landed).
- *
- * Likewise the `alert` branch below is currently unreachable because
- * `formatComments` filters alerts out before this function is called; that
- * dead code is preserved here intentionally as a placeholder for the same
- * registry-hook redesign (#262574), which will fold both alert and unified
- * attachment formatting into per-type registrations.
+ * Returns the body text for a comment pushed to an external incident system
+ * (ServiceNow, Jira, Resilient, Swimlane).
  */
 const getCommentContent = (comment: AttachmentV2): string => {
-  if (isLegacyAttachmentRequest(comment)) {
-    if (comment.type === AttachmentType.user) {
-      return comment.comment;
-    } else if (comment.type === AttachmentType.alert) {
-      const ids = getAlertIds(comment);
-      return `Alert with ids ${ids.join(', ')} added to case`;
-    }
+  if (isLegacyAttachmentRequest(comment) && comment.type === AttachmentType.user) {
+    return comment.comment;
+  }
+
+  if (comment.type === COMMENT_ATTACHMENT_TYPE && 'data' in comment) {
+    const content = comment.data?.content;
+    return typeof content === 'string' ? content : '';
   }
 
   return '';
@@ -131,6 +121,19 @@ interface CountAlertsInfo {
   totalAlerts: number;
 }
 
+// Returns the number of alert ids on the attachment, or `null` when the
+// attachment is not an alert
+const countAlertIds = (comment: AttachmentV2): number | null => {
+  if (isLegacyAttachmentRequest(comment) && comment.type === AttachmentType.alert) {
+    return toStringArray(comment.alertId).length;
+  }
+  const asRequest = comment as AttachmentRequestV2;
+  if (isUnifiedAlertAttachment(asRequest)) {
+    return toStringArray(asRequest.attachmentId).length;
+  }
+  return null;
+};
+
 const getAlertsInfo = (
   comments: Case['comments']
 ): { totalAlerts: number; hasUnpushedAlertComments: boolean } => {
@@ -138,14 +141,16 @@ const getAlertsInfo = (
 
   const res =
     comments?.reduce<CountAlertsInfo>(({ totalComments, pushed, totalAlerts }, comment) => {
-      if (isLegacyAttachmentRequest(comment) && comment.type === AttachmentType.alert) {
-        return {
-          totalComments: totalComments + 1,
-          pushed: comment.pushed_at != null ? pushed + 1 : pushed,
-          totalAlerts: totalAlerts + (Array.isArray(comment.alertId) ? comment.alertId.length : 1),
-        };
+      const alertIdCount = countAlertIds(comment);
+      if (alertIdCount === null) {
+        return { totalComments, pushed, totalAlerts };
       }
-      return { totalComments, pushed, totalAlerts };
+
+      return {
+        totalComments: totalComments + 1,
+        pushed: comment.pushed_at != null ? pushed + 1 : pushed,
+        totalAlerts: totalAlerts + alertIdCount,
+      };
     }, countingInfo) ?? countingInfo;
 
   return {
@@ -279,13 +284,8 @@ export const formatComments = ({
   );
 
   const commentsToBeUpdated = theCase.comments?.filter(
-    // We push only user-authored comments. `AttachmentType.actions` was dropped
-    // when legacy `actions` attachments were folded into `security.endpoint`
-    // (the unified type does not surface here as legacy `actions`). The
-    // registry-hook redesign tracked in
-    // https://github.com/elastic/kibana/issues/262574 will let unified
-    // attachment types opt into push-to-connector formatting.
-    (comment) => comment.type === AttachmentType.user && commentsIdsToBeUpdated.has(comment.id)
+    // Push only user-authored comments — legacy `user` and unified `comment`.
+    (comment) => isCommentAttachmentType(comment.type) && commentsIdsToBeUpdated.has(comment.id)
   );
 
   let comments: ExternalServiceComment[] = [];


### PR DESCRIPTION
## Summary

When pushing a case, only legacy attachment types (`user`, `alert`) were captured, this causes missing comments and miscounted alerts in the external case. This PR widens the push-to-connector formatting helpers to support unified types. 
- `formatComments` filters on `isCommentAttachmentType`, so unified `comment` attachments push to external services.
- `getAlertsInfo` and the new `countAlertIds` helper count unified  alert attachments (`attachmentId` array length) toward  `totalAlerts` / `hasUnpushedAlertComments`.


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.