### PR TITLE
[9.4] [Flaky] Fix alert_context_menu Case actions test flakiness (fixes #268147) (#274244)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { render, waitFor } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { AlertContextMenu } from './alert_context_menu';
 import { TestProviders } from '../../../../common/mock';
 import React from 'react';
@@ -142,49 +141,43 @@ const documentWorkflowPanelContent = 'document-workflow-panel-content';
 
 describe('Alert table context menu', () => {
   describe('Case actions', () => {
-    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', async () => {
+    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', () => {
       const wrapper = render(
         <TestProviders>
           <AlertContextMenu {...props} scopeId={TableId.alertsOnAlertsPage} />
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      await waitFor(() => {
-        expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
-        expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
-      });
+      expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
+      expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
     });
 
-    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsRulesDetailsPage', async () => {
+    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsRulesDetailsPage', () => {
       const wrapper = render(
         <TestProviders>
           <AlertContextMenu {...props} scopeId={TableId.alertsOnRuleDetailsPage} />
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      await waitFor(() => {
-        expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
-        expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
-      });
+      expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
+      expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
     });
 
-    test('it render AddToCase context menu item if timelineId === TimelineId.active', async () => {
+    test('it render AddToCase context menu item if timelineId === TimelineId.active', () => {
       const wrapper = render(
         <TestProviders>
           <AlertContextMenu {...props} scopeId={TimelineId.active} />
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      await waitFor(() => {
-        expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
-        expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
-      });
+      expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
+      expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
     });
   });
 
@@ -196,7 +189,7 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
       expect(wrapper.queryByTestId(markAsOpenButton)).toBeNull();
       expect(wrapper.getByTestId(markAsAcknowledgedButton)).toBeInTheDocument();
@@ -234,7 +227,7 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
       expect(wrapper.queryByTestId(runWorkflowActionButton)).not.toBeInTheDocument();
     });
@@ -251,7 +244,7 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
       expect(wrapper.getByTestId(runWorkflowActionButton)).toBeInTheDocument();
     });
