### PR TITLE
[Discover][Traces] Remove syncTooltips in traces RED metrics charts

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/error_rate.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/error_rate.tsx
@@ -84,7 +84,6 @@ const ErrorRateChartContent = ({
       chartLayers={chartLayers}
       legend={breakdownField ? BREAKDOWN_LEGEND_CONFIG : undefined}
       syncCursor
-      syncTooltips
       yBounds={ERROR_RATE_Y_BOUNDS}
       extraDisabledActions={[ACTION_OPEN_IN_DISCOVER]}
       profileId={profileId}

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/latency.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/latency.tsx
@@ -57,7 +57,6 @@ const LatencyChartContent = ({ esqlQuery, seriesType, color, title }: LatencyCha
       chartLayers={chartLayers}
       legend={breakdownField ? BREAKDOWN_LEGEND_CONFIG : undefined}
       syncCursor
-      syncTooltips
       extraDisabledActions={[ACTION_OPEN_IN_DISCOVER]}
       profileId={profileId}
     />

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/throughput.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/throughput.tsx
@@ -63,7 +63,6 @@ const ThroughputChartContent = ({
       title={title}
       chartLayers={chartLayers}
       legend={breakdownField ? BREAKDOWN_LEGEND_CONFIG : undefined}
-      syncTooltips
       syncCursor
       extraDisabledActions={[ACTION_OPEN_IN_DISCOVER]}
       profileId={profileId}


### PR DESCRIPTION
## Summary

Remove `syncTooltips` from the three RED metrics charts (latency, error rate, throughput) in Discover's traces profile.

With tooltip sync enabled, hovering over any chart causes a tooltip to appear on the other two, showing series names and colors from a different metric. 

This can create a sense of visual overload when hovering over the charts, so we decided to only display the tooltip on the chart that is currently being hovered.


|Before|After|
|-|-|
|<img width="1919" height="968" alt="Screenshot 2026-06-25 at 00 54 13" src="https://github.com/user-attachments/assets/29e3cd59-1c60-45f5-9380-271d0144aebd" />|<img width="1918" height="969" alt="Screenshot 2026-06-25 at 00 54 34" src="https://github.com/user-attachments/assets/b6d24437-4b07-4368-a134-43aa0e7bcf58" />|
