### PR TITLE
add privileges check to update API

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/entity_maintainers/init.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/entity_maintainers/init.ts
@@ -13,7 +13,7 @@ import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../../constants';
 import { ENTITY_STORE_STATUS } from '../../../domain/constants';
 import type { EntityStorePluginRouter } from '../../../types';
 import { wrapMiddlewares } from '../../middleware';
-import { getMissingPrivileges } from '../utils/get_missing_privileges';
+import { enforceEntityStorePrivileges } from '../utils/check_entity_store_privileges';
 import type { AssetManagerClient } from '../../../domain/asset_manager';
 import { initMaintainersBodySchema } from './utils/validator';
 
@@ -68,15 +68,8 @@ async function validateInitMaintainersRequest(
   req: KibanaRequest,
   res: KibanaResponseFactory
 ): Promise<IKibanaResponse | null> {
-  const privileges = await assetManagerClient.getPrivileges(req);
-  if (!privileges.hasAllRequested) {
-    return res.forbidden({
-      body: {
-        attributes: getMissingPrivileges(privileges),
-        message: `User '${privileges.username}' has insufficient privileges`,
-      },
-    });
-  }
+  const forbidden = await enforceEntityStorePrivileges(assetManagerClient, req, res);
+  if (forbidden) return forbidden;
 
   const { status } = await assetManagerClient.getStatus(false);
   if (status === ENTITY_STORE_STATUS.NOT_INSTALLED) {

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/index.ts
@@ -13,7 +13,7 @@ import type { EntityStorePluginRouter } from '../../../types';
 import { wrapMiddlewares } from '../../middleware';
 import { BodySchema } from './validator';
 import { API_VERSIONS, ENTITY_STORE_ROUTES } from '../../../../common';
-import { getMissingPrivileges } from '../utils/get_missing_privileges';
+import { enforceEntityStorePrivileges } from '../utils/check_entity_store_privileges';
 
 export function registerInstall(router: EntityStorePluginRouter) {
   router.versioned
@@ -56,18 +56,13 @@ export function registerInstall(router: EntityStorePluginRouter) {
         const { entityTypes, logExtraction, historySnapshot } = req.body;
         logger.debug('Install api called');
 
-        const privileges = await assetManager.getPrivileges(
+        const forbidden = await enforceEntityStorePrivileges(
+          assetManager,
           req,
+          res,
           logExtraction?.additionalIndexPatterns
         );
-        if (!privileges.hasAllRequested) {
-          return res.forbidden({
-            body: {
-              attributes: getMissingPrivileges(privileges),
-              message: `User '${privileges.username}' has insufficient privileges`,
-            },
-          });
-        }
+        if (forbidden) return forbidden;
         const { engines } = await assetManager.getStatus();
         const installedTypes = new Set(engines.map((e) => e.type));
         const toInstall = entityTypes.filter((type) => !installedTypes.has(type));

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/update.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/update.ts
@@ -15,6 +15,7 @@ import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
 import type { EntityStorePluginRouter } from '../../types';
 import { wrapMiddlewares } from '../middleware';
 import { LogExtractionUpdadeSchema } from './utils/log_extraction_validator';
+import { enforceEntityStorePrivileges } from './utils/check_entity_store_privileges';
 
 const bodySchema = z.object({
   logExtraction: LogExtractionUpdadeSchema,
@@ -48,8 +49,20 @@ export function registerUpdate(router: EntityStorePluginRouter) {
         },
       },
       wrapMiddlewares(async (ctx, req, res): Promise<IKibanaResponse> => {
-        const { logsExtractionClient, logger } = await ctx.entityStore;
+        const {
+          logsExtractionClient,
+          assetManagerClient: assetManager,
+          logger,
+        } = await ctx.entityStore;
         logger.debug('Update api called');
+
+        const forbidden = await enforceEntityStorePrivileges(
+          assetManager,
+          req,
+          res,
+          req.body.logExtraction?.additionalIndexPatterns
+        );
+        if (forbidden) return forbidden;
 
         try {
           await logsExtractionClient.updateConfig(req.body.logExtraction);

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_entity_store_privileges.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_entity_store_privileges.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getMissingPrivileges } from './get_missing_privileges';
+import { getMissingPrivileges } from './check_entity_store_privileges';
 import type { CheckPrivilegesResponse } from '@kbn/security-plugin-types-server';
 
 function createMockPrivilegesResponse(

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_entity_store_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_entity_store_privileges.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
+import type { IKibanaResponse, KibanaRequest, KibanaResponseFactory } from '@kbn/core/server';
 import type { CheckPrivilegesResponse } from '@kbn/security-plugin-types-server';
+import type { AssetManagerClient } from '../../../domain/asset_manager/asset_manager_client';
 
 export function getMissingPrivileges({
   privileges: { kibana, elasticsearch },
@@ -26,4 +28,22 @@ export function getMissingPrivileges({
       }, []),
     },
   };
+}
+
+export async function enforceEntityStorePrivileges(
+  assetManager: AssetManagerClient,
+  req: KibanaRequest,
+  res: KibanaResponseFactory,
+  additionalIndexPatterns?: string[]
+): Promise<IKibanaResponse | null> {
+  const privileges = await assetManager.getPrivileges(req, additionalIndexPatterns);
+  if (!privileges.hasAllRequested) {
+    return res.forbidden({
+      body: {
+        attributes: getMissingPrivileges(privileges),
+        message: `User '${privileges.username}' has insufficient privileges`,
+      },
+    });
+  }
+  return null;
 }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
@@ -204,7 +204,7 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
       const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
         responseType: 'json',
-        body: {},
+        body: { logExtraction: {} },
       });
 
       expect(response.statusCode).toBe(403);
@@ -232,7 +232,7 @@ apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, 
       const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
         responseType: 'json',
-        body: {},
+        body: { logExtraction: {} },
       });
 
       expect(response.statusCode).toBe(403);

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_store_privileges.spec.ts
@@ -20,7 +20,7 @@ import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
 import { clearEntityStoreIndices } from '../fixtures/helpers';
 import { getUpdatesEntitiesDataStreamName } from '../../../../server/domain/asset_manager/updates_data_stream';
 
-apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_TAGS }, () => {
+apiTest.describe('Entity Store - privilege checks', { tag: ENTITY_STORE_TAGS }, () => {
   const TARGET_INDEX_LATEST = getEntitiesAlias(ENTITY_LATEST, 'default');
   const TARGET_INDEX_UPDATES = getUpdatesEntitiesDataStreamName('default');
 
@@ -90,8 +90,10 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
     await clearEntityStoreIndices(esClient);
   });
 
+  // --- install API ---
+
   apiTest(
-    'Should fail when user lacks permissions for source index patterns',
+    'install - Should fail when user lacks permissions for source index patterns',
     async ({ apiClient, esClient, requestAuth }) => {
       const restrictedIndex = 'restricted-test-logs';
       additionalIndicesToCleanup = [restrictedIndex];
@@ -117,7 +119,7 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
   );
 
   apiTest(
-    'Should fail when user lacks permissions for target index patterns',
+    'install - Should fail when user lacks permissions for target index patterns',
     async ({ apiClient, requestAuth }) => {
       const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
         getRoleWithoutTargetIndexPrivileges()
@@ -145,13 +147,89 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
   );
 
   apiTest(
-    'Should fail when user lacks permissions for entity store saved object descriptor',
+    'install - Should fail when user lacks permissions for entity store saved object descriptor',
     async ({ apiClient, requestAuth }) => {
       const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
         getRoleWithoutSavedObjectCreate()
       );
 
       const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: {},
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_kibana_privileges: [SAVED_OBJECT_PRIVILEGE],
+      });
+    }
+  );
+
+  // --- update API ---
+
+  apiTest(
+    'update - Should fail when user lacks permissions for source index patterns',
+    async ({ apiClient, esClient, requestAuth }) => {
+      const restrictedIndex = 'restricted-test-logs';
+      additionalIndicesToCleanup = [restrictedIndex];
+
+      await esClient.indices.create({ index: restrictedIndex });
+
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(getRoleWithAllPrivileges());
+
+      const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: { logExtraction: { additionalIndexPatterns: [restrictedIndex] } },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [{ index: restrictedIndex, privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES }],
+        },
+      });
+    }
+  );
+
+  apiTest(
+    'update - Should fail when user lacks permissions for target index patterns',
+    async ({ apiClient, requestAuth }) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
+        getRoleWithoutTargetIndexPrivileges()
+      );
+
+      const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: {},
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [
+            {
+              index: TARGET_INDEX_LATEST,
+              privileges: expect.arrayContaining(ENTITY_STORE_TARGET_INDICES_PRIVILEGES),
+            },
+          ],
+        },
+      });
+    }
+  );
+
+  apiTest(
+    'update - Should fail when user lacks permissions for entity store saved object descriptor',
+    async ({ apiClient, requestAuth }) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
+        getRoleWithoutSavedObjectCreate()
+      );
+
+      const response = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
         responseType: 'json',
         body: {},


### PR DESCRIPTION
## Summary

  The update API (`PUT /api/security/entity_store`) accepted `additionalIndexPatterns` in its request body but did not enforce the same index privilege check that the install API does, potentially allowing
  under-privileged users to reconfigure source index patterns.

  ## Changes

  - Extracts the repeated privilege-check logic from the install and entity-maintainers-init route handlers into a shared `enforceEntityStorePrivileges` helper, reducing code duplication across all three routes.
  - Wires `enforceEntityStorePrivileges` into the update route handler so that a 403 with missing-privileges detail is returned before `updateConfig` is called.
  - Merges `get_missing_privileges.ts` into `check_entity_store_privileges.ts` since it had no other direct consumers; test file renamed accordingly.
  - Extends the Scout privilege-check spec (`install_privileges.spec.ts` → `entity_store_privileges.spec.ts`) to cover the update API across the same three scenarios: source index patterns, target index patterns,
  and saved-object descriptor privilege.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->