### PR TITLE
[Streams] Fix aborted onboarding status poll error on navigation

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/hooks/use_onboarding_status_update_queue.ts
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/hooks/use_onboarding_status_update_queue.ts
@@ -32,7 +32,18 @@ export function useOnboardingStatusUpdateQueue(
 
     const streamNames = [...queue.current];
 
-    const statuses = await getOnboardingStatuses(streamNames);
+    let statuses: Awaited<ReturnType<typeof getOnboardingStatuses>>;
+    try {
+      statuses = await getOnboardingStatuses(streamNames);
+    } catch (error) {
+      // The request signal is aborted when the component unmounts (e.g. on
+      // navigation). Treat this as an expected cancellation and stop polling
+      // rather than surfacing an unhandled rejection.
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+      throw error;
+    }
 
     for (const streamName of streamNames) {
       const statusResult = statuses[streamName];

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/hooks/use_onboarding_status_update_queue.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/hooks/use_onboarding_status_update_queue.ts
@@ -11,6 +11,7 @@ import {
 } from '@kbn/streams-schema';
 import { useCallback, useRef } from 'react';
 import { useOnboardingApi } from '../../../../hooks/use_onboarding_api';
+import { isAbortError } from '../../../../util/errors';
 
 type StreamOnboardingStatusUpdateCallback = (
   streamName: string,
@@ -32,7 +33,18 @@ export function useOnboardingStatusUpdateQueue(
 
     const streamNames = [...queue.current];
 
-    const statuses = await getOnboardingStatuses(streamNames);
+    let statuses: Awaited<ReturnType<typeof getOnboardingStatuses>>;
+    try {
+      statuses = await getOnboardingStatuses(streamNames);
+    } catch (error) {
+      // The request signal is aborted when the component unmounts (e.g. on
+      // navigation). Treat this as an expected cancellation and stop polling
+      // rather than surfacing an unhandled rejection.
+      if (isAbortError(error)) {
+        return;
+      }
+      throw error;
+    }
 
     for (const streamName of streamNames) {
       const statusResult = statuses[streamName];

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/hooks/use_knowledge_indicators_onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/hooks/use_knowledge_indicators_onboarding.ts
@@ -14,7 +14,7 @@ import {
   type StreamsKIsOnboardingStatusResult,
 } from '@kbn/streams-schema';
 import { useOnboardingApi } from '../../../../hooks/use_onboarding_api';
-import { getFormattedError } from '../../../../util/errors';
+import { getFormattedError, isAbortError } from '../../../../util/errors';
 import { useKibana } from '../../../../hooks/use_kibana';
 
 interface Props {
@@ -69,7 +69,18 @@ export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onErr
     STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES.has(onboardingState.status);
 
   const fetchStatus = useCallback(async () => {
-    const state = await getOnboardingStatus(streamName);
+    let state: StreamsKIsOnboardingStatusResult;
+    try {
+      state = await getOnboardingStatus(streamName);
+    } catch (error) {
+      // The request signal is aborted when the component unmounts (e.g. on
+      // navigation). Surface the last known state instead of an error so the
+      // aborted poll is treated as an expected cancellation.
+      if (isAbortError(error) && onboardingState !== null) {
+        return onboardingState;
+      }
+      throw error;
+    }
 
     // Preserve the optimistic BeingCanceled state while the engine
     // still reports InProgress — the cancel request was sent but the
@@ -114,7 +125,7 @@ export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onErr
     previousStatusRef.current = state.status;
 
     return state;
-  }, [getOnboardingStatus, streamName, onComplete, onError]);
+  }, [getOnboardingStatus, streamName, onComplete, onError, onboardingState]);
 
   useQuery<StreamsKIsOnboardingStatusResult, Error>({
     queryKey: ['knowledgeIndicatorsOnboardingStatus', streamName],

--- a/x-pack/platform/plugins/shared/streams_app/public/util/errors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/util/errors.ts
@@ -41,3 +41,11 @@ export const getFormattedError = (error: unknown): Error => {
 
   return new Error('Unknown error');
 };
+
+/**
+ * Returns true when an error originates from an aborted request (e.g. an
+ * `AbortController` signal firing on component unmount / navigation). These are
+ * expected cancellations rather than real failures and should be swallowed.
+ */
+export const isAbortError = (error: unknown): boolean =>
+  isRecord(error) && error.name === 'AbortError';


### PR DESCRIPTION
## Summary

Triggering knowledge indicator extraction on a stream and then navigating away produced an unhandled rejection:

```
Error: logs-generic-default: signal is aborted without reason
```

While extraction runs, the UI polls the stream's onboarding status. The status requests in `useOnboardingApi` attach a component-scoped `AbortController` signal (`useAbortController`), which fires on unmount. On navigation the in-flight request aborts, and because the polling loops only chained `.finally()` (never `.catch()`), the abort surfaced as an unhandled `"signal is aborted without reason"` rejection (the `at async ... at async ...` frames are the recursive status poll).

## Changes

- Add a shared `isAbortError` helper in `util/errors.ts`.
- `use_onboarding_status_update_queue.ts` (discovery page poll): stop polling cleanly on abort; still propagate genuine errors.
- `use_knowledge_indicators_onboarding.ts` (per-stream react-query poll): return the last known onboarding state on abort instead of erroring.

The behavior change is minimal: aborts on navigation (the expected case) are swallowed; real fetch failures still surface as before.

## Test plan

- [ ] Trigger knowledge indicator extraction on a stream, then switch pages while it's generating — verify no `"signal is aborted without reason"` error appears.
- [ ] Verify genuine status fetch failures still surface (toast / error state).
- [ ] Verify completion/failure callbacks still fire when staying on the page.