### PR TITLE
Add READMEs for five Security eval suites

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-alerts-rag/README.md
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-alerts-rag/README.md
@@ -1,0 +1,71 @@
+# @kbn/evals-suite-alerts-rag
+
+End-to-end evaluation suite for the Agent Builder **`alert-analysis`** skill,
+which answers natural-language questions about open Security alerts by querying
+Elasticsearch through the `security.alerts` ES|QL tool. The suite drives the
+default agent via `/api/agent_builder/converse` and verifies it activates the
+correct skill (rather than freelancing with raw alternatives) and grounds its
+answer in the actual alert data.
+
+## Prerequisites
+
+- No dedicated `serverConfigSet` — the suite runs against the default evals
+  server configuration.
+- An AI connector available (see `@kbn/evals` docs for standard connector setup).
+- Realistic alert data. In CI the suite restores the shared Security alerts GCS
+  snapshot (`ALERTS_RAG_ALERTS_SNAPSHOT_*` env vars) in `beforeAll`; if GCS
+  credentials are absent it evaluates against whatever alerts already exist in
+  the cluster. After restore, `verifyAlertsRagSnapshot` asserts the dataset
+  invariants (≥5 open alerts, ≥1 critical/high, ≥2 distinct hosts, etc.) and
+  fails fast if they are not met.
+
+## Running
+
+From the Kibana repo root:
+
+```sh
+# Start the evals server
+node scripts/scout start-server --arch stateful --domain classic
+
+# In another terminal, run the suite
+node scripts/evals run --suite security-alerts-rag-regression
+```
+
+`node scripts/evals start --suite security-alerts-rag-regression` manages the
+Scout server for you.
+
+All evaluation specs live under [`evals`](./evals).
+
+## Dataset
+
+8 examples defined locally in
+[`src/datasets/alerts_rag_dataset.ts`](./src/datasets/alerts_rag_dataset.ts)
+(not JSONL, not fetched live). Each example is annotated with an expected
+`tool_sequence` (`['security.alerts']`). The spec groups examples by category and
+runs one `evaluate()` test per category:
+
+| Category | Example questions |
+| --- | --- |
+| `multi_alert_correlation` | "Which alerts should I look at first?"; "Are any open alerts targeting the same host or user?" |
+| `field_specific_lookup` | "What hosts are affected?"; "Which `user.name` is mentioned the most?" |
+| `temporal_query` | "What is the most recent alert?"; "Any new alerts in the last hour?" |
+| `single_alert_query` | "Tell me about the most severe open alert."; "What's the lowest-severity open alert?" |
+
+## Evaluators
+
+Built in `buildAlertsRagEvaluators`
+([`src/evaluate_dataset.ts`](./src/evaluate_dataset.ts)):
+
+| Evaluator | Kind | Measures |
+| --- | --- | --- |
+| `Factuality`, `Relevance`, `Sequence Accuracy` | LLM (quantitative) | Answer correctness vs. the alert data |
+| `Groundedness` | LLM (quantitative) | Whether claims are grounded in retrieved context |
+| `Tool Calls`, `Latency`, `Input Tokens`, `Output Tokens`, `Cached Tokens` | CODE (trace-based) | Non-functional metrics from the OTel trace (no extra LLM cost) |
+| `Skill Invoked (alert-analysis)` | CODE (trace-based) | That the `alert-analysis` skill file was actually read |
+| `Trajectory` | CODE | Tool-call order vs. the per-example `tool_sequence` |
+
+The registered evaluator set is pinned by
+[`src/evaluate_dataset.test.ts`](./src/evaluate_dataset.test.ts): it asserts the
+exact ordered list of evaluator names so a silent rename or drop fails in Jest
+before reaching CI, and explicitly guards against re-introducing the retired
+`Faithfulness` / `AnswerCorrectness` evaluators.

