### PR TITLE
[Streams] Fix significant_event SML type registered too late to be crawled

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
@@ -7,7 +7,6 @@
 
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
-import type { AgentContextLayerPluginSetup } from '@kbn/agent-context-layer-plugin/server';
 import type { StreamsServer } from '../types';
 import type { GetScopedClients } from '../routes/types';
 import type { EbtTelemetryClient } from '../lib/telemetry/ebt';
@@ -17,7 +16,6 @@ import type { MemoryToolsOptions } from './tools/memory';
 import { registerAgentBuilderTools } from './tools/register_tools';
 import { registerAgentBuilderSkills } from './skills/register_skills';
 import { registerAgentBuilderAttachments } from './attachments/register_attachments';
-import { registerAgentBuilderSmlTypes } from './sml/register_sml_types';
 import { registerSignificantEventsDiscoveryAgents } from './agents/discovery';
 import { registerInvestigationAgents } from './agents/investigation';
 
@@ -47,7 +45,6 @@ export const createMemoryToolsOptions = ({
 
 export const registerStreamsAgentBuilder = async ({
   agentBuilder,
-  agentContextLayer,
   getScopedClients,
   server,
   logger,
@@ -56,7 +53,6 @@ export const registerStreamsAgentBuilder = async ({
   investigationEnabled = false,
 }: {
   agentBuilder: AgentBuilderPluginSetup;
-  agentContextLayer?: AgentContextLayerPluginSetup;
   getScopedClients: GetScopedClients;
   server: StreamsServer;
   logger: Logger;
@@ -67,7 +63,6 @@ export const registerStreamsAgentBuilder = async ({
   const memoryToolsOptions = createMemoryToolsOptions({ getScopedClients, server, logger });
 
   registerAgentBuilderAttachments({ agentBuilder, getScopedClients, logger });
-  registerAgentBuilderSmlTypes({ agentContextLayer, getScopedClients });
   registerAgentBuilderTools({ agentBuilder, getScopedClients, server, logger, telemetry });
   registerAgentBuilderSkills({
     agentBuilder,

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -71,6 +71,7 @@ import {
 import { baseFields } from './lib/streams/component_templates/logs_layer';
 import { ecsBaseFields } from './lib/streams/component_templates/logs_ecs_layer';
 import { createMemoryToolsOptions, registerStreamsAgentBuilder } from './agent_builder/register';
+import { registerAgentBuilderSmlTypes } from './agent_builder/sml/register_sml_types';
 import { registerStreamsMemoryAgentBuilder } from './agent_builder/skills/register_memory_skills';
 import { registerSignificantEventsInferenceFeatures } from './register_significant_events_inference_features';
 import { registerSuggestionsInferenceFeatures } from './register_suggestions_inference_features';
@@ -322,6 +323,17 @@ export class StreamsPlugin
     );
     const streamsKIsOnboardingClient = workflowClients.streamsKIsOnboardingClient;
 
+    // Register SML types synchronously during setup so agent_context_layer can schedule
+    // their crawler tasks during its start phase. Must happen in setup() — scheduling
+    // snapshots the registry at start() and types registered later are never crawled.
+    // Matches the contract followed by alerting_v2 and agent_builder_dashboards.
+    if (plugins.agentContextLayer && this.streamsGetScopedClients) {
+      registerAgentBuilderSmlTypes({
+        agentContextLayer: plugins.agentContextLayer,
+        getScopedClients: this.streamsGetScopedClients,
+      });
+    }
+
     if (plugins.agentBuilder) {
       void core
         .getStartServices()
@@ -333,7 +345,6 @@ export class StreamsPlugin
           await registerStreamsAgentBuilder({
             agentBuilder: plugins.agentBuilder!,
             getScopedClients: streamsGetScopedClients,
-            agentContextLayer: plugins.agentContextLayer,
             server,
             logger: this.logger,
             telemetry: telemetryClient,


### PR DESCRIPTION
## Summary

The `significant_event` Semantic Metadata Layer (SML) type was never indexed into `.chat-sml-data`, so significant events never appeared in `@`-mention autocomplete. 

The root cause is a lifecycle ordering violation: the `agent_context_layer` plugin snapshots the SML type registry and schedules one crawler task per registered type during its `start()` phase, so all SML types must be registered during `setup()` to be included

The fix moves `registerAgentBuilderSmlTypes` to a synchronous call in `setup()`.