### PR TITLE
[9.3] [Actions] Fix HTTP connector TLS options through proxies (#269898)

### DIFF
--- a/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts
+++ b/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts
@@ -52,6 +52,50 @@ describe('getCustomAgents', () => {
     expect(httpsAgent instanceof HttpsProxyAgent).toBeTruthy();
   });
 
+  test('passes target SSL overrides to the CONNECT-upgraded TLS request', async () => {
+    const callbackSpy = jest
+      .spyOn(HttpsProxyAgent.prototype, 'callback')
+      .mockResolvedValue({} as Awaited<ReturnType<HttpsProxyAgent['callback']>>);
+    const proxySettings = {
+      proxyUrl: 'http://someproxyhost',
+      proxySSLSettings: {
+        verificationMode: 'full',
+      },
+      proxyBypassHosts: undefined,
+      proxyOnlyHosts: undefined,
+    } as ProxySettings;
+
+    const { httpsAgent } = getCustomAgents({
+      logger,
+      proxySettings,
+      sslOverrides: {
+        verificationMode: 'none',
+      },
+      sslSettings: defaultSSLSettings,
+      url: targetUrl,
+    });
+
+    try {
+      await (httpsAgent as unknown as HttpsProxyAgent).callback(
+        {} as Parameters<HttpsProxyAgent['callback']>[0],
+        {
+          host: targetHost,
+          port: 443,
+          secureEndpoint: true,
+        } as Parameters<HttpsProxyAgent['callback']>[1]
+      );
+
+      expect(callbackSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          rejectUnauthorized: false,
+        })
+      );
+    } finally {
+      callbackSpy.mockRestore();
+    }
+  });
+
   test('return default agents for invalid proxy URL', () => {
     const proxySettings = {
       proxyUrl: ':nope: not a valid URL',

--- a/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.ts
+++ b/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.ts
@@ -33,6 +33,24 @@ interface GetCustomAgentsOpts {
   url: string;
 }
 
+class TargetSslHttpsProxyAgent extends HttpsProxyAgent {
+  constructor(
+    proxyOptions: ConstructorParameters<typeof HttpsProxyAgent>[0],
+    private readonly targetSSLOptions: AgentOptions
+  ) {
+    super(proxyOptions);
+  }
+
+  callback(
+    req: Parameters<HttpsProxyAgent['callback']>[0],
+    opts: Parameters<HttpsProxyAgent['callback']>[1]
+  ) {
+    // HttpsProxyAgent constructor options configure the proxy connection. Target TLS
+    // options must be merged into the CONNECT-upgraded request options instead.
+    return super.callback(req, { ...opts, ...this.targetSSLOptions });
+  }
+}
+
 export function getCustomAgents(opts: GetCustomAgentsOpts): GetCustomAgentsResponse {
   const {
     customHostSettings,
@@ -135,20 +153,24 @@ export function getCustomAgents(opts: GetCustomAgentsOpts): GetCustomAgentsRespo
   // We will though, copy over the calculated ssl options from above, into
   // the https agent.
   const httpAgent = new HttpProxyAgent(proxySettings.proxyUrl) as unknown as HttpAgent;
-  const httpsAgent = new HttpsProxyAgent({
-    host: proxyUrl.hostname,
-    port: Number(proxyUrl.port),
-    protocol: proxyUrl.protocol,
-    headers: proxySettings.proxyHeaders,
-    // do not fail on invalid certs if value is false
-    ...proxyNodeSSLOptions,
-  }) as unknown as HttpsAgent;
+  const targetSSLOptions = agentOptions ?? agentSSLOptions;
+  const httpsAgent = new TargetSslHttpsProxyAgent(
+    {
+      host: proxyUrl.hostname,
+      port: Number(proxyUrl.port),
+      protocol: proxyUrl.protocol,
+      headers: proxySettings.proxyHeaders,
+      // do not fail on invalid certs if value is false
+      ...proxyNodeSSLOptions,
+    },
+    targetSSLOptions
+  ) as unknown as HttpsAgent;
   // vsCode wasn't convinced HttpsProxyAgent is an https.Agent, so we convinced it
 
-  if (agentOptions) {
+  if (targetSSLOptions) {
     httpsAgent.options = {
       ...httpsAgent.options,
-      ...agentOptions,
+      ...targetSSLOptions,
     };
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Actions] Fix HTTP connector TLS options through proxies (#269898)](https://github.com/elastic/kibana/pull/269898)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahar Glazner","email":"shaharglazner@gmail.com"},"sourceCommit":{"committedDate":"2026-05-20T08:50:22Z","message":"[Actions] Fix HTTP connector TLS options through proxies (#269898)\n\n## Summary\n- For HTTPS requests through an HTTP proxy, forward target TLS options\nto the CONNECT-upgraded request created by `HttpsProxyAgent`.\n- Ensures connector `verificationMode: none` and per-request SSL\noverrides like `fetcher.skip_ssl_verification` are honored when the\nproxy performs TLS inspection.\n- Adds a regression test covering target SSL overrides through the proxy\nagent callback.\n\n## Test plan\n- `node scripts/jest\nsrc/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts`\n- `node scripts/check_changes.ts`\n- Manually reproduced with local mitmproxy before the fix and verified\n`_execute` succeeds after the fix.\n\n## References\nCloses elastic/security-team#17454\nCloses https://github.com/elastic/kibana/issues/196602\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"4783bfafd2d0e25d59d5f2a835ef5f84defd1333","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","Team:One Workflow","v9.5.0","v9.4.2"],"title":"[Actions] Fix HTTP connector TLS options through proxies","number":269898,"url":"https://github.com/elastic/kibana/pull/269898","mergeCommit":{"message":"[Actions] Fix HTTP connector TLS options through proxies (#269898)\n\n## Summary\n- For HTTPS requests through an HTTP proxy, forward target TLS options\nto the CONNECT-upgraded request created by `HttpsProxyAgent`.\n- Ensures connector `verificationMode: none` and per-request SSL\noverrides like `fetcher.skip_ssl_verification` are honored when the\nproxy performs TLS inspection.\n- Adds a regression test covering target SSL overrides through the proxy\nagent callback.\n\n## Test plan\n- `node scripts/jest\nsrc/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts`\n- `node scripts/check_changes.ts`\n- Manually reproduced with local mitmproxy before the fix and verified\n`_execute` succeeds after the fix.\n\n## References\nCloses elastic/security-team#17454\nCloses https://github.com/elastic/kibana/issues/196602\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"4783bfafd2d0e25d59d5f2a835ef5f84defd1333"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269898","number":269898,"mergeCommit":{"message":"[Actions] Fix HTTP connector TLS options through proxies (#269898)\n\n## Summary\n- For HTTPS requests through an HTTP proxy, forward target TLS options\nto the CONNECT-upgraded request created by `HttpsProxyAgent`.\n- Ensures connector `verificationMode: none` and per-request SSL\noverrides like `fetcher.skip_ssl_verification` are honored when the\nproxy performs TLS inspection.\n- Adds a regression test covering target SSL overrides through the proxy\nagent callback.\n\n## Test plan\n- `node scripts/jest\nsrc/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts`\n- `node scripts/check_changes.ts`\n- Manually reproduced with local mitmproxy before the fix and verified\n`_execute` succeeds after the fix.\n\n## References\nCloses elastic/security-team#17454\nCloses https://github.com/elastic/kibana/issues/196602\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"4783bfafd2d0e25d59d5f2a835ef5f84defd1333"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/270104","number":270104,"state":"MERGED","mergeCommit":{"sha":"a52796fd91238e42d13f5044f0fd8958aabe08ee","message":"[9.4] [Actions] Fix HTTP connector TLS options through proxies (#269898) (#270104)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Actions] Fix HTTP connector TLS options through proxies\n(#269898)](https://github.com/elastic/kibana/pull/269898)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Shahar Glazner <shaharglazner@gmail.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"url":"https://github.com/elastic/kibana/pull/272321","number":272321,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->

---
**Note:** This PR was created with conflicts auto-resolved in favor of the source commit (`--strategy-option=theirs`). Please review the changes carefully.