--- a/x-pack/solutions/security/packages/kbn-evals-suite-endpoint/README.md
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-endpoint/README.md
@@ -1,0 +1,85 @@
+# @kbn/evals-suite-endpoint
+
+End-to-end evaluation suite for the **Elastic Defend automatic troubleshooting**
+Agent Builder skill. Given a natural-language question about an unhealthy
+endpoint host, the agent must read the troubleshooting skill file, call the
+`automatic_troubleshooting.check_endpoint_package_freshness` and
+`generate_insight` tools, and produce a correct root-cause diagnosis against a
+small, deterministic seeded dataset.
+
+This is the reference suite the other Security eval suites are modeled on (e.g.
+`@kbn/evals-suite-pci-compliance`): the `src/evaluate.ts` + `src/evaluate_dataset.ts`
++ `src/chat_client.ts` shape, traces, spans, and evaluator fields are kept
+comparable across suites.
+
+## Prerequisites
+
+- The suite runs through the `evals_endpoint` Scout `serverConfigSet`
+  (`src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_endpoint`),
+  which extends `evals_tracing` and additionally:
+  - enables the `automaticTroubleshootingSkill` experimental feature,
+  - turns on Agent Builder experimental features,
+  - installs the `endpoint` Fleet package.
+- An AI connector available (see `@kbn/evals` docs for standard connector setup).
+  The chat client talks to `/api/agent_builder/converse`; override the agent with
+  `AGENT_BUILDER_AGENT_ID`.
+
+## Running
+
+From the Kibana repo root:
+
+```sh
+# Start Kibana + ES test server with the endpoint config set
+node scripts/scout start-server \
+  --arch stateful \
+  --domain classic \
+  --serverConfigSet evals_endpoint
+
+# In another terminal, run the suite
+node scripts/evals run --suite endpoint
+```
+
+`node scripts/evals start --suite endpoint` manages the Scout server for you and
+restarts it when the config set changes. Filter to one scenario with `--grep`,
+e.g. `--grep "linux_high_cpu"`.
+
+All evaluation specs live under
+[`evals/automatic_troubleshooting`](./evals/automatic_troubleshooting).
+
+## Scenarios
+
+15 scenarios, one example each, defined inline in the spec. Seed data for every
+scenario lives in [`src/data_generators/endpoint_data.ts`](./src/data_generators/endpoint_data.ts)
+(`SCENARIOS`) and is provisioned into the endpoint metadata, Fleet, policy,
+events, and alerts indices in `beforeAll`. Representative cases:
+
+| Scenario | Root cause asserted |
+| --- | --- |
+| `incompatible antivirus detection` | Conflicting third-party AV processes |
+| `policy response failure` | Kernel extension load failure |
+| `endpoint alerts missing — shipping failure` | Logstash SSL handshake failure; alerts never reach ES |
+| `endpoint exception field mismatch` | Exception on `file.path` while the alert field is `process.executable` |
+| `linux high CPU — monitoring scripts` | Monitoring-script process churn |
+| `windows high CPU — auth events` | lsass auth events (4624/4634) dominating CPU |
+| `linux missed check-ins — SELinux` | SELinux `unlabeled_t` denies `elastic-endpoint` exec (status 203/EXEC) |
+| `windows missed check-ins — crash dump` | Repeated `elastic-endpoint.exe` crashes |
+| `kafka message size rejection` | Non-retriable "Message size too large" output rejection |
+| `windows BSOD — driver regression` | `elastic_endpoint_driver.sys` kernel heap corruption |
+| `AWS VPC CNI eBPF conflict` | TC eBPF conflict with host-isolation probes |
+| `currently healthy endpoint` | Agent must **not** invent a root cause; must ask for a symptom |
+| `stopped united transform` | Stopped `endpoint.metadata_united` transform → missing endpoint list |
+
+## Evaluators
+
+A single LLM evaluator, `Criteria`
+([`createEndpointCriteriaEvaluator`](./src/evaluate_dataset.ts)), which judges the
+agent response against per-example `output.criteria`. A shared `COMMON_CRITERIA`
+set, applied to every scenario, asserts the agent:
+
+1. activated the skill by reading its `SKILL.md`,
+2. called `check_endpoint_package_freshness` before diagnosing, and
+3. called `generate_insight` to persist structured findings.
+
+The `evals_endpoint` config set also enables OTel tracing, so the framework's
+trace-based metrics (tool calls, latency, token usage) are available from each
+run's trace.

