### PR TITLE
[Security Solution] feat(timeline): Super Timeline — open hook and read-only modal gating (2/5)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/threat_hunting/timelines/super_timeline.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/threat_hunting/timelines/super_timeline.md
@@ -1,6 +1,6 @@
 # Test plan: Super Timeline <!-- omit from toc -->
 
-**Status**: `in progress — PR 1 of 5`
+**Status**: `in progress — PR 2 of 5`
 
 ## Summary <!-- omit from toc -->
 
@@ -60,4 +60,34 @@ No browser UI in this PR. Run the unit tests:
 
 ```bash
 node scripts/jest x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+```
+
+---
+
+## PR 2 — Opener hook and read-only modal gating
+
+### What this introduces
+
+- `useOpenSuperTimeline(savedObjectIds)` — fetches N timelines in parallel via `resolveTimeline`,
+  builds the super model via `buildSuperTimelineModel`, dispatches it into the active timeline
+  slot. Shows a warning toast naming any EQL/ESQL timelines whose queries were skipped. Enforces
+  the 10-timeline cap with a toast.
+- **Modal header**: when `isSuperTimeline`, hides Save / Attach to Case / Add to Favorites and
+  shows a "Super Timeline — read-only" badge.
+- **Tabs**: ESQL and EQL tabs are hidden when `isSuperTimeline` is true.
+- **Overwrite guard**: before dispatching, checks whether the active timeline has unsaved changes
+  (`changed: true`) and prompts before overwriting.
+
+### Why
+
+The hook owns the full open lifecycle (fetch → build → dispatch) so all future entry points
+(PRs 4 and 5) just pass `savedObjectIds`. Header and tab gating is centralised here so every
+entry point gets read-only semantics automatically.
+
+### How to verify
+
+No browser entry point in this PR. Run the unit tests:
+
+```bash
+node scripts/jest x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
 ```

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/threat_hunting/timelines/super_timeline.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/threat_hunting/timelines/super_timeline.md
@@ -1,0 +1,63 @@
+# Test plan: Super Timeline <!-- omit from toc -->
+
+**Status**: `in progress — PR 1 of 5`
+
+## Summary <!-- omit from toc -->
+
+Super Timeline lets an incident lead aggregate multiple Timeline investigations into a single
+transient, read-only view. Pinned events from all selected timelines are merged; notes are shown
+read-only (never duplicated); KQL/filter queries are OR'd into one combined filter pill with
+per-timeline labels. ESQL and EQL timelines still contribute their pins and notes — only their
+query is skipped.
+
+The view is **transient** — never saved. Opened from two entry points (added in PRs 4–5):
+1. Timelines list page → bulk-select timelines → "View Super Timeline"
+2. Cases → Attachments tab → select timeline rows → "View Super Timeline"
+
+## References <!-- omit from toc -->
+
+- [Epic: elastic/security-team#14357](https://github.com/elastic/security-team/issues/14357)
+- [Enhancement request: elastic/enhancements#25590](https://github.com/elastic/enhancements/issues/25590)
+- Contractual deadline: January 2027 (BASF)
+
+## Requirements <!-- omit from toc -->
+
+- Opening Super Timeline must not create any new saved objects (`siem-timeline`, `siem-note`,
+  `siem-pinned-event`).
+- A note shared across source timelines must appear exactly once (no duplication).
+- Closing and reopening the timeline modal must not restore the Super Timeline (transient).
+- Capped at 10 source timelines.
+
+---
+
+## PR 1 — Mode flag and aggregation utility
+
+### What this introduces
+
+- `isSuperTimeline?: boolean` and `superTimelineSourceIds?: string[]` on `TimelineModel` —
+  runtime-only, never persisted to the saved object.
+- `selectIsSuperTimeline` selector.
+- `buildSuperTimelineModel(timelines, { dataView, browserFields, esQueryConfig })` — pure
+  client-side utility that merges N timelines into one:
+  - **Pinned events**: union of all `pinnedEventIds` records (deduped by Record key).
+  - **Notes**: reference union — `noteIds` and `eventIdToNoteIds` merged without copying note
+    objects.
+  - **Date range**: earliest start → latest end across all source timelines.
+  - **Columns**: union in first-seen order, falling back to `defaultColumns`.
+  - **Queries**: one OR `CombinedFilter` built from each timeline's `combineQueries` result.
+    EQL/ESQL-only timelines contribute no sub-filter and are listed in `skippedQueryTimelines`.
+
+### Why
+
+The aggregation logic is isolated as a pure utility so it can be fully unit-tested before any UI
+is wired up. Runtime-only flags (`isSuperTimeline`, `superTimelineSourceIds`) avoid saved-object
+schema changes — precedent: `savedSearch`, `changed`, `show` are also runtime-only on
+`TimelineModel`.
+
+### How to verify
+
+No browser UI in this PR. Run the unit tests:
+
+```bash
+node scripts/jest x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+```

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/pin_event_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/pin_event_action.test.tsx
@@ -128,6 +128,53 @@ describe('PinEventAction', () => {
     });
   });
 
