### PR TITLE
[Entity store] [POC] Graph actor target correlation via Knowledge Indicators

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
@@ -54,6 +54,18 @@ Schema features describe the **log schema family** evident from field names and 
 - **Evidence**: Field names and log structure (e.g. ECS: `@timestamp`, `ecs.version`, `event.*`, `log.*`, `service.name`; OTel: `resource.attributes.*`, `severity_text`, `body.text`). Use only evidence from sample_documents.
 - **Short properties**: For `type: "schema"`, `properties` must be minimal: include `schema_family` (`"ecs"` | `"otel"` | `"custom"`) and optionally `ecs_version` when ECS is detected and version is evident. Do not list all fields or paste long analysis.
 - **Multiple schemas**: If evidence supports more than one schema family (e.g. ECS and OTel both present), emit one schema feature per detected family; list all of them. Each feature keeps short `properties`.
+- **ECS identity & graph-role aliases (entity-extraction + graph correlation support)**: When the stream's documents carry identity-bearing or action fields under non-ECS paths (e.g. `azure.signinlogs.properties.user_principal_name`, `okta.actor.alternateId`, or `aws.cloudtrail.user_identity.user_name` for users; `infoblox_nios.log.dhcp.client_hostname`, `cisco_asa.dhcp.host_name`, or `forescout.asset.hostname` for hosts), include an `ecs_identity_aliases` table in `properties`. The table maps ECS destinations to the non-ECS source paths in this stream that carry the same value. Downstream entity extraction uses the **actor-identity** destinations to project canonical entities, and the cloud-security graph additionally uses the **`.target.*`** and **`event.action`** destinations to correlate non-ECS streams into `actor → action → target` edges — both without per-integration ECS normalization.
+  - **Allowed destination keys (closed vocabulary)** — three groups; any other key is ignored downstream:
+    - **Actor identity**: `user.email`, `user.id`, `user.name`, `user.domain`, `host.id`, `host.name`, `host.hostname`, `service.name`, `entity.id`.
+    - **Target identity (the `.target.*` mirror — the object an actor acts upon)**: `user.target.email`, `user.target.id`, `user.target.name`, `user.target.domain`, `host.target.id`, `host.target.name`, `host.target.hostname`, `service.target.name`, `entity.target.id`.
+    - **Edge action / verb**: `event.action`.
+  - **Values**: arrays of non-ECS field paths in this stream that carry the same role, ordered by preference (highest-quality source first).
+  - **Actor vs. target discipline**: map a path to an **actor** destination only when it identifies who/what initiated the event; map to the **`.target.*`** mirror only when it identifies the object the actor acted upon (the resource signed into, the principal modified, the host connected to). Do not map one value to both an actor and a target destination.
+  - **`event.action` aliasing**: alias `event.action` only from a field that already reads as the event's verb/operation (e.g. `azure.signinlogs.operation_name`, `okta.event.type`). It is a COALESCE-from-source mapping — do not invent a normalized verb taxonomy.
+  - **Evidence-bound emission**: only emit an alias when sample documents directly support the mapping (e.g. the same value appears under both an existing ECS field and the aliased path, or a sample doc shows the non-ECS path carrying a clearly role-shaped value).
+  - **Never alias non-identity fields**: group memberships, role names, permission grants, etc. These look identity-shaped but are neither an actor nor a target identity.
+  - **Filter scoping for one-field-two-semantics cases**: when the same non-ECS path is an actor identity in some docs and a target/object in other docs (e.g. `azure.signinlogs.properties.user_principal_name` in a sign-in event vs. an audit event), use the schema feature's `filter` to scope the alias to docs that match the intended context. The downstream consumer applies aliases only to docs that match the feature's filter.
+  - When in doubt, omit the alias rather than guess.
 
 ## Entity Extraction Guidelines
 
