### PR TITLE
[OAS] Add tech_preview to TypeMetaAvailability stability union

### DIFF
--- a/src/platform/packages/shared/kbn-config-schema/src/types/type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/type.ts
@@ -30,7 +30,7 @@ import { Reference } from '../references';
  */
 export interface TypeMetaAvailability {
   /** @default stable */
-  stability?: 'experimental' | 'beta' | 'stable';
+  stability?: 'experimental' | 'beta' | 'stable' | 'tech_preview';
   /**
    * The stack version in which this field was introduced (eg: 9.4.0).
    */

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.ts
@@ -793,6 +793,50 @@ describe('generateOpenApiDocument', () => {
         expectedState: 'Generally available',
       },
       {
+        name: 'router with tech_preview stability',
+        routerConfig: {
+          routers: {
+            testRouter: {
+              routes: [
+                {
+                  path: '/test-path/{id}/{path*}',
+                  options: { availability: { stability: 'tech_preview' }, access: 'public' },
+                },
+              ],
+            },
+          },
+          versionedRouters: {},
+        } as CreateTestRouterArgs,
+        expectedPath: '/test-path/{id}/{path}',
+        expectedState: 'Technical Preview',
+      },
+      {
+        name: 'versioned router with tech_preview stability',
+        routerConfig: {
+          routers: {},
+          versionedRouters: {
+            testVersionedRouter: {
+              routes: [
+                {
+                  path: '/test-path',
+                  options: {
+                    access: 'public',
+                    options: { availability: { stability: 'tech_preview' } },
+                    security: {
+                      authz: {
+                        requiredPrivileges: ['foo'],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        } as CreateTestRouterArgs,
+        expectedPath: '/test-path',
+        expectedState: 'Technical Preview',
+      },
+      {
         name: 'versioned router without availability',
         routerConfig: {
           routers: {},


### PR DESCRIPTION
## Summary

Follow-up to [#274670](https://github.com/elastic/kibana/pull/274670).

This PR adds `'tech_preview'` to the `stability` union in `TypeMetaAvailability` (missed in [#270051](https://github.com/elastic/kibana/pull/270051)) and adds the missing test cases for `tech_preview`.

`TypeMetaAvailability` in `kbn-config-schema` is the field-level equivalent to route-level availability.
Not including `tech_preview` meant authors could mark a route as `tech_preview` but TypeScript would reject the same value on any of its schema fields. OAS generation already handles `tech_preview` correctly, so no output would've been broken if someone cast around the type error, but nobody could use it cleanly.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

This is a pure type addition to an interface — no runtime behavior changes. The new union member is already handled correctly by all downstream OAS generation code. Risk: none.