### PR TITLE
[Alerting V2] Display episode severity in the episodes table.

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/episodes_table_cell_renderers.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/episodes_table_cell_renderers.test.tsx
@@ -12,9 +12,11 @@ import {
   EpisodeStatusCell,
   EpisodeTagsCell,
   EpisodeRuleCell,
+  EpisodeSeverityCell,
 } from './episodes_table_cell_renderers';
 import { AlertEpisodeStatusBadges } from './status/status_badges';
 import { AlertEpisodeTags } from './actions/tags';
+import { AlertEpisodeSeverityBadge } from './severity/episode_severity_badge';
 
 jest.mock('./status/status_badges', () => ({
   AlertEpisodeStatusBadges: jest.fn(() => <div data-test-subj="statusBadges" />),
@@ -22,9 +24,13 @@ jest.mock('./status/status_badges', () => ({
 jest.mock('./actions/tags', () => ({
   AlertEpisodeTags: jest.fn(() => <div data-test-subj="episodeTags" />),
 }));
+jest.mock('./severity/episode_severity_badge', () => ({
+  AlertEpisodeSeverityBadge: jest.fn(() => <div data-test-subj="severityBadge" />),
+}));
 
 const mockStatusBadges = jest.mocked(AlertEpisodeStatusBadges);
 const mockTags = jest.mocked(AlertEpisodeTags);
+const mockSeverityBadge = jest.mocked(AlertEpisodeSeverityBadge);
 
 type Rule = FindRulesResponse['items'][number];
 
@@ -119,6 +125,21 @@ describe('EpisodeTagsCell', () => {
     render(<EpisodeTagsCell {...baseCellProps} row={row} />);
     const props = mockTags.mock.calls[0][0];
     expect(props.tags).toEqual([]);
+  });
+});
+
+describe('EpisodeSeverityCell', () => {
+  it('passes severity from row flattened field', () => {
+    const row = makeRow({ severity: 'high' });
+    render(<EpisodeSeverityCell {...baseCellProps} row={row} />);
+    expect(screen.getByTestId('severityBadge')).toBeInTheDocument();
+    expect(mockSeverityBadge.mock.calls[0][0].severity).toBe('high');
+  });
+
+  it('passes undefined severity when row field is absent', () => {
+    const row = makeRow({});
+    render(<EpisodeSeverityCell {...baseCellProps} row={row} />);
+    expect(mockSeverityBadge.mock.calls[0][0].severity).toBeUndefined();
   });
 });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/episodes_table_cell_renderers.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/components/episodes_table_cell_renderers.tsx
@@ -27,6 +27,8 @@ import { parseEpisodeDataJson } from '../utils/episode_grouping_data';
 import { AlertingEpisodeGroupingTags } from './grouping/alerting_episode_grouping_tags';
 import { AlertEpisodeStatusBadges } from './status/status_badges';
 import { AlertEpisodeTags } from './actions/tags';
+import { AlertEpisodeSeverityBadge } from './severity/episode_severity_badge';
+import type { EpisodeSeverity } from './severity/severity_utils';
 
 type Rule = FindRulesResponse['items'][number];
 type CellRendererProps = Parameters<CustomCellRenderer[string]>[0];
@@ -67,6 +69,12 @@ export const EpisodeTagsCell = ({ row }: CellRendererProps) => {
   const tags = (row.flattened.last_tags as string[] | undefined) ?? [];
 
   return <AlertEpisodeTags tags={tags} />;
+};
+
+export const EpisodeSeverityCell = ({ row }: CellRendererProps) => {
+  const severity = row.flattened.severity as EpisodeSeverity | undefined | null;
+
+  return <AlertEpisodeSeverityBadge severity={severity} />;
 };
 
 export interface EpisodeRuleCellProps extends CellRendererProps {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/translations.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/translations.ts
@@ -13,3 +13,32 @@ export const RELATED_EPISODES_LOAD_ERROR = i18n.translate(
     defaultMessage: 'Failed to load related alert episodes',
   }
 );
+
+export const RULE_FIELD_LABEL = i18n.translate('xpack.alertingV2EpisodesUi.ruleFieldLabel', {
+  defaultMessage: 'Rule',
+});
+
+export const STATUS_FIELD_LABEL = i18n.translate('xpack.alertingV2EpisodesUi.statusFieldLabel', {
+  defaultMessage: 'Status',
+});
+
+export const SEVERITY_FIELD_LABEL = i18n.translate(
+  'xpack.alertingV2EpisodesUi.severityFieldLabel',
+  {
+    defaultMessage: 'Severity',
+  }
+);
+
+export const DURATION_FIELD_LABEL = i18n.translate(
+  'xpack.alertingV2EpisodesUi.durationFieldLabel',
+  {
+    defaultMessage: 'Duration',
+  }
+);
+
+export const ASSIGNEES_FIELD_LABEL = i18n.translate(
+  'xpack.alertingV2EpisodesUi.assigneesFieldLabel',
+  {
+    defaultMessage: 'Assignee',
+  }
+);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_episodes_data_view.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_episodes_data_view.ts
@@ -11,9 +11,9 @@ import type { HttpStart } from '@kbn/core-http-browser';
 import type { DataViewsContract, RuntimeField } from '@kbn/data-views-plugin/public';
 import { useMemo } from 'react';
 import type { SerializedFieldFormat } from '@kbn/field-formats-plugin/common';
-import { i18n } from '@kbn/i18n';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { buildEpisodesBaseQuery } from '../queries/episodes_query';
+import * as i18n from './translations';
 import { useSpaceId } from './use_space_id';
 
 export interface UseAlertingEpisodesDataViewOptions {
@@ -31,23 +31,20 @@ export interface KnownFieldOverrides {
 
 const knownFieldsOverrides: Record<string, KnownFieldOverrides> = {
   'rule.id': {
-    customLabel: i18n.translate('xpack.alertingV2EpisodesUi.ruleFieldLabel', {
-      defaultMessage: 'Rule',
-    }),
+    customLabel: i18n.RULE_FIELD_LABEL,
   },
   'episode.status': {
-    customLabel: i18n.translate('xpack.alertingV2EpisodesUi.statusFieldLabel', {
-      defaultMessage: 'Status',
-    }),
+    customLabel: i18n.STATUS_FIELD_LABEL,
+  },
+  severity: {
+    customLabel: i18n.SEVERITY_FIELD_LABEL,
   },
 };
 
 const computedFields: Record<string, RuntimeField> = {
   duration: {
     type: 'long',
-    customLabel: i18n.translate('xpack.alertingV2EpisodesUi.durationFieldLabel', {
-      defaultMessage: 'Duration',
-    }),
+    customLabel: i18n.DURATION_FIELD_LABEL,
     format: {
       id: 'duration',
       params: {
@@ -62,9 +59,7 @@ const computedFields: Record<string, RuntimeField> = {
   assignees: {
     type: 'keyword',
     script: { source: "emit('')" },
-    customLabel: i18n.translate('xpack.alertingV2EpisodesUi.assigneesFieldLabel', {
-      defaultMessage: 'Assignee',
-    }),
+    customLabel: i18n.ASSIGNEES_FIELD_LABEL,
   },
 };
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
@@ -238,6 +238,21 @@ describe('AlertEpisodesListPage', () => {
     expect(Array.isArray(lastCall?.rowAdditionalLeadingControls)).toBe(true);
   });
 
+  it('passes severity column and custom renderer to UnifiedDataTable', () => {
+    const lastCall = mockUnifiedDataTable.mock.calls.at(-1)?.[0];
+    expect(lastCall?.columns).toEqual([
+      'episode.status',
+      'severity',
+      '@timestamp',
+      'rule.id',
+      'duration',
+      'tags',
+      'assignees',
+    ]);
+    expect(lastCall?.externalCustomRenderers).toHaveProperty('severity');
+    expect(typeof lastCall?.externalCustomRenderers?.severity).toBe('function');
+  });
+
   it('does not pass key prop derived from tableKey (no tableKey state)', () => {
     // The table should be rendered without a dynamic key that causes remounts
     const lastCall = mockUnifiedDataTable.mock.calls.at(-1)?.[0];

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
@@ -49,6 +49,7 @@ import {
   EpisodeStatusCell,
   EpisodeTagsCell,
   EpisodeRuleCell,
+  EpisodeSeverityCell,
 } from '@kbn/alerting-v2-episodes-ui/components/episodes_table_cell_renderers';
 import { AlertEpisodeAssigneeCell } from '@kbn/alerting-v2-episodes-ui/components/assignee_cell';
 import { ExperimentalBadge } from '../../components/experimental_badge';
@@ -75,6 +76,7 @@ const ALERT_EPISODES_TABLE_SETTINGS: UnifiedDataTableSettings = {
     duration: { width: 110 },
     assignees: { width: 120 },
     'episode.status': { width: 110 },
+    severity: { width: 100 },
   },
 };
 
@@ -153,6 +155,7 @@ export const AlertEpisodesListPage = () => {
   const [sortState, setSortState] = useState<EpisodesSortState>(DEFAULT_SORT);
   const [columns, setColumns] = useState<string[]>([
     'episode.status',
+    'severity',
     '@timestamp',
     'rule.id',
     'duration',
@@ -321,6 +324,7 @@ export const AlertEpisodesListPage = () => {
   const externalCustomRenderers = useMemo<CustomCellRenderer>(
     () => ({
       'episode.status': (props) => <EpisodeStatusCell {...props} />,
+      severity: (props) => <EpisodeSeverityCell {...props} />,
       tags: (props) => <EpisodeTagsCell {...props} />,
       'rule.id': (props) => (
         <EpisodeRuleCell


### PR DESCRIPTION
First PR for https://github.com/elastic/kibana/issues/262924

## Summary

Display severity in the episodes list. **No filtering yet.** I am splitting the PRs in case I dont have time for everything this iteration.

<img width="2291" height="1180" alt="Screenshot 2026-06-24 at 15 39 00" src="https://github.com/user-attachments/assets/a232d622-8368-430c-9289-f2fac94438ca" />

## Testing

Similar to https://github.com/elastic/kibana/pull/274513

The important thing is having a query that produces a severity column. Using the `kibana_sample_data_logs` you can create a rule with the following:

```
FROM kibana_sample_data_logs 
| EVAL severity = CASE(
    host == "elastic-elastic-elastic.org", "critical", 
    host == "artifacts.elastic.co", "high", 
    host == "www.elastic.co", "medium", 
    host == "cdn.elastic-elastic-elastic.org", "low", 
    "info")
| KEEP severity, agent, clientip, geo.srcdest, host, bytes, geo.dest, geo.src 
| WHERE bytes > 1000 
| LIMIT 1
```

The "Alert Condition" can be whatever.


