### PR TITLE
[Cases][Attachments] Fix user action reference and import export

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/delete.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/delete.ts
@@ -17,6 +17,7 @@ import { Operations } from '../../authorization';
 import type { DeleteAllArgs, DeleteArgs } from './types';
 import type { AttachmentRequestV2 } from '../../../common/types/api';
 import { AttachmentRequestRtV2 } from '../../../common/types/api';
+import type { AttachmentSavedObjectType } from '../../services/user_actions/types';
 
 /**
  * Delete all comments for a case.
@@ -68,6 +69,7 @@ export async function deleteAll(
         id: comment.id,
         owner: comment.attributes.owner,
         attachment: comment.attributes,
+        savedObjectType: comment.type as AttachmentSavedObjectType,
       })),
       user,
     });
@@ -144,6 +146,7 @@ export async function deleteComment(
         action: UserActionActions.delete,
         caseId: id,
         savedObjectId,
+        savedObjectType: attachment.type as AttachmentSavedObjectType,
         payload: { attachment: attachmentRequestAttributes },
         user,
         owner: attachment.attributes.owner,

--- a/x-pack/platform/plugins/shared/cases/server/common/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/constants.ts
@@ -6,7 +6,11 @@
  */
 
 import { CaseSeverity, CaseStatuses } from '../../common/types/domain';
