### PR TITLE
[Cases][AttachmentsV2] Add Lens as reference attachment in saved object modal

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/attachments.ts
@@ -41,6 +41,7 @@ export const MAP_ATTACHMENT_TYPE = 'map';
  * management `_find` API.
  */
 export const DASHBOARD_SO_TYPE = 'dashboard';
+export const LENS_SO_TYPE = 'lens';
 export const MAP_SO_TYPE = 'map';
 export const DISCOVER_SESSION_SO_TYPE = 'search';
 

--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -171,6 +171,11 @@ export const MAX_SUPPORTED_CONNECTORS_RETURNED = 1000 as const;
  */
 
 export const MAX_TITLE_LENGTH = 160 as const;
+export const MAX_OWNER_LENGTH = 30 as const;
+export const MAX_ISO_DATE_LENGTH = 30 as const;
+export const MAX_ATTACHMENT_ID_LENGTH = 512 as const; // ES `_id` upper bound
+export const MAX_ATTACHMENT_TYPE_LENGTH = 50 as const;
+export const MAX_USERNAME_LENGTH = 1024 as const;
 export const MAX_RULE_NAME_LENGTH = 100 as const;
 export const MAX_SUFFIX_LENGTH = 60 as const;
 export const MAX_CATEGORY_LENGTH = 50 as const;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/lens/v2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/lens/v2.test.ts
@@ -6,10 +6,10 @@
  */
 
 import { LENS_ATTACHMENT_TYPE } from '../../../../constants/attachments';
