### PR TITLE
[APM] Hide service map controls for missing fields

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_search_bar.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_search_bar.test.tsx
@@ -41,11 +41,9 @@ jest.mock('../../../hooks/use_adhoc_apm_data_view', () => ({
       id: 'apm-data-view',
       title: 'apm-*',
       fields: {
-        getByName: (name: string) =>
-          mockMissingFields.includes(name) ? undefined : { name },
+        getByName: (name: string) => (mockMissingFields.includes(name) ? undefined : { name }),
       },
-      getFieldByName: (name: string) =>
-        mockMissingFields.includes(name) ? undefined : { name },
+      getFieldByName: (name: string) => (mockMissingFields.includes(name) ? undefined : { name }),
     },
   }),
 }));

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_search_bar.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_search_bar.test.tsx
@@ -16,6 +16,8 @@ let mockOnFiltersChange: (filters: Filter[]) => void;
 let mockHistoryReplace: jest.Mock;
 let mockLocationSearch: string;
 let mockInitialAppFilters: Filter[];
+// Field names that should be reported as absent from the data view.
+let mockMissingFields: string[];
 const filterUpdates$ = new Subject<void>();
 
 jest.mock('../../../hooks/use_apm_params', () => ({
@@ -38,8 +40,12 @@ jest.mock('../../../hooks/use_adhoc_apm_data_view', () => ({
     dataView: {
       id: 'apm-data-view',
       title: 'apm-*',
-      fields: [],
-      getFieldByName: () => undefined,
+      fields: {
+        getByName: (name: string) =>
+          mockMissingFields.includes(name) ? undefined : { name },
+      },
+      getFieldByName: (name: string) =>
+        mockMissingFields.includes(name) ? undefined : { name },
     },
   }),
 }));
@@ -95,13 +101,15 @@ jest.mock('./service_map_controls', () => ({
     controlsConfig,
   }: {
     onFiltersChange: (filters: Filter[]) => void;
-    controlsConfig: Array<{ field_name: string }>;
+    controlsConfig: Array<{ field_name: string; width: string; grow: boolean }>;
   }) => {
     mockOnFiltersChange = onFiltersChange;
     return (
       <div
         data-testid="service-map-controls"
         data-fields={controlsConfig.map((c) => c.field_name).join(',')}
+        data-widths={controlsConfig.map((c) => c.width).join(',')}
+        data-grows={controlsConfig.map((c) => String(c.grow)).join(',')}
       />
     );
   },
@@ -136,6 +144,7 @@ describe('ServiceMapSearchBar', () => {
     mockHistoryReplace = jest.fn();
     mockLocationSearch = '?environment=production&kuery=service.name%3A%22opbeans-go%22';
     mockInitialAppFilters = [];
+    mockMissingFields = [];
     mockFilterManager.getAppFilters.mockReturnValue([]);
     mockFilterManager.getGlobalFilters.mockReturnValue([]);
   });
@@ -151,6 +160,75 @@ describe('ServiceMapSearchBar', () => {
     // buildEsQuery was called with [{ query: '', language: 'kuery' }] so the mock
     // only includes filters, not the kuery content.
     expect(esQuery.bool.filter).toEqual([]);
+  });
+
+  it('excludes controls whose field is missing from the data view', async () => {
+    mockMissingFields = ['cloud.region'];
+
+    const { container } = render(<ServiceMapSearchBar />);
+
+    let controls: Element | null = null;
+    await waitFor(() => {
+      controls = container.querySelector('[data-testid="service-map-controls"]');
+      expect(controls).not.toBeNull();
+    });
+
+    const fields = controls!.getAttribute('data-fields') ?? '';
+    expect(fields.split(',')).toEqual([
+      'service.environment',
+      'service.name',
+      'cloud.availability_zone',
+    ]);
+  });
+
+  it('renders a single remaining control at a fixed medium width', async () => {
+    mockMissingFields = ['service.name', 'cloud.region', 'cloud.availability_zone'];
+
+    const { container } = render(<ServiceMapSearchBar />);
+
+    let controls: Element | null = null;
+    await waitFor(() => {
+      controls = container.querySelector('[data-testid="service-map-controls"]');
+      expect(controls).not.toBeNull();
+    });
+
+    expect(controls!.getAttribute('data-fields')).toBe('service.environment');
+    expect(controls!.getAttribute('data-widths')).toBe('medium');
+    expect(controls!.getAttribute('data-grows')).toBe('false');
+  });
+
+  it('renders two remaining controls at a fixed medium width', async () => {
+    mockMissingFields = ['cloud.region', 'cloud.availability_zone'];
+
+    const { container } = render(<ServiceMapSearchBar />);
+
+    let controls: Element | null = null;
+    await waitFor(() => {
+      controls = container.querySelector('[data-testid="service-map-controls"]');
+      expect(controls).not.toBeNull();
+    });
+
+    expect(controls!.getAttribute('data-fields')).toBe('service.environment,service.name');
+    expect(controls!.getAttribute('data-widths')).toBe('medium,medium');
+    expect(controls!.getAttribute('data-grows')).toBe('false,false');
+  });
+
+  it('keeps small growing controls when three or more remain', async () => {
+    mockMissingFields = ['cloud.availability_zone'];
+
+    const { container } = render(<ServiceMapSearchBar />);
+
+    let controls: Element | null = null;
+    await waitFor(() => {
+      controls = container.querySelector('[data-testid="service-map-controls"]');
+      expect(controls).not.toBeNull();
+    });
+
+    expect(controls!.getAttribute('data-fields')).toBe(
+      'service.environment,service.name,cloud.region'
+    );
+    expect(controls!.getAttribute('data-widths')).toBe('small,small,small');
+    expect(controls!.getAttribute('data-grows')).toBe('true,true,true');
   });
 
   it('does not include inherited app filters from another app on initial render', async () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_search_bar.tsx
@@ -55,13 +55,21 @@ export function ServiceMapSearchBar() {
   const history = useHistory();
   const serviceName = useServiceName();
 
-  const controlsConfig = useMemo(
-    () =>
-      serviceName
-        ? SERVICE_MAP_CONTROLS_CONFIG.filter((c) => c.field_name !== 'service.name')
-        : SERVICE_MAP_CONTROLS_CONFIG,
-    [serviceName]
-  );
+  const controlsConfig = useMemo(() => {
+    const base = serviceName
+      ? SERVICE_MAP_CONTROLS_CONFIG.filter((c) => c.field_name !== 'service.name')
+      : SERVICE_MAP_CONTROLS_CONFIG;
+
+    const visible = dataView
+      ? base.filter((c) => dataView.fields.getByName(c.field_name) !== undefined)
+      : base;
+
+    if (visible.length <= 2) {
+      return visible.map((c) => ({ ...c, width: 'medium' as const, grow: false }));
+    }
+
+    return visible;
+  }, [serviceName, dataView]);
 
   // Persist filter-bar pills and control selections in the URL (_a) so they survive refresh.
   const { initialAppFilters, persistControlSelections, getRestoredControlSelections } =


### PR DESCRIPTION
## Summary

Fixes the APM service map search controls so that controls backed by a field that does not exist in the data view (e.g. `cloud.region`, `cloud.availability_zone`) are no longer rendered with a `Could not locate field: <field>` error. Instead, the control is hidden, mirroring the behavior already used in the Hosts view. Controls with no values in the selected time range are still shown.

- Filter the service map controls config by data-view field existence (`dataView.fields.getByName(...)`), hiding controls for missing fields.
- When only one or two controls remain, render them at a fixed `medium` width (instead of `small` + `grow`) so a lone/paired control doesn't stretch across the entire row. Three or more controls keep the default `small` + `grow` layout so they share the row without wrapping.
- Added unit tests covering missing-field exclusion and the medium-width behavior for one/two controls vs. small/grow for three or more.

## Testing

When the cloud fields are not available in the dataview the controls should be hidden: 


https://github.com/user-attachments/assets/2e836712-d569-4ccf-9a61-5187e43abc8e

<img width="3248" height="1740" alt="image" src="https://github.com/user-attachments/assets/4f6aaa06-9078-4715-b222-7db6e59893ad" />

In case of cloud fields in the dataview they should be available and no error should be shown

## References

Closes elastic/kibana#274831

Made with [Cursor](https://cursor.com)