### PR TITLE
[Lens] Add time range to lens so

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/lens/10.2.0.json
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/lens/10.2.0.json
@@ -1,0 +1,27 @@
+{
+  "10.1.0": [
+    {
+      "TODO": "Please create one or more sample objects with properties that reflect real '[object Object]' objects",
+      "NOTE": "That each modelVersion has a corresponding fixture file, which defines the previous and current versions.",
+      "NOTE2": "These fixtures define the before and after state, and are used for both upgrade and rollback testing.",
+      "HINT": "You can use the template below and create sample objects for 10.1.0 and 10.2.0 versions.",
+      "HINT2": "Alternatively, you can copy the contents from older fixture files (if they exist) and adapt them accordingly.",
+      "IMPORTANT": "The current version fixtures (below) are defining how objects from the previous version fixtures (this array) would look like AFTER upgrading.",
+      "IMPORTANT2": "They are NOT defining random sample objects with properties that are valid for the current model version."
+    }
+  ],
+  "10.2.0": [
+    {
+      "title": "string",
+      "description": "string?|null",
+      "visualizationType": "string?|null",
+      "state": "any?",
+      "version": "number?",
+      "time_range": {
+        "from": "string",
+        "to": "string",
+        "mode": "absolute?|relative?"
+      }
+    }
+  ]
+}

--- a/src/platform/packages/shared/kbn-lens-common/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/types.ts
@@ -428,6 +428,7 @@ export interface LensDocument {
   };
   references: Reference[];
   version?: LENS_ITEM_LATEST_VERSION;
+  time_range?: TimeRange;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { isFilterPinned } from '@kbn/es-query';
+import { isFilterPinned, type TimeRange } from '@kbn/es-query';
 import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { Reference } from '@kbn/content-management-utils';
 import type { ControlPanelsState } from '@kbn/control-group-renderer';
