### PR TITLE
Stabilize links panel functional tests

### DIFF
--- a/src/platform/test/functional/apps/dashboard_elements/links/links_create_edit.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/links/links_create_edit.ts
@@ -35,6 +35,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await dashboardLinks.addDashboardLink('links 001');
   }
 
+  async function openLinksPanelEditor() {
+    await dashboardAddPanel.openAddPanelFlyout();
+    await dashboardAddPanel.clickAddNewPanelFromUIActionLink('Links');
+    await dashboardLinks.expectPanelEditorFlyoutIsOpen();
+    await testSubjects.missingOrFail('dashboardAddPanel');
+  }
+
   const DASHBOARD_NAME = 'Test Links panel';
   const LINKS_PANEL_NAME = 'Some links';
 
@@ -53,8 +60,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('can not add an external link that violates externalLinks.policy', async () => {
-        await dashboardAddPanel.openAddPanelFlyout();
-        await dashboardAddPanel.clickAddNewPanelFromUIActionLink('Links');
+        await openLinksPanelEditor();
 
         await dashboardLinks.setExternalUrlInput('https://danger.example.com');
         expect(await testSubjects.exists('links--linkDestination--error')).to.be(true);
@@ -63,8 +69,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('can create a new by-reference links panel', async () => {
-        await dashboardAddPanel.openAddPanelFlyout();
-        await dashboardAddPanel.clickAddNewPanelFromUIActionLink('Links');
+        await openLinksPanelEditor();
 
         await createSomeLinks();
         await dashboardLinks.toggleSaveByReference(true);
@@ -83,8 +88,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('does not close the flyout when the user cancels the save as modal', async () => {
-        await dashboardAddPanel.openAddPanelFlyout();
-        await dashboardAddPanel.clickAddNewPanelFromUIActionLink('Links');
+        await openLinksPanelEditor();
         await createSomeLinks();
         await dashboardLinks.toggleSaveByReference(true);
         await dashboardLinks.clickPanelEditorSaveButton();
@@ -97,8 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       describe('by-value links panel', () => {
         it('can create a new by-value links panel', async () => {
-          await dashboardAddPanel.openAddPanelFlyout();
-          await dashboardAddPanel.clickAddNewPanelFromUIActionLink('Links');
+          await openLinksPanelEditor();
           await dashboardLinks.setLayout('horizontal');
           await createSomeLinks();
           await dashboardLinks.toggleSaveByReference(false);

--- a/src/platform/test/functional/page_objects/dashboard_page_links.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page_links.ts
@@ -67,6 +67,7 @@ export class DashboardPageLinks extends FtrService {
   public async clickPanelEditorCloseButton() {
     this.log.debug('click links panel editor close button');
     await this.testSubjects.click('links--panelEditor--closeBtn');
+    await this.testSubjects.waitForDeleted('links--panelEditor--flyout');
   }
 
   public async clickLinksEditorSaveButton() {
@@ -210,7 +211,9 @@ export class DashboardPageLinks extends FtrService {
       const option = await this.testSubjects.find('links--linkEditor--externalLink--radioBtn');
       const label = await option.findByCssSelector('label[for="externalLink"]');
       await label.click();
-      await this.testSubjects.existOrFail('links--linkEditor--externalLink--input');
+      if (!(await this.testSubjects.exists('links--linkEditor--externalLink--input'))) {
+        throw new Error('External link input did not render');
+      }
     });
     await this.testSubjects.setValue('links--linkEditor--externalLink--input', destination);
   }


### PR DESCRIPTION
## Summary

Stabilizes links panel functional tests by waiting for the Links panel editor flyout to fully open and close before continuing, and by making the external link input retry use a short existence check so the selection can be retried.

## Testing

- node scripts/eslint src/platform/test/functional/page_objects/dashboard_page_links.ts src/platform/test/functional/apps/dashboard_elements/links/links_create_edit.ts
- node scripts/functional_tests --config src/platform/test/functional/apps/dashboard_elements/links/config.ts --grep "links panel create and edit" (aborted during Elasticsearch startup)

part of https://github.com/elastic/kibana/issues/268525

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->