### PR TITLE
[Significant events] Icon: adding sig events icon

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/find_significant_events_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/find_significant_events_button.tsx
@@ -58,7 +58,7 @@ export const FindSignificantEventsButton = ({
   return (
     <ContextMenuSplitButton
       primaryLabel={FIND_SIGNIFICANT_EVENTS_LABEL}
-      primaryIconType="sparkles"
+      primaryIconType="significantEvents"
       onPrimaryClick={onRun}
       isPrimaryDisabled={isDisabled || isRunning}
       isPrimaryLoading={isRunning}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -198,7 +198,7 @@ export function StreamListView() {
               <EuiFlexItem grow={false}>
                 <EuiButton
                   href={router.link('/_discovery')}
-                  iconType="crosshairs"
+                  iconType="significantEvents"
                   size="s"
                   data-test-subj="streamsSignificantEventsDiscoveryButton"
                 >


### PR DESCRIPTION
## Summary

Simple icon swap for significant events, where applicable.

<img width="3360" height="1872" alt="image" src="https://github.com/user-attachments/assets/87b521bc-ae09-4f12-9982-83a3cce5d27b" />