@@ -67,6 +67,7 @@ export type SaveModalContainerProps = {
     | 'userProfile'
     | 'stateTransfer'
     | 'lensDocumentService'
+    | 'data'
   >;
   initialContext?: VisualizeFieldContext | VisualizeEditorContext;
   // is this visualization managed by the system?
@@ -220,9 +221,11 @@ function fromDocumentToSerializedState(
 const getDocToSave = (
   lastKnownDoc: LensDocument,
   saveProps: SaveProps,
-  references: Reference[]
+  references: Reference[],
+  currentTimeRange: TimeRange | undefined,
+  saveToLibrary: boolean
 ): LensDocument => {
-  const docToSave = {
+  const docToSave: LensDocument = {
     ...removePinnedFilters(lastKnownDoc)!,
     references,
   };
@@ -233,6 +236,12 @@ const getDocToSave = (
 
   if (saveProps.newTitle !== undefined) {
     docToSave.title = saveProps.newTitle;
+  }
+
+  // Persist the current view time range when saving to the library so the SO
+  // can be opened (or referenced from Cases) with its intended window.
+  if (saveToLibrary && currentTimeRange) {
+    docToSave.time_range = currentTimeRange;
   }
 
   return docToSave;
@@ -261,6 +270,7 @@ export type SaveVisualizationProps = Simplify<
       | 'stateTransfer'
       | 'attributeService'
       | 'savedObjectsTagging'
+      | 'data'
     >
 >;
 
@@ -285,6 +295,7 @@ export const runSaveLensVisualization = async (
     switchDatasource,
     application,
     controlsState,
+    data,
   } = props;
 
   if (!lastKnownDoc) {
@@ -304,7 +315,14 @@ export const runSaveLensVisualization = async (
     );
   }
 
-  const docToSave = getDocToSave(lastKnownDoc, saveProps, references);
+  const currentTimeRange = data.query.timefilter.timefilter.getTime();
+  const docToSave = getDocToSave(
+    lastKnownDoc,
+    saveProps,
+    references,
+    currentTimeRange,
+    options.saveToLibrary
+  );
 
   const originalInput = saveProps.newCopyOnSave ? undefined : initialInput;
   const originalSavedObjectId = originalInput?.ref_id;

--- a/x-pack/platform/plugins/shared/lens/public/persistence/lens_client.ts
+++ b/x-pack/platform/plugins/shared/lens/public/persistence/lens_client.ts
@@ -87,7 +87,7 @@ export class LensClient {
   }
 
   async create(
-    { description, visualizationType, state, title, version }: LooseLensAttributes,
+    { description, visualizationType, state, title, version, time_range }: LooseLensAttributes,
     references: Reference[]
   ): Promise<LensItemResponse> {
     if (visualizationType === null) {
@@ -111,6 +111,7 @@ export class LensClient {
             state,
             title,
             version,
+            time_range,
             references,
           };
 
@@ -150,7 +151,7 @@ export class LensClient {
 
   async update(
     id: string,
-    { description, visualizationType, state, title, version }: LooseLensAttributes,
+    { description, visualizationType, state, title, version, time_range }: LooseLensAttributes,
     references: Reference[],
     options: LensUpdateRequestQuery = {}
   ): Promise<LensItemResponse> {
@@ -175,6 +176,7 @@ export class LensClient {
             state,
             title,
             version,
+            time_range,
             references,
           };
 

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -252,11 +252,20 @@ async function loadFromSavedObject(
   autoApplyDisabled: boolean,
   inlineEditing?: boolean,
   projectRouting?: ProjectRouting,
-  hideTextBasedEditor?: boolean
+  hideTextBasedEditor?: boolean,
+  skipTimeRangeRestore?: boolean
 ) {
   const { doc, sharingSavedObjectProps, managed } = persisted;
   if (savedObjectId) {
     chrome.recentlyAccessed.add(getFullPath(savedObjectId), doc.title, savedObjectId);
+  }
+
+  // Apply the time range captured at save time so the editor opens with the
+  // window the visualization was authored against. Skipped when an explicit
+  // time range arrived from the URL/locator (handled by the caller) or when
+  // the editor is embedded (parent container owns the time range).
+  if (doc.time_range && !inlineEditing && !skipTimeRangeRestore) {
+    data.query.timefilter.timefilter.setTime(doc.time_range);
   }
 
   const docDatasourceStates = Object.entries(doc.state.datasourceStates).reduce(
@@ -456,6 +465,9 @@ export async function loadInitial(
     const persisted = await getFromPreloaded({ initialInput, lensServices, history });
     if (persisted) {
       try {
+        // An explicit time range coming in via the URL locator should win over
+        // the SO-saved one; the locator branch above already set the timefilter.
+        const skipTimeRangeRestore = Boolean(initialStateFromLocator?.resolvedDateRange);
         return loadFromSavedObject(
           store,
           initialInput.ref_id,
@@ -465,7 +477,8 @@ export async function loadInitial(
           autoApplyDisabled,
           inlineEditing,
           projectRouting,
-          hideTextBasedEditor
+          hideTextBasedEditor,
+          skipTimeRangeRestore
         );
       } catch ({ message }) {
         notifications.toasts.addDanger({

--- a/x-pack/platform/plugins/shared/lens/server/content_management/lens_storage.ts
+++ b/x-pack/platform/plugins/shared/lens/server/content_management/lens_storage.ts
@@ -70,6 +70,7 @@ export class LensStorage extends SOContentStorage<LensCrud> {
         'visualizationType',
         'version',
         'state',
+        'time_range',
       ],
       logger: params.logger,
       throwOnResultValidationError: params.throwOnResultValidationError,

--- a/x-pack/platform/plugins/shared/lens/server/content_management/schema/versioned.ts
+++ b/x-pack/platform/plugins/shared/lens/server/content_management/schema/versioned.ts
@@ -10,6 +10,12 @@ import { savedObjectSchema } from '@kbn/content-management-utils';
 
 import { pickFromObjectSchema } from '../../utils';
 
+const lensTimeRangeSchema = schema.object({
+  from: schema.string(),
+  to: schema.string(),
+  mode: schema.maybe(schema.oneOf([schema.literal('absolute'), schema.literal('relative')])),
+});
+
 /**
  * Builds the Lens schema set for a given item version so callers can opt into
  * different version literals without duplicating schema definitions.
@@ -21,6 +27,7 @@ export function createVersionedLensSchemas<Version extends number>(version: Vers
       description: schema.maybe(schema.string()),
       visualizationType: schema.string(),
       state: schema.maybe(schema.any()),
+      time_range: schema.maybe(lensTimeRangeSchema),
       // TODO make version required
       version: schema.maybe(schema.literal(version)), // pin version explicitly
     },

--- a/x-pack/platform/plugins/shared/lens/server/saved_objects.ts
+++ b/x-pack/platform/plugins/shared/lens/server/saved_objects.ts
@@ -30,6 +30,23 @@ const lensSOSchemaV1 = lensItemAttributesSchemaV0.extends(
   { unknowns: 'forbid' }
 );
 
+/**
+ * Adds the optional `time_range` attribute persisted alongside the
+ * visualization. Stored shape mirrors `TimeRange` from `@kbn/es-query`.
+ */
+const lensSOSchemaV2 = lensSOSchemaV1.extends(
+  {
+    time_range: schema.maybe(
+      schema.object({
+        from: schema.string(),
+        to: schema.string(),
+        mode: schema.maybe(schema.oneOf([schema.literal('absolute'), schema.literal('relative')])),
+      })
+    ),
+  },
+  { unknowns: 'forbid' }
+);
+
 export function setupSavedObjects(
   core: CoreSetup,
   getFilterMigrations: () => MigrateFunctionsObject,
@@ -69,6 +86,15 @@ export function setupSavedObjects(
         schemas: {
           forwardCompatibility: lensSOSchemaV1.extendsDeep({ unknowns: 'ignore' }),
           create: lensSOSchemaV1,
+        },
+      },
+      [2]: {
+        // No mapping change needed: the SO mapping is `dynamic: false`, so the
+        // optional `time_range` attribute is stored in `_source` only.
+        changes: [],
+        schemas: {
+          forwardCompatibility: lensSOSchemaV2.extendsDeep({ unknowns: 'ignore' }),
+          create: lensSOSchemaV2,
         },
       },
     },


### PR DESCRIPTION
## Summary

This PR adds time range to be persisted in the lens SO

Before: upon saving a visualization, the time range is not saved in the SO, changing the time range filter in another lens will change the time range for a previously accessed viz.

https://github.com/user-attachments/assets/e0875891-e69b-42fd-958f-c2bdad6b377c

After: time range is persisted at the time of saving a lens visualization, accessing a viz in different time range does not impact a previously saved one

https://github.com/user-attachments/assets/2763bf47-8def-4c1c-8a72-fdc72de1bd74


### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

