### PR TITLE
[9.3][Security Solution] Skip flaky 8.0 id migration timeline FTR test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/tests/timeline_migrations.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/tests/timeline_migrations.ts
@@ -47,7 +47,9 @@ export default function ({ getService }: FtrProviderContextWithSpaces) {
     const kibanaServer = getService('kibanaServer');
     const spacesService = getService('spaces');
 
-    describe('8.0 id migration', () => {
+    // Flaky on CI: esArchiver.load triggers SO migration which returns 500 under shared CI agents.
+    // Coverage moved to Jest integration tests in server/integration_tests/ on main. See #233580.
+    describe.skip('8.0 id migration', () => {
       const resolveWithSpaceApi = '/s/awesome-space/api/timeline/resolve';
 
       before(async () => {


### PR DESCRIPTION
## Summary

Closes #233580

Skips the `8.0 id migration` describe block in the `timeline_migrations.ts` FTR suite on the `9.3` branch.

### Why

The `8.0 id migration` suite fails intermittently on shared CI agents with a `500` from `POST /internal/saved_objects/_migrate` during `esArchiver.load` in the `before` hook — before any product assertion runs. The failure is a test-harness/SO-migration-framework issue, not a product regression (maintainer confirmed it cannot be reproduced locally, see #233580).

On `main`, the equivalent coverage was replaced by two Jest integration tests (`server/integration_tests/timeline_migrations_8_0_id.test.ts`) in PR #264709 (merged 2026-05-05). That PR was labeled `backport:skip`, leaving the flaky FTR block still running on release branches.

### What changed

Single-line change: `describe` → `describe.skip` on the `8.0 id migration` block, with a comment linking to the issue and explaining the reason.

The `7.16.0` describe block and all other tests in the file are **unchanged**.

### Risk

Test-only change. No production code, plugin config, or HTTP routes touched. The skipped tests have equivalent coverage in Jest integration tests on `main`.

Made with [Cursor](https://cursor.com)