### PR TITLE
[ES|QL] Fixes warning regression at the editor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
@@ -247,8 +247,12 @@ export const registerCustomCommands = (deps: MonacoCommandDependencies): monaco.
   commandDisposables.push(
     monaco.editor.registerCommand('esql.multiCommands', (...args) => {
       const [, { commands }] = args;
-      const commandsToExecute: { id: string; payload?: unknown; arguments?: unknown[] }[] =
-        JSON.parse(commands);
+      let commandsToExecute: { id: string; payload?: unknown; arguments?: unknown[] }[];
+      try {
+        commandsToExecute = JSON.parse(commands);
+      } catch {
+        return;
+      }
       commandsToExecute.forEach((command) => {
         const payload = command.payload ?? command.arguments?.[0] ?? {};
         editorRef.current?.trigger(undefined, command.id, payload);

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -144,7 +144,7 @@ describe('helpers', function () {
         '299 Elasticsearch-8.10.0-SNAPSHOT-adb9fce96079b421c2575f0d2d445f492eb5f075 "Line 1:52: evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded."';
       expect(parseWarning(warning)).toEqual([
         {
-          endColumn: 138,
+          endColumn: 71,
           endLineNumber: 1,
           message:
             'evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded.',
@@ -161,7 +161,7 @@ describe('helpers', function () {
         '299 Elasticsearch-8.10.0-SNAPSHOT-adb9fce96079b421c2575f0d2d445f492eb5f075 "Line 1:52: evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded.", 299 Elasticsearch-8.10.0-SNAPSHOT-adb9fce96079b421c2575f0d2d445f492eb5f075 "Line 1:84: evaluation of [date_parse(geo.src)] failed, treating result as null. Only first 20 failures recorded."';
       expect(parseWarning(warning)).toEqual([
         {
-          endColumn: 138,
+          endColumn: 71,
           endLineNumber: 1,
           message:
             'evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded.',
@@ -171,7 +171,7 @@ describe('helpers', function () {
           code: 'warningFromES',
         },
         {
-          endColumn: 169,
+          endColumn: 102,
           endLineNumber: 1,
           message:
             'evaluation of [date_parse(geo.src)] failed, treating result as null. Only first 20 failures recorded.',
@@ -188,7 +188,7 @@ describe('helpers', function () {
         '299 Elasticsearch-8.10.0-SNAPSHOT-adb9fce96079b421c2575f0d2d445f492eb5f075 "Line 1:52: evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded.", 299 Elasticsearch-8.10.0-SNAPSHOT-adb9fce96079b421c2575f0d2d445f492eb5f075 "Line 1:84: java.lang.IllegalArgumentException: evaluation of [date_parse(geo.src)] failed, treating result as null. Only first 20 failures recorded."';
       expect(parseWarning(warning)).toEqual([
         {
-          endColumn: 138,
+          endColumn: 71,
           endLineNumber: 1,
           message:
             'evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded.',
@@ -198,7 +198,7 @@ describe('helpers', function () {
           code: 'warningFromES',
         },
         {
-          endColumn: 169,
+          endColumn: 102,
           endLineNumber: 1,
           message:
             'evaluation of [date_parse(geo.src)] failed, treating result as null. Only first 20 failures recorded.',
@@ -271,12 +271,28 @@ describe('helpers', function () {
           code: 'warningFromES',
         },
         {
-          endColumn: 138,
+          endColumn: 71,
           endLineNumber: 1,
           message:
             'evaluation of [date_parse(geo.dest)] failed, treating result as null. Only first 20 failures recorded.',
           severity: 4,
           startColumn: 52,
+          startLineNumber: 1,
+          code: 'warningFromES',
+        },
+      ]);
+    });
+
+    it('should preserve the full message when it contains extra colons after the exception class', function () {
+      const warning =
+        '299 Elasticsearch-9.1.0 "Line 1:10: java.lang.IllegalArgumentException: reason: detail with colon"';
+      expect(parseWarning(warning)).toEqual([
+        {
+          endColumn: 19,
+          endLineNumber: 1,
+          message: 'reason: detail with colon',
+          severity: 4,
+          startColumn: 10,
           startLineNumber: 1,
           code: 'warningFromES',
         },
@@ -296,7 +312,7 @@ describe('helpers', function () {
           code: 'warningFromES',
         },
         {
-          endColumn: 40,
+          endColumn: 30,
           endLineNumber: 1,
           message: 'evaluation of [TO_LOWER(["FOO", "BAR"])] failed',
           severity: 4,

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -73,8 +73,10 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
       // if there's line number encoded in the message use it as new positioning
       // and replace the actual message without it
       if (/Line (\d+):(\d+):/.test(warningMessage)) {
-        const [encodedLine, encodedColumn, innerMessage, additionalInfoMessage] =
+        const [encodedLine, encodedColumn, innerMessage, ...additionalParts] =
           warningMessage.split(':');
+        const additionalInfoMessage =
+          additionalParts.length > 0 ? additionalParts.join(':') : undefined;
         // sometimes the warning comes to the format java.lang.IllegalArgumentException: warning message
         warningMessage = additionalInfoMessage ?? innerMessage;
         if (!Number.isNaN(Number(encodedColumn))) {
@@ -85,7 +87,7 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
         if (openingSquareBracketIndex !== -1) {
           const closingSquareBracketIndex = warningMessage.indexOf(']', openingSquareBracketIndex);
           if (closingSquareBracketIndex !== -1) {
-            errorLength = warningMessage.length - openingSquareBracketIndex - 1;
+            errorLength = closingSquareBracketIndex - openingSquareBracketIndex - 1;
           }
         }
       }

--- a/src/platform/packages/shared/kbn-search-types/src/search_methods_types.ts
+++ b/src/platform/packages/shared/kbn-search-types/src/search_methods_types.ts
@@ -220,6 +220,10 @@ export interface IEsqlSearchResult {
    * Request parameters for inspector
    */
   requestParams?: SanitizedConnectionRequestParams;
+  /**
+   * Warning message from the ES Warning HTTP response header
+   */
+  warning?: string;
 }
 
 // ============================================================================

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -87,7 +87,12 @@ function extractTypeAndReason(attributes: any): { type?: string; reason?: string
   return {};
 }
 
-function mapResponseToDatatable(body: ESQLSearchResponse, query: string, input: Input): Datatable {
+function mapResponseToDatatable(
+  body: ESQLSearchResponse,
+  query: string,
+  input: Input,
+  warning?: string
+): Datatable {
   // all_columns in the response means that there is a separation between
   // columns with data and empty columns
   // columns contain only columns with data while all_columns everything
@@ -177,7 +182,7 @@ function mapResponseToDatatable(body: ESQLSearchResponse, query: string, input: 
     },
     columns: updatedWithVariablesColumns,
     rows,
-    warning: undefined,
+    warning,
   } as Datatable;
 }
 
@@ -337,7 +342,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
       };
 
       try {
-        const { rawResponse, requestParams } = await searchService.esql(
+        const { rawResponse, requestParams, warning } = await searchService.esql(
           {
             query: fixedQuery,
             params: params.params,
@@ -403,7 +408,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
           .ok({ json: { rawResponse }, requestParams });
 
         // Map to Datatable
-        return mapResponseToDatatable(rawResponse as any, query, input);
+        return mapResponseToDatatable(rawResponse as any, query, input, warning);
       } catch (error) {
         // Inspector logging on error
         logInspectorRequest()

--- a/src/platform/plugins/shared/data/common/search/search_methods.ts
+++ b/src/platform/plugins/shared/data/common/search/search_methods.ts
@@ -58,7 +58,11 @@ export class SearchMethodsService implements ISearchMethods {
       request,
       this.mapESQLOptions(options, 'esql_async' as typeof ESQL_ASYNC_SEARCH_STRATEGY)
     );
-    return { rawResponse: response.rawResponse, requestParams: response.requestParams };
+    return {
+      rawResponse: response.rawResponse,
+      requestParams: response.requestParams,
+      warning: response.warning,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR is improving some warning related things at the editor but most importantly it fixes a regression


**parseWarning drops message content after the 4th colon**

Java exception messages in ES warning headers follow the format Line N:N: ExceptionClass: actual message. The parser split on : and destructured into exactly four variables, silently dropping everything from the 5th segment on. A message like reason: detail with colon would come through as just reason. Fixed by using rest spread and rejoining the tail.

  **Warning squiggle underlines one character too many**

When a warning message contains a bracketed token (e.g. [date_parse(geo.dest)]), the length was computed as message.length - openingBracketIndex - 1 — measuring from the opening bracket to the end of the entire string instead of to the closing bracket. Fixed by using closingBracketIndex - openingBracketIndex - 1.

  **Unguarded JSON.parse in esql.multiCommands**

  The esql.multiCommands Monaco command called JSON.parse(commands) with no error handling. Wrapped in a try/catch that bails early on parse failure.

  **ES warning header not reaching the editor** THIS IS THE REGRESSION

 The Warning HTTP response header from Elasticsearch (e.g. "No limit defined, adding default limit of [1000]") was correctly captured by the async search strategy but silently dropped in search_methods.ts, which only forwarded rawResponse and requestParams. As a result mapResponseToDatatable always set warning: undefined on the Datatable and the warning
  never appeared in the editor panel. Threaded the warning through IEsqlSearchResult, search_methods.ts, and the ES|QL expression function. Regression introduced in #269394.


### Release note

The fix is applied only in serverless as thankfully the bug was only introduced there

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