@@ -361,6 +373,80 @@ Version formatting rules (important for vulnerability analysis):
 }
 ```
 
+**Example 8 — Schema: graph actor / target / action aliases (Azure Sign-in Logs)**
+
+Azure Sign-in Logs carry the signing-in user, the resource signed into, and the operation under non-ECS `azure.signinlogs.*` paths. Aliasing the actor (`user.*`), the target (`*.target.*`), and the verb (`event.action`) lets the cloud-security graph render `alice@contoso.com → signed in to → Microsoft Graph` without per-integration ECS normalization.
+```
+{
+  "type": "schema",
+  "subtype": "custom",
+  "id": "azure-signinlogs-schema",
+  "title": "Azure Sign-in Logs schema",
+  "description": "Custom Azure Sign-in Logs schema; the signing-in user lives under azure.signinlogs.properties.user_principal_name, the accessed resource under azure.signinlogs.properties.resource_display_name, and the operation under azure.signinlogs.operation_name rather than ECS user.*, *.target.*, and event.action.",
+  "properties": {
+    "schema_family": "custom",
+    "ecs_identity_aliases": {
+      "user.email": ["azure.signinlogs.properties.user_principal_name"],
+      "user.id": ["azure.signinlogs.properties.user_id"],
+      "user.name": ["azure.signinlogs.identity"],
+      "service.target.name": ["azure.signinlogs.properties.resource_display_name"],
+      "entity.target.id": ["azure.signinlogs.properties.resource_id"],
+      "event.action": ["azure.signinlogs.operation_name"]
+    }
+  },
+  "confidence": 88,
+  "evidence": [
+    "azure.signinlogs.properties.user_principal_name=alice@contoso.com",
+    "azure.signinlogs.properties.resource_display_name=Microsoft Graph",
+    "azure.signinlogs.operation_name=Sign-in activity",
+    "event.dataset=azure.signinlogs"
+  ],
+  "evidence_doc_ids": ["a1b2c3d", "e4f5g6h"],
+  "tags": ["schema", "azure", "identity-alias", "graph-roles"],
+  "filter": {
+    "field": "event.dataset",
+    "eq": "azure.signinlogs"
+  }
+}
+```
+
+**Example 9 — Schema: ECS family with host identity aliases (no co-occurring ECS host.\*)**
+
+Asset-tracking streams (DHCP leases, CMDB/inventory exports, AD computer accounts, network-device discovery) routinely carry the asset's hostname under a vendor-specific non-ECS path while the corresponding ECS `host.*` fields are never populated. The stream's purpose makes the non-ECS path a canonical host identity, so an alias is warranted even without co-occurrence — provided the path identifies the asset the event is *about* (the leasing client, the inventoried device) and not an observer/relay/lookup target.
+```
+{
+  "type": "schema",
+  "subtype": "ecs",
+  "id": "infoblox-nios-log-schema",
+  "title": "Infoblox NIOS log schema",
+  "description": "Infoblox NIOS DHCP/DNS log stream. The leasing client's hostname is carried under the non-ECS path infoblox_nios.log.dhcp.client_hostname; the corresponding ECS host.* fields are not populated on this stream, but the stream's purpose (DHCP lease tracking) makes it a canonical source for host identity. The DHCP relay/server hostname carried elsewhere on the same stream (observer.* / host.domain) is intentionally NOT aliased — it identifies the observer, not the leased asset.",
+  "properties": {
+    "schema_family": "ecs",
+    "ecs_version": "8.11.0",
+    "ecs_identity_aliases": {
+      "host.name": ["infoblox_nios.log.dhcp.client_hostname"],
+      "host.hostname": ["infoblox_nios.log.dhcp.client_hostname"]
+    }
+  },
+  "confidence": 90,
+  "evidence": [
+    "data_stream.dataset=infoblox_nios.log",
+    "infoblox_nios.log.service_name=dhcpd",
+    "infoblox_nios.log.dhcp.client_hostname=MacBook-Pro-16-inch",
+    "event.action=dhcpack",
+    "ecs.version=8.11.0"
+  ],
+  "evidence_doc_ids": ["a1b2c3d"],
+  "tags": ["schema", "ecs", "identity-alias", "host"],
+  "filter": {
+    "and": [
+      { "field": "data_stream.dataset", "eq": "infoblox_nios.log" },
+      { "field": "infoblox_nios.log.type", "eq": "DHCP" }
+    ]
+  }
+}
+```
+
 ## Previously Identified Features
 
 If `previously_identified_features` are provided in the input, they contain features already identified in previous iterations. Follow these rules:
@@ -400,6 +486,6 @@ If `excluded_features` is empty or absent, ignore this section entirely and leav
 - Dependency anti-spam: only emit a dependency feature when logs contain explicit evidence of a relationship; aggregate endpoints in `meta.endpoints` and cap the list.
 - Entity threshold: only create entity features when there is clear evidence of a distinct, named system component. When in doubt, omit the entity.
 - Entity filters: for each emitted entity, include a valid `filter` unless there is no stable/selective condition available from evidence.
-- Schema: when multiple schema families are evident (e.g. ECS and OTel), emit one schema feature per family; keep each schema feature's `properties` short (`schema_family`, optional `ecs_version` only).
+- Schema: when multiple schema families are evident (e.g. ECS and OTel), emit one schema feature per family; keep each schema feature's `properties` short (`schema_family`, optional `ecs_version`, optional `ecs_identity_aliases` table when the stream carries identity/action-bearing fields under non-ECS paths).
 
 Build one complete, deduplicated feature list internally, then call **finalize_features** exactly once.

--- a/x-pack/platform/plugins/shared/streams/server/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/index.ts
@@ -12,6 +12,10 @@ import type { StreamsRouteRepository } from './routes';
 import { config } from './config';
 
 export type { StreamsConfig, StreamsPluginSetup, StreamsPluginStart, StreamsRouteRepository };
+export type {
+  StreamsKnowledgeIndicatorsReader,
+  StreamsKnowledgeIndicatorsListOptions,
+} from './lib/streams/cross_plugin/knowledge_indicators_reader';
 export { config };
 
 export const plugin = async (context: PluginInitializerContext<StreamsConfig>) => {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.test.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Feature } from '@kbn/streams-schema';
+import { DefinitionNotFoundError } from '../errors/definition_not_found_error';
+import type { KnowledgeIndicatorClient } from '../ki';
+import type { StreamsClient } from '../client';
+import { createKnowledgeIndicatorsReader } from './knowledge_indicators_reader';
+
+const buildFeature = (overrides: Partial<Feature> = {}): Feature =>
+  ({
+    uuid: 'u',
+    id: 'f',
+    stream_name: 'logs.k8s.pods',
+    type: 'entity',
+    subtype: 'service',
+    title: 'svc',
+    description: 'desc',
+    properties: {},
+    confidence: 90,
+    ...overrides,
+  } as Feature);
+
+const buildStreamDef = (name: string) =>
+  ({ name } as Awaited<ReturnType<StreamsClient['listStreams']>>[number]);
+
+const buildClients = () => {
+  const knowledgeIndicatorClient = {
+    getFeatures: jest.fn(),
+  } as unknown as jest.Mocked<Pick<KnowledgeIndicatorClient, 'getFeatures'>> &
+    KnowledgeIndicatorClient;
+
+  const streamsClient = {
+    listStreams: jest.fn(),
+    getStream: jest.fn(),
+  } as unknown as jest.Mocked<Pick<StreamsClient, 'listStreams' | 'getStream'>> & StreamsClient;
+
+  return { knowledgeIndicatorClient, streamsClient };
+};
+
+describe('createKnowledgeIndicatorsReader', () => {
+  describe('listEntityFeatures', () => {
+    it('returns an empty array without calling the KI client when there are no streams', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([]);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const result = await reader.listEntityFeatures();
+
+      expect(result).toEqual([]);
+      expect(knowledgeIndicatorClient.getFeatures).not.toHaveBeenCalled();
+    });
+
+    it("forwards every stream name and hardwires type=['entity'] to the underlying client", async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([
+        buildStreamDef('logs.k8s.pods'),
+        buildStreamDef('logs.ecs.nginx'),
+      ]);
+      const features = [buildFeature(), buildFeature({ stream_name: 'logs.ecs.nginx' })];
+      knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: features });
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const result = await reader.listEntityFeatures();
+
+      expect(result).toEqual(features);
+      expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledTimes(1);
+      expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledWith(
+        ['logs.k8s.pods', 'logs.ecs.nginx'],
+        expect.objectContaining({
+          type: ['entity'],
+          minConfidence: undefined,
+        })
+      );
+    });
+
+    it('pushes minConfidence into the underlying query', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.k8s.pods')]);
+      knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: [] });
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      await reader.listEntityFeatures({ minConfidence: 70 });
+
+      expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledWith(
+        ['logs.k8s.pods'],
+        expect.objectContaining({ type: ['entity'], minConfidence: 70 })
+      );
+    });
+
+    it('does not pass limit or includeExcluded to the underlying client (narrowed surface)', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.k8s.pods')]);
+      knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: [] });
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      await reader.listEntityFeatures();
+
+      const optionsArg = knowledgeIndicatorClient.getFeatures.mock.calls[0][1];
+      expect(optionsArg).not.toHaveProperty('limit');
+      expect(optionsArg).not.toHaveProperty('includeExcluded');
+    });
+
+    it('propagates underlying errors so callers can decide how to handle them', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.k8s.pods')]);
+      const failure = new Error('boom');
+      knowledgeIndicatorClient.getFeatures.mockRejectedValue(failure);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      await expect(reader.listEntityFeatures()).rejects.toBe(failure);
+    });
+  });
+
+  describe('listDependencyFeatures', () => {
+    it("hardwires type=['dependency'] to the underlying client", async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.k8s.pods')]);
+      const dep = buildFeature({
+        type: 'dependency',
+        subtype: 'service-to-service',
+        properties: { source: 'a', target: 'b', protocol: 'http' },
+      });
+      knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: [dep] });
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const result = await reader.listDependencyFeatures({ minConfidence: 80 });
+
+      expect(result).toEqual([dep]);
+      expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledWith(
+        ['logs.k8s.pods'],
+        expect.objectContaining({ type: ['dependency'], minConfidence: 80 })
+      );
+    });
+
+    it('returns an empty array without calling the KI client when there are no streams', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([]);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const result = await reader.listDependencyFeatures();
+
+      expect(result).toEqual([]);
+      expect(knowledgeIndicatorClient.getFeatures).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listSchemaFeatures', () => {
+    it("hardwires type=['schema'] to the underlying client", async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.azure.signinlogs')]);
+      const schemaFeature = buildFeature({
+        type: 'schema',
+        subtype: 'custom',
+        stream_name: 'logs.azure.signinlogs',
+        properties: {
+          schema_family: 'custom',
+          ecs_identity_aliases: {
+            'user.email': ['azure.signinlogs.properties.user_principal_name'],
+          },
+        },
+      });
+      knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: [schemaFeature] });
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const result = await reader.listSchemaFeatures({ minConfidence: 85 });
+
+      expect(result).toEqual([schemaFeature]);
+      expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledWith(
+        ['logs.azure.signinlogs'],
+        expect.objectContaining({ type: ['schema'], minConfidence: 85 })
+      );
+    });
+
+    it('returns an empty array without calling the KI client when there are no streams', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([]);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const result = await reader.listSchemaFeatures();
+
+      expect(result).toEqual([]);
+      expect(knowledgeIndicatorClient.getFeatures).not.toHaveBeenCalled();
+    });
+
+    it('omits minConfidence when the caller does not pass it', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.azure.signinlogs')]);
+      knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: [] });
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      await reader.listSchemaFeatures();
+
+      expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledWith(
+        ['logs.azure.signinlogs'],
+        expect.objectContaining({ type: ['schema'], minConfidence: undefined })
+      );
+    });
+  });
+
+  it('list*Features methods never share a call (independent type scope)', async () => {
+    const { knowledgeIndicatorClient, streamsClient } = buildClients();
+    streamsClient.listStreams.mockResolvedValue([buildStreamDef('logs.k8s.pods')]);
+    knowledgeIndicatorClient.getFeatures.mockResolvedValue({ hits: [] });
+
+    const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+    await reader.listEntityFeatures();
+    await reader.listDependencyFeatures();
+    await reader.listSchemaFeatures();
+
+    expect(knowledgeIndicatorClient.getFeatures).toHaveBeenCalledTimes(3);
+    expect(knowledgeIndicatorClient.getFeatures.mock.calls[0][1]?.type).toEqual(['entity']);
+    expect(knowledgeIndicatorClient.getFeatures.mock.calls[1][1]?.type).toEqual(['dependency']);
+    expect(knowledgeIndicatorClient.getFeatures.mock.calls[2][1]?.type).toEqual(['schema']);
+  });
+
+  describe('resolveIndexPatterns', () => {
+    it('returns [streamName] for an existing wired stream', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.getStream.mockResolvedValue({ name: 'logs.k8s.pods' } as Awaited<
+        ReturnType<StreamsClient['getStream']>
+      >);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const patterns = await reader.resolveIndexPatterns('logs.k8s.pods');
+
+      expect(patterns).toEqual(['logs.k8s.pods']);
+      expect(streamsClient.getStream).toHaveBeenCalledWith('logs.k8s.pods');
+    });
+
+    it('returns [streamName] for an existing classic (unmanaged) stream too', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      // Classic streams are returned through the same getStream() path
+      // (resolved via getDataStreamAsIngestStream); we don't need to know
+      // the variant to compute the index pattern.
+      streamsClient.getStream.mockResolvedValue({ name: 'metrics.classic' } as Awaited<
+        ReturnType<StreamsClient['getStream']>
+      >);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const patterns = await reader.resolveIndexPatterns('metrics.classic');
+
+      expect(patterns).toEqual(['metrics.classic']);
+    });
+
+    it('returns an empty array when the stream cannot be found, without throwing', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      streamsClient.getStream.mockRejectedValue(new DefinitionNotFoundError('not found'));
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      const patterns = await reader.resolveIndexPatterns('logs.does-not-exist');
+
+      expect(patterns).toEqual([]);
+    });
+
+    it('propagates non-not-found errors (e.g. permission errors) to the caller', async () => {
+      const { knowledgeIndicatorClient, streamsClient } = buildClients();
+      const failure = new Error('insufficient privileges');
+      streamsClient.getStream.mockRejectedValue(failure);
+
+      const reader = createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      await expect(reader.resolveIndexPatterns('logs.private')).rejects.toBe(failure);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/cross_plugin/knowledge_indicators_reader.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Feature } from '@kbn/streams-schema';
+import { isDefinitionNotFoundError } from '../errors/definition_not_found_error';
+import type { KnowledgeIndicatorClient } from '../ki';
+import type { StreamsClient } from '../client';
+
+/**
+ * Options shared by the per-class list methods on
+ * `StreamsKnowledgeIndicatorsReader`. Kept deliberately small: this surface
+ * only exposes knobs cross-plugin consumers should reach for. Pagination,
+ * excluded-feature inclusion, and arbitrary type selection are NOT exposed
+ * — those are properties of the internal `KnowledgeIndicatorClient` that the
+ * integration has no business depending on.
+ */
+export interface StreamsKnowledgeIndicatorsListOptions {
+  /**
+   * Drops features below the given confidence (0–100). Cross-plugin consumers
+   * should pass their configured threshold here so changes are honored without
+   * code changes. Omit to receive every confidence level.
+   */
+  minConfidence?: number;
+}
+
+/**
+ * Read-only Knowledge Indicators surface intentionally narrowed for
+ * cross-plugin consumers (currently Entity Store v2's KI integration, which
+ * also powers the cloud-security graph alias prelude).
+ *
+ * Design constraints:
+ * - One method per feature class the integration consumes. No `type` filter
+ *   is exposed to callers; each method hardwires its single value so a
+ *   future consumer cannot accidentally read feature classes outside the
+ *   integration's scope through this surface.
+ * - No `limit` and no `includeExcluded`. Excluded features must never be
+ *   returned here, and pagination is an internal concern of the underlying
+ *   storage client.
+ * - Stale / expired features are filtered server-side by the underlying
+ *   `KnowledgeIndicatorClient` defaults; this surface inherits that behavior.
+ *
+ * If a future use case genuinely needs broader access, extend this interface
+ * with another narrow, intent-named method rather than adding escape hatches
+ * to the existing methods.
+ */
+export interface StreamsKnowledgeIndicatorsReader {
+  /**
+   * Lists `type: 'entity'` Knowledge Indicators across all streams the
+   * caller is authorized to read. Filters are pushed into the underlying
+   * storage query — they are not applied client-side.
+   */
+  listEntityFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Lists `type: 'dependency'` Knowledge Indicators across all streams the
+   * caller is authorized to read. Each dependency feature carries
+   * `properties.source`, `properties.target`, and `properties.protocol`
+   * naming the two endpoints of a relationship. Filters are pushed into
+   * the underlying storage query — they are not applied client-side.
+   */
+  listDependencyFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Lists `type: 'schema'` Knowledge Indicators across all streams the caller
+   * is authorized to read. Schema features describe the log schema family
+   * evident in a stream (`properties.schema_family` ∈ `'ecs' | 'otel' |
+   * 'custom'`). Cross-plugin consumers read these for their
+   * `properties.ecs_identity_aliases` table — an LLM-emitted mapping of ECS
+   * identity / graph-role destinations (e.g. `user.email`, `user.target.email`,
+   * `event.action`) to the non-ECS source paths in this stream that carry the
+   * same role. The aliases let entity extraction and the cloud-security graph
+   * project canonical actors / targets / edges from log sources nobody has
+   * ECS-normalized.
+   *
+   * Filters are pushed into the underlying storage query — they are not
+   * applied client-side.
+   */
+  listSchemaFeatures(options?: StreamsKnowledgeIndicatorsListOptions): Promise<Feature[]>;
+
+  /**
+   * Resolves a stream name to the Elasticsearch index pattern(s) backing it.
+   *
+   * For wired streams the stream name equals the data-stream name, and
+   * Elasticsearch resolves the data-stream name in `FROM` clauses, so a
+   * single-element array `[streamName]` is sufficient. For classic
+   * (unmanaged) streams the same convention holds — the stream is itself
+   * the pre-existing data stream.
+   *
+   * Returns an empty array when the stream does not exist (rather than
+   * throwing) so callers can skip missing streams without try/catch.
+   */
+  resolveIndexPatterns(streamName: string): Promise<string[]>;
+}
+
+/**
+ * Builds a `StreamsKnowledgeIndicatorsReader` over already-scoped underlying
+ * clients. Pass the `KnowledgeIndicatorClient` and `StreamsClient` you obtained
+ * from the streams plugin's `getScopedClients({ request })` (or, for tests,
+ * mocks matching the same interface).
+ */
+export const createKnowledgeIndicatorsReader = (deps: {
+  knowledgeIndicatorClient: KnowledgeIndicatorClient;
+  streamsClient: StreamsClient;
+}): StreamsKnowledgeIndicatorsReader => {
+  const { knowledgeIndicatorClient, streamsClient } = deps;
+
+  const listFeaturesOfType = async (
+    type: 'entity' | 'dependency' | 'schema',
+    options?: StreamsKnowledgeIndicatorsListOptions
+  ): Promise<Feature[]> => {
+    const streams = await streamsClient.listStreams();
+    const streamNames = streams.map((stream) => stream.name);
+    if (streamNames.length === 0) {
+      return [];
+    }
+    const { hits } = await knowledgeIndicatorClient.getFeatures(streamNames, {
+      type: [type],
+      minConfidence: options?.minConfidence,
+    });
+    return hits;
+  };
+
+  return {
+    listEntityFeatures: (options) => listFeaturesOfType('entity', options),
+    listDependencyFeatures: (options) => listFeaturesOfType('dependency', options),
+    listSchemaFeatures: (options) => listFeaturesOfType('schema', options),
+
+    resolveIndexPatterns: async (streamName) => {
+      try {
+        await streamsClient.getStream(streamName);
+      } catch (error) {
+        if (isDefinitionNotFoundError(error)) {
+          return [];
+        }
+        throw error;
+      }
+      // Wired and classic streams alike: the stream name resolves directly to
+      // its backing data-stream pattern. Future variants (e.g. group streams
+      // composing multiple data streams) can extend this without breaking
+      // callers that only care about the array shape.
+      return [streamName];
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -50,6 +50,10 @@ import {
 import { StreamsService } from './lib/streams/service';
 import { EbtTelemetryService, StatsTelemetryService } from './lib/telemetry';
 import { streamsRouteRepository } from './routes';
+import {
+  createKnowledgeIndicatorsReader,
+  type StreamsKnowledgeIndicatorsReader,
+} from './lib/streams/cross_plugin/knowledge_indicators_reader';
 import type { GetScopedClients, RouteHandlerScopedClients } from './routes/types';
 import type {
   StreamsPluginSetupDependencies,
@@ -88,8 +92,21 @@ const STREAMS_MANAGED_WORKFLOW_OWNER = 'streams';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface StreamsPluginStart {}
+
+export interface StreamsPluginStart {
+  /**
+   * Builds a request-scoped, read-only Knowledge Indicators reader for
+   * cross-plugin consumers (e.g. entity_store's KI integration, which also
+   * powers the cloud-security graph alias prelude). The returned surface is
+   * narrowed so consumers can read schema / entity / dependency features and
+   * resolve stream index patterns without depending on the internal
+   * KnowledgeIndicatorClient or StreamsClient. The reader inherits the
+   * request's auth / space scoping.
+   */
+  getKnowledgeIndicatorsReader(args: {
+    request: KibanaRequest;
+  }): Promise<StreamsKnowledgeIndicatorsReader>;
+}
 
 export class StreamsPlugin
   implements
@@ -662,7 +679,20 @@ export class StreamsPlugin
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);
 
-    return {};
+    const getScopedClients = this.streamsGetScopedClients;
+
+    return {
+      getKnowledgeIndicatorsReader: async ({ request }: { request: KibanaRequest }) => {
+        if (!getScopedClients) {
+          throw new Error(
+            'Streams scoped clients are not available; getKnowledgeIndicatorsReader was called before setup completed'
+          );
+        }
+        const { streamsClient, getKnowledgeIndicatorClient } = await getScopedClients({ request });
+        const knowledgeIndicatorClient = await getKnowledgeIndicatorClient();
+        return createKnowledgeIndicatorsReader({ knowledgeIndicatorClient, streamsClient });
+      },
+    };
   }
 
   private async installMemoryWorkflowsIfEnabled(

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -120,6 +120,17 @@ export const nodeDocumentDataSchema = schema.object({
     })
   ),
   entity: schema.maybe(entitySchema),
+  /**
+   * Streams-Knowledge-Indicators provenance, present only on documents whose
+   * actor / target / action slot was filled by an inferred (non-ECS) alias.
+   * Drives the "Inferred (KI)" badge. Absent on ECS-native documents.
+   */
+  knowledge_indicator: schema.maybe(
+    schema.object({
+      feature_uuid: schema.maybe(schema.string()),
+      confidence: schema.maybe(schema.number()),
+    })
+  ),
 });
 
 export const REACHED_NODES_LIMIT = 'REACHED_NODES_LIMIT';

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.test.ts
@@ -418,4 +418,129 @@ describe('layoutGraph', () => {
       expect(entity2!.position.x).toBeGreaterThan(relNode!.position.x);
     });
   });
+
+  describe('cyclic graphs (must not throw)', () => {
+    it('lays out a self-referential cycle without throwing', () => {
+      // `A` is both the source and the target of action `L` (e.g. a user that
+      // logs itself on/off), so `A → L` and `L → A` form a cycle. `A` also fans
+      // out to a leaf `C`, which makes the cycle reachable from a sink during
+      // the alignment topological sort — the exact shape that used to throw
+      // `CycleException` and abort the entire graph render.
+      const nodes: Array<Node<NodeViewModel>> = [
+        {
+          id: 'A',
+          type: 'entity',
+          position: { x: 0, y: 0 },
+          data: { id: 'A', label: 'Actor', color: 'primary', shape: 'ellipse', icon: 'user' },
+        },
+        {
+          id: 'L',
+          type: 'label',
+          position: { x: 0, y: 0 },
+          data: { id: 'L', label: 'logon', color: 'primary', shape: 'label' },
+        },
+        {
+          id: 'C',
+          type: 'entity',
+          position: { x: 0, y: 0 },
+          data: { id: 'C', label: 'Leaf', color: 'primary', shape: 'hexagon', icon: 'storage' },
+        },
+      ];
+
+      const edges: Array<Edge<EdgeViewModel>> = [
+        { id: 'A-L', source: 'A', target: 'L' },
+        { id: 'L-A', source: 'L', target: 'A' },
+        { id: 'A-C', source: 'A', target: 'C' },
+      ];
+
+      expect(() => layoutGraph(nodes, edges)).not.toThrow();
+
+      const result = layoutGraph(nodes, edges);
+      expect(result.nodes).toHaveLength(3);
+      result.nodes.forEach((node) => {
+        expect(Number.isFinite(node.position.x)).toBe(true);
+        expect(Number.isFinite(node.position.y)).toBe(true);
+      });
+    });
+
+    it('lays out bidirectional entity↔group edges without throwing', () => {
+      // Mirrors the real payload that crashed: a group of stacked actions
+      // (logon/logoff) whose actor entity is also their target, producing both
+      // `entity → group` and `group → entity` edges. The entity also fans out to
+      // a labelled action that reaches a leaf, so the cycle is reachable from a
+      // sink during the alignment pass.
+      const nodes: Array<Node<NodeViewModel>> = [
+        {
+          id: 'entity',
+          type: 'rectangle',
+          position: { x: 0, y: 0 },
+          data: { id: 'entity', label: 'user', color: 'primary', shape: 'rectangle', icon: 'user' },
+        },
+        {
+          id: 'grp',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          data: { id: 'grp', shape: 'group' },
+        },
+        {
+          id: 'logon',
+          type: 'label',
+          position: { x: 0, y: 0 },
+          parentId: 'grp',
+          data: { id: 'logon', label: 'logon', color: 'primary', shape: 'label', parentId: 'grp' },
+        },
+        {
+          id: 'logoff',
+          type: 'label',
+          position: { x: 0, y: 0 },
+          parentId: 'grp',
+          data: { id: 'logoff', label: 'logoff', color: 'primary', shape: 'label', parentId: 'grp' },
+        },
+        {
+          id: 'access',
+          type: 'label',
+          position: { x: 0, y: 0 },
+          data: { id: 'access', label: 'access', color: 'primary', shape: 'label' },
+        },
+        {
+          id: 'leaf',
+          type: 'rectangle',
+          position: { x: 0, y: 0 },
+          data: {
+            id: 'leaf',
+            label: 'Target',
+            color: 'primary',
+            shape: 'rectangle',
+            icon: 'storage',
+          },
+        },
+      ];
+
+      const edges: Array<Edge<EdgeViewModel>> = [
+        { id: 'grp-entity', source: 'grp', target: 'entity' },
+        { id: 'entity-grp', source: 'entity', target: 'grp' },
+        { id: 'grp-logon', source: 'grp', target: 'logon' },
+        { id: 'grp-logoff', source: 'grp', target: 'logoff' },
+        { id: 'logon-grp', source: 'logon', target: 'grp' },
+        { id: 'logoff-grp', source: 'logoff', target: 'grp' },
+        { id: 'entity-access', source: 'entity', target: 'access' },
+        { id: 'access-leaf', source: 'access', target: 'leaf' },
+      ];
+
+      expect(() => layoutGraph(nodes, edges)).not.toThrow();
+
+      const result = layoutGraph(nodes, edges);
+      const entity = result.nodes.find((n) => n.id === 'entity');
+      const grp = result.nodes.find((n) => n.id === 'grp');
+      const leaf = result.nodes.find((n) => n.id === 'leaf');
+
+      expect(entity).toBeDefined();
+      expect(grp).toBeDefined();
+      expect(leaf).toBeDefined();
+      [entity, grp, leaf].forEach((node) => {
+        expect(Number.isFinite(node!.position.x)).toBe(true);
+        expect(Number.isFinite(node!.position.y)).toBe(true);
+      });
+    });
+  });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/layout_graph.ts
@@ -464,8 +464,17 @@ const topsort = (g: Dagre.graphlib.Graph, filter: (node: string) => boolean): st
       return;
     }
 
+    // The input graph can legitimately contain cycles — e.g. a self-referential
+    // actor that is also the target of its own grouped actions yields
+    // bidirectional entity↔group edges (logon/logoff on the same user). Dagre
+    // already breaks cycles internally during `Dagre.layout()` before this
+    // cosmetic alignment pass runs, so we must tolerate them here too. Hitting a
+    // node that is still on the recursion stack means we followed a back-edge:
+    // skip it to break the cycle. Throwing here is uncaught and aborts the
+    // entire graph render (full-page error boundary) instead of just degrading
+    // the optional vertical-centering of the few nodes in the cycle.
     if (Object.hasOwn(stack, node)) {
-      throw new Error('CycleException');
+      return;
     }
 
     if (!Object.hasOwn(visited, node)) {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/diamond_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/diamond_node.tsx
@@ -25,6 +25,7 @@ import { DiamondHoverShape, DiamondShape } from './shapes/diamond_shape';
 import { NodeExpandButton } from './node_expand_button';
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { NodeDetails } from './node_details';
+import { hasKnowledgeIndicatorProvenance } from './inferred_knowledge_indicator_badge';
 import {
   GRAPH_ENTITY_NODE_ID,
   GRAPH_ENTITY_NODE_HOVER_SHAPE_ID,
@@ -52,6 +53,7 @@ export const DiamondNode = memo<NodeProps>((props: NodeProps) => {
     nodeClick,
     ipClickHandler,
     countryClickHandler,
+    documentsData,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -137,6 +139,7 @@ export const DiamondNode = memo<NodeProps>((props: NodeProps) => {
         label={label}
         ips={ips}
         countryCodes={countryCodes}
+        isInferred={hasKnowledgeIndicatorProvenance(documentsData)}
         onIpClick={ipClickHandler}
         onCountryClick={countryClickHandler}
       />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ellipse_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ellipse_node.tsx
@@ -25,6 +25,7 @@ import { EllipseHoverShape, EllipseShape } from './shapes/ellipse_shape';
 import { NodeExpandButton } from './node_expand_button';
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { NodeDetails } from './node_details';
+import { hasKnowledgeIndicatorProvenance } from './inferred_knowledge_indicator_badge';
 import {
   GRAPH_ENTITY_NODE_ID,
   GRAPH_ENTITY_NODE_HOVER_SHAPE_ID,
@@ -52,6 +53,7 @@ export const EllipseNode = memo<NodeProps>((props: NodeProps) => {
     nodeClick,
     ipClickHandler,
     countryClickHandler,
+    documentsData,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -137,6 +139,7 @@ export const EllipseNode = memo<NodeProps>((props: NodeProps) => {
         label={label}
         ips={ips}
         countryCodes={countryCodes}
+        isInferred={hasKnowledgeIndicatorProvenance(documentsData)}
         onIpClick={ipClickHandler}
         onCountryClick={countryClickHandler}
       />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/hexagon_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/hexagon_node.tsx
@@ -25,6 +25,7 @@ import { HexagonHoverShape, HexagonShape } from './shapes/hexagon_shape';
 import { NodeExpandButton } from './node_expand_button';
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { NodeDetails } from './node_details';
+import { hasKnowledgeIndicatorProvenance } from './inferred_knowledge_indicator_badge';
 import {
   GRAPH_ENTITY_NODE_ID,
   GRAPH_ENTITY_NODE_HOVER_SHAPE_ID,
@@ -52,6 +53,7 @@ export const HexagonNode = memo<NodeProps>((props: NodeProps) => {
     nodeClick,
     ipClickHandler,
     countryClickHandler,
+    documentsData,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -141,6 +143,7 @@ export const HexagonNode = memo<NodeProps>((props: NodeProps) => {
         label={label}
         ips={ips}
         countryCodes={countryCodes}
+        isInferred={hasKnowledgeIndicatorProvenance(documentsData)}
         onIpClick={ipClickHandler}
         onCountryClick={countryClickHandler}
       />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/inferred_knowledge_indicator_badge.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/inferred_knowledge_indicator_badge.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { NodeDocumentDataModel } from '@kbn/cloud-security-posture-common/types/graph/latest';
+import {
+  InferredKnowledgeIndicatorBadge,
+  hasKnowledgeIndicatorProvenance,
+} from './inferred_knowledge_indicator_badge';
+import { GRAPH_INFERRED_KI_BADGE_ID } from '../test_ids';
+
+const doc = (overrides: Partial<NodeDocumentDataModel> = {}): NodeDocumentDataModel =>
+  ({ id: 'doc-1', type: 'event', ...overrides } as NodeDocumentDataModel);
+
+describe('hasKnowledgeIndicatorProvenance', () => {
+  it('is false for undefined / empty / non-array input', () => {
+    expect(hasKnowledgeIndicatorProvenance(undefined)).toBe(false);
+    expect(hasKnowledgeIndicatorProvenance([])).toBe(false);
+    expect(hasKnowledgeIndicatorProvenance({} as unknown as NodeDocumentDataModel[])).toBe(false);
+  });
+
+  it('is false when no document carries knowledge_indicator provenance', () => {
+    expect(hasKnowledgeIndicatorProvenance([doc(), doc({ id: 'doc-2' })])).toBe(false);
+  });
+
+  it('is true when at least one document carries a feature_uuid', () => {
+    expect(
+      hasKnowledgeIndicatorProvenance([
+        doc(),
+        doc({
+          id: 'doc-2',
+          knowledge_indicator: { feature_uuid: 'azure-feature-1', confidence: 88 },
+        }),
+      ])
+    ).toBe(true);
+  });
+
+  it('is false when knowledge_indicator is present but feature_uuid is missing', () => {
+    expect(
+      hasKnowledgeIndicatorProvenance([doc({ knowledge_indicator: { confidence: 88 } })])
+    ).toBe(false);
+  });
+});
+
+describe('InferredKnowledgeIndicatorBadge', () => {
+  it('renders the badge with the default label', () => {
+    render(<InferredKnowledgeIndicatorBadge />);
+    const badge = screen.getByTestId(GRAPH_INFERRED_KI_BADGE_ID);
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Inferred (KI)');
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/inferred_knowledge_indicator_badge.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/inferred_knowledge_indicator_badge.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { NodeDocumentDataModel } from '@kbn/cloud-security-posture-common/types/graph/latest';
+import { GRAPH_INFERRED_KI_BADGE_ID } from '../test_ids';
+
+const INFERRED_KI_LABEL = i18n.translate(
+  'securitySolutionPackages.csp.graph.inferredKnowledgeIndicator.label',
+  {
+    defaultMessage: 'Inferred (KI)',
+  }
+);
+
+const INFERRED_KI_TOOLTIP = i18n.translate(
+  'securitySolutionPackages.csp.graph.inferredKnowledgeIndicator.tooltip',
+  {
+    defaultMessage:
+      'This actor, target, or action was derived from a non-ECS field by a Streams Knowledge Indicator alias rather than read directly from a canonical ECS field.',
+  }
+);
+
+/**
+ * True when at least one of the node's underlying documents carries
+ * Streams-Knowledge-Indicators provenance (i.e. an inferred, non-ECS alias
+ * filled one of its actor / target / action slots). Drives the "Inferred (KI)"
+ * badge. ECS-native documents never carry this object, so the badge stays off
+ * for them.
+ */
+export const hasKnowledgeIndicatorProvenance = (documentsData?: NodeDocumentDataModel[]): boolean =>
+  Array.isArray(documentsData) &&
+  documentsData.some((doc) => doc?.knowledge_indicator?.feature_uuid != null);
+
+export interface InferredKnowledgeIndicatorBadgeProps {
+  /** Optional override for the badge label; defaults to "Inferred (KI)". */
+  label?: string;
+}
+
+export const InferredKnowledgeIndicatorBadge = ({
+  label = INFERRED_KI_LABEL,
+}: InferredKnowledgeIndicatorBadgeProps) => (
+  <EuiToolTip content={INFERRED_KI_TOOLTIP} position="top">
+    <EuiBadge
+      data-test-subj={GRAPH_INFERRED_KI_BADGE_ID}
+      color="hollow"
+      iconType="inspect"
+      aria-label={INFERRED_KI_TOOLTIP}
+    >
+      {label}
+    </EuiBadge>
+  </EuiToolTip>
+);

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.tsx
@@ -34,6 +34,7 @@ import { analyzeDocuments } from './analyze_documents';
 import { LabelNodeBadges } from './label_node_badges';
 import { LabelNodeDetails } from './label_node_details';
 import { showStackedShape } from '../../utils';
+import { hasKnowledgeIndicatorProvenance } from '../inferred_knowledge_indicator_badge';
 
 export const TEST_SUBJ_SHAPE = 'label-node-shape';
 export const TEST_SUBJ_STACKED_SHAPE = 'label-node-stacked-shape';
@@ -60,6 +61,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
     ipClickHandler,
     countryClickHandler,
     eventClickHandler,
+    documentsData,
   } = props.data as LabelNodeViewModel;
 
   const { euiTheme } = useEuiTheme();
@@ -76,6 +78,7 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
   const numAlerts = uniqueAlertsCount ?? 0;
 
   const analysis = analyzeDocuments({ uniqueEventsCount: numEvents, uniqueAlertsCount: numAlerts });
+  const isInferred = hasKnowledgeIndicatorProvenance(documentsData);
 
   return (
     <>
@@ -125,7 +128,11 @@ export const LabelNode = memo<NodeProps>((props: NodeProps) => {
                 />
               )}
             </EuiText>
-            <LabelNodeBadges analysis={analysis} onEventClick={eventClickHandler} />
+            <LabelNodeBadges
+              analysis={analysis}
+              isInferred={isInferred}
+              onEventClick={eventClickHandler}
+            />
           </div>
         </LabelShape>
         {showStackedShape(numEvents + numAlerts) && (

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
@@ -17,6 +17,7 @@ import {
   TEST_SUBJ_EVENT_COUNT_BUTTON,
 } from './label_node_badges';
 import { analyzeDocuments } from './analyze_documents';
+import { GRAPH_INFERRED_KI_BADGE_ID } from '../../test_ids';
 
 describe('LabelNodeBadges', () => {
   test('renders nothing for single event', () => {
@@ -28,6 +29,22 @@ describe('LabelNodeBadges', () => {
     expect(screen.queryByTestId(TEST_SUBJ_EVENT_COUNT)).not.toBeInTheDocument();
     expect(screen.queryByTestId(TEST_SUBJ_ALERT_ICON)).not.toBeInTheDocument();
     expect(screen.queryByTestId(TEST_SUBJ_ALERT_COUNT)).not.toBeInTheDocument();
+  });
+
+  test('renders the Inferred (KI) badge for a single event when isInferred is true', () => {
+    const analysis = analyzeDocuments({ uniqueEventsCount: 1, uniqueAlertsCount: 0 });
+
+    render(<LabelNodeBadges analysis={analysis} isInferred />);
+
+    expect(screen.getByTestId(GRAPH_INFERRED_KI_BADGE_ID)).toBeInTheDocument();
+  });
+
+  test('does not render the Inferred (KI) badge when isInferred is falsy', () => {
+    const analysis = analyzeDocuments({ uniqueEventsCount: 3, uniqueAlertsCount: 0 });
+
+    render(<LabelNodeBadges analysis={analysis} />);
+
+    expect(screen.queryByTestId(GRAPH_INFERRED_KI_BADGE_ID)).not.toBeInTheDocument();
   });
 
   test('renders alert badge with icon only for single alert', () => {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.tsx
@@ -11,6 +11,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
 import { RoundedBadge } from '../styles';
+import { InferredKnowledgeIndicatorBadge } from '../inferred_knowledge_indicator_badge';
 import type { DocumentAnalysisOutput } from './analyze_documents';
 
 export const TEST_SUBJ_ALERT_ICON = 'label-node-alert-icon';
@@ -35,6 +36,8 @@ const POPOVER_ALERT_ARIA_LABEL = i18n.translate(
 
 interface LabelNodeBadgesProps {
   analysis: DocumentAnalysisOutput;
+  /** When true, render the "Inferred (KI)" badge (the edge's action was alias-derived). */
+  isInferred?: boolean;
   onEventClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -141,10 +144,12 @@ const AlertIconBadge: React.FC = () => (
     <AlertIcon color="danger" />
   </RoundedBadge>
 );
-export const LabelNodeBadges = ({ analysis, onEventClick }: LabelNodeBadgesProps) => {
+export const LabelNodeBadges = ({ analysis, isInferred, onEventClick }: LabelNodeBadgesProps) => {
   const { euiTheme } = useEuiTheme();
 
-  if (analysis.isSingleEvent) {
+  // A single-event edge normally renders no badges, but an inferred (KI) edge
+  // must still surface its provenance badge.
+  if (analysis.isSingleEvent && !isInferred) {
     return null;
   }
 
@@ -157,6 +162,7 @@ export const LabelNodeBadges = ({ analysis, onEventClick }: LabelNodeBadgesProps
         gap: ${euiTheme.size.xs};
       `}
     >
