### PR TITLE
[SIEM Readiness] Volume drop and Silence Columns on Table in Continuity tab

### DIFF
--- a/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/get_pipeline_data_flow_health.test.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/get_pipeline_data_flow_health.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PipelineStats } from '../types';
+import { VOLUME_DROP_CRITICAL_PCT, VOLUME_DROP_WARNING_PCT } from '../constants';
+import { getContinuityDataFlowHealth } from './get_pipeline_data_flow_health';
+
+const makePipeline = (overrides: Partial<PipelineStats> = {}): PipelineStats => ({
+  name: 'test-pipeline',
+  indices: ['logs-test-default'],
+  docsCount: 1000,
+  failedDocsCount: 0,
+  statsAvailable: true,
+  isSilent: false,
+  silenceMs: null,
+  volumeDropPct: null,
+  lastEventMs: null,
+  lastFullDayDocs: null,
+  baseline7dAvg: null,
+  ...overrides,
+});
+
+describe('getContinuityDataFlowHealth', () => {
+  describe('healthy baseline', () => {
+    it('returns healthy when not silent and no volume drop', () => {
+      expect(getContinuityDataFlowHealth(makePipeline({ volumeDropPct: 0 }))).toBe('healthy');
+    });
+
+    it('returns healthy when volumeDropPct is null (insufficient history)', () => {
+      expect(getContinuityDataFlowHealth(makePipeline({ volumeDropPct: null }))).toBe('healthy');
+    });
+
+    it('returns healthy when volumeDropPct is below warning threshold', () => {
+      expect(
+        getContinuityDataFlowHealth(makePipeline({ volumeDropPct: VOLUME_DROP_WARNING_PCT - 1 }))
+      ).toBe('healthy');
+    });
+  });
+
+  describe('volume_drop_warning', () => {
+    it('returns volume_drop_warning at exactly the warning threshold', () => {
+      expect(
+        getContinuityDataFlowHealth(makePipeline({ volumeDropPct: VOLUME_DROP_WARNING_PCT }))
+      ).toBe('volume_drop_warning');
+    });
+
+    it('returns volume_drop_warning when above warning but below critical', () => {
+      expect(
+        getContinuityDataFlowHealth(
+          makePipeline({ volumeDropPct: VOLUME_DROP_CRITICAL_PCT - 1 })
+        )
+      ).toBe('volume_drop_warning');
+    });
+  });
+
+  describe('volume_drop_critical', () => {
+    it('returns volume_drop_critical at exactly the critical threshold', () => {
+      expect(
+        getContinuityDataFlowHealth(makePipeline({ volumeDropPct: VOLUME_DROP_CRITICAL_PCT }))
+      ).toBe('volume_drop_critical');
+    });
+
+    it('returns volume_drop_critical for a 100% drop when not silent', () => {
+      // Parity: a non-silent pipeline with 100% drop is volume_drop_critical, not silent.
+      // This ensures the two checks remain independent and isSilent is required for 'silent'.
+      expect(
+        getContinuityDataFlowHealth(makePipeline({ isSilent: false, volumeDropPct: 100 }))
+      ).toBe('volume_drop_critical');
+    });
+  });
+
+  describe('silent (highest precedence)', () => {
+    it('returns silent when isSilent is true', () => {
+      expect(getContinuityDataFlowHealth(makePipeline({ isSilent: true }))).toBe('silent');
+    });
+
+    it('returns silent even when volumeDropPct is 100 — silence wins', () => {
+      // Parity with get_continuity.ts: when both conditions apply, silence is the primary signal
+      // and the finding includes volume context rather than emitting two separate findings.
+      expect(
+        getContinuityDataFlowHealth(makePipeline({ isSilent: true, volumeDropPct: 100 }))
+      ).toBe('silent');
+    });
+
+    it('returns silent even when volumeDropPct is at the critical threshold', () => {
+      expect(
+        getContinuityDataFlowHealth(
+          makePipeline({ isSilent: true, volumeDropPct: VOLUME_DROP_CRITICAL_PCT })
+        )
+      ).toBe('silent');
+    });
+  });
+
+  describe('precedence order — matches get_continuity.ts if/else chain', () => {
+    // This fixture documents the canonical precedence: silent > critical > warning > healthy.
+    // If get_continuity.ts ever adds a new tier or changes the order, this test should fail
+    // to prompt updating getContinuityDataFlowHealth alongside it.
+    const PRECEDENCE_FIXTURES: Array<[Partial<PipelineStats>, string]> = [
+      [{ isSilent: true, volumeDropPct: 100 }, 'silent'],
+      [{ isSilent: false, volumeDropPct: 100 }, 'volume_drop_critical'],
+      [{ isSilent: false, volumeDropPct: VOLUME_DROP_CRITICAL_PCT }, 'volume_drop_critical'],
+      [{ isSilent: false, volumeDropPct: VOLUME_DROP_WARNING_PCT }, 'volume_drop_warning'],
+      [{ isSilent: false, volumeDropPct: VOLUME_DROP_WARNING_PCT - 1 }, 'healthy'],
+      [{ isSilent: false, volumeDropPct: null }, 'healthy'],
+    ];
+
+    PRECEDENCE_FIXTURES.forEach(([input, expected]) => {
+      it(`${JSON.stringify(input)} → '${expected}'`, () => {
+        expect(getContinuityDataFlowHealth(makePipeline(input))).toBe(expected);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/get_pipeline_data_flow_health.test.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/get_pipeline_data_flow_health.test.ts
@@ -50,9 +50,7 @@ describe('getContinuityDataFlowHealth', () => {
 
     it('returns volume_drop_warning when above warning but below critical', () => {
       expect(
-        getContinuityDataFlowHealth(
-          makePipeline({ volumeDropPct: VOLUME_DROP_CRITICAL_PCT - 1 })
-        )
+        getContinuityDataFlowHealth(makePipeline({ volumeDropPct: VOLUME_DROP_CRITICAL_PCT - 1 }))
       ).toBe('volume_drop_warning');
     });
   });

--- a/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/get_pipeline_data_flow_health.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/get_pipeline_data_flow_health.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PipelineStats } from '../types';
+import { VOLUME_DROP_CRITICAL_PCT, VOLUME_DROP_WARNING_PCT } from '../constants';
+
+/**
+ * Represents the data-flow health state of a pipeline, in descending severity order.
+ *
+ * Silence takes precedence over volume drop: a pipeline that is both silent and has a
+ * 100% volume drop is classified as 'silent'. This mirrors the finding-merge logic in
+ * get_continuity.ts so the UI badge and the server finding always agree.
+ */
+export type PipelineDataFlowHealth =
+  | 'silent'
+  | 'volume_drop_critical'
+  | 'volume_drop_warning'
+  | 'healthy';
+
+/**
+ * Classifies a pipeline into a data-flow health state using the canonical precedence:
+ *   silent > volume_drop_critical > volume_drop_warning > healthy
+ *
+ * This is the single source of truth shared by:
+ *   - the UI continuity tab badge column (continuity_tab.tsx)
+ *   - the server-side finding classifier (get_continuity.ts)
+ *
+ * Keeping the logic here ensures both consumers always agree when precedence or thresholds change.
+ */
+export const getContinuityDataFlowHealth = (p: PipelineStats): PipelineDataFlowHealth => {
+  if (p.isSilent) return 'silent';
+  if (p.volumeDropPct != null && p.volumeDropPct >= VOLUME_DROP_CRITICAL_PCT) {
+    return 'volume_drop_critical';
+  }
+  if (p.volumeDropPct != null && p.volumeDropPct >= VOLUME_DROP_WARNING_PCT) {
+    return 'volume_drop_warning';
+  }
+  return 'healthy';
+};

--- a/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/index.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/get_siem_readiness_statuses/index.ts
@@ -15,3 +15,5 @@ export {
   isRetentionNonCompliant,
   hasMissingIntegrations,
 } from './status_check_helpers';
+export { getContinuityDataFlowHealth } from './get_pipeline_data_flow_health';
+export type { PipelineDataFlowHealth } from './get_pipeline_data_flow_health';

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
@@ -15,11 +15,17 @@ import {
   EuiText,
   EuiButtonEmpty,
   EuiCallOut,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { MainCategories, PipelineStats } from '@kbn/siem-readiness';
-import { CATEGORY_ORDER, filterPipelinesByCategories } from '@kbn/siem-readiness';
+import {
+  CATEGORY_ORDER,
+  filterPipelinesByCategories,
+  VOLUME_DROP_WARNING_PCT,
+  VOLUME_DROP_CRITICAL_PCT,
+} from '@kbn/siem-readiness';
 import { useSiemReadinessApi } from '../../../hooks/use_siem_readiness_api';
 import {
   CategoryAccordionTable,
@@ -43,13 +49,32 @@ import { SIEM_READINESS_ACCORDIONS_STORAGE_KEY } from '../../../constants';
 
 const DATA_CONTINUITY_CASE_TAGS = ['siem-readiness', 'data-continuity', 'ingest-pipelines'];
 
+type ContinuityDataFlowHealth =
+  | 'silent'
+  | 'volume_drop_critical'
+  | 'volume_drop_warning'
+  | 'healthy';
+
 export interface PipelineInfoWithStatus extends PipelineStats, Record<string, unknown> {
   failureRate: string;
   status: 'healthy' | 'critical';
+  continuityDataFlowHealth: ContinuityDataFlowHealth;
 }
 
 const getDocInjectionStatus = (failureRate: string): 'healthy' | 'critical' => {
   return isCriticalFailureRateFromString(failureRate) ? 'critical' : 'healthy';
+};
+
+// Silence takes precedence over volume drop, mirroring how get_continuity merges them into one finding.
+const getContinuityDataFlowHealth = (p: PipelineStats): ContinuityDataFlowHealth => {
+  if (p.isSilent) return 'silent';
+  if (p.volumeDropPct != null && p.volumeDropPct >= VOLUME_DROP_CRITICAL_PCT) {
+    return 'volume_drop_critical';
+  }
+  if (p.volumeDropPct != null && p.volumeDropPct >= VOLUME_DROP_WARNING_PCT) {
+    return 'volume_drop_warning';
+  }
+  return 'healthy';
 };
 
 export const getIngestPipelineUrl = (basePath: string, pipelineName: string): string => {
@@ -105,6 +130,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
         ...pipeline,
         failureRate,
         status: getDocInjectionStatus(failureRate),
+        continuityDataFlowHealth: getContinuityDataFlowHealth(pipeline),
       };
 
       const pipelineCategories = new Set<MainCategories>();
@@ -163,7 +189,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
         }),
         sortable: true,
         truncateText: true,
-        width: statsAvailable ? '30%' : '70%',
+        width: statsAvailable ? '25%' : '70%',
       },
       ...(statsAvailable
         ? [
@@ -175,7 +201,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
               ),
               sortable: true,
               render: (docsCount: number) => docsCount.toLocaleString(),
-              width: '20%',
+              width: '15%',
             } as EuiBasicTableColumn<PipelineInfoWithStatus>,
             {
               field: 'failedDocsCount',
@@ -185,7 +211,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
               ),
               sortable: true,
               render: (failedDocsCount: number) => failedDocsCount.toLocaleString(),
-              width: '15%',
+              width: '12%',
             } as EuiBasicTableColumn<PipelineInfoWithStatus>,
             {
               field: 'failureRate',
@@ -195,7 +221,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
               ),
               sortable: true,
               render: (failureRate: string) => `${failureRate}%`,
-              width: '15%',
+              width: '13%',
             } as EuiBasicTableColumn<PipelineInfoWithStatus>,
             {
               field: 'failureRate',
@@ -216,6 +242,68 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
                           'xpack.securitySolution.siemReadiness.continuity.status.healthy',
                           { defaultMessage: 'Healthy' }
                         )}
+                  </EuiBadge>
+                );
+              },
+              width: '15%',
+            } as EuiBasicTableColumn<PipelineInfoWithStatus>,
+            {
+              field: 'continuityDataFlowHealth',
+              name: i18n.translate('xpack.securitySolution.siemReadiness.continuity.column.issue', {
+                defaultMessage: 'Issue',
+              }),
+              sortable: true,
+              render: (
+                continuityDataFlowHealth: ContinuityDataFlowHealth,
+                item: PipelineInfoWithStatus
+              ) => {
+                if (continuityDataFlowHealth === 'silent') {
+                  const tooltip =
+                    item.silenceMs != null
+                      ? i18n.translate(
+                          'xpack.securitySolution.siemReadiness.continuity.health.silentTooltip',
+                          {
+                            defaultMessage: 'No events received for {hours}h',
+                            values: { hours: Math.round(item.silenceMs / (60 * 60 * 1000)) },
+                          }
+                        )
+                      : undefined;
+                  const badge = (
+                    <EuiBadge color="danger">
+                      {i18n.translate(
+                        'xpack.securitySolution.siemReadiness.continuity.health.silent',
+                        { defaultMessage: 'Silent' }
+                      )}
+                    </EuiBadge>
+                  );
+                  return tooltip ? <EuiToolTip content={tooltip}>{badge}</EuiToolTip> : badge;
+                }
+                if (continuityDataFlowHealth === 'volume_drop_critical') {
+                  return (
+                    <EuiBadge color="danger">
+                      {i18n.translate(
+                        'xpack.securitySolution.siemReadiness.continuity.health.volumeDropCritical',
+                        { defaultMessage: 'Volume drop (critical)' }
+                      )}
+                    </EuiBadge>
+                  );
+                }
+                if (continuityDataFlowHealth === 'volume_drop_warning') {
+                  return (
+                    <EuiBadge color="warning">
+                      {i18n.translate(
+                        'xpack.securitySolution.siemReadiness.continuity.health.volumeDrop',
+                        { defaultMessage: 'Volume drop' }
+                      )}
+                    </EuiBadge>
+                  );
+                }
+                return (
+                  <EuiBadge color="success">
+                    {i18n.translate(
+                      'xpack.securitySolution.siemReadiness.continuity.health.healthy',
+                      { defaultMessage: 'Healthy' }
+                    )}
                   </EuiBadge>
                 );
               },

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
@@ -19,12 +19,11 @@ import {
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { MainCategories, PipelineStats } from '@kbn/siem-readiness';
+import type { MainCategories, PipelineDataFlowHealth, PipelineStats } from '@kbn/siem-readiness';
 import {
   CATEGORY_ORDER,
   filterPipelinesByCategories,
-  VOLUME_DROP_WARNING_PCT,
-  VOLUME_DROP_CRITICAL_PCT,
+  getContinuityDataFlowHealth,
 } from '@kbn/siem-readiness';
 import { useSiemReadinessApi } from '../../../hooks/use_siem_readiness_api';
 import {
@@ -49,32 +48,14 @@ import { SIEM_READINESS_ACCORDIONS_STORAGE_KEY } from '../../../constants';
 
 const DATA_CONTINUITY_CASE_TAGS = ['siem-readiness', 'data-continuity', 'ingest-pipelines'];
 
-type ContinuityDataFlowHealth =
-  | 'silent'
-  | 'volume_drop_critical'
-  | 'volume_drop_warning'
-  | 'healthy';
-
 export interface PipelineInfoWithStatus extends PipelineStats, Record<string, unknown> {
   failureRate: string;
   status: 'healthy' | 'critical';
-  continuityDataFlowHealth: ContinuityDataFlowHealth;
+  continuityDataFlowHealth: PipelineDataFlowHealth;
 }
 
 const getDocInjectionStatus = (failureRate: string): 'healthy' | 'critical' => {
   return isCriticalFailureRateFromString(failureRate) ? 'critical' : 'healthy';
-};
-
-// Silence takes precedence over volume drop, mirroring how get_continuity merges them into one finding.
-const getContinuityDataFlowHealth = (p: PipelineStats): ContinuityDataFlowHealth => {
-  if (p.isSilent) return 'silent';
-  if (p.volumeDropPct != null && p.volumeDropPct >= VOLUME_DROP_CRITICAL_PCT) {
-    return 'volume_drop_critical';
-  }
-  if (p.volumeDropPct != null && p.volumeDropPct >= VOLUME_DROP_WARNING_PCT) {
-    return 'volume_drop_warning';
-  }
-  return 'healthy';
 };
 
 export const getIngestPipelineUrl = (basePath: string, pipelineName: string): string => {
@@ -254,7 +235,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
               }),
               sortable: true,
               render: (
-                continuityDataFlowHealth: ContinuityDataFlowHealth,
+                continuityDataFlowHealth: PipelineDataFlowHealth,
                 item: PipelineInfoWithStatus
               ) => {
                 if (continuityDataFlowHealth === 'silent') {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/dimensions/get_continuity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/dimensions/get_continuity.ts
@@ -8,11 +8,7 @@
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import type { ActionableFinding, CategoriesResponse, ContinuityPayload } from '@kbn/siem-readiness';
-import {
-  isCriticalFailureRate,
-  VOLUME_DROP_WARNING_PCT,
-  VOLUME_DROP_CRITICAL_PCT,
-} from '@kbn/siem-readiness';
+import { getContinuityDataFlowHealth, isCriticalFailureRate } from '@kbn/siem-readiness';
 import { fetchPipelines } from '../fetchers';
 
 export const getContinuity = async ({
@@ -43,17 +39,16 @@ export const getContinuity = async ({
       })
     );
 
-  // silence and volume-drop findings — merged when both apply to the same pipeline
+  // silence and volume-drop findings — merged when both apply to the same pipeline.
+  // getContinuityDataFlowHealth is the shared classifier (from @kbn/siem-readiness) that enforces
+  // the canonical precedence: silent > volume_drop_critical > volume_drop_warning > healthy.
+  // The UI badge column uses the same function so both surfaces always agree.
   pipelines.forEach((p) => {
-    const hasSilence = p.isSilent;
+    const health = getContinuityDataFlowHealth(p);
     const volumeDropPct = p.volumeDropPct ?? null;
-    const isVolumeCritical = volumeDropPct !== null && volumeDropPct >= VOLUME_DROP_CRITICAL_PCT;
-    const isVolumeWarning =
-      volumeDropPct !== null && !isVolumeCritical && volumeDropPct >= VOLUME_DROP_WARNING_PCT;
 
-    if (hasSilence) {
-      // Silence is the primary signal. Include volume context when a baseline exists
-      // so the operator sees both facts in one finding rather than two separate bullets.
+    if (health === 'silent') {
+      // Include volume context when a baseline exists so the operator sees both facts in one finding.
       const volumeContext =
         volumeDropPct !== null && p.baseline7dAvg != null
           ? ` (${volumeDropPct}% volume drop vs ~${Math.round(p.baseline7dAvg)} docs/day baseline)`
@@ -64,7 +59,7 @@ export const getContinuity = async ({
         message: `Data stream serving pipeline ${p.name} has gone silent${volumeContext}`,
         resource: p.name,
       });
-    } else if (isVolumeCritical) {
+    } else if (health === 'volume_drop_critical') {
       const baseline =
         p.baseline7dAvg != null
           ? `~${Math.round(p.baseline7dAvg)} docs/day baseline`
@@ -75,7 +70,7 @@ export const getContinuity = async ({
         message: `Pipeline ${p.name} volume dropped ${volumeDropPct}% vs 7-day (${baseline})`,
         resource: p.name,
       });
-    } else if (isVolumeWarning) {
+    } else if (health === 'volume_drop_warning') {
       const baseline =
         p.baseline7dAvg != null
           ? `~${Math.round(p.baseline7dAvg)} docs/day baseline`


### PR DESCRIPTION
## Summary

This PR adds a column in Table in SIEM Readiness Continuity tab, that shows if data is Silent or experiencing Volume Drop

<img width="1669" height="944" alt="Screenshot 2026-06-24 at 6 08 28 PM" src="https://github.com/user-attachments/assets/347e7569-678d-464b-81ca-9b7eea9324f8" />




