### PR TITLE
[Flaky] Fix alert_details_right_panel_table_tab.cy.ts (fixes #270433)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -454,9 +454,9 @@ export const showTopNAlertProperty = (propertySelector: string, rowIndex: number
 export const waitForAlerts = () => {
   waitForPageFilters();
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
-  cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
+  cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test `alert_details_right_panel_table_tab.cy.ts` was failing with a 150-second timeout on `cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist')` in `waitForAlerts` (`tasks/alerts.ts`), called from `waitForAlertsToPopulate`. The global loading indicator (`globalLoadingIndicator`) tracks ALL in-flight HTTP requests made through Kibana's `http` service — not just the specific search strategy endpoint. The root cause was an ordering issue in `waitForAlerts`: `cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500)` was called BEFORE the `LOADING_INDICATOR` check. During the 500ms idle window for that specific endpoint, other background requests (entity analytics, data view init, histogram fetches, etc.) would fire. After `waitForNetworkIdle` resolved, those non-search requests were still in flight and kept the spinner visible for the entire 150s Cypress retry window. The fix moves `waitForNetworkIdle` to AFTER the `LOADING_INDICATOR` check, so the spinner naturally waits for ALL in-flight requests (not just the search endpoint) to complete before the assertion passes. Then `waitForNetworkIdle` confirms the search endpoint is also idle. This is the same root cause and fix as identified for the related `bulk_add_to_timeline` flaky test on a parallel fix branch.

**Changes**

- 53f83407fc29 fix(test): fix flaky alert_details_right_panel_table_tab by checking loading indicator before network idle

Fixes #270433
Fixes #270434




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->