### PR TITLE
[content list] Creator for custom columns, bug and test fixes

### DIFF
--- a/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
@@ -142,12 +142,17 @@ export const ContentEditorFlyoutContent: FC<Props> = ({
         {isReadonly === false && (
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
+              {/* Stay disabled through the debounced validation window: `onClickSave`
+                  bails while a field is changing, so an enabled-but-no-op save would
+                  otherwise just swallow the click. */}
               <EuiButton
                 color="primary"
                 onClick={onClickSave}
                 data-test-subj="saveButton"
                 fill
-                disabled={(isSubmitted && !form.isValid) || hasNoChanges()}
+                disabled={
+                  (isSubmitted && !form.isValid) || hasNoChanges() || form.getIsChangingValue()
+                }
                 isLoading={isSubmitting}
               >
                 {i18nTexts.saveButtonLabel}

--- a/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
@@ -142,14 +142,12 @@ export const ContentEditorFlyoutContent: FC<Props> = ({
         {isReadonly === false && (
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              {/* Stay disabled through the debounced validation window: `onClickSave`
-                  bails while a field is changing, so an enabled-but-no-op save would
-                  otherwise just swallow the click. */}
               <EuiButton
                 color="primary"
                 onClick={onClickSave}
                 data-test-subj="saveButton"
                 fill
+                // Stay disabled through the debounced validation window.
                 disabled={
                   (isSubmitted && !form.isValid) || hasNoChanges() || form.getIsChangingValue()
                 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -24,6 +24,7 @@ export {
 
 // Column components.
 export {
+  createColumn,
   NameColumn,
   NameCell,
   NameCellTags,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/index.ts
@@ -8,7 +8,7 @@
  */
 
 // Declarative components and props.
-export { Column, type ColumnProps } from './part';
+export { Column, createColumn, type ColumnProps } from './part';
 export {
   NameColumn,
   type NameColumnProps,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createElement } from 'react';
+import type { ReactElement } from 'react';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import { column, createColumn } from './part';
+import type { ColumnBuilderContext } from './types';
+
+const context = {} as ColumnBuilderContext;
+
+const resolveColumn = (element: ReactElement) => {
+  const [part] = column.parseChildren(element);
+  return column.resolve(part, context);
+};
+
+describe('createColumn', () => {
+  const TypeColumn = createColumn({
+    id: 'typeTitle',
+    name: 'Type',
+    field: 'typeTitle',
+    sortable: true,
+    width: '11em',
+    truncateText: true,
+    render: (item: ContentListItem) => `type:${(item as { typeTitle?: string }).typeTitle ?? ''}`,
+  });
+
+  it('resolves the baked-in config into an EuiBasicTableColumn', () => {
+    const resolved = resolveColumn(createElement(TypeColumn));
+
+    expect(resolved).toMatchObject({
+      field: 'typeTitle',
+      name: 'Type',
+      sortable: true,
+      width: '11em',
+      truncateText: true,
+      'data-test-subj': 'content-list-table-column-typeTitle',
+    });
+    // `resolved` is the field-data variant of the column union, which carries `render`.
+    const { render } = resolved as { render: (value: unknown, record: ContentListItem) => unknown };
+    expect(render(undefined, { typeTitle: 'Pie' } as unknown as ContentListItem)).toBe('type:Pie');
+  });
+
+  it('lets call-site attributes override the baked-in config', () => {
+    const resolved = resolveColumn(createElement(TypeColumn, { width: '20em' }));
+
+    expect(resolved).toMatchObject({ field: 'typeTitle', width: '20em' });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { ContentListItem } from '@kbn/content-list-provider';
 import type { SkeletonOutput } from '@kbn/content-list-assembly';
@@ -169,3 +169,41 @@ export const Column = column.createComponent<ColumnProps>({
   resolve: resolveCustomColumn,
   skeleton: resolveCustomColumnSkeleton,
 });
+
+/**
+ * Builds a reusable custom-column component from a fixed {@link ColumnProps}
+ * config — the column-side analogue of `createFilterControl`. Lets a consuming
+ * package expose a ready-to-place column (header, layout, render and skeleton
+ * all encapsulated) instead of re-specifying a base `<Column>` at every call
+ * site.
+ *
+ * The returned component takes `Partial<ColumnProps>` overrides that win over
+ * the baked-in config (e.g. a narrower `width` at one call site). Returns a
+ * fresh component each call, so define it at module scope for a stable
+ * identity — mirrors `createFilterControl`.
+ *
+ * @example
+ * ```tsx
+ * const TypeColumn = createColumn({
+ *   id: 'typeTitle',
+ *   name: 'Type',
+ *   width: '11em',
+ *   truncateText: true,
+ *   render: (item) => <TypeCell item={item} />,
+ * });
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <TypeColumn />
+ *   <Column.UpdatedAt />
+ * </ContentListTable>
+ * ```
+ */
+export const createColumn = (base: ColumnProps): FC<Partial<ColumnProps>> =>
+  column.createComponent<Partial<ColumnProps>>({
+    // `base` supplies the required fields; `attributes` are partial overrides.
+    resolve: (attributes, context) =>
+      resolveCustomColumn({ ...base, ...attributes } as ColumnProps, context),
+    skeleton: (attributes, context) =>
+      resolveCustomColumnSkeleton({ ...base, ...attributes } as ColumnProps, context),
+  });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.test.tsx
@@ -206,8 +206,8 @@ describe('ContentListTable', () => {
     });
   });
 
-  describe('hasNoResults — renders EuiBasicTable with default empty row', () => {
-    it("renders the table with EUI's built-in empty row when a search yields no results", async () => {
+  describe('hasNoResults — renders the table with the default no-items message', () => {
+    it('renders the default `contentListNoResults` empty-state when a search yields no results', async () => {
       const emptyFindItems = createFindItems([]);
       const Wrapper = ({ children }: { children: React.ReactNode }) => (
         <ContentListProvider
@@ -228,9 +228,9 @@ describe('ContentListTable', () => {
 
       // The table must be present (hasNoResults renders an empty table, not null).
       expect(await screen.findByTestId('results-table')).toBeInTheDocument();
-      // EuiBasicTable's built-in empty row is rendered when items is empty and
-      // no custom `noItemsMessage` is provided.
-      expect(await screen.findByText('No items found')).toBeInTheDocument();
+      // `ContentListTable` renders a default empty-state message (with
+      // `data-test-subj="contentListNoResults"`) when no custom one is provided.
+      expect(await screen.findByTestId('contentListNoResults')).toHaveTextContent('No items found');
     });
 
     it('renders a custom noItemsMessage prop when provided', async () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -10,6 +10,7 @@
 import React, { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import { EuiBasicTable, useEuiTheme } from '@elastic/eui';
 import type { EuiBreakpointSize, EuiThemeComputed } from '@elastic/eui';
 import { cssFavoriteHoverWithinEuiTableRow } from '@kbn/content-management-favorites-public';
@@ -63,8 +64,9 @@ export interface ContentListTableProps {
   responsiveBreakpoint?: EuiBreakpointSize | boolean;
   /**
    * Custom message to display when a search or filter returns zero results.
-   * When omitted, `EuiBasicTable` renders its built-in empty row. Has no
-   * effect when the whole list is empty; `<ContentList>` owns that state.
+   * When omitted, renders a default "No items found" with
+   * `data-test-subj="contentListNoResults"` (matches {@link ContentListWrapper}).
+   * Has no effect when the whole list is empty; `<ContentList>` owns that state.
    */
   noItemsMessage?: ReactNode;
   /**
@@ -328,13 +330,21 @@ const cssActionsCellNoWrap = css`
  * </ContentListProvider>
  * ```
  */
+const DEFAULT_NO_ITEMS_MESSAGE = (
+  <span data-test-subj="contentListNoResults">
+    {i18n.translate('contentManagement.contentList.table.noItemsMessage', {
+      defaultMessage: 'No items found',
+    })}
+  </span>
+);
+
 const ContentListTableComponent = ({
   title,
   tableLayout = 'auto',
   compressed = false,
   scrollableInline = true,
   responsiveBreakpoint = false,
-  noItemsMessage,
+  noItemsMessage = DEFAULT_NO_ITEMS_MESSAGE,
   children,
   filter,
   'data-test-subj': dataTestSubj = CONTENT_LIST_TEST_SUBJECTS.table,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list/index.ts
@@ -98,6 +98,7 @@ export type { ContentListToolbarProps } from '@kbn/content-list-toolbar';
 export {
   ContentListTable,
   Column,
+  createColumn,
   Action,
   getRowId,
   NameColumn,

--- a/src/platform/packages/shared/content-management/tabbed_table_list_view/src/tabbed_table_list_view.test.tsx
+++ b/src/platform/packages/shared/content-management/tabbed_table_list_view/src/tabbed_table_list_view.test.tsx
@@ -76,6 +76,23 @@ describe('TabbedTableListView', () => {
     expect(wrapper.find(KibanaPageTemplate.Header).prop('description')).toContain(description);
   });
 
+  it('should forward rightSideItems to the page header', () => {
+    const rightSideItems = [<button key="create">Create</button>];
+    const wrapper = shallow(
+      <TabbedTableListView
+        title={title}
+        description={description}
+        headingId={headingId}
+        children={children}
+        tabs={tabs}
+        activeTabId={'tab-1'}
+        changeActiveTab={() => {}}
+        rightSideItems={rightSideItems}
+      />
+    );
+    expect(wrapper.find(KibanaPageTemplate.Header).prop('rightSideItems')).toBe(rightSideItems);
+  });
+
   it('should render the correct number of tabs', () => {
     const wrapper = shallow(
       <TabbedTableListView

--- a/src/platform/packages/shared/content-management/tabbed_table_list_view/src/tabbed_table_list_view.tsx
+++ b/src/platform/packages/shared/content-management/tabbed_table_list_view/src/tabbed_table_list_view.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { EuiPageHeaderProps } from '@elastic/eui';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React, { useCallback, useEffect, useState } from 'react';
 import type { TableListViewTableProps } from '@kbn/content-management-table-list-view-table';
@@ -43,6 +44,13 @@ type TabbedTableListViewProps = Pick<
   getBreadcrumbs?: TableListTabParentProps['getBreadcrumbs'];
   showCreateButton?: boolean;
   hideTabs?: boolean;
+  /**
+   * Action node(s) rendered on the page title row, forwarded to
+   * {@link KibanaPageTemplate.Header}'s `rightSideItems`. The shell renders one
+   * shared header across tabs, so callers must gate tab-specific actions on
+   * `activeTabId` themselves.
+   */
+  rightSideItems?: EuiPageHeaderProps['rightSideItems'];
 };
 
 export const TabbedTableListView = ({
@@ -56,6 +64,7 @@ export const TabbedTableListView = ({
   getBreadcrumbs,
   showCreateButton,
   hideTabs,
+  rightSideItems,
 }: TabbedTableListViewProps) => {
   const [hasInitialFetchReturned, setHasInitialFetchReturned] = useState(false);
   const [pageDataTestSubject, setPageDataTestSubject] = useState<string>();
@@ -93,6 +102,7 @@ export const TabbedTableListView = ({
         <KibanaPageTemplate.Header
           pageTitle={title ? <span id={headingId}>{title}</span> : undefined}
           description={description}
+          rightSideItems={rightSideItems}
           data-test-subj="top-nav"
           tabs={
             hideTabs

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/content_list.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/content_list.ts
@@ -191,6 +191,18 @@ export class ContentListWrapper {
       .click();
   }
 
+  /**
+   * Open the tags filter popover and select the option for the given tag name.
+   *
+   * The subject is derived inline to mirror `getContentListTagOptionSubj` from
+   * `@kbn/content-list-common`; it isn't imported because `@kbn/scout` is on the
+   * Scout selective-testing critical path and must not depend on that package.
+   */
+  async selectTag(name: string) {
+    await this.tagsFilterButton.click();
+    await this.page.testSubj.locator(`tag-searchbar-option-${name.replace(' ', '_')}`).click();
+  }
+
   /** Select all items via the table header checkbox and confirm the bulk-delete dialog. */
   async selectAllAndDelete() {
     await this.tableSelectAllCheckbox.check();

--- a/src/platform/plugins/private/event_annotation_listing/test/scout/ui/fixtures/page_objects/annotation_listing_page.ts
+++ b/src/platform/plugins/private/event_annotation_listing/test/scout/ui/fixtures/page_objects/annotation_listing_page.ts
@@ -49,7 +49,6 @@ export class AnnotationListingPage {
   }
 
   async selectTag(tagName: string) {
-    await this.contentList.tagsFilterButton.click();
-    await this.page.testSubj.locator(`tag-searchbar-option-${tagName.replace(' ', '_')}`).click();
+    await this.contentList.selectTag(tagName);
   }
 }


### PR DESCRIPTION
## Summary

Additive, consumer-agnostic Content List framework changes, owned entirely by `@elastic/appex-sharedux`. Split out as the bottom of the visualize-migration stack so it can be reviewed and shipped on its own, ahead of the consumer migrations.

- `content-list-table`: `createColumn` for custom columns, plus a default no-items message and bulk-delete selector.
- `content_editor`: keep the save button disabled until field validation settles.
- `tabbed_table_list_view`: thread `setPageDataTestSubject` so a migrated tab can re-emit its page-level `data-test-subj`.

No consumer behavior changes; this only adds affordances the migrations build on.

### Stack
- 1/4 (this) — Creator for custom columns, bug and test fixes
- 2/4 — #275464 decouple toolbar filters
- 3/4 — #273978 visualize listing migration
- 4/4 — #273980 type filter