+      {isInferred && <InferredKnowledgeIndicatorBadge />}
       {analysis.isSingleAlert && <AlertIconBadge />}
       {analysis.isGroupOfEvents && (
         <EventBadge count={analysis.uniqueEventsCount} onEventClick={onEventClick} />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_details.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_details.tsx
@@ -13,6 +13,7 @@ import { Tag } from './tag/tag';
 import { Ips } from './ips/ips';
 import { CountryFlags } from './country_flags/country_flags';
 import { Label } from './label/label';
+import { InferredKnowledgeIndicatorBadge } from './inferred_knowledge_indicator_badge';
 
 interface NodeDetailsProps {
   count?: number;
@@ -20,6 +21,7 @@ interface NodeDetailsProps {
   label?: string;
   ips?: string[];
   countryCodes?: string[];
+  isInferred?: boolean;
   onIpClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onCountryClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
@@ -30,6 +32,7 @@ export const NodeDetails = ({
   label,
   ips,
   countryCodes,
+  isInferred,
   onIpClick,
   onCountryClick,
 }: NodeDetailsProps) => {
@@ -40,7 +43,7 @@ export const NodeDetails = ({
   const shouldRenderIps = ips && ips.length > 0;
   const shouldRenderFlags = countryCodes && countryCodes.length > 0;
 
-  const shouldRenderTop = shouldRenderTag;
+  const shouldRenderTop = shouldRenderTag || isInferred;
   const shouldRenderBottom = shouldRenderLabel || shouldRenderIps || shouldRenderFlags;
 
   return (
@@ -53,8 +56,18 @@ export const NodeDetails = ({
       `}
     >
       {shouldRenderTop ? (
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: center;
+            gap: ${euiTheme.size.xxs};
+          `}
+        >
           {shouldRenderTag ? <Tag count={count} text={tag} /> : null}
+          {isInferred ? <InferredKnowledgeIndicatorBadge /> : null}
         </EuiFlexItem>
       ) : null}
       {shouldRenderBottom ? (

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/pentagon_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/pentagon_node.tsx
@@ -25,6 +25,7 @@ import { PentagonHoverShape, PentagonShape } from './shapes/pentagon_shape';
 import { NodeExpandButton } from './node_expand_button';
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { NodeDetails } from './node_details';
+import { hasKnowledgeIndicatorProvenance } from './inferred_knowledge_indicator_badge';
 import {
   GRAPH_ENTITY_NODE_ID,
   GRAPH_ENTITY_NODE_HOVER_SHAPE_ID,
@@ -52,6 +53,7 @@ export const PentagonNode = memo<NodeProps>((props: NodeProps) => {
     nodeClick,
     ipClickHandler,
     countryClickHandler,
+    documentsData,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -141,6 +143,7 @@ export const PentagonNode = memo<NodeProps>((props: NodeProps) => {
         label={label}
         ips={ips}
         countryCodes={countryCodes}
+        isInferred={hasKnowledgeIndicatorProvenance(documentsData)}
         onIpClick={ipClickHandler}
         onCountryClick={countryClickHandler}
       />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/rectangle_node.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/rectangle_node.tsx
@@ -25,6 +25,7 @@ import { RectangleHoverShape, RectangleShape } from './shapes/rectangle_shape';
 import { NodeExpandButton } from './node_expand_button';
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { NodeDetails } from './node_details';
+import { hasKnowledgeIndicatorProvenance } from './inferred_knowledge_indicator_badge';
 import {
   GRAPH_ENTITY_NODE_ID,
   GRAPH_ENTITY_NODE_HOVER_SHAPE_ID,
@@ -52,6 +53,7 @@ export const RectangleNode = memo<NodeProps>((props: NodeProps) => {
     nodeClick,
     ipClickHandler,
     countryClickHandler,
+    documentsData,
   } = props.data as EntityNodeViewModel;
   const { euiTheme } = useEuiTheme();
   const shadow = useEuiShadow('m', { property: 'filter' });
@@ -137,6 +139,7 @@ export const RectangleNode = memo<NodeProps>((props: NodeProps) => {
         label={label}
         ips={ips}
         countryCodes={countryCodes}
+        isInferred={hasKnowledgeIndicatorProvenance(documentsData)}
         onIpClick={ipClickHandler}
         onCountryClick={countryClickHandler}
       />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/test_ids.ts
@@ -108,6 +108,9 @@ export const GRAPH_TAG_WRAPPER_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagWrapper` a
 export const GRAPH_TAG_COUNT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagCount` as const;
 export const GRAPH_TAG_TEXT_ID = `${GRAPH_INVESTIGATION_TEST_ID}TagText` as const;
 
+export const GRAPH_INFERRED_KI_BADGE_ID =
+  `${GRAPH_INVESTIGATION_TEST_ID}InferredKnowledgeIndicatorBadge` as const;
+
 export const GRAPH_POPOVER_PREVIEW_PANEL =
   `${GRAPH_INVESTIGATION_TEST_ID}PopoverPreviewPanel` as const;
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.test.ts
@@ -65,6 +65,11 @@ describe('Cloud Security Posture Plugin', () => {
         security: securityMock.createStart(),
         licensing: licensingMock.createStart(),
         dataViews: createIndexPatternsStartMock(),
+        entityStore: {
+          createCRUDClient: jest.fn(),
+          createResolutionClient: jest.fn(),
+          getGraphRoleAliases: jest.fn().mockResolvedValue([]),
+        } as unknown as CspServerPluginStartDeps['entityStore'],
       };
 
       contextMock = coreMock.createCustomRequestHandlerContext(mockRouteContext);

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.test.ts
@@ -66,13 +66,33 @@ describe('buildGraphAliasPrelude', () => {
     it('guards every slot fill with the stream _index/dataset guard', () => {
       const { esql } = buildGraphAliasPrelude([ctx()]);
       expect(esql).toContain(
-        `CASE((_index LIKE "*${AZURE_STREAM}*" OR \`data_stream.dataset\` == "${AZURE_STREAM}"), COALESCE(MV_FIRST(\`azure.signinlogs.properties.user_principal_name\`)), null)`
+        `CASE((_index LIKE "*${AZURE_STREAM}*" OR \`data_stream.dataset\` == "${AZURE_STREAM}"), COALESCE(TO_STRING(MV_FIRST(\`azure.signinlogs.properties.user_principal_name\`))), null)`
       );
     });
 
     it('reads each source via MV_FIRST so multi-value fields collapse to a single value', () => {
       const { esql } = buildGraphAliasPrelude([ctx()]);
       expect(esql).toContain('MV_FIRST(`azure.signinlogs.properties.user_principal_name`)');
+    });
+
+    it('casts every source to keyword so non-keyword vendor fields (e.g. a long id) do not break COALESCE', () => {
+      // Regression: graph-role destinations are ECS keyword, but a numeric vendor
+      // source (gitlab.audit.target_id is a `long`) made the folded slot-fill
+      // COALESCE type-invalid -> `verification_exception ... must be [keyword],
+      // found ... type [long]`, aborting the whole graph query.
+      const numericSource = ctx({
+        streamName: 'logs-gitlab.audit-default',
+        indexPatterns: ['logs-gitlab.audit-default'],
+        aliases: new Map<string, readonly string[]>([
+          ['user.target.id', ['gitlab.audit.target_id']],
+        ]) as GraphRoleAliasContext['aliases'],
+        featureUuid: 'gitlab-feature-1',
+        confidence: 80,
+      });
+      const { esql } = buildGraphAliasPrelude([numericSource]);
+      expect(esql).toContain('COALESCE(TO_STRING(MV_FIRST(`gitlab.audit.target_id`)))');
+      // the raw, uncast source must never reach the COALESCE (that is the bug).
+      expect(esql).not.toMatch(/COALESCE\(MV_FIRST\(`gitlab\.audit\.target_id`\)\)/);
     });
   });
 
@@ -92,7 +112,7 @@ describe('buildGraphAliasPrelude', () => {
     it('marks a context fired only when an ECS slot was null but a source supplied a value', () => {
       const { esql } = buildGraphAliasPrelude([ctx()]);
       expect(esql).toMatch(
-        /\| EVAL _ki_fired_0 = \(.*\) AND \(\(`user\.email` IS NULL AND COALESCE\(MV_FIRST\(`azure\.signinlogs\.properties\.user_principal_name`\)\) IS NOT NULL\)/
+        /\| EVAL _ki_fired_0 = \(.*\) AND \(\(`user\.email` IS NULL AND COALESCE\(TO_STRING\(MV_FIRST\(`azure\.signinlogs\.properties\.user_principal_name`\)\)\) IS NOT NULL\)/
       );
     });
   });
@@ -122,11 +142,11 @@ describe('buildGraphAliasPrelude', () => {
 
       // Azure source is only ever wrapped by the Azure guard…
       expect(esql).toContain(
-        `CASE((_index LIKE "*${AZURE_STREAM}*" OR \`data_stream.dataset\` == "${AZURE_STREAM}"), COALESCE(MV_FIRST(\`azure.signinlogs.properties.user_principal_name\`)), null)`
+        `CASE((_index LIKE "*${AZURE_STREAM}*" OR \`data_stream.dataset\` == "${AZURE_STREAM}"), COALESCE(TO_STRING(MV_FIRST(\`azure.signinlogs.properties.user_principal_name\`))), null)`
       );
       // …and Okta source only by the Okta guard.
       expect(esql).toContain(
-        `CASE((_index LIKE "*${OKTA_STREAM}*" OR \`data_stream.dataset\` == "${OKTA_STREAM}"), COALESCE(MV_FIRST(\`okta.actor.alternate_id\`)), null)`
+        `CASE((_index LIKE "*${OKTA_STREAM}*" OR \`data_stream.dataset\` == "${OKTA_STREAM}"), COALESCE(TO_STRING(MV_FIRST(\`okta.actor.alternate_id\`))), null)`
       );
       // The Okta source never appears inside an Azure-guarded arm.
       expect(esql).not.toMatch(new RegExp(`${AZURE_STREAM}[^)]*okta\\.actor\\.alternate_id`));

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GraphRoleAliasContext } from '@kbn/entity-store/server';
+import {
+  buildGraphAliasPrelude,
+  KI_PROVENANCE_CONFIDENCE_FIELD,
+  KI_PROVENANCE_FEATURE_UUID_FIELD,
+} from './build_graph_alias_prelude';
+
+const AZURE_STREAM = 'logs-azure.signinlogs-default';
+const OKTA_STREAM = 'logs-okta.system-default';
+
+const ctx = (overrides: Partial<GraphRoleAliasContext> = {}): GraphRoleAliasContext => ({
+  streamName: AZURE_STREAM,
+  indexPatterns: [AZURE_STREAM],
+  aliases: new Map<string, readonly string[]>([
+    ['user.email', ['azure.signinlogs.properties.user_principal_name']],
+    ['service.target.name', ['azure.signinlogs.properties.resource_display_name']],
+    ['event.action', ['azure.signinlogs.operation_name']],
+  ]) as GraphRoleAliasContext['aliases'],
+  featureUuid: 'azure-feature-1',
+  confidence: 88,
+  ...overrides,
+});
+
+describe('buildGraphAliasPrelude', () => {
+  describe('off-by-default / no-op safety', () => {
+    it('returns an empty prelude for undefined contexts', () => {
+      const prelude = buildGraphAliasPrelude(undefined);
+      expect(prelude.hasAliases).toBe(false);
+      expect(prelude.esql).toBe('');
+      expect(prelude.targetSourceFields).toEqual([]);
+      expect(prelude.provenanceColumns).toEqual([]);
+    });
+
+    it('returns an empty prelude for an empty contexts array', () => {
+      expect(buildGraphAliasPrelude([]).esql).toBe('');
+    });
+
+    it('drops a context whose stream/index cannot be resolved', () => {
+      const prelude = buildGraphAliasPrelude([ctx({ indexPatterns: [] })]);
+      expect(prelude.hasAliases).toBe(false);
+    });
+
+    it('drops a context with a malformed feature UUID before it reaches a literal', () => {
+      const prelude = buildGraphAliasPrelude([ctx({ featureUuid: 'bad uuid "; DROP' })]);
+      expect(prelude.hasAliases).toBe(false);
+    });
+  });
+
+  describe('slot fills', () => {
+    it('fills only null ECS slots (native ECS values win via leading COALESCE arg)', () => {
+      const { esql } = buildGraphAliasPrelude([ctx()]);
+      expect(esql).toContain('| EVAL `user.email` = COALESCE(`user.email`, CASE(');
+      expect(esql).toContain('| EVAL `event.action` = COALESCE(`event.action`, CASE(');
+      expect(esql).toContain(
+        '| EVAL `service.target.name` = COALESCE(`service.target.name`, CASE('
+      );
+    });
+
+    it('guards every slot fill with the stream _index/dataset guard', () => {
+      const { esql } = buildGraphAliasPrelude([ctx()]);
+      expect(esql).toContain(
+        `CASE((_index LIKE "*${AZURE_STREAM}*" OR \`data_stream.dataset\` == "${AZURE_STREAM}"), COALESCE(MV_FIRST(\`azure.signinlogs.properties.user_principal_name\`)), null)`
+      );
+    });
+
+    it('reads each source via MV_FIRST so multi-value fields collapse to a single value', () => {
+      const { esql } = buildGraphAliasPrelude([ctx()]);
+      expect(esql).toContain('MV_FIRST(`azure.signinlogs.properties.user_principal_name`)');
+    });
+  });
+
+  describe('provenance', () => {
+    it('writes feature_uuid and confidence provenance columns keyed off the fired flag', () => {
+      const { esql, provenanceColumns } = buildGraphAliasPrelude([ctx()]);
+      expect(esql).toContain(`| EVAL \`${KI_PROVENANCE_FEATURE_UUID_FIELD}\` = CASE(`);
+      expect(esql).toContain('"azure-feature-1"');
+      expect(esql).toContain(`| EVAL \`${KI_PROVENANCE_CONFIDENCE_FIELD}\` = CASE(`);
+      expect(esql).toContain('88');
+      expect(provenanceColumns).toEqual([
+        KI_PROVENANCE_FEATURE_UUID_FIELD,
+        KI_PROVENANCE_CONFIDENCE_FIELD,
+      ]);
+    });
+
+    it('marks a context fired only when an ECS slot was null but a source supplied a value', () => {
+      const { esql } = buildGraphAliasPrelude([ctx()]);
+      expect(esql).toMatch(
+        /\| EVAL _ki_fired_0 = \(.*\) AND \(\(`user\.email` IS NULL AND COALESCE\(MV_FIRST\(`azure\.signinlogs\.properties\.user_principal_name`\)\) IS NOT NULL\)/
+      );
+    });
+  });
+
+  describe('target source fields (DSL exists pre-filter)', () => {
+    it('exposes target-role sources but not actor-role sources', () => {
+      const { targetSourceFields } = buildGraphAliasPrelude([ctx()]);
+      expect(targetSourceFields).toContain('azure.signinlogs.properties.resource_display_name');
+      expect(targetSourceFields).not.toContain('azure.signinlogs.properties.user_principal_name');
+      expect(targetSourceFields).not.toContain('azure.signinlogs.operation_name');
+    });
+  });
+
+  describe('no cross-stream leakage', () => {
+    it('guards each stream alias arm with its own stream guard', () => {
+      const okta = ctx({
+        streamName: OKTA_STREAM,
+        indexPatterns: [OKTA_STREAM],
+        aliases: new Map<string, readonly string[]>([
+          ['user.email', ['okta.actor.alternate_id']],
+        ]) as GraphRoleAliasContext['aliases'],
+        featureUuid: 'okta-feature-2',
+        confidence: 75,
+      });
+
+      const { esql } = buildGraphAliasPrelude([ctx(), okta]);
+
+      // Azure source is only ever wrapped by the Azure guard…
+      expect(esql).toContain(
+        `CASE((_index LIKE "*${AZURE_STREAM}*" OR \`data_stream.dataset\` == "${AZURE_STREAM}"), COALESCE(MV_FIRST(\`azure.signinlogs.properties.user_principal_name\`)), null)`
+      );
+      // …and Okta source only by the Okta guard.
+      expect(esql).toContain(
+        `CASE((_index LIKE "*${OKTA_STREAM}*" OR \`data_stream.dataset\` == "${OKTA_STREAM}"), COALESCE(MV_FIRST(\`okta.actor.alternate_id\`)), null)`
+      );
+      // The Okta source never appears inside an Azure-guarded arm.
+      expect(esql).not.toMatch(new RegExp(`${AZURE_STREAM}[^)]*okta\\.actor\\.alternate_id`));
+    });
+  });
+
+  describe('vocabulary + injection guards', () => {
+    it('drops destinations outside the closed graph vocabulary', () => {
+      const withBadDest = ctx({
+        aliases: new Map<string, readonly string[]>([
+          ['user.email', ['azure.signinlogs.properties.user_principal_name']],
+          ['user.roles', ['azure.signinlogs.properties.app_roles']],
+        ]) as GraphRoleAliasContext['aliases'],
+      });
+      const { esql } = buildGraphAliasPrelude([withBadDest]);
+      expect(esql).toContain('`user.email`');
+      expect(esql).not.toContain('user.roles');
+      expect(esql).not.toContain('app_roles');
+    });
+
+    it('drops source paths that fail the field-path guard but keeps valid siblings', () => {
+      const withBadSource = ctx({
+        aliases: new Map<string, readonly string[]>([
+          ['user.email', ['azure.signinlogs.properties.user_principal_name', 'bad path"; DROP']],
+        ]) as GraphRoleAliasContext['aliases'],
+      });
+      const { esql } = buildGraphAliasPrelude([withBadSource]);
+      expect(esql).toContain('MV_FIRST(`azure.signinlogs.properties.user_principal_name`)');
+      expect(esql).not.toContain('DROP');
+      expect(esql).not.toContain('bad path');
+    });
+
+    it('drops index patterns that fail the index-pattern guard', () => {
+      const prelude = buildGraphAliasPrelude([
+        ctx({ indexPatterns: ['BAD PATTERN'], streamName: 'BAD PATTERN' }),
+      ]);
+      expect(prelude.hasAliases).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.ts
@@ -114,7 +114,17 @@ const sourceCoalesceExpr = (sources: readonly string[]): string | undefined => {
   if (safeSources.length === 0) {
     return undefined;
   }
-  return `COALESCE(${safeSources.map((source) => `MV_FIRST(${quoteField(source)})`).join(', ')})`;
+  // Every graph-role destination is an ECS keyword identity field, but vendor
+  // source paths can be any ES type (e.g. `gitlab.audit.target_id` is a `long`,
+  // an `*.id` can be numeric, etc.). ES|QL COALESCE/CASE require all branches to
+  // share a single type, and the slot-fill folds these per-stream arms together
+  // with the keyword destination — so a single numeric source aborts the whole
+  // graph query with `verification_exception ... must be [keyword], found ...
+  // type [long]`. Cast each source to keyword via TO_STRING so heterogeneous
+  // vendor types are normalized to the identity slot's type.
+  return `COALESCE(${safeSources
+    .map((source) => `TO_STRING(MV_FIRST(${quoteField(source)}))`)
+    .join(', ')})`;
 };
 
 const resolveContexts = (contexts: GraphRoleAliasContext[]): ResolvedContext[] => {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/build_graph_alias_prelude.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GraphRoleAliasContext } from '@kbn/entity-store/server';
+import { INDEX_PATTERN_REGEX } from '@kbn/cloud-security-posture-common/schema/graph/v1';
+import {
+  GRAPH_ACTOR_EUID_SOURCE_FIELDS,
+  GRAPH_TARGET_EUID_SOURCE_FIELDS,
+  type EuidSourceFields,
+} from './constants';
+
+/**
+ * Provenance columns the prelude writes and the events query carries to the UI.
+ * Both are `graph.knowledge_indicator.*` so they never collide with ECS or with
+ * the entity-store `<type>.entity.knowledge_indicator.*` STATS namespace used by
+ * log extraction.
+ */
+export const KI_PROVENANCE_FEATURE_UUID_FIELD = 'graph.knowledge_indicator.feature_uuid';
+export const KI_PROVENANCE_CONFIDENCE_FIELD = 'graph.knowledge_indicator.confidence';
+
+export interface GraphAliasPrelude {
+  /**
+   * ES|QL `EVAL` statements (no leading newline) to splice immediately after
+   * `FROM … METADATA _id, _index` and before actor resolution. Empty string
+   * when there are no usable alias contexts — callers MUST treat empty as
+   * "splice nothing" so the query is byte-identical to the no-KI path.
+   */
+  esql: string;
+  /** True when `esql` is non-empty (drives provenance folding + KEEP additions). */
+  hasAliases: boolean;
+  /**
+   * Target-role source field paths to add to the `showUnknownTarget: false`
+   * DSL `exists` pre-filter, so KI-inferred targets survive the pre-ES|QL filter.
+   */
+  targetSourceFields: string[];
+  /** Provenance columns to KEEP and fold into actor/target/edge docData. */
+  provenanceColumns: readonly string[];
+}
+
+// Field-path identifiers safe to embed inside ES|QL backticks. Disallows the
+// backtick itself plus whitespace/control characters; allows the dotted ECS /
+// non-ECS path shape (e.g. `azure.signinlogs.properties.user_principal_name`).
+const FIELD_PATH_REGEX = /^[A-Za-z0-9_][A-Za-z0-9_.@-]*$/;
+// Feature UUIDs are v5 uuids; keep the guard tight so nothing else reaches a literal.
+const FEATURE_UUID_REGEX = /^[A-Za-z0-9._:-]+$/;
+
+const EMPTY_PRELUDE: GraphAliasPrelude = {
+  esql: '',
+  hasAliases: false,
+  targetSourceFields: [],
+  provenanceColumns: [],
+};
+
+const flattenSourceFields = (fields: EuidSourceFields): string[] => [
+  ...fields.user,
+  ...fields.host,
+  ...fields.service,
+  ...fields.generic,
+];
+
+// The live, euid-derived destination vocabulary. `.all` (event.dataset,
+// event.module, data_stream.dataset) is intentionally excluded — those are
+// namespace-context fields, not identity slots, and must never be alias targets.
+const ACTOR_DESTINATIONS = new Set(flattenSourceFields(GRAPH_ACTOR_EUID_SOURCE_FIELDS));
+const TARGET_DESTINATIONS = new Set(flattenSourceFields(GRAPH_TARGET_EUID_SOURCE_FIELDS));
+const ACTION_DESTINATION = 'event.action';
+const VALID_DESTINATIONS = new Set<string>([
+  ...ACTOR_DESTINATIONS,
+  ...TARGET_DESTINATIONS,
+  ACTION_DESTINATION,
+]);
+
+const quoteField = (field: string): string => `\`${field}\``;
+const quoteStringLiteral = (value: string): string =>
+  `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+interface ResolvedContext {
+  index: number;
+  guard: string;
+  featureUuid: string;
+  confidence: number;
+  /** destination -> ordered, validated, quoted source COALESCE expression */
+  destinations: Map<string, string>;
+}
+
+/**
+ * Builds the per-stream `data_stream.dataset` / `_index` guard for a context.
+ * `_index LIKE "*<stream>*"` matches the stream's backing data-stream indices
+ * (`.ds-<stream>-…`); the `data_stream.dataset == "<stream>"` arm covers the
+ * cases where the dataset equals the stream name. Index patterns / stream names
+ * are validated against `INDEX_PATTERN_REGEX` before interpolation.
+ */
+const buildGuard = (context: GraphRoleAliasContext): string | undefined => {
+  const safePatterns = context.indexPatterns.filter((pattern) => INDEX_PATTERN_REGEX.test(pattern));
+  if (safePatterns.length === 0) {
+    return undefined;
+  }
+  const indexArms = safePatterns.map(
+    (pattern) => `_index LIKE ${quoteStringLiteral(`*${pattern}*`)}`
+  );
+  const datasetArm = INDEX_PATTERN_REGEX.test(context.streamName)
+    ? `${quoteField('data_stream.dataset')} == ${quoteStringLiteral(context.streamName)}`
+    : undefined;
+  const arms = datasetArm ? [...indexArms, datasetArm] : indexArms;
+  return `(${arms.join(' OR ')})`;
+};
+
+const sourceCoalesceExpr = (sources: readonly string[]): string | undefined => {
+  const safeSources = sources.filter((source) => FIELD_PATH_REGEX.test(source));
+  if (safeSources.length === 0) {
+    return undefined;
+  }
+  return `COALESCE(${safeSources.map((source) => `MV_FIRST(${quoteField(source)})`).join(', ')})`;
+};
+
+const resolveContexts = (contexts: GraphRoleAliasContext[]): ResolvedContext[] => {
+  const resolved: ResolvedContext[] = [];
+  contexts.forEach((context) => {
+    if (!FEATURE_UUID_REGEX.test(context.featureUuid)) {
+      return;
+    }
+    const guard = buildGuard(context);
+    if (!guard) {
+      return;
+    }
+    const destinations = new Map<string, string>();
+    for (const [destination, sources] of context.aliases) {
+      if (!VALID_DESTINATIONS.has(destination)) {
+        continue;
+      }
+      const expr = sourceCoalesceExpr(sources);
+      if (expr) {
+        destinations.set(destination, expr);
+      }
+    }
+    if (destinations.size === 0) {
+      return;
+    }
+    resolved.push({
+      index: resolved.length,
+      guard,
+      featureUuid: context.featureUuid,
+      confidence: Math.round(context.confidence),
+      destinations,
+    });
+  });
+  return resolved;
+};
+
+const firedColumn = (index: number): string => `_ki_fired_${index}`;
+
+/**
+ * Builds the Streams-KI graph alias prelude: per-stream guarded `COALESCE`s that
+ * fill canonical ECS actor / target / action slots from non-ECS source paths,
+ * plus `graph.knowledge_indicator.*` provenance columns. COALESCE writes into a
+ * slot only when it is null, so native ECS values always win; guards keep one
+ * stream's aliases from leaking onto another stream's documents.
+ *
+ * Returns {@link EMPTY_PRELUDE} (empty `esql`, no folding) when there are no
+ * usable contexts — the off-by-default path that keeps the graph byte-identical.
+ */
+export const buildGraphAliasPrelude = (
+  contexts: GraphRoleAliasContext[] = []
+): GraphAliasPrelude => {
+  const resolved = resolveContexts(contexts);
+  if (resolved.length === 0) {
+    return EMPTY_PRELUDE;
+  }
+
+  // 1) Per-context "fired" flags. Computed BEFORE any slot fill so they read the
+  //    raw destination value: a context fired iff its guard matches AND at least
+  //    one of its destinations was null but a source supplied a value. This keeps
+  //    the "Inferred (KI)" provenance honest (native ECS values do not get flagged).
+  const firedStatements = resolved.map((context) => {
+    const anyInferred = [...context.destinations.entries()]
+      .map(([destination, expr]) => `(${quoteField(destination)} IS NULL AND ${expr} IS NOT NULL)`)
+      .join(' OR ');
+    return `| EVAL ${firedColumn(context.index)} = ${context.guard} AND (${anyInferred})`;
+  });
+
+  // 2) Slot fills, grouped per destination so a destination targeted by multiple
+  //    streams becomes a single COALESCE with one guarded CASE arm per stream.
+  const destinationToArms = new Map<string, string[]>();
+  resolved.forEach((context) => {
+    context.destinations.forEach((expr, destination) => {
+      const arm = `CASE(${context.guard}, ${expr}, null)`;
+      const arms = destinationToArms.get(destination) ?? [];
+      arms.push(arm);
+      destinationToArms.set(destination, arms);
+    });
+  });
+  const slotFillStatements = [...destinationToArms.entries()].map(
+    ([destination, arms]) =>
+      `| EVAL ${quoteField(destination)} = COALESCE(${quoteField(destination)}, ${arms.join(', ')})`
+  );
+
+  // 3) Provenance columns derived from the fired flags.
+  const uuidArms = resolved
+    .map((context) => `${firedColumn(context.index)}, ${quoteStringLiteral(context.featureUuid)}`)
+    .join(', ');
+  const confidenceArms = resolved
+    .map((context) => `${firedColumn(context.index)}, ${context.confidence}`)
+    .join(', ');
+  const provenanceStatements = [
+    `| EVAL ${quoteField(KI_PROVENANCE_FEATURE_UUID_FIELD)} = CASE(${uuidArms})`,
+    `| EVAL ${quoteField(KI_PROVENANCE_CONFIDENCE_FIELD)} = CASE(${confidenceArms})`,
+  ];
+
+  const esql = [...firedStatements, ...slotFillStatements, ...provenanceStatements].join('\n');
+
+  // Target-role sources for the showUnknownTarget=false DSL exists pre-filter.
+  const targetSourceFields = new Set<string>();
+  contexts.forEach((context) => {
+    for (const [destination, sources] of context.aliases) {
+      if (!TARGET_DESTINATIONS.has(destination)) {
+        continue;
+      }
+      sources
+        .filter((source) => FIELD_PATH_REGEX.test(source))
+        .forEach((s) => targetSourceFields.add(s));
+    }
+  });
+
+  return {
+    esql,
+    hasAliases: true,
+    targetSourceFields: [...targetSourceFields],
+    provenanceColumns: [KI_PROVENANCE_FEATURE_UUID_FIELD, KI_PROVENANCE_CONFIDENCE_FIELD],
+  };
+};

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.test.ts
@@ -9,6 +9,7 @@ import { createHash } from 'crypto';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { fetchEvents, regroupEvents, enrichEventDocData } from './fetch_events_graph';
 import type { Logger } from '@kbn/core/server';
+import type { GraphRoleAliasContext } from '@kbn/entity-store/server';
 import type { OriginEventId, EsQuery, EventEsqlRow } from './types';
 import { GRAPH_ACTOR_EUID_SOURCE_FIELDS, GRAPH_TARGET_EUID_SOURCE_FIELDS } from './constants';
 import type { EntityEnrichmentFields } from './fetch_entity_enrichment';
@@ -512,6 +513,111 @@ describe('fetchEvents', () => {
       expect(esClient.asCurrentUser.helpers.esql).toBeCalledTimes(1);
       const [args] = esClient.asCurrentUser.helpers.esql.mock.calls[0];
       expect(args).not.toHaveProperty('project_routing');
+    });
+  });
+
+  describe('Streams-KI alias prelude', () => {
+    const AZURE_STREAM = 'logs-azure.signinlogs-default';
+    const azureContext: GraphRoleAliasContext = {
+      streamName: AZURE_STREAM,
+      indexPatterns: [AZURE_STREAM],
+      aliases: new Map<string, readonly string[]>([
+        ['user.email', ['azure.signinlogs.properties.user_principal_name']],
+        ['service.target.name', ['azure.signinlogs.properties.resource_display_name']],
+        ['event.action', ['azure.signinlogs.operation_name']],
+      ]) as GraphRoleAliasContext['aliases'],
+      featureUuid: 'azure-feature-1',
+      confidence: 88,
+    };
+
+    const baseParams = {
+      start: 0,
+      end: 1000,
+      originEventIds: [] as OriginEventId[],
+      showUnknownTarget: false,
+      indexPatterns: ['logs-*'],
+      spaceId: 'default',
+      esQuery: undefined as EsQuery | undefined,
+    };
+
+    const runQuery = async (graphRoleAliases?: GraphRoleAliasContext[]): Promise<string> => {
+      await fetchEvents({ esClient, logger, ...baseParams, graphRoleAliases });
+      const calls = esClient.asCurrentUser.helpers.esql.mock.calls;
+      const [args] = calls[calls.length - 1];
+      return args.query as string;
+    };
+
+    it('is byte-identical to the no-KI path when no alias contexts are supplied (knob off)', async () => {
+      const withoutAliases = await runQuery(undefined);
+      const withEmptyAliases = await runQuery([]);
+
+      expect(withoutAliases).toEqual(withEmptyAliases);
+      // The off path never emits prelude/provenance ES|QL.
+      expect(withoutAliases).not.toContain('knowledge_indicator');
+      expect(withoutAliases).not.toContain('_ki_fired_');
+    });
+
+    it('splices guarded slot fills + provenance and folds knowledge_indicator into docData', async () => {
+      const query = await runQuery([azureContext]);
+
+      // Guarded COALESCE slot fills for actor / target / action.
+      expect(query).toContain('| EVAL `user.email` = COALESCE(`user.email`, CASE(');
+      expect(query).toContain('| EVAL `event.action` = COALESCE(`event.action`, CASE(');
+      expect(query).toContain(
+        '| EVAL `service.target.name` = COALESCE(`service.target.name`, CASE('
+      );
+      // Provenance columns.
+      expect(query).toContain('graph.knowledge_indicator.feature_uuid');
+      expect(query).toContain('graph.knowledge_indicator.confidence');
+      // Provenance folded into the docData JSON objects.
+      expect(query).toContain('\\"knowledge_indicator\\":');
+      // The prelude lands before actor resolution / the event.action WHERE gate.
+      expect(query.indexOf('graph.knowledge_indicator.feature_uuid')).toBeLessThan(
+        query.indexOf('WHERE event.action IS NOT NULL')
+      );
+    });
+
+    it('adds KI target source paths to the showUnknownTarget=false exists pre-filter', async () => {
+      await fetchEvents({
+        esClient,
+        logger,
+        ...baseParams,
+        showUnknownTarget: false,
+        graphRoleAliases: [azureContext],
+      });
+
+      const [args] = esClient.asCurrentUser.helpers.esql.mock.calls[0];
+      const filterArg = args.filter as any;
+      const targetFilter = filterArg.bool.filter.find((f: any) =>
+        f.bool?.should?.some(
+          (s: any) => s.exists?.field === 'azure.signinlogs.properties.resource_display_name'
+        )
+      );
+      expect(targetFilter).toBeDefined();
+      // Actor-only sources are NOT added to the target exists list.
+      const hasActorSource = filterArg.bool.filter.some((f: any) =>
+        f.bool?.should?.some(
+          (s: any) => s.exists?.field === 'azure.signinlogs.properties.user_principal_name'
+        )
+      );
+      expect(hasActorSource).toBe(false);
+    });
+
+    it('does not leak alias source paths into the DSL filter when showUnknownTarget is true', async () => {
+      await fetchEvents({
+        esClient,
+        logger,
+        ...baseParams,
+        showUnknownTarget: true,
+        graphRoleAliases: [azureContext],
+      });
+
+      const [args] = esClient.asCurrentUser.helpers.esql.mock.calls[0];
+      const filterArg = args.filter as any;
+      const hasTargetExists = filterArg.bool.filter.some((f: any) =>
+        f.bool?.should?.some((s: any) => s.exists?.field?.startsWith('azure.signinlogs'))
+      );
+      expect(hasTargetExists).toBe(false);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_events_graph.ts
@@ -19,10 +19,17 @@ import {
 import type { ProjectRouting } from '@kbn/cloud-security-posture-common/schema/graph/v1';
 
 import { ALL_ENTITY_TYPES } from '@kbn/entity-store/common';
+import type { GraphRoleAliasContext } from '@kbn/entity-store/server';
 import {
   getEuidEsqlEvaluation,
   getFieldEvaluationsEsql,
 } from '@kbn/entity-store/common/domain/euid';
+import {
+  buildGraphAliasPrelude,
+  type GraphAliasPrelude,
+  KI_PROVENANCE_FEATURE_UUID_FIELD,
+  KI_PROVENANCE_CONFIDENCE_FIELD,
+} from './build_graph_alias_prelude';
 import {
   concatJsonObjectPropertyEsqlExprSafe,
   JSON_OBJECT_START,
@@ -50,6 +57,7 @@ interface BuildEsqlQueryParams {
   originAlertIds: OriginEventId[];
   alertsMappingsIncluded: boolean;
   pinnedIds?: string[];
+  aliasPrelude: GraphAliasPrelude;
 }
 
 /**
@@ -73,6 +81,7 @@ export const fetchEvents = async ({
   esQuery,
   pinnedIds,
   projectRouting,
+  graphRoleAliases,
 }: {
   esClient: IScopedClusterClient;
   logger: Logger;
@@ -85,6 +94,7 @@ export const fetchEvents = async ({
   esQuery?: EsQuery;
   pinnedIds?: string[];
   projectRouting?: ProjectRouting;
+  graphRoleAliases?: GraphRoleAliasContext[];
 }): Promise<EsqlToRecords<EventEsqlRow>> => {
   const originAlertIds = originEventIds.filter((originEventId) => originEventId.isAlert);
 
@@ -102,12 +112,17 @@ export const fetchEvents = async ({
     indexPattern.includes(SECURITY_ALERTS_PARTIAL_IDENTIFIER)
   );
 
+  // Off-by-default Streams-KI alias prelude. Empty (the default) ⇒ the query and
+  // DSL filter below are byte-identical to the no-KI path.
+  const aliasPrelude = buildGraphAliasPrelude(graphRoleAliases);
+
   const filter = buildDslFilter(
     originEventIds.map((originEventId) => originEventId.id),
     showUnknownTarget,
     start,
     end,
-    esQuery
+    esQuery,
+    aliasPrelude.targetSourceFields
   );
 
   const params = [
@@ -122,6 +137,7 @@ export const fetchEvents = async ({
     originAlertIds,
     alertsMappingsIncluded,
     pinnedIds,
+    aliasPrelude,
   });
 
   logger.trace(`Executing events query [project_routing: ${projectRouting ?? 'default'}]`);
@@ -142,7 +158,8 @@ const buildDslFilter = (
   showUnknownTarget: boolean,
   start: string | number,
   end: string | number,
-  esQuery?: EsQuery
+  esQuery?: EsQuery,
+  kiTargetSourceFields: string[] = []
 ) => ({
   bool: {
     filter: [
@@ -159,11 +176,15 @@ const buildDslFilter = (
         : [
             {
               bool: {
+                // KI target source paths are added so that events whose target is only
+                // expressed in a non-ECS field (resolved by the alias prelude) survive
+                // this pre-filter. When no alias contexts are present this is a no-op.
                 should: [
                   ...GRAPH_TARGET_EUID_SOURCE_FIELDS.generic,
                   ...GRAPH_TARGET_EUID_SOURCE_FIELDS.host,
                   ...GRAPH_TARGET_EUID_SOURCE_FIELDS.user,
                   ...GRAPH_TARGET_EUID_SOURCE_FIELDS.service,
+                  ...kiTargetSourceFields,
                 ].map((field) => ({
                   exists: { field },
                 })),
@@ -412,18 +433,39 @@ const buildActorSourceFieldsEsql = (): string =>
 const buildTargetSourceFieldsEsql = (): string =>
   buildSourceFieldsJson(GRAPH_TARGET_EUID_SOURCE_FIELDS, 'targetEntityId');
 
+/**
+ * The trailing `,"knowledge_indicator":{...}` arm folded into actor/target/edge
+ * docData JSON. Emits `""` for rows where no KI alias fired (provenance columns
+ * null), so ECS-native rows keep the exact JSON shape of the no-KI path. Only
+ * spliced when the alias prelude produced columns (see {@link GraphAliasPrelude}).
+ */
+const buildKnowledgeIndicatorJsonArm = (): string =>
+  `CASE(\`${KI_PROVENANCE_FEATURE_UUID_FIELD}\` IS NOT NULL, CONCAT(` +
+  `${JSON_OBJECT_SEPARATOR}, "\\"knowledge_indicator\\":", ${JSON_OBJECT_START}, ` +
+  `${concatJsonObjectPropertyEsqlExprAsString(
+    'feature_uuid',
+    `\`${KI_PROVENANCE_FEATURE_UUID_FIELD}\``
+  )}, ${JSON_OBJECT_SEPARATOR}, ` +
+  `CONCAT("\\"confidence\\":", TO_STRING(\`${KI_PROVENANCE_CONFIDENCE_FIELD}\`)), ` +
+  `${JSON_OBJECT_END}), "")`;
+
 const buildEsqlQuery = ({
   indexPatterns,
   originEventIds,
   originAlertIds,
   alertsMappingsIncluded,
   pinnedIds,
+  aliasPrelude,
 }: BuildEsqlQueryParams): string => {
+  // Off-by-default Streams-KI alias prelude. Empty ⇒ byte-identical to the no-KI path.
+  const aliasPreludeEsql = aliasPrelude.hasAliases ? `${aliasPrelude.esql}\n` : '';
+  // Provenance arm folded into each docData JSON object; empty unless aliases fired.
+  const kiArm = aliasPrelude.hasAliases ? `\n    ${buildKnowledgeIndicatorJsonArm()},` : '';
   const query = `SET unmapped_fields="nullify";
 FROM ${indexPatterns
     .filter((indexPattern) => indexPattern.length > 0)
     .join(',')} METADATA _id, _index
-${buildV2ActorResolution()}
+${aliasPreludeEsql}${buildV2ActorResolution()}
 | WHERE event.action IS NOT NULL AND actorEntityId IS NOT NULL
 ${buildV2TargetResolution()}
 // Save EUID source fields after MV_EXPAND (single-value per row) but before entity enrichment overwrites them
@@ -435,12 +477,12 @@ ${buildPinnedEsql(pinnedIds)}
 | EVAL actorDocData = CONCAT(${JSON_OBJECT_START},
     ${concatJsonObjectPropertyEsqlExprAsString('id', 'actorEntityId')},
     ${JSON_OBJECT_SEPARATOR}, ${concatJsonObjectPropertyString('type', DOCUMENT_TYPE_ENTITY)},
-    ${JSON_OBJECT_SEPARATOR}, ${buildActorSourceFieldsEsql()},
+    ${JSON_OBJECT_SEPARATOR}, ${buildActorSourceFieldsEsql()},${kiArm}
   ${JSON_OBJECT_END})
 | EVAL targetDocData = CONCAT(${JSON_OBJECT_START},
     ${concatJsonObjectPropertyEsqlExprAsString('id', 'COALESCE(targetEntityId, "")')},
     ${JSON_OBJECT_SEPARATOR}, ${concatJsonObjectPropertyString('type', DOCUMENT_TYPE_ENTITY)},
-    ${JSON_OBJECT_SEPARATOR}, ${buildTargetSourceFieldsEsql()},
+    ${JSON_OBJECT_SEPARATOR}, ${buildTargetSourceFieldsEsql()},${kiArm}
   ${JSON_OBJECT_END})
 
 // Map host and source values to enriched contextual data
@@ -479,7 +521,7 @@ ${buildPinnedEsql(pinnedIds)}
       "\\"ruleName\\":\\"", kibana.alert.rule.name, "\\"",
     "}"), ""),`
         : ''
-    }
+    }${kiArm}
   "}")
 // Per-triple rows. All grouping (action × actor/target type × origin/pinned)
 // happens in TypeScript via regroupEvents. STATS … BY (action, actorEntityId, targetEntityId, …)

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_graph.ts
@@ -7,6 +7,7 @@
 
 import type { Logger, IScopedClusterClient } from '@kbn/core/server';
 import type { EsqlToRecords } from '@elastic/elasticsearch/lib/helpers';
+import type { GraphRoleAliasContext } from '@kbn/entity-store/server';
 import type { ProjectRouting } from '@kbn/cloud-security-posture-common/schema/graph/v1';
 import { fetchEvents, regroupEvents, enrichEventDocData } from './fetch_events_graph';
 import {
@@ -42,6 +43,7 @@ export interface FetchGraphParams {
   entityIds?: EntityId[];
   pinnedIds?: string[];
   projectRouting?: ProjectRouting;
+  graphRoleAliases?: GraphRoleAliasContext[];
 }
 
 export interface FetchGraphResult {
@@ -73,6 +75,7 @@ export const fetchGraph = async ({
   entityIds,
   pinnedIds,
   projectRouting,
+  graphRoleAliases,
 }: FetchGraphParams): Promise<FetchGraphResult> => {
   // Only fetch events when originEventIds or esQuery are provided
   const hasOriginEventIds = originEventIds.length > 0;
@@ -101,6 +104,7 @@ export const fetchGraph = async ({
           esQuery,
           pinnedIds,
           projectRouting,
+          graphRoleAliases,
         }).catch((error) => {
           logger.error(`Failed to fetch events: ${error.message}`);
           throw error;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/parse_records.ts
@@ -226,17 +226,27 @@ const createEntityNode = (
     : undefined;
 
   documentsData?.forEach((doc) => {
-    if (doc.entity?.sourceFields) {
+    // The events-graph ES|QL writes entity source fields at the top level of the
+    // doc JSON (`{ id, type, sourceFields, ... }`), but the response schema and
+    // the UI expect them under `entity.sourceFields`. Relocate them (dropping the
+    // EUID join keys) so the payload both validates and renders. The already
+    // nested shape is tolerated too, so this is safe regardless of the source.
+    const writableDoc = doc as Writable<typeof doc> & {
+      sourceFields?: Record<string, unknown>;
+    };
+    const rawSourceFields = writableDoc.sourceFields ?? doc.entity?.sourceFields;
+    if (rawSourceFields) {
       const currentlySupportedSourceFields = omit(
-        doc.entity.sourceFields,
+        rawSourceFields,
         GRAPH_ACTOR_EUID_SOURCE_FIELDS.all
       );
-      (doc as Writable<typeof doc>).entity = {
+      writableDoc.entity = {
         ...doc.entity,
         sourceFields: EXPAND_DOT_NOTATION
           ? expandDotNotation(currentlySupportedSourceFields)
           : currentlySupportedSourceFields,
       };
+      delete writableDoc.sourceFields;
     }
   });
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/route.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/route.ts
@@ -65,6 +65,10 @@ export const defineGraphRoute = (router: CspRouter) =>
         }
 
         try {
+          // Off by default: resolves to `[]` unless the entity-store
+          // `graphAliasMinConfidence` knob is set, so the query is unchanged.
+          const graphRoleAliases = await cspContext.getGraphRoleAliases();
+
           const resp = await getGraphV1({
             services: {
               logger: cspContext.logger,
@@ -83,6 +87,7 @@ export const defineGraphRoute = (router: CspRouter) =>
             },
             showUnknownTarget,
             nodesLimit,
+            graphRoleAliases,
           });
 
           return response.ok({ body: resp });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/v1.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/v1.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger, IScopedClusterClient } from '@kbn/core/server';
+import type { GraphRoleAliasContext } from '@kbn/entity-store/server';
 import type { GraphResponse } from '@kbn/cloud-security-posture-common/types/graph/v1';
 import type { ProjectRouting } from '@kbn/cloud-security-posture-common/schema/graph/v1';
 import { fetchGraph } from './fetch_graph';
@@ -32,6 +33,11 @@ export interface GetGraphParams {
   };
   showUnknownTarget: boolean;
   nodesLimit?: number;
+  /**
+   * Streams-KI graph-role alias contexts. Empty (the default) means the alias
+   * prelude is not spliced and the query is byte-identical to today.
+   */
+  graphRoleAliases?: GraphRoleAliasContext[];
 }
 
 export const getGraph = async ({
@@ -49,6 +55,7 @@ export const getGraph = async ({
   },
   showUnknownTarget,
   nodesLimit,
+  graphRoleAliases,
 }: GetGraphParams): Promise<Pick<GraphResponse, 'nodes' | 'edges' | 'messages'>> => {
   indexPatterns = indexPatterns ?? [`.alerts-security.alerts-${spaceId}`, 'logs-*'];
 
@@ -73,6 +80,7 @@ export const getGraph = async ({
     pinnedIds,
     entityIds,
     projectRouting,
+    graphRoleAliases,
   });
 
   return parseRecords(logger, events, relationships, entities, nodesLimit);

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/setup_routes.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/setup_routes.ts
@@ -76,7 +76,7 @@ export function setupRoutes({
   core.http.registerRouteHandlerContext<CspRequestHandlerContext, typeof PLUGIN_ID>(
     PLUGIN_ID,
     async (context, request) => {
-      const [, { security, fleet, spaces }] = await core.getStartServices();
+      const [, { security, fleet, spaces, entityStore }] = await core.getStartServices();
       const coreContext = await context.core;
       await fleet.fleetSetupCompleted();
 
@@ -101,6 +101,14 @@ export function setupRoutes({
         agentService: fleet.agentService,
         packagePolicyService: fleet.packagePolicyService,
         packageService: fleet.packageService,
+        getGraphRoleAliases: async () => {
+          const namespace = spaces?.spacesService?.getSpaceId(request) ?? 'default';
+          return entityStore.getGraphRoleAliases(
+            request,
+            coreContext.elasticsearch.client.asCurrentUser,
+            namespace
+          );
+        },
         isPluginInitialized,
       };
     }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/types.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/types.ts
@@ -38,6 +38,7 @@ import type { AlertingApiRequestHandlerContext } from '@kbn/alerting-plugin/serv
 import type { LicensingApiRequestHandlerContext } from '@kbn/licensing-plugin/server';
 import type { AlertingPluginSetup } from '@kbn/alerting-plugin/public/plugin';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { EntityStoreStartContract, GraphRoleAliasContext } from '@kbn/entity-store/server';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CspServerPluginSetup {}
@@ -64,6 +65,7 @@ export interface CspServerPluginStartDeps {
   security: SecurityPluginStart;
   licensing: LicensingPluginStart;
   dataViews: DataViewsPluginStart;
+  entityStore: EntityStoreStartContract;
   spaces?: SpacesPluginStart;
 }
 
@@ -82,6 +84,15 @@ export interface CspApiRequestHandlerContext {
   packagePolicyService: PackagePolicyClient;
   packageService: PackageService;
   spacesService?: SpacesPluginStart['spacesService'];
+
+  /**
+   * Resolves the Streams-KI graph-role alias contexts for this request via the
+   * entity_store start contract. Returns `[]` when the `graphAliasMinConfidence`
+   * knob is disabled (default) or streams is not enabled, so the graph query is
+   * byte-identical to today unless a tenant opts in. Used by the graph events
+   * route to splice the alias prelude into the ES|QL query.
+   */
+  getGraphRoleAliases: () => Promise<GraphRoleAliasContext[]>;
 
   isPluginInitialized(): boolean;
 }

--- a/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
@@ -17,7 +17,8 @@
       "licensing"
     ],
     "optionalPlugins": [
-      "encryptedSavedObjects"
+      "encryptedSavedObjects",
+      "streams"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -55,6 +55,22 @@ export const LogExtractionConfig = z.object({
     .default(LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT),
 });
 
+// `null` => the cloud-security graph KI alias prelude is disabled and the graph
+// stays byte-identical to today. A number (0–100) opts in and is the minimum
+// schema-feature confidence whose `ecs_identity_aliases` the graph will apply.
+export const KI_GRAPH_ALIAS_MIN_CONFIDENCE_DEFAULT = null;
+
+export type KnowledgeIndicatorsConfig = z.infer<typeof KnowledgeIndicatorsConfig>;
+export const KnowledgeIndicatorsConfig = z.object({
+  graphAliasMinConfidence: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .nullable()
+    .default(KI_GRAPH_ALIAS_MIN_CONFIDENCE_DEFAULT),
+});
+
 export type HistorySnapshotStatus = z.infer<typeof HistorySnapshotStatus>;
 export const HistorySnapshotStatus = z.enum(['started', 'stopped']);
 
@@ -78,4 +94,7 @@ export type EntityStoreGlobalState = z.infer<typeof EntityStoreGlobalState>;
 export const EntityStoreGlobalState = z.object({
   historySnapshot: HistorySnapshotState,
   logsExtraction: LogExtractionConfig,
+  knowledgeIndicators: KnowledgeIndicatorsConfig.default({
+    graphAliasMinConfidence: KI_GRAPH_ALIAS_MIN_CONFIDENCE_DEFAULT,
+  }),
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/index.ts
@@ -11,7 +11,12 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import { SavedObjectsErrorHelpers, type Logger } from '@kbn/core/server';
 import Boom from '@hapi/boom';
-import { EntityStoreGlobalState, HistorySnapshotState, LogExtractionConfig } from './constants';
+import {
+  EntityStoreGlobalState,
+  HistorySnapshotState,
+  KnowledgeIndicatorsConfig,
+  LogExtractionConfig,
+} from './constants';
 import { EntityStoreGlobalStateTypeName } from './types';
 
 export class EntityStoreGlobalStateClient {
@@ -55,9 +60,13 @@ export class EntityStoreGlobalStateClient {
 
     const historySnapshot = HistorySnapshotState.parse(initialState?.historySnapshot ?? {});
     const logsExtraction = LogExtractionConfig.parse(initialState?.logsExtraction ?? {});
+    const knowledgeIndicators = KnowledgeIndicatorsConfig.parse(
+      initialState?.knowledgeIndicators ?? {}
+    );
     const defaultState: EntityStoreGlobalState = {
       historySnapshot,
       logsExtraction,
+      knowledgeIndicators,
     };
     const parsed = EntityStoreGlobalState.parse(defaultState);
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
@@ -12,6 +12,7 @@ import {
   LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT,
   LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT,
   LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT,
+  KI_GRAPH_ALIAS_MIN_CONFIDENCE_DEFAULT,
 } from './constants';
 
 export const EntityStoreGlobalStateTypeName = 'entity-store-global-state';
@@ -120,11 +121,41 @@ const version3: SavedObjectsFullModelVersion = {
   },
 };
 
+// v4 introduces the `knowledgeIndicators` config block. The single knob,
+// `graphAliasMinConfidence`, is null by default so the cloud-security graph KI
+// alias prelude is opt-in and the graph is byte-identical until a tenant sets it.
+const knowledgeIndicatorsSchemaV4 = schema.object({
+  graphAliasMinConfidence: schema.maybe(schema.nullable(schema.number())),
+});
+
+const globalStateSchemaV4 = globalStateSchemaV3.extends({
+  knowledgeIndicators: schema.maybe(knowledgeIndicatorsSchemaV4),
+});
+
+const version4: SavedObjectsFullModelVersion = {
+  changes: [
+    {
+      type: 'data_backfill',
+      backfillFn: () => ({
+        attributes: {
+          knowledgeIndicators: {
+            graphAliasMinConfidence: KI_GRAPH_ALIAS_MIN_CONFIDENCE_DEFAULT,
+          },
+        },
+      }),
+    },
+  ],
+  schemas: {
+    create: globalStateSchemaV4,
+    forwardCompatibility: globalStateSchemaV4.extends({}, { unknowns: 'ignore' }),
+  },
+};
+
 export const EntityStoreGlobalStateType: SavedObjectsType = {
   name: EntityStoreGlobalStateTypeName,
   hidden: false,
   namespaceType: 'multiple-isolated',
   mappings: EntityStoreGlobalStateTypeMappings,
-  modelVersions: { 1: version1, 2: version2, 3: version3 },
+  modelVersions: { 1: version1, 2: version2, 3: version3, 4: version4 },
   hiddenFromHttpApis: true,
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  createKnowledgeIndicatorsReader,
+  createKnowledgeIndicatorsReaderFromStreamsStart,
+} from './knowledge_indicators_reader_factory';
+export {
+  GRAPH_ROLE_DESTINATION_SET,
+  loadGraphRoleAliases,
+  validateGraphAliasTable,
+} from './load_graph_role_aliases';
+export type {
+  GraphAliasMap,
+  GraphRoleDestination,
+  GraphRoleAliasContext,
+  LoadGraphRoleAliasesOptions,
+} from './load_graph_role_aliases';

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import type { EntityStoreCoreSetup } from '../../types';
+import {
+  __NO_OP_KI_READER_FOR_TESTING,
+  createKnowledgeIndicatorsReader,
+} from './knowledge_indicators_reader_factory';
+
+const buildLogger = () => {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as jest.Mocked<Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>> & Logger;
+};
+
+const buildFakeRequest = () => ({ headers: {} } as KibanaRequest);
+
+const buildCore = (pluginsStart: Record<string, unknown>): EntityStoreCoreSetup =>
+  ({
+    getStartServices: jest.fn().mockResolvedValue([{}, pluginsStart, {}]),
+  } as unknown as EntityStoreCoreSetup);
+
+describe('createKnowledgeIndicatorsReader', () => {
+  it('delegates to streams.getKnowledgeIndicatorsReader and forwards the fakeRequest', async () => {
+    const logger = buildLogger();
+    const fakeRequest = buildFakeRequest();
+    const reader: StreamsKnowledgeIndicatorsReader = {
+      listEntityFeatures: jest.fn().mockResolvedValue([]),
+      listDependencyFeatures: jest.fn().mockResolvedValue([]),
+      listSchemaFeatures: jest.fn().mockResolvedValue([]),
+      resolveIndexPatterns: jest.fn().mockResolvedValue(['logs.k8s.pods']),
+    };
+    const getKnowledgeIndicatorsReader = jest.fn().mockResolvedValue(reader);
+    const core = buildCore({ streams: { getKnowledgeIndicatorsReader } });
+
+    const result = await createKnowledgeIndicatorsReader({ core, fakeRequest, logger });
+
+    expect(result).toBe(reader);
+    expect(getKnowledgeIndicatorsReader).toHaveBeenCalledTimes(1);
+    expect(getKnowledgeIndicatorsReader).toHaveBeenCalledWith({ request: fakeRequest });
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('returns the no-op reader when the streams plugin is not enabled (optional dep missing)', async () => {
+    const logger = buildLogger();
+    const fakeRequest = buildFakeRequest();
+    const core = buildCore({}); // pluginsStart.streams === undefined
+
+    const result = await createKnowledgeIndicatorsReader({ core, fakeRequest, logger });
+
+    expect(result).toBe(__NO_OP_KI_READER_FOR_TESTING);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Streams plugin not available')
+    );
+  });
+
+  it('the no-op reader yields empty arrays for every method without performing any I/O', async () => {
+    expect(await __NO_OP_KI_READER_FOR_TESTING.listEntityFeatures()).toEqual([]);
+    expect(await __NO_OP_KI_READER_FOR_TESTING.listDependencyFeatures()).toEqual([]);
+    expect(await __NO_OP_KI_READER_FOR_TESTING.listSchemaFeatures()).toEqual([]);
+    expect(await __NO_OP_KI_READER_FOR_TESTING.resolveIndexPatterns('any-stream')).toEqual([]);
+  });
+
+  it('the no-op reader is the same reference across invocations (callers can compare by identity if needed)', async () => {
+    const logger = buildLogger();
+    const fakeRequest = buildFakeRequest();
+    const core = buildCore({});
+
+    const a = await createKnowledgeIndicatorsReader({ core, fakeRequest, logger });
+    const b = await createKnowledgeIndicatorsReader({ core, fakeRequest, logger });
+
+    expect(a).toBe(b);
+    expect(a).toBe(__NO_OP_KI_READER_FOR_TESTING);
+  });
+
+  it('propagates errors from streams.getKnowledgeIndicatorsReader to the caller', async () => {
+    const logger = buildLogger();
+    const fakeRequest = buildFakeRequest();
+    const failure = new Error('unauthorized');
+    const core = buildCore({
+      streams: { getKnowledgeIndicatorsReader: jest.fn().mockRejectedValue(failure) },
+    });
+
+    await expect(createKnowledgeIndicatorsReader({ core, fakeRequest, logger })).rejects.toBe(
+      failure
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/knowledge_indicators_reader_factory.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type {
+  StreamsKnowledgeIndicatorsReader,
+  StreamsPluginStart,
+} from '@kbn/streams-plugin/server';
+import type { EntityStoreCoreSetup } from '../../types';
+
+/**
+ * No-op reader returned when the streams plugin is not enabled in the
+ * deployment (it's an optional dependency in entity_store's `kibana.jsonc`).
+ *
+ * Returning empty arrays — rather than `null` or throwing — lets callers in
+ * the extract task and entity maintainers drive a uniform "no Knowledge
+ * Indicators to process" branch without scattering `if (reader)` guards
+ * through the task flow. The semantics also align with `resolveIndexPatterns`'s
+ * documented behavior of returning `[]` for missing streams.
+ */
+const NO_OP_KI_READER: StreamsKnowledgeIndicatorsReader = {
+  listEntityFeatures: async () => [],
+  listDependencyFeatures: async () => [],
+  listSchemaFeatures: async () => [],
+  resolveIndexPatterns: async () => [],
+};
+
+/**
+ * Resolves a request-scoped `StreamsKnowledgeIndicatorsReader` for the given
+ * `fakeRequest`. Use this from any entity-store flow that needs to read
+ * Knowledge Indicators or resolve stream-backed index patterns.
+ *
+ * Behavior:
+ * - When streams is enabled, delegates to
+ *   `streamsStart.getKnowledgeIndicatorsReader({ request })`. The returned
+ *   reader inherits the request's auth / space scoping.
+ * - When streams is NOT enabled (optional dependency missing), returns
+ *   `NO_OP_KI_READER` and logs a single debug line. Subsequent calls also
+ *   return the same no-op reader; entity store keeps functioning without
+ *   stream-derived entities.
+ */
+export const createKnowledgeIndicatorsReader = async ({
+  core,
+  fakeRequest,
+  logger,
+}: {
+  core: EntityStoreCoreSetup;
+  fakeRequest: KibanaRequest;
+  logger: Logger;
+}): Promise<StreamsKnowledgeIndicatorsReader> => {
+  const [, pluginsStart] = await core.getStartServices();
+  if (!pluginsStart.streams) {
+    logger.debug(
+      'Streams plugin not available; Knowledge Indicators reader will return empty results'
+    );
+    return NO_OP_KI_READER;
+  }
+  return pluginsStart.streams.getKnowledgeIndicatorsReader({ request: fakeRequest });
+};
+
+/**
+ * Request-scoped variant of {@link createKnowledgeIndicatorsReader} for callers
+ * that already hold a started `StreamsPluginStart` (typical in route handlers,
+ * which receive the start contract via the request context). Skips the
+ * `coreSetup.getStartServices()` round-trip that the background-task variant
+ * needs.
+ *
+ * Behavior matches the background-task factory: returns the no-op reader when
+ * `streams` is `undefined` (streams plugin not enabled in the deployment) so
+ * callers can drive a uniform "no Knowledge Indicators" branch without
+ * scattered `if (reader)` guards.
+ */
+export const createKnowledgeIndicatorsReaderFromStreamsStart = async ({
+  streams,
+  request,
+  logger,
+}: {
+  streams: StreamsPluginStart | undefined;
+  request: KibanaRequest;
+  logger: Logger;
+}): Promise<StreamsKnowledgeIndicatorsReader> => {
+  if (!streams) {
+    logger.debug(
+      'Streams plugin not available; Knowledge Indicators reader will return empty results'
+    );
+    return NO_OP_KI_READER;
+  }
+  return streams.getKnowledgeIndicatorsReader({ request });
+};
+
+/** Exported for tests so they can assert reference-equality against the fallback. */
+export const __NO_OP_KI_READER_FOR_TESTING = NO_OP_KI_READER;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_graph_role_aliases.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_graph_role_aliases.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+import { loadGraphRoleAliases, validateGraphAliasTable } from './load_graph_role_aliases';
+import { createKnowledgeIndicatorsReaderFromStreamsStart } from './knowledge_indicators_reader_factory';
+
+const createLogger = (): jest.Mocked<Logger> =>
+  ({
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as jest.Mocked<Logger>);
+
+const schemaFeature = (overrides: Partial<Record<string, unknown>> = {}): Feature =>
+  ({
+    uuid: 'feature-1',
+    stream_name: 'logs-azure.signinlogs-default',
+    type: 'schema',
+    subtype: 'custom',
+    id: 'azure-signinlogs-schema',
+    title: 'Azure Sign-in Logs schema',
+    description: 'Azure sign-in logs',
+    confidence: 88,
+    evidence: [],
+    evidence_doc_ids: [],
+    tags: [],
+    meta: {},
+    properties: {
+      schema_family: 'custom',
+      ecs_identity_aliases: {
+        'user.email': ['azure.signinlogs.properties.user_principal_name'],
+        'service.target.name': ['azure.signinlogs.properties.resource_display_name'],
+        'event.action': ['azure.signinlogs.operation_name'],
+      },
+    },
+    ...overrides,
+  } as unknown as Feature);
+
+describe('validateGraphAliasTable', () => {
+  const context = { streamName: 'logs-azure.signinlogs-default', featureUuid: 'feature-1' };
+
+  it('keeps actor, target, and action destinations from the closed graph vocabulary', () => {
+    const logger = createLogger();
+    const table = validateGraphAliasTable(
+      {
+        'user.email': ['azure.signinlogs.properties.user_principal_name'],
+        'service.target.name': ['azure.signinlogs.properties.resource_display_name'],
+        'event.action': ['azure.signinlogs.operation_name'],
+      },
+      { ...context, logger }
+    );
+
+    expect(table).toBeDefined();
+    expect([...table!.keys()].sort()).toEqual([
+      'event.action',
+      'service.target.name',
+      'user.email',
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops destinations outside the closed vocabulary and warns', () => {
+    const logger = createLogger();
+    const table = validateGraphAliasTable(
+      {
+        'user.email': ['azure.signinlogs.properties.user_principal_name'],
+        'user.roles': ['azure.signinlogs.properties.app_roles'],
+      },
+      { ...context, logger }
+    );
+
+    expect([...table!.keys()]).toEqual(['user.email']);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('user.roles'));
+  });
+
+  it('drops a destination whose value is not an array and warns', () => {
+    const logger = createLogger();
+    const table = validateGraphAliasTable(
+      {
+        'user.email': 'azure.signinlogs.properties.user_principal_name',
+        'user.name': ['azure.signinlogs.identity'],
+      },
+      { ...context, logger }
+    );
+
+    expect([...table!.keys()]).toEqual(['user.name']);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('non-array value'));
+  });
+
+  it('filters out empty / non-string sources and drops the key when none remain', () => {
+    const logger = createLogger();
+    const table = validateGraphAliasTable(
+      {
+        'user.email': ['', 123, null],
+        'user.name': ['azure.signinlogs.identity', ''],
+      },
+      { ...context, logger }
+    );
+
+    expect([...table!.keys()]).toEqual(['user.name']);
+    expect(table!.get('user.name')).toEqual(['azure.signinlogs.identity']);
+  });
+
+  it('returns undefined for non-object input', () => {
+    const logger = createLogger();
+    expect(validateGraphAliasTable(null, { ...context, logger })).toBeUndefined();
+    expect(validateGraphAliasTable([], { ...context, logger })).toBeUndefined();
+    expect(validateGraphAliasTable('x', { ...context, logger })).toBeUndefined();
+  });
+
+  it('returns undefined when every key is invalid', () => {
+    const logger = createLogger();
+    expect(
+      validateGraphAliasTable({ 'user.roles': ['x'] }, { ...context, logger })
+    ).toBeUndefined();
+  });
+});
+
+describe('loadGraphRoleAliases', () => {
+  const reader = (): jest.Mocked<StreamsKnowledgeIndicatorsReader> =>
+    ({
+      listEntityFeatures: jest.fn(),
+      listDependencyFeatures: jest.fn(),
+      listSchemaFeatures: jest.fn(),
+      resolveIndexPatterns: jest.fn(),
+    } as unknown as jest.Mocked<StreamsKnowledgeIndicatorsReader>);
+
+  it('short-circuits to [] without any reader I/O when minConfidence is null (knob off)', async () => {
+    const r = reader();
+    const result = await loadGraphRoleAliases(r, { minConfidence: null }, createLogger());
+
+    expect(result).toEqual([]);
+    expect(r.listSchemaFeatures).not.toHaveBeenCalled();
+    expect(r.resolveIndexPatterns).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when no schema features are above threshold', async () => {
+    const r = reader();
+    r.listSchemaFeatures.mockResolvedValue([]);
+
+    const result = await loadGraphRoleAliases(r, { minConfidence: 50 }, createLogger());
+    expect(result).toEqual([]);
+    expect(r.listSchemaFeatures).toHaveBeenCalledWith({ minConfidence: 50 });
+  });
+
+  it('builds one validated context per schema feature with resolved index patterns', async () => {
+    const r = reader();
+    r.listSchemaFeatures.mockResolvedValue([schemaFeature()]);
+    r.resolveIndexPatterns.mockResolvedValue(['logs-azure.signinlogs-default']);
+
+    const [ctx, ...rest] = await loadGraphRoleAliases(r, { minConfidence: 50 }, createLogger());
+
+    expect(rest).toHaveLength(0);
+    expect(ctx.streamName).toBe('logs-azure.signinlogs-default');
+    expect(ctx.indexPatterns).toEqual(['logs-azure.signinlogs-default']);
+    expect(ctx.featureUuid).toBe('feature-1');
+    expect(ctx.confidence).toBe(88);
+    expect([...ctx.aliases.keys()].sort()).toEqual([
+      'event.action',
+      'service.target.name',
+      'user.email',
+    ]);
+  });
+
+  it('drops features with no valid aliases and streams that resolve to no index patterns', async () => {
+    const r = reader();
+    r.listSchemaFeatures.mockResolvedValue([
+      schemaFeature({ uuid: 'no-aliases', properties: { schema_family: 'custom' } }),
+      schemaFeature({
+        uuid: 'no-index',
+        stream_name: 'logs-deleted-stream',
+      }),
+      schemaFeature({ uuid: 'good' }),
+    ]);
+    r.resolveIndexPatterns.mockImplementation(async (streamName: string) =>
+      streamName === 'logs-deleted-stream' ? [] : [streamName]
+    );
+
+    const result = await loadGraphRoleAliases(r, { minConfidence: 50 }, createLogger());
+
+    expect(result.map((c) => c.featureUuid)).toEqual(['good']);
+  });
+
+  it('yields [] end-to-end when the streams plugin is absent (no-op reader)', async () => {
+    const logger = createLogger();
+    const noOpReader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+      streams: undefined,
+      request: {} as KibanaRequest,
+      logger,
+    });
+
+    const result = await loadGraphRoleAliases(noOpReader, { minConfidence: 50 }, logger);
+    expect(result).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_graph_role_aliases.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/streams_features/load_graph_role_aliases.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { Feature } from '@kbn/streams-schema';
+import type { Condition } from '@kbn/streamlang';
+import type { StreamsKnowledgeIndicatorsReader } from '@kbn/streams-plugin/server';
+
+/**
+ * Closed vocabulary of graph-role destinations a schema-feature
+ * `ecs_identity_aliases` table may target for the cloud-security graph. This
+ * is the graph analog of entity extraction's `ECS_IDENTITY_FIELD_SET`, widened
+ * with the `.target.*` mirror and `event.action` so non-ECS streams can supply
+ * the graph's three roles:
+ *
+ * - actor identity   → `user.*`, `host.*`, `service.name`, `entity.id`
+ * - target identity  → the `.target.*` mirror of the actor set
+ * - edge action/verb → `event.action`
+ *
+ * Anything outside this set is dropped at load time with a warn log. The graph
+ * route re-validates every destination against the live
+ * `GRAPH_ACTOR_EUID_SOURCE_FIELDS` / `GRAPH_TARGET_EUID_SOURCE_FIELDS` before
+ * interpolating it into ES|QL (defense in depth against ES|QL injection), so
+ * this set is the cross-plugin contract, not the sole guard.
+ *
+ * Adding a destination here is a deliberate, audited change — it implies the
+ * graph's actor/target resolution reads a new ECS field.
+ */
+export const GRAPH_ROLE_DESTINATION_SET = [
+  // actor identity
+  'user.email',
+  'user.id',
+  'user.name',
+  'user.domain',
+  'host.id',
+  'host.name',
+  'host.hostname',
+  'service.name',
+  'entity.id',
+  // target identity (.target.* mirror of the actor set)
+  'user.target.email',
+  'user.target.id',
+  'user.target.name',
+  'user.target.domain',
+  'host.target.id',
+  'host.target.name',
+  'host.target.hostname',
+  'service.target.name',
+  'entity.target.id',
+  // edge action / verb
+  'event.action',
+] as const;
+
+export type GraphRoleDestination = (typeof GRAPH_ROLE_DESTINATION_SET)[number];
+
+const isGraphRoleDestination = (key: string): key is GraphRoleDestination =>
+  (GRAPH_ROLE_DESTINATION_SET as readonly string[]).includes(key);
+
+/**
+ * Validated alias table for one schema feature: graph-role destination →
+ * ordered list of non-ECS source paths in the stream that carry the same
+ * role. Order matters for downstream COALESCE precedence — the first non-null
+ * source wins.
+ */
+export type GraphAliasMap = ReadonlyMap<GraphRoleDestination, readonly string[]>;
+
+/**
+ * Per-stream context the graph needs to apply schema-feature aliases at
+ * request time. Exactly one `GraphRoleAliasContext` per (stream, schema
+ * feature) above threshold; if a stream has multiple schema features above
+ * threshold, each one yields its own context — they do NOT merge (their
+ * `filter`s and `confidence`s differ).
+ */
+export interface GraphRoleAliasContext {
+  /** The Streams stream the aliases apply to (e.g. `logs.azure.signinlogs`). */
+  streamName: string;
+  /**
+   * Index patterns backing the stream, resolved via `reader.resolveIndexPatterns`.
+   * Empty when the stream cannot be resolved (deleted, permission denied, …);
+   * such contexts are excluded by the loader so consumers never have to
+   * special-case empty patterns.
+   */
+  indexPatterns: string[];
+  /**
+   * Validated alias table — keys are guaranteed in `GRAPH_ROLE_DESTINATION_SET`
+   * (actor identity, `.target.*` mirror, or `event.action`).
+   */
+  aliases: GraphAliasMap;
+  /** Provenance: the schema feature's UUID. Surfaced on inferred graph nodes/edges. */
+  featureUuid: string;
+  /** Provenance: the schema feature's confidence (0–100). Surfaced on inferred graph nodes/edges. */
+  confidence: number;
+  /**
+   * Optional schema-feature filter. The graph applies it as an extra guard on
+   * the alias prelude (alongside the `data_stream.dataset` / `_index` guard) so
+   * aliases scoped to a specific event shape (e.g. sign-in events but not audit
+   * events on the same stream) only fire on docs that match. Mitigates the
+   * "one field, two semantics" risk.
+   */
+  filter?: Condition;
+}
+
+/**
+ * Validates a raw `properties.ecs_identity_aliases` value into a typed
+ * `GraphAliasMap`. Drops keys not in the closed graph vocabulary, drops
+ * sources that aren't non-empty strings, drops the entry entirely when no
+ * valid sources remain.
+ *
+ * Logs a warn line per dropped key (with stream name and key for grep) so
+ * LLM-noise rates can be quantified post-rollout. Returns `undefined` when the
+ * input isn't a usable object — callers must skip the feature in that case.
+ */
+export const validateGraphAliasTable = (
+  rawTable: unknown,
+  context: { streamName: string; featureUuid: string; logger: Logger }
+): GraphAliasMap | undefined => {
+  if (rawTable === null || typeof rawTable !== 'object' || Array.isArray(rawTable)) {
+    return undefined;
+  }
+
+  const result = new Map<GraphRoleDestination, readonly string[]>();
+  for (const [rawKey, rawValue] of Object.entries(rawTable)) {
+    if (!isGraphRoleDestination(rawKey)) {
+      context.logger.warn(
+        `[entity_store] Stream schema feature ${context.featureUuid} on stream ${context.streamName} declared a graph alias for unknown destination "${rawKey}"; ignoring`
+      );
+      continue;
+    }
+    if (!Array.isArray(rawValue)) {
+      context.logger.warn(
+        `[entity_store] Stream schema feature ${context.featureUuid} on stream ${context.streamName} declared a non-array value for graph alias "${rawKey}"; ignoring`
+      );
+      continue;
+    }
+    const sources = rawValue.filter(
+      (source): source is string => typeof source === 'string' && source.length > 0
+    );
+    if (sources.length === 0) {
+      continue;
+    }
+    result.set(rawKey, sources);
+  }
+
+  return result.size > 0 ? result : undefined;
+};
+
+const extractAliasesFromFeature = (feature: Feature): unknown => {
+  if (!feature.properties || typeof feature.properties !== 'object') return undefined;
+  return (feature.properties as Record<string, unknown>).ecs_identity_aliases;
+};
+
+export interface LoadGraphRoleAliasesOptions {
+  /**
+   * Mirror of `StreamsKnowledgeIndicatorsListOptions.minConfidence` (the
+   * graph's `graphAliasMinConfidence` knob). When `null` the loader returns an
+   * empty array WITHOUT calling the reader — this is the "graph alias adoption
+   * disabled" branch and must short-circuit before any I/O so disabled tenants
+   * pay zero cost and the graph stays byte-identical to today.
+   */
+  minConfidence: number | null;
+}
+
+/**
+ * Loads validated schema-feature graph-role aliases for the current request.
+ *
+ * Behavior:
+ * - Returns `[]` immediately when `minConfidence` is `null` (graph alias
+ *   adoption off). This is the runtime no-op branch the config knob defaults to.
+ * - Otherwise lists `type: 'schema'` features above threshold via the reader,
+ *   validates each feature's `properties.ecs_identity_aliases` against the
+ *   closed graph vocabulary, drops features with no valid aliases, and resolves
+ *   index patterns once per stream.
+ * - Multiple schema features per stream are returned as separate contexts; they
+ *   do NOT merge because their `filter`s and `confidence`s differ.
+ */
+export const loadGraphRoleAliases = async (
+  reader: StreamsKnowledgeIndicatorsReader,
+  options: LoadGraphRoleAliasesOptions,
+  logger: Logger
+): Promise<GraphRoleAliasContext[]> => {
+  if (options.minConfidence === null) {
+    return [];
+  }
+
+  const features = await reader.listSchemaFeatures({ minConfidence: options.minConfidence });
+  if (features.length === 0) {
+    return [];
+  }
+
+  // resolveIndexPatterns may return [] for deleted / inaccessible streams; we
+  // resolve once per distinct stream name to avoid repeated I/O when a stream
+  // carries multiple schema features.
+  const indexPatternsByStream = new Map<string, string[]>();
+  const distinctStreamNames = Array.from(new Set(features.map((feature) => feature.stream_name)));
+  await Promise.all(
+    distinctStreamNames.map(async (streamName) => {
+      try {
+        const patterns = await reader.resolveIndexPatterns(streamName);
+        indexPatternsByStream.set(streamName, patterns);
+      } catch (error) {
+        logger.warn(
+          `[entity_store] Failed to resolve index patterns for stream ${streamName}: ${
+            error instanceof Error ? error.message : String(error)
+          }; graph aliases for this stream will be skipped`
+        );
+        indexPatternsByStream.set(streamName, []);
+      }
+    })
+  );
+
+  const contexts: GraphRoleAliasContext[] = [];
+  for (const feature of features) {
+    const indexPatterns = indexPatternsByStream.get(feature.stream_name) ?? [];
+    if (indexPatterns.length === 0) {
+      continue;
+    }
+    const aliases = validateGraphAliasTable(extractAliasesFromFeature(feature), {
+      streamName: feature.stream_name,
+      featureUuid: feature.uuid,
+      logger,
+    });
+    if (!aliases) {
+      continue;
+    }
+    contexts.push({
+      streamName: feature.stream_name,
+      indexPatterns,
+      aliases,
+      featureUuid: feature.uuid,
+      confidence: feature.confidence,
+      filter: feature.filter,
+    });
+  }
+  return contexts;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/index.ts
@@ -12,6 +12,11 @@ export type {
   EntityStoreStartContract,
   EntityStoreCRUDClient,
 } from './types';
+export type {
+  GraphRoleAliasContext,
+  GraphAliasMap,
+  GraphRoleDestination,
+} from './domain/streams_features';
 export type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';
 export type { EntityUpdateClient, BulkObject, BulkObjectResponse } from './domain/crud';
 export type { ResolutionClient } from './domain/resolution';

--- a/x-pack/solutions/security/plugins/entity_store/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/plugin.ts
@@ -22,8 +22,13 @@ import { registerUiSettings } from './infra/feature_flags/register';
 import {
   CcsLogExtractionStateType,
   EngineDescriptorType,
+  EntityStoreGlobalStateClient,
   EntityStoreGlobalStateType,
 } from './domain/saved_objects';
+import {
+  createKnowledgeIndicatorsReaderFromStreamsStart,
+  loadGraphRoleAliases,
+} from './domain/streams_features';
 import { registerEntityMaintainerTask } from './tasks/entity_maintainers';
 import type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';
 import { CRUDClient } from './domain/crud';
@@ -121,6 +126,35 @@ export class EntityStorePlugin
       createCRUDClient: (esClient, namespace) => new CRUDClient({ logger, esClient, namespace }),
       createResolutionClient: (esClient, namespace) =>
         new ResolutionClient({ logger, esClient, namespace }),
+      getGraphRoleAliases: async (request, _esClient, namespace) => {
+        try {
+          // The `graphAliasMinConfidence` knob is read internally (CSP cannot
+          // reach entity_store's global-state SO). `null` => disabled => `[]`,
+          // which keeps the cloud-security graph byte-identical to today.
+          const soClient = core.savedObjects.getScopedClient(request);
+          const globalStateClient = new EntityStoreGlobalStateClient(soClient, namespace, logger);
+          const state = await globalStateClient.find();
+          const minConfidence = state?.knowledgeIndicators.graphAliasMinConfidence ?? null;
+          if (minConfidence === null) {
+            return [];
+          }
+          // Request-scoped reader: schema features are read with the caller's
+          // auth / space scope. Returns a no-op reader when streams is disabled.
+          const reader = await createKnowledgeIndicatorsReaderFromStreamsStart({
+            streams: plugins.streams,
+            request,
+            logger,
+          });
+          return await loadGraphRoleAliases(reader, { minConfidence }, logger);
+        } catch (error) {
+          logger.warn(
+            `[entity_store] getGraphRoleAliases failed; returning no graph aliases: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+          return [];
+        }
+      },
     };
   }
 

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/update.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/update.ts
@@ -15,9 +15,18 @@ import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
 import type { EntityStorePluginRouter } from '../../types';
 import { wrapMiddlewares } from '../middleware';
 import { LogExtractionUpdadeSchema } from './utils/log_extraction_validator';
+import { EntityStoreGlobalStateClient } from '../../domain/saved_objects';
 
 const bodySchema = z.object({
-  logExtraction: LogExtractionUpdadeSchema,
+  logExtraction: LogExtractionUpdadeSchema.optional(),
+  // Cloud-security graph KI alias knob. `null` disables the alias prelude
+  // (graph stays byte-identical to today); a number (0–100) is the minimum
+  // schema-feature confidence whose `ecs_identity_aliases` the graph applies.
+  knowledgeIndicators: z
+    .object({
+      graphAliasMinConfidence: z.number().int().min(0).max(100).nullable(),
+    })
+    .optional(),
 });
 
 export function registerUpdate(router: EntityStorePluginRouter) {
@@ -48,11 +57,21 @@ export function registerUpdate(router: EntityStorePluginRouter) {
         },
       },
       wrapMiddlewares(async (ctx, req, res): Promise<IKibanaResponse> => {
-        const { logsExtractionClient, logger } = await ctx.entityStore;
+        const { logsExtractionClient, logger, core, namespace } = await ctx.entityStore;
         logger.debug('Update api called');
 
         try {
-          await logsExtractionClient.updateConfig(req.body.logExtraction);
+          if (req.body.logExtraction) {
+            await logsExtractionClient.updateConfig(req.body.logExtraction);
+          }
+          if (req.body.knowledgeIndicators) {
+            const globalStateClient = new EntityStoreGlobalStateClient(
+              core.savedObjects.client,
+              namespace,
+              logger
+            );
+            await globalStateClient.update({ knowledgeIndicators: req.body.knowledgeIndicators });
+          }
         } catch (error) {
           if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
             return res.notFound({ body: { message: 'Entity store is not installed' } });

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -26,8 +26,11 @@ import type {
   LicensingPluginStart,
 } from '@kbn/licensing-plugin/server';
 import type { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { StreamsPluginStart } from '@kbn/streams-plugin/server';
 import type { CoreSetup } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { GraphRoleAliasContext } from './domain/streams_features';
 import type { AssetManagerClient } from './domain/asset_manager';
 import type { EntityMaintainersClient } from './domain/entity_maintainers';
 import type { FeatureFlags } from './infra/feature_flags';
@@ -50,6 +53,15 @@ export interface EntityStoreStartPlugins {
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   licensing: LicensingPluginStart;
+  /**
+   * Optional, declared in `kibana.jsonc` as `optionalPlugins.streams` so the
+   * entity store keeps working in deployments that don't have streams
+   * enabled. Consumers must guard against `undefined` at the call site (the
+   * no-op reader pattern in `createKnowledgeIndicatorsReader` is the canonical
+   * fallback). Used to read Streams Knowledge Indicators for the schema-feature
+   * graph alias contexts exposed via `getGraphRoleAliases`.
+   */
+  streams?: StreamsPluginStart;
 }
 
 export interface EntityStoreApiRequestHandlerContext {
@@ -81,6 +93,22 @@ export type EntityStoreCRUDClient = Omit<CRUDClient, 'createEntity'>;
 export interface EntityStoreStartContract {
   createCRUDClient: (esClient: ElasticsearchClient, namespace: string) => EntityStoreCRUDClient;
   createResolutionClient: (esClient: ElasticsearchClient, namespace: string) => ResolutionClient;
+  /**
+   * Returns the validated Streams-KI schema-feature alias contexts that the
+   * cloud-security graph splices into its events query to bridge non-ECS
+   * actor / target / action paths onto canonical ECS slots.
+   *
+   * Off by default: reads the entity-store global-state `graphAliasMinConfidence`
+   * knob internally and resolves to `[]` when it is `null` (or when the streams
+   * plugin is not enabled), so the graph stays byte-identical to today unless a
+   * tenant opts in. The `request` is used to build a request-scoped Knowledge
+   * Indicators reader so features are read with the caller's auth / space scope.
+   */
+  getGraphRoleAliases: (
+    request: KibanaRequest,
+    esClient: ElasticsearchClient,
+    namespace: string
+  ) => Promise<GraphRoleAliasContext[]>;
 }
 
 export interface EntityStoreSetupContract {

--- a/x-pack/solutions/security/plugins/entity_store/tsconfig.json
+++ b/x-pack/solutions/security/plugins/entity_store/tsconfig.json
@@ -44,5 +44,7 @@
     "@kbn/esql-language",
     "@kbn/licensing-plugin",
     "@kbn/licensing-types",
+    "@kbn/streams-plugin",
+    "@kbn/streams-schema",
   ]
 }


### PR DESCRIPTION
## Summary

The Graph previously relied solely on ECS-normalized fields for actor-action-target correlation. This change enables the graph to leverage Streams Knowledge Indicators (KI) to dynamically infer these roles from non-ECS paths in log streams.

This involves:
- Updating the Streams AI system prompt to guide the emission of `ecs_identity_aliases` in schema features.
- Introducing a `StreamsKnowledgeIndicatorsReader` to provide controlled access to KI schema features.
- Enhancing Entity Store to manage KI alias configuration (`graphAliasMinConfidence`) and load validated schema features.
- Integrating an ES|QL "alias prelude" into the graph's events query. This prelude uses `COALESCE` to fill null ECS actor/target/action fields from aliased non-ECS sources and adds `graph.knowledge_indicator.*` provenance.
- Updating the graph UI with an "Inferred (KI)" badge to indicate when an actor, target, or action was derived from a KI alias.
- Adjusting graph query filters to ensure KI-inferred targets are not prematurely excluded.

This expands the graph's ability to correlate events from diverse, non-ECS-normalized log sources, providing richer insights without requiring upstream normalization.## Summary
