### PR TITLE
fix(a11y): wrap EuiButtonIcon with EuiToolTip in esql_ast_inspector examples

### DIFF
--- a/examples/esql_ast_inspector/public/components/esql_inspector/components/preview/components/preview_ui/components/from_command/source.tsx
+++ b/examples/esql_ast_inspector/public/components/esql_inspector/components/preview/components/preview_ui/components/from_command/source.tsx
@@ -92,17 +92,19 @@ export const Source: React.FC<SourceProps> = ({ node, index }) => {
         </EuiFormRow>
         <div style={{ position: 'absolute', right: 0, top: 0 }}>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="cross"
-              aria-label="Remove"
-              onClick={() => {
-                if (!query) return;
-                const from = state.from$.getValue();
-                if (!from) return;
-                from.args = from.args.filter((c) => c !== node);
-                state.reprint();
-              }}
-            />
+            <EuiToolTip content="Remove" disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label="Remove"
+                onClick={() => {
+                  if (!query) return;
+                  const from = state.from$.getValue();
+                  if (!from) return;
+                  from.args = from.args.filter((c) => c !== node);
+                  state.reprint();
+                }}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </div>
       </div>

--- a/examples/esql_ast_inspector/public/components/esql_inspector/components/preview/components/preview_ui/components/limit_command/index.tsx
+++ b/examples/esql_ast_inspector/public/components/esql_inspector/components/preview/components/preview_ui/components/limit_command/index.tsx
@@ -16,6 +16,7 @@ import {
   EuiFormRow,
   EuiPanel,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { Builder } from '@elastic/esql';
 import { useEsqlInspector } from '../../../../../../context';
@@ -108,16 +109,18 @@ export const LimitCommand: React.FC = () => {
         </div>
         <div style={{ position: 'absolute', right: 0, top: 0 }}>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="cross"
-              aria-label="Remove"
-              onClick={() => {
-                const query = state.query$.getValue();
-                if (!query) return;
-                query.ast.commands = query.ast.commands.filter((c) => c !== limit);
-                state.reprint();
-              }}
-            />
+            <EuiToolTip content="Remove" disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label="Remove"
+                onClick={() => {
+                  const query = state.query$.getValue();
+                  if (!query) return;
+                  query.ast.commands = query.ast.commands.filter((c) => c !== limit);
+                  state.reprint();
+                }}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes `@elastic/eui/tooltip-button-icon-wrap` ESLint violations in `esql_ast_inspector` example files by wrapping `EuiButtonIcon` elements with `EuiToolTip`, giving sighted users a visible tooltip.

Closes #274596

## Changes

- `from_command/source.tsx`: Wrapped the "Remove" `EuiButtonIcon` with `EuiToolTip content="Remove" disableScreenReaderOutput`
- `limit_command/index.tsx`: Added `EuiToolTip` import and wrapped the "Remove" `EuiButtonIcon` with `EuiToolTip content="Remove" disableScreenReaderOutput`

`disableScreenReaderOutput` is added in both cases because the tooltip `content` matches the button's `aria-label`, preventing screen reader announcement duplication.

## Skill compliance checklist

- [x] Read and applied [`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)
- [x] Added label `a11y:agent-pr`
- [x] Fixed all files (or documented skips in the PR body)

## Acceptance criteria

- [x] All items in **PR metadata (required)** are satisfied
- [x] PR has label `a11y:agent-pr`
- [x] PR body contains `Closes #274596`
- [x] PR is opened against `main`
- [x] All listed files are fixed
- [x] Fixes follow `.agents/skills/accessibility/SKILL.md`