--- a/x-pack/solutions/security/packages/kbn-evals-suite-lead-generation/README.md
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-lead-generation/README.md
@@ -1,0 +1,72 @@
+# @kbn/evals-suite-lead-generation
+
+End-to-end evaluation suite for the Security Entity Analytics **Lead Generation**
+pipeline — an async background task that queries the live Entity Store and
+produces prioritized investigation leads (title, byline, description, entities,
+priority 1–10, observations). The suite measures both the structural correctness
+of the pipeline output (a CODE evaluator) and the holistic quality/specificity of
+the generated leads (an LLM rubric judge).
+
+> **On-demand only.** This suite is **not** part of the weekly eval pipeline; it
+> runs only when the `evals:lead-generation` PR label is applied.
+
+## Prerequisites
+
+- The suite runs through the `evals_lead_generation` Scout `serverConfigSet`
+  (`src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_lead_generation`),
+  which extends the Entity Store V2 tracing config and enables the
+  `entityAnalyticsEntityStoreV2` and `leadGenerationEnabled` experimental
+  features.
+- An AI connector available (see `@kbn/evals` docs for standard connector setup).
+- For meaningful rubric scores, the Entity Store must be seeded with entities;
+  the smoke tests still pass against an empty store.
+
+## Running
+
+From the Kibana repo root:
+
+```sh
+# Start Kibana + ES test server with the lead-generation config set
+node scripts/scout start-server \
+  --arch stateful \
+  --domain classic \
+  --serverConfigSet evals_lead_generation
+
+# In another terminal, run the suite (bundled 8-example dataset, no env vars needed)
+node scripts/evals run --suite lead-generation
+```
+
+`node scripts/evals start --suite lead-generation` manages the Scout server for you.
+
+All evaluation specs live under [`evals/lead_generation`](./evals/lead_generation).
+
+> **Concurrency is forced to 1** by default: the async pipeline overwrites its
+> last-execution UUID on each `generate` call, so parallel runs race. Override
+> with `LEAD_GENERATION_EVAL_CONCURRENCY` only against a server that supports
+> per-execution status.
+
+## Dataset
+
+8 examples in the checked-in
+[`data/eval_dataset_lead_generation_all_scenarios.jsonl`](./data) (works out of
+the box). The `input` is minimal because the pipeline queries the live Entity
+Store; `output.leads` is a structural reference — quality is judged holistically
+by the rubric, not by exact field comparison. Three dataset modes are supported
+(see [`data/README.md`](./data/README.md)):
+
+1. `LEAD_GENERATION_DATASET_JSONL_PATH` → a local JSONL file
+2. `LEAD_GENERATION_DATASET_NAME` + `EVALUATIONS_KBN_URL` → an upstream golden cluster
+3. bundled default (no env vars required)
+
+## Evaluators
+
+| Evaluator | Kind | Measures |
+| --- | --- | --- |
+| `LeadGenerationBasic` | CODE | No pipeline errors; `leads` is an array; every lead is structurally valid (non-empty id/title/byline/description, entities array, priority 1–10, observations, executionUuid) |
+| `LeadGenerationRubric` | LLM | Holistic quality/specificity of the leads; short-circuits to 0 on errors or null leads (no LLM call) |
+
+The spec also includes inline smoke evaluators (`Ran`, `StatusMatchesExecution`)
+and **calibration** runs that feed deliberately bad outputs (empty title,
+out-of-range priority, vague leads) through the evaluators and record the results
+to experiment history, so a human can confirm the evaluators correctly score
+them at/near 0.

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-alert-triage/README.md
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-alert-triage/README.md
@@ -1,0 +1,69 @@
+# @kbn/evals-suite-security-alert-triage
+
+End-to-end evaluation suite for the Security AI Assistant's **bulk alert triage**
+capability: whether the assistant correctly prioritizes critical/high-severity
+alerts buried inside large alert sets, identifies hosts targeted by multiple
+correlated alerts, and — when an alert set is large enough to trigger
+"summary mode" — reads every alert batch (`attachment_read`) before reasoning
+over the data.
+
+## Prerequisites
+
+- No dedicated `serverConfigSet`; the suite uses the evals CLI default
+  (`evals_tracing`), which enables OTel tracing required by the trace-based
+  evaluators.
+- An AI connector available (see `@kbn/evals` docs). `EVALUATION_CONNECTOR_ID`
+  must be set.
+
+## Running
+
+From the Kibana repo root:
+
+```sh
+# Start the evals server (tracing config set)
+node scripts/scout start-server \
+  --arch stateful \
+  --domain classic \
+  --serverConfigSet evals_tracing
+
+# In another terminal, run the suite
+node scripts/evals run --suite security-alert-triage
+```
+
+`node scripts/evals start --suite security-alert-triage` manages the Scout server
+for you.
+
+All evaluation specs live under [`evals`](./evals).
+
+## Scenarios
+
+Synthetic alert data is defined in
+[`src/synthetic_alerts.ts`](./src/synthetic_alerts.ts) and seeded into
+`.alerts-security.alerts-default` in `beforeAll` (cleaned up in `afterAll`).
+
+[`evals/alert_triage_quality.spec.ts`](./evals/alert_triage_quality.spec.ts) — 3 scenarios:
+
+| Scenario | Setup | What it asserts |
+| --- | --- | --- |
+| priority triage | 100 alerts, inline mode | Finds the single critical alert buried at index 49; names specific hosts; no hallucinated entities |
+| entity correlation | 100 alerts, inline mode | Identifies the host appearing in 20/100 alerts and the attack progression |
+| end-to-end / summary mode | 200 alerts (10 batches) | Calls `attachment_read` 10 times, then surfaces the critical alert and correlated host |
+
+[`evals/bulk_alerts_attachment_read.spec.ts`](./evals/bulk_alerts_attachment_read.spec.ts) — 1 scenario:
+
+| Scenario | Setup | What it asserts |
+| --- | --- | --- |
+| bulk attachment read | 120 synthetic IDs (6 batches), summary mode | Deterministic compliance: `attachment_read` is called once per batch |
+
+## Evaluators
+
+Assembled inline per spec:
+
+| Evaluator | Kind | Measures |
+| --- | --- | --- |
+| `criteria` (per scenario) | LLM | Triage quality against scenario-specific criteria (quality spec only) |
+| `AttachmentReadCompliance` | CODE | `attachment_read` calls in the trace ÷ expected batches ([`src/evaluators.ts`](./src/evaluators.ts)) |
+| `Tool Calls`, `Latency`, `Input/Output/Cached Tokens` | CODE (trace-based) | Non-functional metrics from the OTel trace |
+
+`AttachmentReadCompliance` passes through (`score: 1`) when an example sets no
+`expectedAttachmentReads`, so it is a no-op for inline-mode scenarios.