@@ -268,8 +261,8 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
-      await userEvent.click(wrapper.getByTestId(runWorkflowActionButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(runWorkflowActionButton));
 
       await waitFor(() => {
         expect(wrapper.getByTestId(alertWorkflowPanelContent)).toBeInTheDocument();
@@ -330,7 +323,7 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
       expect(wrapper.queryByTestId(runDocumentWorkflowActionButton)).not.toBeInTheDocument();
     });
@@ -347,13 +340,12 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
       expect(wrapper.getByTestId(runDocumentWorkflowActionButton)).toBeInTheDocument();
     });
 
     test('it shows the document workflow panel when run workflow action is clicked', async () => {
-      const user = userEvent.setup({ pointerEventsCheck: 0 });
       mockUseRunDocumentWorkflowPanel.mockReturnValue({
         runWorkflowMenuItem: mockDocumentWorkflowMenuItem,
         runDocumentWorkflowPanel: mockDocumentWorkflowPanel,
@@ -365,8 +357,8 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await user.click(wrapper.getByTestId(actionMenuButton));
-      await user.click(wrapper.getByTestId(runDocumentWorkflowActionButton));
+      fireEvent.click(wrapper.getByTestId(actionMenuButton));
+      fireEvent.click(wrapper.getByTestId(runDocumentWorkflowActionButton));
 
       await waitFor(() => {
         expect(wrapper.getByTestId(documentWorkflowPanelContent)).toBeInTheDocument();
@@ -403,7 +395,7 @@ describe('Alert table context menu', () => {
             </TestProviders>
           );
 
-          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+          fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
           const button = wrapper.getByTestId(addEndpointEventFilterButton);
 
@@ -418,7 +410,7 @@ describe('Alert table context menu', () => {
             </TestProviders>
           );
 
-          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+          fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
           const button = wrapper.getByTestId(addEndpointEventFilterButton);
 
@@ -437,7 +429,7 @@ describe('Alert table context menu', () => {
             </TestProviders>
           );
 
-          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+          fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
           const button = wrapper.getByTestId(addEndpointEventFilterButton);
 
@@ -452,7 +444,7 @@ describe('Alert table context menu', () => {
             </TestProviders>
           );
 
-          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+          fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
           const button = wrapper.getByTestId(addEndpointEventFilterButton);
 
@@ -471,7 +463,7 @@ describe('Alert table context menu', () => {
             </TestProviders>
           );
 
-          await userEvent.click(wrapper.getByTestId(actionMenuButton));
+          fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
           const button = wrapper.getByTestId(addEndpointEventFilterButton);
 
@@ -489,7 +481,7 @@ describe('Alert table context menu', () => {
           </TestProviders>
         );
 
-        await userEvent.click(wrapper.getByTestId(actionMenuButton));
+        fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
         await waitFor(() => {
           expect(wrapper.getByTestId(applyAlertTagsButton)).toBeTruthy();
@@ -505,7 +497,7 @@ describe('Alert table context menu', () => {
           </TestProviders>
         );
 
-        await userEvent.click(wrapper.getByTestId(actionMenuButton));
+        fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
         await waitFor(() => {
           expect(wrapper.getByTestId(applyAlertAssigneesButton)).toBeTruthy();


### PR DESCRIPTION
# Backport

Closes: [268147](https://github.com/elastic/kibana/issues/268147)

This will backport the following commits from `main` to `9.4`:
 - [[Flaky] Fix alert_context_menu Case actions test flakiness (fixes #268147) (#274244)](https://github.com/elastic/kibana/pull/274244)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-06-22T10:59:53Z","message":"[Flaky] Fix alert_context_menu Case actions test flakiness (fixes #268147) (#274244)\n\n## Summary\n\nFixes #268147\n\nThe three \"Case actions\" tests used `await waitFor()` after\n`fireEvent.click`, but EUI's `EuiPopover` renders its content\nsynchronously when `isOpen` becomes `true`. RTL's `waitFor` wraps each\npolling interval in an internal `act()` that flushes the microtask\nqueue; under CI load this async overhead, combined with first-run module\nloading, was pushing the first test past Jest's 5s wall. Other tests in\nthe same file (`Alert status actions`, `Workflow actions`, `Endpoint\nevent filter`) already use direct assertions after `fireEvent.click`\nwithout `waitFor`, confirming the popover renders synchronously.\n\n**Fix:** Removed `await waitFor()` from all three Case actions tests,\nreplaced with synchronous `getByTestId` assertions, removed `async`\nkeyword from those test functions, and replaced `await\nuserEvent.click()` calls with `fireEvent.click()` throughout the file.\n\n## Risk\n\nLow — simplifies async overhead, aligns with existing patterns in the\nsame file.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"11c9dded42f6c464fc5acc923d20a930bf222803","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Threat Hunting","v9.5.0"],"title":"[Flaky] Fix alert_context_menu Case actions test flakiness (fixes #268147)","number":274244,"url":"https://github.com/elastic/kibana/pull/274244","mergeCommit":{"message":"[Flaky] Fix alert_context_menu Case actions test flakiness (fixes #268147) (#274244)\n\n## Summary\n\nFixes #268147\n\nThe three \"Case actions\" tests used `await waitFor()` after\n`fireEvent.click`, but EUI's `EuiPopover` renders its content\nsynchronously when `isOpen` becomes `true`. RTL's `waitFor` wraps each\npolling interval in an internal `act()` that flushes the microtask\nqueue; under CI load this async overhead, combined with first-run module\nloading, was pushing the first test past Jest's 5s wall. Other tests in\nthe same file (`Alert status actions`, `Workflow actions`, `Endpoint\nevent filter`) already use direct assertions after `fireEvent.click`\nwithout `waitFor`, confirming the popover renders synchronously.\n\n**Fix:** Removed `await waitFor()` from all three Case actions tests,\nreplaced with synchronous `getByTestId` assertions, removed `async`\nkeyword from those test functions, and replaced `await\nuserEvent.click()` calls with `fireEvent.click()` throughout the file.\n\n## Risk\n\nLow — simplifies async overhead, aligns with existing patterns in the\nsame file.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"11c9dded42f6c464fc5acc923d20a930bf222803"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274244","number":274244,"mergeCommit":{"message":"[Flaky] Fix alert_context_menu Case actions test flakiness (fixes #268147) (#274244)\n\n## Summary\n\nFixes #268147\n\nThe three \"Case actions\" tests used `await waitFor()` after\n`fireEvent.click`, but EUI's `EuiPopover` renders its content\nsynchronously when `isOpen` becomes `true`. RTL's `waitFor` wraps each\npolling interval in an internal `act()` that flushes the microtask\nqueue; under CI load this async overhead, combined with first-run module\nloading, was pushing the first test past Jest's 5s wall. Other tests in\nthe same file (`Alert status actions`, `Workflow actions`, `Endpoint\nevent filter`) already use direct assertions after `fireEvent.click`\nwithout `waitFor`, confirming the popover renders synchronously.\n\n**Fix:** Removed `await waitFor()` from all three Case actions tests,\nreplaced with synchronous `getByTestId` assertions, removed `async`\nkeyword from those test functions, and replaced `await\nuserEvent.click()` calls with `fireEvent.click()` throughout the file.\n\n## Risk\n\nLow — simplifies async overhead, aligns with existing patterns in the\nsame file.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"11c9dded42f6c464fc5acc923d20a930bf222803"}}]}] BACKPORT-->