### PR TITLE
[Flaky] Fix alert_details_left_panel_analyzer_graph_tab.cy.ts (fixes #270434)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -61,7 +61,7 @@ import {
   TIMELINE_CONTEXT_MENU_BTN,
   TOOLTIP,
 } from '../screens/alerts';
-import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
+import { REFRESH_BUTTON } from '../screens/security_header';
 import {
   ENRICHMENT_QUERY_END_INPUT,
   ENRICHMENT_QUERY_RANGE_PICKER,
@@ -457,7 +457,6 @@ export const waitForAlerts = () => {
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
-  cy.get(LOADING_INDICATOR).should('not.exist');
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test `Alert details expandable flyout left panel analyzer graph "before each" hook for "should display analyzer graph and node list under visualize"` was failing with a 150-second timeout on `cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist')` in `waitForAlerts()` (`tasks/alerts.ts:460`). The `LOADING_INDICATOR` selector (`[data-test-subj="globalLoadingIndicator"]`) maps to the Kibana chrome's page-wide loading spinner, which remains visible whenever *any* HTTP request is in-flight — including requests completely unrelated to the alerts grid (e.g., background rule status polls, telemetry, entity analytics). By the time `waitForAlertsToPopulate()` calls `waitForAlerts()`, the alert count threshold has already been confirmed via `cy.waitUntil`, so alerts are populated; the failure is solely on the global-indicator assertion that follows. The fix removes `cy.get(LOADING_INDICATOR).should('not.exist')` (and its now-unused import) from `waitForAlerts()`. The remaining three checks — `cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500)`, `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')`, and `cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist')` — already precisely target the alerts grid's loading state and are sufficient to confirm readiness without being susceptible to unrelated background traffic. This matches the same fix pattern that resolved issue #270434's sibling flake in `bulk_add_to_timeline.cy.ts`.

**Changes**

- 6a53e75f616b fix(test): remove over-broad globalLoadingIndicator check from waitForAlerts

Fixes #270434




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`