### PR TITLE
[Agent Builder] HITL: Remove askUserQuestion experimental feature flag

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/agents/provider.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/agents/provider.ts
@@ -103,8 +103,6 @@ export interface ExperimentalFeatures {
   subagents: boolean;
   /** Whether the todo list tool and task-management prompt are enabled */
   todos: boolean;
-  /** Whether the ask_user_question HITL tool is enabled */
-  askUserQuestion: boolean;
   /** Whether the bash tool (and the just-bash runtime) is enabled */
   bash: boolean;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/register_internal_tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/register_internal_tools.ts
@@ -95,8 +95,8 @@ export const registerInternalTools = async ({
     tools.push(createSleepTool());
   }
 
-  // ask_user_question — experimental, and not available in standalone mode.
-  if (experimentalFeatures.askUserQuestion && interactive) {
+  // ask_user_question — not available in standalone mode.
+  if (interactive) {
     tools.push(createAskUserQuestionTool());
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_agent.ts
@@ -77,7 +77,6 @@ export const createAgentHandlerContext = async <TParams = Record<string, unknown
     skills: true,
     subagents: isExperimentalEnabled,
     todos: isExperimentalEnabled,
-    askUserQuestion: isExperimentalEnabled,
     bash: isBashEnabled,
   };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -327,7 +327,6 @@ export const createAgentHandlerContextMock = (): AgentHandlerContextMock => {
       skills: false,
       subagents: false,
       todos: false,
-      askUserQuestion: false,
       bash: false,
     },
     subAgentExecutor: {


### PR DESCRIPTION
## Summary

Clears the experimental FF `askUserQuestion`.

## Release Note

Adds the ability for Agent Builder to pause and ask clarifying questions before acting — so instead of guessing your intent, the agent presents up to 5 focused multiple-choice questions, then picks up exactly where it left off once you answer.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

None

Closes https://github.com/elastic/search-team/issues/15015