### PR TITLE
[9.3] [Synthetics] Honor searchExcludedDataTiers advanced setting in SyntheticsEsClient (#273418)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/index.ts
@@ -23,6 +23,7 @@ export { ElapsedTimestampTooltip } from './components/elapsed_timestamp_tooltip'
 
 export {
   enableInspectEsQueries,
+  searchExcludedDataTiers,
   maxSuggestions,
   enableComparisonByDefault,
   defaultApmServiceEnvironment,

--- a/x-pack/solutions/observability/plugins/observability/server/ui_settings.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/ui_settings.ts
@@ -426,7 +426,7 @@ export const uiSettings: Record<string, UiSettingsParams<boolean | number | stri
       'xpack.observability.advancedSettings.searchExcludedDataTiersDesc',
       {
         defaultMessage: `Specify the data tiers to exclude from search, such as data_cold and/or data_frozen.
-        When configured, indices allocated in the selected tiers will be ignored from search requests. Affected apps: APM, Infrastructure`,
+        When configured, indices allocated in the selected tiers will be ignored from search requests. Affected apps: APM, Infrastructure, Synthetics`,
       }
     ),
     value: [],

--- a/x-pack/solutions/observability/plugins/synthetics/moon.yml
+++ b/x-pack/solutions/observability/plugins/synthetics/moon.yml
@@ -74,6 +74,7 @@ dependsOn:
   - '@kbn/alerts-as-data-utils'
   - '@kbn/exploratory-view-plugin'
   - '@kbn/observability-shared-plugin'
+  - '@kbn/observability-utils-common'
   - '@kbn/core-http-server'
   - '@kbn/std'
   - '@kbn/core-saved-objects-server-mocks'

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/use_std_error_logs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/use_std_error_logs.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import { createEsParams, useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { createEsParams } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import type { Ping } from '../../../../../../common/runtime_types';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 
 export const useStdErrorLogs = ({ checkGroup }: { checkGroup?: string }) => {
-  const { data, loading } = useEsSearch(
+  const { data, loading } = useSyntheticsEsSearch(
     createEsParams({
       index: !checkGroup ? '' : SYNTHETICS_INDEX_PATTERN,
       size: 1000,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_error_failed_step.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_error_failed_step.tsx
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { useEsSearch } from '@kbn/observability-shared-plugin/public';
 import { useParams } from 'react-router-dom';
 import { useMemo } from 'react';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import { STEP_END_FILTER } from '../../../../../../common/constants/data_filters';
 import { asMutableArray } from '../../../../../../common/utils/as_mutable_array';
 import type { Ping } from '../../../../../../common/runtime_types';
@@ -20,7 +20,7 @@ export function useErrorFailedStep(checkGroups: string[]) {
 
   const { monitorId } = useParams<{ monitorId: string }>();
 
-  const { data, loading } = useEsSearch(
+  const { data, loading } = useSyntheticsEsSearch(
     {
       index: checkGroups?.length > 0 ? SYNTHETICS_INDEX_PATTERN : '',
       size: checkGroups.length,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_inline_errors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_inline_errors.ts
@@ -7,7 +7,7 @@
 
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
-import { useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import { selectEncryptedSyntheticsSavedMonitors } from '../../../state';
 import type { Ping } from '../../../../../../common/runtime_types';
 import { ConfigKey } from '../../../../../../common/runtime_types';
@@ -75,7 +75,7 @@ export function useInlineErrors({
 
   const doFetch = configIds.length > 0 || onlyInvalidMonitors;
 
-  const { data } = useEsSearch(
+  const { data } = useSyntheticsEsSearch(
     {
       index: doFetch ? SYNTHETICS_INDEX_PATTERN : '',
       size: 1000,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_inline_errors_count.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_inline_errors_count.ts
@@ -7,7 +7,7 @@
 
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
-import { useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import { selectEncryptedSyntheticsSavedMonitors } from '../../../state';
 import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
 import { getInlineErrorFilters } from './use_inline_errors';
@@ -18,7 +18,7 @@ export function useInlineErrorsCount() {
 
   const { lastRefresh } = useSyntheticsRefreshContext();
 
-  const { data, loading } = useEsSearch(
+  const { data, loading } = useSyntheticsEsSearch(
     {
       index: SYNTHETICS_INDEX_PATTERN,
       size: 0,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { createEsParams, useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { createEsParams } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 import type { MarkerItems } from './waterfall/context/waterfall_context';
 
@@ -20,7 +21,7 @@ export const BROWSER_TRACE_START = 'browser.relative_trace.start.us';
 export const NAVIGATION_START = 'navigationStart';
 
 export const useStepWaterfallMetrics = ({ checkGroup, hasNavigationRequest, stepIndex }: Props) => {
-  const { data, loading } = useEsSearch(
+  const { data, loading } = useSyntheticsEsSearch(
     hasNavigationRequest
       ? createEsParams({
           index: SYNTHETICS_INDEX_PATTERN,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/hooks/use_browser_run_once_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/hooks/use_browser_run_once_monitors.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 import { useEffect, useState, useRef } from 'react';
-import { createEsParams, useEsSearch, useFetcher } from '@kbn/observability-shared-plugin/public';
+import { createEsParams, useFetcher } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import { useTickTick } from './use_tick_tick';
 import { isStepEnd } from '../../common/monitor_test_result/browser_steps_list';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
@@ -29,7 +30,7 @@ export const useBrowserEsResults = ({
   testRunId: string;
   lastRefresh: number;
 }) => {
-  return useEsSearch(
+  return useSyntheticsEsSearch(
     createEsParams({
       index: SYNTHETICS_INDEX_PATTERN,
       sort: [

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/hooks/use_simple_run_once_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/hooks/use_simple_run_once_monitors.ts
@@ -6,7 +6,8 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { createEsParams, useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { createEsParams } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from '../../../hooks/use_synthetics_es_search';
 import { FINAL_SUMMARY_FILTER } from '../../../../../../common/constants/client_defaults';
 import type { Ping } from '../../../../../../common/runtime_types';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
@@ -24,7 +25,7 @@ export const useSimpleRunOnceMonitors = ({
   const { refreshTimer, lastRefresh } = useTickTick(2 * 1000);
   const [numberOfRetries, setNumberOfRetries] = useState(0);
 
-  const { data, loading } = useEsSearch(
+  const { data, loading } = useSyntheticsEsSearch(
     createEsParams({
       index: SYNTHETICS_INDEX_PATTERN,
       sort: [

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
-import { useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { useSyntheticsEsSearch } from './use_synthetics_es_search';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../common/constants';
 import type { Ping } from '../../../../common/runtime_types';
 
@@ -40,13 +40,12 @@ export const useMonitorDetail = (
     },
     sort: [{ '@timestamp': 'desc' as const }],
   };
-  const { data: result, loading } = useEsSearch<Ping & { '@timestamp': string }, SearchRequest>(
-    params,
-    [configId, location],
-    {
-      name: 'getMonitorStatusByLocation',
-    }
-  );
+  const { data: result, loading } = useSyntheticsEsSearch<
+    Ping & { '@timestamp': string },
+    SearchRequest
+  >(params, [configId, location], {
+    name: 'getMonitorStatusByLocation',
+  });
 
   if (!result || result.hits.hits.length !== 1) return { data: undefined, loading };
   return {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_status_by_location.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_status_by_location.tsx
@@ -6,7 +6,6 @@
  */
 
 import { useEuiTheme } from '@elastic/eui';
-import { useEsSearch } from '@kbn/observability-shared-plugin/public';
 import { useMemo } from 'react';
 import { SYNTHETICS_INDEX_PATTERN, UNNAMED_LOCATION } from '../../../../common/constants';
 import {
@@ -16,6 +15,7 @@ import {
 import type { EncryptedSyntheticsSavedMonitor, Ping } from '../../../../common/runtime_types';
 import { useSyntheticsRefreshContext } from '../contexts';
 import { useLocations } from './use_locations';
+import { useSyntheticsEsSearch } from './use_synthetics_es_search';
 
 export type LocationsStatus = Array<{ status: string; id: string; label: string; color: string }>;
 
@@ -32,7 +32,7 @@ export function useStatusByLocation({
 
   const { locations: allLocations } = useLocations();
 
-  const { data, loading } = useEsSearch(
+  const { data, loading } = useSyntheticsEsSearch(
     {
       index: SYNTHETICS_INDEX_PATTERN,
       size: 0,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_es_search.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_es_search.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import type { IInspectorInfo } from '@kbn/data-plugin/common';
+import { useEsSearch } from '@kbn/observability-shared-plugin/public';
+import { applyExcludedDataTiersToParams } from '../utils/excluded_data_tiers';
+
+/**
+ * Synthetics-aware wrapper around the shared `useEsSearch` hook that injects the
+ * `observability:searchExcludedDataTiers` exclusion into every browser-issued
+ * query, matching the server-side `SyntheticsEsClient`. Use this instead of
+ * `useEsSearch` for any query targeting `synthetics-*` indices.
+ */
+export const useSyntheticsEsSearch = <
+  DocumentSource extends unknown,
+  TParams extends estypes.SearchRequest
+>(
+  params: TParams,
+  fnDeps: any[],
+  options: { inspector?: IInspectorInfo; name: string }
+) => {
+  return useEsSearch<DocumentSource, TParams>(
+    applyExcludedDataTiersToParams(params),
+    fnDeps,
+    options
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/elasticsearch/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/elasticsearch/api.ts
@@ -12,15 +12,20 @@ import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 import { getInspectResponse } from '@kbn/observability-shared-plugin/common';
 import { kibanaService } from '../../../../utils/kibana_service';
 import { apiService } from '../../../../utils/api_service';
+import { applyExcludedDataTiersToParams } from '../../utils/excluded_data_tiers';
 
 export const executeEsQueryAPI = async ({
-  params,
+  params: rawParams,
   name,
 }: {
   params: estypes.SearchRequest;
   name: string;
 }) => {
   const data = kibanaService.startPlugins.data;
+
+  // Inject the `observability:searchExcludedDataTiers` exclusion so redux-backed
+  // queries skip the same tiers as the server-side `SyntheticsEsClient`.
+  const params = applyExcludedDataTiersToParams(rawParams);
 
   const addInspectorRequest = apiService.addInspectorRequest;
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/excluded_data_tiers.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/excluded_data_tiers.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTier } from '@kbn/observability-shared-plugin/common';
+import { kibanaService } from '../../../utils/kibana_service';
+import { applyExcludedDataTiersToParams, getExcludedDataTiers } from './excluded_data_tiers';
+
+describe('excluded data tiers (client)', () => {
+  const getMock = jest.fn();
+
+  const setExcludedTiers = (tiers: DataTier[] | undefined) => {
+    getMock.mockReturnValue(tiers);
+    // @ts-expect-error partial CoreStart stub for the singleton under test
+    kibanaService.coreStart = { uiSettings: { get: getMock } };
+  };
+
+  afterEach(() => {
+    getMock.mockReset();
+    // @ts-expect-error reset the singleton between tests
+    kibanaService.coreStart = undefined;
+  });
+
+  describe('getExcludedDataTiers', () => {
+    it('reads the searchExcludedDataTiers advanced setting', () => {
+      setExcludedTiers(['data_frozen']);
+
+      expect(getExcludedDataTiers()).toEqual(['data_frozen']);
+      expect(getMock).toHaveBeenCalledWith('observability:searchExcludedDataTiers', []);
+    });
+
+    it('returns [] when uiSettings is unavailable', () => {
+      // coreStart is undefined (see afterEach), so accessing uiSettings throws
+      expect(getExcludedDataTiers()).toEqual([]);
+    });
+
+    it('returns [] when the setting resolves to undefined', () => {
+      setExcludedTiers(undefined);
+
+      expect(getExcludedDataTiers()).toEqual([]);
+    });
+  });
+
+  describe('applyExcludedDataTiersToParams', () => {
+    const matchAll = { match_all: {} };
+
+    it('returns the params untouched when no tiers are excluded', () => {
+      setExcludedTiers([]);
+      const params = { index: 'synthetics-*', query: matchAll };
+
+      expect(applyExcludedDataTiersToParams(params)).toBe(params);
+    });
+
+    it('wraps an existing query with a must_not _tier filter', () => {
+      setExcludedTiers(['data_cold', 'data_frozen']);
+
+      expect(applyExcludedDataTiersToParams({ index: 'synthetics-*', query: matchAll })).toEqual({
+        index: 'synthetics-*',
+        query: {
+          bool: {
+            filter: [
+              matchAll,
+              { bool: { must_not: [{ terms: { _tier: ['data_cold', 'data_frozen'] } }] } },
+            ],
+          },
+        },
+      });
+    });
+
+    it('builds a filter-only query when there is no original query', () => {
+      setExcludedTiers(['data_frozen']);
+
+      expect(applyExcludedDataTiersToParams({ index: 'synthetics-*', size: 1 })).toEqual({
+        index: 'synthetics-*',
+        size: 1,
+        query: {
+          bool: {
+            filter: [{ bool: { must_not: [{ terms: { _tier: ['data_frozen'] } }] } }],
+          },
+        },
+      });
+    });
+
+    it('preserves other params (size, aggs) while wrapping the query', () => {
+      setExcludedTiers(['data_frozen']);
+      const aggs = { total: { cardinality: { field: 'monitor.id' } } };
+
+      expect(
+        applyExcludedDataTiersToParams({ index: 'synthetics-*', size: 0, aggs, query: matchAll })
+      ).toEqual({
+        index: 'synthetics-*',
+        size: 0,
+        aggs,
+        query: {
+          bool: {
+            filter: [matchAll, { bool: { must_not: [{ terms: { _tier: ['data_frozen'] } }] } }],
+          },
+        },
+      });
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/excluded_data_tiers.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/excluded_data_tiers.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import { searchExcludedDataTiers } from '@kbn/observability-plugin/common';
+import type { DataTier } from '@kbn/observability-shared-plugin/common';
+import { excludeTiersQuery } from '@kbn/observability-utils-common/es/queries/exclude_tiers_query';
+import { kibanaService } from '../../../utils/kibana_service';
+
+/**
+ * Reads the `observability:searchExcludedDataTiers` advanced setting from the
+ * client-side uiSettings cache. Mirrors the server-side `SyntheticsEsClient` so
+ * browser-issued queries (via `data.search`) skip the same tiers. Falls back to
+ * `[]` (no exclusion) when uiSettings is unavailable, e.g. in unit tests.
+ */
+export const getExcludedDataTiers = (): DataTier[] => {
+  try {
+    return kibanaService.coreStart.uiSettings.get<DataTier[]>(searchExcludedDataTiers, []) ?? [];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Wraps a search request's query with a `must_not { terms: { _tier } }` filter
+ * for the configured excluded data tiers, reusing the shared `excludeTiersQuery`
+ * util. Returns the params untouched when no tiers are excluded (the default),
+ * so existing behavior is unchanged unless an operator opts in.
+ */
+export const applyExcludedDataTiersToParams = <TParams extends estypes.SearchRequest>(
+  params: TParams
+): TParams => {
+  const excludedDataTiers = getExcludedDataTiers();
+  if (!excludedDataTiers.length) {
+    return params;
+  }
+
+  const { query } = params;
+  // The spread only replaces `query` with a valid `QueryDslQueryContainer`, so
+  // the result is still a `TParams`; TS cannot infer that through a generic spread.
+  return {
+    ...params,
+    query: {
+      bool: {
+        filter: [...(query ? [query] : []), ...excludeTiersQuery(excludedDataTiers)],
+      },
+    },
+  } as TParams;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
@@ -78,6 +78,7 @@ export const registerSyntheticsStatusCheckRule = (
         scopedClusterClient.asCurrentUser,
         {
           heartbeatIndices: SYNTHETICS_INDEX_PATTERN,
+          uiSettingsClient,
         }
       );
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
@@ -77,7 +77,7 @@ export const registerSyntheticsTLSCheckRule = (
       >
     ) => {
       const { state: ruleState, params, services, spaceId, previousStartedAt, rule } = options;
-      const { alertsClient, savedObjectsClient, scopedClusterClient } = services;
+      const { alertsClient, savedObjectsClient, scopedClusterClient, uiSettingsClient } = services;
       if (!alertsClient) {
         throw new AlertsClientError();
       }
@@ -91,7 +91,8 @@ export const registerSyntheticsTLSCheckRule = (
         server,
         syntheticsMonitorClient,
         spaceId,
-        rule.name
+        rule.name,
+        uiSettingsClient
       );
 
       const { foundCerts, certs, absoluteExpirationThreshold, absoluteAgeThreshold, latestPings } =

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
@@ -8,7 +8,7 @@ import type {
   SavedObjectsClientContract,
   SavedObjectsFindResult,
 } from '@kbn/core-saved-objects-api-server';
-import type { Logger } from '@kbn/core/server';
+import type { IUiSettingsClient, Logger } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { TLSRuleParams } from '@kbn/response-ops-rule-params/synthetics_tls';
@@ -57,13 +57,15 @@ export class TLSRuleExecutor {
     server: SyntheticsServerSetup,
     syntheticsMonitorClient: SyntheticsMonitorClient,
     spaceId: string,
-    ruleName: string
+    ruleName: string,
+    uiSettingsClient?: IUiSettingsClient
   ) {
     this.previousStartedAt = previousStartedAt;
     this.params = p;
     this.soClient = soClient;
     this.esClient = new SyntheticsEsClient(this.soClient, scopedClient, {
       heartbeatIndices: SYNTHETICS_INDEX_PATTERN,
+      uiSettingsClient,
     });
     this.server = server;
     this.syntheticsMonitorClient = syntheticsMonitorClient;

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts
@@ -6,7 +6,8 @@
  */
 
 import type { MsearchResponse } from '@elastic/elasticsearch/lib/api/types';
-import { SyntheticsEsClient } from './lib';
+import type { DataTier } from '@kbn/observability-shared-plugin/common';
+import { SyntheticsEsClient, applyExcludedDataTiersToQuery } from './lib';
 import { savedObjectsClientMock, uiSettingsServiceMock } from '@kbn/core/server/mocks';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 
@@ -183,6 +184,149 @@ describe('SyntheticsEsClient', () => {
       expect(esClient.count).toHaveBeenCalledWith(mockCountParams, {
         meta: true,
         context: { loggingOptions: { loggerName: 'synthetics' } },
+      });
+    });
+  });
+
+  describe('excluded data tiers', () => {
+    const matchAll = { match_all: {} };
+    const frozen: DataTier[] = ['data_frozen'];
+    const expectedFrozenFilter = { bool: { must_not: [{ terms: { _tier: frozen } }] } };
+
+    const createClientWithExcludedTiers = (tiers: DataTier[]) => {
+      const uiSettings = uiSettingsServiceMock.createClient();
+      uiSettings.get.mockResolvedValue(tiers);
+      const client = new SyntheticsEsClient(savedObjectsClient, esClient, {
+        uiSettingsClient: uiSettings,
+      });
+      return { client, uiSettings };
+    };
+
+    it('wraps the search query with a tier exclusion filter when configured', async () => {
+      const { client, uiSettings } = createClientWithExcludedTiers(frozen);
+
+      await client.search({ query: matchAll });
+
+      expect(uiSettings.get).toHaveBeenCalledWith('observability:searchExcludedDataTiers');
+      expect(esClient.search).toHaveBeenCalledWith(
+        {
+          index: 'synthetics-*',
+          ignore_unavailable: true,
+          query: { bool: { filter: [matchAll, expectedFrozenFilter] } },
+        },
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+      );
+    });
+
+    it('does not modify the search query when no tiers are excluded', async () => {
+      const { client } = createClientWithExcludedTiers([]);
+
+      await client.search({ query: matchAll });
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        { index: 'synthetics-*', ignore_unavailable: true, query: matchAll },
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+      );
+    });
+
+    it('wraps each msearch request with a tier exclusion filter when configured', async () => {
+      esClient.msearch.mockResolvedValueOnce({
+        body: { responses: [{}] },
+      } as unknown as MsearchResponse);
+      const { client } = createClientWithExcludedTiers(frozen);
+
+      await client.msearch([{ query: matchAll }]);
+
+      expect(esClient.msearch).toHaveBeenCalledWith(
+        {
+          searches: [
+            { index: 'synthetics-*', ignore_unavailable: true },
+            { query: { bool: { filter: [matchAll, expectedFrozenFilter] } } },
+          ],
+        },
+        { meta: true }
+      );
+    });
+
+    it('does not modify msearch requests when no tiers are excluded', async () => {
+      esClient.msearch.mockResolvedValueOnce({
+        body: { responses: [{}] },
+      } as unknown as MsearchResponse);
+      const { client, uiSettings } = createClientWithExcludedTiers([]);
+
+      await client.msearch([{ query: matchAll }]);
+
+      expect(uiSettings.get).toHaveBeenCalledWith('observability:searchExcludedDataTiers');
+      expect(esClient.msearch).toHaveBeenCalledWith(
+        {
+          searches: [{ index: 'synthetics-*', ignore_unavailable: true }, { query: matchAll }],
+        },
+        { meta: true }
+      );
+    });
+
+    it('wraps the count query with a tier exclusion filter when configured', async () => {
+      const { client } = createClientWithExcludedTiers(frozen);
+
+      await client.count({ query: matchAll });
+
+      expect(esClient.count).toHaveBeenCalledWith(
+        {
+          index: 'synthetics-*',
+          ignore_unavailable: true,
+          query: { bool: { filter: [matchAll, expectedFrozenFilter] } },
+        },
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+      );
+    });
+
+    it('does not modify the count query when no tiers are excluded', async () => {
+      const { client, uiSettings } = createClientWithExcludedTiers([]);
+
+      await client.count({ query: matchAll });
+
+      expect(uiSettings.get).toHaveBeenCalledWith('observability:searchExcludedDataTiers');
+      expect(esClient.count).toHaveBeenCalledWith(
+        { index: 'synthetics-*', ignore_unavailable: true, query: matchAll },
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+      );
+    });
+
+    it('does not read ui settings when no client is provided', async () => {
+      await syntheticsEsClient.search({ query: matchAll });
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        { index: 'synthetics-*', ignore_unavailable: true, query: matchAll },
+        { meta: true, context: { loggingOptions: { loggerName: 'synthetics' } } }
+      );
+    });
+  });
+
+  describe('applyExcludedDataTiersToQuery', () => {
+    it('returns the original query when no tiers are excluded', () => {
+      const query = { match_all: {} };
+
+      expect(applyExcludedDataTiersToQuery(query, [])).toBe(query);
+    });
+
+    it('wraps an existing query with a must_not _tier filter', () => {
+      const query = { term: { 'monitor.id': 'test-id' } };
+
+      expect(applyExcludedDataTiersToQuery(query, ['data_cold', 'data_frozen'])).toEqual({
+        bool: {
+          filter: [
+            query,
+            { bool: { must_not: [{ terms: { _tier: ['data_cold', 'data_frozen'] } }] } },
+          ],
+        },
+      });
+    });
+
+    it('builds a filter-only query when there is no original query', () => {
+      expect(applyExcludedDataTiersToQuery(undefined, ['data_frozen'])).toEqual({
+        bool: {
+          filter: [{ bool: { must_not: [{ terms: { _tier: ['data_frozen'] } }] } }],
+        },
       });
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/lib.ts
@@ -8,6 +8,7 @@
 import type {
   SearchSearchRequestBody,
   MsearchMultisearchHeader,
+  QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/types';
 import type {
   ElasticsearchClient,
@@ -15,15 +16,40 @@ import type {
   SavedObjectsClientContract,
   KibanaRequest,
   CoreRequestHandlerContext,
+  IUiSettingsClient,
 } from '@kbn/core/server';
 import type { estypes } from '@elastic/elasticsearch';
 import type { ESSearchResponse, InferSearchResponseOf } from '@kbn/es-types';
 import { RequestStatus } from '@kbn/inspector-plugin/common';
 import type { InspectResponse } from '@kbn/observability-plugin/typings/common';
-import { enableInspectEsQueries } from '@kbn/observability-plugin/common';
-import { getInspectResponse } from '@kbn/observability-shared-plugin/common';
+import { enableInspectEsQueries, searchExcludedDataTiers } from '@kbn/observability-plugin/common';
+import { getInspectResponse, type DataTier } from '@kbn/observability-shared-plugin/common';
+import { excludeTiersQuery } from '@kbn/observability-utils-common/es/queries/exclude_tiers_query';
 import { SYNTHETICS_API_URLS, SYNTHETICS_INDEX_PATTERN } from '../common/constants';
 import type { SyntheticsServerSetup } from './types';
+
+/**
+ * Combines an existing query with a filter that excludes the configured data
+ * tiers (see the `observability:searchExcludedDataTiers` advanced setting).
+ *
+ * Excluding tiers such as `data_frozen` keeps Synthetics searches from fanning
+ * out to slow, throttled searchable-snapshot shards, which otherwise drives up
+ * latency and search thread pool pressure on clusters with long retention.
+ */
+export const applyExcludedDataTiersToQuery = (
+  query: QueryDslQueryContainer | undefined,
+  excludedDataTiers: DataTier[]
+): QueryDslQueryContainer | undefined => {
+  if (!excludedDataTiers.length) {
+    return query;
+  }
+
+  return {
+    bool: {
+      filter: [...(query ? [query] : []), ...excludeTiersQuery(excludedDataTiers)],
+    },
+  };
+};
 
 export interface CountResponse {
   result: {
@@ -47,7 +73,9 @@ export class SyntheticsEsClient {
   isInspectorEnabled?: Promise<boolean | undefined>;
   inspectableEsQueries: InspectResponse = [];
   uiSettings?: CoreRequestHandlerContext['uiSettings'];
+  uiSettingsClient?: IUiSettingsClient;
   savedObjectsClient: SavedObjectsClientContract;
+  private excludedDataTiers?: Promise<DataTier[]>;
 
   constructor(
     savedObjectsClient: SavedObjectsClientContract,
@@ -55,18 +83,37 @@ export class SyntheticsEsClient {
     options?: {
       isDev?: boolean;
       uiSettings?: CoreRequestHandlerContext['uiSettings'];
+      uiSettingsClient?: IUiSettingsClient;
       request?: KibanaRequest;
       heartbeatIndices?: string;
     }
   ) {
-    const { isDev = false, uiSettings, request } = options ?? {};
+    const { isDev = false, uiSettings, uiSettingsClient, request } = options ?? {};
     this.uiSettings = uiSettings;
+    // Alerting rule executors only have access to a plain `IUiSettingsClient`,
+    // whereas route handlers pass the full `uiSettings` context. Support both so
+    // every caller can resolve advanced settings such as the excluded data tiers.
+    this.uiSettingsClient = uiSettingsClient ?? uiSettings?.client;
     this.baseESClient = esClient;
     this.savedObjectsClient = savedObjectsClient;
     this.request = request;
     this.isDev = isDev;
     this.inspectableEsQueries = [];
     this.getInspectEnabled().catch(() => {});
+  }
+
+  async getExcludedDataTiers(): Promise<DataTier[]> {
+    if (!this.uiSettingsClient) {
+      return [];
+    }
+
+    if (this.excludedDataTiers === undefined) {
+      this.excludedDataTiers = this.uiSettingsClient
+        .get<DataTier[]>(searchExcludedDataTiers)
+        .catch(() => [] as DataTier[]);
+    }
+
+    return this.excludedDataTiers;
   }
 
   async search<DocumentSource extends unknown, TParams extends estypes.SearchRequest>(
@@ -77,6 +124,10 @@ export class SyntheticsEsClient {
     let esError: any;
 
     const esParams = { index: SYNTHETICS_INDEX_PATTERN, ignore_unavailable: true, ...params };
+    const excludedDataTiers = await this.getExcludedDataTiers();
+    if (excludedDataTiers.length) {
+      esParams.query = applyExcludedDataTiersToQuery(esParams.query, excludedDataTiers);
+    }
     const startTimeNow = Date.now();
 
     let esRequestStatus: RequestStatus = RequestStatus.PENDING;
@@ -124,10 +175,15 @@ export class SyntheticsEsClient {
     requests: SearchSearchRequestBody[],
     operationName?: string
   ): Promise<{ responses: Array<InferSearchResponseOf<TDocument, TSearchRequest>> }> {
+    const excludedDataTiers = await this.getExcludedDataTiers();
     const searches: Array<MsearchMultisearchHeader | SearchSearchRequestBody> = [];
     for (const request of requests) {
       searches.push({ index: SYNTHETICS_INDEX_PATTERN, ignore_unavailable: true });
-      searches.push(request);
+      searches.push(
+        excludedDataTiers.length
+          ? { ...request, query: applyExcludedDataTiersToQuery(request.query, excludedDataTiers) }
+          : request
+      );
     }
 
     const startTimeNow = Date.now();
@@ -156,6 +212,9 @@ export class SyntheticsEsClient {
               index: SYNTHETICS_INDEX_PATTERN,
               ignore_unavailable: true,
               ...request,
+              ...(excludedDataTiers.length
+                ? { query: applyExcludedDataTiersToQuery(request.query, excludedDataTiers) }
+                : {}),
             },
             esRequestStatus: RequestStatus.OK,
             esResponse: res?.body.responses[index],
@@ -179,7 +238,12 @@ export class SyntheticsEsClient {
     let res: any;
     let esError: any;
 
-    const esParams = { index: SYNTHETICS_INDEX_PATTERN, ignore_unavailable: true, ...params };
+    const esParams: { index: string; ignore_unavailable: boolean; query?: QueryDslQueryContainer } =
+      { index: SYNTHETICS_INDEX_PATTERN, ignore_unavailable: true, ...params };
+    const excludedDataTiers = await this.getExcludedDataTiers();
+    if (excludedDataTiers.length) {
+      esParams.query = applyExcludedDataTiersToQuery(esParams.query, excludedDataTiers);
+    }
 
     try {
       res = await this.baseESClient.count(esParams, {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/rules/inspect_tls_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/rules/inspect_tls_rule.ts
@@ -25,7 +25,7 @@ export const syntheticsInspectTLSRuleRoute: SyntheticsRestApiRouteFactory = () =
     context,
     spaceId,
   }) => {
-    const { elasticsearch } = await context.core;
+    const { elasticsearch, uiSettings } = await context.core;
 
     const tlsRule = new TLSRuleExecutor(
       new Date(),
@@ -35,7 +35,8 @@ export const syntheticsInspectTLSRuleRoute: SyntheticsRestApiRouteFactory = () =
       server,
       syntheticsMonitorClient,
       spaceId,
-      'Inspect TLS Rule'
+      'Inspect TLS Rule',
+      uiSettings.client
     );
 
     return tlsRule.getRuleThresholdOverview();

--- a/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
@@ -70,6 +70,7 @@
     "@kbn/alerts-as-data-utils",
     "@kbn/exploratory-view-plugin",
     "@kbn/observability-shared-plugin",
+    "@kbn/observability-utils-common",
     "@kbn/core-http-server",
     "@kbn/std",
     "@kbn/core-saved-objects-server-mocks",


### PR DESCRIPTION
# Backport

Manual backport of [#273418](https://github.com/elastic/kibana/pull/273418) to `9.3`.

## Summary

Makes Synthetics honor the existing `observability:searchExcludedDataTiers` advanced setting (the same mechanism APM/Infrastructure use), so excluded data tiers (e.g. `data_frozen`) are skipped. Defaults to `[]` → no behavior change unless an operator opts in.

- **Server `SyntheticsEsClient`**: reads the setting and injects a `must_not { terms: { _tier: [...] } }` filter into every `search` / `msearch` / `count` via `applyExcludedDataTiersToQuery`, reusing `excludeTiersQuery` from `@kbn/observability-utils-common`.
- **Rule executors**: status + TLS rule executors (and inspect-TLS route) pass `uiSettingsClient`.
- **Browser/UI search hooks**: `applyExcludedDataTiersToParams` applied in the redux `executeEsQueryAPI` thunk and via new `useSyntheticsEsSearch` wrapper replacing direct `useEsSearch` usages.
- **Bundle ref fix**: `searchExcludedDataTiers` re-exported from `@kbn/observability-plugin/common`; advanced-setting description updated to list Synthetics.

## Adaptations for 9.3

Cherry-picked squash commit `3ea738ece74e9924c6b3269902edb3008a6e902d` and resolved merge conflicts by keeping 9.3 code paths that differ from `main`:

- **No CCS / remote-monitor wiring on 9.3**: skipped main-only files (`use_monitor_latest_ping.tsx`, `use_remote_monitor.ts`) and kept 9.3's `SYNTHETICS_INDEX_PATTERN` index selection in hooks such as `use_monitor_detail.ts` (only swapped `useEsSearch` → `useSyntheticsEsSearch`).
- **Conflict-prone hooks/components**: merged tier-exclusion changes into 9.3 versions without pulling unrelated main-only CCS refactors.
- **`moon.yml` / `tsconfig.json`**: updated dependency references for `@kbn/observability-utils-common` on 9.3.

## Test plan

- [x] `node scripts/type_check --project x-pack/solutions/observability/plugins/synthetics/tsconfig.json`
- [x] ESLint on changed files
- [x] `node scripts/jest x-pack/solutions/observability/plugins/synthetics/server/lib.test.ts`
- [x] Status + TLS rule executor jest suites

> This backport was generated manually after the auto-backport bot failed on merge conflicts. Please review carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":273418,"url":"https://github.com/elastic/kibana/pull/273418","title":"[Synthetics] Honor searchExcludedDataTiers advanced setting in SyntheticsEsClient"},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"sourceCommit":{"sha":"3ea738ece74e9924c6b3269902edb3008a6e902d"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)