--- a/x-pack/solutions/security/packages/kbn-evals-suite-siem-readiness/README.md
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-siem-readiness/README.md
@@ -1,0 +1,77 @@
+# @kbn/evals-suite-siem-readiness
+
+End-to-end evaluation suite for the **SIEM Readiness** Agent Builder skill. Each
+scenario sends a natural-language question to the default agent
+(`/api/agent_builder/converse`) and asserts the agent calls the readiness tools
+(`get_coverage`, `get_quality`, `get_continuity`, `get_retention`) and returns a
+structured four-section report — Status / Summary / Findings / Suggested Actions
+— with blast-radius sub-bullets per finding and **no fabricated findings** for
+dimensions that have no issues.
+
+## Prerequisites
+
+- The suite runs through the `evals_tracing` Scout `serverConfigSet`
+  (`src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_tracing`),
+  which enables `xpack.evals` and full Kibana OTel tracing (sampled at 100%).
+- Agent Builder experimental features are enabled per-run by the spec
+  (`agentBuilder:experimentalFeatures`).
+- An AI connector available (see `@kbn/evals` docs for standard connector setup).
+  Override the agent with `AGENT_BUILDER_AGENT_ID`.
+
+## Running
+
+From the Kibana repo root:
+
+```sh
+# Start Kibana + ES test server with the tracing config set
+node scripts/scout start-server \
+  --arch stateful \
+  --domain classic \
+  --serverConfigSet evals_tracing
+
+# In another terminal, run the suite
+node scripts/evals run --suite siem-readiness
+```
+
+`node scripts/evals start --suite siem-readiness` manages the Scout server for you.
+
+All evaluation specs live under
+[`evals/siem_readiness`](./evals/siem_readiness).
+
+## Scenarios
+
+9 scenarios, one example each, defined inline in
+[`evals/siem_readiness/siem_readiness.spec.ts`](./evals/siem_readiness/siem_readiness.spec.ts):
+
+| Scenario | What it asserts |
+| --- | --- |
+| full report | All four tools called; overall status `actionsRequired` |
+| coverage — missing Application/SaaS | Missing categories flagged; present categories not falsely flagged |
+| quality — ECS incompatibility | Identity index's incompatible ECS fields surfaced; healthy index not flagged |
+| continuity — critical pipeline failure | Failing ingest pipeline flagged critical; healthy pipeline not flagged |
+| retention — FedRAMP non-compliance | Below-threshold data stream flagged; compliant stream not flagged |
+| blast-radius accuracy | Affected rules and MITRE tactics rendered as labeled sub-bullets |
+| dimension-scoped continuity | Only `get_continuity` called; other dimensions omitted |
+| `noData` for non-existent index | No fabricated findings; status `noData` |
+| four-section format | Sections appear in order Status → Summary → Findings → Suggested Actions |
+
+## Data
+
+No golden cluster and no pre-loaded snapshot: all fixture data is seeded fresh
+per run by [`src/data_generators/siem_readiness_data.ts`](./src/data_generators/siem_readiness_data.ts)
+across the four readiness dimensions (coverage indices, data-quality results,
+ingest-pipeline continuity, and DSL retention). Every index, pipeline, and
+data-stream name gets a random per-run prefix so the agent cannot rely on
+predictable names, and all artifacts are cleaned up in `afterAll`.
+
+## Evaluators
+
+The registered quality judge is `SIEM Readiness Criteria` (LLM,
+[`createSiemReadinessCriteriaEvaluator`](./src/evaluate_dataset.ts)). It layers
+each example's `output.criteria` on top of a shared `BASELINE_SIEM_READINESS_CRITERIA`
+set (six criteria covering the section contract, blast-radius sub-bullets, and
+the no-fabrication rule) so the contract does not drift across specs.
+
+Because the suite runs under `evals_tracing`, the framework's trace-based metrics
+(tool calls, latency, input/output/cached tokens) are also captured from each
+run's OTel trace and recorded alongside the quality score.


