### PR TITLE
[Cases] Add auto extract observables in add 

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/add.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/add.ts
@@ -18,7 +18,9 @@ import { Operations } from '../../authorization';
 import type { AddArgs } from './types';
 import { validateRegisteredAttachments } from './validators';
 import { validateMaxUserActions } from '../../common/validators';
+import { extractAndAddObservables } from './extract_observables';
 import { emitAttachmentsAddedEvent } from './trigger_utils';
+
 /**
  * Create an attachment to a case.
  *
@@ -76,6 +78,9 @@ export const addComment = async (addArgs: AddArgs, clientArgs: CasesClientArgs):
     const updatedCase = await updatedModel.encodeWithComments({ mode });
 
     emitAttachmentsAddedEvent(clientArgs, updatedCase, [savedObjectID], query.type);
+
+    // This call never throws — failures are logged and do not abort the attachment creation.
+    await extractAndAddObservables(caseId, [comment], updatedCase, clientArgs);
 
     return updatedCase;
   } catch (error) {


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/273455, adding auto extraction to `add` so that alerts added via `/api/cases/{caseId}/comments` has auto extraction kicked in.

How to test:
- Create a case and generate some alerts
- Attach alerts via comments api, observables should be added 

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->