### PR TITLE
Check for expected file kind in file blob download

### DIFF
--- a/src/platform/plugins/shared/files/server/routes/file_kind/helpers.test.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/helpers.test.ts
@@ -45,7 +45,6 @@ describe('helpers', () => {
     });
   });
 
-
   describe('validateMimeType', () => {
     const createFileKind = (allowedMimeTypes?: string[]): FileKind => ({
       id: 'test-file-kind',

--- a/src/platform/plugins/shared/files/server/routes/file_kind/helpers.test.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/helpers.test.ts
@@ -9,9 +9,43 @@
 
 import type { IKibanaResponse } from '@kbn/core/server';
 import type { File, FileJSON, FileKind } from '../../../common';
-import { validateFileNameExtension, validateMimeType } from './helpers';
+import { createFileServiceMock, createFileMock } from '../../mocks';
+import { getById, validateFileNameExtension, validateMimeType } from './helpers';
 
 describe('helpers', () => {
+  describe('getById', () => {
+    it('returns the file when its fileKind matches the requested kind', async () => {
+      const fileService = createFileServiceMock();
+      const file = createFileMock({ fileKind: 'myKind' });
+      fileService.getById.mockResolvedValue(file);
+
+      const result = await getById(fileService, 'abc', 'myKind');
+      expect(result.error).toBeUndefined();
+      expect(result.result).toBe(file);
+    });
+
+    it('returns 404 when the resolved file belongs to a different kind', async () => {
+      const fileService = createFileServiceMock();
+      const file = createFileMock({ fileKind: 'securitySolutionFilesCases' });
+      fileService.getById.mockResolvedValue(file);
+
+      const result = await getById(fileService, 'abc', 'defaultImage');
+      expect(result.result).toBeUndefined();
+      expect((result.error as IKibanaResponse).status).toBe(404);
+    });
+
+    it('returns 404 when the file does not exist', async () => {
+      const { FileNotFoundError } = await import('../../file_service/errors');
+      const fileService = createFileServiceMock();
+      fileService.getById.mockRejectedValue(new FileNotFoundError('not found'));
+
+      const result = await getById(fileService, 'missing', 'myKind');
+      expect(result.result).toBeUndefined();
+      expect((result.error as IKibanaResponse).status).toBe(404);
+    });
+  });
+
+
   describe('validateMimeType', () => {
     const createFileKind = (allowedMimeTypes?: string[]): FileKind => ({
       id: 'test-file-kind',

--- a/src/platform/plugins/shared/files/server/routes/file_kind/helpers.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/helpers.ts
@@ -20,11 +20,13 @@ type ResultOrHttpError =
 
 /**
  * A helper that given an ID will return a file or map errors to an http response.
+ * Enforces that the resolved file belongs to the requested file kind so that
+ * authorization on the URL kind cannot be bypassed by supplying a cross-kind ID.
  */
 export async function getById(
   fileService: FileServiceStart,
   id: string,
-  _fileKind: string
+  fileKind: string
 ): Promise<ResultOrHttpError> {
   let result: undefined | File;
   try {
@@ -37,6 +39,12 @@ export async function getById(
       error = kibanaResponseFactory.custom({ statusCode: 500, body: { message: e.message } });
     }
     return { error };
+  }
+
+  if (result.data.fileKind !== fileKind) {
+    return {
+      error: kibanaResponseFactory.notFound({ body: { message: 'File not found' } }),
+    };
   }
 
   return { result };

--- a/src/platform/plugins/shared/files/server/routes/file_kind/upload.test.ts
+++ b/src/platform/plugins/shared/files/server/routes/file_kind/upload.test.ts
@@ -40,7 +40,7 @@ describe('upload', () => {
     deleteFn = jest.fn(async () => {}); // We need it to be a promise, or it'll crash because of missing `.catch`
     fileService.getById.mockResolvedValueOnce({
       id: 'test',
-      data: { size: 1 },
+      data: { size: 1, fileKind: 'test' },
       uploadContent,
       delete: deleteFn,
     } as unknown as File);


### PR DESCRIPTION
## Summary

The blob download route authorized against the file kind in the URL, but then dereferenced the file by global ID alone. So the kind that was authorized and the kind that was actually returned could differ.

## Release note: fixed an issue in the Files plugin blob download route, to ensure the kind of file that is returned matches the kind that was requested.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- ~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->