-import { LensAttachmentPayloadSchema } from './v2';
+import { isLensPersistableData, LensAttachmentPayloadSchema } from './v2';
 
 describe('LensAttachmentPayloadSchema', () => {
-  const validPayload = {
+  const validPersistablePayload = {
     type: LENS_ATTACHMENT_TYPE,
     owner: 'cases',
     data: {
@@ -19,15 +19,47 @@ describe('LensAttachmentPayloadSchema', () => {
       },
     },
   };
+  const validSavedObjectPayload = {
+    type: LENS_ATTACHMENT_TYPE,
+    owner: 'cases',
+    attachmentId: 'lens-1',
+    metadata: {
+      title: 'My Lens visualization',
+      soType: 'lens',
+    },
+    data: {
+      attributes: {
+        state: { query: {} },
+        references: [{ type: 'index-pattern', id: 'data-view-1', name: 'indexpattern-datasource' }],
+      },
+      timeRange: { from: 'now-15m', to: 'now', mode: 'relative' },
+    },
+  };
 
-  it('accepts a valid lens payload', () => {
-    const result = LensAttachmentPayloadSchema.safeParse(validPayload);
+  it('accepts a valid persistable lens payload', () => {
+    const result = LensAttachmentPayloadSchema.safeParse(validPersistablePayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid saved-object lens payload', () => {
+    const result = LensAttachmentPayloadSchema.safeParse(validSavedObjectPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a saved-object lens payload without inline data', () => {
+    const payload = {
+      type: validSavedObjectPayload.type,
+      owner: validSavedObjectPayload.owner,
+      attachmentId: validSavedObjectPayload.attachmentId,
+      metadata: validSavedObjectPayload.metadata,
+    };
+    const result = LensAttachmentPayloadSchema.safeParse(payload);
     expect(result.success).toBe(true);
   });
 
   it('accepts an empty `state` bag', () => {
     const result = LensAttachmentPayloadSchema.safeParse({
-      ...validPayload,
+      ...validPersistablePayload,
       data: { state: {} },
     });
     expect(result.success).toBe(true);
@@ -35,14 +67,39 @@ describe('LensAttachmentPayloadSchema', () => {
 
   it('rejects a missing `state` field on data', () => {
     const result = LensAttachmentPayloadSchema.safeParse({
-      ...validPayload,
+      ...validPersistablePayload,
       data: {},
     });
     expect(result.success).toBe(false);
   });
 
-  it('rejects a wrong type literal', () => {
-    const result = LensAttachmentPayloadSchema.safeParse({ ...validPayload, type: 'comment' });
+  it('rejects a saved-object payload with the wrong SO type', () => {
+    const result = LensAttachmentPayloadSchema.safeParse({
+      ...validSavedObjectPayload,
+      metadata: { ...validSavedObjectPayload.metadata, soType: 'dashboard' },
+    });
     expect(result.success).toBe(false);
+  });
+
+  it('rejects a wrong type literal', () => {
+    const result = LensAttachmentPayloadSchema.safeParse({
+      ...validPersistablePayload,
+      type: 'comment',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('narrows persistable lens data', () => {
+    expect(isLensPersistableData(validPersistablePayload.data)).toBe(true);
+    expect(isLensPersistableData(validSavedObjectPayload.data)).toBe(false);
+  });
+
+  it('does not misclassify an SO snapshot that happens to expose a `state` key alongside `attributes`', () => {
+    expect(
+      isLensPersistableData({
+        attributes: { state: { query: {} } },
+        state: 'something',
+      })
+    ).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/lens/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/lens/v2.ts
@@ -6,20 +6,71 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { LENS_ATTACHMENT_TYPE } from '../../../../constants/attachments';
+import { LENS_ATTACHMENT_TYPE, LENS_SO_TYPE } from '../../../../constants/attachments';
+import { jsonValueSchema } from '../../../../schema_zod';
+import { buildSavedObjectMetadataSchema, TimeRangeSchema } from '../saved_object/v2';
 
+// --- Persistable shape from legacy lens attachment ---
 /** `state` shape is owned by the lens plugin; kept permissive to round-trip what lens persists. */
-export const LensAttachmentDataSchema = z.object({
+export const LensPersistableAttachmentDataSchema = z.object({
   state: z.record(z.string(), z.unknown()),
 });
-export type LensAttachmentData = z.infer<typeof LensAttachmentDataSchema>;
+export type LensPersistableAttachmentData = z.infer<typeof LensPersistableAttachmentDataSchema>;
 
-export const LensAttachmentPayloadSchema = z
+export const LensPersistableAttachmentPayloadSchema = z
   .object({
     type: z.literal(LENS_ATTACHMENT_TYPE),
     owner: z.string(),
-    data: LensAttachmentDataSchema,
+    data: LensPersistableAttachmentDataSchema,
   })
   .strict();
 
+// --- Reference shape from saved object lens attachment ---
+// Snapshot of the Lens SO `attributes` at attach time. Intentionally opaque:
+// the shape is owned by the Lens plugin and may evolve, so we round-trip it
+// as JSON. The renderer reads only `attributes` and `references` from it.
+const LensSavedObjectAttributesSchema = z.record(z.string(), jsonValueSchema);
+export type LensSavedObjectAttributes = z.infer<typeof LensSavedObjectAttributesSchema>;
+export const LensSavedObjectAttachmentDataSchema = z
+  .object({
+    attributes: LensSavedObjectAttributesSchema,
+    timeRange: TimeRangeSchema.optional(),
+  })
+  .strict();
+export type LensSavedObjectAttachmentData = z.infer<typeof LensSavedObjectAttachmentDataSchema>;
+export type LensAttachmentData = LensPersistableAttachmentData | LensSavedObjectAttachmentData;
+
+const LensSavedObjectAttachmentMetadataSchema = buildSavedObjectMetadataSchema(LENS_SO_TYPE);
+export type LensSavedObjectAttachmentMetadata = z.infer<
+  typeof LensSavedObjectAttachmentMetadataSchema
+>;
+
+export const LensSavedObjectAttachmentPayloadSchema = z
+  .object({
+    type: z.literal(LENS_ATTACHMENT_TYPE),
+    owner: z.string(),
+    attachmentId: z.string(),
+    metadata: LensSavedObjectAttachmentMetadataSchema,
+    data: LensSavedObjectAttachmentDataSchema.optional(),
+  })
+  .strict();
+export type LensSavedObjectAttachmentPayload = z.infer<
+  typeof LensSavedObjectAttachmentPayloadSchema
+>;
+
+export const LensAttachmentPayloadSchema = z.union([
+  LensPersistableAttachmentPayloadSchema,
+  LensSavedObjectAttachmentPayloadSchema,
+]);
+
 export type LensAttachmentPayload = z.infer<typeof LensAttachmentPayloadSchema>;
+
+/**
+ * Narrows a lens attachment `data` to the persistable arm. The saved-object
+ * arm always carries `attributes` and never `state`, so we use the absence of
+ * `attributes` together with the presence of `state` as a discriminator —
+ * `state in data` alone would misclassify any future SO snapshot that happens
+ * to expose a `state` key inside `attributes`.
+ */
+export const isLensPersistableData = (data: unknown): data is LensPersistableAttachmentData =>
+  typeof data === 'object' && data !== null && 'state' in data && !('attributes' in data);

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/lens/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/lens/v2.ts
@@ -7,6 +7,7 @@
 
 import { z } from '@kbn/zod/v4';
 import { LENS_ATTACHMENT_TYPE, LENS_SO_TYPE } from '../../../../constants/attachments';
+import { MAX_ATTACHMENT_ID_LENGTH, MAX_OWNER_LENGTH } from '../../../../constants';
 import { jsonValueSchema } from '../../../../schema_zod';
 import { buildSavedObjectMetadataSchema, TimeRangeSchema } from '../saved_object/v2';
 
@@ -20,7 +21,7 @@ export type LensPersistableAttachmentData = z.infer<typeof LensPersistableAttach
 export const LensPersistableAttachmentPayloadSchema = z
   .object({
     type: z.literal(LENS_ATTACHMENT_TYPE),
-    owner: z.string(),
+    owner: z.string().max(MAX_OWNER_LENGTH),
     data: LensPersistableAttachmentDataSchema,
   })
   .strict();
@@ -48,8 +49,8 @@ export type LensSavedObjectAttachmentMetadata = z.infer<
 export const LensSavedObjectAttachmentPayloadSchema = z
   .object({
     type: z.literal(LENS_ATTACHMENT_TYPE),
-    owner: z.string(),
-    attachmentId: z.string(),
+    owner: z.string().max(MAX_OWNER_LENGTH),
+    attachmentId: z.string().max(MAX_ATTACHMENT_ID_LENGTH),
     metadata: LensSavedObjectAttachmentMetadataSchema,
     data: LensSavedObjectAttachmentDataSchema.optional(),
   })

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/saved_object/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/saved_object/v2.ts
@@ -17,7 +17,13 @@ export interface SavedObjectReferenceMetadata {
   soType: string;
 }
 
-export const TimeRangeSchema = z.object({ from: z.string(), to: z.string() }).strict();
+export const TimeRangeSchema = z
+  .object({
+    from: z.string(),
+    to: z.string(),
+    mode: z.enum(['absolute', 'relative']).optional(),
+  })
+  .strict();
 
 export const buildSavedObjectMetadataSchema = <SoType extends string>(soType: SoType) =>
   z

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/saved_object/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/saved_object/v2.ts
@@ -10,7 +10,12 @@ import {
   DISCOVER_SESSION_ATTACHMENT_TYPE,
   DISCOVER_SESSION_SO_TYPE,
 } from '../../../../constants/attachments';
-import { MAX_TITLE_LENGTH } from '../../../../constants';
+import {
+  MAX_ATTACHMENT_ID_LENGTH,
+  MAX_ISO_DATE_LENGTH,
+  MAX_OWNER_LENGTH,
+  MAX_TITLE_LENGTH,
+} from '../../../../constants';
 
 export interface SavedObjectReferenceMetadata {
   title: string;
@@ -19,8 +24,8 @@ export interface SavedObjectReferenceMetadata {
 
 export const TimeRangeSchema = z
   .object({
-    from: z.string(),
-    to: z.string(),
+    from: z.string().max(MAX_ISO_DATE_LENGTH),
+    to: z.string().max(MAX_ISO_DATE_LENGTH),
     mode: z.enum(['absolute', 'relative']).optional(),
   })
   .strict();
@@ -45,8 +50,8 @@ export const buildSavedObjectPayloadSchema = <AttachmentType extends string, SoT
   z
     .object({
       type: z.literal(attachmentType),
-      owner: z.string(),
-      attachmentId: z.string(),
+      owner: z.string().max(MAX_OWNER_LENGTH),
+      attachmentId: z.string().max(MAX_ATTACHMENT_ID_LENGTH),
       metadata: buildSavedObjectMetadataSchema(soType),
     })
     .strict();

--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/define_attachment.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/define_attachment.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { z } from '@kbn/zod/v4';
+import type {
+  ReferenceData,
+  UnifiedHybridAttachmentType,
+  UnifiedReferenceAttachmentType,
+  UnifiedValueAttachmentType,
+} from './types';
+
+/**
+ * READ ME:
+ * `defineAttachment()` is the public helper used by unified attachment registrations.
+ * It infers renderer prop types from the attachment's full Zod payload schema:
+ *  - reference payloads: contain `attachmentId`
+ *  - value payloads: contain inline `data` and no `attachmentId`
+ *  - hybrid payloads: support both reference and value payload shapes
+ *
+ * The inferred type is used only at the call site, so attachment renderers get precise
+ * `attachmentId`, `metadata`, and `data` types.
+ *
+ * For hybrid registrations, the renderer receives `data?: ValueData | ReferenceData`
+ * (always optional) because the reference arm makes inline data optional. The
+ * renderer is responsible for narrowing the two arms at runtime.
+ *
+ * The returned value is widened before entering the registry. This avoids TypeScript
+ * contravariance issues when storing many attachment registrations with different
+ * renderer prop types in one registry.
+ */
+
+type PayloadFromSchema<S extends z.ZodType> = z.infer<S>;
+
+/** Schema branch with an attachment id. */
+type ReferencePayloadFromSchema<S extends z.ZodType> = Extract<
+  PayloadFromSchema<S>,
+  { attachmentId: unknown }
+>;
+
+/** Schema branch with inline data and no attachment id. */
+type ValuePayloadFromSchema<S extends z.ZodType> = Exclude<
+  Extract<PayloadFromSchema<S>, { data: unknown }>,
+  { attachmentId: unknown }
+>;
+
+/** True when the schema accepts a reference payload. */
+type HasReferenceSchema<S extends z.ZodType> = [ReferencePayloadFromSchema<S>] extends [never]
+  ? false
+  : true;
+
+/** True when the schema accepts a value payload. */
+type HasValueSchema<S extends z.ZodType> = [ValuePayloadFromSchema<S>] extends [never]
+  ? false
+  : true;
+
+/** Data passed to reference renderers, falling back to the base reference payload shape. */
+type ReferenceDataFromSchema<S extends z.ZodType> =
+  'data' extends keyof ReferencePayloadFromSchema<S>
+    ? ReferencePayloadFromSchema<S> extends { data?: infer D }
+      ? D
+      : ReferenceData
+    : ReferenceData;
+
+/** Data passed to value renderers. */
+type ValueDataFromSchema<S extends z.ZodType> = ValuePayloadFromSchema<S> extends { data: infer D }
+  ? D
+  : never;
+
+/** Data passed to hybrid renderers. */
+type HybridDataFromSchema<S extends z.ZodType> =
+  | ValueDataFromSchema<S>
+  | ReferenceDataFromSchema<S>;
+
+/** Renderer props are inferred from the full payload schema passed at registration. */
+type UnifiedAttachmentTypeFromSchema<S extends z.ZodType> = HasReferenceSchema<S> extends true
+  ? HasValueSchema<S> extends true
+    ? UnifiedHybridAttachmentType<
+        HybridDataFromSchema<S>,
+        ReferencePayloadFromSchema<S> extends { metadata?: infer M } ? M : never,
+        ReferencePayloadFromSchema<S> extends { attachmentId: infer A } ? A : never
+      >
+    : UnifiedReferenceAttachmentType<
+        ReferencePayloadFromSchema<S> extends { metadata?: infer M } ? M : never,
+        ReferencePayloadFromSchema<S> extends { attachmentId: infer A } ? A : never,
+        ReferenceDataFromSchema<S>
+      >
+  : UnifiedValueAttachmentType<ValueDataFromSchema<S>>;
+
+/** Registry consumers need the broad attachment type to avoid renderer prop intersections. */
+type UnifiedAttachmentTypeForRegistry<S extends z.ZodType> = HasReferenceSchema<S> extends true
+  ? HasValueSchema<S> extends true
+    ? UnifiedHybridAttachmentType
+    : UnifiedReferenceAttachmentType
+  : UnifiedValueAttachmentType;
+
+export const defineAttachment = <S extends z.ZodType>(
+  attachmentType: UnifiedAttachmentTypeFromSchema<S> & { schema: S }
+): UnifiedAttachmentTypeForRegistry<S> =>
+  attachmentType as unknown as UnifiedAttachmentTypeForRegistry<S>;

--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
@@ -18,6 +18,7 @@ import type { CaseUI, CaseUser } from '../../containers/types';
 import { AttachmentActionType } from '../../../common/utils/attachment_actions';
 
 export { AttachmentActionType };
+export { defineAttachment } from './define_attachment';
 
 interface BaseAttachmentAction {
   type: AttachmentActionType;
@@ -85,34 +86,44 @@ export interface RowContext {
   euiTheme: EuiThemeComputed<{}>;
 }
 
-/**
- * View props for reference-based unified attachments (e.g., alerts, events).
- * These attachments reference external entities by id and may optionally
- * carry an inline `data` snapshot
- */
-export interface UnifiedReferenceAttachmentViewProps<
-  Metadata = UnifiedReferenceAttachmentPayload['metadata'],
-  AttachmentId = UnifiedReferenceAttachmentPayload['attachmentId'],
-  Data = UnifiedReferenceAttachmentPayload['data']
-> extends CommonAttachmentViewProps {
-  attachmentId: AttachmentId;
-  metadata?: Metadata;
-  data?: Data;
+type AttachmentId = UnifiedReferenceAttachmentPayload['attachmentId'];
+type ReferenceMetadata = UnifiedReferenceAttachmentPayload['metadata'];
+export type ReferenceData = UnifiedReferenceAttachmentPayload['data'];
+type ValueData = UnifiedValueAttachmentPayload['data'];
+type HybridData = ValueData | ReferenceData;
+
+interface UnifiedAttachmentViewPropsBase extends CommonAttachmentViewProps {
   createdBy: CaseUser;
   version: string;
   rowContext: RowContext;
 }
 
-/**
- * View props for value-based unified attachments (e.g., lens, user comments)
- * These attachments contain data/content directly
- */
-export interface UnifiedValueAttachmentViewProps<Data = UnifiedValueAttachmentPayload['data']>
-  extends CommonAttachmentViewProps {
+/** Reference attachments point at another entity and may include a cached snapshot. */
+export interface UnifiedReferenceAttachmentViewProps<
+  Metadata = ReferenceMetadata,
+  Id = AttachmentId,
+  Data = ReferenceData
+> extends UnifiedAttachmentViewPropsBase {
+  attachmentId: Id;
+  data?: Data;
+  metadata?: Metadata;
+}
+
+/** Value attachments store all renderable content directly on the case comment. */
+export interface UnifiedValueAttachmentViewProps<Data = ValueData>
+  extends UnifiedAttachmentViewPropsBase {
   data: Data;
-  createdBy: CaseUser;
-  version: string;
-  rowContext: RowContext;
+}
+
+/** Hybrid attachments support value and reference payloads under one attachment type id. */
+export interface UnifiedHybridAttachmentViewProps<
+  Data = HybridData,
+  Metadata = ReferenceMetadata,
+  Id = AttachmentId
+> extends UnifiedAttachmentViewPropsBase {
+  attachmentId?: Id;
+  metadata?: Metadata;
+  data?: Data;
 }
 
 export interface AttachmentType<Props> {
@@ -134,14 +145,29 @@ interface UnifiedAttachmentSchema {
 
 export type ExternalReferenceAttachmentType = AttachmentType<ExternalReferenceAttachmentViewProps>;
 export type PersistableStateAttachmentType = AttachmentType<PersistableStateAttachmentViewProps>;
+
+type UnifiedAttachmentRegistration<Props> = AttachmentType<Props> & UnifiedAttachmentSchema;
 export type UnifiedReferenceAttachmentType<
-  Metadata = UnifiedReferenceAttachmentPayload['metadata'],
-  AttachmentId = UnifiedReferenceAttachmentPayload['attachmentId'],
-  Data = UnifiedReferenceAttachmentPayload['data']
-> = AttachmentType<UnifiedReferenceAttachmentViewProps<Metadata, AttachmentId, Data>> &
-  UnifiedAttachmentSchema;
-export type UnifiedValueAttachmentType<Data = UnifiedValueAttachmentPayload['data']> =
-  AttachmentType<UnifiedValueAttachmentViewProps<Data>> & UnifiedAttachmentSchema;
+  Metadata = ReferenceMetadata,
+  Id = AttachmentId,
+  Data = ReferenceData
+> = UnifiedAttachmentRegistration<UnifiedReferenceAttachmentViewProps<Metadata, Id, Data>>;
+
+export type UnifiedValueAttachmentType<Data = ValueData> = UnifiedAttachmentRegistration<
+  UnifiedValueAttachmentViewProps<Data>
+>;
+
+export type UnifiedHybridAttachmentType<
+  Data = HybridData,
+  Metadata = ReferenceMetadata,
+  Id = AttachmentId
+> = UnifiedAttachmentRegistration<UnifiedHybridAttachmentViewProps<Data, Metadata, Id>>;
+
+export type RegisteredUnifiedAttachmentType =
+  | UnifiedReferenceAttachmentType
+  | UnifiedValueAttachmentType
+  | UnifiedHybridAttachmentType;
+
 export interface AttachmentFramework {
   registerExternalReference: (
     externalReferenceAttachmentType: ExternalReferenceAttachmentType
@@ -149,37 +175,5 @@ export interface AttachmentFramework {
   registerPersistableState: (
     persistableStateAttachmentType: PersistableStateAttachmentType
   ) => void;
-  registerUnified: (
-    unifiedAttachmentType: UnifiedReferenceAttachmentType | UnifiedValueAttachmentType
-  ) => void;
+  registerUnified: (unifiedAttachmentType: RegisteredUnifiedAttachmentType) => void;
 }
-
-/** A payload with `attachmentId` is a reference attachment; otherwise it's value. */
-type IsReferenceSchema<S extends z.ZodType> = z.infer<S> extends { attachmentId: unknown }
-  ? true
-  : false;
-
-/** Narrow registration type — renderers see typed `data`/`metadata`/`attachmentId` from `schema`. */
-type UnifiedAttachmentTypeFromSchema<S extends z.ZodType> = IsReferenceSchema<S> extends true
-  ? UnifiedReferenceAttachmentType<
-      z.infer<S> extends { metadata?: infer M } ? M : never,
-      z.infer<S> extends { attachmentId: infer A } ? A : never,
-      z.infer<S> extends { data?: infer D } ? D : UnifiedReferenceAttachmentPayload['data']
-    >
-  : z.infer<S> extends { data: infer D }
-  ? UnifiedValueAttachmentType<D>
-  : never;
-
-/** Broad registration type returned to callers; avoids a union (contravariant intersection on view props). */
-type UnifiedAttachmentTypeForRegistry<S extends z.ZodType> = IsReferenceSchema<S> extends true
-  ? UnifiedReferenceAttachmentType
-  : UnifiedValueAttachmentType;
-
-/**
- * Defines a unified attachment. Renderer prop narrowing (`data` / `metadata`)
- * is inferred from `schema`, which the registry also uses for full-payload validation.
- */
-export const defineAttachment = <S extends z.ZodType>(
-  attachmentType: UnifiedAttachmentTypeFromSchema<S> & { schema: S }
-): UnifiedAttachmentTypeForRegistry<S> =>
-  attachmentType as unknown as UnifiedAttachmentTypeForRegistry<S>;

--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/unified_attachment_registry.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/unified_attachment_registry.ts
@@ -6,11 +6,9 @@
  */
 
 import { AttachmentTypeRegistry } from '../../../common/registry';
-import type { UnifiedReferenceAttachmentType, UnifiedValueAttachmentType } from './types';
+import type { RegisteredUnifiedAttachmentType } from './types';
 
-export class UnifiedAttachmentTypeRegistry extends AttachmentTypeRegistry<
-  UnifiedValueAttachmentType | UnifiedReferenceAttachmentType
-> {
+export class UnifiedAttachmentTypeRegistry extends AttachmentTypeRegistry<RegisteredUnifiedAttachmentType> {
   constructor() {
     super('UnifiedAttachmentTypeRegistry');
   }

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/attach_saved_object_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/attach_saved_object_modal.test.tsx
@@ -20,13 +20,16 @@ import { registerInternalAttachments } from '../..';
 import { AttachSavedObjectModal } from './attach_saved_object_modal';
 import { useFindSavedObjects } from './use_find_saved_objects';
 import { useAttachSavedObject } from './use_attach_saved_object';
+import { useOpenLensForAttach } from '../../lens/lens_return/use_open_lens_for_attach';
 import type { FoundSavedObject } from './types';
 
 jest.mock('./use_find_saved_objects');
 jest.mock('./use_attach_saved_object');
+jest.mock('../../lens/lens_return/use_open_lens_for_attach');
 
 const useFindSavedObjectsMock = useFindSavedObjects as jest.Mock;
 const useAttachSavedObjectMock = useAttachSavedObject as jest.Mock;
+const useOpenLensForAttachMock = useOpenLensForAttach as jest.Mock;
 
 const sampleItems: FoundSavedObject[] = [
   {
@@ -38,6 +41,11 @@ const sampleItems: FoundSavedObject[] = [
     id: 'map-1',
     type: 'map',
     meta: { title: 'World map' },
+  },
+  {
+    id: 'lens-1',
+    type: 'lens',
+    meta: { title: 'Top hosts' },
   },
 ];
 
@@ -77,12 +85,18 @@ const caseWithSavedObjectAttachment = ({
 
 describe('AttachSavedObjectModal', () => {
   const attach = jest.fn();
+  const openLensForAttach = jest.fn().mockResolvedValue(undefined);
   const onClose = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useFindSavedObjectsMock.mockReturnValue({ items: sampleItems, total: 2, isLoading: false });
+    useFindSavedObjectsMock.mockReturnValue({
+      items: sampleItems,
+      total: sampleItems.length,
+      isLoading: false,
+    });
     useAttachSavedObjectMock.mockReturnValue({ attach, attachmentId: null, isAttaching: false });
+    useOpenLensForAttachMock.mockReturnValue(openLensForAttach);
   });
 
   // Opt in to dashboard/map registrations so the type filter exposes them.
@@ -195,5 +209,18 @@ describe('AttachSavedObjectModal', () => {
     const call = useAttachSavedObjectMock.mock.calls[0][0];
     expect(call.caseId).toBe(basicCase.id);
     expect(call.caseOwner).toBe(basicCase.owner);
+  });
+
+  it('renders lens rows with an "Open in Lens" action', () => {
+    renderModal();
+    expect(screen.getByTestId('cases-attach-so-button-lens-1')).toHaveTextContent('Open in Lens');
+  });
+
+  it('routes lens clicks through useOpenLensForAttach and closes the modal', async () => {
+    renderModal();
+    await userEvent.click(screen.getByTestId('cases-attach-so-button-lens-1'));
+    await waitFor(() => expect(openLensForAttach).toHaveBeenCalledWith(sampleItems[2]));
+    expect(attach).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/attach_saved_object_modal.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/attach_saved_object_modal.tsx
@@ -25,6 +25,8 @@ import {
 import type { CaseUI } from '../../../../../common/ui/types';
 import { useCasesContext } from '../../../cases_context/use_cases_context';
 import { KibanaServices, useKibana } from '../../../../common/lib/kibana';
+import { LENS_SO_TYPE } from '../../../../../common/constants/attachments';
+import { useOpenLensForAttach } from '../../lens/lens_return/use_open_lens_for_attach';
 import { SavedObjectRow } from './saved_object_row';
 import { useFindSavedObjects } from './use_find_saved_objects';
 import { useAttachSavedObject } from './use_attach_saved_object';
@@ -117,8 +119,20 @@ export const AttachSavedObjectModal: React.FC<AttachSavedObjectModalProps> = ({
     onAttached: onClose,
   });
 
+  // Open Lens for the chosen id, and let the user adjust time/state, and auto-attach on "Save and return".
+  const openLensForAttach = useOpenLensForAttach({ caseId: caseData.id, caseOwner });
+
   const handleAttach = useCallback(
     async (savedObject: FoundSavedObject) => {
+      if (savedObject.type === LENS_SO_TYPE) {
+        try {
+          await openLensForAttach(savedObject);
+        } finally {
+          onClose();
+        }
+        return;
+      }
+
       try {
         await attach(savedObject);
       } catch {
@@ -137,7 +151,7 @@ export const AttachSavedObjectModal: React.FC<AttachSavedObjectModalProps> = ({
         return next;
       });
     },
-    [attach]
+    [attach, onClose, openLensForAttach]
   );
 
   const availableSoTypes = useMemo<SupportedSavedObjectType[]>(
@@ -210,6 +224,7 @@ export const AttachSavedObjectModal: React.FC<AttachSavedObjectModalProps> = ({
           ? http.basePath.prepend(inAppPath)
           : undefined;
 
+      const isLens = savedObject.type === LENS_SO_TYPE;
       return (
         <SavedObjectRow
           key={savedObjectKey}
@@ -222,6 +237,8 @@ export const AttachSavedObjectModal: React.FC<AttachSavedObjectModalProps> = ({
           isAttachingAny={isAttaching}
           taggingApi={taggingApi}
           onAttach={handleAttach}
+          actionLabel={isLens ? i18n.OPEN_IN_LENS_ACTION : undefined}
+          actionIconType={isLens ? 'lensApp' : undefined}
         />
       );
     },

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/helpers.test.ts
@@ -10,6 +10,7 @@ import type { AttachmentUIV2 } from '../../../../../common/ui/types';
 import {
   DASHBOARD_ATTACHMENT_TYPE,
   DISCOVER_SESSION_ATTACHMENT_TYPE,
+  LENS_ATTACHMENT_TYPE,
   MAP_ATTACHMENT_TYPE,
 } from '../../../../../common/constants/attachments';
 import {
@@ -46,13 +47,14 @@ describe('saved_object/helpers', () => {
       expect(ATTACHMENT_TYPE_TO_SO_TYPE).toEqual({
         [DASHBOARD_ATTACHMENT_TYPE]: 'dashboard',
         [DISCOVER_SESSION_ATTACHMENT_TYPE]: 'search',
+        [LENS_ATTACHMENT_TYPE]: 'lens',
         [MAP_ATTACHMENT_TYPE]: 'map',
       });
     });
 
     it('inverts cleanly into SO_TYPE_TO_ATTACHMENT_TYPE', () => {
       for (const [attachmentType, soType] of Object.entries(ATTACHMENT_TYPE_TO_SO_TYPE)) {
-        expect(SO_TYPE_TO_ATTACHMENT_TYPE[soType as 'dashboard' | 'map' | 'search']).toBe(
+        expect(SO_TYPE_TO_ATTACHMENT_TYPE[soType as 'dashboard' | 'lens' | 'map' | 'search']).toBe(
           attachmentType
         );
       }
@@ -66,6 +68,7 @@ describe('saved_object/helpers', () => {
 
     it('exposes the attachment-type ids via SAVED_OBJECT_ATTACHMENT_TYPES', () => {
       expect(SAVED_OBJECT_ATTACHMENT_TYPES.has(DASHBOARD_ATTACHMENT_TYPE)).toBe(true);
+      expect(SAVED_OBJECT_ATTACHMENT_TYPES.has(LENS_ATTACHMENT_TYPE)).toBe(true);
       expect(SAVED_OBJECT_ATTACHMENT_TYPES.has(MAP_ATTACHMENT_TYPE)).toBe(true);
       expect(SAVED_OBJECT_ATTACHMENT_TYPES.has(DISCOVER_SESSION_ATTACHMENT_TYPE)).toBe(true);
       expect(SAVED_OBJECT_ATTACHMENT_TYPES.has('user')).toBe(false);
@@ -97,6 +100,17 @@ describe('saved_object/helpers', () => {
           metadata: { title: 'A map', soType: 'map' },
         } as unknown as AttachmentUIV2)
       ).toEqual({ attachmentId: 'map-1', soType: 'map', title: 'A map' });
+    });
+
+    it('extracts attributes for a lens attachment', () => {
+      expect(
+        extractAttributes({
+          ...baseComment,
+          type: LENS_ATTACHMENT_TYPE,
+          attachmentId: 'lens-1',
+          metadata: { title: 'A Lens visualization', soType: 'lens' },
+        } as unknown as AttachmentUIV2)
+      ).toEqual({ attachmentId: 'lens-1', soType: 'lens', title: 'A Lens visualization' });
     });
 
     it('extracts attributes for a discover-session attachment', () => {
@@ -149,12 +163,14 @@ describe('saved_object/helpers', () => {
         soAttachment('a', DASHBOARD_ATTACHMENT_TYPE, 'dash-1', 'dashboard'),
         soAttachment('b', MAP_ATTACHMENT_TYPE, 'map-1', 'map'),
         soAttachment('c', DISCOVER_SESSION_ATTACHMENT_TYPE, 'search-1', 'search'),
+        soAttachment('d', LENS_ATTACHMENT_TYPE, 'lens-1', 'lens'),
       ]);
       expect(keys).toEqual(
         new Set([
           getSavedObjectKey('dashboard', 'dash-1'),
           getSavedObjectKey('map', 'map-1'),
           getSavedObjectKey('search', 'search-1'),
+          getSavedObjectKey('lens', 'lens-1'),
         ])
       );
     });

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/helpers.ts
@@ -11,6 +11,8 @@ import {
   DASHBOARD_SO_TYPE,
   DISCOVER_SESSION_ATTACHMENT_TYPE,
   DISCOVER_SESSION_SO_TYPE,
+  LENS_ATTACHMENT_TYPE,
+  LENS_SO_TYPE,
   MAP_ATTACHMENT_TYPE,
   MAP_SO_TYPE,
 } from '../../../../../common/constants/attachments';
@@ -21,6 +23,8 @@ import type {
   SavedObjectAttachmentUI,
 } from './types';
 
+const MAX_SNAPSHOT_BYTES = 200_000;
+
 /**
  * Maps each attachment-type id that represents a saved-object attachment to
  * its SO type name as understood by the `_find` API and in-app URLs. Single
@@ -30,6 +34,7 @@ import type {
 export const ATTACHMENT_TYPE_TO_SO_TYPE = {
   [DASHBOARD_ATTACHMENT_TYPE]: DASHBOARD_SO_TYPE,
   [DISCOVER_SESSION_ATTACHMENT_TYPE]: DISCOVER_SESSION_SO_TYPE,
+  [LENS_ATTACHMENT_TYPE]: LENS_SO_TYPE,
   [MAP_ATTACHMENT_TYPE]: MAP_SO_TYPE,
 } as const satisfies Record<string, string>;
 
@@ -95,6 +100,14 @@ export const getSavedObjectAttachmentAttributes = (
 
 export const getSavedObjectKey = (soType: SupportedSavedObjectType, id: string): string =>
   `${soType}:${id}`;
+
+export const fitsSnapshotBudget = (snapshot: unknown): boolean => {
+  try {
+    return JSON.stringify(snapshot).length <= MAX_SNAPSHOT_BYTES;
+  } catch {
+    return false;
+  }
+};
 
 /**
  * Walks `caseData.comments` once to collect the foreign SO keys of every

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/saved_object_in_app_urls_context.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/saved_object_in_app_urls_context.tsx
@@ -9,6 +9,7 @@ import React, { createContext, useContext, useMemo } from 'react';
 import {
   DASHBOARD_SO_TYPE,
   DISCOVER_SESSION_SO_TYPE,
+  LENS_SO_TYPE,
   MAP_SO_TYPE,
 } from '../../../../../common/constants/attachments';
 import type { CaseUI } from '../../../../../common/ui/types';
@@ -44,6 +45,7 @@ export const SavedObjectInAppUrlsProvider: React.FC<SavedObjectInAppUrlsProvider
 }) => {
   const idsBySoType = useMemo(() => {
     const dashboardIds = new Set<string>();
+    const lensIds = new Set<string>();
     const mapIds = new Set<string>();
     const searchIds = new Set<string>();
     for (const attachment of caseData.comments) {
@@ -51,6 +53,8 @@ export const SavedObjectInAppUrlsProvider: React.FC<SavedObjectInAppUrlsProvider
         const attributes = getSavedObjectAttachmentAttributes(attachment);
         if (attributes.soType === DASHBOARD_SO_TYPE) {
           dashboardIds.add(attributes.attachmentId);
+        } else if (attributes.soType === LENS_SO_TYPE) {
+          lensIds.add(attributes.attachmentId);
         } else if (attributes.soType === MAP_SO_TYPE) {
           mapIds.add(attributes.attachmentId);
         } else if (attributes.soType === DISCOVER_SESSION_SO_TYPE) {
@@ -60,22 +64,25 @@ export const SavedObjectInAppUrlsProvider: React.FC<SavedObjectInAppUrlsProvider
     }
     return {
       [DASHBOARD_SO_TYPE]: Array.from(dashboardIds),
+      [LENS_SO_TYPE]: Array.from(lensIds),
       [MAP_SO_TYPE]: Array.from(mapIds),
       [DISCOVER_SESSION_SO_TYPE]: Array.from(searchIds),
     };
   }, [caseData.comments]);
 
   const dashboardUrls = useSavedObjectInAppUrlsQuery(DASHBOARD_SO_TYPE, idsBySoType.dashboard);
+  const lensUrls = useSavedObjectInAppUrlsQuery(LENS_SO_TYPE, idsBySoType.lens);
   const mapUrls = useSavedObjectInAppUrlsQuery(MAP_SO_TYPE, idsBySoType.map);
   const searchUrls = useSavedObjectInAppUrlsQuery(DISCOVER_SESSION_SO_TYPE, idsBySoType.search);
 
   const value = useMemo<UrlsBySoType>(
     () => ({
       [DASHBOARD_SO_TYPE]: dashboardUrls,
+      [LENS_SO_TYPE]: lensUrls,
       [MAP_SO_TYPE]: mapUrls,
       [DISCOVER_SESSION_SO_TYPE]: searchUrls,
     }),
-    [dashboardUrls, mapUrls, searchUrls]
+    [dashboardUrls, lensUrls, mapUrls, searchUrls]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/saved_object_row.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/saved_object_row.tsx
@@ -30,6 +30,10 @@ export interface SavedObjectRowProps {
   isAttachingAny: boolean;
   taggingApi: SavedObjectsTaggingApi | undefined;
   onAttach: (savedObject: FoundSavedObject) => void;
+  /** Override the default "Attach" action button label. */
+  actionLabel?: string;
+  /** Override the default "Attach" action icon. */
+  actionIconType?: string;
 }
 
 const SavedObjectRowComponent: React.FC<SavedObjectRowProps> = ({
@@ -42,6 +46,8 @@ const SavedObjectRowComponent: React.FC<SavedObjectRowProps> = ({
   isAttachingAny,
   taggingApi,
   onAttach,
+  actionLabel,
+  actionIconType,
 }) => {
   const handleClick = useCallback(() => onAttach(savedObject), [onAttach, savedObject]);
 
@@ -96,13 +102,13 @@ const SavedObjectRowComponent: React.FC<SavedObjectRowProps> = ({
           <EuiButton
             size="s"
             color={isAttached ? 'success' : 'primary'}
-            iconType={isAttached ? 'check' : 'plusInCircle'}
+            iconType={isAttached ? 'check' : actionIconType ?? 'plusInCircle'}
             isLoading={isAttachInFlight}
             isDisabled={isAttachingAny || isAttached}
             onClick={handleClick}
             data-test-subj={`cases-attach-so-button-${savedObject.id}`}
           >
-            {isAttached ? i18n.ATTACHED_ACTION : i18n.ATTACH_ACTION}
+            {isAttached ? i18n.ATTACHED_ACTION : actionLabel ?? i18n.ATTACH_ACTION}
           </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/saved_object_row.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/saved_object_row.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { EuiBadge, EuiButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import type { EuiButtonProps } from '@elastic/eui';
 import type { SavedObjectsTaggingApi } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import { FormattedRelativePreferenceDate } from '../../../formatted_date';
 import { SavedObjectLink } from './saved_object_link';
@@ -33,7 +34,7 @@ export interface SavedObjectRowProps {
   /** Override the default "Attach" action button label. */
   actionLabel?: string;
   /** Override the default "Attach" action icon. */
-  actionIconType?: string;
+  actionIconType?: EuiButtonProps['iconType'];
 }
 
 const SavedObjectRowComponent: React.FC<SavedObjectRowProps> = ({

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/translations.ts
@@ -87,6 +87,13 @@ export const ATTACH_ACTION = i18n.translate(
   }
 );
 
+export const OPEN_IN_LENS_ACTION = i18n.translate(
+  'xpack.cases.caseView.attach.savedObjectModal.openInLensAction',
+  {
+    defaultMessage: 'Open in Lens',
+  }
+);
+
 export const ATTACHED_ACTION = i18n.translate(
   'xpack.cases.caseView.attach.savedObjectModal.attachedAction',
   {

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.test.tsx
@@ -41,6 +41,7 @@ describe('useAttachSavedObject', () => {
   const addSuccess = jest.fn();
   const findById = jest.fn();
   const cmGet = jest.fn();
+  const getTime = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -50,8 +51,10 @@ describe('useAttachSavedObject', () => {
       services: {
         dashboard: { findDashboardsService: jest.fn().mockResolvedValue({ findById }) },
         contentManagement: { client: { get: cmGet } },
+        data: { query: { timefilter: { timefilter: { getTime } } } },
       },
     });
+    getTime.mockReturnValue({ from: 'now-24h', to: 'now', mode: 'relative' });
   });
 
   const render = () =>
@@ -179,6 +182,58 @@ describe('useAttachSavedObject', () => {
         ],
       })
     );
+  });
+
+  it('snapshots lens attributes and always uses the current timefilter as the view time range', async () => {
+    // Lens SOs do not persist a view time range by design; the surrounding
+    // context (here: the attach action) owns it, so any `time_range` on the
+    // SO is ignored in favor of the live timefilter at attach time.
+    cmGet.mockResolvedValue({
+      item: {
+        attributes: { state: { query: {} }, time_range: { from: 'now-15m', to: 'now' } },
+        references: [{ type: 'index-pattern', id: 'data-view-1', name: 'indexpattern-datasource' }],
+      },
+    });
+    const { result } = render();
+    await act(async () => {
+      await result.current.attach(buildSO({ id: 'lens-1', type: 'lens' }));
+    });
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            attachmentId: 'lens-1',
+            data: {
+              attributes: {
+                state: { query: {} },
+                time_range: { from: 'now-15m', to: 'now' },
+                references: [
+                  { type: 'index-pattern', id: 'data-view-1', name: 'indexpattern-datasource' },
+                ],
+              },
+              timeRange: { from: 'now-24h', to: 'now', mode: 'relative' },
+            },
+            metadata: { title: 'My title', soType: 'lens' },
+          }),
+        ],
+      })
+    );
+  });
+
+  it('degrades a lens to title-only when the snapshot is too large to embed', async () => {
+    cmGet.mockResolvedValue({
+      item: { attributes: { state: { query: {} }, payload: 'x'.repeat(250_000) } },
+    });
+    const { result } = render();
+    await act(async () => {
+      await result.current.attach(buildSO({ id: 'lens-1', type: 'lens' }));
+    });
+    const sent = mutateAsync.mock.calls[0][0].attachments[0];
+    expect(sent).not.toHaveProperty('data');
+    expect(sent).toMatchObject({
+      attachmentId: 'lens-1',
+      metadata: { title: 'My title', soType: 'lens' },
+    });
   });
 
   it('falls back to the id when the SO has no title', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.test.tsx
@@ -41,7 +41,6 @@ describe('useAttachSavedObject', () => {
   const addSuccess = jest.fn();
   const findById = jest.fn();
   const cmGet = jest.fn();
-  const getTime = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -51,10 +50,8 @@ describe('useAttachSavedObject', () => {
       services: {
         dashboard: { findDashboardsService: jest.fn().mockResolvedValue({ findById }) },
         contentManagement: { client: { get: cmGet } },
-        data: { query: { timefilter: { timefilter: { getTime } } } },
       },
     });
-    getTime.mockReturnValue({ from: 'now-24h', to: 'now', mode: 'relative' });
   });
 
   const render = () =>
@@ -184,56 +181,12 @@ describe('useAttachSavedObject', () => {
     );
   });
 
-  it('snapshots lens attributes and always uses the current timefilter as the view time range', async () => {
-    // Lens SOs do not persist a view time range by design; the surrounding
-    // context (here: the attach action) owns it, so any `time_range` on the
-    // SO is ignored in favor of the live timefilter at attach time.
-    cmGet.mockResolvedValue({
-      item: {
-        attributes: { state: { query: {} }, time_range: { from: 'now-15m', to: 'now' } },
-        references: [{ type: 'index-pattern', id: 'data-view-1', name: 'indexpattern-datasource' }],
-      },
-    });
+  it('no-ops for lens — lens is routed through the editor round trip', async () => {
     const { result } = render();
     await act(async () => {
       await result.current.attach(buildSO({ id: 'lens-1', type: 'lens' }));
     });
-    expect(mutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attachments: [
-          expect.objectContaining({
-            attachmentId: 'lens-1',
-            data: {
-              attributes: {
-                state: { query: {} },
-                time_range: { from: 'now-15m', to: 'now' },
-                references: [
-                  { type: 'index-pattern', id: 'data-view-1', name: 'indexpattern-datasource' },
-                ],
-              },
-              timeRange: { from: 'now-24h', to: 'now', mode: 'relative' },
-            },
-            metadata: { title: 'My title', soType: 'lens' },
-          }),
-        ],
-      })
-    );
-  });
-
-  it('degrades a lens to title-only when the snapshot is too large to embed', async () => {
-    cmGet.mockResolvedValue({
-      item: { attributes: { state: { query: {} }, payload: 'x'.repeat(250_000) } },
-    });
-    const { result } = render();
-    await act(async () => {
-      await result.current.attach(buildSO({ id: 'lens-1', type: 'lens' }));
-    });
-    const sent = mutateAsync.mock.calls[0][0].attachments[0];
-    expect(sent).not.toHaveProperty('data');
-    expect(sent).toMatchObject({
-      attachmentId: 'lens-1',
-      metadata: { title: 'My title', soType: 'lens' },
-    });
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
   it('falls back to the id when the SO has no title', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.ts
@@ -15,8 +15,6 @@ import type { DashboardPayload } from '../../dashboard/build_dashboard_payload';
 import { buildDashboardPayload } from '../../dashboard/build_dashboard_payload';
 import type { MapPayload } from '../../map/build_map_payload';
 import { buildMapPayload } from '../../map/build_map_payload';
-import type { LensPayload } from '../../lens/build_lens_payload';
-import { buildLensPayload } from '../../lens/build_lens_payload';
 import type { DiscoverSessionPayload } from '../../discover_session/build_discover_session_payload';
 import { buildDiscoverSessionPayload } from '../../discover_session/build_discover_session_payload';
 import { useKibana, useToasts } from '../../../../common/lib/kibana';
@@ -50,9 +48,8 @@ export const useAttachSavedObject = ({
   onAttached,
 }: UseAttachSavedObjectArgs): UseAttachSavedObjectResult => {
   const {
-    services: { contentManagement, dashboard, data: dataService },
+    services: { contentManagement, dashboard },
   } = useKibana();
-  const { timefilter } = dataService.query.timefilter;
   const toasts = useToasts();
   const refreshCaseViewPage = useRefreshCaseViewPage();
   const { mutateAsync: createAttachments, isLoading: isAttaching } = useCreateAttachments();
@@ -65,28 +62,21 @@ export const useAttachSavedObject = ({
       if (!attachmentType) {
         return;
       }
+      if (supportedType === LENS_SO_TYPE) {
+        // Lens attach is owned by `useOpenLensForAttach`
+        return;
+      }
 
       const title = object.meta.title ?? object.id;
       setAttachmentId(object.id);
       try {
-        let attachment: DashboardPayload | MapPayload | DiscoverSessionPayload | LensPayload;
+        let attachment: DashboardPayload | MapPayload | DiscoverSessionPayload;
         if (supportedType === MAP_SO_TYPE) {
           attachment = await buildMapPayload({ contentManagement, id: object.id, title });
         } else if (supportedType === DASHBOARD_SO_TYPE) {
           attachment = await buildDashboardPayload({ dashboard, id: object.id, title });
-        } else if (supportedType === LENS_SO_TYPE) {
-          // Lens does not persist a view time range on the SO by design — the
-          // surrounding context (here: the attach action) owns it. Mirrors the
-          // "Add to existing case" embeddable action, which snapshots the live
-          // `lensApi.timeRange$` at action time.
-          const timeRange = timefilter.getTime();
-          attachment = await buildLensPayload({
-            contentManagement,
-            id: object.id,
-            timeRange,
-            title,
-          });
         } else {
+          // Lens routes through `useOpenLensForAttach` -> Lens editor -> return
           attachment = buildDiscoverSessionPayload({ id: object.id, title });
         }
 
@@ -113,7 +103,6 @@ export const useAttachSavedObject = ({
       dashboard,
       onAttached,
       refreshCaseViewPage,
-      timefilter,
       toasts,
     ]
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/common/saved_object/use_attach_saved_object.ts
@@ -7,54 +7,24 @@
 
 import { useCallback, useState } from 'react';
 import {
-  dashboardStateToAttachmentData,
-  type DashboardAttachmentData as DashboardAttachmentApiData,
-} from '@kbn/agent-builder-dashboards-common';
-import {
-  DASHBOARD_ATTACHMENT_TYPE,
   DASHBOARD_SO_TYPE,
-  DISCOVER_SESSION_ATTACHMENT_TYPE,
-  DISCOVER_SESSION_SO_TYPE,
-  MAP_ATTACHMENT_TYPE,
+  LENS_SO_TYPE,
   MAP_SO_TYPE,
 } from '../../../../../common/constants/attachments';
-import type {
-  MapAttributesSnapshot,
-  MapAttachmentPayload,
-} from '../../../../../common/types/domain_zod/attachment/map/v2';
-import type { DashboardAttachmentPayload } from '../../../../../common/types/domain_zod/attachment/dashboard/v2';
-import type { DiscoverSessionAttachmentPayload } from '../../../../../common/types/domain_zod/attachment/saved_object/v2';
+import type { DashboardPayload } from '../../dashboard/build_dashboard_payload';
+import { buildDashboardPayload } from '../../dashboard/build_dashboard_payload';
+import type { MapPayload } from '../../map/build_map_payload';
+import { buildMapPayload } from '../../map/build_map_payload';
+import type { LensPayload } from '../../lens/build_lens_payload';
+import { buildLensPayload } from '../../lens/build_lens_payload';
+import type { DiscoverSessionPayload } from '../../discover_session/build_discover_session_payload';
+import { buildDiscoverSessionPayload } from '../../discover_session/build_discover_session_payload';
 import { useKibana, useToasts } from '../../../../common/lib/kibana';
 import { useCreateAttachments } from '../../../../containers/use_create_attachments';
 import { useRefreshCaseViewPage } from '../../../case_view/use_on_refresh_case_view_page';
 import { SO_TYPE_TO_ATTACHMENT_TYPE, type SupportedSavedObjectType } from './helpers';
 import type { FoundSavedObject } from './types';
 import * as i18n from './translations';
-
-// Each payload below describes what `useCreateAttachments` accepts (owner is
-// stamped on by the container). The union is narrower than
-// `CaseAttachmentWithoutOwner` and lets the SO attach hook build payloads
-// without any casts.
-type DashboardAttachmentRequest = Omit<DashboardAttachmentPayload, 'owner'>;
-type MapAttachmentRequest = Omit<MapAttachmentPayload, 'owner'>;
-type DiscoverSessionAttachmentRequest = Omit<DiscoverSessionAttachmentPayload, 'owner'>;
-
-/**
- * Hard ceiling on the serialized size (bytes) of a dashboard/map snapshot we
- * embed in the cases-attachment SO. Beyond this we drop the snapshot and
- * degrade to a title-only attachment — the SO is still attached, just without
- * the inline embed. Lifted high enough to accommodate typical dashboards
- * (dozens of panels) but well below ES per-document limits.
- */
-const MAX_SNAPSHOT_BYTES = 200_000;
-
-const fitsSnapshotBudget = (snapshot: unknown): boolean => {
-  try {
-    return JSON.stringify(snapshot).length <= MAX_SNAPSHOT_BYTES;
-  } catch {
-    return false;
-  }
-};
 
 export interface UseAttachSavedObjectArgs {
   caseId: string;
@@ -80,62 +50,13 @@ export const useAttachSavedObject = ({
   onAttached,
 }: UseAttachSavedObjectArgs): UseAttachSavedObjectResult => {
   const {
-    services: { contentManagement, dashboard },
+    services: { contentManagement, dashboard, data: dataService },
   } = useKibana();
+  const { timefilter } = dataService.query.timefilter;
   const toasts = useToasts();
   const refreshCaseViewPage = useRefreshCaseViewPage();
   const { mutateAsync: createAttachments, isLoading: isAttaching } = useCreateAttachments();
   const [attachmentId, setAttachmentId] = useState<string | null>(null);
-
-  /**
-   * Fetch a Dashboard SO and convert its `DashboardState` to the
-   * `DashboardAttachmentData` API shape (panels, sections, controls, …) so the
-   * renderer can embed the dashboard inline. Returns `undefined` on failure or
-   * when the dashboard plugin isn't installed.
-   */
-  const fetchDashboardConfig = useCallback(
-    async (id: string): Promise<DashboardAttachmentApiData | undefined> => {
-      if (!dashboard) {
-        return undefined;
-      }
-      try {
-        const findService = await dashboard.findDashboardsService();
-        const result = await findService.findById(id);
-        if (result.status !== 'success') {
-          return undefined;
-        }
-        const config = dashboardStateToAttachmentData(result.attributes);
-        // Drop oversize snapshots; the attachment still gets created (title-only).
-        return fitsSnapshotBudget(config) ? config : undefined;
-      } catch {
-        return undefined;
-      }
-    },
-    [dashboard]
-  );
-
-  /**
-   * Fetch a Map SO and snapshot its `attributes` verbatim. The CM client
-   * returns the parsed REST shape (`layers`, `center`, `settings`, …), which
-   * the renderer forwards to `services.maps.Map`. Returns `undefined` on any
-   * failure; the attachment then degrades to a title-only event.
-   */
-  const fetchMapAttributes = useCallback(
-    async (id: string): Promise<MapAttributesSnapshot | undefined> => {
-      try {
-        const result = (await contentManagement.client.get({
-          contentTypeId: MAP_SO_TYPE,
-          id,
-        })) as { item?: { attributes?: MapAttributesSnapshot } } | undefined;
-        const attributes = result?.item?.attributes ?? undefined;
-        // Drop oversize snapshots; the attachment still gets created (title-only).
-        return attributes && fitsSnapshotBudget(attributes) ? attributes : undefined;
-      } catch {
-        return undefined;
-      }
-    },
-    [contentManagement]
-  );
 
   const attach = useCallback(
     async (object: FoundSavedObject) => {
@@ -148,32 +69,25 @@ export const useAttachSavedObject = ({
       const title = object.meta.title ?? object.id;
       setAttachmentId(object.id);
       try {
-        let attachment:
-          | DashboardAttachmentRequest
-          | MapAttachmentRequest
-          | DiscoverSessionAttachmentRequest;
+        let attachment: DashboardPayload | MapPayload | DiscoverSessionPayload | LensPayload;
         if (supportedType === MAP_SO_TYPE) {
-          const attributes = await fetchMapAttributes(object.id);
-          attachment = {
-            type: MAP_ATTACHMENT_TYPE,
-            attachmentId: object.id,
-            metadata: { title, soType: MAP_SO_TYPE },
-            ...(attributes ? { data: { attributes } } : {}),
-          };
+          attachment = await buildMapPayload({ contentManagement, id: object.id, title });
         } else if (supportedType === DASHBOARD_SO_TYPE) {
-          const config = await fetchDashboardConfig(object.id);
-          attachment = {
-            type: DASHBOARD_ATTACHMENT_TYPE,
-            attachmentId: object.id,
-            metadata: { title, soType: DASHBOARD_SO_TYPE },
-            ...(config ? { data: { config } } : {}),
-          };
+          attachment = await buildDashboardPayload({ dashboard, id: object.id, title });
+        } else if (supportedType === LENS_SO_TYPE) {
+          // Lens does not persist a view time range on the SO by design — the
+          // surrounding context (here: the attach action) owns it. Mirrors the
+          // "Add to existing case" embeddable action, which snapshots the live
+          // `lensApi.timeRange$` at action time.
+          const timeRange = timefilter.getTime();
+          attachment = await buildLensPayload({
+            contentManagement,
+            id: object.id,
+            timeRange,
+            title,
+          });
         } else {
-          attachment = {
-            type: DISCOVER_SESSION_ATTACHMENT_TYPE,
-            attachmentId: object.id,
-            metadata: { title, soType: DISCOVER_SESSION_SO_TYPE },
-          };
+          attachment = buildDiscoverSessionPayload({ id: object.id, title });
         }
 
         await createAttachments({
@@ -194,11 +108,12 @@ export const useAttachSavedObject = ({
     [
       caseId,
       caseOwner,
+      contentManagement,
       createAttachments,
-      fetchDashboardConfig,
-      fetchMapAttributes,
+      dashboard,
       onAttached,
       refreshCaseViewPage,
+      timefilter,
       toasts,
     ]
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/dashboard/build_dashboard_payload.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/dashboard/build_dashboard_payload.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardStart } from '@kbn/dashboard-plugin/public';
+import {
+  dashboardStateToAttachmentData,
+  type DashboardAttachmentData as DashboardAttachmentApiData,
+} from '@kbn/agent-builder-dashboards-common';
+import { DASHBOARD_ATTACHMENT_TYPE, DASHBOARD_SO_TYPE } from '../../../../common/constants';
+import type { DashboardAttachmentPayload } from '../../../../common/types/domain_zod/attachment/dashboard/v2';
+import { fitsSnapshotBudget } from '../common/saved_object/helpers';
+
+export type DashboardPayload = Omit<DashboardAttachmentPayload, 'owner'>;
+
+const fetchDashboardConfig = async (
+  dashboard: DashboardStart | undefined,
+  id: string
+): Promise<DashboardAttachmentApiData | undefined> => {
+  if (!dashboard) {
+    return undefined;
+  }
+  try {
+    const findService = await dashboard.findDashboardsService();
+    const result = await findService.findById(id);
+    if (result.status !== 'success') {
+      return undefined;
+    }
+    const config = dashboardStateToAttachmentData(result.attributes);
+    return fitsSnapshotBudget(config) ? config : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const buildDashboardPayload = async ({
+  dashboard,
+  id,
+  title,
+}: {
+  dashboard: DashboardStart | undefined;
+  id: string;
+  title: string;
+}): Promise<DashboardPayload> => {
+  const config = await fetchDashboardConfig(dashboard, id);
+  return {
+    type: DASHBOARD_ATTACHMENT_TYPE,
+    attachmentId: id,
+    metadata: { title, soType: DASHBOARD_SO_TYPE },
+    ...(config ? { data: { config } } : {}),
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/discover_session/build_discover_session_payload.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/discover_session/build_discover_session_payload.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  DISCOVER_SESSION_ATTACHMENT_TYPE,
+  DISCOVER_SESSION_SO_TYPE,
+} from '../../../../common/constants/attachments';
+import type { DiscoverSessionAttachmentPayload } from '../../../../common/types/domain_zod/attachment/saved_object/v2';
+
+export type DiscoverSessionPayload = Omit<DiscoverSessionAttachmentPayload, 'owner'>;
+
+export const buildDiscoverSessionPayload = ({
+  id,
+  title,
+}: {
+  id: string;
+  title: string;
+}): DiscoverSessionPayload => ({
+  type: DISCOVER_SESSION_ATTACHMENT_TYPE,
+  attachmentId: id,
+  metadata: { title, soType: DISCOVER_SESSION_SO_TYPE },
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/build_lens_payload.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/build_lens_payload.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
+import type { TimeRange } from '@kbn/es-query';
+import { LENS_ATTACHMENT_TYPE, LENS_SO_TYPE } from '../../../../common/constants/attachments';
+import type {
+  LensSavedObjectAttachmentData,
+  LensSavedObjectAttachmentPayload,
+  LensSavedObjectAttributes,
+} from '../../../../common/types/domain_zod/attachment/lens/v2';
+import { fitsSnapshotBudget } from '../common/saved_object/helpers';
+
+export type LensPayload = Omit<LensSavedObjectAttachmentPayload, 'owner'>;
+
+interface LensContentManagementGetResult {
+  item?: {
+    attributes?: LensSavedObjectAttributes;
+    references?: Array<{ type: string; id: string; name: string }>;
+  };
+}
+
+// Lens does not persist a view time range on the SO by design — the surrounding
+// context (dashboard panel, embeddable consumer, etc.) owns it. We mirror the
+// existing "Add to existing case" Lens embeddable action, which snapshots the
+// live `lensApi.timeRange$` at action time, by capturing the global timefilter
+// at attach time and storing it on the attachment payload.
+const fetchLensAttributes = async ({
+  id,
+  contentManagement,
+  timeRange,
+}: {
+  id: string;
+  contentManagement: ContentManagementPublicStart;
+  timeRange?: TimeRange;
+}): Promise<LensSavedObjectAttachmentData | undefined> => {
+  try {
+    const result = (await contentManagement.client.get({
+      contentTypeId: LENS_SO_TYPE,
+      id,
+    })) as LensContentManagementGetResult | undefined;
+    const attributes = result?.item?.attributes ?? undefined;
+    if (!attributes) {
+      return undefined;
+    }
+
+    const references = result?.item?.references ?? [];
+    const attributesSnapshot = references.length > 0 ? { ...attributes, references } : attributes;
+    const snapshot = {
+      attributes: attributesSnapshot,
+      ...(timeRange ? { timeRange } : {}),
+    };
+    return fitsSnapshotBudget(snapshot) ? snapshot : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const buildLensPayload = async ({
+  id,
+  title,
+  contentManagement,
+  timeRange,
+}: {
+  id: string;
+  title: string;
+  contentManagement: ContentManagementPublicStart;
+  timeRange?: TimeRange;
+}): Promise<LensPayload> => {
+  const data = await fetchLensAttributes({ id, contentManagement, timeRange });
+  return {
+    type: LENS_ATTACHMENT_TYPE,
+    attachmentId: id,
+    metadata: { title, soType: LENS_SO_TYPE },
+    ...(data ? { data } : {}),
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.test.tsx
@@ -10,7 +10,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { LENS_ATTACHMENT_TYPE } from '../../../../common';
 import {
   AttachmentActionType,
-  type UnifiedValueAttachmentViewProps,
+  type UnifiedHybridAttachmentViewProps,
 } from '../../../client/attachment_framework/types';
 
 import { basicCase } from '../../../containers/mock';
@@ -23,7 +23,7 @@ describe('getVisualizationAttachmentType', () => {
     .fn()
     .mockReturnValue(<div data-test-subj="embeddableComponent" />);
 
-  const attachmentViewProps: UnifiedValueAttachmentViewProps = {
+  const attachmentViewProps: UnifiedHybridAttachmentViewProps = {
     data: {
       state: {
         attributes: { state: { query: {} } },
@@ -56,6 +56,7 @@ describe('getVisualizationAttachmentType', () => {
       displayName: 'Visualizations',
       getAttachmentViewObject: expect.any(Function),
       getAttachmentRemovalObject: expect.any(Function),
+      getAttachmentTabViewObject: expect.any(Function),
       schema: expect.any(Object),
     });
   });
@@ -66,6 +67,20 @@ describe('getVisualizationAttachmentType', () => {
       const event = lensType.getAttachmentViewObject(attachmentViewProps).event;
 
       expect(event).toBe('added visualization');
+    });
+
+    it('renders the saved-object event correctly', () => {
+      const lensType = getVisualizationAttachmentType();
+      const event = lensType.getAttachmentViewObject({
+        ...attachmentViewProps,
+        attachmentId: 'lens-1',
+        metadata: { title: 'My lens', soType: 'lens' },
+      }).event;
+
+      const services = createStartServicesMock();
+      renderWithTestingProviders(<>{event}</>, { wrapperProps: { services } });
+
+      expect(screen.getByText('added visualization My lens')).toBeInTheDocument();
     });
 
     it('renders the timelineAvatar correctly', () => {
@@ -96,6 +111,19 @@ describe('getVisualizationAttachmentType', () => {
         isPrimary: false,
         render: expect.any(Function),
       });
+    });
+
+    it('does not set custom actions for a saved-object attachment without inline data', () => {
+      const lensType = getVisualizationAttachmentType();
+      const attachmentViewObject = lensType.getAttachmentViewObject({
+        ...attachmentViewProps,
+        data: undefined,
+        attachmentId: 'lens-1',
+        metadata: { title: 'My lens', soType: 'lens' },
+      });
+
+      expect(attachmentViewObject.getActions).toBeUndefined();
+      expect('children' in attachmentViewObject).toBe(false);
     });
 
     it('renders the open visualization button correctly', () => {
@@ -132,6 +160,75 @@ describe('getVisualizationAttachmentType', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('embeddableComponent'));
+      });
+    });
+
+    it('renders saved-object snapshot children correctly', async () => {
+      const lensType = getVisualizationAttachmentType();
+      const viewProps = {
+        ...attachmentViewProps,
+        attachmentId: 'lens-1',
+        metadata: { title: 'My lens', soType: 'lens' },
+        data: {
+          attributes: { state: { query: {} } },
+        },
+      };
+      // eslint-disable-next-line testing-library/no-node-access
+      const Component = lensType.getAttachmentViewObject(viewProps).children!;
+
+      const services = createStartServicesMock();
+      services.lens.EmbeddableComponent = mockEmbeddableComponent;
+
+      renderWithTestingProviders(
+        <Suspense fallback={'Loading...'}>
+          <Component {...viewProps} />
+        </Suspense>,
+        { wrapperProps: { services } }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('embeddableComponent'));
+      });
+
+      expect(mockEmbeddableComponent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeRange: undefined,
+        }),
+        {}
+      );
+    });
+
+    it('renders saved-object snapshot children with their stored time range', async () => {
+      const lensType = getVisualizationAttachmentType();
+      const viewProps = {
+        ...attachmentViewProps,
+        attachmentId: 'lens-1',
+        metadata: { title: 'My lens', soType: 'lens' },
+        data: {
+          attributes: { state: { query: {} } },
+          timeRange: { from: 'now-15m', to: 'now' },
+        },
+      };
+      // eslint-disable-next-line testing-library/no-node-access
+      const Component = lensType.getAttachmentViewObject(viewProps).children!;
+
+      const services = createStartServicesMock();
+      services.lens.EmbeddableComponent = mockEmbeddableComponent;
+
+      renderWithTestingProviders(
+        <Suspense fallback={'Loading...'}>
+          <Component {...viewProps} />
+        </Suspense>,
+        { wrapperProps: { services } }
+      );
+
+      await waitFor(() => {
+        expect(mockEmbeddableComponent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            timeRange: { from: 'now-15m', to: 'now' },
+          }),
+          {}
+        );
       });
     });
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/index.tsx
@@ -10,21 +10,32 @@ import React from 'react';
 import deepEqual from 'fast-deep-equal';
 import { LENS_ATTACHMENT_TYPE } from '../../../../common/constants';
 import {
+  isLensPersistableData,
   LensAttachmentPayloadSchema,
+  type LensPersistableAttachmentData,
+  type LensSavedObjectAttachmentData,
+  type LensSavedObjectAttachmentMetadata,
   type LensAttachmentData,
 } from '../../../../common/types/domain_zod/attachment/lens/v2';
+import { LENS_SO_TYPE } from '../../../../common/constants/attachments';
 import * as i18n from './translations';
 
 import {
   AttachmentActionType,
   defineAttachment,
-  type UnifiedValueAttachmentViewProps,
+  type UnifiedHybridAttachmentViewProps,
 } from '../../../client/attachment_framework/types';
 import type { LensProps } from './types';
 import { OpenLensButton } from './open_lens_button';
 import { LensRenderer } from './lens_renderer';
+import { SavedObjectAddedEvent } from '../common/saved_object/saved_object_added_event';
+import { createSavedObjectAttachmentsTab } from '../common/saved_object/saved_object_attachments_tab';
 
-type LensViewProps = UnifiedValueAttachmentViewProps<LensAttachmentData>;
+type LensViewProps = UnifiedHybridAttachmentViewProps<
+  LensPersistableAttachmentData | LensSavedObjectAttachmentData,
+  LensSavedObjectAttachmentMetadata,
+  string
+>;
 
 function getOpenLensButton(savedObjectId: string, props: LensProps) {
   return (
@@ -45,14 +56,22 @@ const getVisualizationAttachmentActions = (savedObjectId: string, props: LensPro
   },
 ];
 
+const toLensProps = (data: LensAttachmentData) => {
+  if (isLensPersistableData(data)) {
+    return data.state as LensProps;
+  }
+  return { attributes: data.attributes, timeRange: data.timeRange } as unknown as LensProps;
+};
+
 const LensAttachment = React.memo(
-  (props: LensViewProps) => {
-    // `data.state` is `Record<string, unknown>` in the schema; the concrete
-    // shape (`LensProps`) is owned by the lens plugin and asserted here.
-    const { attributes, timeRange, metadata } = props.data.state as LensProps;
+  ({ data }: LensViewProps) => {
+    if (!data) {
+      return null;
+    }
+    const { attributes, timeRange, metadata } = toLensProps(data);
     return <LensRenderer attributes={attributes} timeRange={timeRange} metadata={metadata} />;
   },
-  (prevProps, nextProps) => deepEqual(prevProps.data.state, nextProps.data.state)
+  (prevProps, nextProps) => deepEqual(prevProps.data, nextProps.data)
 );
 
 LensAttachment.displayName = 'LensAttachment';
@@ -61,19 +80,39 @@ const LensAttachmentRendererLazyComponent = React.lazy(async () => ({
   default: LensAttachment,
 }));
 
-const getVisualizationAttachmentViewObject = ({ savedObjectId, data }: LensViewProps) => {
-  const { attributes: lensAttributes, timeRange: lensTimeRange } = data.state as LensProps;
+const LensAttachmentsTab = createSavedObjectAttachmentsTab({
+  attachmentTypeId: LENS_ATTACHMENT_TYPE,
+  soType: LENS_SO_TYPE,
+});
 
+const getVisualizationAttachmentViewObject = ({
+  savedObjectId,
+  data,
+  attachmentId,
+  metadata,
+}: LensViewProps) => {
+  const openLensId = attachmentId ?? savedObjectId;
+  const event =
+    attachmentId != null ? (
+      <SavedObjectAddedEvent
+        soType={LENS_SO_TYPE}
+        attachmentId={attachmentId}
+        title={metadata?.title}
+        label={i18n.ADDED_VISUALIZATION}
+        data-test-subj="cases-lens-event-link"
+      />
+    ) : (
+      i18n.ADDED_VISUALIZATION
+    );
+  const lensProps = data ? toLensProps(data) : undefined;
   return {
-    event: i18n.ADDED_VISUALIZATION,
+    event,
     timelineAvatar: 'lensApp',
-    getActions: () =>
-      getVisualizationAttachmentActions(savedObjectId, {
-        attributes: lensAttributes,
-        timeRange: lensTimeRange,
-      }),
+    ...(lensProps
+      ? { getActions: () => getVisualizationAttachmentActions(openLensId, lensProps) }
+      : {}),
     hideDefaultActions: false,
-    children: LensAttachmentRendererLazyComponent,
+    ...(data ? { children: LensAttachmentRendererLazyComponent } : {}),
   };
 };
 
@@ -84,5 +123,6 @@ export const getVisualizationAttachmentType = () =>
     displayName: i18n.VISUALIZATIONS,
     getAttachmentViewObject: getVisualizationAttachmentViewObject,
     getAttachmentRemovalObject: () => ({ event: i18n.REMOVED_VISUALIZATION }),
+    getAttachmentTabViewObject: () => ({ children: LensAttachmentsTab }),
     schema: LensAttachmentPayloadSchema,
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Storage key for the "Open in Lens -> Save and return -> auto attach" round
+// trip. Mirrors the markdown editor's `DRAFT_COMMENT_STORAGE_ID` pattern.
+export const PENDING_LENS_ATTACH_STORAGE_ID = 'xpack.cases.pendingLensAttach';

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/lens_attach_return_consumer.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/lens_attach_return_consumer.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useConsumeLensReturn } from './use_consume_lens_return';
+
+interface LensAttachReturnConsumerProps {
+  caseId: string;
+}
+
+/**
+ * Renders nothing; mounted on the case view so a Lens "Save and return" round
+ * trip auto-attaches the saved object to this case. Gate the mount on
+ * `xpack.cases.attachments.enabled` at the call site.
+ */
+export const LensAttachReturnConsumer: React.FC<LensAttachReturnConsumerProps> = React.memo(
+  ({ caseId }) => {
+    useConsumeLensReturn({ caseId });
+    return null;
+  }
+);
+LensAttachReturnConsumer.displayName = 'LensAttachReturnConsumer';

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
+import { clearPendingLensAttach, getPendingLensAttach, setPendingLensAttach } from './storage';
+import { PENDING_LENS_ATTACH_STORAGE_ID } from './constants';
+
+const buildStorage = (
+  initial: Record<string, unknown> = {}
+): IStorageWrapper & {
+  store: Record<string, unknown>;
+} => {
+  const store: Record<string, unknown> = { ...initial };
+  return {
+    store,
+    get: jest.fn((key: string) => store[key]),
+    set: jest.fn((key: string, value: unknown) => {
+      store[key] = value;
+    }),
+    remove: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      for (const key of Object.keys(store)) delete store[key];
+    }),
+  };
+};
+
+const validRecord = {
+  caseId: 'case-1',
+  caseOwner: 'cases',
+  savedObjectId: 'lens-1',
+  title: 'Top hosts',
+  createdAt: 1700000000000,
+};
+
+describe('pending lens attach storage', () => {
+  it('round trips a valid record', () => {
+    const storage = buildStorage();
+    setPendingLensAttach(storage, validRecord);
+    expect(storage.set).toHaveBeenCalledWith(PENDING_LENS_ATTACH_STORAGE_ID, validRecord);
+    expect(getPendingLensAttach(storage)).toEqual(validRecord);
+  });
+
+  it('returns null for a missing record', () => {
+    expect(getPendingLensAttach(buildStorage())).toBeNull();
+  });
+
+  it('returns null when the stored value is malformed', () => {
+    const storage = buildStorage({ [PENDING_LENS_ATTACH_STORAGE_ID]: { caseId: 1 } });
+    expect(getPendingLensAttach(storage)).toBeNull();
+  });
+
+  it('clears the record', () => {
+    const storage = buildStorage({ [PENDING_LENS_ATTACH_STORAGE_ID]: validRecord });
+    clearPendingLensAttach(storage);
+    expect(storage.remove).toHaveBeenCalledWith(PENDING_LENS_ATTACH_STORAGE_ID);
+    expect(storage.store[PENDING_LENS_ATTACH_STORAGE_ID]).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.test.ts
@@ -35,7 +35,6 @@ const validRecord = {
   caseOwner: 'cases',
   savedObjectId: 'lens-1',
   title: 'Top hosts',
-  createdAt: 1700000000000,
 };
 
 describe('pending lens attach storage', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isPlainObject } from 'lodash';
+import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
+import { PENDING_LENS_ATTACH_STORAGE_ID } from './constants';
+
+// Persisted across the navigation to Lens and back. Scoped to a single
+// in-flight attach; the consumer must clear it on success or when the user
+// returns without saving (the state-transfer consume call drains the package).
+export interface PendingLensAttach {
+  caseId: string;
+  caseOwner: string;
+  savedObjectId: string;
+  title: string;
+  createdAt: number;
+}
+
+const isPendingLensAttach = (value: unknown): value is PendingLensAttach => {
+  if (!isPlainObject(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.caseId === 'string' &&
+    typeof record.caseOwner === 'string' &&
+    typeof record.savedObjectId === 'string' &&
+    typeof record.title === 'string' &&
+    typeof record.createdAt === 'number'
+  );
+};
+
+export const setPendingLensAttach = (storage: IStorageWrapper, record: PendingLensAttach): void => {
+  storage.set(PENDING_LENS_ATTACH_STORAGE_ID, record);
+};
+
+export const getPendingLensAttach = (storage: IStorageWrapper): PendingLensAttach | null => {
+  const raw = storage.get(PENDING_LENS_ATTACH_STORAGE_ID);
+  return isPendingLensAttach(raw) ? raw : null;
+};
+
+export const clearPendingLensAttach = (storage: IStorageWrapper): void => {
+  storage.remove(PENDING_LENS_ATTACH_STORAGE_ID);
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/storage.ts
@@ -17,7 +17,6 @@ export interface PendingLensAttach {
   caseOwner: string;
   savedObjectId: string;
   title: string;
-  createdAt: number;
 }
 
 const isPendingLensAttach = (value: unknown): value is PendingLensAttach => {
@@ -27,8 +26,7 @@ const isPendingLensAttach = (value: unknown): value is PendingLensAttach => {
     typeof record.caseId === 'string' &&
     typeof record.caseOwner === 'string' &&
     typeof record.savedObjectId === 'string' &&
-    typeof record.title === 'string' &&
-    typeof record.createdAt === 'number'
+    typeof record.title === 'string'
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { of } from 'rxjs';
+import { TestProviders } from '../../../../common/mock';
+import { useKibana, useToasts } from '../../../../common/lib/kibana';
+import { useCreateAttachments } from '../../../../containers/use_create_attachments';
+import { useRefreshCaseViewPage as getRefreshCaseViewPageMock } from '../../../case_view/use_on_refresh_case_view_page';
+import { useConsumeLensReturn } from './use_consume_lens_return';
+import { PENDING_LENS_ATTACH_STORAGE_ID } from './constants';
+
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../containers/use_create_attachments');
+jest.mock('../../../case_view/use_on_refresh_case_view_page');
+
+const useKibanaMock = useKibana as jest.Mock;
+const useToastsMock = useToasts as jest.Mock;
+const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
+const refreshCaseViewPage = getRefreshCaseViewPageMock() as jest.Mock;
+
+const pending = {
+  caseId: 'case-1',
+  caseOwner: 'cases',
+  savedObjectId: 'lens-1',
+  title: 'Top hosts',
+  createdAt: Date.now(),
+};
+
+describe('useConsumeLensReturn', () => {
+  const mutateAsync = jest.fn().mockResolvedValue(undefined);
+  const addSuccess = jest.fn();
+  const getIncomingEmbeddablePackage = jest.fn();
+  const cmGet = jest.fn();
+  const getTime = jest.fn();
+  const storageGet = jest.fn();
+  const storageRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCreateAttachmentsMock.mockReturnValue({ mutateAsync, isLoading: false });
+    useToastsMock.mockReturnValue({ addSuccess, addError: jest.fn() });
+    getTime.mockReturnValue({ from: 'now-24h', to: 'now', mode: 'relative' });
+    cmGet.mockResolvedValue({
+      item: { attributes: { state: { query: {} } }, references: [] },
+    });
+    useKibanaMock.mockReturnValue({
+      services: {
+        application: { currentAppId$: of('securitySolutionUI') },
+        contentManagement: { client: { get: cmGet } },
+        data: { query: { timefilter: { timefilter: { getTime } } } },
+        embeddable: { getStateTransfer: () => ({ getIncomingEmbeddablePackage }) },
+        storage: { get: storageGet, set: jest.fn(), remove: storageRemove },
+      },
+    });
+  });
+
+  const renderConsume = (caseId = 'case-1') =>
+    renderHook(() => useConsumeLensReturn({ caseId }), { wrapper: TestProviders });
+
+  it('no-ops when there is no pending record', async () => {
+    storageGet.mockReturnValue(undefined);
+    getIncomingEmbeddablePackage.mockReturnValue([{ type: 'lens' }]);
+    renderConsume();
+    await waitFor(() => expect(storageGet).toHaveBeenCalled());
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the pending record is for a different case', async () => {
+    storageGet.mockReturnValue({ ...pending, caseId: 'case-2' });
+    getIncomingEmbeddablePackage.mockReturnValue([{ type: 'lens' }]);
+    renderConsume('case-1');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('clears the marker without attaching when no lens package returns', async () => {
+    storageGet.mockReturnValue(pending);
+    getIncomingEmbeddablePackage.mockReturnValue([{ type: 'dashboard' }]);
+    renderConsume();
+    await waitFor(() => expect(storageRemove).toHaveBeenCalledWith(PENDING_LENS_ATTACH_STORAGE_ID));
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('creates a lens attachment, drains the package, clears storage, refreshes, and toasts', async () => {
+    storageGet.mockReturnValue(pending);
+    // Lens transfers the package keyed by the embeddable type ("vis").
+    getIncomingEmbeddablePackage.mockReturnValue([{ type: 'vis' }]);
+    renderConsume();
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+
+    const sent = mutateAsync.mock.calls[0][0];
+    expect(sent.caseId).toBe('case-1');
+    expect(sent.attachments[0]).toMatchObject({
+      type: 'lens',
+      attachmentId: 'lens-1',
+      metadata: { title: 'Top hosts', soType: 'lens' },
+    });
+    // The global time range is snapshotted as absolute so the attachment
+    // doesn't drift with relative values like `now-24h`.
+    const { timeRange } = sent.attachments[0].data;
+    expect(timeRange.from).not.toContain('now');
+    expect(timeRange.to).not.toContain('now');
+    // Peeked (false) before draining (true).
+    expect(getIncomingEmbeddablePackage).toHaveBeenCalledWith('securitySolutionUI', false);
+    expect(getIncomingEmbeddablePackage).toHaveBeenCalledWith('securitySolutionUI', true);
+    expect(storageRemove).toHaveBeenCalledWith(PENDING_LENS_ATTACH_STORAGE_ID);
+    expect(addSuccess).toHaveBeenCalled();
+    expect(refreshCaseViewPage).toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.test.tsx
@@ -28,7 +28,6 @@ const pending = {
   caseOwner: 'cases',
   savedObjectId: 'lens-1',
   title: 'Top hosts',
-  createdAt: Date.now(),
 };
 
 describe('useConsumeLensReturn', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+import { first } from 'rxjs';
+import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
+import { useKibana, useToasts } from '../../../../common/lib/kibana';
+import { useCreateAttachments } from '../../../../containers/use_create_attachments';
+import { useRefreshCaseViewPage } from '../../../case_view/use_on_refresh_case_view_page';
+import { buildLensPayload } from '../build_lens_payload';
+import { convertToAbsoluteTimeRange } from '../actions/convert_to_absolute_time_range';
+import * as i18n from '../../common/saved_object/translations';
+import { clearPendingLensAttach, getPendingLensAttach } from './storage';
+
+interface UseConsumeLensReturnArgs {
+  caseId: string;
+}
+
+/**
+ * Mount on the case view to auto-attach a Lens visualization when the user
+ * returns from the Lens editor via "Save and return". Reads the pending
+ * marker written by `useOpenLensForAttach`, claims the incoming embeddable
+ * package, and creates the attachment with the current global timefilter as
+ * the snapshot's view time range.
+ */
+export const useConsumeLensReturn = ({ caseId }: UseConsumeLensReturnArgs): void => {
+  const {
+    services: {
+      application: { currentAppId$ },
+      contentManagement,
+      data: dataService,
+      embeddable,
+      storage,
+    },
+  } = useKibana();
+  const { timefilter } = dataService.query.timefilter;
+  const toasts = useToasts();
+  const refreshCaseViewPage = useRefreshCaseViewPage();
+  const { mutateAsync: createAttachments } = useCreateAttachments();
+  // Guards against the effect running twice in StrictMode and against
+  // re-processing the same package within a single mount.
+  const hasProcessedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasProcessedRef.current) {
+      return;
+    }
+    const stateTransfer = embeddable?.getStateTransfer();
+    if (!stateTransfer) {
+      return;
+    }
+
+    // Only this hook owns the pending marker, so resolve its fate here.
+    const pending = getPendingLensAttach(storage);
+    if (!pending || pending.caseId !== caseId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      const currentAppId = await currentAppId$.pipe(first()).toPromise();
+      if (cancelled || !currentAppId) {
+        return;
+      }
+
+      const peeked = stateTransfer.getIncomingEmbeddablePackage(currentAppId, false);
+      const lensPackage = peeked?.find((pkg) => pkg.type === LENS_EMBEDDABLE_TYPE);
+
+      // No package means the user returned without saving. Clear the marker so
+      // it can't suppress the markdown editor's incoming-state handling later.
+      if (!lensPackage) {
+        clearPendingLensAttach(storage);
+        return;
+      }
+
+      hasProcessedRef.current = true;
+      // Drain so a remount or sibling consumer can't re-process it.
+      stateTransfer.getIncomingEmbeddablePackage(currentAppId, true);
+      clearPendingLensAttach(storage);
+
+      try {
+        const attachment = await buildLensPayload({
+          contentManagement,
+          id: pending.savedObjectId,
+          title: pending.title,
+          timeRange: convertToAbsoluteTimeRange(timefilter.getTime()),
+        });
+        await createAttachments({
+          caseId: pending.caseId,
+          caseOwner: pending.caseOwner,
+          attachments: [attachment],
+        });
+        if (cancelled) {
+          return;
+        }
+        toasts.addSuccess({
+          title: i18n.ATTACH_SUCCESS_TITLE,
+          text: pending.title,
+        });
+        refreshCaseViewPage();
+      } catch {
+        // `useCreateAttachments` surfaces its own error toast.
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    caseId,
+    contentManagement,
+    createAttachments,
+    currentAppId$,
+    embeddable,
+    refreshCaseViewPage,
+    storage,
+    timefilter,
+    toasts,
+  ]);
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_consume_lens_return.ts
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { first } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
 import { useKibana, useToasts } from '../../../../common/lib/kibana';
 import { useCreateAttachments } from '../../../../containers/use_create_attachments';
@@ -63,7 +63,7 @@ export const useConsumeLensReturn = ({ caseId }: UseConsumeLensReturnArgs): void
     let cancelled = false;
 
     const run = async () => {
-      const currentAppId = await currentAppId$.pipe(first()).toPromise();
+      const currentAppId = await firstValueFrom(currentAppId$, { defaultValue: undefined });
       if (cancelled || !currentAppId) {
         return;
       }

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_open_lens_for_attach.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_open_lens_for_attach.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { of } from 'rxjs';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useIsMainApplication } from '../../../../common/hooks';
+import { useOpenLensForAttach } from './use_open_lens_for_attach';
+import { PENDING_LENS_ATTACH_STORAGE_ID } from './constants';
+import type { FoundSavedObject } from '../../common/saved_object/types';
+
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../common/hooks');
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/cases/case-1', search: '?tab=activity' }),
+}));
+
+const useKibanaMock = useKibana as jest.Mock;
+const useIsMainApplicationMock = useIsMainApplication as jest.Mock;
+
+const buildSO = (overrides: Partial<FoundSavedObject> = {}): FoundSavedObject => ({
+  id: 'lens-1',
+  type: 'lens',
+  meta: { title: 'Top hosts' },
+  ...overrides,
+});
+
+describe('useOpenLensForAttach', () => {
+  const navigateToEditor = jest.fn().mockResolvedValue(undefined);
+  const storageSet = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useIsMainApplicationMock.mockReturnValue(true);
+    useKibanaMock.mockReturnValue({
+      services: {
+        application: { currentAppId$: of('securitySolutionUI') },
+        embeddable: { getStateTransfer: () => ({ navigateToEditor }) },
+        storage: { set: storageSet, get: jest.fn(), remove: jest.fn() },
+      },
+    });
+  });
+
+  const renderOpen = () =>
+    renderHook(() => useOpenLensForAttach({ caseId: 'case-1', caseOwner: 'cases' }));
+
+  it('writes a pending record and navigates to the Lens editor for the SO id', async () => {
+    const { result } = renderOpen();
+    await act(async () => {
+      await result.current(buildSO());
+    });
+    expect(storageSet).toHaveBeenCalledWith(
+      PENDING_LENS_ATTACH_STORAGE_ID,
+      expect.objectContaining({
+        caseId: 'case-1',
+        caseOwner: 'cases',
+        savedObjectId: 'lens-1',
+        title: 'Top hosts',
+      })
+    );
+    expect(navigateToEditor).toHaveBeenCalledWith(
+      'lens',
+      expect.objectContaining({
+        path: '#/edit/lens-1',
+        state: expect.objectContaining({ originatingApp: 'securitySolutionUI' }),
+      })
+    );
+  });
+
+  it('prefixes the originating path with the stack cases mount when in the main app', async () => {
+    useIsMainApplicationMock.mockReturnValue(true);
+    const { result } = renderOpen();
+    await act(async () => {
+      await result.current(buildSO());
+    });
+    const { state } = navigateToEditor.mock.calls.at(-1)![1];
+    expect(state.originatingPath).toBe('/insightsAndAlerting/cases/cases/case-1?tab=activity');
+  });
+
+  it('uses the raw location path when embedded in a solution app', async () => {
+    useIsMainApplicationMock.mockReturnValue(false);
+    const { result } = renderOpen();
+    await act(async () => {
+      await result.current(buildSO());
+    });
+    const { state } = navigateToEditor.mock.calls.at(-1)![1];
+    expect(state.originatingPath).toBe('/cases/case-1?tab=activity');
+  });
+
+  it('falls back to the saved object id when the SO has no title', async () => {
+    const { result } = renderOpen();
+    await act(async () => {
+      await result.current(buildSO({ meta: {} }));
+    });
+    expect(storageSet.mock.calls.at(-1)?.[1]).toMatchObject({ title: 'lens-1' });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_open_lens_for_attach.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_open_lens_for_attach.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { first } from 'rxjs';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useIsMainApplication } from '../../../../common/hooks';
+import type { FoundSavedObject } from '../../common/saved_object/types';
+import { setPendingLensAttach } from './storage';
+
+const LENS_APP_ID = 'lens';
+// Cases in the stack app is mounted under `/insightsAndAlerting/cases`. The
+// embeddable state transfer concatenates `originatingPath` with that app's
+// root, so for the stack we need to include the cases mount prefix; for
+// solution-embedded mounts the path is already relative to the solution app.
+const STACK_CASES_PATH_PREFIX = '/insightsAndAlerting/cases';
+
+interface UseOpenLensForAttachArgs {
+  caseId: string;
+  caseOwner: string;
+}
+
+/**
+ * Navigates to the Lens editor for an existing saved object id, recording a
+ * pending-attach marker so the case view can auto-attach when the user clicks
+ * "Save and return".
+ */
+export const useOpenLensForAttach = ({ caseId, caseOwner }: UseOpenLensForAttachArgs) => {
+  const {
+    services: {
+      application: { currentAppId$ },
+      embeddable,
+      storage,
+    },
+  } = useKibana();
+  const location = useLocation();
+  const isMainApplication = useIsMainApplication();
+  const originatingPath = isMainApplication
+    ? `${STACK_CASES_PATH_PREFIX}${location.pathname}${location.search}`
+    : `${location.pathname}${location.search}`;
+
+  return useCallback(
+    async (savedObject: FoundSavedObject) => {
+      const stateTransfer = embeddable?.getStateTransfer();
+      if (!stateTransfer) {
+        return;
+      }
+      const currentAppId = await currentAppId$.pipe(first()).toPromise();
+      if (!currentAppId) {
+        return;
+      }
+
+      const title = savedObject.meta.title ?? savedObject.id;
+      setPendingLensAttach(storage, {
+        caseId,
+        caseOwner,
+        savedObjectId: savedObject.id,
+        title,
+        createdAt: Date.now(),
+      });
+
+      // Path-based navigation to the Lens edit route for the existing SO.
+      await stateTransfer.navigateToEditor(LENS_APP_ID, {
+        path: `#/edit/${encodeURIComponent(savedObject.id)}`,
+        state: {
+          originatingApp: currentAppId,
+          originatingPath,
+        },
+      });
+    },
+    [caseId, caseOwner, currentAppId$, embeddable, originatingPath, storage]
+  );
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_open_lens_for_attach.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/lens/lens_return/use_open_lens_for_attach.ts
@@ -7,7 +7,7 @@
 
 import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
-import { first } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useIsMainApplication } from '../../../../common/hooks';
 import type { FoundSavedObject } from '../../common/saved_object/types';
@@ -50,7 +50,7 @@ export const useOpenLensForAttach = ({ caseId, caseOwner }: UseOpenLensForAttach
       if (!stateTransfer) {
         return;
       }
-      const currentAppId = await currentAppId$.pipe(first()).toPromise();
+      const currentAppId = await firstValueFrom(currentAppId$, { defaultValue: undefined });
       if (!currentAppId) {
         return;
       }
@@ -61,7 +61,6 @@ export const useOpenLensForAttach = ({ caseId, caseOwner }: UseOpenLensForAttach
         caseOwner,
         savedObjectId: savedObject.id,
         title,
-        createdAt: Date.now(),
       });
 
       // Path-based navigation to the Lens edit route for the existing SO.

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/map/build_map_payload.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/map/build_map_payload.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
+import { MAP_ATTACHMENT_TYPE, MAP_SO_TYPE } from '../../../../common/constants';
+import type {
+  MapAttributesSnapshot,
+  MapAttachmentPayload,
+} from '../../../../common/types/domain_zod/attachment/map/v2';
+import { fitsSnapshotBudget } from '../common/saved_object/helpers';
+
+export type MapPayload = Omit<MapAttachmentPayload, 'owner'>;
+
+const fetchMapAttributes = async (
+  contentManagement: ContentManagementPublicStart,
+  id: string
+): Promise<MapAttributesSnapshot | undefined> => {
+  try {
+    const result = (await contentManagement.client.get({
+      contentTypeId: MAP_SO_TYPE,
+      id,
+    })) as { item?: { attributes?: MapAttributesSnapshot } } | undefined;
+    const attributes = result?.item?.attributes ?? undefined;
+    return attributes && fitsSnapshotBudget(attributes) ? attributes : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const buildMapPayload = async ({
+  contentManagement,
+  id,
+  title,
+}: {
+  contentManagement: ContentManagementPublicStart;
+  id: string;
+  title: string;
+}): Promise<MapPayload> => {
+  const attributes = await fetchMapAttributes(contentManagement, id);
+  return {
+    type: MAP_ATTACHMENT_TYPE,
+    attachmentId: id,
+    metadata: { title, soType: MAP_SO_TYPE },
+    ...(attributes ? { data: { attributes } } : {}),
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
@@ -24,6 +24,8 @@ import { filterCaseAttachmentsBySearchTerm } from './components/helpers';
 import { ATTACHMENT_TAB_ALIASES } from './use_case_attachment_tabs';
 import { CaseViewTabs } from './case_view_tabs';
 import { SavedObjectInAppUrlsProvider } from '../attachments/common/saved_object/saved_object_in_app_urls_context';
+import { LensAttachReturnConsumer } from '../attachments/lens/lens_return/lens_attach_return_consumer';
+import { KibanaServices } from '../../common/lib/kibana';
 
 const getActiveTabId = (tabId?: string) => {
   if (tabId && Object.values(CASE_VIEW_PAGE_TABS).includes(tabId as CASE_VIEW_PAGE_TABS)) {
@@ -116,6 +118,9 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(({ caseData, refreshRe
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="l" />
+      {KibanaServices.getConfig()?.attachments?.enabled === true && (
+        <LensAttachReturnConsumer caseId={caseData.id} />
+      )}
       <SavedObjectInAppUrlsProvider caseData={caseData}>
         <CaseViewTabs
           caseData={caseWithFilteredAttachments}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -9,6 +9,7 @@ import { alertComment, eventComment, basicCase, basicComment } from '../../../co
 import {
   DASHBOARD_ATTACHMENT_TYPE,
   DISCOVER_SESSION_ATTACHMENT_TYPE,
+  LENS_ATTACHMENT_TYPE,
   MAP_ATTACHMENT_TYPE,
   SECURITY_ALERT_ATTACHMENT_TYPE,
   SECURITY_EVENT_ATTACHMENT_TYPE,
@@ -101,6 +102,27 @@ describe('Case view helpers', () => {
 
     it('counts a basic user comment as 1', () => {
       expect(getAttachmentItemCount(basicComment as unknown as AttachmentUIV2)).toBe(1);
+    });
+
+    it('does not count persistable lens attachments for saved-object tabs', () => {
+      expect(
+        getAttachmentItemCount({
+          ...basicComment,
+          type: LENS_ATTACHMENT_TYPE,
+          data: { state: {} },
+        } as unknown as AttachmentUIV2)
+      ).toBe(0);
+    });
+
+    it('counts saved-object lens attachments', () => {
+      expect(
+        getAttachmentItemCount({
+          ...basicComment,
+          type: LENS_ATTACHMENT_TYPE,
+          attachmentId: 'lens-1',
+          metadata: { title: 'Lens', soType: 'lens' },
+        } as unknown as AttachmentUIV2)
+      ).toBe(1);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -24,6 +24,7 @@ import {
   getSavedObjectAttachmentAttributes,
   isSavedObjectAttachment,
 } from '../../attachments/common/saved_object/helpers';
+import { LENS_ATTACHMENT_TYPE } from '../../../../common/constants/attachments';
 import type { SavedObjectAttachmentAttributes } from '../../attachments/common/saved_object/types';
 import { UNKNOWN } from '../../../common/translations';
 
@@ -42,6 +43,12 @@ export const getAttachmentAuthorLabel = (user: AttachmentUIV2['createdBy']): str
   user.fullName || user.username || user.email || UNKNOWN;
 
 export const getAttachmentItemCount = (comment: AttachmentUIV2): number => {
+  // Persistable (value) lens has no countable id and the attachments tab
+  // renderer only handles the SO-reference arm, so exclude it from the count.
+  // Explicit Lens carve-out for now; revisit when we generalize hybrid types.
+  if (comment.type === LENS_ATTACHMENT_TYPE && !isSavedObjectAttachment(comment)) {
+    return 0;
+  }
   if (isAlertAttachment(comment)) {
     return Array.isArray(comment.alertId) ? comment.alertId.length : 1;
   }

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/case_view_page.tsx
@@ -13,6 +13,8 @@ import type { CaseViewPageProps } from '../../case_view/types';
 
 import { useOnUpdateField } from '../../case_view/use_on_update_field';
 import { filterCaseAttachmentsBySearchTerm } from '../../case_view/components/helpers';
+import { LensAttachReturnConsumer } from '../../attachments/lens/lens_return/lens_attach_return_consumer';
+import { KibanaServices } from '../../../common/lib/kibana';
 import { CaseDetailsAppHeader } from './components/case_details_header';
 import { CaseViewTabContent } from './components/case_view_tab_content';
 import { useCaseRefreshRef } from './hooks/use_case_refresh_ref';
@@ -51,6 +53,9 @@ export const CaseViewPageRedesign = React.memo<CaseViewPageRedesignProps>(
         />
         {showMetrics && <CaseViewMetrics data-test-subj="case-view-metrics" caseId={caseData.id} />}
         <EuiSpacer size="l" />
+        {KibanaServices.getConfig()?.attachments?.enabled === true && (
+          <LensAttachReturnConsumer caseId={caseData.id} />
+        )}
         <CaseViewTabContent
           caseData={caseWithFilteredAttachments}
           searchTerm={searchTerm}

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
@@ -39,6 +39,7 @@ import { useLensDraftComment } from './use_lens_draft_comment';
 import { VISUALIZATION } from './translations';
 import { useIsMainApplication } from '../../../../common/hooks';
 import { convertToAbsoluteTimeRange } from '../../../attachments/lens/actions/convert_to_absolute_time_range';
+import { getPendingLensAttach } from '../../../attachments/lens/lens_return/storage';
 import { toLensAttributes } from './to_lens_attributes';
 
 const DEFAULT_TIMERANGE: TimeRange = {
@@ -250,26 +251,37 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
     if (!currentAppId) {
       return;
     }
-    // `draftComment` hydrates asynchronously; wait for it so we don't drain the
-    // package before the draft is ready and drop the edit.
+    // A pending SO-attach marker means the incoming Lens package belongs to
+    // the "Open in Lens -> Save and return" round trip, not the markdown flow.
+    // Leave the package for the SO-attach consumer to claim.
+    if (getPendingLensAttach(storage)) {
+      return;
+    }
+    // Wait until the draft has loaded from storage before consuming the
+    // incoming package. `useLensDraftComment` hydrates `draftComment`
+    // asynchronously; if we drained the package here on the first render
+    // (before the draft resolved), the second run — the one that actually
+    // has a draft to update against — would find nothing and silently drop
+    // the user's "Save and return" edit.
     if (!draftComment) {
       return;
     }
 
+    const stateTransfer = embeddable?.getStateTransfer();
     // Peek first so we only drain when we are committing an add/update.
-    const incomingEmbeddablePackage = embeddable
-      ?.getStateTransfer()
-      .getIncomingEmbeddablePackage(currentAppId, false);
-
-    const lensEmbeddablePackage = incomingEmbeddablePackage?.find(
-      (pkg) => pkg.type === LENS_EMBEDDABLE_TYPE
-    ) as LensIncomingEmbeddablePackage;
+    const peeked = stateTransfer?.getIncomingEmbeddablePackage(currentAppId, false);
+    // Lens transfers its package back keyed by the embeddable type
+    // (LENS_EMBEDDABLE_TYPE, "vis"), not the app id ("lens").
+    const lensEmbeddablePackage = peeked?.find((pkg) => pkg.type === LENS_EMBEDDABLE_TYPE) as
+      | LensIncomingEmbeddablePackage
+      | undefined;
 
     if (!lensEmbeddablePackage?.serializedState?.attributes) {
       return;
     }
 
-    embeddable?.getStateTransfer().getIncomingEmbeddablePackage(currentAppId, true);
+    // Drain so a re-render or sibling consumer can't double-process it.
+    stateTransfer?.getIncomingEmbeddablePackage(currentAppId, true);
 
     const lensTime = timefilter.getTime();
     const newTimeRange =

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/use_lens_draft_comment.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/use_lens_draft_comment.ts
@@ -11,6 +11,7 @@ import { first } from 'rxjs';
 import { useKibana } from '../../../../common/lib/kibana';
 import { DRAFT_COMMENT_STORAGE_ID } from './constants';
 import { VISUALIZATION } from './translations';
+import { getPendingLensAttach } from '../../../attachments/lens/lens_return/storage';
 import type { MarkdownEditorRef } from '../../types';
 
 interface DraftComment {
@@ -35,6 +36,15 @@ export const useLensDraftComment = () => {
       const currentAppId = await currentAppId$.pipe(first()).toPromise();
 
       if (!currentAppId) {
+        return;
+      }
+
+      // A pending SO-attach marker means the incoming Lens package belongs to
+      // the "Open in Lens -> Save and return -> auto attach" round trip, not
+      // the markdown editor. Ignore it here so the markdown flow doesn't claim
+      // the package (which would reopen the "Add visualization" modal and race
+      // the SO-attach consumer for the same package).
+      if (getPendingLensAttach(storage)) {
         return;
       }
 

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/__snapshots__/registered_attachments.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/__snapshots__/registered_attachments.test.tsx.snap
@@ -26,21 +26,23 @@ Array [
         }
       />
     </Memo(UserActionContentToolbar)>,
-    "children": <React.Suspense
-      fallback={<EuiLoadingSpinner />}
-    >
-      <UNDEFINED
-        attachmentId="event-id-123"
-        caseData={
-          Object {
-            "id": "basic-case-id",
-            "title": "Another horrible breach!!",
+    "children": <AttachmentRenderErrorBoundary>
+      <React.Suspense
+        fallback={<EuiLoadingSpinner />}
+      >
+        <UNDEFINED
+          attachmentId="event-id-123"
+          caseData={
+            Object {
+              "id": "basic-case-id",
+              "title": "Another horrible breach!!",
+            }
           }
-        }
-        foo="bar"
-        savedObjectId="basic-comment-id"
-      />
-    </React.Suspense>,
+          foo="bar"
+          savedObjectId="basic-comment-id"
+        />
+      </React.Suspense>
+    </AttachmentRenderErrorBoundary>,
     "className": "comment-user-attachment-test",
     "css": undefined,
     "data-test-subj": "comment-user-test",
@@ -125,21 +127,23 @@ Array [
         }
       />
     </Memo(UserActionContentToolbar)>,
-    "children": <React.Suspense
-      fallback={<EuiLoadingSpinner />}
-    >
-      <UNDEFINED
-        attachmentId="event-id-123"
-        caseData={
-          Object {
-            "id": "basic-case-id",
-            "title": "Another horrible breach!!",
+    "children": <AttachmentRenderErrorBoundary>
+      <React.Suspense
+        fallback={<EuiLoadingSpinner />}
+      >
+        <UNDEFINED
+          attachmentId="event-id-123"
+          caseData={
+            Object {
+              "id": "basic-case-id",
+              "title": "Another horrible breach!!",
+            }
           }
-        }
-        foo="bar"
-        savedObjectId="basic-comment-id"
-      />
-    </React.Suspense>,
+          foo="bar"
+          savedObjectId="basic-comment-id"
+        />
+      </React.Suspense>
+    </AttachmentRenderErrorBoundary>,
     "className": "comment-user-attachment-test",
     "css": undefined,
     "data-test-subj": "comment-user-test",
@@ -211,20 +215,22 @@ Array [
         registeredAttachmentActions={Array []}
       />
     </Memo(UserActionContentToolbar)>,
-    "children": <React.Suspense
-      fallback={<EuiLoadingSpinner />}
-    >
-      <UNDEFINED
-        caseData={
-          Object {
-            "id": "basic-case-id",
-            "title": "Another horrible breach!!",
+    "children": <AttachmentRenderErrorBoundary>
+      <React.Suspense
+        fallback={<EuiLoadingSpinner />}
+      >
+        <UNDEFINED
+          caseData={
+            Object {
+              "id": "basic-case-id",
+              "title": "Another horrible breach!!",
+            }
           }
-        }
-        foo="bar"
-        savedObjectId="basic-comment-id"
-      />
-    </React.Suspense>,
+          foo="bar"
+          savedObjectId="basic-comment-id"
+        />
+      </React.Suspense>
+    </AttachmentRenderErrorBoundary>,
     "className": "comment-user-attachment-test",
     "css": undefined,
     "data-test-subj": "comment-user-test",
@@ -286,10 +292,7 @@ Array [
 exports[`createRegisteredAttachmentUserActionBuilder returns an unknown user action if the attachment type is not registered 1`] = `
 Array [
   Object {
-    "children": <EuiCallOut
-      announceOnMount={false}
-      color="danger"
-      iconType="warning"
+    "children": <Memo(AttachmentErrorCallout)
       title="Attachment type is not registered"
     />,
     "className": "comment-user-not-found",

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/attachment_error_callout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/attachment_error_callout.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCallOut } from '@elastic/eui';
+
+interface AttachmentErrorCalloutProps {
+  title: string;
+  announceOnMount?: boolean;
+  'data-test-subj'?: string;
+}
+
+/**
+ * Shared "something is wrong with this attachment" callout. Used both when an
+ * attachment type is not registered and as the fallback for a renderer that
+ * throws, so the two failure modes look the same to the user.
+ */
+export const AttachmentErrorCallout = React.memo<AttachmentErrorCalloutProps>(
+  ({ title, announceOnMount = false, ...rest }) => (
+    <EuiCallOut
+      announceOnMount={announceOnMount}
+      title={title}
+      color="danger"
+      iconType="warning"
+      {...rest}
+    />
+  )
+);
+
+AttachmentErrorCallout.displayName = 'AttachmentErrorCallout';

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/attachment_render_error_boundary.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/attachment_render_error_boundary.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component, type ReactNode } from 'react';
+import { AttachmentErrorCallout } from './attachment_error_callout';
+import { ATTACHMENT_RENDER_ERROR } from './translations';
+
+interface AttachmentRenderErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface AttachmentRenderErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Isolates a single attachment renderer so a throw (including from a third-party
+ * or embeddable renderer's effects) degrades to an inline callout instead of
+ * unmounting the whole case view. React still logs the original error to the
+ * console when it is caught here.
+ */
+export class AttachmentRenderErrorBoundary extends Component<
+  AttachmentRenderErrorBoundaryProps,
+  AttachmentRenderErrorBoundaryState
+> {
+  static displayName = 'AttachmentRenderErrorBoundary';
+
+  state: AttachmentRenderErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <AttachmentErrorCallout
+          announceOnMount
+          title={ATTACHMENT_RENDER_ERROR}
+          data-test-subj="attachment-render-error"
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/registered_attachments.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/registered_attachments.tsx
@@ -14,14 +14,7 @@
 import React, { Suspense } from 'react';
 import { memoize, partition } from 'lodash';
 
-import {
-  EuiButtonIcon,
-  EuiCallOut,
-  EuiCode,
-  EuiFlexItem,
-  EuiLoadingSpinner,
-  EuiToolTip,
-} from '@elastic/eui';
+import { EuiButtonIcon, EuiCode, EuiFlexItem, EuiLoadingSpinner, EuiToolTip } from '@elastic/eui';
 
 import type {
   AttachmentType,
@@ -43,6 +36,8 @@ import {
 import { UserActionContentToolbar } from '../content_toolbar';
 import { HoverableUserWithAvatarResolver } from '../../user_profiles/hoverable_user_with_avatar_resolver';
 import { RegisteredAttachmentsPropertyActions } from '../property_actions/registered_attachments_property_actions';
+import { AttachmentErrorCallout } from './attachment_error_callout';
+import { AttachmentRenderErrorBoundary } from './attachment_render_error_boundary';
 
 type BuilderArgs<C, R> = Pick<
   UserActionBuilderArgs,
@@ -76,7 +71,11 @@ const getAttachmentRenderer = memoize((cachingKey: string) => {
       AttachmentElement = React.cloneElement(AttachmentElement, props);
     }
 
-    return <Suspense fallback={<EuiLoadingSpinner />}>{AttachmentElement}</Suspense>;
+    return (
+      <AttachmentRenderErrorBoundary>
+        <Suspense fallback={<EuiLoadingSpinner />}>{AttachmentElement}</Suspense>
+      </AttachmentRenderErrorBoundary>
+    );
   };
 
   return renderCallback;
@@ -119,14 +118,7 @@ export const createRegisteredAttachmentUserActionBuilder = <
           className: `comment-${attachment.type}-not-found`,
           'data-test-subj': `comment-${attachment.type}-not-found`,
           timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
-          children: (
-            <EuiCallOut
-              announceOnMount={false}
-              title={ATTACHMENT_NOT_REGISTERED_ERROR}
-              color="danger"
-              iconType="warning"
-            />
-          ),
+          children: <AttachmentErrorCallout title={ATTACHMENT_NOT_REGISTERED_ERROR} />,
         },
       ];
     }

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
@@ -15,6 +15,13 @@ export const ATTACHMENT_NOT_REGISTERED_ERROR = i18n.translate(
   }
 );
 
+export const ATTACHMENT_RENDER_ERROR = i18n.translate(
+  'xpack.cases.userActions.attachmentRenderErrorMsg',
+  {
+    defaultMessage: "Couldn't render this attachment",
+  }
+);
+
 export const DEFAULT_EVENT_ATTACHMENT_TITLE = i18n.translate(
   'xpack.cases.userActions.defaultEventAttachmentTitle',
   {

--- a/x-pack/platform/plugins/shared/cases/public/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/index.tsx
@@ -30,9 +30,12 @@ export {
   useCaseViewParams,
 } from './common/navigation';
 export type {
+  RegisteredUnifiedAttachmentType,
+  UnifiedHybridAttachmentType,
   UnifiedReferenceAttachmentType,
   UnifiedValueAttachmentType,
   CommonAttachmentTabViewProps,
+  UnifiedHybridAttachmentViewProps,
   UnifiedReferenceAttachmentViewProps,
   UnifiedValueAttachmentViewProps,
 } from './client/attachment_framework/types';

--- a/x-pack/platform/plugins/shared/cases/server/common/attachments/persistable_state.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/attachments/persistable_state.ts
@@ -21,6 +21,7 @@ import type {
   AttachmentPersistedAttributes,
   UnifiedAttachmentAttributes,
 } from '../types/attachments_v2';
+import { isUnifiedAttachmentWithSoReference } from '../../services/type_guards';
 import type { AttachmentTypeTransformer } from './base';
 
 const isRecord = (value: unknown): value is Record<string, unknown> => isPlainObject(value);
@@ -49,6 +50,8 @@ const getStateFromLegacyAttachment = (
   return {};
 };
 
+// Exclude SO-reference attachments (e.g. Lens-by-reference): they have no
+// by-value legacy counterpart, so `toLegacySchema` must not downgrade them.
 const isUnifiedValueAttachmentForType = (
   value: unknown,
   typeId: string
@@ -56,7 +59,8 @@ const isUnifiedValueAttachmentForType = (
   isRecord(value) &&
   value.type === typeId &&
   typeof value.owner === 'string' &&
-  isRecord(value.data);
+  isRecord(value.data) &&
+  !isUnifiedAttachmentWithSoReference(value);
 
 const getStateFromUnifiedData = (
   data: Record<string, unknown>

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/internal/bulk_create_attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/internal/bulk_create_attachments.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { INTERNAL_BULK_CREATE_ATTACHMENTS_URL } from '../../../../common/constants';
-import { isUnifiedOnlyAttachmentType } from '../../../../common/utils/attachments';
+import { isUnifiedOnlyAttachment } from '../../../services/type_guards';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { escapeHatch } from '../utils';
@@ -34,13 +34,13 @@ export const bulkCreateAttachmentsRoute = createCasesRoute({
       const casesClient = await casesContext.getCasesClient();
       const caseId = request.params.case_id;
       const attachments = request.body as attachmentApiV2.BulkCreateAttachmentsRequestV2;
-      // Encode the response in `unified` mode only when the batch contains a
-      // unified-only attachment type (dashboard, map, discoverSession) that
-      // has no V1 form to downgrade to. Legacy types (alerts, user comments,
-      // file, …) keep the legacy-shaped response so existing public consumers
-      // of this route aren't affected by the new SO attachment types.
+      // Encode the response in `unified` mode when the batch contains an
+      // attachment with no V1 form to downgrade to: a unified-only type
+      // (dashboard, map, discoverSession) or an SO-reference instance of a
+      // hybrid type (e.g. Lens-by-reference). Everything else stays legacy-shaped
+      // so existing public consumers of this route are unaffected.
       const hasUnifiedOnlyAttachment = attachments.some((attachment) =>
-        isUnifiedOnlyAttachmentType(attachment.type, attachment.owner)
+        isUnifiedOnlyAttachment(attachment)
       );
       const res: caseDomainV1.Case = await casesClient.attachments.bulkCreate({
         caseId,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/model_versions/model_version_1.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/model_versions/model_version_1.ts
@@ -7,7 +7,15 @@
 
 import { schema } from '@kbn/config-schema';
 import type { SavedObjectsFullModelVersion } from '@kbn/core-saved-objects-server';
-import { MAX_ALERTS_PER_CASE, MAX_COMMENT_LENGTH } from '../../../../common/constants';
+import {
+  MAX_ALERTS_PER_CASE,
+  MAX_ATTACHMENT_ID_LENGTH,
+  MAX_COMMENT_LENGTH,
+  MAX_ISO_DATE_LENGTH,
+  MAX_OWNER_LENGTH,
+  MAX_ATTACHMENT_TYPE_LENGTH,
+  MAX_USERNAME_LENGTH,
+} from '../../../../common/constants';
 
 // The SO mapping uses `dynamic: false`, so only a subset of attributes is indexed.
 // The `create` schema must declare every indexed field (see
@@ -20,11 +28,6 @@ import { MAX_ALERTS_PER_CASE, MAX_COMMENT_LENGTH } from '../../../../common/cons
 // (string): 512 = ES `_id` upper bound, covering every current producer
 // (alert/event ES ids, foreign SO UUIDs). `attachmentId` (array): reuses
 // MAX_ALERTS_PER_CASE. `username`: matches Kibana security plugin routes.
-const MAX_OWNER_LENGTH = 30;
-const MAX_ISO_DATE_LENGTH = 30;
-const MAX_ATTACHMENT_TYPE_LENGTH = 50;
-const MAX_ATTACHMENT_ID_LENGTH = 512;
-const MAX_USERNAME_LENGTH = 1024;
 
 const userSchema = schema.object(
   {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -25,6 +25,8 @@ import { createErrorSO, createSOFindResponse } from '../test_utils';
 import {
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
+  LENS_ATTACHMENT_TYPE,
+  LENS_SO_TYPE,
   SECURITY_ENTITY_ATTACHMENT_TYPE,
   SECURITY_SOLUTION_OWNER,
 } from '../../../common/constants';
@@ -579,6 +581,34 @@ describe('AttachmentService', () => {
           isBoom: true,
           output: { statusCode: 400 },
           message: expect.stringContaining(SECURITY_ENTITY_ATTACHMENT_TYPE),
+        });
+
+        expect(unsecuredSavedObjectsClient.create).not.toHaveBeenCalled();
+      });
+
+      // A Lens-by-reference attachment is a unified-only *instance* of a hybrid
+      // type (by-value lens still downgrades). The legacy write path must reject
+      // it with a 400 rather than 500/silently corrupt it into a persistableState.
+      it('create throws Boom 400 for a Lens-by-reference attachment when attachments flag is off', async () => {
+        const lensByRefAttrs = {
+          type: LENS_ATTACHMENT_TYPE,
+          attachmentId: 'lens-1',
+          metadata: { title: 'My lens', soType: LENS_SO_TYPE },
+          owner: SECURITY_SOLUTION_OWNER,
+          created_at: '2024-01-01T00:00:00.000Z',
+          created_by: { username: 'u', full_name: null, email: null },
+          pushed_at: null,
+          pushed_by: null,
+          updated_at: null,
+          updated_by: null,
+        };
+
+        await expect(
+          service.create({ attributes: lensByRefAttrs, references: [], id: '1' })
+        ).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 400 },
+          message: expect.stringContaining(LENS_ATTACHMENT_TYPE),
         });
 
         expect(unsecuredSavedObjectsClient.create).not.toHaveBeenCalled();
@@ -1422,6 +1452,46 @@ describe('AttachmentService', () => {
         type: 'user',
         comment: 'from unified',
         owner: SECURITY_SOLUTION_OWNER,
+      });
+    });
+
+    // A Lens-by-reference attachment has no legacy form, so a legacy-mode read
+    // must return it in the unified shape instead of throwing or corrupting it.
+    it('returns a Lens-by-reference attachment in unified shape for legacy mode reads', async () => {
+      const serviceWithFlagOn = new AttachmentService({
+        log: mockLogger,
+        unsecuredSavedObjectsClient,
+        config: createAttachmentServiceConfig(true),
+      });
+      unsecuredSavedObjectsClient.find.mockResolvedValue(
+        createSOFindResponse([
+          {
+            id: 'lens-ref-1',
+            type: CASE_ATTACHMENT_SAVED_OBJECT,
+            score: 0,
+            attributes: {
+              type: LENS_ATTACHMENT_TYPE,
+              attachmentId: 'lens-1',
+              metadata: { title: 'My lens', soType: LENS_SO_TYPE },
+              owner: SECURITY_SOLUTION_OWNER,
+              created_at: '2024-01-01T00:00:00.000Z',
+              created_by: { username: 'u', full_name: null, email: null },
+              pushed_at: null,
+              pushed_by: null,
+              updated_at: null,
+              updated_by: null,
+            },
+            references: [],
+          },
+        ])
+      );
+
+      const res = await serviceWithFlagOn.find({ mode: 'legacy' });
+
+      expect(res.saved_objects[0].attributes).toMatchObject({
+        type: LENS_ATTACHMENT_TYPE,
+        attachmentId: 'lens-1',
+        metadata: { soType: LENS_SO_TYPE },
       });
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -453,10 +453,7 @@ export class AttachmentService {
         }) as unknown as UnifiedAttachmentSavedObjectTransformed;
       }
 
-      assertLegacyWriteableAttachmentType(
-        getAttachmentTypeFromAttributes(decodedAttributes),
-        decodedAttributes.owner
-      );
+      assertLegacyWriteableAttachmentType(decodedAttributes);
 
       const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
       const { attributes: extractedAttributes, references: extractedReferences } =
@@ -534,10 +531,7 @@ export class AttachmentService {
               attachment.attributes
             );
 
-            assertLegacyWriteableAttachmentType(
-              getAttachmentTypeFromAttributes(decodedAttributes),
-              decodedAttributes.owner
-            );
+            assertLegacyWriteableAttachmentType(decodedAttributes);
             const transformer = getAttachmentTypeTransformers(
               getAttachmentTypeFromAttributes(decodedAttributes),
               decodedAttributes.owner
@@ -642,10 +636,7 @@ export class AttachmentService {
         return Object.assign(res, { attributes: decodedAttributes });
       }
 
-      assertLegacyWriteableAttachmentType(
-        getAttachmentTypeFromAttributes(decodedAttributes),
-        decodedAttributes.owner ?? ''
-      );
+      assertLegacyWriteableAttachmentType(decodedAttributes);
 
       const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
       const {
@@ -744,10 +735,7 @@ export class AttachmentService {
           // Skip when `requestWithoutType` is set: the patch carries no `type`
           // to resolve, and only the typed path can introduce a unified-only type.
           if (!requestWithoutType) {
-            assertLegacyWriteableAttachmentType(
-              getAttachmentTypeFromAttributes(decodedAttributes),
-              decodedAttributes.owner ?? ''
-            );
+            assertLegacyWriteableAttachmentType(decodedAttributes);
           }
           const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
           const {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.test.ts
@@ -9,9 +9,15 @@ import { assertLegacyWriteableAttachmentType, transformAttributesForMode } from 
 import { isUnifiedOnlyAttachment } from '../../type_guards';
 import { createUserAttachment } from '../test_utils';
 import {
+  AIOPS_CHANGE_POINT_CHART_ATTACHMENT_TYPE,
+  FILE_ATTACHMENT_TYPE,
+  INDICATOR_ATTACHMENT_TYPE,
   LEGACY_LENS_ATTACHMENT_TYPE,
   LENS_ATTACHMENT_TYPE,
   LENS_SO_TYPE,
+  ML_ANOMALY_SWIMLANE_ATTACHMENT_TYPE,
+  OSQUERY_ATTACHMENT_TYPE,
+  SECURITY_ENDPOINT_ATTACHMENT_TYPE,
   SECURITY_TIMELINE_ATTACHMENT_TYPE,
 } from '../../../../common/constants';
 import { AttachmentType } from '../../../../common/types/domain';
@@ -43,6 +49,56 @@ const createByReferenceLens = (withSnapshot = false) =>
     attachmentId: 'lens-1',
     metadata: { title: 'My lens', soType: LENS_SO_TYPE },
     ...(withSnapshot ? { data: { attributes: { title: 'My lens' } } } : {}),
+    ...basicAttributes,
+  } as unknown as Parameters<typeof transformAttributesForMode>[0]['attributes']);
+
+// A unified file attachment is SO-backed (`metadata.soType`) but, unlike Lens-by-ref,
+// maps cleanly onto a legacy externalReference, so it must stay legacy-writeable.
+const createUnifiedFile = () =>
+  ({
+    type: FILE_ATTACHMENT_TYPE,
+    owner: 'cases',
+    attachmentId: 'file-1',
+    metadata: {
+      soType: 'file',
+      files: [
+        { name: 'test.txt', extension: 'txt', mimeType: 'text/plain', created: '2026-05-29' },
+      ],
+    },
+    ...basicAttributes,
+  } as unknown as Parameters<typeof transformAttributesForMode>[0]['attributes']);
+
+// Every unified type that maps onto a legacy externalReference. These are SO-backed
+// (`metadata.soType`) yet always have a legacy form, so they are never unified-only.
+const externalReferenceTypes = [
+  ['endpoint', SECURITY_ENDPOINT_ATTACHMENT_TYPE],
+  ['file', FILE_ATTACHMENT_TYPE],
+  ['osquery', OSQUERY_ATTACHMENT_TYPE],
+  ['indicator', INDICATOR_ATTACHMENT_TYPE],
+] as const;
+
+const createExternalReference = (type: string) =>
+  ({
+    type,
+    owner: 'cases',
+    attachmentId: `${type}-1`,
+    metadata: { soType: type },
+    ...basicAttributes,
+  } as unknown as Parameters<typeof transformAttributesForMode>[0]['attributes']);
+
+// Every persistable-state subtype. Their legacy form is by-value, so a by-value
+// instance is legacy-writeable (only a by-reference instance would be unified-only).
+const persistableStateTypes = [
+  ['lens', LENS_ATTACHMENT_TYPE],
+  ['ml anomaly swimlane', ML_ANOMALY_SWIMLANE_ATTACHMENT_TYPE],
+  ['aiops change point chart', AIOPS_CHANGE_POINT_CHART_ATTACHMENT_TYPE],
+] as const;
+
+const createByValuePersistableState = (type: string) =>
+  ({
+    type,
+    owner: 'cases',
+    data: { state: {} },
     ...basicAttributes,
   } as unknown as Parameters<typeof transformAttributesForMode>[0]['attributes']);
 
@@ -149,6 +205,16 @@ describe('transformAttributesForMode', () => {
     }
   });
 
+  // Files are SO-backed but have a legacy externalReference form, so mode=legacy
+  // must downgrade them rather than keep them unified.
+  it('downgrades a unified file to legacy externalReference in legacy mode', () => {
+    const out = transformAttributesForMode({ attributes: createUnifiedFile(), mode: 'legacy' });
+    expect(out.isUnified).toBe(false);
+    if (!out.isUnified) {
+      expect(out.attributes.type).toBe(AttachmentType.externalReference);
+    }
+  });
+
   // A Lens-by-reference instance has no by-value legacy form, so it must stay on
   // the unified branch even for mode=legacy — otherwise toLegacySchema would
   // fabricate a bogus persistableState from the snapshot and drop attachmentId.
@@ -172,17 +238,32 @@ describe('transformAttributesForMode', () => {
 });
 
 describe('isUnifiedOnlyAttachment', () => {
-  it('is false for by-value lens (has a legacy persistableState form)', () => {
-    expect(isUnifiedOnlyAttachment(createByValueLens())).toBe(false);
+  it('is false for legacy user comments', () => {
+    expect(isUnifiedOnlyAttachment(createUserAttachment().attributes)).toBe(false);
   });
 
+  // External-reference-mapped types are SO-backed (`metadata.soType`) but always have a
+  // legacy externalReference form. Flagging them unified-only broke every file write with
+  // the flag off, so guard the whole map (endpoint/file/osquery/indicator).
+  it.each(externalReferenceTypes)(
+    'is false for a unified %s attachment (has a legacy externalReference form)',
+    (_desc, type) => {
+      expect(isUnifiedOnlyAttachment(createExternalReference(type))).toBe(false);
+    }
+  );
+
+  it.each(persistableStateTypes)(
+    'is false for by-value %s (has a legacy persistableState form)',
+    (_desc, type) => {
+      expect(isUnifiedOnlyAttachment(createByValuePersistableState(type))).toBe(false);
+    }
+  );
+
+  // A by-reference persistable-state instance (only Lens supports this today) has no
+  // by-value legacy counterpart, so it is the one persistable case that is unified-only.
   it('is true for a Lens-by-reference attachment (no legacy form)', () => {
     expect(isUnifiedOnlyAttachment(createByReferenceLens())).toBe(true);
     expect(isUnifiedOnlyAttachment(createByReferenceLens(true))).toBe(true);
-  });
-
-  it('is false for legacy user comments', () => {
-    expect(isUnifiedOnlyAttachment(createUserAttachment().attributes)).toBe(false);
   });
 });
 
@@ -201,5 +282,9 @@ describe('assertLegacyWriteableAttachmentType', () => {
     expect(() => assertLegacyWriteableAttachmentType(createByReferenceLens())).toThrow(
       /has no legacy representation/
     );
+  });
+
+  it('does not throw for a unified file attachment', () => {
+    expect(() => assertLegacyWriteableAttachmentType(createUnifiedFile())).not.toThrow();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.test.ts
@@ -265,6 +265,20 @@ describe('isUnifiedOnlyAttachment', () => {
     expect(isUnifiedOnlyAttachment(createByReferenceLens())).toBe(true);
     expect(isUnifiedOnlyAttachment(createByReferenceLens(true))).toBe(true);
   });
+
+  // Runs on the raw request body (before decode), so a payload whose type can't be
+  // resolved must return false rather than throw — otherwise the route 500s instead of
+  // letting validation reject it with a 400.
+  it.each([
+    ['missing type', { owner: 'cases' }],
+    ['non-object', 'not-an-object'],
+    ['null', null],
+  ])('is false and does not throw for a malformed payload (%s)', (_desc, payload) => {
+    expect(() =>
+      isUnifiedOnlyAttachment(payload as unknown as Record<string, unknown>)
+    ).not.toThrow();
+    expect(isUnifiedOnlyAttachment(payload as unknown as Record<string, unknown>)).toBe(false);
+  });
 });
 
 describe('assertLegacyWriteableAttachmentType', () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.test.ts
@@ -5,9 +5,46 @@
  * 2.0.
  */
 
-import { transformAttributesForMode } from './utils';
+import { assertLegacyWriteableAttachmentType, transformAttributesForMode } from './utils';
+import { isUnifiedOnlyAttachment } from '../../type_guards';
 import { createUserAttachment } from '../test_utils';
-import { SECURITY_TIMELINE_ATTACHMENT_TYPE } from '../../../../common/constants';
+import {
+  LEGACY_LENS_ATTACHMENT_TYPE,
+  LENS_ATTACHMENT_TYPE,
+  LENS_SO_TYPE,
+  SECURITY_TIMELINE_ATTACHMENT_TYPE,
+} from '../../../../common/constants';
+import { AttachmentType } from '../../../../common/types/domain';
+
+const basicAttributes = {
+  created_at: '2026-05-29T00:00:00.000Z',
+  created_by: { username: 'tester', full_name: null, email: null },
+  pushed_at: null,
+  pushed_by: null,
+  updated_at: null,
+  updated_by: null,
+};
+
+const createByValueLens = () =>
+  ({
+    type: LENS_ATTACHMENT_TYPE,
+    owner: 'cases',
+    data: { state: { visualization: {} } },
+    ...basicAttributes,
+  } as unknown as Parameters<typeof transformAttributesForMode>[0]['attributes']);
+
+// A saved-object reference lens carries `metadata.soType` and, optionally, a
+// snapshot of the referenced SO under `data.attributes`. It has no by-value
+// legacy form.
+const createByReferenceLens = (withSnapshot = false) =>
+  ({
+    type: LENS_ATTACHMENT_TYPE,
+    owner: 'cases',
+    attachmentId: 'lens-1',
+    metadata: { title: 'My lens', soType: LENS_SO_TYPE },
+    ...(withSnapshot ? { data: { attributes: { title: 'My lens' } } } : {}),
+    ...basicAttributes,
+  } as unknown as Parameters<typeof transformAttributesForMode>[0]['attributes']);
 
 describe('transformAttributesForMode', () => {
   it('maps legacy user comments to unified schema when mode is unified', () => {
@@ -99,5 +136,70 @@ describe('transformAttributesForMode', () => {
     if (out.isUnified) {
       expect(out.attributes.type).toBe('discoverSession');
     }
+  });
+
+  // By-value lens keeps a legacy `persistableState` representation, so mode=legacy
+  // must still downgrade it (this is the pre-existing hybrid behavior).
+  it('downgrades by-value lens to legacy persistableState in legacy mode', () => {
+    const out = transformAttributesForMode({ attributes: createByValueLens(), mode: 'legacy' });
+    expect(out.isUnified).toBe(false);
+    if (!out.isUnified) {
+      expect(out.attributes.type).toBe(AttachmentType.persistableState);
+      expect(out.attributes.persistableStateAttachmentTypeId).toBe(LEGACY_LENS_ATTACHMENT_TYPE);
+    }
+  });
+
+  // A Lens-by-reference instance has no by-value legacy form, so it must stay on
+  // the unified branch even for mode=legacy — otherwise toLegacySchema would
+  // fabricate a bogus persistableState from the snapshot and drop attachmentId.
+  it.each([
+    ['without a data snapshot', false],
+    ['with a data snapshot', true],
+  ])('keeps a Lens-by-reference attachment unified in legacy mode (%s)', (_desc, withSnapshot) => {
+    const out = transformAttributesForMode({
+      attributes: createByReferenceLens(withSnapshot as boolean),
+      mode: 'legacy',
+    });
+    expect(out.isUnified).toBe(true);
+    if (out.isUnified) {
+      expect(out.attributes).toMatchObject({
+        type: LENS_ATTACHMENT_TYPE,
+        attachmentId: 'lens-1',
+        metadata: { soType: LENS_SO_TYPE },
+      });
+    }
+  });
+});
+
+describe('isUnifiedOnlyAttachment', () => {
+  it('is false for by-value lens (has a legacy persistableState form)', () => {
+    expect(isUnifiedOnlyAttachment(createByValueLens())).toBe(false);
+  });
+
+  it('is true for a Lens-by-reference attachment (no legacy form)', () => {
+    expect(isUnifiedOnlyAttachment(createByReferenceLens())).toBe(true);
+    expect(isUnifiedOnlyAttachment(createByReferenceLens(true))).toBe(true);
+  });
+
+  it('is false for legacy user comments', () => {
+    expect(isUnifiedOnlyAttachment(createUserAttachment().attributes)).toBe(false);
+  });
+});
+
+describe('assertLegacyWriteableAttachmentType', () => {
+  it('does not throw for by-value lens', () => {
+    expect(() => assertLegacyWriteableAttachmentType(createByValueLens())).not.toThrow();
+  });
+
+  it('does not throw for legacy user comments', () => {
+    expect(() =>
+      assertLegacyWriteableAttachmentType(createUserAttachment().attributes)
+    ).not.toThrow();
+  });
+
+  it('throws a 400 for a Lens-by-reference attachment', () => {
+    expect(() => assertLegacyWriteableAttachmentType(createByReferenceLens())).toThrow(
+      /has no legacy representation/
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.ts
@@ -15,14 +15,12 @@ import {
   type AttachmentMode,
   UnifiedAttachmentAttributesRt,
 } from '../../../../common/types/domain/attachment/v2';
-import {
-  isMigratedAttachmentType,
-  isUnifiedOnlyAttachmentType,
-} from '../../../../common/utils/attachments';
+import { isMigratedAttachmentType } from '../../../../common/utils/attachments';
 import {
   getAttachmentTypeFromAttributes,
   getAttachmentTypeTransformers,
 } from '../../../common/attachments';
+import { isUnifiedOnlyAttachment } from '../../type_guards';
 
 export type ModeTransformedAttributes =
   | { isUnified: true; attributes: UnifiedAttachmentAttributes }
@@ -41,9 +39,10 @@ export function transformAttributesForMode({
   const attachmentType = getAttachmentTypeFromAttributes(attributes);
   const owner = attributes?.owner ?? '';
   const transformer = getAttachmentTypeTransformers(attachmentType, owner);
-  // Unified-only attachment types (no legacy counterpart, e.g. entity/timeline)
-  // cannot be represented in the legacy schema and must stay in unified mode.
-  const isUnifiedOnly = isUnifiedOnlyAttachmentType(attachmentType, owner);
+  // Unified-only attachments (no legacy counterpart, e.g. entity/timeline or a
+  // Lens-by-reference instance) cannot be represented in the legacy schema and
+  // must stay in unified mode even when a legacy read is requested.
+  const isUnifiedOnly = isUnifiedOnlyAttachment(attributes);
 
   if ((mode === 'unified' || isUnifiedOnly) && isMigratedAttachmentType(attachmentType, owner)) {
     const unifiedAttrs = transformer.toUnifiedSchema(attributes);
@@ -57,18 +56,27 @@ export function transformAttributesForMode({
 
 /**
  * Guards the legacy comment-SO write paths (`create`/`bulkCreate`/`update`/
- * `bulkUpdate`). Unified-only attachment types (no legacy counterpart, e.g.
- * `security.entity`/`security.timeline`) cannot be represented in the legacy
- * schema, so persisting them as a `CASE_COMMENT_SAVED_OBJECT` fails deep in the
- * response decode step with an opaque 500. This surfaces an actionable 400
- * instead, pointing operators at the required Kibana config.
+ * `bulkUpdate`). Unified-only attachments (no legacy counterpart) cannot be
+ * represented in the legacy schema, so persisting them as a
+ * `CASE_COMMENT_SAVED_OBJECT` fails deep in the response decode step with an
+ * opaque 500. This surfaces an actionable 400 instead, pointing operators at the
+ * required Kibana config.
  *
- * This case is only reachable on a misconfiguration where a unified-only type is
- * registered (its own feature flag is on) while `xpack.cases.attachments.enabled`
- * is off, so the service still resolves to the legacy SO type.
+ * Two flavours are rejected:
+ *  - unified-only *types* (e.g. `security.entity`/`security.timeline`), reachable
+ *    on a misconfiguration where the type's own feature flag is on while
+ *    `xpack.cases.attachments.enabled` is off, and
+ *  - unified-only *instances* of hybrid types — a Lens-by-reference attachment
+ *    has no by-value legacy form even though by-value Lens does.
  */
-export const assertLegacyWriteableAttachmentType = (type: string, owner: string): void => {
-  if (isUnifiedOnlyAttachmentType(type, owner)) {
+export const assertLegacyWriteableAttachmentType = (
+  attributes:
+    | UnifiedAttachmentAttributes
+    | AttachmentPersistedAttributes
+    | AttachmentPatchAttributesV2
+): void => {
+  if (isUnifiedOnlyAttachment(attributes)) {
+    const type = getAttachmentTypeFromAttributes(attributes);
     throw Boom.badRequest(
       `Attachment type '${type}' has no legacy representation and requires the unified attachment SO type. Enable xpack.cases.attachments.enabled in your Kibana configuration.`
     );

--- a/x-pack/platform/plugins/shared/cases/server/services/so_references.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/so_references.test.ts
@@ -6,6 +6,16 @@
  */
 
 import {
+  DASHBOARD_ATTACHMENT_TYPE,
+  DASHBOARD_SO_TYPE,
+  DISCOVER_SESSION_ATTACHMENT_TYPE,
+  DISCOVER_SESSION_SO_TYPE,
+  LENS_ATTACHMENT_TYPE,
+  LENS_SO_TYPE,
+  MAP_ATTACHMENT_TYPE,
+  MAP_SO_TYPE,
+} from '../../common/constants/attachments';
+import {
   externalReferenceAttachmentESAttributes,
   externalReferenceAttachmentSOAttributes,
   externalReferenceAttachmentSOAttributesWithoutRefs,
@@ -244,6 +254,38 @@ describe('so_references', () => {
       expect(res.didDeleteOperation).toBe(false);
     });
 
+    it.each([
+      [DASHBOARD_ATTACHMENT_TYPE, DASHBOARD_SO_TYPE],
+      [DISCOVER_SESSION_ATTACHMENT_TYPE, DISCOVER_SESSION_SO_TYPE],
+      [LENS_ATTACHMENT_TYPE, LENS_SO_TYPE],
+      [MAP_ATTACHMENT_TYPE, MAP_SO_TYPE],
+    ])('should mirror attachmentId for %s saved-object attachments', (type, soType) => {
+      const res = extractAttachmentSORefsFromAttributes(
+        {
+          type,
+          attachmentId: `${soType}-id-1`,
+          metadata: {
+            soType,
+            title: 'Saved object title',
+          },
+          owner: 'securitySolution',
+        } as never,
+        []
+      );
+
+      expect(res.references).toEqual([
+        {
+          id: `${soType}-id-1`,
+          name: 'attachmentId',
+          type: soType,
+        },
+      ]);
+      expect((res.attributes as unknown as Record<string, unknown>).attachmentId).toBe(
+        `${soType}-id-1`
+      );
+      expect(res.didDeleteOperation).toBe(false);
+    });
+
     it('should not extract attachmentId for unified attachments without metadata.soType', () => {
       const unifiedNonSoBackedAttributes = {
         type: 'security.endpoint',
@@ -258,19 +300,22 @@ describe('so_references', () => {
       expect(res.didDeleteOperation).toBe(false);
     });
 
-    it('should NOT extract attachmentId for an unregistered unified type carrying a forged metadata.soType', () => {
-      // `comment` is a unified value type and is NOT mapped in
-      // UNIFIED_TO_EXTERNAL_REFERENCE_TYPE_MAP. Even with a string `metadata.soType`
-      // the dispatcher must refuse to mirror `attachmentId` into references.
-      const forged = {
-        type: 'comment',
-        attachmentId: 'attacker-supplied-id',
-        metadata: { soType: 'file', other: 'payload' },
+    it('should mirror attachmentId for any unified attachment carrying metadata.soType', () => {
+      const customSoBackedAttributes = {
+        type: 'custom.so-backed',
+        attachmentId: 'custom-so-id',
+        metadata: { soType: 'custom-so', title: 'Custom saved object' },
         owner: 'securitySolution',
       };
-      const res = extractAttachmentSORefsFromAttributes(forged as never, []);
+      const res = extractAttachmentSORefsFromAttributes(customSoBackedAttributes as never, []);
 
-      expect(res.references).toEqual([]);
+      expect(res.references).toEqual([
+        {
+          id: 'custom-so-id',
+          name: 'attachmentId',
+          type: 'custom-so',
+        },
+      ]);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
@@ -9,7 +9,6 @@ import { isPlainObject } from 'lodash';
 import type { ExternalReferenceSOAttachmentPayload } from '../../common/types/domain';
 import { AttachmentType, ExternalReferenceStorageType } from '../../common/types/domain';
 import type { AttachmentAttributesV2 } from '../../common/types/domain/attachment/v2';
-import { UNIFIED_TO_EXTERNAL_REFERENCE_TYPE_MAP } from '../../common/constants/attachments';
 import type { AttachmentRequestAttributes } from '../common/types/attachments_v1';
 
 /**
@@ -27,16 +26,12 @@ export const isCommentRequestTypeExternalReferenceSO = (
 /**
  * Narrows to a unified attachment backed by a saved object reference.
  *
- * Two gates: (1) the unified `type` is registered in the
- * legacy <-> unified storage map (only registered migrated SO-backed subtypes
- * qualify), and (2) `metadata.soType` is a non-empty string. Per-subtype zod
- * schemas additionally lock `soType` to a literal so a forged value cannot
- * pass write validation.
+ * `metadata.soType` is the SO-backed marker. It's trusted because per-subtype
+ * zod schemas lock it to a literal on write; new SO-backed types just need
+ * such a schema, no server allowlist required.
  *
- * Note: this is intentionally distinct from `isUnifiedReferenceAttachmentRequest`,
- * which also requires `attachmentId` to be present. This guard tolerates a
- * missing `attachmentId` because read paths inspect raw saved-object attributes
- * where `attachmentId` may live only in `references` (self-heal path).
+ * Unlike `isUnifiedReferenceAttachmentRequest`, this tolerates a missing
+ * `attachmentId` since read paths may find it only in `references` (self-heal).
  */
 export const isUnifiedAttachmentWithSoReference = (
   context: Partial<AttachmentAttributesV2> | Record<string, unknown>
@@ -46,8 +41,7 @@ export const isUnifiedAttachmentWithSoReference = (
   metadata: { soType: string } & Record<string, unknown>;
 } & Record<string, unknown> => {
   const ctx = context as Record<string, unknown> | null | undefined;
-  const type = ctx?.type;
-  if (typeof type !== 'string' || UNIFIED_TO_EXTERNAL_REFERENCE_TYPE_MAP[type] == null) {
+  if (typeof ctx?.type !== 'string') {
     return false;
   }
   const metadata = ctx?.metadata;

--- a/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
@@ -14,6 +14,7 @@ import {
   getAttachmentTypeFromAttributes,
   isUnifiedOnlyAttachmentType,
 } from '../../common/utils/attachments';
+import { UNIFIED_TO_EXTERNAL_REFERENCE_TYPE_MAP } from '../../common/constants/attachments';
 
 /**
  * A type narrowing function for external reference saved object attachments.
@@ -56,14 +57,23 @@ export const isUnifiedAttachmentWithSoReference = (
  * True when an attachment *instance* has no legacy (v1) representation and must be
  * persisted/returned in the unified schema. Combines:
  *  - unified-only *types* (e.g. entity/timeline/dashboard) via `isUnifiedOnlyAttachmentType`, and
- *  - unified-only *instances* of hybrid types: an SO-reference attachment
- *    (e.g. Lens-by-reference) has no by-value legacy counterpart even though the
- *    by-value form of the same type does, so a type-only check misclassifies it.
+ *  - unified-only *instances* of hybrid types: a Lens-by-reference attachment has no
+ *    by-value legacy counterpart even though by-value Lens does.
+ *
+ * The SO-reference branch is scoped to types without a legacy externalReference form:
+ * `file`/`endpoint`/`osquery`/`indicator` are SO-backed but map cleanly onto legacy
+ * externalReference, so their by-reference instances are legacy-writeable.
  */
 export const isUnifiedOnlyAttachment = (
   attributes: Partial<AttachmentAttributesV2> | Record<string, unknown>
 ): boolean => {
   const type = getAttachmentTypeFromAttributes(attributes);
   const owner = (attributes as { owner?: string }).owner ?? '';
-  return isUnifiedOnlyAttachmentType(type, owner) || isUnifiedAttachmentWithSoReference(attributes);
+  if (isUnifiedOnlyAttachmentType(type, owner)) {
+    return true;
+  }
+  return (
+    isUnifiedAttachmentWithSoReference(attributes) &&
+    !(type in UNIFIED_TO_EXTERNAL_REFERENCE_TYPE_MAP)
+  );
 };

--- a/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
@@ -67,7 +67,15 @@ export const isUnifiedAttachmentWithSoReference = (
 export const isUnifiedOnlyAttachment = (
   attributes: Partial<AttachmentAttributesV2> | Record<string, unknown>
 ): boolean => {
-  const type = getAttachmentTypeFromAttributes(attributes);
+  let type: string;
+  try {
+    type = getAttachmentTypeFromAttributes(attributes);
+  } catch {
+    // Type can't be resolved (e.g. a malformed request missing `type`). Such payloads
+    // are rejected downstream with a 400, so they are not unified-only here — this runs
+    // on the raw request body before decode, so it must not throw.
+    return false;
+  }
   const owner = (attributes as { owner?: string }).owner ?? '';
   if (isUnifiedOnlyAttachmentType(type, owner)) {
     return true;

--- a/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/type_guards.ts
@@ -10,6 +10,10 @@ import type { ExternalReferenceSOAttachmentPayload } from '../../common/types/do
 import { AttachmentType, ExternalReferenceStorageType } from '../../common/types/domain';
 import type { AttachmentAttributesV2 } from '../../common/types/domain/attachment/v2';
 import type { AttachmentRequestAttributes } from '../common/types/attachments_v1';
+import {
+  getAttachmentTypeFromAttributes,
+  isUnifiedOnlyAttachmentType,
+} from '../../common/utils/attachments';
 
 /**
  * A type narrowing function for external reference saved object attachments.
@@ -46,4 +50,20 @@ export const isUnifiedAttachmentWithSoReference = (
   }
   const metadata = ctx?.metadata;
   return isPlainObject(metadata) && typeof (metadata as { soType?: unknown }).soType === 'string';
+};
+
+/**
+ * True when an attachment *instance* has no legacy (v1) representation and must be
+ * persisted/returned in the unified schema. Combines:
+ *  - unified-only *types* (e.g. entity/timeline/dashboard) via `isUnifiedOnlyAttachmentType`, and
+ *  - unified-only *instances* of hybrid types: an SO-reference attachment
+ *    (e.g. Lens-by-reference) has no by-value legacy counterpart even though the
+ *    by-value form of the same type does, so a type-only check misclassifies it.
+ */
+export const isUnifiedOnlyAttachment = (
+  attributes: Partial<AttachmentAttributesV2> | Record<string, unknown>
+): boolean => {
+  const type = getAttachmentTypeFromAttributes(attributes);
+  const owner = (attributes as { owner?: string }).owner ?? '';
+  return isUnifiedOnlyAttachmentType(type, owner) || isUnifiedAttachmentWithSoReference(attributes);
 };


### PR DESCRIPTION
## Summary

Dependency: https://github.com/elastic/kibana/pull/275117 to be merged first

This PR extends the Cases unified attachment framework to support Lens as both a by-reference (saved object) and by-value (legacy persistable state) attachment, and wires up an "Open in Lens" round trip from the saved object modal.

**Attachment framework / Lens overloading**
- Added Lens as a supported saved object type in the saved object modal.
- Added a new unified attachment type, `hybrid`. Lens is now a hybrid type that accepts both by value (legacy persistable state) and by reference (saved  object id). Also refactored the attachment framework types to be more comprehensible and extracted `defineAttachment` into its own module.
- Extracted the snapshot-fetching/payload-building logic per saved object type (dashboard / map / discover session / lens) into their own builder files.

**"Open in Lens" round trip (saved object modal)**
- In the saved object modal, the Lens row's action is now "Open in Lens" instead of "Attach". It opens the selected Lens visualization in the Lens editor; on "Save and return" the visualization is auto-attached to the case as  reference attachment.
- A pending-attach marker is stored across the app navigation; a render-gated consumer mounted on the case view claims the returning embeddable package and creates the attachment using the current global time range as the snapshot's view time range.
- Gated behind the `xpack.cases.attachments.enabled` feature flag.

Notes:
1. The attachment tab only renders saved object Lens as links in a table; by-value (persistable state) Lens is excluded in this PR.

https://github.com/user-attachments/assets/5bf4dbbf-4fcd-4ad3-b07e-c1df5215eec1




### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
