### PR TITLE
[Flaky] Fix navigation.cy.ts (fixes #270166)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/serverless_security_header.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/serverless_security_header.ts
@@ -115,6 +115,12 @@ export const openNavigationPanelFor = (pageName: string) => {
  * Unconditionally opening "More" when the control is already visible is a common flake (extra overlay, layout races).
  */
 const clickWhenVisibleElseOpenMore = (selector: string) => {
+  // Wait for chrome to settle before checking visibility — the SideNav can cover elements with a
+  // transient overlay (css-1rrlroc) while it is still measuring/laying out after initial render.
+  // https://github.com/elastic/kibana/issues/239331
+  cy.get('[data-test-subj~="nav-item"]').should('exist');
+  cy.get('[data-test-subj="globalLoadingIndicator-hidden"]').should('exist');
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
   cy.get('body').then(($body) => {
     const hasVisible = $body.find(selector).filter(':visible').length > 0;
     if (hasVisible) {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/serverless_security_header.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/serverless_security_header.ts
@@ -118,7 +118,11 @@ const clickWhenVisibleElseOpenMore = (selector: string) => {
   // Wait for chrome to settle before checking visibility — the SideNav can cover elements with a
   // transient overlay (css-1rrlroc) while it is still measuring/laying out after initial render.
   // https://github.com/elastic/kibana/issues/239331
-  cy.get('[data-test-subj~="nav-item"]').should('exist');
+  // nav-item is a serverless-only chrome selector; skip this check in stateful/ESS environments
+  // where openNavigationPanel from this file may still be called (e.g. siem_migrations.ts).
+  if (Cypress.env('IS_SERVERLESS')) {
+    cy.get('[data-test-subj~="nav-item"]').should('exist');
+  }
   cy.get('[data-test-subj="globalLoadingIndicator-hidden"]').should('exist');
   cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
   cy.get('body').then(($body) => {


### PR DESCRIPTION
## Summary

## Approach and Hypothesis

The test "Serverless side navigation links navigates to the Findings page" in `navigation.cy.ts` failed because `cy.click()` on the Findings sidenav link was blocked by a transient empty `<div class="css-1rrlroc"></div>` overlay. This overlay is rendered by the Kibana SideNav while it performs initial height measurement and layout settling after `visitGetStartedPage()`. The root cause was that `clickWhenVisibleElseOpenMore` in `serverless_security_header.ts` has two branches: (1) when the target element is directly visible on the primary nav strip, it clicked immediately with only a `.should('be.visible')` check; (2) when the element is in the overflow "More" menu, it called `showMoreItems()` which already had waits for `globalLoadingIndicator-hidden`, `globalLoadingIndicator` absence, a `nav-item` existence check, and a 1000ms hardcoded wait. The Findings link happened to be visible on the primary strip (branch 1), so it bypassed all the chrome-settling waits and raced against the transient overlay. The fix hoists the `[data-test-subj~="nav-item"] should exist`, `globalLoadingIndicator-hidden should exist`, and `globalLoadingIndicator should not.exist` checks to the top of `clickWhenVisibleElseOpenMore` — before the `cy.get('body').then()` branch decision — so both the direct-visible path and the more-menu path wait for chrome to finish rendering before attempting any click. The hardcoded `cy.wait(1000)` was intentionally left only inside `showMoreItems()` since it is specific to stabilizing the "more menu" button itself before clicking it.

**Changes**

- 4bb173081bb8 fix(test): wait for chrome to settle before clicking serverless nav items

Fixes #270166




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Test-only change — no production code modified. Risk: **low**.

**Suggested label:** `release_note:skip`

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->