### PR DESCRIPTION
## Summary

Five Security `@kbn/evals` suites shipped without a README. This adds one each, following the existing `pci-compliance` / `endpoint` template:

| Suite | Suite id | Weekly? |
|---|---|---|
| `endpoint` | `endpoint` | ✅ |
| `siem-readiness` | `siem-readiness` | ✅ |
| `alerts-rag` | `security-alerts-rag-regression` | ✅ |
| `security-alert-triage` | `security-alert-triage` | ✅ |
| `lead-generation` | `lead-generation` | ⏸️ on-demand only |

Each README covers: what the suite evaluates, prerequisites (`serverConfigSet` + feature flags), how to run, the scenarios/dataset, and the **registered** evaluators.

## Grounding

- Suite ids verified against `.buildkite/pipelines/evals/evals.suites.json`.
- READMEs document only evaluators that are actually registered — deliberately avoiding the "declared-but-dead" drift the source issue flags.
- `lead-generation` is documented as on-demand only (absent from the weekly pipeline).

## Context

Hygiene item from the Security Evals status issue (elastic/security-team#17908): "Add READMEs to suites missing one." (`entity-highlights` is intentionally excluded — it's an unimplemented stub, tracked separately.)

Docs-only, no code changes.

Addresses elastic/security-team#17908