+  it('should disable button and prevent pin/unpin when timeline is a Super Timeline', async () => {
+    // WHY: Super Timeline is read-only / transient. Allowing pinning would silently persist the
+    // aggregated timeline as a new saved object, defeating the "never persisted" contract.
+    const pinSpy = jest.spyOn(timelineActions, 'pinEvent');
+    const unPinSpy = jest.spyOn(timelineActions, 'unPinEvent');
+
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      timelinePrivileges: { crud: true, read: true },
+    });
+
+    const mockStore = createMockStore({
+      ...mockGlobalState,
+      timeline: {
+        ...mockGlobalState.timeline,
+        timelineById: {
+          [TimelineId.test]: {
+            ...mockGlobalState.timeline.timelineById[TimelineId.test],
+            isSuperTimeline: true,
+          },
+        },
+      },
+    });
+
+    const { getByTestId } = render(
+      <TestProviders store={mockStore}>
+        <PinEventAction
+          ariaRowindex={1}
+          columnValues={''}
+          eventId={'eventId'}
+          eventIdToNoteIds={{}}
+          isAlert={false}
+          noteIds={[]}
+          timelineId={TimelineId.test}
+          timelineType={TimelineTypeEnum.default}
+        />
+      </TestProviders>
+    );
+
+    expect(getByTestId(BUTTON_TEST_ID)).toHaveProperty('disabled', true);
+    getByTestId(BUTTON_TEST_ID).click();
+
+    await waitFor(() => {
+      expect(pinSpy).not.toHaveBeenCalled();
+      expect(unPinSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('should unpin event', async () => {
     const spy = jest.spyOn(timelineActions, 'unPinEvent');
 
@@ -242,6 +289,20 @@ describe('getPinTooltipContent', () => {
   it('should indicate the alert is disabled if timelineType is template', () => {
     expect(getPinTooltipContent(true, false, [], TimelineTypeEnum.template)).toEqual(
       'This alert may not be pinned while editing a template Timeline'
+    );
+  });
+
+  it('should indicate the event may not be pinned in a Super Timeline', () => {
+    // WHY: Super Timeline tooltip must take precedence so the user understands the read-only
+    // constraint regardless of pin state, notes, or timeline type.
+    expect(getPinTooltipContent(false, false, [], TimelineTypeEnum.default, true)).toEqual(
+      'This event may not be pinned in a read-only Super Timeline'
+    );
+  });
+
+  it('should indicate the alert may not be pinned in a Super Timeline', () => {
+    expect(getPinTooltipContent(true, false, [], TimelineTypeEnum.default, true)).toEqual(
+      'This alert may not be pinned in a read-only Super Timeline'
     );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/pin_event_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/pin_event_action.tsx
@@ -9,7 +9,10 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import { isEmpty } from 'lodash/fp';
-import { selectIsPinnedEventInTimeline } from '../../../timelines/store/selectors';
+import {
+  selectIsPinnedEventInTimeline,
+  selectIsSuperTimeline,
+} from '../../../timelines/store/selectors';
 import { EventsTdContent } from '../../../timelines/components/timeline/styles';
 import type { TimelineType } from '../../../../common/api/timeline';
 import { TimelineTypeEnum } from '../../../../common/api/timeline';
@@ -34,9 +37,12 @@ export const getPinTooltipContent = (
   isAlert: boolean,
   isPinned: boolean,
   noteIds: string[],
-  timelineType: TimelineType
+  timelineType: TimelineType,
+  isSuperTimeline: boolean = false
 ): string => {
-  if (timelineType === TimelineTypeEnum.template) {
+  if (isSuperTimeline) {
+    return i18n.DISABLE_PIN_SUPER_TIMELINE(isAlert);
+  } else if (timelineType === TimelineTypeEnum.template) {
     return i18n.DISABLE_PIN(isAlert);
   } else if (eventHasNotes(noteIds)) {
     return i18n.PINNED_WITH_NOTES(isAlert);
@@ -102,10 +108,11 @@ export const PinEventAction = memo(
 
     const isPinnedSelector = useMemo(() => selectIsPinnedEventInTimeline(), []);
     const isPinned = useSelector((state: State) => isPinnedSelector(state, timelineId, eventId));
+    const isSuperTimeline = useSelector((state: State) => selectIsSuperTimeline(state, timelineId));
 
     const tooltipContent = useMemo(
-      () => getPinTooltipContent(isAlert, isPinned, noteIds, timelineType),
-      [timelineType, noteIds, isPinned, isAlert]
+      () => getPinTooltipContent(isAlert, isPinned, noteIds, timelineType, isSuperTimeline),
+      [timelineType, noteIds, isPinned, isAlert, isSuperTimeline]
     );
 
     const handlePinClicked = useCallback(() => {
@@ -131,9 +138,10 @@ export const PinEventAction = memo(
     const isDisabled = useMemo(
       () =>
         !timelinePrivileges.crud ||
+        isSuperTimeline ||
         timelineType === TimelineTypeEnum.template ||
         eventHasNotes(noteIds),
-      [noteIds, timelinePrivileges.crud, timelineType]
+      [isSuperTimeline, noteIds, timelinePrivileges.crud, timelineType]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/translations.ts
@@ -125,6 +125,13 @@ export const DISABLE_PIN = (isAlert: boolean) =>
       'This {isAlert, select, true{alert} other{event}} may not be pinned while editing a template Timeline',
   });
 
+export const DISABLE_PIN_SUPER_TIMELINE = (isAlert: boolean) =>
+  i18n.translate('xpack.securitySolution.timeline.body.pinning.disablePinSuperTimelineTooltip', {
+    values: { isAlert },
+    defaultMessage:
+      'This {isAlert, select, true{alert} other{event}} may not be pinned in a read-only Super Timeline',
+  });
+
 export const PINNED_WITH_NOTES = (isAlert: boolean) =>
   i18n.translate('xpack.securitySolution.timeline.body.pinning.pinnnedWithNotesTooltip', {
     values: { isAlert },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/notes/hooks/use_timeline_config.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/notes/hooks/use_timeline_config.test.tsx
@@ -79,6 +79,28 @@ describe('useTimelineConfig', () => {
     });
   });
 
+  describe('when the active timeline is a Super Timeline', () => {
+    it('returns undefined so the "Attach to current Timeline" callout and Save button are never shown', () => {
+      // WHY: Super Timelines are transient and read-only. Showing "Save current Timeline" would
+      // persist the Super Timeline as a new saved object, defeating the never-persisted contract.
+      const superTimelineStore = createMockStore({
+        ...mockGlobalStateWithSavedTimeline,
+        timeline: {
+          ...mockGlobalStateWithSavedTimeline.timeline,
+          timelineById: {
+            ...mockGlobalStateWithSavedTimeline.timeline.timelineById,
+            [TimelineId.active]: {
+              ...mockGlobalStateWithSavedTimeline.timeline.timelineById[TimelineId.active],
+              isSuperTimeline: true,
+            },
+          },
+        },
+      });
+      const { result } = renderUseTimelineConfig(EVENT_ID, true, superTimelineStore);
+      expect(result.current).toBeUndefined();
+    });
+  });
+
   describe('when in the timeline flyout', () => {
     it('returns a config object', () => {
       const { result } = renderUseTimelineConfig();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/notes/hooks/use_timeline_config.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/tools/notes/hooks/use_timeline_config.tsx
@@ -42,6 +42,8 @@ export const useTimelineConfig = (
     [timeline.status]
   );
 
+  const isSuperTimeline = timeline.isSuperTimeline ?? false;
+
   const onNoteAddInTimeline = useCallback(() => {
     const isEventPinned = documentId ? timeline?.pinnedEventIds[documentId] === true : false;
     if (!isEventPinned && documentId && timelineSavedObjectId) {
@@ -56,7 +58,7 @@ export const useTimelineConfig = (
 
   return useMemo(
     () =>
-      isTimelineFlyout
+      isTimelineFlyout && !isSuperTimeline
         ? {
             timelineSavedObjectId,
             isTimelineSaved,
@@ -74,6 +76,7 @@ export const useTimelineConfig = (
 
     [
       isTimelineFlyout,
+      isSuperTimeline,
       timelineSavedObjectId,
       isTimelineSaved,
       onNoteAddInTimeline,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.test.tsx
@@ -21,7 +21,7 @@ jest.mock('../../../hooks/use_create_timeline');
 jest.mock('../../../../common/components/inspect/use_inspect');
 jest.mock('../../../../common/lib/kibana');
 
-const mockGetState = jest.fn();
+const mockGetState = jest.fn().mockReturnValue({});
 jest.mock('react-redux-v7', () => {
   const actual = jest.requireActual('react-redux-v7');
   return {
@@ -99,6 +99,26 @@ describe('TimelineModalHeader', () => {
     const { getByTestId } = renderTimelineModalHeader();
 
     expect(getByTestId('timeline-modal-attach-to-case-dropdown-button')).toBeInTheDocument();
+  });
+
+  describe('Super Timeline read-only mode', () => {
+    beforeEach(() => {
+      mockGetState.mockReturnValue({ isSuperTimeline: true });
+    });
+    afterEach(() => {
+      mockGetState.mockReturnValue({});
+    });
+
+    it('hides Save, Attach to Case, and Favorites buttons and shows the read-only badge', () => {
+      const { getByTestId, queryByTestId } = renderTimelineModalHeader();
+
+      expect(getByTestId('timeline-modal-super-timeline-badge')).toBeInTheDocument();
+      expect(queryByTestId('timeline-modal-save-timeline')).not.toBeInTheDocument();
+      expect(queryByTestId('timeline-favorite-empty-star')).not.toBeInTheDocument();
+      expect(
+        queryByTestId('timeline-modal-attach-to-case-dropdown-button')
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('should call showTimeline action when closing timeline', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import {
+  EuiBadge,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -24,6 +25,7 @@ import { OpenTimelineButton } from '../actions/open_timeline_button';
 import { APP_ID } from '../../../../../common';
 import {
   selectDataInTimeline,
+  selectIsSuperTimeline,
   selectKqlQuery,
   selectTimelineById,
   selectTitleByTimelineById,
@@ -82,6 +84,7 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
     const title = useSelector((state: State) => selectTitleByTimelineById(state, timelineId));
     const isDataInTimeline = useSelector((state: State) => selectDataInTimeline(state, timelineId));
     const kqlQueryObj = useSelector((state: State) => selectKqlQuery(state, timelineId));
+    const isSuperTimeline = useSelector((state: State) => selectIsSuperTimeline(state, timelineId));
 
     const { activeTab, dataProviders, timelineType, filters, kqlMode } = useSelector(
       (state: State) => selectTimelineById(state, timelineId)
@@ -127,9 +130,11 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
         >
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <AddToFavoritesButton timelineId={timelineId} />
-              </EuiFlexItem>
+              {!isSuperTimeline && (
+                <EuiFlexItem grow={false}>
+                  <AddToFavoritesButton timelineId={timelineId} />
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={false}>
                 <EuiText
                   grow={false}
@@ -139,9 +144,17 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
                   <h3>{title}</h3>
                 </EuiText>
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <TimelineSaveStatus timelineId={timelineId} />
-              </EuiFlexItem>
+              {isSuperTimeline ? (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow" data-test-subj="timeline-modal-super-timeline-badge">
+                    {i18n.SUPER_TIMELINE_READONLY_BADGE}
+                  </EuiBadge>
+                </EuiFlexItem>
+              ) : (
+                <EuiFlexItem grow={false}>
+                  <TimelineSaveStatus timelineId={timelineId} />
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -165,7 +178,9 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
                   isDisabled={isInspectDisabled}
                 />
               </EuiFlexItem>
-              {userCasesPermissions.createComment && userCasesPermissions.read ? (
+              {!isSuperTimeline &&
+              userCasesPermissions.createComment &&
+              userCasesPermissions.read ? (
                 <>
                   <EuiFlexItem>
                     <VerticalDivider />
@@ -175,9 +190,11 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
                   </EuiFlexItem>
                 </>
               ) : null}
-              <EuiFlexItem>
-                <SaveTimelineButton timelineId={timelineId} />
-              </EuiFlexItem>
+              {!isSuperTimeline && (
+                <EuiFlexItem>
+                  <SaveTimelineButton timelineId={timelineId} />
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={false}>
                 <EuiToolTip
                   content={i18n.CLOSE_TIMELINE_OR_TEMPLATE(timelineType === 'default')}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/translations.ts
@@ -7,6 +7,11 @@
 
 import { i18n } from '@kbn/i18n';
 
+export const SUPER_TIMELINE_READONLY_BADGE = i18n.translate(
+  'xpack.securitySolution.timeline.flyout.header.superTimelineReadonlyBadge',
+  { defaultMessage: 'Super Timeline — read-only' }
+);
+
 export const CLOSE_TIMELINE_OR_TEMPLATE = (isTimeline: boolean) =>
   i18n.translate('xpack.securitySolution.timeline.flyout.header.closeTimelineButtonLabel', {
     defaultMessage: 'Close {isTimeline, select, true {Timeline} other {template}}',

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -9,7 +9,6 @@ import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/dat
 import { isCombinedFilter, BooleanRelation } from '@kbn/es-query';
 import type { CombinedFilter } from '@kbn/es-query';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
-import { TimelineTabs } from '../../../../common/types/timeline';
 import type { DataProvider } from '../../../../common/types';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
@@ -329,7 +328,6 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-timeline',
         title: 'EQL Investigation',
-        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -410,7 +408,6 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-tl',
         title: 'EQL Timeline',
-        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -437,13 +434,12 @@ describe('buildSuperTimelineModel', () => {
     });
 
     it('skips an EQL timeline that has stale KQL filters from a prior query-tab visit', () => {
-      // A timeline saved in EQL mode may still carry filters from when the user
-      // previously visited the Query tab. The old !hasKqlQuery guard would have
-      // treated this as a KQL timeline and silently merged the stale filters.
+      // Detection keys off eqlOptions.query (persisted), not activeTab (runtime-only).
+      // A timeline saved in EQL mode may still carry KQL filters from when the user
+      // previously visited the Query tab. Stale filters must not be merged.
       const eqlWithStaleFilters = makeTimeline({
         savedObjectId: 'eql-stale',
         title: 'EQL with stale filters',
-        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -464,6 +460,31 @@ describe('buildSuperTimelineModel', () => {
       expect(skippedQueryTimelines).toHaveLength(1);
       expect(skippedQueryTimelines[0].reason).toBe('eql');
       expect(model.filters).toHaveLength(0);
+    });
+
+    it('does NOT skip a timeline that has activeTab=eql but an empty eqlOptions.query', () => {
+      // activeTab is runtime-only and resets to TimelineTabs.query after formatTimelineResponseToModel.
+      // A timeline that was opened in EQL mode but has no saved eqlOptions.query should be treated
+      // as a KQL timeline (fall through to the query merge path).
+      const kqlTimeline = makeTimeline({
+        savedObjectId: 'kql-was-eql-tab',
+        title: 'KQL (no EQL query saved)',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: '',
+          size: 100,
+        },
+        filters: [
+          {
+            meta: { alias: null, negate: false, disabled: false, type: 'phrase', key: 'host.name' },
+            query: { match_phrase: { 'host.name': 'some-host' } },
+          },
+        ],
+      });
+
+      const { skippedQueryTimelines } = buildSuperTimelineModel([kqlTimeline], deps);
+      expect(skippedQueryTimelines).toHaveLength(0);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -9,6 +9,7 @@ import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/dat
 import { isCombinedFilter, BooleanRelation } from '@kbn/es-query';
 import type { CombinedFilter } from '@kbn/es-query';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import { TimelineTabs } from '../../../../common/types/timeline';
 import type { DataProvider } from '../../../../common/types';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
@@ -328,6 +329,7 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-timeline',
         title: 'EQL Investigation',
+        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -408,6 +410,7 @@ describe('buildSuperTimelineModel', () => {
       const eqlTimeline = makeTimeline({
         savedObjectId: 'eql-tl',
         title: 'EQL Timeline',
+        activeTab: TimelineTabs.eql,
         eqlOptions: {
           eventCategoryField: 'event.category',
           timestampField: '@timestamp',
@@ -431,6 +434,36 @@ describe('buildSuperTimelineModel', () => {
       // EQL timeline is skipped
       expect(skippedQueryTimelines).toHaveLength(1);
       expect(skippedQueryTimelines[0].title).toBe('EQL Timeline');
+    });
+
+    it('skips an EQL timeline that has stale KQL filters from a prior query-tab visit', () => {
+      // A timeline saved in EQL mode may still carry filters from when the user
+      // previously visited the Query tab. The old !hasKqlQuery guard would have
+      // treated this as a KQL timeline and silently merged the stale filters.
+      const eqlWithStaleFilters = makeTimeline({
+        savedObjectId: 'eql-stale',
+        title: 'EQL with stale filters',
+        activeTab: TimelineTabs.eql,
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: 'process where process.name == "cmd.exe"',
+          size: 100,
+        },
+        filters: [
+          {
+            meta: { alias: null, negate: false, disabled: false, type: 'phrase', key: 'host.name' },
+            query: { match_phrase: { 'host.name': 'stale-host' } },
+          },
+        ],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([eqlWithStaleFilters], deps);
+
+      // Must be reported as skipped — stale filters must not be merged
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0].reason).toBe('eql');
+      expect(model.filters).toHaveLength(0);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -1,0 +1,413 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { isCombinedFilter, BooleanRelation } from '@kbn/es-query';
+import type { CombinedFilter } from '@kbn/es-query';
+import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import type { DataProvider } from '../../../../common/types';
+import type { TimelineModel } from '../../store/model';
+import { timelineDefaults } from '../../store/defaults';
+import {
+  buildSuperTimelineModel,
+  SUPER_TIMELINE_TITLE,
+  SUPER_TIMELINE_QUERY_ALIAS,
+} from './build_super_timeline_model';
+
+const mockDataView = createStubDataView({ spec: { id: 'mock-data-view' } });
+const mockBrowserFields = {};
+const mockEsQueryConfig = { allowLeadingWildcards: true, queryStringOptions: {} };
+
+const deps = {
+  dataView: mockDataView,
+  browserFields: mockBrowserFields,
+  esQueryConfig: mockEsQueryConfig,
+};
+
+/** Builds a minimal TimelineModel for testing */
+const makeTimeline = (overrides: Partial<TimelineModel>): TimelineModel => ({
+  ...(timelineDefaults as unknown as TimelineModel),
+  id: 'timeline-1',
+  savedObjectId: 'saved-obj-1',
+  title: 'Timeline 1',
+  pinnedEventIds: {},
+  pinnedEventsSaveObject: {},
+  noteIds: [],
+  eventIdToNoteIds: {},
+  dataProviders: [],
+  kqlQuery: { filterQuery: null },
+  filters: [],
+  dateRange: { start: '2024-01-01T00:00:00.000Z', end: '2024-01-02T00:00:00.000Z' },
+  columns: [],
+  defaultColumns: timelineDefaults.defaultColumns,
+  indexNames: ['logs-*'],
+  eqlOptions: {
+    eventCategoryField: 'event.category',
+    timestampField: '@timestamp',
+    query: '',
+    size: 100,
+  },
+  savedSearchId: null,
+  savedSearch: null,
+  ...overrides,
+});
+
+describe('buildSuperTimelineModel', () => {
+  describe('basic structure', () => {
+    it('returns a model with isSuperTimeline: true and SUPER_TIMELINE_TITLE', () => {
+      const { model } = buildSuperTimelineModel([makeTimeline({})], deps);
+      expect(model.isSuperTimeline).toBe(true);
+      expect(model.title).toBe(SUPER_TIMELINE_TITLE);
+    });
+
+    it('carries the source savedObjectIds in superTimelineSourceIds', () => {
+      const t1 = makeTimeline({ savedObjectId: 'id-a' });
+      const t2 = makeTimeline({ savedObjectId: 'id-b' });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.superTimelineSourceIds).toEqual(['id-a', 'id-b']);
+    });
+
+    it('sets savedObjectId to null (transient, never persisted)', () => {
+      const { model } = buildSuperTimelineModel([makeTimeline({})], deps);
+      expect(model.savedObjectId).toBeNull();
+    });
+
+    it('clears dataProviders and kqlQuery (query lives in CombinedFilter)', () => {
+      const dataProvider: DataProvider = {
+        id: 'dp-1',
+        name: 'host',
+        enabled: true,
+        excluded: false,
+        kqlQuery: '',
+        queryMatch: { field: 'host.name', value: 'foo', operator: ':' },
+        and: [],
+      };
+      const t = makeTimeline({
+        dataProviders: [dataProvider],
+        kqlQuery: {
+          filterQuery: {
+            kuery: { kind: 'kuery', expression: 'host.name: foo' },
+            serializedQuery: '',
+          },
+        },
+      });
+      const { model } = buildSuperTimelineModel([t], deps);
+      expect(model.dataProviders).toEqual([]);
+      expect(model.kqlQuery.filterQuery).toBeNull();
+    });
+
+    it('returns an empty model when no timelines are provided', () => {
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([], deps);
+      expect(model.isSuperTimeline).toBe(true);
+      expect(model.superTimelineSourceIds).toEqual([]);
+      expect(skippedQueryTimelines).toEqual([]);
+    });
+  });
+
+  describe('pinned event union', () => {
+    it('unions pinned events across timelines', () => {
+      const t1 = makeTimeline({ pinnedEventIds: { 'event-a': true, 'event-b': true } });
+      const t2 = makeTimeline({ pinnedEventIds: { 'event-c': true } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.pinnedEventIds).toEqual({
+        'event-a': true,
+        'event-b': true,
+        'event-c': true,
+      });
+    });
+
+    it('deduplicates overlapping pinned events without duplicating the entry', () => {
+      const t1 = makeTimeline({ pinnedEventIds: { 'event-shared': true } });
+      const t2 = makeTimeline({ pinnedEventIds: { 'event-shared': true } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      // Record deduplication: key exists once
+      expect(Object.keys(model.pinnedEventIds)).toHaveLength(1);
+      expect(model.pinnedEventIds['event-shared']).toBe(true);
+    });
+  });
+
+  describe('note union (reference-only, no duplication)', () => {
+    it('unions noteIds across timelines without duplicating shared notes', () => {
+      const t1 = makeTimeline({ noteIds: ['note-1', 'note-shared'] });
+      const t2 = makeTimeline({ noteIds: ['note-2', 'note-shared'] });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      // note-shared appears once
+      expect(model.noteIds).toEqual(['note-1', 'note-shared', 'note-2']);
+    });
+
+    it('merges eventIdToNoteIds without duplicating note references on shared events', () => {
+      const t1 = makeTimeline({ eventIdToNoteIds: { 'event-x': ['note-1', 'note-shared'] } });
+      const t2 = makeTimeline({ eventIdToNoteIds: { 'event-x': ['note-2', 'note-shared'] } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      const notes = model.eventIdToNoteIds['event-x'];
+      expect(notes).toContain('note-1');
+      expect(notes).toContain('note-2');
+      expect(notes).toContain('note-shared');
+      // note-shared must appear only once
+      expect(notes.filter((n) => n === 'note-shared')).toHaveLength(1);
+    });
+
+    it('combines eventIdToNoteIds from separate events', () => {
+      const t1 = makeTimeline({ eventIdToNoteIds: { 'event-a': ['note-1'] } });
+      const t2 = makeTimeline({ eventIdToNoteIds: { 'event-b': ['note-2'] } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.eventIdToNoteIds['event-a']).toEqual(['note-1']);
+      expect(model.eventIdToNoteIds['event-b']).toEqual(['note-2']);
+    });
+  });
+
+  describe('date range union', () => {
+    it('sets the earliest start and latest end across all timelines', () => {
+      const t1 = makeTimeline({
+        dateRange: { start: '2024-01-03T00:00:00.000Z', end: '2024-01-05T00:00:00.000Z' },
+      });
+      const t2 = makeTimeline({
+        dateRange: { start: '2024-01-01T00:00:00.000Z', end: '2024-01-07T00:00:00.000Z' },
+      });
+      const t3 = makeTimeline({
+        dateRange: { start: '2024-01-02T00:00:00.000Z', end: '2024-01-06T00:00:00.000Z' },
+      });
+      const { model } = buildSuperTimelineModel([t1, t2, t3], deps);
+      expect(model.dateRange.start).toBe('2024-01-01T00:00:00.000Z');
+      expect(model.dateRange.end).toBe('2024-01-07T00:00:00.000Z');
+    });
+  });
+
+  describe('column union', () => {
+    const col = (id: string): ColumnHeaderOptions => ({
+      id,
+      columnHeaderType: 'not-filtered',
+      initialWidth: 100,
+    });
+
+    it('unions columns in first-seen order without duplicates', () => {
+      const t1 = makeTimeline({ columns: [col('@timestamp'), col('host.name')] });
+      const t2 = makeTimeline({ columns: [col('host.name'), col('user.name')] });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.columns.map((c) => c.id)).toEqual(['@timestamp', 'host.name', 'user.name']);
+    });
+
+    it('falls back to defaultColumns when all source timelines have no columns', () => {
+      const t1 = makeTimeline({ columns: [] });
+      const { model } = buildSuperTimelineModel([t1], deps);
+      expect(model.columns).toEqual(timelineDefaults.defaultColumns);
+    });
+  });
+
+  describe('query merging — CombinedFilter', () => {
+    it('produces one CombinedFilter with OR relation when timelines have KQL queries', () => {
+      // Timelines with only filters (no KQL expression, no data providers) — combineQueries
+      // returns a result when filters are non-empty
+      const t1 = makeTimeline({
+        title: 'Timeline A',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'host.name',
+              params: { query: 'foo' },
+            },
+            query: { match_phrase: { 'host.name': 'foo' } },
+          },
+        ],
+      });
+      const t2 = makeTimeline({
+        title: 'Timeline B',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'host.name',
+              params: { query: 'bar' },
+            },
+            query: { match_phrase: { 'host.name': 'bar' } },
+          },
+        ],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([t1, t2], deps);
+
+      expect(skippedQueryTimelines).toHaveLength(0);
+      expect(model.filters).toHaveLength(1);
+      const combinedRaw = model.filters![0];
+      expect(isCombinedFilter(combinedRaw)).toBe(true);
+      const combined = combinedRaw as CombinedFilter;
+      expect(combined.meta.relation).toBe(BooleanRelation.OR);
+      expect(combined.meta.alias).toBe(SUPER_TIMELINE_QUERY_ALIAS);
+      // One sub-filter per source timeline
+      expect(combined.meta.params).toHaveLength(2);
+    });
+
+    it('produces the correct number of sub-filters for each source timeline', () => {
+      // Note: buildCombinedFilter calls cleanUpFilter on each sub-filter, which strips meta.alias.
+      // Individual sub-filters are identifiable by their DSL content, not by alias. The top-level
+      // CombinedFilter pill is labelled via SUPER_TIMELINE_QUERY_ALIAS (tested above).
+      const t1 = makeTimeline({
+        title: 'Endpoint Investigation',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'process.name',
+              params: { query: 'cmd.exe' },
+            },
+            query: { match_phrase: { 'process.name': 'cmd.exe' } },
+          },
+        ],
+      });
+      const t2 = makeTimeline({
+        title: 'Network Investigation',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'network.direction',
+              params: { query: 'egress' },
+            },
+            query: { match_phrase: { 'network.direction': 'egress' } },
+          },
+        ],
+      });
+
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+
+      const combined = model.filters![0];
+      // One sub-filter per source timeline
+      expect(combined.meta.params).toHaveLength(2);
+    });
+
+    it('produces no filters when all timelines have empty queries', () => {
+      const t1 = makeTimeline({ dataProviders: [], kqlQuery: { filterQuery: null }, filters: [] });
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([t1], deps);
+      expect(model.filters).toHaveLength(0);
+      expect(skippedQueryTimelines).toHaveLength(0);
+    });
+  });
+
+  describe('EQL / ESQL handling', () => {
+    it('reports an EQL-only timeline in skippedQueryTimelines and still aggregates its pins/notes', () => {
+      const eqlTimeline = makeTimeline({
+        savedObjectId: 'eql-timeline',
+        title: 'EQL Investigation',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: 'process where process.name == "cmd.exe"',
+          size: 100,
+        },
+        dataProviders: [],
+        kqlQuery: { filterQuery: null },
+        filters: [],
+        pinnedEventIds: { 'pinned-from-eql': true },
+        noteIds: ['note-from-eql'],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([eqlTimeline], deps);
+
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0]).toMatchObject({
+        id: 'eql-timeline',
+        title: 'EQL Investigation',
+        reason: 'eql',
+      });
+      // Pinned events and notes still aggregate
+      expect(model.pinnedEventIds['pinned-from-eql']).toBe(true);
+      expect(model.noteIds).toContain('note-from-eql');
+      // But no query filter from this timeline
+      expect(model.filters).toHaveLength(0);
+    });
+
+    it('reports an ESQL-only timeline in skippedQueryTimelines and still aggregates its pins/notes', () => {
+      const esqlTimeline = makeTimeline({
+        savedObjectId: 'esql-timeline',
+        title: 'ESQL Investigation',
+        savedSearchId: 'some-saved-search-id',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: '',
+          size: 100,
+        },
+        dataProviders: [],
+        kqlQuery: { filterQuery: null },
+        filters: [],
+        pinnedEventIds: { 'pinned-from-esql': true },
+        noteIds: ['note-from-esql'],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel([esqlTimeline], deps);
+
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0]).toMatchObject({
+        id: 'esql-timeline',
+        title: 'ESQL Investigation',
+        reason: 'esql',
+      });
+      expect(model.pinnedEventIds['pinned-from-esql']).toBe(true);
+      expect(model.noteIds).toContain('note-from-esql');
+      expect(model.filters).toHaveLength(0);
+    });
+
+    it('merges KQL timelines and skips EQL/ESQL timelines in one call', () => {
+      const kqlTimeline = makeTimeline({
+        savedObjectId: 'kql-tl',
+        title: 'KQL Timeline',
+        filters: [
+          {
+            meta: {
+              alias: null,
+              negate: false,
+              disabled: false,
+              type: 'phrase',
+              key: 'host.name',
+              params: { query: 'web' },
+            },
+            query: { match_phrase: { 'host.name': 'web' } },
+          },
+        ],
+      });
+      const eqlTimeline = makeTimeline({
+        savedObjectId: 'eql-tl',
+        title: 'EQL Timeline',
+        eqlOptions: {
+          eventCategoryField: 'event.category',
+          timestampField: '@timestamp',
+          query: 'any where true',
+          size: 100,
+        },
+        dataProviders: [],
+        kqlQuery: { filterQuery: null },
+        filters: [],
+      });
+
+      const { model, skippedQueryTimelines } = buildSuperTimelineModel(
+        [kqlTimeline, eqlTimeline],
+        deps
+      );
+
+      // KQL timeline contributes a sub-filter
+      expect(model.filters).toHaveLength(1);
+      expect(isCombinedFilter(model.filters![0])).toBe(true);
+      expect((model.filters![0].meta.params as unknown[]).length).toBe(1);
+      // EQL timeline is skipped
+      expect(skippedQueryTimelines).toHaveLength(1);
+      expect(skippedQueryTimelines[0].title).toBe('EQL Timeline');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.test.ts
@@ -175,6 +175,29 @@ describe('buildSuperTimelineModel', () => {
       expect(model.dateRange.start).toBe('2024-01-01T00:00:00.000Z');
       expect(model.dateRange.end).toBe('2024-01-07T00:00:00.000Z');
     });
+
+    it('correctly unions relative date strings (now-7d is earlier than now-24h)', () => {
+      // Lexicographic comparison gets this wrong: '7' > '2', so 'now-7d' < 'now-24h' is
+      // false by char code, but now-7d is actually an earlier point in time than now-24h.
+      const t1 = makeTimeline({ dateRange: { start: 'now-24h', end: 'now' } });
+      const t2 = makeTimeline({ dateRange: { start: 'now-7d', end: 'now' } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      // now-7d is earlier, so it should win as the start
+      expect(model.dateRange.start).toBe('now-7d');
+      expect(model.dateRange.end).toBe('now');
+    });
+
+    it('unions mixed ISO and relative date strings correctly', () => {
+      // ISO 2020-01-01 is always earlier than now-7d; ISO end 2021-01-01 is always earlier
+      // than now. Verifies that ISO and relative strings can be compared across types.
+      const t1 = makeTimeline({
+        dateRange: { start: '2020-01-01T00:00:00.000Z', end: '2021-01-01T00:00:00.000Z' },
+      });
+      const t2 = makeTimeline({ dateRange: { start: 'now-7d', end: 'now' } });
+      const { model } = buildSuperTimelineModel([t1, t2], deps);
+      expect(model.dateRange.start).toBe('2020-01-01T00:00:00.000Z');
+      expect(model.dateRange.end).toBe('now');
+    });
   });
 
   describe('column union', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -11,6 +11,7 @@ import type { EsQueryConfig } from '@kbn/es-query';
 import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
 import type { BrowserFields } from '../../../../common/search_strategy';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import { TimelineTabs } from '../../../../common/types/timeline';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
 import { combineQueries } from '../../../common/lib/kuery';
@@ -115,19 +116,18 @@ export const buildSuperTimelineModel = (
     const title = timeline.title || timeline.savedObjectId || 'Untitled Timeline';
     const id = timeline.savedObjectId ?? '';
 
-    // Detect EQL/ESQL-only timelines (their query lives outside KQL/dataProviders/filters)
-    const hasEqlQuery = !!timeline.eqlOptions?.query;
-    const hasEsqlQuery = !!timeline.savedSearchId;
-    const hasKqlQuery =
-      (timeline.dataProviders && timeline.dataProviders.length > 0) ||
-      timeline.kqlQuery?.filterQuery?.kuery?.expression ||
-      (timeline.filters && timeline.filters.length > 0);
+    // Key off the saved activeTab to identify the primary query mode.
+    // savedSearchId definitively identifies ESQL. activeTab === 'eql' identifies EQL.
+    // This avoids false-positives from stale filters/dataProviders that remain on the
+    // model when the user visited the Query tab before switching to EQL mode.
+    const isEsqlTimeline = !!timeline.savedSearchId;
+    const isEqlTimeline = !isEsqlTimeline && timeline.activeTab === TimelineTabs.eql;
 
-    if (!hasKqlQuery && (hasEqlQuery || hasEsqlQuery)) {
+    if (isEqlTimeline || isEsqlTimeline) {
       skippedQueryTimelines.push({
         id,
         title,
-        reason: hasEsqlQuery ? 'esql' : 'eql',
+        reason: isEsqlTimeline ? 'esql' : 'eql',
       });
     } else {
       const kqlQuery = {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import dateMath from '@kbn/datemath';
 import type { DataView } from '@kbn/data-plugin/common';
 import type { EsQueryConfig } from '@kbn/es-query';
 import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
@@ -175,12 +176,22 @@ export const buildSuperTimelineModel = (
       : [];
 
   // ── Date range: earliest start → latest end ──────────────────────────────────
+  // dateRange strings can be relative (e.g. "now-7d") or absolute ISO. Parse to
+  // milliseconds before comparing so relative strings sort correctly.
   const dateRange = timelines.reduce(
-    (acc, timeline) => ({
-      start:
-        !acc.start || timeline.dateRange.start < acc.start ? timeline.dateRange.start : acc.start,
-      end: !acc.end || timeline.dateRange.end > acc.end ? timeline.dateRange.end : acc.end,
-    }),
+    (acc, timeline) => {
+      const startMs = dateMath.parse(timeline.dateRange.start)?.valueOf() ?? Infinity;
+      const endMs =
+        dateMath.parse(timeline.dateRange.end, { roundUp: true })?.valueOf() ?? -Infinity;
+      const accStartMs = acc.start ? dateMath.parse(acc.start)?.valueOf() ?? Infinity : Infinity;
+      const accEndMs = acc.end
+        ? dateMath.parse(acc.end, { roundUp: true })?.valueOf() ?? -Infinity
+        : -Infinity;
+      return {
+        start: startMs < accStartMs ? timeline.dateRange.start : acc.start,
+        end: endMs > accEndMs ? timeline.dateRange.end : acc.end,
+      };
+    },
     { start: '', end: '' }
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -11,7 +11,6 @@ import type { EsQueryConfig } from '@kbn/es-query';
 import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
 import type { BrowserFields } from '../../../../common/search_strategy';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
-import { TimelineTabs } from '../../../../common/types/timeline';
 import type { TimelineModel } from '../../store/model';
 import { timelineDefaults } from '../../store/defaults';
 import { combineQueries } from '../../../common/lib/kuery';
@@ -116,12 +115,12 @@ export const buildSuperTimelineModel = (
     const title = timeline.title || timeline.savedObjectId || 'Untitled Timeline';
     const id = timeline.savedObjectId ?? '';
 
-    // Key off the saved activeTab to identify the primary query mode.
-    // savedSearchId definitively identifies ESQL. activeTab === 'eql' identifies EQL.
-    // This avoids false-positives from stale filters/dataProviders that remain on the
-    // model when the user visited the Query tab before switching to EQL mode.
+    // Use persisted fields to identify the primary query mode — NOT activeTab, which
+    // is runtime-only and always resets to TimelineTabs.query after formatTimelineResponseToModel.
+    // savedSearchId is the canonical ESQL indicator (persisted). eqlOptions.query is the
+    // canonical EQL indicator (persisted). Both survive a resolveTimeline → model round-trip.
     const isEsqlTimeline = !!timeline.savedSearchId;
-    const isEqlTimeline = !isEsqlTimeline && timeline.activeTab === TimelineTabs.eql;
+    const isEqlTimeline = !isEsqlTimeline && !!timeline.eqlOptions?.query?.trim();
 
     if (isEqlTimeline || isEsqlTimeline) {
       skippedQueryTimelines.push({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView } from '@kbn/data-plugin/common';
+import type { EsQueryConfig } from '@kbn/es-query';
+import { buildCombinedFilter, BooleanRelation, FilterStateStore } from '@kbn/es-query';
+import type { BrowserFields } from '../../../../common/search_strategy';
+import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
+import type { TimelineModel } from '../../store/model';
+import { timelineDefaults } from '../../store/defaults';
+import { combineQueries } from '../../../common/lib/kuery';
+
+export const SUPER_TIMELINE_TITLE = 'Super Timeline';
+export const SUPER_TIMELINE_QUERY_ALIAS = 'Super Timeline Sources';
+
+export type SkippedQueryReason = 'eql' | 'esql';
+
+export interface SkippedQueryTimeline {
+  id: string;
+  title: string;
+  reason: SkippedQueryReason;
+}
+
+export interface BuildSuperTimelineModelDeps {
+  dataView: DataView;
+  browserFields: BrowserFields;
+  esQueryConfig: EsQueryConfig;
+}
+
+export interface BuildSuperTimelineModelResult {
+  model: TimelineModel;
+  /** Source timelines whose query type (EQL/ESQL) couldn't be merged. Their pins and notes still aggregate. */
+  skippedQueryTimelines: SkippedQueryTimeline[];
+}
+
+/**
+ * Merges N fully-resolved TimelineModels into a single transient Super Timeline model.
+ *
+ * What this does:
+ * - Unions pinnedEventIds (deduped by key)
+ * - Unions eventIdToNoteIds + noteIds (references only — no note objects are cloned)
+ * - Combines all KQL/filter queries into a single OR CombinedFilter (one labelled sub-filter per
+ *   source timeline). Timelines with EQL-only or ESQL-only queries contribute no sub-filter but
+ *   are reported in `skippedQueryTimelines` so the caller can warn the user.
+ * - Sets dateRange to the union of all source ranges (earliest start → latest end).
+ * - Unions the column sets (first-seen order, falling back to defaultColumns).
+ *
+ * The returned model has `isSuperTimeline: true` and `superTimelineSourceIds` set.
+ * It is NOT persisted — the persist path (`convertTimelineAsInput`) is an allow-list and neither
+ * field is included, matching the existing pattern for runtime-only fields like `savedSearch` and
+ * `changed`.
+ */
+export const buildSuperTimelineModel = (
+  timelines: TimelineModel[],
+  deps: BuildSuperTimelineModelDeps
+): BuildSuperTimelineModelResult => {
+  const { dataView, browserFields, esQueryConfig } = deps;
+  const skippedQueryTimelines: SkippedQueryTimeline[] = [];
+
+  if (timelines.length === 0) {
+    return {
+      model: {
+        ...timelineDefaults,
+        id: '',
+        title: SUPER_TIMELINE_TITLE,
+        isSuperTimeline: true,
+        superTimelineSourceIds: [],
+      } as TimelineModel,
+      skippedQueryTimelines,
+    };
+  }
+
+  // ── Pinned events ────────────────────────────────────────────────────────────
+  const pinnedEventIds: Record<string, boolean> = {};
+  const pinnedEventsSaveObject: TimelineModel['pinnedEventsSaveObject'] = {};
+
+  for (const timeline of timelines) {
+    Object.assign(pinnedEventIds, timeline.pinnedEventIds);
+    Object.assign(pinnedEventsSaveObject, timeline.pinnedEventsSaveObject);
+  }
+
+  // ── Notes (reference union — no duplication) ─────────────────────────────────
+  const noteIds: string[] = [];
+  const seenNoteIds = new Set<string>();
+  const eventIdToNoteIds: Record<string, string[]> = {};
+
+  for (const timeline of timelines) {
+    for (const noteId of timeline.noteIds) {
+      if (!seenNoteIds.has(noteId)) {
+        seenNoteIds.add(noteId);
+        noteIds.push(noteId);
+      }
+    }
+    for (const [eventId, ids] of Object.entries(timeline.eventIdToNoteIds)) {
+      const existing = eventIdToNoteIds[eventId] ?? [];
+      const merged = [...existing];
+      for (const id of ids) {
+        if (!merged.includes(id)) {
+          merged.push(id);
+        }
+      }
+      eventIdToNoteIds[eventId] = merged;
+    }
+  }
+
+  // ── Query merging: one CombinedFilter with OR semantics ──────────────────────
+  const subFilters: Array<{ meta: object; query: object }> = [];
+
+  for (const timeline of timelines) {
+    const title = timeline.title || timeline.savedObjectId || 'Untitled Timeline';
+    const id = timeline.savedObjectId ?? '';
+
+    // Detect EQL/ESQL-only timelines (their query lives outside KQL/dataProviders/filters)
+    const hasEqlQuery = !!timeline.eqlOptions?.query;
+    const hasEsqlQuery = !!timeline.savedSearchId;
+    const hasKqlQuery =
+      (timeline.dataProviders && timeline.dataProviders.length > 0) ||
+      timeline.kqlQuery?.filterQuery?.kuery?.expression ||
+      (timeline.filters && timeline.filters.length > 0);
+
+    if (!hasKqlQuery && (hasEqlQuery || hasEsqlQuery)) {
+      skippedQueryTimelines.push({
+        id,
+        title,
+        reason: hasEsqlQuery ? 'esql' : 'eql',
+      });
+    } else {
+      const kqlQuery = {
+        query: timeline.kqlQuery?.filterQuery?.kuery?.expression ?? '',
+        language: timeline.kqlQuery?.filterQuery?.kuery?.kind ?? 'kuery',
+      };
+
+      const combined = combineQueries({
+        config: esQueryConfig,
+        dataProviders: timeline.dataProviders ?? [],
+        dataView,
+        browserFields,
+        filters: timeline.filters ?? [],
+        kqlQuery,
+        kqlMode: timeline.kqlMode ?? 'filter',
+      });
+
+      if (combined?.filterQuery) {
+        subFilters.push({
+          meta: {
+            alias: title,
+            type: 'custom',
+            disabled: false,
+            negate: false,
+            key: 'query',
+          },
+          query: JSON.parse(combined.filterQuery),
+        });
+      }
+    }
+  }
+
+  const mergedFilters =
+    subFilters.length > 0
+      ? [
+          buildCombinedFilter(
+            BooleanRelation.OR,
+            subFilters as Parameters<typeof buildCombinedFilter>[1],
+            { id: dataView.id },
+            false,
+            false,
+            SUPER_TIMELINE_QUERY_ALIAS,
+            FilterStateStore.APP_STATE
+          ),
+        ]
+      : [];
+
+  // ── Date range: earliest start → latest end ──────────────────────────────────
+  const dateRange = timelines.reduce(
+    (acc, timeline) => ({
+      start:
+        !acc.start || timeline.dateRange.start < acc.start ? timeline.dateRange.start : acc.start,
+      end: !acc.end || timeline.dateRange.end > acc.end ? timeline.dateRange.end : acc.end,
+    }),
+    { start: '', end: '' }
+  );
+
+  // ── Columns: union in first-seen order ───────────────────────────────────────
+  const seenColumnIds = new Set<string>();
+  const columns: ColumnHeaderOptions[] = [];
+
+  for (const timeline of timelines) {
+    for (const col of timeline.columns) {
+      if (!seenColumnIds.has(col.id)) {
+        seenColumnIds.add(col.id);
+        columns.push(col);
+      }
+    }
+  }
+  const finalColumns = columns.length > 0 ? columns : timelineDefaults.defaultColumns;
+
+  // ── Index names / data view: union ───────────────────────────────────────────
+  const seenIndexNames = new Set<string>();
+  for (const timeline of timelines) {
+    for (const name of timeline.indexNames) {
+      seenIndexNames.add(name);
+    }
+  }
+  const indexNames = Array.from(seenIndexNames);
+
+  // ── Source ids ───────────────────────────────────────────────────────────────
+  const superTimelineSourceIds = timelines
+    .map((t) => t.savedObjectId)
+    .filter((id): id is string => id !== null);
+
+  const model: TimelineModel = {
+    ...timelineDefaults,
+    id: '',
+    title: SUPER_TIMELINE_TITLE,
+    pinnedEventIds,
+    pinnedEventsSaveObject,
+    noteIds,
+    eventIdToNoteIds,
+    filters: mergedFilters,
+    // Clear KQL / data providers — queries live entirely in the CombinedFilter above
+    dataProviders: [],
+    kqlQuery: { filterQuery: null },
+    dateRange,
+    columns: finalColumns,
+    defaultColumns: finalColumns,
+    indexNames,
+    // savedObjectId null: this timeline is never persisted
+    savedObjectId: null,
+    // isSuperTimeline gates all read-only behaviour (CTA hiding, notes multi-fetch, etc.)
+    // runtime-only, not persisted (not in convertTimelineAsInput allow-list)
+    isSuperTimeline: true,
+    // runtime-only, not persisted
+    superTimelineSourceIds,
+  };
+
+  return { model, skippedQueryTimelines };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/build_super_timeline_model.ts
@@ -145,16 +145,24 @@ export const buildSuperTimelineModel = (
       });
 
       if (combined?.filterQuery) {
-        subFilters.push({
-          meta: {
-            alias: title,
-            type: 'custom',
-            disabled: false,
-            negate: false,
-            key: 'query',
-          },
-          query: JSON.parse(combined.filterQuery),
-        });
+        let parsedQuery: object | null = null;
+        try {
+          parsedQuery = JSON.parse(combined.filterQuery);
+        } catch {
+          skippedQueryTimelines.push({ id, title, reason: 'eql' });
+        }
+        if (parsedQuery !== null) {
+          subFilters.push({
+            meta: {
+              alias: title,
+              type: 'custom',
+              disabled: false,
+              negate: false,
+              key: 'query',
+            },
+            query: parsedQuery,
+          });
+        }
       }
     }
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
@@ -244,7 +244,7 @@ describe('useOpenSuperTimeline', () => {
       expect(call.id).toBe(TimelineId.active);
       expect(call.timeline.show).toBe(true);
       expect(call.timeline.isSuperTimeline).toBe(true);
-      expect(call.timeline.activeTab).toBe(TimelineTabs.pinned);
+      expect(call.timeline.activeTab).toBe(TimelineTabs.query);
       expect(call.duplicate).toBe(false);
       expect(call.preventSettingQuery).toBe(true);
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
@@ -1,0 +1,336 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { TimelineId, TimelineTabs } from '../../../../common/types/timeline';
+import { TimelineStatusEnum } from '../../../../common/api/timeline';
+import type { TimelineModel } from '../../store/model';
+import { timelineDefaults } from '../../store/defaults';
+import { MAX_SUPER_TIMELINE_COUNT, useOpenSuperTimeline } from './use_open_super_timeline';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockAddWarning = jest.fn();
+const mockAddError = jest.fn();
+const mockOpenConfirm = jest.fn();
+const mockUpdateTimeline = jest.fn();
+const mockResolveTimeline = jest.fn();
+const mockFormatTimelineResponseToModel = jest.fn();
+const mockBuildSuperTimelineModel = jest.fn();
+
+// Active timeline state — mutated per test; referenced inside the factory via closure.
+// The key 'timeline-1' is the literal value of TimelineId.active (enum checked in index.ts).
+let mockActiveTimeline: Partial<TimelineModel> = {};
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      timeline: {
+        timelineById: {
+          'timeline-1': mockActiveTimeline,
+        },
+      },
+    }),
+}));
+
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      uiSettings: {},
+      notifications: { toasts: { addWarning: mockAddWarning, addError: mockAddError } },
+      overlays: { openConfirm: mockOpenConfirm },
+    },
+  }),
+}));
+
+jest.mock('@kbn/data-plugin/common', () => ({
+  getEsQueryConfig: () => ({ allowLeadingWildcards: true, queryStringOptions: {} }),
+}));
+
+jest.mock('../../../data_view_manager/hooks/use_data_view', () => ({
+  useDataView: () => ({ dataView: { id: 'mock-dv', fields: [] }, status: 'ready' }),
+}));
+
+jest.mock('../../../data_view_manager/hooks/use_browser_fields', () => ({
+  useBrowserFields: () => ({}),
+}));
+
+jest.mock('../open_timeline/use_update_timeline', () => ({
+  useUpdateTimeline: () => mockUpdateTimeline,
+}));
+
+jest.mock('../../containers/api', () => ({
+  resolveTimeline: (...args: unknown[]) => mockResolveTimeline(...args),
+}));
+
+jest.mock('../open_timeline/helpers', () => ({
+  formatTimelineResponseToModel: (...args: unknown[]) => mockFormatTimelineResponseToModel(...args),
+}));
+
+jest.mock('./build_super_timeline_model', () => ({
+  buildSuperTimelineModel: (...args: unknown[]) => mockBuildSuperTimelineModel(...args),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeMergedModel = (overrides: Partial<TimelineModel> = {}): TimelineModel => ({
+  ...(timelineDefaults as unknown as TimelineModel),
+  id: '',
+  title: 'Super Timeline',
+  isSuperTimeline: true,
+  superTimelineSourceIds: ['id-1', 'id-2'],
+  savedObjectId: null,
+  dateRange: { start: '2024-01-01T00:00:00.000Z', end: '2024-01-07T00:00:00.000Z' },
+  filters: [],
+  ...overrides,
+});
+
+const makeRawTimeline = (id: string) => ({
+  savedObjectId: id,
+  title: `Timeline ${id}`,
+  pinnedEventIds: {},
+});
+
+const setupHappyPath = (ids: string[] = ['id-1', 'id-2']) => {
+  ids.forEach((id) => {
+    mockResolveTimeline.mockResolvedValueOnce({ timeline: makeRawTimeline(id) });
+    mockFormatTimelineResponseToModel.mockReturnValueOnce({
+      timeline: { ...timelineDefaults, id: '', savedObjectId: id } as TimelineModel,
+      notes: [],
+    });
+  });
+  mockBuildSuperTimelineModel.mockReturnValue({
+    model: makeMergedModel(),
+    skippedQueryTimelines: [],
+  });
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockActiveTimeline = {};
+  mockOpenConfirm.mockResolvedValue(true);
+});
+
+describe('useOpenSuperTimeline', () => {
+  describe('selection cap guard', () => {
+    it('shows a warning toast and returns early when more than MAX timelines are selected', async () => {
+      const ids = Array.from({ length: MAX_SUPER_TIMELINE_COUNT + 1 }, (_, i) => `id-${i}`);
+      const { result } = renderHook(() => useOpenSuperTimeline());
+
+      await act(async () => {
+        await result.current.openSuperTimeline(ids);
+      });
+
+      expect(mockAddWarning).toHaveBeenCalledTimes(1);
+      expect(mockResolveTimeline).not.toHaveBeenCalled();
+    });
+
+    it('returns early without toast when fewer than 2 timelines are selected', async () => {
+      const { result } = renderHook(() => useOpenSuperTimeline());
+
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1']);
+      });
+
+      expect(mockAddWarning).not.toHaveBeenCalled();
+      expect(mockResolveTimeline).not.toHaveBeenCalled();
+    });
+
+    it('accepts exactly MAX timelines without showing a cap warning', async () => {
+      const ids = Array.from({ length: MAX_SUPER_TIMELINE_COUNT }, (_, i) => `id-${i}`);
+      setupHappyPath(ids);
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(ids);
+      });
+
+      expect(mockAddWarning).not.toHaveBeenCalled();
+      expect(mockResolveTimeline).toHaveBeenCalledTimes(MAX_SUPER_TIMELINE_COUNT);
+    });
+  });
+
+  describe('overwrite guard', () => {
+    it('shows a confirm dialog when active timeline has unsaved changes (changed: true)', async () => {
+      mockActiveTimeline = { changed: true, status: TimelineStatusEnum.draft };
+      mockOpenConfirm.mockResolvedValue(true);
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockOpenConfirm).toHaveBeenCalledTimes(1);
+      expect(mockResolveTimeline).toHaveBeenCalledTimes(2);
+    });
+
+    it('shows a confirm dialog when active timeline is a draft with an update timestamp', async () => {
+      mockActiveTimeline = {
+        changed: false,
+        status: TimelineStatusEnum.draft,
+        updated: 1234567890,
+      };
+      mockOpenConfirm.mockResolvedValue(true);
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockOpenConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts when the user cancels the overwrite confirmation', async () => {
+      mockActiveTimeline = { changed: true };
+      mockOpenConfirm.mockResolvedValue(false);
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockOpenConfirm).toHaveBeenCalledTimes(1);
+      expect(mockResolveTimeline).not.toHaveBeenCalled();
+      expect(mockUpdateTimeline).not.toHaveBeenCalled();
+    });
+
+    it('skips the confirm dialog when the active timeline has no unsaved changes', async () => {
+      mockActiveTimeline = { changed: false, status: TimelineStatusEnum.active };
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockOpenConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('parallel fetch and model build', () => {
+    it('fetches all source timelines in parallel and opens the super timeline', async () => {
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockResolveTimeline).toHaveBeenCalledTimes(2);
+      expect(mockResolveTimeline).toHaveBeenCalledWith('id-1');
+      expect(mockResolveTimeline).toHaveBeenCalledWith('id-2');
+      expect(mockBuildSuperTimelineModel).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches the merged model into the active timeline slot with show: true', async () => {
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockUpdateTimeline).toHaveBeenCalledTimes(1);
+      const call = mockUpdateTimeline.mock.calls[0][0];
+      expect(call.id).toBe(TimelineId.active);
+      expect(call.timeline.show).toBe(true);
+      expect(call.timeline.isSuperTimeline).toBe(true);
+      expect(call.timeline.activeTab).toBe(TimelineTabs.pinned);
+      expect(call.duplicate).toBe(false);
+      expect(call.preventSettingQuery).toBe(true);
+    });
+
+    it('never calls updateTimeline with a savedObjectId (super timeline is transient)', async () => {
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      const call = mockUpdateTimeline.mock.calls[0][0];
+      expect(call.timeline.savedObjectId).toBeNull();
+    });
+  });
+
+  describe('EQL/ESQL skipped-query toast', () => {
+    it('shows a warning toast naming EQL/ESQL timelines when skippedQueryTimelines is non-empty', async () => {
+      setupHappyPath();
+      mockBuildSuperTimelineModel.mockReturnValue({
+        model: makeMergedModel(),
+        skippedQueryTimelines: [
+          { id: 'eql-id', title: 'EQL Investigation', reason: 'eql' as const },
+        ],
+      });
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockAddWarning).toHaveBeenCalledTimes(1);
+      const warningText = mockAddWarning.mock.calls[0][0].text as string;
+      expect(warningText).toContain('EQL Investigation');
+    });
+
+    it('shows no toast when all timelines contribute KQL queries', async () => {
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockAddWarning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('shows an error toast when resolveTimeline rejects', async () => {
+      mockResolveTimeline.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(mockAddError).toHaveBeenCalledTimes(1);
+      expect(mockUpdateTimeline).not.toHaveBeenCalled();
+    });
+
+    it('resets isLoading to false after an error', async () => {
+      mockResolveTimeline.mockRejectedValue(new Error('boom'));
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('isLoading state', () => {
+    it('is false before opening and false after successful open', async () => {
+      setupHappyPath();
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      expect(result.current.isLoading).toBe(false);
+
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2']);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.test.ts
@@ -26,8 +26,8 @@ const mockBuildSuperTimelineModel = jest.fn();
 // The key 'timeline-1' is the literal value of TimelineId.active (enum checked in index.ts).
 let mockActiveTimeline: Partial<TimelineModel> = {};
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
+jest.mock('react-redux-v7', () => ({
+  ...jest.requireActual('react-redux-v7'),
   useSelector: (selector: (s: unknown) => unknown) =>
     selector({
       timeline: {
@@ -132,14 +132,14 @@ describe('useOpenSuperTimeline', () => {
       expect(mockResolveTimeline).not.toHaveBeenCalled();
     });
 
-    it('returns early without toast when fewer than 2 timelines are selected', async () => {
+    it('shows a warning toast when fewer than 2 timelines are selected', async () => {
       const { result } = renderHook(() => useOpenSuperTimeline());
 
       await act(async () => {
         await result.current.openSuperTimeline(['id-1']);
       });
 
-      expect(mockAddWarning).not.toHaveBeenCalled();
+      expect(mockAddWarning).toHaveBeenCalledTimes(1);
       expect(mockResolveTimeline).not.toHaveBeenCalled();
     });
 
@@ -295,7 +295,9 @@ describe('useOpenSuperTimeline', () => {
   });
 
   describe('error handling', () => {
-    it('shows an error toast when resolveTimeline rejects', async () => {
+    it('shows warning toasts (not an error) when all resolveTimeline calls reject', async () => {
+      // WHY: with Promise.allSettled a single failure should not abort the whole batch.
+      // When all fail we surface which IDs failed and a "too few loaded" guard — not a generic error.
       mockResolveTimeline.mockRejectedValue(new Error('Network error'));
 
       const { result } = renderHook(() => useOpenSuperTimeline());
@@ -303,11 +305,37 @@ describe('useOpenSuperTimeline', () => {
         await result.current.openSuperTimeline(['id-1', 'id-2']);
       });
 
-      expect(mockAddError).toHaveBeenCalledTimes(1);
+      expect(mockAddError).not.toHaveBeenCalled();
+      expect(mockAddWarning).toHaveBeenCalledTimes(2); // partial-fetch warning + too-few warning
       expect(mockUpdateTimeline).not.toHaveBeenCalled();
     });
 
-    it('resets isLoading to false after an error', async () => {
+    it('shows a partial-fetch warning but still opens when enough timelines succeed', async () => {
+      // WHY: one deleted/unavailable timeline should not block the rest from aggregating.
+      mockResolveTimeline.mockRejectedValueOnce(new Error('Not found'));
+      mockResolveTimeline.mockResolvedValueOnce({ timeline: makeRawTimeline('id-2') });
+      mockResolveTimeline.mockResolvedValueOnce({ timeline: makeRawTimeline('id-3') });
+      mockFormatTimelineResponseToModel.mockReturnValue({
+        timeline: { ...timelineDefaults, id: '', savedObjectId: 'id-2' } as TimelineModel,
+        notes: [],
+      });
+      mockBuildSuperTimelineModel.mockReturnValue({
+        model: makeMergedModel({ superTimelineSourceIds: ['id-2', 'id-3'] }),
+        skippedQueryTimelines: [],
+      });
+
+      const { result } = renderHook(() => useOpenSuperTimeline());
+      await act(async () => {
+        await result.current.openSuperTimeline(['id-1', 'id-2', 'id-3']);
+      });
+
+      expect(mockAddWarning).toHaveBeenCalledTimes(1);
+      const warningTitle = mockAddWarning.mock.calls[0][0].title as string;
+      expect(warningTitle).toContain('could not be loaded');
+      expect(mockUpdateTimeline).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets isLoading to false when all fetches fail', async () => {
       mockResolveTimeline.mockRejectedValue(new Error('boom'));
 
       const { result } = renderHook(() => useOpenSuperTimeline());

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
@@ -134,7 +134,7 @@ export const useOpenSuperTimeline = () => {
           timeline: {
             ...model,
             show: true,
-            activeTab: TimelineTabs.pinned,
+            activeTab: TimelineTabs.query,
           },
           preventSettingQuery: true,
         });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import { i18n } from '@kbn/i18n';
+import { resolveTimeline } from '../../containers/api';
+import { formatTimelineResponseToModel } from '../open_timeline/helpers';
+import { useUpdateTimeline } from '../open_timeline/use_update_timeline';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useBrowserFields } from '../../../data_view_manager/hooks/use_browser_fields';
+import { PageScope } from '../../../data_view_manager/constants';
+import { useKibana } from '../../../common/lib/kibana';
+import { TimelineId, TimelineTabs } from '../../../../common/types/timeline';
+import { TimelineStatusEnum } from '../../../../common/api/timeline';
+import { selectTimelineById } from '../../store/selectors';
+import type { State } from '../../../common/store';
+import { buildSuperTimelineModel } from './build_super_timeline_model';
+
+export const MAX_SUPER_TIMELINE_COUNT = 10;
+const MIN_SUPER_TIMELINE_COUNT = 2;
+
+/**
+ * Hook that opens a Super Timeline from a list of saved object IDs.
+ *
+ * Fetches all source timelines in parallel, aggregates their pinned events, notes, and KQL
+ * queries (via buildSuperTimelineModel), then loads the result into the active timeline slot.
+ * The result is transient — it is never persisted.
+ *
+ * Enforces:
+ * - A cap of MAX_SUPER_TIMELINE_COUNT (10) source timelines.
+ * - An overwrite-guard confirm dialog when the active timeline has unsaved changes.
+ * - A warning toast naming any EQL/ESQL timelines whose queries could not be merged.
+ */
+export const useOpenSuperTimeline = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const updateTimeline = useUpdateTimeline();
+  const { dataView } = useDataView(PageScope.timeline);
+  const browserFields = useBrowserFields(PageScope.timeline);
+  const { services } = useKibana();
+  const { uiSettings, notifications, overlays } = services;
+
+  const activeTimeline = useSelector((state: State) =>
+    selectTimelineById(state, TimelineId.active)
+  );
+
+  const openSuperTimeline = useCallback(
+    async (savedObjectIds: string[]) => {
+      if (savedObjectIds.length > MAX_SUPER_TIMELINE_COUNT) {
+        notifications.toasts.addWarning({
+          title: i18n.translate('xpack.securitySolution.timeline.superTimeline.capExceededTitle', {
+            defaultMessage: 'Too many timelines selected',
+          }),
+          text: i18n.translate('xpack.securitySolution.timeline.superTimeline.capExceededText', {
+            defaultMessage:
+              'You can combine at most {max} timelines into a Super Timeline. Select {max} or fewer.',
+            values: { max: MAX_SUPER_TIMELINE_COUNT },
+          }),
+        });
+        return;
+      }
+
+      if (savedObjectIds.length < MIN_SUPER_TIMELINE_COUNT) {
+        return;
+      }
+
+      // Overwrite guard: confirm before replacing a dirty active timeline
+      const hasUnsavedChanges =
+        activeTimeline?.changed ||
+        (activeTimeline?.status === TimelineStatusEnum.draft && activeTimeline?.updated != null);
+
+      if (hasUnsavedChanges) {
+        const confirmed = await overlays?.openConfirm(
+          i18n.translate('xpack.securitySolution.timeline.superTimeline.overwriteConfirmMessage', {
+            defaultMessage: 'Opening a Super Timeline will discard your unsaved changes. Continue?',
+          }),
+          {
+            title: i18n.translate(
+              'xpack.securitySolution.timeline.superTimeline.overwriteConfirmTitle',
+              { defaultMessage: 'Discard unsaved changes?' }
+            ),
+            confirmButtonText: i18n.translate(
+              'xpack.securitySolution.timeline.superTimeline.overwriteConfirmButton',
+              { defaultMessage: 'Open Super Timeline' }
+            ),
+            'data-test-subj': 'superTimeline-overwrite-confirm-modal',
+          }
+        );
+        if (!confirmed) return;
+      }
+
+      setIsLoading(true);
+      try {
+        const results = await Promise.all(savedObjectIds.map((id) => resolveTimeline(id)));
+        const timelineModels = results.map(
+          (result) => formatTimelineResponseToModel(result.timeline).timeline
+        );
+
+        const esQueryConfig = getEsQueryConfig(uiSettings);
+
+        const { model, skippedQueryTimelines } = buildSuperTimelineModel(timelineModels, {
+          dataView,
+          browserFields,
+          esQueryConfig,
+        });
+
+        if (skippedQueryTimelines.length > 0) {
+          notifications.toasts.addWarning({
+            title: i18n.translate(
+              'xpack.securitySolution.timeline.superTimeline.skippedQueryTitle',
+              { defaultMessage: 'Some timeline queries could not be merged' }
+            ),
+            text: i18n.translate('xpack.securitySolution.timeline.superTimeline.skippedQueryText', {
+              defaultMessage:
+                'The following timelines use EQL or ESQL and their queries were not included: {titles}. Their pinned events and notes are still shown.',
+              values: {
+                titles: skippedQueryTimelines.map((t) => t.title).join(', '),
+              },
+            }),
+          });
+        }
+
+        updateTimeline({
+          duplicate: false,
+          from: model.dateRange.start,
+          to: model.dateRange.end,
+          id: TimelineId.active,
+          notes: null,
+          timeline: {
+            ...model,
+            show: true,
+            activeTab: TimelineTabs.pinned,
+          },
+          preventSettingQuery: true,
+        });
+      } catch (error) {
+        notifications.toasts.addError(error as Error, {
+          title: i18n.translate('xpack.securitySolution.timeline.superTimeline.errorTitle', {
+            defaultMessage: 'Failed to open Super Timeline',
+          }),
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [activeTimeline, browserFields, dataView, notifications, overlays, uiSettings, updateTimeline]
+  );
+
+  return { openSuperTimeline, isLoading };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector } from 'react-redux-v7';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { resolveTimeline } from '../../containers/api';

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/super_timeline/use_open_super_timeline.ts
@@ -66,6 +66,21 @@ export const useOpenSuperTimeline = () => {
       }
 
       if (savedObjectIds.length < MIN_SUPER_TIMELINE_COUNT) {
+        // Caller is responsible for enforcing minimum — the batch action button is disabled for < 2.
+        // If somehow reached programmatically, warn rather than silently no-op.
+        notifications.toasts.addWarning({
+          title: i18n.translate(
+            'xpack.securitySolution.timeline.superTimeline.tooFewTimelinesTitle',
+            { defaultMessage: 'Select at least 2 timelines' }
+          ),
+          text: i18n.translate(
+            'xpack.securitySolution.timeline.superTimeline.tooFewTimelinesText',
+            {
+              defaultMessage: 'A Super Timeline requires at least {min} source timelines.',
+              values: { min: MIN_SUPER_TIMELINE_COUNT },
+            }
+          ),
+        });
         return;
       }
 
@@ -96,10 +111,50 @@ export const useOpenSuperTimeline = () => {
 
       setIsLoading(true);
       try {
-        const results = await Promise.all(savedObjectIds.map((id) => resolveTimeline(id)));
-        const timelineModels = results.map(
-          (result) => formatTimelineResponseToModel(result.timeline).timeline
-        );
+        const settled = await Promise.allSettled(savedObjectIds.map((id) => resolveTimeline(id)));
+
+        const failedIds: string[] = [];
+        const timelineModels = settled
+          .map((result, idx) => {
+            if (result.status === 'rejected') {
+              failedIds.push(savedObjectIds[idx]);
+              return null;
+            }
+            return formatTimelineResponseToModel(result.value.timeline).timeline;
+          })
+          .filter((m): m is NonNullable<typeof m> => m !== null);
+
+        if (failedIds.length > 0) {
+          notifications.toasts.addWarning({
+            title: i18n.translate(
+              'xpack.securitySolution.timeline.superTimeline.partialFetchTitle',
+              { defaultMessage: 'Some timelines could not be loaded' }
+            ),
+            text: i18n.translate('xpack.securitySolution.timeline.superTimeline.partialFetchText', {
+              defaultMessage:
+                'The following timelines could not be fetched and were skipped: {ids}.',
+              values: { ids: failedIds.join(', ') },
+            }),
+          });
+        }
+
+        if (timelineModels.length < MIN_SUPER_TIMELINE_COUNT) {
+          notifications.toasts.addWarning({
+            title: i18n.translate(
+              'xpack.securitySolution.timeline.superTimeline.tooFewSucceededTitle',
+              { defaultMessage: 'Not enough timelines loaded' }
+            ),
+            text: i18n.translate(
+              'xpack.securitySolution.timeline.superTimeline.tooFewSucceededText',
+              {
+                defaultMessage:
+                  'At least {min} timelines must load successfully to build a Super Timeline.',
+                values: { min: MIN_SUPER_TIMELINE_COUNT },
+              }
+            ),
+          });
+          return;
+        }
 
         const esQueryConfig = getEsQueryConfig(uiSettings);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.test.tsx
@@ -111,6 +111,37 @@ describe('Timeline', () => {
     });
   });
 
+  describe('Super Timeline mode', () => {
+    let mockStore: ReturnType<typeof createMockStore>;
+    beforeEach(() => {
+      const superState = structuredClone(mockGlobalState);
+      superState.timeline.timelineById[TimelineId.test].isSuperTimeline = true;
+      mockStore = createMockStore(superState);
+    });
+
+    it('hides the ESQL tab when isSuperTimeline is true', async () => {
+      render(
+        <TestProviders store={mockStore}>
+          <TabsContent {...defaultProps} />
+        </TestProviders>
+      );
+      await waitFor(() => {
+        expect(screen.queryByTestId(`timelineTabs-${TimelineTabs.esql}`)).toBeNull();
+      });
+    });
+
+    it('hides the EQL tab when isSuperTimeline is true', async () => {
+      render(
+        <TestProviders store={mockStore}>
+          <TabsContent {...defaultProps} />
+        </TestProviders>
+      );
+      await waitFor(() => {
+        expect(screen.queryByTestId(`timelineTabs-${TimelineTabs.eql}`)).toBeNull();
+      });
+    });
+  });
+
   describe('privileges', () => {
     it('should show notes and pinned tabs for users with the required privileges', () => {
       (useUserPrivileges as jest.Mock).mockReturnValue({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.tsx
@@ -98,9 +98,12 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
     const timelineESQLSavedSearch = useShallowEqualSelector((state) =>
       selectTimelineESQLSavedSearchId(state, timelineId)
     );
+    const isSuperTimeline = useShallowEqualSelector(
+      (state) => selectTimelineById(state, timelineId)?.isSuperTimeline ?? false
+    );
     const shouldShowESQLTab = useMemo(
-      () => isEsqlAdvancedSettingEnabled || timelineESQLSavedSearch != null,
-      [isEsqlAdvancedSettingEnabled, timelineESQLSavedSearch]
+      () => !isSuperTimeline && (isEsqlAdvancedSettingEnabled || timelineESQLSavedSearch != null),
+      [isSuperTimeline, isEsqlAdvancedSettingEnabled, timelineESQLSavedSearch]
     );
 
     return (
@@ -136,7 +139,7 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
             timelineId={timelineId}
           />
         </LazyTimelineTabRenderer>
-        {timelineType === TimelineTypeEnum.default && (
+        {!isSuperTimeline && timelineType === TimelineTypeEnum.default && (
           <LazyTimelineTabRenderer
             timelineId={timelineId}
             shouldShowTab={TimelineTabs.eql === activeTimelineTab}
@@ -208,16 +211,17 @@ const TabsContentComponent: React.FC<BasicTimelineTab> = ({
 
   const activeTab = useShallowEqualSelector((state) => getActiveTab(state, timelineId));
   const showTimeline = useShallowEqualSelector((state) => getShowTimeline(state, timelineId));
+  const timeline = useSelector((state: State) => selectTimelineById(state, timelineId));
+  const isSuperTimeline = timeline?.isSuperTimeline ?? false;
+
   const shouldShowESQLTab = useMemo(
-    () => isEsqlAdvancedSettingEnabled || timelineESQLSavedSearch != null,
-    [isEsqlAdvancedSettingEnabled, timelineESQLSavedSearch]
+    () => !isSuperTimeline && (isEsqlAdvancedSettingEnabled || timelineESQLSavedSearch != null),
+    [isSuperTimeline, isEsqlAdvancedSettingEnabled, timelineESQLSavedSearch]
   );
 
   const numberOfPinnedEvents = useShallowEqualSelector((state) =>
     getNumberOfPinnedEvents(state, timelineId)
   );
-
-  const timeline = useSelector((state: State) => selectTimelineById(state, timelineId));
   const timelineSavedObjectId = useMemo(() => timeline?.savedObjectId ?? '', [timeline]);
   const isTimelineSaved: boolean = useMemo(
     () => timelineSavedObjectId.length > 0,
@@ -316,7 +320,7 @@ const TabsContentComponent: React.FC<BasicTimelineTab> = ({
               <span>{i18n.DISCOVER_ESQL_IN_TIMELINE_TAB}</span>
             </StyledEuiTab>
           )}
-          {timelineType === TimelineTypeEnum.default && (
+          {!isSuperTimeline && timelineType === TimelineTypeEnum.default && (
             <StyledEuiTab
               data-test-subj={`timelineTabs-${TimelineTabs.eql}`}
               onClick={setEqlAsActiveTab}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/defaults.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/defaults.ts
@@ -102,6 +102,8 @@ export const timelineDefaults: SubsetTimelineModel &
   isDataProviderVisible: false,
   sampleSize: 500,
   rowHeight: 3,
+  isSuperTimeline: false,
+  superTimelineSourceIds: [],
 };
 
 export const getTimelineManageDefaults = (id: string) => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/helpers.test.ts
@@ -292,6 +292,33 @@ describe('Timeline', () => {
         bar: barWithPopulatedColumns,
       });
     });
+
+    test('should reset isSuperTimeline and superTimelineSourceIds when creating a new timeline from a Super Timeline', () => {
+      // WHY: Super Timeline is a transient, read-only view. Clicking "New" must return the user to
+      // a normal editable timeline. Without explicit resets in timelineDefaults, the stale
+      // isSuperTimeline: true flag would survive the spread in addNewTimeline and the new timeline
+      // would still render in read-only mode (tabs hidden, save disabled).
+      const superTimelineById: TimelineById = {
+        foo: {
+          ...basicTimeline,
+          isSuperTimeline: true,
+          superTimelineSourceIds: ['source-id-1', 'source-id-2'],
+        },
+      };
+
+      const update = addNewTimeline({
+        id: 'foo',
+        columns: timelineDefaults.columns,
+        dataViewId: null,
+        indexNames: [],
+        timelineById: superTimelineById,
+        timelineType: TimelineTypeEnum.default,
+        savedSearchId: null,
+      });
+
+      expect(update.foo.isSuperTimeline).toBe(false);
+      expect(update.foo.superTimelineSourceIds).toEqual([]);
+    });
   });
 
   describe('#updateTimelineShowTimeline', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/model.ts
@@ -137,6 +137,16 @@ export interface TimelineModel {
   rowHeight?: number;
   /* sample size, total record number stored in in memory EuiDataGrid */
   sampleSize: number;
+  /**
+   * When true, this timeline is a transient, read-only Super Timeline aggregated from multiple
+   * source timelines. Runtime-only — not persisted to the saved object.
+   */
+  isSuperTimeline?: boolean;
+  /**
+   * The savedObjectIds of the source timelines that were aggregated to build this Super Timeline.
+   * Used to fetch notes across all source timelines. Runtime-only — not persisted.
+   */
+  superTimelineSourceIds?: string[];
 }
 
 export type SubsetTimelineModel = Readonly<
@@ -190,6 +200,8 @@ export type SubsetTimelineModel = Readonly<
     | 'savedSearch'
     | 'isDataProviderVisible'
     | 'changed'
+    | 'isSuperTimeline'
+    | 'superTimelineSourceIds'
   >
 >;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/selectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/selectors.ts
@@ -180,3 +180,11 @@ export const selectIsPinnedEventInTimeline = () =>
     (_: State, __: string, pinnedEventId: string) => pinnedEventId,
     (timeline, pinnedEventId): boolean => !!timeline?.pinnedEventIds?.[pinnedEventId]
   );
+
+/**
+ * Selector that returns true when the active timeline is a transient, read-only Super Timeline.
+ */
+export const selectIsSuperTimeline = createSelector(
+  selectTimelineById,
+  (timeline): boolean => !!timeline?.isSuperTimeline
+);


### PR DESCRIPTION
## Summary

### What
Wires the aggregation utility from PR 1 into the timeline modal. Adds the `useOpenSuperTimeline` hook that fetches N timelines in parallel, builds the merged model, and dispatches it into the active timeline slot. Gates the modal UI into read-only mode when a Super Timeline is active.

### Why
The hook owns the full open lifecycle (fetch → build → dispatch) so all future entry points (PRs 4 and 5) just call it with a list of saved-object IDs. Modal read-only gating is centralised here so every entry point gets correct semantics automatically.

Part of epic [elastic/security-team#14357](https://github.com/elastic/security-team/issues/14357).

## Changes

- New `use_open_super_timeline.ts`: fetches N timelines in parallel via `resolveTimeline`, builds the super model, dispatches `updateTimeline` + `showTimeline`. Enforces the 10-timeline cap with a toast. Shows a warning toast naming any EQL/ESQL timelines whose queries were skipped. Includes an overwrite guard — prompts before replacing an unsaved active timeline.
- `modal/header/index.tsx`: when `isSuperTimeline`, hides Save / Attach to Case / Add to Favorites buttons and shows a "Super Timeline — read-only" badge
- `timeline/tabs/index.tsx`: ESQL and EQL tabs hidden when `isSuperTimeline` is true
- 336-line unit test covering: parallel fetch, 10-cap toast, overwrite guard, EQL/ESQL callout, header gating, tab gating
- `super_timeline.md` extended with PR 2 section

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Overwriting active timeline**: The overwrite guard mitigates the risk of losing unsaved work. Without it, dispatching to `TimelineId.active` would silently replace the active timeline.
- **Transience**: The super model dispatches with `status: draft`; the save middleware only triggers on `saveTimeline` action — structural transience, no accidental persist path.
- **No entry point in this PR**: All assertions are unit-level with mocked `resolveTimeline`; browser verification requires PR 4 or 5.

### Release note

> Adds the internal hook and modal read-only gating for Super Timeline — no user-facing entry point in this PR.

**Suggested label:** `release_note:skip`

---

### Stack

- [PR 1/5 — mode flag + aggregation utility](https://github.com/elastic/kibana/pull/274930)
- **PR 2/5 — open hook and read-only modal gating ← you are here**
- [PR 3/5 — multi-source notes aggregation](https://github.com/elastic/kibana/pull/274932)
- [PR 4/5 — "View Super Timeline" bulk action on Timelines list](https://github.com/elastic/kibana/pull/274933)
- [PR 5/5 — Cases timeline attachments entry point](https://github.com/elastic/kibana/pull/274937)