### PR TITLE
[Scout] Surface GitHub issue link in failure summary for Scout failures

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.test.ts
@@ -14,6 +14,8 @@ import Path from 'path';
 import { ToolingLog } from '@kbn/tooling-log';
 
 import { generateScoutTestFailureArtifacts } from './generate_scout_test_failure_artifacts';
+import { updateScoutHtmlReport } from './process_scout_reports';
+import type { ScoutTestFailureExtended } from './get_scout_failures';
 
 const REPORT_DIR = Path.join(
   '.scout',
@@ -21,19 +23,8 @@ const REPORT_DIR = Path.join(
   'scout-playwright-test-failures-2024-01-01T00-00-00'
 );
 
-const htmlWithGithubIssue = (issueUrl: string, failureCount: number) => `
-  <html>
-    <body>
-      <div class="section" id="tracked-branches-status">
-        <strong>Failures in tracked branches</strong>:
-        <span class="badge rounded-pill bg-danger" id="failure-count">${failureCount}</span>
-        <a id="github-issue-link" href="${issueUrl}" target="_blank">${issueUrl}</a>
-      </div>
-    </body>
-  </html>
-`;
-
-const htmlWithoutGithubIssue = `
+// Base report template that `updateScoutHtmlReport` injects the GitHub issue link into.
+const BASE_HTML = `
   <html>
     <body>
       <div class="section" id="tracked-branches-status">
@@ -43,13 +34,27 @@ const htmlWithoutGithubIssue = `
   </html>
 `;
 
+const createFailure = (
+  overrides: Partial<ScoutTestFailureExtended> = {}
+): ScoutTestFailureExtended => ({
+  id: 'failure-id',
+  target: 'serverless-oblt',
+  location: 'x-pack/test.ts',
+  duration: 1234,
+  owners: 'team:test',
+  classname: 'suite name',
+  name: 'test name',
+  time: '1.23',
+  failure: 'error message',
+  likelyIrrelevant: false,
+  ...overrides,
+});
+
 const readArtifactFor = (name: string) => {
-  const files = fs.readdirSync(Path.join('target', 'test_failures'));
-  const jsonFiles = files.filter((file) => file.endsWith('.json'));
+  const dir = Path.join('target', 'test_failures');
+  const jsonFiles = fs.readdirSync(dir).filter((file) => file.endsWith('.json'));
   for (const file of jsonFiles) {
-    const content = JSON.parse(
-      fs.readFileSync(Path.join('target', 'test_failures', file), 'utf-8')
-    );
+    const content = JSON.parse(fs.readFileSync(Path.join(dir, file), 'utf-8'));
     if (content.name === name) {
       return content;
     }
@@ -60,21 +65,20 @@ const readArtifactFor = (name: string) => {
 describe('generateScoutTestFailureArtifacts', () => {
   let tempDir: string;
   let prevCwd: string;
+  let reportDir: string;
+
+  const log = new ToolingLog();
 
   beforeEach(() => {
     prevCwd = process.cwd();
     tempDir = fs.mkdtempSync(Path.join(os.tmpdir(), 'scout-artifacts-'));
     process.chdir(tempDir);
 
-    const reportDir = Path.join(tempDir, REPORT_DIR);
+    reportDir = Path.join(tempDir, REPORT_DIR);
     fs.mkdirSync(reportDir, { recursive: true });
 
-    fs.writeFileSync(
-      Path.join(reportDir, 'with-issue.html'),
-      htmlWithGithubIssue('https://github.com/elastic/kibana/issues/123', 6),
-      'utf-8'
-    );
-    fs.writeFileSync(Path.join(reportDir, 'without-issue.html'), htmlWithoutGithubIssue, 'utf-8');
+    fs.writeFileSync(Path.join(reportDir, 'with-issue.html'), BASE_HTML.trim(), 'utf-8');
+    fs.writeFileSync(Path.join(reportDir, 'without-issue.html'), BASE_HTML.trim(), 'utf-8');
     fs.writeFileSync(
       Path.join(reportDir, 'test-failures-summary.json'),
       JSON.stringify([
@@ -91,7 +95,19 @@ describe('generateScoutTestFailureArtifacts', () => {
   });
 
   it('carries the GitHub issue link and failure count into the artifact', async () => {
-    await generateScoutTestFailureArtifacts({ log: new ToolingLog(), bkMeta: {} });
+    // Produce the report HTML via the real writer so the parser stays coupled to its markup.
+    updateScoutHtmlReport({
+      log,
+      reportDir,
+      failure: createFailure({
+        id: 'with-issue',
+        githubIssue: 'https://github.com/elastic/kibana/issues/123',
+        failureCount: 6,
+      }),
+      reportUpdate: true,
+    });
+
+    await generateScoutTestFailureArtifacts({ log, bkMeta: {} });
 
     const artifact = readArtifactFor('suite - tracked failure');
     expect(artifact.githubIssue).toBe('https://github.com/elastic/kibana/issues/123');
@@ -99,7 +115,7 @@ describe('generateScoutTestFailureArtifacts', () => {
   });
 
   it('omits the GitHub fields when the report has no tracked issue', async () => {
-    await generateScoutTestFailureArtifacts({ log: new ToolingLog(), bkMeta: {} });
+    await generateScoutTestFailureArtifacts({ log, bkMeta: {} });
 
     const artifact = readArtifactFor('suite - untracked failure');
     expect(artifact).not.toHaveProperty('githubIssue');

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import os from 'os';
+import Path from 'path';
+
+import { ToolingLog } from '@kbn/tooling-log';
+
+import { generateScoutTestFailureArtifacts } from './generate_scout_test_failure_artifacts';
+
+const REPORT_DIR = Path.join(
+  '.scout',
+  'reports',
+  'scout-playwright-test-failures-2024-01-01T00-00-00'
+);
+
+const htmlWithGithubIssue = (issueUrl: string, failureCount: number) => `
+  <html>
+    <body>
+      <div class="section" id="tracked-branches-status">
+        <strong>Failures in tracked branches</strong>:
+        <span class="badge rounded-pill bg-danger" id="failure-count">${failureCount}</span>
+        <a id="github-issue-link" href="${issueUrl}" target="_blank">${issueUrl}</a>
+      </div>
+    </body>
+  </html>
+`;
+
+const htmlWithoutGithubIssue = `
+  <html>
+    <body>
+      <div class="section" id="tracked-branches-status">
+        <strong>No failures found in tracked branches</strong>
+      </div>
+    </body>
+  </html>
+`;
+
+const readArtifactFor = (name: string) => {
+  const files = fs.readdirSync(Path.join('target', 'test_failures'));
+  const jsonFiles = files.filter((file) => file.endsWith('.json'));
+  for (const file of jsonFiles) {
+    const content = JSON.parse(
+      fs.readFileSync(Path.join('target', 'test_failures', file), 'utf-8')
+    );
+    if (content.name === name) {
+      return content;
+    }
+  }
+  throw new Error(`No artifact found for "${name}"`);
+};
+
+describe('generateScoutTestFailureArtifacts', () => {
+  let tempDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    tempDir = fs.mkdtempSync(Path.join(os.tmpdir(), 'scout-artifacts-'));
+    process.chdir(tempDir);
+
+    const reportDir = Path.join(tempDir, REPORT_DIR);
+    fs.mkdirSync(reportDir, { recursive: true });
+
+    fs.writeFileSync(
+      Path.join(reportDir, 'with-issue.html'),
+      htmlWithGithubIssue('https://github.com/elastic/kibana/issues/123', 6),
+      'utf-8'
+    );
+    fs.writeFileSync(Path.join(reportDir, 'without-issue.html'), htmlWithoutGithubIssue, 'utf-8');
+    fs.writeFileSync(
+      Path.join(reportDir, 'test-failures-summary.json'),
+      JSON.stringify([
+        { name: 'suite - tracked failure', htmlReportFilename: 'with-issue.html' },
+        { name: 'suite - untracked failure', htmlReportFilename: 'without-issue.html' },
+      ]),
+      'utf-8'
+    );
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('carries the GitHub issue link and failure count into the artifact', async () => {
+    await generateScoutTestFailureArtifacts({ log: new ToolingLog(), bkMeta: {} });
+
+    const artifact = readArtifactFor('suite - tracked failure');
+    expect(artifact.githubIssue).toBe('https://github.com/elastic/kibana/issues/123');
+    expect(artifact.failureCount).toBe(6);
+  });
+
+  it('omits the GitHub fields when the report has no tracked issue', async () => {
+    await generateScoutTestFailureArtifacts({ log: new ToolingLog(), bkMeta: {} });
+
+    const artifact = readArtifactFor('suite - untracked failure');
+    expect(artifact).not.toHaveProperty('githubIssue');
+    expect(artifact).not.toHaveProperty('failureCount');
+  });
+});

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.test.ts
@@ -14,8 +14,7 @@ import Path from 'path';
 import { ToolingLog } from '@kbn/tooling-log';
 
 import { generateScoutTestFailureArtifacts } from './generate_scout_test_failure_artifacts';
-import { updateScoutHtmlReport } from './process_scout_reports';
-import type { ScoutTestFailureExtended } from './get_scout_failures';
+import { SCOUT_GITHUB_ISSUES_FILENAME } from './process_scout_reports';
 
 const REPORT_DIR = Path.join(
   '.scout',
@@ -23,32 +22,7 @@ const REPORT_DIR = Path.join(
   'scout-playwright-test-failures-2024-01-01T00-00-00'
 );
 
-// Base report template that `updateScoutHtmlReport` injects the GitHub issue link into.
-const BASE_HTML = `
-  <html>
-    <body>
-      <div class="section" id="tracked-branches-status">
-        <strong>No failures found in tracked branches</strong>
-      </div>
-    </body>
-  </html>
-`;
-
-const createFailure = (
-  overrides: Partial<ScoutTestFailureExtended> = {}
-): ScoutTestFailureExtended => ({
-  id: 'failure-id',
-  target: 'serverless-oblt',
-  location: 'x-pack/test.ts',
-  duration: 1234,
-  owners: 'team:test',
-  classname: 'suite name',
-  name: 'test name',
-  time: '1.23',
-  failure: 'error message',
-  likelyIrrelevant: false,
-  ...overrides,
-});
+const FAILURE_HTML = '<html><body>failure report</body></html>';
 
 const readArtifactFor = (name: string) => {
   const dir = Path.join('target', 'test_failures');
@@ -77,8 +51,8 @@ describe('generateScoutTestFailureArtifacts', () => {
     reportDir = Path.join(tempDir, REPORT_DIR);
     fs.mkdirSync(reportDir, { recursive: true });
 
-    fs.writeFileSync(Path.join(reportDir, 'with-issue.html'), BASE_HTML.trim(), 'utf-8');
-    fs.writeFileSync(Path.join(reportDir, 'without-issue.html'), BASE_HTML.trim(), 'utf-8');
+    fs.writeFileSync(Path.join(reportDir, 'with-issue.html'), FAILURE_HTML, 'utf-8');
+    fs.writeFileSync(Path.join(reportDir, 'without-issue.html'), FAILURE_HTML, 'utf-8');
     fs.writeFileSync(
       Path.join(reportDir, 'test-failures-summary.json'),
       JSON.stringify([
@@ -95,17 +69,17 @@ describe('generateScoutTestFailureArtifacts', () => {
   });
 
   it('carries the GitHub issue link and failure count into the artifact', async () => {
-    // Produce the report HTML via the real writer so the parser stays coupled to its markup.
-    updateScoutHtmlReport({
-      log,
-      reportDir,
-      failure: createFailure({
-        id: 'with-issue',
-        githubIssue: 'https://github.com/elastic/kibana/issues/123',
-        failureCount: 6,
+    // `processScoutReports` persists this sidecar keyed by failure id (the html filename stem).
+    fs.writeFileSync(
+      Path.join(reportDir, SCOUT_GITHUB_ISSUES_FILENAME),
+      JSON.stringify({
+        'with-issue': {
+          githubIssue: 'https://github.com/elastic/kibana/issues/123',
+          failureCount: 6,
+        },
       }),
-      reportUpdate: true,
-    });
+      'utf-8'
+    );
 
     await generateScoutTestFailureArtifacts({ log, bkMeta: {} });
 
@@ -114,7 +88,7 @@ describe('generateScoutTestFailureArtifacts', () => {
     expect(artifact.failureCount).toBe(6);
   });
 
-  it('omits the GitHub fields when the report has no tracked issue', async () => {
+  it('omits the GitHub fields when there is no tracked issue for the failure', async () => {
     await generateScoutTestFailureArtifacts({ log, bkMeta: {} });
 
     const artifact = readArtifactFor('suite - untracked failure');

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
@@ -11,12 +11,28 @@ import Path from 'path';
 
 import type { ToolingLog } from '@kbn/tooling-log';
 import { createHash } from 'crypto';
+import { decode } from 'he';
 import fs from 'fs';
 import globby from 'globby';
 import type { BuildkiteMetadata } from './buildkite_metadata';
 
 const SCOUT_TEST_FAILURE_DIR_PATTERN = '.scout/reports/scout-playwright-test-failures-*';
 const SUMMARY_REPORT_FILENAME = 'test-failures-summary.json';
+
+// `processScoutReports` writes the GitHub issue link and failure count into the
+// HTML report (see `updateScoutHtmlReport`), but not into the summary JSON we read
+// below. Parse them back out so the Buildkite/Slack failure summary can render the
+// `[N failures]` link the same way it does for FTR failures.
+const extractGithubIssueDetails = (
+  html: string
+): { githubIssue?: string; failureCount?: number } => {
+  const issueMatch = html.match(/id="github-issue-link"[^>]*href="([^"]*)"/);
+  const countMatch = html.match(/id="failure-count"[^>]*>(\d+)</);
+  return {
+    githubIssue: issueMatch ? decode(issueMatch[1]) : undefined,
+    failureCount: countMatch ? Number(countMatch[1]) : undefined,
+  };
+};
 
 export async function generateScoutTestFailureArtifacts({
   log,
@@ -53,6 +69,7 @@ export async function generateScoutTestFailureArtifacts({
     for (const { name, htmlReportFilename } of summaryData) {
       const htmlFilePath = Path.join(dirPath, htmlReportFilename);
       const failureHTML = fs.readFileSync(htmlFilePath, 'utf-8');
+      const { githubIssue, failureCount } = extractGithubIssueDetails(failureHTML);
 
       const hash = createHash('sha256').update(name).digest('hex');
       const filenameBase = `${
@@ -68,6 +85,8 @@ export async function generateScoutTestFailureArtifacts({
           url: bkMeta.url,
           jobUrl: bkMeta.jobUrl,
           jobName: bkMeta.jobName,
+          ...(githubIssue ? { githubIssue } : {}),
+          ...(failureCount !== undefined ? { failureCount } : {}),
         },
         null,
         2

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
@@ -11,27 +11,26 @@ import Path from 'path';
 
 import type { ToolingLog } from '@kbn/tooling-log';
 import { createHash } from 'crypto';
-import { decode } from 'he';
 import fs from 'fs';
 import globby from 'globby';
 import type { BuildkiteMetadata } from './buildkite_metadata';
+import {
+  SCOUT_GITHUB_ISSUES_FILENAME,
+  type ScoutGithubIssueDetails,
+} from './process_scout_reports';
 
 const SCOUT_TEST_FAILURE_DIR_PATTERN = '.scout/reports/scout-playwright-test-failures-*';
 const SUMMARY_REPORT_FILENAME = 'test-failures-summary.json';
 
-// `processScoutReports` writes the GitHub issue link and failure count into the
-// HTML report (see `updateScoutHtmlReport`), but not into the summary JSON we read
-// below. Parse them back out so the Buildkite/Slack failure summary can render the
-// `[N failures]` link the same way it does for FTR failures.
-const extractGithubIssueDetails = (
-  html: string
-): { githubIssue?: string; failureCount?: number } => {
-  const issueMatch = html.match(/id="github-issue-link"[^>]*href="([^"]*)"/);
-  const countMatch = html.match(/id="failure-count"[^>]*>(\d+)</);
-  return {
-    githubIssue: issueMatch ? decode(issueMatch[1]) : undefined,
-    failureCount: countMatch ? Number(countMatch[1]) : undefined,
-  };
+// `processScoutReports` persists the GitHub issue link and failure count per failure id in
+// `SCOUT_GITHUB_ISSUES_FILENAME`. Load it so the Buildkite/Slack failure summary can render
+// the `[N failures]` link the same way it does for FTR failures.
+const loadGithubIssues = (dirPath: string): Record<string, ScoutGithubIssueDetails> => {
+  const filePath = Path.join(dirPath, SCOUT_GITHUB_ISSUES_FILENAME);
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 };
 
 export async function generateScoutTestFailureArtifacts({
@@ -64,12 +63,14 @@ export async function generateScoutTestFailureArtifacts({
     const summaryData: Array<{ name: string; htmlReportFilename: string }> = JSON.parse(
       fs.readFileSync(summaryFilePath, 'utf-8')
     );
+    const githubIssues = loadGithubIssues(dirPath);
 
     log.info(`Creating failure artifacts for report in ${dirPath}`);
     for (const { name, htmlReportFilename } of summaryData) {
       const htmlFilePath = Path.join(dirPath, htmlReportFilename);
       const failureHTML = fs.readFileSync(htmlFilePath, 'utf-8');
-      const { githubIssue, failureCount } = extractGithubIssueDetails(failureHTML);
+      const failureId = Path.basename(htmlReportFilename, '.html');
+      const { githubIssue, failureCount } = githubIssues[failureId] ?? {};
 
       const hash = createHash('sha256').update(name).digest('hex');
       const filenameBase = `${

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_scout_reports.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_scout_reports.ts
@@ -15,6 +15,15 @@ import type { ProcessReportsParams } from './process_reports_types';
 import { createFailureIssue, updateFailureIssue } from './report_failure';
 import { reportFailuresToEs } from './report_failures_to_es';
 
+// Sidecar file written next to the Scout HTML reports so `generateScoutTestFailureArtifacts`
+// can pick up the GitHub issue link and failure count without re-parsing the HTML report.
+export const SCOUT_GITHUB_ISSUES_FILENAME = 'github-issues.json';
+
+export interface ScoutGithubIssueDetails {
+  githubIssue: string;
+  failureCount: number;
+}
+
 export const updateScoutHtmlReport = ({
   log,
   reportDir,
@@ -95,6 +104,16 @@ export async function processScoutReports(
     }
 
     const reportDir = Path.dirname(reportPath);
+    const githubIssues: Record<string, ScoutGithubIssueDetails> = {};
+
+    const recordGithubIssue = (failure: ScoutTestFailureExtended) => {
+      if (failure.githubIssue) {
+        githubIssues[failure.id] = {
+          githubIssue: failure.githubIssue,
+          failureCount: failure.failureCount ?? 0,
+        };
+      }
+    };
 
     for (const failure of failures) {
       if (failure.likelyIrrelevant) {
@@ -120,6 +139,7 @@ export async function processScoutReports(
           log.info(`Updated existing Scout issue: ${url} (fail count: ${newCount})`);
         }
         updateScoutHtmlReport({ log, reportDir, failure, reportUpdate });
+        recordGithubIssue(failure);
         continue;
       }
 
@@ -138,6 +158,15 @@ export async function processScoutReports(
       }
       failure.failureCount = updateGithub ? 1 : 0;
       updateScoutHtmlReport({ log, reportDir, failure, reportUpdate });
+      recordGithubIssue(failure);
+    }
+
+    if (Object.keys(githubIssues).length > 0) {
+      fs.writeFileSync(
+        Path.join(reportDir, SCOUT_GITHUB_ISSUES_FILENAME),
+        JSON.stringify(githubIssues, null, 2),
+        'utf-8'
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Scout test failures were missing the `[N failures]` GitHub-issue link in the Buildkite/Slack failure summary, even when the flaky-test issue **had** been created/updated for them. FTR failures show the link; Scout failures did not.

### Root cause

The Slack/annotation renderer only shows the link when the failure record carries both `githubIssue` and `failureCount` (`.buildkite/pipeline-utils/test-failures/annotate.ts`). FTR's artifact writer spreads the full failure object (including those fields), but the Scout artifact generator (`generate_scout_test_failure_artifacts.ts`) only wrote `name/hash/build/job` metadata.

`processScoutReports` does compute `githubIssue`/`failureCount`, but only writes them into the HTML report (`updateScoutHtmlReport`) — never into the summary JSON the artifact generator reads. So the data existed but never reached the artifact.

### Fix

Parse `githubIssue` and `failureCount` back out of the HTML report (which the artifact generator already reads, and which the renderer tags with `id="github-issue-link"` / `id="failure-count"`) and include them in `target/test_failures/*.json` when present. No behavior change when there is no tracked issue.

> Note: this is separate from the intentional Scout gate that withholds GitHub updates until a lane fails twice in a build — that part is working as designed. This only fixes the missing *link* once an issue does exist.

### Testing

- New unit tests in `generate_scout_test_failure_artifacts.test.ts` (link carried through; fields omitted when no issue).
- Full `kbn-failed-test-reporter-cli` suite passes; typecheck + lint clean.