-import { CASE_COMMENT_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../common/constants';
+import {
+  CASE_ATTACHMENT_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_SAVED_OBJECT,
+} from '../../common/constants';
 import { CasePersistedSeverity, CasePersistedStatus } from './types/case';
 
 /**
@@ -29,6 +33,11 @@ export const CASE_REF_NAME = `associated-${CASE_SAVED_OBJECT}`;
  * The name of the saved object reference indicating the commentId reference
  */
 export const COMMENT_REF_NAME = `associated-${CASE_COMMENT_SAVED_OBJECT}`;
+
+/**
+ * The name of the saved object reference indicating the attachmentId reference
+ */
+export const CASE_ATTACHMENT_REF_NAME = `associated-${CASE_ATTACHMENT_SAVED_OBJECT}`;
 
 /**
  * The name of the saved object reference indicating the externalReferenceId reference

--- a/x-pack/platform/plugins/shared/cases/server/common/models/case_with_comments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/models/case_with_comments.ts
@@ -37,6 +37,7 @@ import {
 import { CASE_SAVED_OBJECT, MAX_DOCS_PER_PAGE } from '../../../common/constants';
 import type { CasesClientArgs } from '../../client';
 import type { RefreshSetting } from '../../services/types';
+import type { AttachmentSavedObjectType } from '../../services/user_actions/types';
 import { createCaseError } from '../error';
 import { AttachmentLimitChecker } from '../limiter_checker';
 import type { AlertInfo } from '../types';
@@ -255,6 +256,7 @@ export class CaseCommentModel {
         action: UserActionActions.update,
         caseId: this.caseInfo.id,
         savedObjectId: comment.id,
+        savedObjectType: comment.type as AttachmentSavedObjectType,
         payload: { attachment: queryRestAttributes },
         user: this.params.user,
         owner,
@@ -599,6 +601,7 @@ export class CaseCommentModel {
         action: UserActionActions.create,
         caseId: this.caseInfo.id,
         savedObjectId: comment.id,
+        savedObjectType: comment.type as AttachmentSavedObjectType,
         payload: {
           attachment: req,
         },
@@ -609,14 +612,17 @@ export class CaseCommentModel {
   }
 
   private async bulkCreateCommentUserAction(
-    attachments: Array<{ id: string } & AttachmentRequestV2>
+    attachments: Array<
+      { id: string; savedObjectType: AttachmentSavedObjectType } & AttachmentRequestV2
+    >
   ) {
     await this.params.services.userActionService.creator.bulkCreateAttachmentCreation({
       caseId: this.caseInfo.id,
-      attachments: attachments.map(({ id, ...attachment }) => ({
+      attachments: attachments.map(({ id, savedObjectType, ...attachment }) => ({
         id,
         owner: attachment.owner,
         attachment,
+        savedObjectType,
       })),
       user: this.params.user,
     });
@@ -708,9 +714,18 @@ export class CaseCommentModel {
         (attachment) => attachment.error == null
       );
 
-      const attachmentsWithoutErrors = attachments.filter((attachment) =>
-        savedObjectsWithoutErrors.some((so) => so.id === attachment.id)
-      );
+      const attachmentsWithoutErrors = attachments.flatMap((attachment) => {
+        const savedObject = savedObjectsWithoutErrors.find((so) => so.id === attachment.id);
+
+        return savedObject
+          ? [
+              {
+                ...attachment,
+                savedObjectType: savedObject.type as AttachmentSavedObjectType,
+              },
+            ]
+          : [];
+      });
 
       await Promise.all([
         commentableCase.handleAlertComments(attachmentsWithoutErrors),

--- a/x-pack/platform/plugins/shared/cases/server/common/references.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/references.ts
@@ -6,8 +6,12 @@
  */
 
 import type { SavedObjectReference } from '@kbn/core-saved-objects-api-server';
-import { CASE_SAVED_OBJECT } from '../../common/constants';
-import { CASE_REF_NAME } from './constants';
+import {
+  CASE_ATTACHMENT_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_SAVED_OBJECT,
+} from '../../common/constants';
+import { CASE_ATTACHMENT_REF_NAME, CASE_REF_NAME, COMMENT_REF_NAME } from './constants';
 
 export const getCaseReferenceId = (references: SavedObjectReference[]): string | undefined => {
   return findReferenceId(CASE_REF_NAME, CASE_SAVED_OBJECT, references);
@@ -19,4 +23,12 @@ export const findReferenceId = (
   references?: SavedObjectReference[]
 ): string | undefined => {
   return references?.find((ref) => ref.name === name && ref.type === type)?.id;
+};
+
+export const findCommentReferenceId = (references?: SavedObjectReference[]): string | undefined => {
+  return references?.find(
+    (ref) =>
+      (ref.name === COMMENT_REF_NAME && ref.type === CASE_COMMENT_SAVED_OBJECT) ||
+      (ref.name === CASE_ATTACHMENT_REF_NAME && ref.type === CASE_ATTACHMENT_SAVED_OBJECT)
+  )?.id;
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
@@ -29,10 +29,12 @@ import {
   modelVersion9,
 } from './model_versions';
 import { handleImport } from '../import_export/import';
+import type { ConfigType } from '../../config';
 
 export const createCaseSavedObjectType = (
   coreSetup: CoreSetup,
-  logger: Logger
+  logger: Logger,
+  config: ConfigType
 ): SavedObjectsType => ({
   name: CASE_SAVED_OBJECT,
   indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
@@ -308,7 +310,7 @@ export const createCaseSavedObjectType = (
     onExport: async (
       context: SavedObjectsExportTransformContext,
       objects: Array<SavedObject<CasePersistedAttributes>>
-    ) => handleExport({ context, objects, coreSetup, logger }),
+    ) => handleExport({ context, objects, coreSetup, logger, config }),
     onImport: (objects: Array<SavedObject<CasePersistedAttributes>>) => handleImport({ objects }),
   },
 });

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/versioning.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/versioning.test.ts
@@ -18,7 +18,7 @@ import { modelVersion9 } from './model_versions';
 
 const mockLogger = loggerMock.create();
 const mockCoreSetup = coreMock.createSetup();
-const caseSavedObjectType = createCaseSavedObjectType(mockCoreSetup, mockLogger);
+const caseSavedObjectType = createCaseSavedObjectType(mockCoreSetup, mockLogger, {} as never);
 
 describe('caseSavedObjectType model version transformations', () => {
   let migrator: ModelVersionTestMigrator;

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.test.ts
@@ -10,6 +10,8 @@ import type { SavedObjectsExportTransformContext } from '@kbn/core/server';
 import { handleExport } from './export';
 import { mockCases } from '../../mocks';
 import type { CaseSavedObjectTransformed } from '../../common/types/case';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../common/constants';
+import { getAttachmentsAndUserActionsForCases } from './utils';
 
 jest.mock('./utils', () => {
   return {
@@ -21,6 +23,9 @@ describe('case export', () => {
   const testRequest = httpServerMock.createFakeKibanaRequest({});
   const testContext: SavedObjectsExportTransformContext = { request: testRequest };
   const logger = loggingSystemMock.createLogger();
+  const config = {
+    attachments: { enabled: true },
+  } as never;
   const testCases: CaseSavedObjectTransformed[] = mockCases.map((_case, idx) => ({
     ..._case,
     attributes: {
@@ -36,6 +41,7 @@ describe('case export', () => {
       // @ts-ignore: mock objects are not matching persisted objects
       objects: testCases,
       logger,
+      config,
     });
 
     const containsIncrementalId = exported.some((exportedCase) => {
@@ -46,5 +52,32 @@ describe('case export', () => {
     });
 
     expect(containsIncrementalId).toBeFalsy();
+  });
+
+  it('includes cases-attachments when exporting with unified attachments enabled', async () => {
+    const coreSetup = coreMock.createSetup();
+
+    await handleExport({
+      context: testContext,
+      coreSetup,
+      // @ts-ignore: mock objects are not matching persisted objects
+      objects: testCases,
+      logger,
+      config,
+    });
+
+    const [coreStart] = await coreSetup.getStartServices();
+
+    expect(coreStart.savedObjects.getScopedClient).toHaveBeenCalledWith(
+      testRequest,
+      expect.objectContaining({
+        includedHiddenTypes: expect.arrayContaining([CASE_ATTACHMENT_SAVED_OBJECT]),
+      })
+    );
+    expect(getAttachmentsAndUserActionsForCases).toHaveBeenCalledWith(
+      expect.anything(),
+      testCases.map((testCase) => testCase.id),
+      true
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.ts
@@ -15,8 +15,10 @@ import type {
   CaseUserActionWithoutReferenceIds,
   AttachmentAttributesWithoutRefs,
 } from '../../../common/types/domain';
+import type { AttachmentAttributesV2 } from '../../../common/types/domain/attachment/v2';
 import { createCaseError } from '../../common/error';
 import type { CasePersistedAttributes } from '../../common/types/case';
+import type { ConfigType } from '../../config';
 import { getAttachmentsAndUserActionsForCases } from './utils';
 import { getSavedObjectsTypes } from '../../../common';
 
@@ -25,15 +27,20 @@ export async function handleExport({
   objects,
   coreSetup,
   logger,
+  config,
 }: {
   context: SavedObjectsExportTransformContext;
   objects: Array<SavedObject<CasePersistedAttributes>>;
   coreSetup: CoreSetup;
   logger: Logger;
+  config: ConfigType;
 }): Promise<
   Array<
     SavedObject<
-      CasePersistedAttributes | AttachmentAttributesWithoutRefs | CaseUserActionWithoutReferenceIds
+      | CasePersistedAttributes
+      | AttachmentAttributesWithoutRefs
+      | AttachmentAttributesV2
+      | CaseUserActionWithoutReferenceIds
     >
   >
 > {
@@ -51,13 +58,14 @@ export async function handleExport({
     }));
     const [{ savedObjects }] = await coreSetup.getStartServices();
     const savedObjectsClient = savedObjects.getScopedClient(context.request, {
-      includedHiddenTypes: getSavedObjectsTypes(),
+      includedHiddenTypes: getSavedObjectsTypes(config),
     });
 
     const caseIds = cleanedObjects.map((caseObject) => caseObject.id);
     const attachmentsAndUserActionsForCases = await getAttachmentsAndUserActionsForCases(
       savedObjectsClient,
-      caseIds
+      caseIds,
+      config.attachments?.enabled === true
     );
 
     return [...cleanedObjects, ...attachmentsAndUserActionsForCases.flat()];

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import {
+  CASE_ATTACHMENT_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+  CASE_USER_ACTION_SAVED_OBJECT,
+} from '../../../common/constants';
+import { getAttachmentsAndUserActionsForCases } from './utils';
+
+describe('import_export utils', () => {
+  it('exports attachments from both attachment saved object types when enabled', async () => {
+    const createPointInTimeFinder = jest.fn().mockReturnValue({
+      async *find() {
+        yield { saved_objects: [] };
+      },
+    });
+    const savedObjectsClient = {
+      createPointInTimeFinder,
+    } as unknown as SavedObjectsClientContract;
+
+    await getAttachmentsAndUserActionsForCases(savedObjectsClient, ['case-id'], true);
+
+    expect(createPointInTimeFinder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
+      })
+    );
+    expect(createPointInTimeFinder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: CASE_USER_ACTION_SAVED_OBJECT,
+      })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.ts
@@ -10,7 +10,9 @@ import type {
   CaseUserActionWithoutReferenceIds,
   AttachmentAttributesWithoutRefs,
 } from '../../../common/types/domain';
+import type { AttachmentAttributesV2 } from '../../../common/types/domain/attachment/v2';
 import {
+  CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
@@ -20,16 +22,25 @@ import { defaultSortField } from '../../common/utils';
 
 export async function getAttachmentsAndUserActionsForCases(
   savedObjectsClient: SavedObjectsClientContract,
-  caseIds: string[]
+  caseIds: string[],
+  includeCaseAttachments = false
 ): Promise<
-  Array<SavedObject<AttachmentAttributesWithoutRefs | CaseUserActionWithoutReferenceIds>>
+  Array<
+    SavedObject<
+      AttachmentAttributesWithoutRefs | AttachmentAttributesV2 | CaseUserActionWithoutReferenceIds
+    >
+  >
 > {
+  const attachmentTypes = includeCaseAttachments
+    ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
+    : CASE_COMMENT_SAVED_OBJECT;
+
   const [attachments, userActions] = await Promise.all([
-    getAssociatedObjects<AttachmentAttributesWithoutRefs>({
+    getAssociatedObjects<AttachmentAttributesWithoutRefs | AttachmentAttributesV2>({
       savedObjectsClient,
       caseIds,
       sortField: defaultSortField,
-      type: CASE_COMMENT_SAVED_OBJECT,
+      type: attachmentTypes,
     }),
     getAssociatedObjects<CaseUserActionWithoutReferenceIds>({
       savedObjectsClient,
@@ -51,7 +62,7 @@ async function getAssociatedObjects<T>({
   savedObjectsClient: SavedObjectsClientContract;
   caseIds: string[];
   sortField: string;
-  type: string;
+  type: string | string[];
 }): Promise<Array<SavedObject<T>>> {
   const references = caseIds.map((id) => ({ type: CASE_SAVED_OBJECT, id }));
   const finder = savedObjectsClient.createPointInTimeFinder<T>({

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
@@ -48,7 +48,7 @@ export const registerSavedObjects = ({
   core.savedObjects.registerType(caseConfigureSavedObjectType);
   core.savedObjects.registerType(caseConnectorMappingsSavedObjectType);
   core.savedObjects.registerType(caseIdIncrementerSavedObjectType);
-  core.savedObjects.registerType(createCaseSavedObjectType(core, logger));
+  core.savedObjects.registerType(createCaseSavedObjectType(core, logger, config));
   core.savedObjects.registerType(
     createCaseUserActionSavedObjectType({
       persistableStateAttachmentTypeRegistry,

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/abstract_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/abstract_builder.ts
@@ -10,11 +10,13 @@ import { ACTION_SAVED_OBJECT_TYPE } from '@kbn/actions-plugin/server';
 import type { CaseConnector, ExternalService, User } from '../../../common/types/domain';
 import { UserActionTypes } from '../../../common/types/domain';
 import {
+  CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   NONE_CONNECTOR_ID,
 } from '../../../common/constants';
 import {
+  CASE_ATTACHMENT_REF_NAME,
   CASE_REF_NAME,
   COMMENT_REF_NAME,
   CONNECTOR_ID_REFERENCE_NAME,
@@ -26,6 +28,7 @@ import type {
   SavedObjectParameters,
   UserActionParameters,
   UserActionEvent,
+  AttachmentSavedObjectType,
 } from './types';
 
 export abstract class UserActionBuilder {
@@ -58,12 +61,20 @@ export abstract class UserActionBuilder {
       : [];
   }
 
-  protected createCommentReferences(id: string | null): SavedObjectReference[] {
+  protected createCommentReferences(
+    id: string | null,
+    savedObjectType: AttachmentSavedObjectType = CASE_COMMENT_SAVED_OBJECT
+  ): SavedObjectReference[] {
+    const referenceName =
+      savedObjectType === CASE_ATTACHMENT_SAVED_OBJECT
+        ? CASE_ATTACHMENT_REF_NAME
+        : COMMENT_REF_NAME;
+
     return id != null
       ? [
           {
-            type: CASE_COMMENT_SAVED_OBJECT,
-            name: COMMENT_REF_NAME,
+            type: savedObjectType,
+            name: referenceName,
             id,
           },
         ]
@@ -93,6 +104,7 @@ export abstract class UserActionBuilder {
     valueKey,
     caseId,
     savedObjectId,
+    savedObjectType,
     connectorId,
     type,
   }: CommonBuilderArguments): SavedObjectParameters => {
@@ -105,7 +117,10 @@ export abstract class UserActionBuilder {
       },
       references: [
         ...this.createCaseReferences(caseId),
-        ...this.createCommentReferences(savedObjectId ?? null),
+        ...this.createCommentReferences(
+          savedObjectId ?? null,
+          savedObjectType ?? CASE_COMMENT_SAVED_OBJECT
+        ),
         ...(type === UserActionTypes.connector
           ? this.createConnectorReference(connectorId ?? null)
           : []),

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.test.ts
@@ -14,6 +14,8 @@ import {
   UserActionTypes,
 } from '../../../common/types/domain';
 import { SECURITY_SOLUTION_OWNER } from '../../../common';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../common/constants';
+import { CASE_ATTACHMENT_REF_NAME } from '../../common/constants';
 import {
   externalReferenceAttachmentES,
   externalReferenceAttachmentSO,
@@ -194,6 +196,30 @@ describe('UserActionBuilder', () => {
           ],
         }
       `);
+    });
+
+    it('builds a comment user action with the attachment saved object type', () => {
+      const builder = builderFactory.getBuilder(UserActionTypes.comment)!;
+      const userAction = builder.build({
+        action: UserActionActions.update,
+        payload: {
+          attachment: {
+            comment: 'a comment!',
+            type: AttachmentType.user,
+            owner: SECURITY_SOLUTION_OWNER,
+          },
+        },
+        savedObjectId: 'test-id',
+        savedObjectType: CASE_ATTACHMENT_SAVED_OBJECT,
+        ...commonArgs,
+      });
+
+      expect(userAction!.parameters.references).toContainEqual({
+        id: 'test-id',
+        name: CASE_ATTACHMENT_REF_NAME,
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+      });
+      expect(userAction!.eventDetails.savedObjectType).toBe(CASE_ATTACHMENT_SAVED_OBJECT);
     });
 
     it('builds an external reference attachment (savedObject) user action correctly', () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builders/comment.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builders/comment.ts
@@ -16,6 +16,7 @@ import { getPastTenseVerb } from './audit_logger_utils';
 
 export class CommentUserActionBuilder extends UserActionBuilder {
   build(args: UserActionParameters<'comment'>): UserActionEvent {
+    const savedObjectType = args.savedObjectType ?? CASE_COMMENT_SAVED_OBJECT;
     const soExtractor = getAttachmentSOExtractor(args.payload.attachment);
     const { transformedFields, references: refsWithExternalRefId } =
       soExtractor.extractFieldsToReferences<CommentUserAction['payload']['comment']>({
@@ -53,7 +54,7 @@ export class CommentUserActionBuilder extends UserActionBuilder {
       action,
       descriptiveAction: `case_user_action_${action}_comment`,
       savedObjectId: args.savedObjectId ?? args.caseId,
-      savedObjectType: CASE_COMMENT_SAVED_OBJECT,
+      savedObjectType,
     };
 
     return {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
@@ -18,7 +18,11 @@ import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
 import type { CaseUserActionWithoutReferenceIds } from '../../../common/types/domain';
 import type { UserActionEvent } from './types';
 
-import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
+import {
+  CASE_ATTACHMENT_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+  SECURITY_SOLUTION_OWNER,
+} from '../../../common/constants';
 import { createSOFindResponse } from '../test_utils';
 import {
   casePayload,
@@ -143,45 +147,53 @@ describe('CaseUserActionService', () => {
           nonDeletedCommentUpdates: {
             doc_count: 2,
             comments: {
-              doc_count: 2,
-              byCommentId: {
-                buckets: [
-                  {
-                    key: 'deleted-comment',
-                    doc_count: 3,
-                    reverse: {
-                      doc_count: 3,
-                      hasDelete: { doc_count: 1 },
-                      updates: {
+              buckets: {
+                [CASE_COMMENT_SAVED_OBJECT]: {
+                  doc_count: 2,
+                  byCommentId: {
+                    buckets: [
+                      {
+                        key: 'deleted-comment',
                         doc_count: 3,
-                        byCommentType: {
-                          buckets: [
-                            { key: 'user', doc_count: 2 },
-                            { key: 'comment', doc_count: 4 },
-                            { key: 'alert', doc_count: 1 },
-                          ],
+                        reverse: {
+                          doc_count: 3,
+                          hasDelete: { doc_count: 1 },
+                          updates: {
+                            doc_count: 3,
+                            byCommentType: {
+                              buckets: [
+                                { key: 'user', doc_count: 2 },
+                                { key: 'comment', doc_count: 4 },
+                                { key: 'alert', doc_count: 1 },
+                              ],
+                            },
+                          },
                         },
                       },
-                    },
-                  },
-                  {
-                    key: 'active-comment',
-                    doc_count: 2,
-                    reverse: {
-                      doc_count: 2,
-                      hasDelete: { doc_count: 0 },
-                      updates: {
+                      {
+                        key: 'active-comment',
                         doc_count: 2,
-                        byCommentType: {
-                          buckets: [
-                            { key: 'user', doc_count: 5 },
-                            { key: 'comment', doc_count: 5 },
-                          ],
+                        reverse: {
+                          doc_count: 2,
+                          hasDelete: { doc_count: 0 },
+                          updates: {
+                            doc_count: 2,
+                            byCommentType: {
+                              buckets: [
+                                { key: 'user', doc_count: 5 },
+                                { key: 'comment', doc_count: 5 },
+                              ],
+                            },
+                          },
                         },
                       },
-                    },
+                    ],
                   },
-                ],
+                },
+                [CASE_ATTACHMENT_SAVED_OBJECT]: {
+                  doc_count: 0,
+                  byCommentId: { buckets: [] },
+                },
               },
             },
           },
@@ -227,6 +239,39 @@ describe('CaseUserActionService', () => {
           total_other_actions: 10,
           total_other_action_deletions: 1,
         });
+      });
+
+      it('groups non-deleted comment updates by both attachment saved object types', async () => {
+        unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
+
+        await service.getCaseUserActionStats({ caseId: '123' });
+
+        expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            aggs: expect.objectContaining({
+              nonDeletedCommentUpdates: expect.objectContaining({
+                aggs: expect.objectContaining({
+                  comments: expect.objectContaining({
+                    filters: {
+                      filters: {
+                        [CASE_COMMENT_SAVED_OBJECT]: {
+                          term: {
+                            'cases-user-actions.references.type': CASE_COMMENT_SAVED_OBJECT,
+                          },
+                        },
+                        [CASE_ATTACHMENT_SAVED_OBJECT]: {
+                          term: {
+                            'cases-user-actions.references.type': CASE_ATTACHMENT_SAVED_OBJECT,
+                          },
+                        },
+                      },
+                    },
+                  }),
+                }),
+              }),
+            }),
+          })
+        );
       });
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
@@ -18,6 +18,7 @@ import { AttachmentType, UserActionActions, UserActionTypes } from '../../../com
 import { decodeOrThrow } from '../../common/runtime_types';
 import {
   CASE_COMMENT_SAVED_OBJECT,
+  CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
   MAX_DOCS_PER_PAGE,
@@ -747,8 +748,9 @@ export class CaseUserActionService {
      * Calculate total_hidden_comment_updates by summing updates for DELETED comments.
      * These are edit actions that are no longer visible to users because the comment was deleted.
      */
-    const commentBuckets =
-      response.aggregations?.nonDeletedCommentUpdates?.comments?.byCommentId?.buckets ?? [];
+    const commentBuckets = Object.values(
+      response.aggregations?.nonDeletedCommentUpdates?.comments?.buckets ?? {}
+    ).flatMap((bucket) => bucket.byCommentId?.buckets ?? []);
 
     for (const bucket of commentBuckets) {
       const hasBeenDeleted = bucket.reverse?.hasDelete?.doc_count > 0;
@@ -823,9 +825,19 @@ export class CaseUserActionService {
         },
         aggs: {
           comments: {
-            filter: {
-              term: {
-                [`${CASE_USER_ACTION_SAVED_OBJECT}.references.type`]: CASE_COMMENT_SAVED_OBJECT,
+            filters: {
+              filters: {
+                [CASE_COMMENT_SAVED_OBJECT]: {
+                  term: {
+                    [`${CASE_USER_ACTION_SAVED_OBJECT}.references.type`]: CASE_COMMENT_SAVED_OBJECT,
+                  },
+                },
+                [CASE_ATTACHMENT_SAVED_OBJECT]: {
+                  term: {
+                    [`${CASE_USER_ACTION_SAVED_OBJECT}.references.type`]:
+                      CASE_ATTACHMENT_SAVED_OBJECT,
+                  },
+                },
               },
             },
             aggs: {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.ts
@@ -442,6 +442,7 @@ export class UserActionPersister {
         user,
         owner: attachment.owner,
         savedObjectId: attachment.id,
+        savedObjectType: attachment.savedObjectType,
         payload: { attachment: attachment.attachment },
       });
 
@@ -510,7 +511,17 @@ export class UserActionPersister {
     userAction,
     refresh,
   }: CreateUserActionArgs<T>): Promise<void> {
-    const { action, type, caseId, user, owner, payload, connectorId, savedObjectId } = userAction;
+    const {
+      action,
+      type,
+      caseId,
+      user,
+      owner,
+      payload,
+      connectorId,
+      savedObjectId,
+      savedObjectType,
+    } = userAction;
 
     try {
       this.context.log.debug(`Attempting to create a user action of type: ${type}`);
@@ -523,6 +534,7 @@ export class UserActionPersister {
         owner,
         connectorId,
         savedObjectId,
+        savedObjectType,
         payload,
       });
 
@@ -547,24 +559,37 @@ export class UserActionPersister {
       }
 
       const userActionsPayload = userActions
-        .map(({ action, type, caseId, user, owner, payload, connectorId, savedObjectId }) => {
-          const userActionBuilder = this.builderFactory.getBuilder<T>(type);
-          const userAction = userActionBuilder?.build({
+        .map(
+          ({
             action,
+            type,
             caseId,
             user,
             owner,
+            payload,
             connectorId,
             savedObjectId,
-            payload,
-          });
+            savedObjectType,
+          }) => {
+            const userActionBuilder = this.builderFactory.getBuilder<T>(type);
+            const userAction = userActionBuilder?.build({
+              action,
+              caseId,
+              user,
+              owner,
+              connectorId,
+              savedObjectId,
+              savedObjectType,
+              payload,
+            });
 
-          if (userAction == null) {
-            return null;
+            if (userAction == null) {
+              return null;
+            }
+
+            return userAction;
           }
-
-          return userAction;
-        })
+        )
         .filter(Boolean) as UserActionEvent[];
 
       await this.bulkCreateAndLog({ userActions: userActionsPayload, refresh });

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/transform.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/transform.test.ts
@@ -25,6 +25,8 @@ import {
 import type { SavedObjectsFindResponse } from '@kbn/core-saved-objects-api-server';
 import type { ConnectorUserAction } from '../../../common/types/domain';
 import { UserActionActions } from '../../../common/types/domain';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../common/constants';
+import { CASE_ATTACHMENT_REF_NAME } from '../../common/constants';
 
 describe('transform', () => {
   describe('action_id', () => {
@@ -157,6 +159,31 @@ describe('transform', () => {
         });
 
         const transformed = transformer(createSOFindResponse([createUserActionFindSO(userAction)]));
+
+        expect(transformed.saved_objects[0].attributes.comment_id).toEqual('5');
+      });
+
+      it('sets comment_id correctly from a cases-attachments reference', () => {
+        const userAction = createUserActionSO({
+          action: UserActionActions.create,
+          commentId: '5',
+        });
+        const transformed = transformer(
+          createSOFindResponse([
+            createUserActionFindSO({
+              ...userAction,
+              references: userAction.references.map((reference) =>
+                reference.id === '5'
+                  ? {
+                      ...reference,
+                      name: CASE_ATTACHMENT_REF_NAME,
+                      type: CASE_ATTACHMENT_SAVED_OBJECT,
+                    }
+                  : reference
+              ),
+            }),
+          ])
+        );
 
         expect(transformed.saved_objects[0].attributes.comment_id).toEqual('5');
       });

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/transform.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/transform.ts
@@ -14,15 +14,10 @@ import {
   isCreateCaseUserAction,
   isCommentUserAction,
 } from '../../../common/utils/user_actions';
-import {
-  CASE_SAVED_OBJECT,
-  CASE_COMMENT_SAVED_OBJECT,
-  NONE_CONNECTOR_ID,
-} from '../../../common/constants';
+import { CASE_SAVED_OBJECT, NONE_CONNECTOR_ID } from '../../../common/constants';
 import {
   ATTACHMENT_ID_REF_NAME,
   CASE_REF_NAME,
-  COMMENT_REF_NAME,
   CONNECTOR_ID_REFERENCE_NAME,
   EXTERNAL_REFERENCE_REF_NAME,
   PUSH_CONNECTOR_ID_REFERENCE_NAME,
@@ -32,7 +27,7 @@ import {
   isCommentRequestTypeExternalReferenceSO,
   isUnifiedAttachmentWithSoReference,
 } from '../type_guards';
-import { findReferenceId } from '../../common/references';
+import { findCommentReferenceId, findReferenceId } from '../../common/references';
 import type {
   UserActionPersistedAttributes,
   UserActionSavedObjectTransformed,
@@ -57,8 +52,7 @@ export function transformToExternalModel(
 ): UserActionSavedObjectTransformed {
   const { references } = userAction;
 
-  const commentId =
-    findReferenceId(COMMENT_REF_NAME, CASE_COMMENT_SAVED_OBJECT, references) ?? null;
+  const commentId = findCommentReferenceId(references) ?? null;
   const payload = addReferenceIdToPayload(userAction);
 
   return {
@@ -98,8 +92,7 @@ function legacyTransformToExternalModel(
   const { references } = userAction;
 
   const caseId = findReferenceId(CASE_REF_NAME, CASE_SAVED_OBJECT, references) ?? '';
-  const commentId =
-    findReferenceId(COMMENT_REF_NAME, CASE_COMMENT_SAVED_OBJECT, references) ?? null;
+  const commentId = findCommentReferenceId(references) ?? null;
   const payload = addReferenceIdToPayload(userAction);
 
   return {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
@@ -39,6 +39,14 @@ import type {
   UserActionFindRequest,
 } from '../../../common/types/api';
 import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
+import type {
+  CASE_ATTACHMENT_SAVED_OBJECT,
+  CASE_COMMENT_SAVED_OBJECT,
+} from '../../../common/constants';
+
+export type AttachmentSavedObjectType =
+  | typeof CASE_COMMENT_SAVED_OBJECT
+  | typeof CASE_ATTACHMENT_SAVED_OBJECT;
 
 export interface BuilderParameters {
   title: {
@@ -130,6 +138,7 @@ export interface CommonArguments {
   caseId: string;
   owner: string;
   savedObjectId?: string;
+  savedObjectType?: AttachmentSavedObjectType;
   connectorId?: string;
   action?: UserActionAction;
 }
@@ -273,28 +282,33 @@ export interface UserActionsStatsAggsResult {
   nonDeletedCommentUpdates: {
     doc_count: number;
     comments: {
-      doc_count: number;
-      byCommentId: {
-        buckets: Array<{
-          key: string;
+      buckets: Record<
+        string,
+        {
           doc_count: number;
-          reverse: {
-            doc_count: number;
-            hasDelete: {
+          byCommentId: {
+            buckets: Array<{
+              key: string;
               doc_count: number;
-            };
-            updates: {
-              doc_count: number;
-              byCommentType: {
-                buckets: Array<{
-                  key: string;
+              reverse: {
+                doc_count: number;
+                hasDelete: {
                   doc_count: number;
-                }>;
+                };
+                updates: {
+                  doc_count: number;
+                  byCommentType: {
+                    buckets: Array<{
+                      key: string;
+                      doc_count: number;
+                    }>;
+                  };
+                };
               };
-            };
+            }>;
           };
-        }>;
-      };
+        }
+      >;
     };
   };
 }
@@ -379,7 +393,12 @@ export interface BulkCreateBulkUpdateCaseUserActions extends IndexRefresh {
 export interface BulkCreateAttachmentUserAction
   extends Omit<CommonUserActionArgs, 'owner'>,
     IndexRefresh {
-  attachments: Array<{ id: string; owner: string; attachment: AttachmentRequestV2 }>;
+  attachments: Array<{
+    id: string;
+    owner: string;
+    attachment: AttachmentRequestV2;
+    savedObjectType?: AttachmentSavedObjectType;
+  }>;
 }
 
 export type CreateUserActionArgs<T extends keyof BuilderParameters> = {


### PR DESCRIPTION
## Summary

Fixes case user-action references for unified attachments by pointing to the actual attachment saved object type (cases-attachments) instead of always using legacy cases-comments.

Also updates case export to include unified attachment saved objects when the attachments feature flag is enabled, so exported cases include both legacy and unified attachments.

<img width="1395" height="612" alt="image" src="https://github.com/user-attachments/assets/78c61193-2e6c-4518-b311-13c372906b8b" />

Before: 
- In Discover, user action for a `cases-attachments` attachment still points to `cases-comments` in references
- Exporting a case with unified attachments (add a comment with `xpack.cases.attachments.enabled: true`), then reimporting it, the reimported case does not show attachments

After
- In Discover, user action points to the correct saved object type
- Exporting and importing a case with attachments show all attachments

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.