### PR TITLE
[Security Solution] feat(timeline): Super Timeline — mode flag and aggregation utility (1/5)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/threat_hunting/timelines/super_timeline.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/threat_hunting/timelines/super_timeline.md
@@ -1,0 +1,63 @@
+# Test plan: Super Timeline <!-- omit from toc -->
+
+**Status**: `in progress — PR 1 of 5`
+
+## Summary <!-- omit from toc -->
+
+Super Timeline lets an incident lead aggregate multiple Timeline investigations into a single
+transient, read-only view. Pinned events from all selected timelines are merged; notes are shown
+read-only (never duplicated); KQL/filter queries are OR'd into one combined filter pill with
+per-timeline labels. ESQL and EQL timelines still contribute their pins and notes — only their
+query is skipped.
+
+The view is **transient** — never saved. Opened from two entry points (added in PRs 4–5):
+1. Timelines list page → bulk-select timelines → "View Super Timeline"
+2. Cases → Attachments tab → select timeline rows → "View Super Timeline"
+
+## References <!-- omit from toc -->
+
+- [Epic: elastic/security-team#14357](https://github.com/elastic/security-team/issues/14357)
+- [Enhancement request: elastic/enhancements#25590](https://github.com/elastic/enhancements/issues/25590)
+- Contractual deadline: January 2027 (BASF)
+
+## Requirements <!-- omit from toc -->
+
+- Opening Super Timeline must not create any new saved objects (`siem-timeline`, `siem-note`,
+  `siem-pinned-event`).
+- A note shared across source timelines must appear exactly once (no duplication).
+- Closing and reopening the timeline modal must not restore the Super Timeline (transient).
+- Capped at 10 source timelines.
+
+---
+
+## PR 1 — Mode flag and aggregation utility
+
+### What this introduces
+
+- `isSuperTimeline?: boolean` and `superTimelineSourceIds?: string[]` on `TimelineModel` —
+  runtime-only, never persisted to the saved object.
+- `selectIsSuperTimeline` selector.
+- `buildSuperTimelineModel(timelines, { dataView, browserFields, esQueryConfig })` — pure
+  client-side utility that merges N timelines into one:
+  - **Pinned events**: union of all `pinnedEventIds` records (deduped by Record key).
+  - **Notes**: reference union — `noteIds` and `eventIdToNoteIds` merged without copying note
+    objects.
+  - **Date range**: earliest start → latest end across all source timelines.
+  - **Columns**: union in first-seen order, falling back to `defaultColumns`.
+  - **Queries**: one OR `CombinedFilter` built from each timeline's `combineQueries` result.
+    EQL/ESQL-only timelines contribute no sub-filter and are listed in `skippedQueryTimelines`.
+
+### Why
+
+The aggregation logic is isolated as a pure utility so it can be fully unit-tested before any UI
+is wired up. Runtime-only flags (`isSuperTimeline`, `superTimelineSourceIds`) avoid saved-object
+schema changes — precedent: `savedSearch`, `changed`, `show` are also runtime-only on
+`TimelineModel`.
+
+### How to verify
+
+No browser UI in this PR. Run the unit tests:
+
+```bash
+node scripts/jest x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+```

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -9,7 +9,6 @@ import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/dat
 import { isCombinedFilter, BooleanRelation } from '@kbn/es-query';
 import type { CombinedFilter } from '@kbn/es-query';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
-import { TimelineTabs } from '../../../../common/types/timeline';
 import type { DataProvider } from '../../../../common/types';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
@@ -329,7 +328,6 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-timeline',
         title: 'EQL Investigation',
-        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -410,7 +408,6 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-tl',
         title: 'EQL Timeline',
-        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -437,13 +434,12 @@ describe('buildSuperTimelineModel', () => {
     });
 
     it('skips an EQL timeline that has stale KQL filters from a prior query-tab visit', () => {
-      // A timeline saved in EQL mode may still carry filters from when the user
-      // previously visited the Query tab. The old !hasKqlQuery guard would have
-      // treated this as a KQL timeline and silently merged the stale filters.
+      // Detection keys off eqlOptions.query (persisted), not activeTab (runtime-only).
+      // A timeline saved in EQL mode may still carry KQL filters from when the user
+      // previously visited the Query tab. Stale filters must not be merged.
       const eqlWithStaleFilters = makeTimeline({
         savedObjectId: 'eql-stale',
         title: 'EQL with stale filters',
-        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -464,6 +460,31 @@ describe('buildSuperTimelineModel', () => {
       expect(skippedQueryTimelines).toHaveLength(1);
       expect(skippedQueryTimelines[0].reason).toBe('eql');
       expect(model.filters).toHaveLength(0);
+    });
+
+    it('does NOT skip a timeline that has activeTab=eql but an empty eqlOptions.query', () => {
+      // activeTab is runtime-only and resets to TimelineTabs.query after formatTimelineResponseToModel.
+      // A timeline that was opened in EQL mode but has no saved eqlOptions.query should be treated
+      // as a KQL timeline (fall through to the query merge path).
+      const kqlTimeline = makeTimeline({
+        savedObjectId: 'kql-was-eql-tab',
+        title: 'KQL (no EQL query saved)',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: '',
+          size: 100,
+        },
+        filters: [
+          {
+            meta: { alias: null, negate: false, disabled: false, type: 'phrase', key: 'host.name' },
+            query: { match_phrase: { 'host.name': 'some-host' } },
+          },
+        ],
+      });
+
+      const { skippedQueryTimelines } = buildSuperTimelineModel([kqlTimeline], deps);
+      expect(skippedQueryTimelines).toHaveLength(0);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -9,6 +9,7 @@ import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/dat
 import { isCombinedFilter, BooleanRelation } from '@kbn/es-query';
 import type { CombinedFilter } from '@kbn/es-query';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import { TimelineTabs } from '../../../../common/types/timeline';
 import type { DataProvider } from '../../../../common/types';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
@@ -328,6 +329,7 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-timeline',
         title: 'EQL Investigation',
+        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -408,6 +410,7 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-tl',
         title: 'EQL Timeline',
+        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -431,6 +434,36 @@ describe('buildSuperTimelineModel', () => {
       // EQL timeline is skipped
       expect(skippedQueryTimelines).toHaveLength(1);
       expect(skippedQueryTimelines[0].title).toBe('EQL Timeline');
+    });
+
+    it('skips an EQL timeline that has stale KQL filters from a prior query-tab visit', () => {
+      // A timeline saved in EQL mode may still carry filters from when the user
+      // previously visited the Query tab. The old !hasKqlQuery guard would have
+      // treated this as a KQL timeline and silently merged the stale filters.
+      const eqlWithStaleFilters = makeTimeline({
+        savedObjectId: 'eql-stale',
+        title: 'EQL with stale filters',
+        activeTab: TimelineTabs.eql,
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: 'process where process.name == "cmd.exe"',
+          size: 100,
+        },
+        filters: [
+          {
+            meta: { alias: null, negate: false, disabled: false, type: 'phrase', key: 'host.name' },
+            query: { match_phrase: { 'host.name': 'stale-host' } },
+          },
+        ],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([eqlWithStaleFilters], deps);
+
+      // Must be reported as skipped — stale filters must not be merged
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0].reason).toBe('eql');
+      expect(model.filters).toHaveLength(0);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -1,0 +1,413 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { isCombinedFilter, BooleanRelation } from '@kbn/es-query';
+import type { CombinedFilter } from '@kbn/es-query';
+import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import type { DataProvider } from '../../../../common/types';
+import type { TimelineModel } from '../../store/model';
+import { timelineDefaults } from '../../store/defaults';
+import {
+  buildSuperTimelineModel,
+  SUPER_TIMELINE_TITLE,
+  SUPER_TIMELINE_QUERY_ALIAS,
+} from './build_super_timeline_model';
+
+const mockDataView = createStubDataView({ spec: { id: 'mock-data-view' } });
+const mockBrowserFields = {};
+const mockEsQueryConfig = { allowLeadingWildcards: true, queryStringOptions: {} };
+
+const deps = {
+  dataView: mockDataView,
+  browserFields: mockBrowserFields,
+  esQueryConfig: mockEsQueryConfig,
+};
+
+/** Builds a minimal TimelineModel for testing */
+const makeTimeline = (overrides: Partial<TimelineModel>): TimelineModel => ({
+  ...(timelineDefaults as unknown as TimelineModel),
+  id: 'timeline-1',
+  savedObjectId: 'saved-obj-1',
+  title: 'Timeline 1',
+  pinnedEventIds: {},
+  pinnedEventsSaveObject: {},
+  noteIds: [],
+  eventIdToNoteIds: {},
+  dataProviders: [],
+  kqlQuery: { filterQuery: null },
+  filters: [],
+  dateRange: { start: '2024-01-01T00:00:00.000Z', end: '2024-01-02T00:00:00.000Z' },
+  columns: [],
+  defaultColumns: timelineDefaults.defaultColumns,
+  indexNames: ['logs-*'],
+  eqlOptions: {
+    eventCategoryField: 'event.category',
+    timestampField: '@timestamp',
+    query: '',
+    size: 100,
+  },
+  savedSearchId: null,
+  savedSearch: null,
+  ...overrides,
+});
+
+describe('buildSuperTimelineModel', () => {
+  describe('basic structure', () => {
+    it('returns a model with isSuperTimeline: true and SUPER_TIMELINE_TITLE', () => {
+      const { model } = buildSuperTimelineModel([makeTimeline({})], deps);
+      expect(model.isSuperTimeline).toBe(true);
+      expect(model.title).toBe(SUPER_TIMELINE_TITLE);
+    });
+
+    it('carries the source savedObjectIds in superTimelineSourceIds', () => {
+      const t1 = makeTimeline({ savedObjectId: 'id-a' });
+      const t2 = makeTimeline({ savedObjectId: 'id-b' });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.superTimelineSourceIds).toEqual(['id-a', 'id-b']);
+    });
+
+    it('sets savedObjectId to null (transient, never persisted)', () => {
+      const { model } = buildSuperTimelineModel([makeTimeline({})], deps);
+      expect(model.savedObjectId).toBeNull();
+    });
+
+    it('clears dataProviders and kqlQuery (query lives in CombinedFilter)', () => {
+      const dataProvider: DataProvider = {
+        id: 'dp-1',
+        name: 'host',
+        enabled: true,
+        excluded: false,
+        kqlQuery: '',
+        queryMatch: { field: 'host.name', value: 'foo', operator: ':' },
+        and: [],
+      };
+      const t = makeTimeline({
+        dataProviders: [dataProvider],
+        kqlQuery: {
+          filterQuery: {
+            kuery: { kind: 'kuery', expression: 'host.name: foo' },
+            serializedQuery: '',
+          },
+        },
+      });
+      const { model } = buildSuperTimelineModel([t], deps);
+      expect(model.dataProviders).toEqual([]);
+      expect(model.kqlQuery.filterQuery).toBeNull();
+    });
+
+    it('returns an empty model when no timelines are provided', () => {
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([], deps);
+      expect(model.isSuperTimeline).toBe(true);
+      expect(model.superTimelineSourceIds).toEqual([]);
+      expect(skippedQueryTimelines).toEqual([]);
+    });
+  });
+
+  describe('pinned event union', () => {
+    it('unions pinned events across timelines', () => {
+      const t1 = makeTimeline({ pinnedEventIds: { 'event-a': true, 'event-b': true } });
+      const t2 = makeTimeline({ pinnedEventIds: { 'event-c': true } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.pinnedEventIds).toEqual({
+        'event-a': true,
+        'event-b': true,
+        'event-c': true,
+      });
+    });
+
+    it('deduplicates overlapping pinned events without duplicating the entry', () => {
+      const t1 = makeTimeline({ pinnedEventIds: { 'event-shared': true } });
+      const t2 = makeTimeline({ pinnedEventIds: { 'event-shared': true } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      // Record deduplication: key exists once
+      expect(Object.keys(model.pinnedEventIds)).toHaveLength(1);
+      expect(model.pinnedEventIds['event-shared']).toBe(true);
+    });
+  });
+
+  describe('note union (reference-only, no duplication)', () => {
+    it('unions noteIds across timelines without duplicating shared notes', () => {
+      const t1 = makeTimeline({ noteIds: ['note-1', 'note-shared'] });
+      const t2 = makeTimeline({ noteIds: ['note-2', 'note-shared'] });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      // note-shared appears once
+      expect(model.noteIds).toEqual(['note-1', 'note-shared', 'note-2']);
+    });
+
+    it('merges eventIdToNoteIds without duplicating note references on shared events', () => {
+      const t1 = makeTimeline({ eventIdToNoteIds: { 'event-x': ['note-1', 'note-shared'] } });
+      const t2 = makeTimeline({ eventIdToNoteIds: { 'event-x': ['note-2', 'note-shared'] } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      const notes = model.eventIdToNoteIds['event-x'];
+      expect(notes).toContain('note-1');
+      expect(notes).toContain('note-2');
+      expect(notes).toContain('note-shared');
+      // note-shared must appear only once
+      expect(notes.filter((n) => n === 'note-shared')).toHaveLength(1);
+    });
+
+    it('combines eventIdToNoteIds from separate events', () => {
+      const t1 = makeTimeline({ eventIdToNoteIds: { 'event-a': ['note-1'] } });
+      const t2 = makeTimeline({ eventIdToNoteIds: { 'event-b': ['note-2'] } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.eventIdToNoteIds['event-a']).toEqual(['note-1']);
+      expect(model.eventIdToNoteIds['event-b']).toEqual(['note-2']);
+    });
+  });
+
+  describe('date range union', () => {
+    it('sets the earliest start and latest end across all timelines', () => {
+      const t1 = makeTimeline({
+        dateRange: { start: '2024-01-03T00:00:00.000Z', end: '2024-01-05T00:00:00.000Z' },
+      });
+      const t2 = makeTimeline({
+        dateRange: { start: '2024-01-01T00:00:00.000Z', end: '2024-01-07T00:00:00.000Z' },
+      });
+      const t3 = makeTimeline({
+        dateRange: { start: '2024-01-02T00:00:00.000Z', end: '2024-01-06T00:00:00.000Z' },
+      });
+      const { model } = buildSuperTimelineModel([t1, t2, t3], deps);
+      expect(model.dateRange.start).toBe('2024-01-01T00:00:00.000Z');
+      expect(model.dateRange.end).toBe('2024-01-07T00:00:00.000Z');
+    });
+  });
+
+  describe('column union', () => {
+    const col = (id: string): ColumnHeaderOptions => ({
+      id,
+      columnHeaderType: 'not-filtered',
+      initialWidth: 100,
+    });
+
+    it('unions columns in first-seen order without duplicates', () => {
+      const t1 = makeTimeline({ columns: [col('@timestamp'), col('host.name')] });
+      const t2 = makeTimeline({ columns: [col('host.name'), col('user.name')] });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.columns.map((c) => c.id)).toEqual(['@timestamp', 'host.name', 'user.name']);
+    });
+
+    it('falls back to defaultColumns when all source timelines have no columns', () => {
+      const t1 = makeTimeline({ columns: [] });
+      const { model } = buildSuperTimelineModel([t1], deps);
+      expect(model.columns).toEqual(timelineDefaults.defaultColumns);
+    });
+  });
+
+  describe('query merging — CombinedFilter', () => {
+    it('produces one CombinedFilter with OR relation when timelines have KQL queries', () => {
+      // Timelines with only filters (no KQL expression, no data providers) — combineQueries
+      // returns a result when filters are non-empty
+      const t1 = makeTimeline({
+        title: 'Timeline A',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'host.name',
+              params: { query: 'foo' },
+            },
+            query: { match_phrase: { 'host.name': 'foo' } },
+          },
+        ],
+      });
+      const t2 = makeTimeline({
+        title: 'Timeline B',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'host.name',
+              params: { query: 'bar' },
+            },
+            query: { match_phrase: { 'host.name': 'bar' } },
+          },
+        ],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([t1, t2], deps);
+
+      expect(skippedQueryTimelines).toHaveLength(0);
+      expect(model.filters).toHaveLength(1);
+      const combinedRaw = model.filters![0];
+      expect(isCombinedFilter(combinedRaw)).toBe(true);
+      const combined = combinedRaw as CombinedFilter;
+      expect(combined.meta.relation).toBe(BooleanRelation.OR);
+      expect(combined.meta.alias).toBe(SUPER_TIMELINE_QUERY_ALIAS);
+      // One sub-filter per source timeline
+      expect(combined.meta.params).toHaveLength(2);
+    });
+
+    it('produces the correct number of sub-filters for each source timeline', () => {
+      // Note: buildCombinedFilter calls cleanUpFilter on each sub-filter, which strips meta.alias.
+      // Individual sub-filters are identifiable by their DSL content, not by alias. The top-level
+      // CombinedFilter pill is labelled via SUPER_TIMELINE_QUERY_ALIAS (tested above).
+      const t1 = makeTimeline({
+        title: 'Endpoint Investigation',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'process.name',
+              params: { query: 'cmd.exe' },
+            },
+            query: { match_phrase: { 'process.name': 'cmd.exe' } },
+          },
+        ],
+      });
+      const t2 = makeTimeline({
+        title: 'Network Investigation',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'network.direction',
+              params: { query: 'egress' },
+            },
+            query: { match_phrase: { 'network.direction': 'egress' } },
+          },
+        ],
+      });
+
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+
+      const combined = model.filters![0];
+      // One sub-filter per source timeline
+      expect(combined.meta.params).toHaveLength(2);
+    });
+
+    it('produces no filters when all timelines have empty queries', () => {
+      const t1 = makeTimeline({ dataProviders: [], kqlQuery: { filterQuery: null }, filters: [] });
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([t1], deps);
+      expect(model.filters).toHaveLength(0);
+      expect(skippedQueryTimelines).toHaveLength(0);
+    });
+  });
+
+  describe('EQL / ESQL handling', () => {
+    it('reports an EQL-only timeline in skippedQueryTimelines and still aggregates its pins/notes', () => {
+      const eqlTimeline = makeTimeline({
+        savedObjectId: 'eql-timeline',
+        title: 'EQL Investigation',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: 'process where process.name == "cmd.exe"',
+          size: 100,
+        },
+        dataProviders: [],
+        kqlQuery: { filterQuery: null },
+        filters: [],
+        pinnedEventIds: { 'pinned-from-eql': true },
+        noteIds: ['note-from-eql'],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([eqlTimeline], deps);
+
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0]).toMatchObject({
+        id: 'eql-timeline',
+        title: 'EQL Investigation',
+        reason: 'eql',
+      });
+      // Pinned events and notes still aggregate
+      expect(model.pinnedEventIds['pinned-from-eql']).toBe(true);
+      expect(model.noteIds).toContain('note-from-eql');
+      // But no query filter from this timeline
+      expect(model.filters).toHaveLength(0);
+    });
+
+    it('reports an ESQL-only timeline in skippedQueryTimelines and still aggregates its pins/notes', () => {
+      const esqlTimeline = makeTimeline({
+        savedObjectId: 'esql-timeline',
+        title: 'ESQL Investigation',
+        savedSearchId: 'some-saved-search-id',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: '',
+          size: 100,
+        },
+        dataProviders: [],
+        kqlQuery: { filterQuery: null },
+        filters: [],
+        pinnedEventIds: { 'pinned-from-esql': true },
+        noteIds: ['note-from-esql'],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([esqlTimeline], deps);
+
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0]).toMatchObject({
+        id: 'esql-timeline',
+        title: 'ESQL Investigation',
+        reason: 'esql',
+      });
+      expect(model.pinnedEventIds['pinned-from-esql']).toBe(true);
+      expect(model.noteIds).toContain('note-from-esql');
+      expect(model.filters).toHaveLength(0);
+    });
+
+    it('merges KQL timelines and skips EQL/ESQL timelines in one call', () => {
+      const kqlTimeline = makeTimeline({
+        savedObjectId: 'kql-tl',
+        title: 'KQL Timeline',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'host.name',
+              params: { query: 'web' },
+            },
+            query: { match_phrase: { 'host.name': 'web' } },
+          },
+        ],
+      });
+      const eqlTimeline = makeTimeline({
+        savedObjectId: 'eql-tl',
+        title: 'EQL Timeline',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: 'any where true',
+          size: 100,
+        },
+        dataProviders: [],
+        kqlQuery: { filterQuery: null },
+        filters: [],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel(
+        [kqlTimeline, eqlTimeline],
+        deps
+      );
+
+      // KQL timeline contributes a sub-filter
+      expect(model.filters).toHaveLength(1);
+      expect(isCombinedFilter(model.filters![0])).toBe(true);
+      expect((model.filters![0].meta.params as unknown[]).length).toBe(1);
+      // EQL timeline is skipped
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0].title).toBe('EQL Timeline');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -175,6 +175,29 @@ describe('buildSuperTimelineModel', () => {
       expect(model.dateRange.start).toBe('2024-01-01T00:00:00.000Z');
       expect(model.dateRange.end).toBe('2024-01-07T00:00:00.000Z');
     });
+
+    it('correctly unions relative date strings (now-7d is earlier than now-24h)', () => {
+      // Lexicographic comparison gets this wrong: '7' > '2', so 'now-7d' < 'now-24h' is
+      // false by char code, but now-7d is actually an earlier point in time than now-24h.
+      const t1 = makeTimeline({ dateRange: { start: 'now-24h', end: 'now' } });
+      const t2 = makeTimeline({ dateRange: { start: 'now-7d', end: 'now' } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      // now-7d is earlier, so it should win as the start
+      expect(model.dateRange.start).toBe('now-7d');
+      expect(model.dateRange.end).toBe('now');
+    });
+
+    it('unions mixed ISO and relative date strings correctly', () => {
+      // ISO 2020-01-01 is always earlier than now-7d; ISO end 2021-01-01 is always earlier
+      // than now. Verifies that ISO and relative strings can be compared across types.
+      const t1 = makeTimeline({
+        dateRange: { start: '2020-01-01T00:00:00.000Z', end: '2021-01-01T00:00:00.000Z' },
+      });
+      const t2 = makeTimeline({ dateRange: { start: 'now-7d', end: 'now' } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.dateRange.start).toBe('2020-01-01T00:00:00.000Z');
+      expect(model.dateRange.end).toBe('now');
+    });
   });
 
   describe('column union', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -11,6 +11,7 @@ import type { EsQueryConfig } from '@kbn/es-query';
 import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
 import type { BrowserFields } from '../../../../common/search_strategy';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import { TimelineTabs } from '../../../../common/types/timeline';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
 import { combineQueries } from '../../../common/lib/kuery';
@@ -115,19 +116,18 @@ export const buildSuperTimelineModel = (
     const title = timeline.title || timeline.savedObjectId || 'Untitled Timeline';
     const id = timeline.savedObjectId ?? '';
 
-    // Detect EQL/ESQL-only timelines (their query lives outside KQL/dataProviders/filters)
-    const hasEqlQuery = !!timeline.eqlOptions?.query;
-    const hasEsqlQuery = !!timeline.savedSearchId;
-    const hasKqlQuery =
-      (timeline.dataProviders && timeline.dataProviders.length > 0) ||
-      timeline.kqlQuery?.filterQuery?.kuery?.expression ||
-      (timeline.filters && timeline.filters.length > 0);
+    // Key off the saved activeTab to identify the primary query mode.
+    // savedSearchId definitively identifies ESQL. activeTab === 'eql' identifies EQL.
+    // This avoids false-positives from stale filters/dataProviders that remain on the
+    // model when the user visited the Query tab before switching to EQL mode.
+    const isEsqlTimeline = !!timeline.savedSearchId;
+    const isEqlTimeline = !isEsqlTimeline && timeline.activeTab === TimelineTabs.eql;
 
-    if (!hasKqlQuery && (hasEqlQuery || hasEsqlQuery)) {
+    if (isEqlTimeline || isEsqlTimeline) {
       skippedQueryTimelines.push({
         id,
         title,
-        reason: hasEsqlQuery ? 'esql' : 'eql',
+        reason: isEsqlTimeline ? 'esql' : 'eql',
       });
     } else {
       const kqlQuery = {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import dateMath from '@kbn/datemath';
 import type { DataView } from '@kbn/data-plugin/common';
 import type { EsQueryConfig } from '@kbn/es-query';
 import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
@@ -175,12 +176,22 @@ export const buildSuperTimelineModel = (
       : [];
 
   // ── Date range: earliest start → latest end ──────────────────────────────────
+  // dateRange strings can be relative (e.g. "now-7d") or absolute ISO. Parse to
+  // milliseconds before comparing so relative strings sort correctly.
   const dateRange = timelines.reduce(
-    (acc, timeline) => ({
-      start:
-        !acc.start || timeline.dateRange.start < acc.start ? timeline.dateRange.start : acc.start,
-      end: !acc.end || timeline.dateRange.end > acc.end ? timeline.dateRange.end : acc.end,
-    }),
+    (acc, timeline) => {
+      const startMs = dateMath.parse(timeline.dateRange.start)?.valueOf() ?? Infinity;
+      const endMs =
+        dateMath.parse(timeline.dateRange.end, { roundUp: true })?.valueOf() ?? -Infinity;
+      const accStartMs = acc.start ? dateMath.parse(acc.start)?.valueOf() ?? Infinity : Infinity;
+      const accEndMs = acc.end
+        ? dateMath.parse(acc.end, { roundUp: true })?.valueOf() ?? -Infinity
+        : -Infinity;
+      return {
+        start: startMs < accStartMs ? timeline.dateRange.start : acc.start,
+        end: endMs > accEndMs ? timeline.dateRange.end : acc.end,
+      };
+    },
     { start: '', end: '' }
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -11,7 +11,6 @@ import type { EsQueryConfig } from '@kbn/es-query';
 import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
 import type { BrowserFields } from '../../../../common/search_strategy';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
-import { TimelineTabs } from '../../../../common/types/timeline';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
 import { combineQueries } from '../../../common/lib/kuery';
@@ -116,12 +115,12 @@ export const buildSuperTimelineModel = (
     const title = timeline.title || timeline.savedObjectId || 'Untitled Timeline';
     const id = timeline.savedObjectId ?? '';
 
-    // Key off the saved activeTab to identify the primary query mode.
-    // savedSearchId definitively identifies ESQL. activeTab === 'eql' identifies EQL.
-    // This avoids false-positives from stale filters/dataProviders that remain on the
-    // model when the user visited the Query tab before switching to EQL mode.
+    // Use persisted fields to identify the primary query mode — NOT activeTab, which
+    // is runtime-only and always resets to TimelineTabs.query after formatTimelineResponseToModel.
+    // savedSearchId is the canonical ESQL indicator (persisted). eqlOptions.query is the
+    // canonical EQL indicator (persisted). Both survive a resolveTimeline → model round-trip.
     const isEsqlTimeline = !!timeline.savedSearchId;
-    const isEqlTimeline = !isEsqlTimeline && timeline.activeTab === TimelineTabs.eql;
+    const isEqlTimeline = !isEsqlTimeline && !!timeline.eqlOptions?.query?.trim();
 
     if (isEqlTimeline || isEsqlTimeline) {
       skippedQueryTimelines.push({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView } from '@kbn/data-plugin/common';
+import type { EsQueryConfig } from '@kbn/es-query';
+import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
+import type { BrowserFields } from '../../../../common/search_strategy';
+import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import type { TimelineModel } from '../../store/model';
+import { timelineDefaults } from '../../store/defaults';
+import { combineQueries } from '../../../common/lib/kuery';
+
+export const SUPER_TIMELINE_TITLE = 'Super Timeline';
+export const SUPER_TIMELINE_QUERY_ALIAS = 'Super Timeline Sources';
+
+export type SkippedQueryReason = 'eql' | 'esql';
+
+export interface SkippedQueryTimeline {
+  id: string;
+  title: string;
+  reason: SkippedQueryReason;
+}
+
+export interface BuildSuperTimelineModelDeps {
+  dataView: DataView;
+  browserFields: BrowserFields;
+  esQueryConfig: EsQueryConfig;
+}
+
+export interface BuildSuperTimelineModelResult {
+  model: TimelineModel;
+  /** Source timelines whose query type (EQL/ESQL) couldn't be merged. Their pins and notes still aggregate. */
+  skippedQueryTimelines: SkippedQueryTimeline[];
+}
+
+/**
+ * Merges N fully-resolved TimelineModels into a single transient Super Timeline model.
+ *
+ * What this does:
+ * - Unions pinnedEventIds (deduped by key)
+ * - Unions eventIdToNoteIds + noteIds (references only — no note objects are cloned)
+ * - Combines all KQL/filter queries into a single OR CombinedFilter (one labelled sub-filter per
+ *   source timeline). Timelines with EQL-only or ESQL-only queries contribute no sub-filter but
+ *   are reported in `skippedQueryTimelines` so the caller can warn the user.
+ * - Sets dateRange to the union of all source ranges (earliest start → latest end).
+ * - Unions the column sets (first-seen order, falling back to defaultColumns).
+ *
+ * The returned model has `isSuperTimeline: true` and `superTimelineSourceIds` set.
+ * It is NOT persisted — the persist path (`convertTimelineAsInput`) is an allow-list and neither
+ * field is included, matching the existing pattern for runtime-only fields like `savedSearch` and
+ * `changed`.
+ */
+export const buildSuperTimelineModel = (
+  timelines: TimelineModel[],
+  deps: BuildSuperTimelineModelDeps
+): BuildSuperTimelineModelResult => {
+  const { dataView, browserFields, esQueryConfig } = deps;
+  const skippedQueryTimelines: SkippedQueryTimeline[] = [];
+
+  if (timelines.length === 0) {
+    return {
+      model: {
+        ...timelineDefaults,
+        id: '',
+        title: SUPER_TIMELINE_TITLE,
+        isSuperTimeline: true,
+        superTimelineSourceIds: [],
+      } as TimelineModel,
+      skippedQueryTimelines,
+    };
+  }
+
+  // ── Pinned events ────────────────────────────────────────────────────────────
+  const pinnedEventIds: Record<string, boolean> = {};
+  const pinnedEventsSaveObject: TimelineModel['pinnedEventsSaveObject'] = {};
+
+  for (const timeline of timelines) {
+    Object.assign(pinnedEventIds, timeline.pinnedEventIds);
+    Object.assign(pinnedEventsSaveObject, timeline.pinnedEventsSaveObject);
+  }
+
+  // ── Notes (reference union — no duplication) ─────────────────────────────────
+  const noteIds: string[] = [];
+  const seenNoteIds = new Set<string>();
+  const eventIdToNoteIds: Record<string, string[]> = {};
+
+  for (const timeline of timelines) {
+    for (const noteId of timeline.noteIds) {
+      if (!seenNoteIds.has(noteId)) {
+        seenNoteIds.add(noteId);
+        noteIds.push(noteId);
+      }
+    }
+    for (const [eventId, ids] of Object.entries(timeline.eventIdToNoteIds)) {
+      const existing = eventIdToNoteIds[eventId] ?? [];
+      const merged = [...existing];
+      for (const id of ids) {
+        if (!merged.includes(id)) {
+          merged.push(id);
+        }
+      }
+      eventIdToNoteIds[eventId] = merged;
+    }
+  }
+
+  // ── Query merging: one CombinedFilter with OR semantics ──────────────────────
+  const subFilters: Array<{ meta: object; query: object }> = [];
+
+  for (const timeline of timelines) {
+    const title = timeline.title || timeline.savedObjectId || 'Untitled Timeline';
+    const id = timeline.savedObjectId ?? '';
+
+    // Detect EQL/ESQL-only timelines (their query lives outside KQL/dataProviders/filters)
+    const hasEqlQuery = !!timeline.eqlOptions?.query;
+    const hasEsqlQuery = !!timeline.savedSearchId;
+    const hasKqlQuery =
+      (timeline.dataProviders && timeline.dataProviders.length > 0) ||
+      timeline.kqlQuery?.filterQuery?.kuery?.expression ||
+      (timeline.filters && timeline.filters.length > 0);
+
+    if (!hasKqlQuery && (hasEqlQuery || hasEsqlQuery)) {
+      skippedQueryTimelines.push({
+        id,
+        title,
+        reason: hasEsqlQuery ? 'esql' : 'eql',
+      });
+    } else {
+      const kqlQuery = {
+        query: timeline.kqlQuery?.filterQuery?.kuery?.expression ?? '',
+        language: timeline.kqlQuery?.filterQuery?.kuery?.kind ?? 'kuery',
+      };
+
+      const combined = combineQueries({
+        config: esQueryConfig,
+        dataProviders: timeline.dataProviders ?? [],
+        dataView,
+        browserFields,
+        filters: timeline.filters ?? [],
+        kqlQuery,
+        kqlMode: timeline.kqlMode ?? 'filter',
+      });
+
+      if (combined?.filterQuery) {
+        subFilters.push({
+          meta: {
+            alias: title,
+            type: 'custom',
+            disabled: false,
+            negate: false,
+            key: 'query',
+          },
+          query: JSON.parse(combined.filterQuery),
+        });
+      }
+    }
+  }
+
+  const mergedFilters =
+    subFilters.length > 0
+      ? [
+          buildCombinedFilter(
+            BooleanRelation.OR,
+            subFilters as Parameters<typeof buildCombinedFilter>[1],
+            { id: dataView.id },
+            false,
+            false,
+            SUPER_TIMELINE_QUERY_ALIAS,
+            FilterStateStore.APP_STATE
+          ),
+        ]
+      : [];
+
+  // ── Date range: earliest start → latest end ──────────────────────────────────
+  const dateRange = timelines.reduce(
+    (acc, timeline) => ({
+      start:
+        !acc.start || timeline.dateRange.start < acc.start ? timeline.dateRange.start : acc.start,
+      end: !acc.end || timeline.dateRange.end > acc.end ? timeline.dateRange.end : acc.end,
+    }),
+    { start: '', end: '' }
+  );
+
+  // ── Columns: union in first-seen order ───────────────────────────────────────
+  const seenColumnIds = new Set<string>();
+  const columns: ColumnHeaderOptions[] = [];
+
+  for (const timeline of timelines) {
+    for (const col of timeline.columns) {
+      if (!seenColumnIds.has(col.id)) {
+        seenColumnIds.add(col.id);
+        columns.push(col);
+      }
+    }
+  }
+  const finalColumns = columns.length > 0 ? columns : timelineDefaults.defaultColumns;
+
+  // ── Index names / data view: union ───────────────────────────────────────────
+  const seenIndexNames = new Set<string>();
+  for (const timeline of timelines) {
+    for (const name of timeline.indexNames) {
+      seenIndexNames.add(name);
+    }
+  }
+  const indexNames = Array.from(seenIndexNames);
+
+  // ── Source ids ───────────────────────────────────────────────────────────────
+  const superTimelineSourceIds = timelines
+    .map((t) => t.savedObjectId)
+    .filter((id): id is string => id !== null);
+
+  const model: TimelineModel = {
+    ...timelineDefaults,
+    id: '',
+    title: SUPER_TIMELINE_TITLE,
+    pinnedEventIds,
+    pinnedEventsSaveObject,
+    noteIds,
+    eventIdToNoteIds,
+    filters: mergedFilters,
+    // Clear KQL / data providers — queries live entirely in the CombinedFilter above
+    dataProviders: [],
+    kqlQuery: { filterQuery: null },
+    dateRange,
+    columns: finalColumns,
+    defaultColumns: finalColumns,
+    indexNames,
+    // savedObjectId null: this timeline is never persisted
+    savedObjectId: null,
+    // isSuperTimeline gates all read-only behaviour (CTA hiding, notes multi-fetch, etc.)
+    // runtime-only, not persisted (not in convertTimelineAsInput allow-list)
+    isSuperTimeline: true,
+    // runtime-only, not persisted
+    superTimelineSourceIds,
+  };
+
+  return { model, skippedQueryTimelines };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/model.ts
@@ -137,6 +137,16 @@ export interface TimelineModel {
   rowHeight?: number;
   /* sample size, total record number stored in in memory EuiDataGrid */
   sampleSize: number;
+  /**
+   * When true, this timeline is a transient, read-only Super Timeline aggregated from multiple
+   * source timelines. Runtime-only — not persisted to the saved object.
+   */
+  isSuperTimeline?: boolean;
+  /**
+   * The savedObjectIds of the source timelines that were aggregated to build this Super Timeline.
+   * Used to fetch notes across all source timelines. Runtime-only — not persisted.
+   */
+  superTimelineSourceIds?: string[];
 }
 
 export type SubsetTimelineModel = Readonly<
@@ -190,6 +200,8 @@ export type SubsetTimelineModel = Readonly<
     | 'savedSearch'
     | 'isDataProviderVisible'
     | 'changed'
+    | 'isSuperTimeline'
+    | 'superTimelineSourceIds'
   >
 >;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/selectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/selectors.ts
@@ -180,3 +180,11 @@ export const selectIsPinnedEventInTimeline = () =>
     (_: State, __: string, pinnedEventId: string) => pinnedEventId,
     (timeline, pinnedEventId): boolean => !!timeline?.pinnedEventIds?.[pinnedEventId]
   );
+
+/**
+ * Selector that returns true when the active timeline is a transient, read-only Super Timeline.
+ */
+export const selectIsSuperTimeline = createSelector(
+  selectTimelineById,
+  (timeline): boolean => !!timeline?.isSuperTimeline
+);


### PR DESCRIPTION
## Summary

### What
Introduces the runtime model fields and pure aggregation utility that all subsequent Super Timeline PRs build on. No UI entry point yet — this PR is entirely tested at the unit level.

### Why
Super Timeline is a transient, read-only view that merges N analyst timelines into one. A strategic account (BASF) requires this by January 2027. The foundation is isolated in its own PR so the merge logic can be fully reviewed and unit-tested independently of any UI wiring.

Part of epic [elastic/security-team#14357](https://github.com/elastic/security-team/issues/14357).

## Changes

- `TimelineModel`: adds `isSuperTimeline?: boolean` and `superTimelineSourceIds?: string[]` — runtime-only, never persisted (like the existing `savedSearch` and `changed` fields)
- `selectIsSuperTimeline` selector added to `store/selectors.ts`
- New `build_super_timeline_model.ts`: pure utility that merges N `TimelineModel` instances:
  - **Pinned events**: union of all `pinnedEventIds` records (deduplicated by key)
  - **Notes**: reference union — `noteIds` and `eventIdToNoteIds` merged without cloning note objects
  - **Date range**: earliest start → latest end, parsed via `dateMath` so relative strings (`now-7d`, `now-24h`) compare correctly
  - **Columns**: union in first-seen order, falling back to `defaultColumns`
  - **Queries**: one OR `CombinedFilter` per KQL timeline; EQL/ESQL-only timelines contribute pins/notes but no query clause and are reported in `skippedQueryTimelines`
- 21 unit tests covering all merge paths, edge cases, and the dateMath fix for relative date ranges
- `super_timeline.md` test plan created (PR 1 section)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Data loss**: None. New fields are runtime-only and never reach the persist path (`convertTimelineAsInput` is an allow-list).
- **Regressions**: Low. The new fields default to `undefined` and existing code paths are unaffected. The utility is only called when explicitly invoked.
- **Date range with unparseable strings**: Mitigated — `dateMath.parse` fallback to `Infinity`/`-Infinity` leaves the original string as-is.

### Release note

> Introduces the internal aggregation utility for Super Timeline — no user-facing change in this PR.

**Suggested label:** `release_note:skip`

---

### Stack

- **PR 1/5 — mode flag + aggregation utility ← you are here**
- [PR 2/5 — open hook and read-only modal gating](https://github.com/elastic/kibana/pull/274931)
- [PR 3/5 — multi-source notes aggregation](https://github.com/elastic/kibana/pull/274932)
- [PR 4/5 — "View Super Timeline" bulk action on Timelines list](https://github.com/elastic/kibana/pull/274933)
- [PR 5/5 — Cases timeline attachments entry point](https://github.com/elastic/kibana/pull/274937)