### PR TITLE
[9.4] [Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion (#274408)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -61,7 +61,7 @@ import {
   TIMELINE_CONTEXT_MENU_BTN,
   TOOLTIP,
 } from '../screens/alerts';
-import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
+import { REFRESH_BUTTON } from '../screens/security_header';
 import {
   ENRICHMENT_QUERY_END_INPUT,
   ENRICHMENT_QUERY_RANGE_PICKER,
@@ -456,7 +456,6 @@ export const waitForAlerts = () => {
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
-  cy.get(LOADING_INDICATOR).should('not.exist');
   cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion (#274408)](https://github.com/elastic/kibana/pull/274408)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-06-23T21:02:27Z","message":"[Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion (#274408)\n\n## Summary\n\n### What\nRemoves `cy.get(LOADING_INDICATOR).should('not.exist')` from the shared\n`waitForAlerts()` Cypress helper and drops the now-unused\n`LOADING_INDICATOR` import.\n\n### Why\n`LOADING_INDICATOR` maps to `[data-test-subj=\"globalLoadingIndicator\"]`\n— the chrome-level EUI spinner driven by `http.getLoadingCount$()`. It\nfires for *any* in-flight HTTP request app-wide (telemetry,\ncapabilities, session pings), not just the alerts search.\n`waitForAlertsToPopulate()` calls `refreshPage()` in a retry loop, which\npiles up unrelated network requests and keeps the spinner mounted\nindefinitely. The 150 s timeout was exhausted before those chrome\nrequests settled.\n\nThe four preceding checks already guarantee the alerts table is fully\nsettled:\n- `waitForPageFilters()` — page filter controls ready\n-\n`cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy',\n500)` — alerts search idle\n- `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')` —\ndatagrid not updating\n- `cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist')` — table\nnot loading\n\nThe global spinner check was redundant and harmful.\n\nFixes #272791\nFixes #274536\nFixes #274543\nFixes #274544\nFixes #274608\nFixes #274616\n\n## Changes\n\n- `cypress/tasks/alerts.ts`: removed\n`cy.get(LOADING_INDICATOR).should('not.exist')` from `waitForAlerts()`\nand dropped the `LOADING_INDICATOR` named import (still exported from\n`screens/security_header.ts` and used by other task files)\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n**Low risk — test helper only.** No production code touched. The removed\nassertion was redundant (already covered by the preceding four checks).\nThe only failure mode is if the alerts table could be unsettled after\nall four preceding guards pass, which is not possible given they include\na network-idle wait on the alerts search endpoint itself. The change\nmakes existing tests more reliable; it does not loosen any\nbusiness-logic assertion.\n\n### Release note\n\n> No user-facing changes — test helper fix only.\n\n**Suggested label:** `release_note:skip`\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"2ad5bfb41fdd6cb6401213bd9cd230ff69cc0693","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","backport:all-open","v9.5.0"],"title":"[Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion","number":274408,"url":"https://github.com/elastic/kibana/pull/274408","mergeCommit":{"message":"[Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion (#274408)\n\n## Summary\n\n### What\nRemoves `cy.get(LOADING_INDICATOR).should('not.exist')` from the shared\n`waitForAlerts()` Cypress helper and drops the now-unused\n`LOADING_INDICATOR` import.\n\n### Why\n`LOADING_INDICATOR` maps to `[data-test-subj=\"globalLoadingIndicator\"]`\n— the chrome-level EUI spinner driven by `http.getLoadingCount$()`. It\nfires for *any* in-flight HTTP request app-wide (telemetry,\ncapabilities, session pings), not just the alerts search.\n`waitForAlertsToPopulate()` calls `refreshPage()` in a retry loop, which\npiles up unrelated network requests and keeps the spinner mounted\nindefinitely. The 150 s timeout was exhausted before those chrome\nrequests settled.\n\nThe four preceding checks already guarantee the alerts table is fully\nsettled:\n- `waitForPageFilters()` — page filter controls ready\n-\n`cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy',\n500)` — alerts search idle\n- `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')` —\ndatagrid not updating\n- `cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist')` — table\nnot loading\n\nThe global spinner check was redundant and harmful.\n\nFixes #272791\nFixes #274536\nFixes #274543\nFixes #274544\nFixes #274608\nFixes #274616\n\n## Changes\n\n- `cypress/tasks/alerts.ts`: removed\n`cy.get(LOADING_INDICATOR).should('not.exist')` from `waitForAlerts()`\nand dropped the `LOADING_INDICATOR` named import (still exported from\n`screens/security_header.ts` and used by other task files)\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n**Low risk — test helper only.** No production code touched. The removed\nassertion was redundant (already covered by the preceding four checks).\nThe only failure mode is if the alerts table could be unsettled after\nall four preceding guards pass, which is not possible given they include\na network-idle wait on the alerts search endpoint itself. The change\nmakes existing tests more reliable; it does not loosen any\nbusiness-logic assertion.\n\n### Release note\n\n> No user-facing changes — test helper fix only.\n\n**Suggested label:** `release_note:skip`\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"2ad5bfb41fdd6cb6401213bd9cd230ff69cc0693"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274408","number":274408,"mergeCommit":{"message":"[Flaky] Fix waitForAlerts: remove globalLoadingIndicator assertion (#274408)\n\n## Summary\n\n### What\nRemoves `cy.get(LOADING_INDICATOR).should('not.exist')` from the shared\n`waitForAlerts()` Cypress helper and drops the now-unused\n`LOADING_INDICATOR` import.\n\n### Why\n`LOADING_INDICATOR` maps to `[data-test-subj=\"globalLoadingIndicator\"]`\n— the chrome-level EUI spinner driven by `http.getLoadingCount$()`. It\nfires for *any* in-flight HTTP request app-wide (telemetry,\ncapabilities, session pings), not just the alerts search.\n`waitForAlertsToPopulate()` calls `refreshPage()` in a retry loop, which\npiles up unrelated network requests and keeps the spinner mounted\nindefinitely. The 150 s timeout was exhausted before those chrome\nrequests settled.\n\nThe four preceding checks already guarantee the alerts table is fully\nsettled:\n- `waitForPageFilters()` — page filter controls ready\n-\n`cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy',\n500)` — alerts search idle\n- `cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true')` —\ndatagrid not updating\n- `cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist')` — table\nnot loading\n\nThe global spinner check was redundant and harmful.\n\nFixes #272791\nFixes #274536\nFixes #274543\nFixes #274544\nFixes #274608\nFixes #274616\n\n## Changes\n\n- `cypress/tasks/alerts.ts`: removed\n`cy.get(LOADING_INDICATOR).should('not.exist')` from `waitForAlerts()`\nand dropped the `LOADING_INDICATOR` named import (still exported from\n`screens/security_header.ts` and used by other task files)\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n**Low risk — test helper only.** No production code touched. The removed\nassertion was redundant (already covered by the preceding four checks).\nThe only failure mode is if the alerts table could be unsettled after\nall four preceding guards pass, which is not possible given they include\na network-idle wait on the alerts search endpoint itself. The change\nmakes existing tests more reliable; it does not loosen any\nbusiness-logic assertion.\n\n### Release note\n\n> No user-facing changes — test helper fix only.\n\n**Suggested label:** `release_note:skip`\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"2ad5bfb41fdd6cb6401213bd9cd230ff69cc0693"}},{"url":"https://github.com/elastic/kibana/pull/274820","number":274820,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->