### PR TITLE
[ci] Disable auto-commit on stacked PRs

### DIFF
--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -24,7 +24,47 @@ is_pr_with_label() {
 }
 
 is_auto_commit_disabled() {
-  is_pr_with_label "ci:no-auto-commit"
+  is_pr_with_label "ci:no-auto-commit" || is_stacked_pr
+}
+
+# True when the current PR belongs to a GitHub Stacked PR set of 2+ (as created
+# by `gh stack submit`/`gh stack link`). CI auto-fix commits are not cascaded up
+# a stack, so committing to one branch desyncs every branch above it; we disable
+# auto-commit for stacks and let the check fail with the command to run locally.
+#
+# Read at build time from GitHub's native stack metadata so it is correct even
+# when the PR was created ready-for-review (no draft window for a labeler to win).
+# Fails open (treats the PR as non-stacked) on any error, preserving the default
+# auto-commit behavior for the common single-PR case. Cached per build since
+# every auto-fix step calls this.
+is_stacked_pr() {
+  is_pr || return 1
+
+  local cached=""
+  if command -v buildkite-agent >/dev/null 2>&1; then
+    cached="$(buildkite-agent meta-data get is_stacked_pr --default "" 2>/dev/null || true)"
+  fi
+  if [[ -z "$cached" ]]; then
+    cached="false"
+    local token="${GITHUB_TOKEN:-${VAULT_GITHUB_TOKEN:-}}"
+    if [[ -n "$token" && -n "${GITHUB_PR_BASE_OWNER:-}" && -n "${GITHUB_PR_BASE_REPO:-}" ]] && command -v gh >/dev/null 2>&1; then
+      local size
+      size="$(GH_TOKEN="$token" gh api graphql \
+        -f owner="$GITHUB_PR_BASE_OWNER" \
+        -f repo="$GITHUB_PR_BASE_REPO" \
+        -F number="$GITHUB_PR_NUMBER" \
+        -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { stack { size } } } }' \
+        --jq '.data.repository.pullRequest.stack.size // 0' 2>/dev/null || echo 0)"
+      if [[ "$size" =~ ^[0-9]+$ && "$size" -ge 2 ]]; then
+        cached="true"
+      fi
+    fi
+    if command -v buildkite-agent >/dev/null 2>&1; then
+      buildkite-agent meta-data set is_stacked_pr "$cached" 2>/dev/null || true
+    fi
+  fi
+
+  [[ "$cached" == "true" ]]
 }
 
 should_enable_fips() {

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -32,11 +32,11 @@ is_auto_commit_disabled() {
 # a stack, so committing to one branch desyncs every branch above it; we disable
 # auto-commit for stacks and let the check fail with the command to run locally.
 #
-# Read at build time from GitHub's native stack metadata so it is correct even
-# when the PR was created ready-for-review (no draft window for a labeler to win).
-# Fails open (treats the PR as non-stacked) on any error, preserving the default
-# auto-commit behavior for the common single-PR case. Cached per build since
-# every auto-fix step calls this.
+# Cached per build since every auto-fix step calls this, but only a *confident*
+# determination is cached: either the `gh` query succeeded, or there is no way to
+# query at all (no token/`gh`), which is stable for the whole build. A transient
+# query failure is left uncached so a later step retries, rather than poisoning
+# the whole build with a spurious "not a stack" that would re-enable auto-commit.
 is_stacked_pr() {
   is_pr || return 1
 
@@ -44,27 +44,35 @@ is_stacked_pr() {
   if command -v buildkite-agent >/dev/null 2>&1; then
     cached="$(buildkite-agent meta-data get is_stacked_pr --default "" 2>/dev/null || true)"
   fi
-  if [[ -z "$cached" ]]; then
-    cached="false"
-    local token="${GITHUB_TOKEN:-${VAULT_GITHUB_TOKEN:-}}"
-    if [[ -n "$token" && -n "${GITHUB_PR_BASE_OWNER:-}" && -n "${GITHUB_PR_BASE_REPO:-}" ]] && command -v gh >/dev/null 2>&1; then
-      local size
-      size="$(GH_TOKEN="$token" gh api graphql \
-        -f owner="$GITHUB_PR_BASE_OWNER" \
-        -f repo="$GITHUB_PR_BASE_REPO" \
-        -F number="$GITHUB_PR_NUMBER" \
-        -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { stack { size } } } }' \
-        --jq '.data.repository.pullRequest.stack.size // 0' 2>/dev/null || echo 0)"
+  if [[ -n "$cached" ]]; then
+    [[ "$cached" == "true" ]]
+    return
+  fi
+
+  local determined="" result="false"
+  local token="${GITHUB_TOKEN:-${VAULT_GITHUB_TOKEN:-}}"
+  if [[ -z "$token" || -z "${GITHUB_PR_BASE_OWNER:-}" || -z "${GITHUB_PR_BASE_REPO:-}" ]] || ! command -v gh >/dev/null 2>&1; then
+    determined="true"
+  else
+    local size
+    if size="$(GH_TOKEN="$token" gh api graphql \
+      -f owner="$GITHUB_PR_BASE_OWNER" \
+      -f repo="$GITHUB_PR_BASE_REPO" \
+      -F number="$GITHUB_PR_NUMBER" \
+      -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { stack { size } } } }' \
+      --jq '.data.repository.pullRequest.stack.size // 0' 2>/dev/null)"; then
+      determined="true"
       if [[ "$size" =~ ^[0-9]+$ && "$size" -ge 2 ]]; then
-        cached="true"
+        result="true"
       fi
-    fi
-    if command -v buildkite-agent >/dev/null 2>&1; then
-      buildkite-agent meta-data set is_stacked_pr "$cached" 2>/dev/null || true
     fi
   fi
 
-  [[ "$cached" == "true" ]]
+  if [[ "$determined" == "true" ]] && command -v buildkite-agent >/dev/null 2>&1; then
+    buildkite-agent meta-data set is_stacked_pr "$result" 2>/dev/null || true
+  fi
+
+  [[ "$result" == "true" ]]
 }
 
 should_enable_fips() {


### PR DESCRIPTION
## Summary

CI's auto-fix steps push lint/type/i18n fixes back onto the PR branch (`check_for_changed_files` in `.buildkite/scripts/common/util.sh`). On a [GitHub stacked PR](https://docs.github.com/en/pull-requests) that commit lands on a single branch and is never cascaded upward, which desyncs every branch above it and produces bogus "revert" diffs on the rest of the stack.

This disables auto-commit for stacked PRs and falls back to the existing behavior of failing the check and printing the command to run locally — the same thing the `ci:no-auto-commit` label already does.

## What changed

`is_auto_commit_disabled` now also returns true when the PR belongs to a stack:

- Membership is read at **build time** from GitHub's native `PullRequest.stack { size }` metadata (a size of 2+ means it's a stack). No topology guessing, no false positives on plain dependent branches.
- Reading it at build time is **race-free** even with `gh stack submit --open` (create-as-ready). A labeler GitHub Action can't reliably win that race because there's no draft window before the first build is triggered; the build-time check has no such window to lose.
- **Fails open**: any error, missing token, or non-stack PR keeps today's auto-commit behavior, so the common single-PR case is unaffected.
- The result is cached in build meta-data since every auto-fix step consults `is_auto_commit_disabled`.
- The `ci:no-auto-commit` label still works as a manual override.

## Other approaches considered

- I briefly toyed with adding the `ci:no-auto-commit` label if the PR was part of a stack, but ran into a race condition: the first build would already have started before that label could be guaranteed to be applied.

## Test plan

- [ ] Open a stacked PR (`gh stack submit`, with and without `--open`), introduce a lint-fixable change, and confirm CI fails the check with the local-fix instructions instead of pushing an auto-commit.
- [ ] Open a normal single PR with a lint-fixable change and confirm CI still auto-commits as before.
- [ ] Confirm a PR with the `ci:no-auto-commit` label still skips auto-commit.

Verified the GraphQL probe locally: a stacked PR returns `stack.size` of `4`; a standalone PR returns `0`.