### PR TITLE
Measure trace-based evaluators in the siem-readiness eval suite

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-siem-readiness/src/evaluate_dataset.test.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-siem-readiness/src/evaluate_dataset.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DefaultEvaluators, EvalsExecutorClient, Evaluator } from '@kbn/evals';
+import type { SiemReadinessEvalChatClient } from './chat_client';
+import { createEvaluateSiemReadinessDataset } from './evaluate_dataset';
+
+const buildEvaluator = (name: string): Evaluator => ({
+  name,
+  kind: 'CODE',
+  evaluate: jest.fn().mockResolvedValue({ score: 0 }),
+});
+
+const buildDeps = () => {
+  const runExperiment = jest.fn().mockResolvedValue(undefined);
+  const executorClient = { runExperiment } as unknown as EvalsExecutorClient;
+  const chatClient = {
+    converse: jest.fn().mockResolvedValue({
+      messages: [],
+      steps: [],
+      errors: [],
+      traceId: 'trace-id-fixture',
+    }),
+  } as unknown as SiemReadinessEvalChatClient;
+  const evaluators = {
+    criteria: jest.fn().mockReturnValue(buildEvaluator('Criteria')),
+    traceBasedEvaluators: {
+      inputTokens: buildEvaluator('Input tokens'),
+      outputTokens: buildEvaluator('Output tokens'),
+      cachedTokens: buildEvaluator('Cached tokens'),
+      toolCalls: buildEvaluator('Tool calls'),
+      latency: buildEvaluator('Latency'),
+    },
+  } as unknown as DefaultEvaluators;
+
+  return { runExperiment, executorClient, chatClient, evaluators };
+};
+
+const getRegisteredEvaluators = async () => {
+  const { runExperiment, executorClient, chatClient, evaluators } = buildDeps();
+
+  await createEvaluateSiemReadinessDataset({ evaluators, executorClient, chatClient })({
+    dataset: { name: 'test', description: 'test', examples: [] },
+  });
+
+  const [, registeredEvaluators] = runExperiment.mock.calls[0] as [unknown, Evaluator[]];
+  return registeredEvaluators;
+};
+
+describe('createEvaluateSiemReadinessDataset', () => {
+  it('registers the SIEM Readiness criteria evaluator', async () => {
+    const names = (await getRegisteredEvaluators()).map((evaluator) => evaluator.name);
+    expect(names).toContain('SIEM Readiness Criteria');
+  });
+
+  // Guard against silently dropping the free, no-extra-LLM-cost trace metrics
+  // (regression that this test was written to prevent).
+  it('registers all five trace-based evaluators alongside the criteria evaluator', async () => {
+    const names = (await getRegisteredEvaluators()).map((evaluator) => evaluator.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'Input tokens',
+        'Output tokens',
+        'Cached tokens',
+        'Tool calls',
+        'Latency',
+      ])
+    );
+  });
+
+  it('registers exactly the criteria evaluator plus the five trace-based evaluators', async () => {
+    const registeredEvaluators = await getRegisteredEvaluators();
+    expect(registeredEvaluators).toHaveLength(6);
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-evals-suite-siem-readiness/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-siem-readiness/src/evaluate_dataset.ts
@@ -113,7 +113,13 @@ export function createEvaluateSiemReadinessDataset({
           };
         },
       },
-      [createSiemReadinessCriteriaEvaluator({ evaluators })]
+      [
+        createSiemReadinessCriteriaEvaluator({ evaluators }),
+        // Non-functional trace-based metrics (tool calls, latency, token usage).
+        // These are derived from the run's OTel trace and add no extra LLM cost,
+        // so always measure them alongside the quality criteria.
+        ...Object.values(evaluators.traceBasedEvaluators),
+      ]
     );
   };
 }


### PR DESCRIPTION
## Summary

The `siem-readiness` eval suite constructs its `DefaultEvaluators` fixture with the framework's trace-based evaluators (**tool calls, latency, input/output/cached tokens**) but never spread them into the `runExperiment` evaluators array — only the LLM criteria judge was registered. Those metrics are derived from the run's existing OTel trace and add **no extra LLM cost**, so they were free signal being silently dropped from every run.

This wires them in, alongside the criteria evaluator, matching how `security-alert-triage` and `agent-builder-dashboards` do it (`...Object.values(evaluators.traceBasedEvaluators)`).

## Changes

- `src/evaluate_dataset.ts` — spread `evaluators.traceBasedEvaluators` into the registered evaluators array.
- `src/evaluate_dataset.test.ts` — **new** (suite's first unit test). Mirrors the `security-esql-generation-regression` guard: asserts the registered set is exactly the criteria evaluator + the five trace-based evaluators, so this regression cannot recur silently.

## Verification

- `node scripts/jest .../evaluate_dataset.test.ts` → 3 passed.
- Reverting the fix turns the guard **red** (2 failed) — confirmed the test bites the exact regression.
- `node scripts/type_check --project .../tsconfig.json` → exit 0.
- eslint clean.

## Context

Found during the "declared-but-dead evaluators" audit in elastic/security-team#17908 (Security Evals status). The trace evaluators weren't dead-but-declared — they were wired into the fixture but dropped before measurement.

Addresses elastic/security-team#17908