### PR TITLE
[Entity Store] Fix empty CPS state

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/moon.yml
+++ b/x-pack/solutions/security/plugins/entity_store/moon.yml
@@ -47,6 +47,7 @@ dependsOn:
   - '@kbn/esql-language'
   - '@kbn/licensing-plugin'
   - '@kbn/licensing-types'
+  - '@kbn/es-errors'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.test.ts
@@ -691,4 +691,54 @@ describe('RemoteLogsExtractionClient', () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
   });
+
+  describe('CPS/CCS extraction error handling', () => {
+    const makeClient = (id: 'ccs' | 'cps') =>
+      new RemoteLogsExtractionClient(mockLogger, namespace, {
+        id,
+        client: mockEsClient,
+        stateClient: mockStateClient,
+        buildPatterns: ({ remoteIndexPatterns }) => remoteIndexPatterns,
+      });
+
+    it('CPS: treats no_such_element_exception (no linked projects) as empty, no error', async () => {
+      mockExecuteEsqlQuery.mockRejectedValueOnce(
+        new Error('verification_exception: ... no_such_element_exception: null')
+      );
+
+      const result = await makeClient('cps').extractToUpdates(defaultExtractParams);
+
+      expect(result).toEqual({ count: 0, pages: 0 });
+    });
+
+    it('CPS: treats no_such_remote_cluster_exception (CPS disabled) as empty, no error', async () => {
+      mockExecuteEsqlQuery.mockRejectedValueOnce(
+        new Error('no_such_remote_cluster_exception: no such remote cluster: [_origin]')
+      );
+
+      const result = await makeClient('cps').extractToUpdates(defaultExtractParams);
+
+      expect(result).toEqual({ count: 0, pages: 0 });
+    });
+
+    it('CCS: surfaces no_such_remote_cluster_exception as an error (real misconfiguration)', async () => {
+      mockExecuteEsqlQuery.mockRejectedValueOnce(
+        new Error('no_such_remote_cluster_exception: no such remote cluster: [my-remote]')
+      );
+
+      const result = await makeClient('ccs').extractToUpdates(defaultExtractParams);
+
+      expect(result.count).toBe(0);
+      expect(result.pages).toBe(0);
+      expect(result.error?.message).toContain('no_such_remote_cluster_exception');
+    });
+
+    it('CPS: surfaces unrelated failures as an error', async () => {
+      mockExecuteEsqlQuery.mockRejectedValueOnce(new Error('some other failure'));
+
+      const result = await makeClient('cps').extractToUpdates(defaultExtractParams);
+
+      expect(result.error?.message).toContain('some other failure');
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.test.ts
@@ -7,6 +7,7 @@
 
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import moment from 'moment';
+import { errors } from '@elastic/elasticsearch';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { RemoteLogsExtractionClient } from './remote_logs_extraction_client';
@@ -701,10 +702,16 @@ describe('RemoteLogsExtractionClient', () => {
         buildPatterns: ({ remoteIndexPatterns }) => remoteIndexPatterns,
       });
 
+    // The matcher reads only body.error.type, so statusCode is irrelevant here.
+    const esResponseError = (type: string) =>
+      new errors.ResponseError({
+        warnings: [],
+        meta: {} as never,
+        body: { error: { type, reason: null } },
+      });
+
     it('CPS: treats no_such_element_exception (no linked projects) as empty, no error', async () => {
-      mockExecuteEsqlQuery.mockRejectedValueOnce(
-        new Error('verification_exception: ... no_such_element_exception: null')
-      );
+      mockExecuteEsqlQuery.mockRejectedValueOnce(esResponseError('no_such_element_exception'));
 
       const result = await makeClient('cps').extractToUpdates(defaultExtractParams);
 
@@ -713,7 +720,7 @@ describe('RemoteLogsExtractionClient', () => {
 
     it('CPS: treats no_such_remote_cluster_exception (CPS disabled) as empty, no error', async () => {
       mockExecuteEsqlQuery.mockRejectedValueOnce(
-        new Error('no_such_remote_cluster_exception: no such remote cluster: [_origin]')
+        esResponseError('no_such_remote_cluster_exception')
       );
 
       const result = await makeClient('cps').extractToUpdates(defaultExtractParams);
@@ -721,16 +728,16 @@ describe('RemoteLogsExtractionClient', () => {
       expect(result).toEqual({ count: 0, pages: 0 });
     });
 
-    it('CCS: surfaces no_such_remote_cluster_exception as an error (real misconfiguration)', async () => {
+    it('CCS: surfaces no_such_remote_cluster_exception as an error (gate is CPS-only)', async () => {
       mockExecuteEsqlQuery.mockRejectedValueOnce(
-        new Error('no_such_remote_cluster_exception: no such remote cluster: [my-remote]')
+        esResponseError('no_such_remote_cluster_exception')
       );
 
       const result = await makeClient('ccs').extractToUpdates(defaultExtractParams);
 
       expect(result.count).toBe(0);
       expect(result.pages).toBe(0);
-      expect(result.error?.message).toContain('no_such_remote_cluster_exception');
+      expect(result.error).toBeDefined();
     });
 
     it('CPS: surfaces unrelated failures as an error', async () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 import { unflattenObject } from '@kbn/object-utils';
 import { get } from 'lodash';
 import { set } from '@kbn/safer-lodash-set';
+import { isResponseError, type ElasticsearchErrorDetails } from '@kbn/es-errors';
 import { entityStoreMetrics } from '../../../monitor/metrics';
 import type { Entity } from '../../../../common/domain/definitions/entity.gen';
 import {
@@ -69,12 +70,19 @@ interface RemoteExtractToUpdatesResult {
   logsCapApplied?: boolean;
 }
 
+const getEsErrorType = (error: unknown): string | undefined =>
+  isResponseError(error) ? (error.body as ElasticsearchErrorDetails)?.error?.type : undefined;
+
 // CPS is not enabled, so '_origin' can't be resolved
-const isNoSuchRemoteClusterError = (message: string) =>
-  message.includes('no_such_remote_cluster_exception');
+const isNoSuchRemoteClusterError = (type?: string) => type === 'no_such_remote_cluster_exception';
 
 // no linked projects, so '-_origin:*' resolves to an empty scope, ESQL throws 500
-const isNoSuchElementError = (message: string) => message.includes('no_such_element_exception');
+const isNoSuchElementError = (type?: string) => type === 'no_such_element_exception';
+
+const isRemoteUnavailableError = (error: unknown): boolean => {
+  const type = getEsErrorType(error);
+  return isNoSuchElementError(type) || isNoSuchRemoteClusterError(type);
+};
 
 export class RemoteLogsExtractionClient {
   private readonly logger: Logger;
@@ -94,12 +102,9 @@ export class RemoteLogsExtractionClient {
       return await this.doExtractToUpdates(params);
     } catch (error) {
       const message = getErrorMessage(error);
-      if (
-        this.strategy.id === 'cps' &&
-        (isNoSuchElementError(message) || isNoSuchRemoteClusterError(message))
-      ) {
+      if (this.strategy.id === 'cps' && isRemoteUnavailableError(error)) {
         this.logger.warn(
-          `CPS remote extraction unavailable (no linked projects or CPS disabled): ${message}. Returning empty result.`
+          `remote extraction unavailable (no linked projects or CPS disabled): ${message}. Returning empty result.`
         );
         return { count: 0, pages: 0 };
       }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/remote/remote_logs_extraction_client.ts
@@ -41,6 +41,7 @@ import {
 } from '../extraction_window';
 import { capAtMaxLogsPerWindow } from '../effective_page_limits';
 import type { RemoteExtractionStrategy } from './strategies';
+import { getErrorMessage } from '../../../../common';
 
 interface RemoteExtractToUpdatesParams {
   type: EntityType;
@@ -68,6 +69,13 @@ interface RemoteExtractToUpdatesResult {
   logsCapApplied?: boolean;
 }
 
+// CPS is not enabled, so '_origin' can't be resolved
+const isNoSuchRemoteClusterError = (message: string) =>
+  message.includes('no_such_remote_cluster_exception');
+
+// no linked projects, so '-_origin:*' resolves to an empty scope, ESQL throws 500
+const isNoSuchElementError = (message: string) => message.includes('no_such_element_exception');
+
 export class RemoteLogsExtractionClient {
   private readonly logger: Logger;
 
@@ -85,8 +93,18 @@ export class RemoteLogsExtractionClient {
     try {
       return await this.doExtractToUpdates(params);
     } catch (error) {
+      const message = getErrorMessage(error);
+      if (
+        this.strategy.id === 'cps' &&
+        (isNoSuchElementError(message) || isNoSuchRemoteClusterError(message))
+      ) {
+        this.logger.warn(
+          `CPS remote extraction unavailable (no linked projects or CPS disabled): ${message}. Returning empty result.`
+        );
+        return { count: 0, pages: 0 };
+      }
       const wrappedError = new Error(
-        `Failed to extract to updates from remote indices: ${error.message}`
+        `Failed to extract to updates from remote indices: ${message}`
       );
       this.logger.error(wrappedError);
       return { count: 0, pages: 0, error: wrappedError };

--- a/x-pack/solutions/security/plugins/entity_store/tsconfig.json
+++ b/x-pack/solutions/security/plugins/entity_store/tsconfig.json
@@ -44,5 +44,6 @@
     "@kbn/esql-language",
     "@kbn/licensing-plugin",
     "@kbn/licensing-types",
+    "@kbn/es-errors",
   ]
 }


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/274804

in cases where CPS is enabled but we have no linked projects, the query ends up being something like: `logs-*,-_origin:*`, which evaluates to something like all logs from all projects except origin, but since we have no linked projects, it's just empty. this returns an error, which we now catch and match for, then log a warning but not surface it to the `error` state, so the status page doesn't show it. 


