### PR TITLE
agentless: decouple enrollment flyout from package policy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -10,9 +10,18 @@ import { useLocation } from 'react-router-dom';
 
 import { AGENTS_PREFIX } from '../../../../../../../../../common/constants';
 import { sendGetAgents } from '../../../../../../hooks';
+// The flyout imports sendGetAgents directly from the top-level public/hooks barrel,
+// which is a different Jest module instance than the integrations hooks barrel the
+// table uses. Import + mock it separately so we can assert the flyout's own agent lookup.
+import { sendGetAgents as sendGetAgentsFromFlyout } from '../../../../../../../../hooks';
 import { createIntegrationsTestRendererMock } from '../../../../../../../../mock';
+import type { PackagePolicy, PackagePolicyInput } from '../../../../../../types';
 
-import { AgentlessPackagePoliciesTable } from './agentless_table';
+import {
+  AgentlessPackagePoliciesTable,
+  getConnectorsFromPackagePolicy,
+  getSelectedInput,
+} from './agentless_table';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -25,10 +34,18 @@ jest.mock('../../../../../../hooks', () => ({
   sendGetAgents: jest.fn(),
 }));
 
+jest.mock('../../../../../../../../hooks', () => ({
+  ...jest.requireActual('../../../../../../../../hooks'),
+  sendGetAgents: jest.fn(),
+}));
+
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
 
 describe('AgentlessPackagePoliciesTable', () => {
   const mockSendGetAgents = sendGetAgents as jest.MockedFunction<typeof sendGetAgents>;
+  const mockSendGetAgentsFromFlyout = sendGetAgentsFromFlyout as jest.MockedFunction<
+    typeof sendGetAgentsFromFlyout
+  >;
 
   beforeEach(() => {
     mockUseLocation.mockReturnValue({
@@ -36,6 +53,13 @@ describe('AgentlessPackagePoliciesTable', () => {
       search: '',
       hash: '',
       state: undefined,
+    });
+
+    // The flyout polls for its enrolled agent; return an empty result so it keeps
+    // rendering its header without resolving to a healthy agent.
+    mockSendGetAgentsFromFlyout.mockResolvedValue({
+      data: { items: [], total: 0, page: 1, perPage: 20 },
+      error: null,
     });
 
     mockSendGetAgents.mockResolvedValue({
@@ -185,6 +209,31 @@ describe('AgentlessPackagePoliciesTable', () => {
     });
   });
 
+  it('looks up the flyout agent by agent-policy id (policy_ids[0]), not the package-policy id', async () => {
+    // Fixture intentionally has packagePolicy.id ('packagePolicy1') !== policy_ids[0]
+    // ('policy1'), the real-data case. The flyout must query by the agent-policy id.
+    mockUseLocation.mockReturnValue({
+      pathname: '/',
+      search: '?openEnrollmentFlyout=packagePolicy1',
+      hash: '',
+      state: undefined,
+    });
+    const renderer = createIntegrationsTestRendererMock();
+    const result = renderer.render(<AgentlessPackagePoliciesTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(result.getByText('Confirm agentless enrollment')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(mockSendGetAgentsFromFlyout).toHaveBeenCalledWith({
+        kuery: `${AGENTS_PREFIX}.policy_id: "policy1"`,
+      });
+    });
+    expect(mockSendGetAgentsFromFlyout).not.toHaveBeenCalledWith({
+      kuery: `${AGENTS_PREFIX}.policy_id: "packagePolicy1"`,
+    });
+  });
+
   it('does not open flyout when openEnrollmentFlyout query param does not match any policy', async () => {
     mockUseLocation.mockReturnValue({
       pathname: '/',
@@ -198,5 +247,83 @@ describe('AgentlessPackagePoliciesTable', () => {
       expect(mockSendGetAgents).toHaveBeenCalled();
     });
     expect(result.queryByText('Confirm agentless enrollment')).not.toBeInTheDocument();
+  });
+});
+
+const makeInput = (overrides: Partial<PackagePolicyInput>): PackagePolicyInput => ({
+  type: 'logs',
+  enabled: true,
+  streams: [],
+  ...overrides,
+});
+
+const makePackagePolicy = (inputs: PackagePolicyInput[]): PackagePolicy =>
+  ({ id: 'pp1', name: 'pp', inputs } as PackagePolicy);
+
+describe('getConnectorsFromPackagePolicy', () => {
+  it('returns an empty array when there are no inputs', () => {
+    expect(getConnectorsFromPackagePolicy(makePackagePolicy([]))).toEqual([]);
+  });
+
+  it('maps an enabled input that carries connector vars', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({
+        enabled: true,
+        vars: {
+          connector_id: { value: 'connector-1' },
+          connector_name: { value: 'My Connector' },
+        },
+      }),
+    ]);
+    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([
+      { id: 'connector-1', name: 'My Connector' },
+    ]);
+  });
+
+  it('excludes disabled inputs even when they carry connector vars', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({
+        enabled: false,
+        vars: { connector_id: { value: 'disabled-connector' } },
+      }),
+    ]);
+    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([]);
+  });
+
+  it('excludes enabled inputs without connector vars', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: true, vars: { period: { value: '5m' } } }),
+    ]);
+    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([]);
+  });
+});
+
+describe('getSelectedInput', () => {
+  it('returns the single enabled input policy template and type', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: true, policy_template: 'aws', type: 'aws/s3' }),
+      makeInput({ enabled: false, policy_template: 'gcp', type: 'gcp/metrics' }),
+    ]);
+    expect(getSelectedInput(packagePolicy)).toEqual({ policyTemplate: 'aws', type: 'aws/s3' });
+  });
+
+  it('returns undefined when no input is enabled', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: false, policy_template: 'aws', type: 'aws/s3' }),
+    ]);
+    expect(getSelectedInput(packagePolicy)).toBeUndefined();
+  });
+
+  it('returns undefined when more than one input is enabled', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: true, policy_template: 'aws', type: 'aws/s3' }),
+      makeInput({ enabled: true, policy_template: 'gcp', type: 'gcp/metrics' }),
+    ]);
+    expect(getSelectedInput(packagePolicy)).toBeUndefined();
+  });
+
+  it('returns undefined when the single enabled input has no policy template', () => {
+    const packagePolicy = makePackagePolicy([makeInput({ enabled: true, type: 'aws/s3' })]);
+    expect(getSelectedInput(packagePolicy)).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -15,13 +15,8 @@ import { sendGetAgents } from '../../../../../../hooks';
 // table uses. Import + mock it separately so we can assert the flyout's own agent lookup.
 import { sendGetAgents as sendGetAgentsFromFlyout } from '../../../../../../../../hooks';
 import { createIntegrationsTestRendererMock } from '../../../../../../../../mock';
-import type { PackagePolicy, PackagePolicyInput } from '../../../../../../types';
 
-import {
-  AgentlessPackagePoliciesTable,
-  getConnectorsFromPackagePolicy,
-  getSelectedInput,
-} from './agentless_table';
+import { AgentlessPackagePoliciesTable } from './agentless_table';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -247,83 +242,5 @@ describe('AgentlessPackagePoliciesTable', () => {
       expect(mockSendGetAgents).toHaveBeenCalled();
     });
     expect(result.queryByText('Confirm agentless enrollment')).not.toBeInTheDocument();
-  });
-});
-
-const makeInput = (overrides: Partial<PackagePolicyInput>): PackagePolicyInput => ({
-  type: 'logs',
-  enabled: true,
-  streams: [],
-  ...overrides,
-});
-
-const makePackagePolicy = (inputs: PackagePolicyInput[]): PackagePolicy =>
-  ({ id: 'pp1', name: 'pp', inputs } as PackagePolicy);
-
-describe('getConnectorsFromPackagePolicy', () => {
-  it('returns an empty array when there are no inputs', () => {
-    expect(getConnectorsFromPackagePolicy(makePackagePolicy([]))).toEqual([]);
-  });
-
-  it('maps an enabled input that carries connector vars', () => {
-    const packagePolicy = makePackagePolicy([
-      makeInput({
-        enabled: true,
-        vars: {
-          connector_id: { value: 'connector-1' },
-          connector_name: { value: 'My Connector' },
-        },
-      }),
-    ]);
-    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([
-      { id: 'connector-1', name: 'My Connector' },
-    ]);
-  });
-
-  it('excludes disabled inputs even when they carry connector vars', () => {
-    const packagePolicy = makePackagePolicy([
-      makeInput({
-        enabled: false,
-        vars: { connector_id: { value: 'disabled-connector' } },
-      }),
-    ]);
-    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([]);
-  });
-
-  it('excludes enabled inputs without connector vars', () => {
-    const packagePolicy = makePackagePolicy([
-      makeInput({ enabled: true, vars: { period: { value: '5m' } } }),
-    ]);
-    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([]);
-  });
-});
-
-describe('getSelectedInput', () => {
-  it('returns the single enabled input policy template and type', () => {
-    const packagePolicy = makePackagePolicy([
-      makeInput({ enabled: true, policy_template: 'aws', type: 'aws/s3' }),
-      makeInput({ enabled: false, policy_template: 'gcp', type: 'gcp/metrics' }),
-    ]);
-    expect(getSelectedInput(packagePolicy)).toEqual({ policyTemplate: 'aws', type: 'aws/s3' });
-  });
-
-  it('returns undefined when no input is enabled', () => {
-    const packagePolicy = makePackagePolicy([
-      makeInput({ enabled: false, policy_template: 'aws', type: 'aws/s3' }),
-    ]);
-    expect(getSelectedInput(packagePolicy)).toBeUndefined();
-  });
-
-  it('returns undefined when more than one input is enabled', () => {
-    const packagePolicy = makePackagePolicy([
-      makeInput({ enabled: true, policy_template: 'aws', type: 'aws/s3' }),
-      makeInput({ enabled: true, policy_template: 'gcp', type: 'gcp/metrics' }),
-    ]);
-    expect(getSelectedInput(packagePolicy)).toBeUndefined();
-  });
-
-  it('returns undefined when the single enabled input has no policy template', () => {
-    const packagePolicy = makePackagePolicy([makeInput({ enabled: true, type: 'aws/s3' })]);
-    expect(getSelectedInput(packagePolicy)).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.test.tsx
@@ -204,31 +204,6 @@ describe('AgentlessPackagePoliciesTable', () => {
     });
   });
 
-  it('looks up the flyout agent by agent-policy id (policy_ids[0]), not the package-policy id', async () => {
-    // Fixture intentionally has packagePolicy.id ('packagePolicy1') !== policy_ids[0]
-    // ('policy1'), the real-data case. The flyout must query by the agent-policy id.
-    mockUseLocation.mockReturnValue({
-      pathname: '/',
-      search: '?openEnrollmentFlyout=packagePolicy1',
-      hash: '',
-      state: undefined,
-    });
-    const renderer = createIntegrationsTestRendererMock();
-    const result = renderer.render(<AgentlessPackagePoliciesTable {...defaultProps} />);
-
-    await waitFor(() => {
-      expect(result.getByText('Confirm agentless enrollment')).toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(mockSendGetAgentsFromFlyout).toHaveBeenCalledWith({
-        kuery: `${AGENTS_PREFIX}.policy_id: "policy1"`,
-      });
-    });
-    expect(mockSendGetAgentsFromFlyout).not.toHaveBeenCalledWith({
-      kuery: `${AGENTS_PREFIX}.policy_id: "packagePolicy1"`,
-    });
-  });
-
   it('does not open flyout when openEnrollmentFlyout query param does not match any policy', async () => {
     mockUseLocation.mockReturnValue({
       pathname: '/',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -39,6 +39,10 @@ import {
   PackagePolicyActionsMenu,
   AgentlessEnrollmentFlyout,
 } from '../../../../../../components';
+import type {
+  AgentlessEnrollmentConnector,
+  AgentlessEnrollmentSelectedInput,
+} from '../../../../../../components';
 
 import { Persona } from '../persona';
 import { AgentHealth } from '../../../../../../../fleet/sections/agents/components';
@@ -50,6 +54,33 @@ const REFRESH_INTERVAL_MS = 30000;
 
 const isConnectorPolicy = (packagePolicy: InMemoryPackagePolicy) =>
   packagePolicy.package?.name === FLEET_CONNECTORS_PACKAGE;
+
+// Adapter: extract connector deep-links from the package policy's enabled inputs.
+// Disabled inputs aren't running, so their connectors shouldn't surface as cards.
+export const getConnectorsFromPackagePolicy = (
+  packagePolicy: PackagePolicy
+): AgentlessEnrollmentConnector[] =>
+  (packagePolicy.inputs ?? [])
+    .filter(
+      (input) =>
+        input.enabled &&
+        (!!input?.vars?.connector_id?.value || !!input?.vars?.connector_name?.value)
+    )
+    .map((input) => ({
+      id: input?.vars?.connector_id?.value,
+      name: input?.vars?.connector_name?.value,
+    }));
+
+// Adapter: identify the single enabled input from the package's policy templates
+export const getSelectedInput = (
+  packagePolicy: PackagePolicy
+): AgentlessEnrollmentSelectedInput | undefined => {
+  const enabledInputs = (packagePolicy.inputs ?? []).filter((input) => input.enabled);
+  if (enabledInputs.length === 1 && enabledInputs[0].policy_template) {
+    return { policyTemplate: enabledInputs[0].policy_template, type: enabledInputs[0].type };
+  }
+  return undefined;
+};
 
 export const AgentlessPackagePoliciesTable = ({
   isLoading,
@@ -192,8 +223,9 @@ export const AgentlessPackagePoliciesTable = ({
     // The agentless save flow sets openEnrollmentFlyout=<packagePolicyId> via
     // appendOnSaveQueryParamsToPath (AgentlessPolicy has no policy_ids, so
     // policy.id is used). Match on packagePolicy.id accordingly.
-    // TODO: decouple this flyout from PackagePolicy — see follow-up issue for
-    // refactoring AgentlessEnrollmentFlyout to accept AgentlessPolicy directly.
+    // TODO: the flyout now takes a decoupled AgentlessEnrollmentFlyoutProps contract;
+    // the remaining work is to source this table from the AgentlessPolicy API and map
+    // AgentlessPolicy -> AgentlessEnrollmentFlyoutProps instead of PackagePolicy.
     const flyoutPolicyIdFromQuery = queryParams.get('openEnrollmentFlyout');
     if (flyoutPolicyIdFromQuery) {
       const pp = packagePolicies.find((p) => p.packagePolicy.id === flyoutPolicyIdFromQuery);
@@ -444,8 +476,17 @@ export const AgentlessPackagePoliciesTable = ({
             setFlyoutPackagePolicy(undefined);
             setFlyoutAgentPolicy(undefined);
           }}
-          packagePolicy={flyoutPackagePolicy}
+          policyId={flyoutPackagePolicy.policy_ids[0]}
+          policyName={flyoutPackagePolicy.name}
+          // package is always set for agentless policies (createAgentlessPolicy);
+          // optional only on the general PackagePolicy type.
+          packageInfo={{
+            name: flyoutPackagePolicy.package!.name,
+            version: flyoutPackagePolicy.package!.version,
+          }}
+          selectedInput={getSelectedInput(flyoutPackagePolicy)}
           agentPolicy={flyoutAgentPolicy}
+          connectors={getConnectorsFromPackagePolicy(flyoutPackagePolicy)}
         />
       )}
     </>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -39,48 +39,18 @@ import {
   PackagePolicyActionsMenu,
   AgentlessEnrollmentFlyout,
 } from '../../../../../../components';
-import type {
-  AgentlessEnrollmentConnector,
-  AgentlessEnrollmentSelectedInput,
-} from '../../../../../../components';
 
 import { Persona } from '../persona';
 import { AgentHealth } from '../../../../../../../fleet/sections/agents/components';
 
 import { PackagePolicyUpgradeCell } from './package_policy_upgrade_cell';
 import { ThroughputCell } from './throughput_cell';
+import { getConnectorsFromPackagePolicy, getSelectedInput } from './agentless_table_adapters';
 
 const REFRESH_INTERVAL_MS = 30000;
 
 const isConnectorPolicy = (packagePolicy: InMemoryPackagePolicy) =>
   packagePolicy.package?.name === FLEET_CONNECTORS_PACKAGE;
-
-// Adapter: extract connector deep-links from the package policy's enabled inputs.
-// Disabled inputs aren't running, so their connectors shouldn't surface as cards.
-export const getConnectorsFromPackagePolicy = (
-  packagePolicy: PackagePolicy
-): AgentlessEnrollmentConnector[] =>
-  (packagePolicy.inputs ?? [])
-    .filter(
-      (input) =>
-        input.enabled &&
-        (!!input?.vars?.connector_id?.value || !!input?.vars?.connector_name?.value)
-    )
-    .map((input) => ({
-      id: input?.vars?.connector_id?.value,
-      name: input?.vars?.connector_name?.value,
-    }));
-
-// Adapter: identify the single enabled input from the package's policy templates
-export const getSelectedInput = (
-  packagePolicy: PackagePolicy
-): AgentlessEnrollmentSelectedInput | undefined => {
-  const enabledInputs = (packagePolicy.inputs ?? []).filter((input) => input.enabled);
-  if (enabledInputs.length === 1 && enabledInputs[0].policy_template) {
-    return { policyTemplate: enabledInputs[0].policy_template, type: enabledInputs[0].type };
-  }
-  return undefined;
-};
 
 export const AgentlessPackagePoliciesTable = ({
   isLoading,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table_adapters.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table_adapters.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackagePolicy, PackagePolicyInput } from '../../../../../../types';
+
+import { getConnectorsFromPackagePolicy, getSelectedInput } from './agentless_table_adapters';
+
+const makeInput = (overrides: Partial<PackagePolicyInput>): PackagePolicyInput => ({
+  type: 'logs',
+  enabled: true,
+  streams: [],
+  ...overrides,
+});
+
+const makePackagePolicy = (inputs: PackagePolicyInput[]): PackagePolicy =>
+  ({ id: 'pp1', name: 'pp', inputs } as PackagePolicy);
+
+describe('getConnectorsFromPackagePolicy', () => {
+  it('returns an empty array when there are no inputs', () => {
+    expect(getConnectorsFromPackagePolicy(makePackagePolicy([]))).toEqual([]);
+  });
+
+  it('maps an enabled input that carries connector vars', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({
+        enabled: true,
+        vars: {
+          connector_id: { value: 'connector-1' },
+          connector_name: { value: 'My Connector' },
+        },
+      }),
+    ]);
+    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([
+      { id: 'connector-1', name: 'My Connector' },
+    ]);
+  });
+
+  it('excludes disabled inputs even when they carry connector vars', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({
+        enabled: false,
+        vars: { connector_id: { value: 'disabled-connector' } },
+      }),
+    ]);
+    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([]);
+  });
+
+  it('excludes enabled inputs without connector vars', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: true, vars: { period: { value: '5m' } } }),
+    ]);
+    expect(getConnectorsFromPackagePolicy(packagePolicy)).toEqual([]);
+  });
+});
+
+describe('getSelectedInput', () => {
+  it('returns the single enabled input policy template and type', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: true, policy_template: 'aws', type: 'aws/s3' }),
+      makeInput({ enabled: false, policy_template: 'gcp', type: 'gcp/metrics' }),
+    ]);
+    expect(getSelectedInput(packagePolicy)).toEqual({ policyTemplate: 'aws', type: 'aws/s3' });
+  });
+
+  it('returns undefined when no input is enabled', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: false, policy_template: 'aws', type: 'aws/s3' }),
+    ]);
+    expect(getSelectedInput(packagePolicy)).toBeUndefined();
+  });
+
+  it('returns undefined when more than one input is enabled', () => {
+    const packagePolicy = makePackagePolicy([
+      makeInput({ enabled: true, policy_template: 'aws', type: 'aws/s3' }),
+      makeInput({ enabled: true, policy_template: 'gcp', type: 'gcp/metrics' }),
+    ]);
+    expect(getSelectedInput(packagePolicy)).toBeUndefined();
+  });
+
+  it('returns undefined when the single enabled input has no policy template', () => {
+    const packagePolicy = makePackagePolicy([makeInput({ enabled: true, type: 'aws/s3' })]);
+    expect(getSelectedInput(packagePolicy)).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table_adapters.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table_adapters.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackagePolicy } from '../../../../../../types';
+import type {
+  AgentlessEnrollmentConnector,
+  AgentlessEnrollmentSelectedInput,
+} from '../../../../../../components';
+
+// Adapter: extract connector deep-links from the package policy's enabled inputs.
+// Disabled inputs aren't running, so their connectors shouldn't surface as cards.
+export const getConnectorsFromPackagePolicy = (
+  packagePolicy: PackagePolicy
+): AgentlessEnrollmentConnector[] =>
+  (packagePolicy.inputs ?? [])
+    .filter(
+      (input) =>
+        input.enabled &&
+        (!!input?.vars?.connector_id?.value || !!input?.vars?.connector_name?.value)
+    )
+    .map((input) => ({
+      id: input?.vars?.connector_id?.value,
+      name: input?.vars?.connector_name?.value,
+    }));
+
+// Adapter: identify the single enabled input from the package's policy templates
+export const getSelectedInput = (
+  packagePolicy: PackagePolicy
+): AgentlessEnrollmentSelectedInput | undefined => {
+  const enabledInputs = (packagePolicy.inputs ?? []).filter((input) => input.enabled);
+  if (enabledInputs.length === 1 && enabledInputs[0].policy_template) {
+    return { policyTemplate: enabledInputs[0].policy_template, type: enabledInputs[0].type };
+  }
+  return undefined;
+};

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.test.tsx
@@ -13,7 +13,7 @@ import { createIntegrationsTestRendererMock } from '../../mock';
 
 import { AGENTS_PREFIX } from '../../constants';
 
-import { AgentlessEnrollmentFlyout, resolveIntegrationTitle } from '.';
+import { AgentlessEnrollmentFlyout } from '.';
 
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
@@ -126,72 +126,5 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
       expect(getByText('Step 2 is complete')).toBeInTheDocument();
       expect(getByText('Incoming data received from agentless integration')).toBeInTheDocument();
     });
-  });
-});
-
-describe('resolveIntegrationTitle', () => {
-  const policyTemplates = [
-    {
-      name: 'aws',
-      inputs: [
-        { type: 's3', title: 'AWS S3' },
-        { type: 'cloudwatch', title: 'AWS CloudWatch' },
-      ],
-    },
-  ];
-
-  it('falls back to the policy name when the package title is unavailable', () => {
-    expect(
-      resolveIntegrationTitle({
-        packageTitle: undefined,
-        policyTemplates,
-        selectedInput: { policyTemplate: 'aws', type: 's3' },
-        fallbackName: 'My agentless policy',
-      })
-    ).toBe('My agentless policy');
-  });
-
-  it('uses the package title when no input is selected', () => {
-    expect(
-      resolveIntegrationTitle({
-        packageTitle: 'Amazon Web Services',
-        policyTemplates,
-        selectedInput: undefined,
-        fallbackName: 'My agentless policy',
-      })
-    ).toBe('Amazon Web Services');
-  });
-
-  it('uses the selected input title when it resolves', () => {
-    expect(
-      resolveIntegrationTitle({
-        packageTitle: 'Amazon Web Services',
-        policyTemplates,
-        selectedInput: { policyTemplate: 'aws', type: 's3' },
-        fallbackName: 'My agentless policy',
-      })
-    ).toBe('AWS S3');
-  });
-
-  it('falls back to the package title when the policy template is not found', () => {
-    expect(
-      resolveIntegrationTitle({
-        packageTitle: 'Amazon Web Services',
-        policyTemplates,
-        selectedInput: { policyTemplate: 'gcp', type: 's3' },
-        fallbackName: 'My agentless policy',
-      })
-    ).toBe('Amazon Web Services');
-  });
-
-  it('falls back to the package title when the input type is not found in the template', () => {
-    expect(
-      resolveIntegrationTitle({
-        packageTitle: 'Amazon Web Services',
-        policyTemplates,
-        selectedInput: { policyTemplate: 'aws', type: 'kinesis' },
-        fallbackName: 'My agentless policy',
-      })
-    ).toBe('Amazon Web Services');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.test.tsx
@@ -13,9 +13,7 @@ import { createIntegrationsTestRendererMock } from '../../mock';
 
 import { AGENTS_PREFIX } from '../../constants';
 
-import type { PackagePolicy } from '../../types';
-
-import { AgentlessEnrollmentFlyout } from '.';
+import { AgentlessEnrollmentFlyout, resolveIntegrationTitle } from '.';
 
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
@@ -34,21 +32,11 @@ const mockUsePollingIncomingData = usePollingIncomingData as jest.Mock;
 // FLAKY: https://github.com/elastic/kibana/issues/201738
 describe.skip('AgentlessEnrollmentFlyout', () => {
   const onClose = jest.fn();
-  const packagePolicy: PackagePolicy = {
-    id: 'test-package-policy-id',
-    name: 'test-package-policy',
-    namespace: 'default',
-    policy_ids: ['test-policy-id'],
-    policy_id: 'test-policy-id',
-    enabled: true,
-    output_id: '',
-    package: { name: 'test-package', title: 'Test Package', version: '1.0.0' },
-    inputs: [{ enabled: true, policy_template: 'test-template', type: 'test-type', streams: [] }],
-    revision: 1,
-    created_at: '',
-    created_by: '',
-    updated_at: '',
-    updated_by: '',
+  const flyoutProps = {
+    onClose,
+    policyId: 'test-policy-id',
+    policyName: 'test-package-policy',
+    packageInfo: { name: 'test-package', version: '1.0.0' },
   };
 
   beforeEach(() => {
@@ -62,9 +50,7 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
 
   it('renders the flyout with initial loading state', async () => {
     const renderer = createIntegrationsTestRendererMock();
-    const { getByText } = renderer.render(
-      <AgentlessEnrollmentFlyout onClose={onClose} packagePolicy={packagePolicy} />
-    );
+    const { getByText } = renderer.render(<AgentlessEnrollmentFlyout {...flyoutProps} />);
     await waitFor(async () => {
       expect(getByText('Confirm agentless enrollment')).toBeInTheDocument();
       expect(getByText('Step 1 is loading')).toBeInTheDocument();
@@ -81,9 +67,7 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
     const agentData = { status: 'error' };
     mockSendGetAgents.mockResolvedValueOnce({ data: { items: [agentData] } });
 
-    const { getByText } = renderer.render(
-      <AgentlessEnrollmentFlyout onClose={onClose} packagePolicy={packagePolicy} />
-    );
+    const { getByText } = renderer.render(<AgentlessEnrollmentFlyout {...flyoutProps} />);
 
     await waitFor(() => {
       expect(getByText('Confirm agentless enrollment')).toBeInTheDocument();
@@ -100,9 +84,7 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
     mockSendGetAgents.mockResolvedValueOnce({ data: { items: [agentData] } });
     mockUsePollingIncomingData.mockReturnValue({ incomingData: [], hasReachedTimeout: false });
 
-    const { getByText } = renderer.render(
-      <AgentlessEnrollmentFlyout onClose={onClose} packagePolicy={packagePolicy} />
-    );
+    const { getByText } = renderer.render(<AgentlessEnrollmentFlyout {...flyoutProps} />);
 
     await waitFor(() => {
       expect(mockSendGetAgents).toHaveBeenCalledWith({
@@ -121,9 +103,7 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
     mockSendGetAgents.mockResolvedValueOnce({ data: { items: [{ status: 'online' }] } });
     mockUsePollingIncomingData.mockReturnValue({ incomingData: [], hasReachedTimeout: true });
 
-    const { getByText } = renderer.render(
-      <AgentlessEnrollmentFlyout onClose={onClose} packagePolicy={packagePolicy} />
-    );
+    const { getByText } = renderer.render(<AgentlessEnrollmentFlyout {...flyoutProps} />);
 
     await waitFor(() => {
       expect(getByText('Step 1 is complete')).toBeInTheDocument();
@@ -138,9 +118,7 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
     mockSendGetAgents.mockResolvedValueOnce({ data: { items: [{ status: 'online' }] } });
     mockUsePollingIncomingData.mockReturnValue({ incomingData: [{ data: 'test-data' }] });
 
-    const { getByText } = renderer.render(
-      <AgentlessEnrollmentFlyout onClose={onClose} packagePolicy={packagePolicy} />
-    );
+    const { getByText } = renderer.render(<AgentlessEnrollmentFlyout {...flyoutProps} />);
 
     await waitFor(() => {
       expect(getByText('Step 1 is complete')).toBeInTheDocument();
@@ -148,5 +126,72 @@ describe.skip('AgentlessEnrollmentFlyout', () => {
       expect(getByText('Step 2 is complete')).toBeInTheDocument();
       expect(getByText('Incoming data received from agentless integration')).toBeInTheDocument();
     });
+  });
+});
+
+describe('resolveIntegrationTitle', () => {
+  const policyTemplates = [
+    {
+      name: 'aws',
+      inputs: [
+        { type: 's3', title: 'AWS S3' },
+        { type: 'cloudwatch', title: 'AWS CloudWatch' },
+      ],
+    },
+  ];
+
+  it('falls back to the policy name when the package title is unavailable', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: undefined,
+        policyTemplates,
+        selectedInput: { policyTemplate: 'aws', type: 's3' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('My agentless policy');
+  });
+
+  it('uses the package title when no input is selected', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: undefined,
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('Amazon Web Services');
+  });
+
+  it('uses the selected input title when it resolves', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: { policyTemplate: 'aws', type: 's3' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('AWS S3');
+  });
+
+  it('falls back to the package title when the policy template is not found', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: { policyTemplate: 'gcp', type: 's3' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('Amazon Web Services');
+  });
+
+  it('falls back to the package title when the input type is not found in the template', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: { policyTemplate: 'aws', type: 'kinesis' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('Amazon Web Services');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.tsx
@@ -22,30 +22,72 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { AGENTS_PREFIX, FLEET_CONNECTORS_PACKAGE, MAX_FLYOUT_WIDTH } from '../../constants';
-import type { Agent, AgentPolicy, PackagePolicy } from '../../types';
+import type { Agent } from '../../types';
 import { sendGetAgents, useStartServices, useGetPackageInfoByKeyQuery } from '../../hooks';
 
 import { AgentlessStepConfirmEnrollment } from './step_confirm_enrollment';
 import { AgentlessStepConfirmData } from './step_confirm_data';
 import { AgentlessStepConfigureConnector } from './step_configure_connector';
+import type { AgentlessEnrollmentFlyoutProps, AgentlessEnrollmentSelectedInput } from './types';
+
+// re-export the flyout contract types so external consumers can import them from this module
+export type {
+  AgentlessEnrollmentConnector,
+  AgentlessEnrollmentSelectedInput,
+  AgentlessEnrollmentFlyoutProps,
+} from './types';
 
 const REFRESH_INTERVAL_MS = 30000;
 
+/** Minimal shape needed from the package's policy templates to resolve a title. */
+interface IntegrationTitleSource {
+  name: string;
+  inputs?: Array<{ type: string; title?: string }>;
+}
+
+/**
+ * Resolves the integration title shown in the enrollment copy. When a single input
+ * is selected, prefer that input's title from the package's policy templates
+ * (e.g. "AWS S3"); otherwise fall back to the package title, then the policy name.
+ */
+export const resolveIntegrationTitle = ({
+  packageTitle,
+  policyTemplates,
+  selectedInput,
+  fallbackName,
+}: {
+  packageTitle?: string;
+  policyTemplates?: IntegrationTitleSource[];
+  selectedInput?: AgentlessEnrollmentSelectedInput;
+  fallbackName: string;
+}): string => {
+  if (!packageTitle) {
+    return fallbackName;
+  }
+  if (!selectedInput) {
+    return packageTitle;
+  }
+  const policyTemplate = policyTemplates?.find(
+    (template) => template.name === selectedInput.policyTemplate
+  );
+  const input = policyTemplate?.inputs?.find((i) => i.type === selectedInput.type);
+  return input?.title || packageTitle;
+};
+
 /**
  * This component displays additional status details of an agentless agent enrolled
- * the chosen package policy (and its agent policy).
- * It also displays confirmation that the agentless agent is ingesting data from
- * the chosen package policy.
+ * into the chosen agentless policy (and its agent policy).
+ * It also displays confirmation that the agentless agent is ingesting data.
  */
 export const AgentlessEnrollmentFlyout = ({
   onClose,
-  packagePolicy,
+  policyId,
+  policyName,
+  packageInfo,
+  selectedInput,
   agentPolicy,
-}: {
-  onClose: () => void;
-  packagePolicy: PackagePolicy;
-  agentPolicy?: AgentPolicy;
-}) => {
+  connectors,
+}: AgentlessEnrollmentFlyoutProps) => {
   const core = useStartServices();
   const { notifications } = core;
   const [confirmEnrollmentStatus, setConfirmEnrollmentStatus] = useState<EuiStepStatus>('loading');
@@ -63,12 +105,12 @@ export const AgentlessEnrollmentFlyout = ({
     };
   }, [agentDataInterval]);
 
-  // Fetch agent(s) data for the first associated agent policy
+  // Fetch agent(s) data for the agent policy identified by the `policyId` prop
   // Polls every 30 seconds until agent is found and healthy
   useEffect(() => {
     const fetchAgents = async () => {
       const { data: agentsData, error } = await sendGetAgents({
-        kuery: `${AGENTS_PREFIX}.policy_id: "${packagePolicy.policy_ids[0]}"`,
+        kuery: `${AGENTS_PREFIX}.policy_id: "${policyId}"`,
       });
 
       if (error) {
@@ -93,7 +135,7 @@ export const AgentlessEnrollmentFlyout = ({
     }, REFRESH_INTERVAL_MS);
 
     return () => clearAgentDataPolling();
-  }, [clearAgentDataPolling, notifications.toasts, packagePolicy.policy_ids]);
+  }, [clearAgentDataPolling, notifications.toasts, policyId]);
 
   // Watches agent data and updates step statuses and clears polling when agent is healthy
   useEffect(() => {
@@ -115,41 +157,29 @@ export const AgentlessEnrollmentFlyout = ({
     }
   }, [agentData, clearAgentDataPolling]);
 
-  // Calculate integration title from the base package info and what
-  // is configured on the package policy.
+  // Calculate integration title from the base package info
   const { data: packageInfoData } = useGetPackageInfoByKeyQuery(
-    packagePolicy.package!.name,
-    packagePolicy.package!.version,
+    packageInfo.name,
+    packageInfo.version,
     {
       prerelease: true,
     }
   );
 
-  const integrationTitle = useMemo(() => {
-    if (packageInfoData?.item) {
-      const enabledInputs = packagePolicy.inputs?.filter((input) => input.enabled);
-
-      // If only one input is enabled, find the input name from the package info and
-      // and use that for integration title. Otherwise, use the package name.
-      if (enabledInputs.length === 1 && enabledInputs[0].policy_template) {
-        const policyTemplate = packageInfoData.item.policy_templates?.find(
-          (template) => template.name === enabledInputs[0].policy_template
-        );
-        const input =
-          policyTemplate && 'inputs' in policyTemplate
-            ? policyTemplate.inputs?.find((i) => i.type === enabledInputs[0].type)
-            : null;
-        return input?.title || packageInfoData.item.title;
-      } else {
-        return packageInfoData.item.title;
-      }
-    }
-    return packagePolicy.name;
-  }, [packageInfoData, packagePolicy]);
+  const integrationTitle = useMemo(
+    () =>
+      resolveIntegrationTitle({
+        packageTitle: packageInfoData?.item?.title,
+        policyTemplates: packageInfoData?.item?.policy_templates,
+        selectedInput,
+        fallbackName: policyName,
+      }),
+    [packageInfoData, selectedInput, policyName]
+  );
 
   // Connector integrations don't ingest data until the connector is configured,
   // so the "Confirm incoming data" step is reframed as a connector setup step.
-  const isConnector = packagePolicy.package?.name === FLEET_CONNECTORS_PACKAGE;
+  const isConnector = packageInfo.name === FLEET_CONNECTORS_PACKAGE;
 
   return (
     <EuiFlyout
@@ -160,7 +190,7 @@ export const AgentlessEnrollmentFlyout = ({
     >
       <EuiFlyoutHeader hasBorder aria-labelledby="FleetAgentlessEnrollmentFlyoutTitle">
         <EuiTitle size="m">
-          <h2 id="FleetAgentlessEnrollmentFlyoutTitle">{packagePolicy.name}</h2>
+          <h2 id="FleetAgentlessEnrollmentFlyoutTitle">{policyName}</h2>
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
@@ -197,16 +227,18 @@ export const AgentlessEnrollmentFlyout = ({
                 agentData && confirmEnrollmentStatus === 'complete' ? (
                   isConnector ? (
                     <AgentlessStepConfigureConnector
-                      packagePolicy={packagePolicy}
-                      policyTemplates={packageInfoData?.item.policy_templates}
+                      connectors={connectors}
+                      policyName={policyName}
+                      policyTemplates={packageInfoData?.item?.policy_templates}
                       setStepStatus={setConfirmDataStatus}
                       onClose={onClose}
                     />
                   ) : (
                     <AgentlessStepConfirmData
                       agent={agentData}
-                      packagePolicy={packagePolicy}
-                      policyTemplates={packageInfoData?.item.policy_templates}
+                      packageName={packageInfo.name}
+                      packageVersion={packageInfo.version}
+                      policyTemplates={packageInfoData?.item?.policy_templates}
                       setConfirmDataStatus={setConfirmDataStatus}
                     />
                   )

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/index.tsx
@@ -28,7 +28,8 @@ import { sendGetAgents, useStartServices, useGetPackageInfoByKeyQuery } from '..
 import { AgentlessStepConfirmEnrollment } from './step_confirm_enrollment';
 import { AgentlessStepConfirmData } from './step_confirm_data';
 import { AgentlessStepConfigureConnector } from './step_configure_connector';
-import type { AgentlessEnrollmentFlyoutProps, AgentlessEnrollmentSelectedInput } from './types';
+import type { AgentlessEnrollmentFlyoutProps } from './types';
+import { resolveIntegrationTitle } from './utils';
 
 // re-export the flyout contract types so external consumers can import them from this module
 export type {
@@ -38,41 +39,6 @@ export type {
 } from './types';
 
 const REFRESH_INTERVAL_MS = 30000;
-
-/** Minimal shape needed from the package's policy templates to resolve a title. */
-interface IntegrationTitleSource {
-  name: string;
-  inputs?: Array<{ type: string; title?: string }>;
-}
-
-/**
- * Resolves the integration title shown in the enrollment copy. When a single input
- * is selected, prefer that input's title from the package's policy templates
- * (e.g. "AWS S3"); otherwise fall back to the package title, then the policy name.
- */
-export const resolveIntegrationTitle = ({
-  packageTitle,
-  policyTemplates,
-  selectedInput,
-  fallbackName,
-}: {
-  packageTitle?: string;
-  policyTemplates?: IntegrationTitleSource[];
-  selectedInput?: AgentlessEnrollmentSelectedInput;
-  fallbackName: string;
-}): string => {
-  if (!packageTitle) {
-    return fallbackName;
-  }
-  if (!selectedInput) {
-    return packageTitle;
-  }
-  const policyTemplate = policyTemplates?.find(
-    (template) => template.name === selectedInput.policyTemplate
-  );
-  const input = policyTemplate?.inputs?.find((i) => i.type === selectedInput.type);
-  return input?.title || packageTitle;
-};
 
 /**
  * This component displays additional status details of an agentless agent enrolled

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/next_steps.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/next_steps.tsx
@@ -16,13 +16,11 @@ import {
 } from '@elastic/eui';
 
 import { useStartServices } from '../../hooks';
-import type { PackagePolicy, RegistryPolicyTemplate } from '../../types';
+import type { RegistryPolicyTemplate } from '../../types';
 
 export const NextSteps = ({
-  packagePolicy,
   policyTemplates,
 }: {
-  packagePolicy: PackagePolicy;
   policyTemplates?: RegistryPolicyTemplate[];
 }) => {
   const { application } = useStartServices();

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/next_steps.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/next_steps.tsx
@@ -18,11 +18,7 @@ import {
 import { useStartServices } from '../../hooks';
 import type { RegistryPolicyTemplate } from '../../types';
 
-export const NextSteps = ({
-  policyTemplates,
-}: {
-  policyTemplates?: RegistryPolicyTemplate[];
-}) => {
+export const NextSteps = ({ policyTemplates }: { policyTemplates?: RegistryPolicyTemplate[] }) => {
   const { application } = useStartServices();
 
   const configurationLinks = useMemo(() => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_configure_connector.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_configure_connector.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiStepStatus } from '@elastic/eui';
@@ -14,9 +14,10 @@ import { EuiText, EuiSpacer, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiCard } fr
 import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 
 import { useStartServices } from '../../hooks';
-import type { PackagePolicy, RegistryPolicyTemplate } from '../../types';
+import type { RegistryPolicyTemplate } from '../../types';
 
 import { NextSteps } from './next_steps';
+import type { AgentlessEnrollmentConnector } from './types';
 
 const CONNECTORS_PATH = '/data/content_connectors/connectors';
 
@@ -26,12 +27,14 @@ const CONNECTORS_PATH = '/data/content_connectors/connectors';
  * connector configuration and is considered complete as soon as it renders.
  */
 export const AgentlessStepConfigureConnector = ({
-  packagePolicy,
+  connectors,
+  policyName,
   setStepStatus,
   policyTemplates,
   onClose,
 }: {
-  packagePolicy: PackagePolicy;
+  connectors?: AgentlessEnrollmentConnector[];
+  policyName: string;
   setStepStatus: (status: EuiStepStatus) => void;
   policyTemplates?: RegistryPolicyTemplate[];
   onClose: () => void;
@@ -49,33 +52,25 @@ export const AgentlessStepConfigureConnector = ({
     });
   };
 
-  // A connector may already be associated with the policy (via its input vars).
-  // When it is, deep-link to that connector; otherwise fall back to the
-  // connectors list so the user can still reach the configuration screen.
-  const connectorInputs = useMemo(
-    () =>
-      packagePolicy.inputs.filter(
-        (input) => !!input?.vars?.connector_id?.value || !!input?.vars?.connector_name?.value
-      ),
-    [packagePolicy.inputs]
-  );
-
   const cardDescription = i18n.translate(
     'xpack.fleet.agentlessEnrollmentFlyout.configureConnector.cardDescription',
     { defaultMessage: 'Configure connector' }
   );
 
+  // A connector may already be associated with the policy. When it is, deep-link
+  // to that connector; otherwise fall back to the connectors list so the user can
+  // still reach the configuration screen.
   const connectorCards =
-    connectorInputs.length > 0 ? (
-      connectorInputs.map((input, index) => {
-        const connectorId = input?.vars?.connector_id?.value ?? index;
+    connectors && connectors.length > 0 ? (
+      connectors.map((connector, index) => {
+        const connectorKey = connector.id ?? index;
         return (
-          <EuiFlexItem key={connectorId}>
+          <EuiFlexItem key={connectorKey}>
             <EuiCard
-              data-test-subj={`agentlessStepConfigureConnector.connectorCard.${connectorId}`}
-              title={`${input?.vars?.connector_name?.value ?? packagePolicy.name}`}
+              data-test-subj={`agentlessStepConfigureConnector.connectorCard.${connectorKey}`}
+              title={`${connector.name ?? policyName}`}
               description={cardDescription}
-              onClick={() => navigateToConnector(input?.vars?.connector_id?.value)}
+              onClick={() => navigateToConnector(connector.id)}
             />
           </EuiFlexItem>
         );
@@ -84,7 +79,7 @@ export const AgentlessStepConfigureConnector = ({
       <EuiFlexItem>
         <EuiCard
           data-test-subj="agentlessStepConfigureConnector.connectorCard"
-          title={packagePolicy.name}
+          title={policyName}
           description={cardDescription}
           onClick={() => navigateToConnector()}
         />
@@ -117,7 +112,7 @@ export const AgentlessStepConfigureConnector = ({
       <EuiFlexGroup alignItems="center" direction="row" wrap={true}>
         {connectorCards}
       </EuiFlexGroup>
-      <NextSteps packagePolicy={packagePolicy} policyTemplates={policyTemplates} />
+      <NextSteps policyTemplates={policyTemplates} />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.tsx
@@ -12,7 +12,7 @@ import type { EuiStepStatus } from '@elastic/eui';
 import { EuiText, EuiLink, EuiSpacer, EuiCallOut } from '@elastic/eui';
 
 import { useStartServices } from '../../hooks';
-import type { Agent, PackagePolicy, RegistryPolicyTemplate } from '../../types';
+import type { Agent, RegistryPolicyTemplate } from '../../types';
 import {
   usePollingIncomingData,
   POLLING_TIMEOUT_MS,
@@ -22,23 +22,25 @@ import { NextSteps } from './next_steps';
 
 export const AgentlessStepConfirmData = ({
   agent,
-  packagePolicy,
+  packageName,
+  packageVersion,
   setConfirmDataStatus,
   policyTemplates,
 }: {
   agent: Agent;
-  packagePolicy: PackagePolicy;
+  packageName: string;
+  packageVersion: string;
   setConfirmDataStatus: (status: EuiStepStatus) => void;
   policyTemplates?: RegistryPolicyTemplate[];
 }) => {
   const { docLinks } = useStartServices();
   const [overallState, setOverallState] = useState<'pending' | 'success' | 'failure'>('pending');
 
-  // Fetch integration data for the given agent and package policy
+  // Fetch integration data for the given agent and package
   const { incomingData, hasReachedTimeout } = usePollingIncomingData({
     agentIds: [agent.id],
-    pkgName: packagePolicy.package!.name,
-    pkgVersion: packagePolicy.package!.version,
+    pkgName: packageName,
+    pkgVersion: packageVersion,
   });
 
   // Calculate overall UI state from polling data
@@ -67,7 +69,7 @@ export const AgentlessStepConfirmData = ({
           iconType="check"
         />
         <EuiSpacer size="m" />
-        <NextSteps packagePolicy={packagePolicy} policyTemplates={policyTemplates} />
+        <NextSteps policyTemplates={policyTemplates} />
       </>
     );
   } else if (overallState === 'failure') {

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/types.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/types.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentPolicy } from '../../types';
+
+/**
+ * A connector referenced by an agentless policy, rendered as a deep-link card.
+ * Intentionally decoupled from both `PackagePolicy` inputs and the `AgentlessPolicy`
+ * DTO: the caller maps its own source into these primitives.
+ */
+export interface AgentlessEnrollmentConnector {
+  /** Connector ID. When present, the card links straight to the connector. */
+  id?: string;
+  /** Connector display name, used as the card title. */
+  name?: string;
+}
+
+/** Identifies the enabled input whose title should label the integration. */
+export interface AgentlessEnrollmentSelectedInput {
+  policyTemplate: string;
+  type: string;
+}
+
+/**
+ * Minimal contract for the agentless enrollment flyout, intentionally decoupled
+ * from both `PackagePolicy` and the `AgentlessPolicy` API DTO. The caller maps its
+ * own data source (today `PackagePolicy`, eventually the agentless policies API)
+ * into these primitives, so the flyout never has to change when the source flips.
+ */
+export interface AgentlessEnrollmentFlyoutProps {
+  onClose: () => void;
+  /**
+   * Agent-policy ID the agentless agent is enrolled into. Used as the key to look
+   * up the agent (`fleet-agents.agent.policy_id`). The caller is responsible for
+   * supplying the agent-policy id from its own source (today `PackagePolicy.policy_ids[0]`,
+   * later `AgentlessPolicy.id`, which equals the agent-policy id by server design).
+   */
+  policyId: string;
+  /** Display name used for the flyout header. */
+  policyName: string;
+  /** Package name and version, used to fetch package info and poll incoming data. */
+  packageInfo: { name: string; version: string };
+  /**
+   * The single enabled input, used to resolve a more specific integration title
+   * (e.g. "AWS S3") from the package's policy templates. When omitted, the flyout
+   * falls back to the package title. The caller maps this from its own source
+   * (today the `PackagePolicy` enabled input).
+   */
+  selectedInput?: AgentlessEnrollmentSelectedInput;
+  /** Used only to render integration details in the enrollment error state. */
+  agentPolicy?: AgentPolicy;
+  /**
+   * Connectors referenced by the policy, rendered as deep-link cards once data is
+   * confirmed. The caller maps these from its own source (`PackagePolicy` inputs
+   * today, the `AgentlessPolicy` API inputs later), so the flyout stays decoupled.
+   */
+  connectors?: AgentlessEnrollmentConnector[];
+}

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/utils.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { resolveIntegrationTitle } from './utils';
+
+describe('resolveIntegrationTitle', () => {
+  const policyTemplates = [
+    {
+      name: 'aws',
+      inputs: [
+        { type: 's3', title: 'AWS S3' },
+        { type: 'cloudwatch', title: 'AWS CloudWatch' },
+      ],
+    },
+  ];
+
+  it('falls back to the policy name when the package title is unavailable', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: undefined,
+        policyTemplates,
+        selectedInput: { policyTemplate: 'aws', type: 's3' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('My agentless policy');
+  });
+
+  it('uses the package title when no input is selected', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: undefined,
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('Amazon Web Services');
+  });
+
+  it('uses the selected input title when it resolves', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: { policyTemplate: 'aws', type: 's3' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('AWS S3');
+  });
+
+  it('falls back to the package title when the policy template is not found', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: { policyTemplate: 'gcp', type: 's3' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('Amazon Web Services');
+  });
+
+  it('falls back to the package title when the input type is not found in the template', () => {
+    expect(
+      resolveIntegrationTitle({
+        packageTitle: 'Amazon Web Services',
+        policyTemplates,
+        selectedInput: { policyTemplate: 'aws', type: 'kinesis' },
+        fallbackName: 'My agentless policy',
+      })
+    ).toBe('Amazon Web Services');
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentlessEnrollmentSelectedInput } from './types';
+
+/** Minimal shape needed from the package's policy templates to resolve a title. */
+interface IntegrationTitleSource {
+  name: string;
+  inputs?: Array<{ type: string; title?: string }>;
+}
+
+/**
+ * Resolves the integration title shown in the enrollment copy. When a single input
+ * is selected, prefer that input's title from the package's policy templates
+ * (e.g. "AWS S3"); otherwise fall back to the package title, then the policy name.
+ */
+export const resolveIntegrationTitle = ({
+  packageTitle,
+  policyTemplates,
+  selectedInput,
+  fallbackName,
+}: {
+  packageTitle?: string;
+  policyTemplates?: IntegrationTitleSource[];
+  selectedInput?: AgentlessEnrollmentSelectedInput;
+  fallbackName: string;
+}): string => {
+  if (!packageTitle) {
+    return fallbackName;
+  }
+  if (!selectedInput) {
+    return packageTitle;
+  }
+  const policyTemplate = policyTemplates?.find(
+    (template) => template.name === selectedInput.policyTemplate
+  );
+  const input = policyTemplate?.inputs?.find((i) => i.type === selectedInput.type);
+  return input?.title || packageTitle;
+};

--- a/x-pack/platform/plugins/shared/fleet/public/components/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/index.ts
@@ -29,3 +29,8 @@ export { HeaderReleaseBadge, InlineReleaseBadge } from './release_badge';
 export { UninstallCommandFlyout } from './uninstall_command_flyout';
 export { MultipleAgentPoliciesSummaryLine } from './multiple_agent_policy_summary_line';
 export { AgentlessEnrollmentFlyout } from './agentless_enrollment_flyout';
+export type {
+  AgentlessEnrollmentFlyoutProps,
+  AgentlessEnrollmentConnector,
+  AgentlessEnrollmentSelectedInput,
+} from './agentless_enrollment_flyout';


### PR DESCRIPTION
## Summary

This PR decouples Agentless enrollment flyout from package policy without changing any functionality.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



