### PR TITLE
[8.19] [Synthetics] Return 404 status code for monitor not found instead of 500 (#238418)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
@@ -15,7 +15,7 @@ import {
   selectEncryptedSyntheticsSavedMonitors,
   selectMonitorListState,
   selectorMonitorDetailsState,
-  selectorError,
+  selectSyntheticsMonitorError,
 } from '../../../state';
 import { useGetUrlParams } from '../../../hooks';
 
@@ -37,7 +37,7 @@ export const useSelectedMonitor = ({
     () => monitorsList.find((monitor) => monitor[ConfigKey.CONFIG_ID] === monitorId) ?? null,
     [monitorId, monitorsList]
   );
-  const error = useSelector(selectorError);
+  const error = useSelector(selectSyntheticsMonitorError);
   const { lastRefresh, refreshInterval } = useSyntheticsRefreshContext();
   const { syntheticsMonitor, syntheticsMonitorLoading, syntheticsMonitorDispatchedAt } =
     useSelector(selectorMonitorDetailsState);

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
@@ -18,6 +18,7 @@ import { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-plugin
 import { withApmSpan } from '@kbn/apm-data-access-plugin/server/utils/with_apm_span';
 import { isEmpty, isEqual } from 'lodash';
 import { Logger } from '@kbn/logging';
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { MONITOR_SEARCH_FIELDS } from '../routes/common';
 import {
   legacyMonitorAttributes,
@@ -63,7 +64,10 @@ export class MonitorConfigRepository {
     ]);
     const resolved = results.saved_objects.find((obj) => obj?.attributes);
     if (!resolved) {
-      throw new Error('Monitor not found');
+      throw SavedObjectsErrorHelpers.createGenericNotFoundError(
+        syntheticsMonitorSavedObjectType,
+        id
+      );
     }
     return resolved;
   }


### PR DESCRIPTION
# Backport

Manual backport of #238418 to `8.19` (auto-backport failed with merge conflicts in Oct 2025).

This will backport the following commits from `main` to `8.19`:
- [[Synthetics] Return 404 status code for monitor not found instead of 500 (#238418)](https://github.com/elastic/kibana/pull/238418)

## Summary

Return HTTP 404 (instead of 500) when a Synthetics monitor saved object is not found, and use the monitor-specific Redux error selector on the monitor details page so not-found responses are handled instead of causing an infinite load loop.

## 8.19 adaptation notes

- Plugin paths on `8.19` match `main`: `x-pack/solutions/observability/plugins/synthetics/`.
- `selectSyntheticsMonitorError` exists on `8.19` and was applied unchanged in `use_selected_monitor.tsx`.
- Cherry-pick conflict in `monitor_config_repository.ts` was limited to imports: kept `8.19`'s value import for `Logger` and added `SavedObjectsErrorHelpers` from `@kbn/core-saved-objects-server`. The not-found throw uses existing in-scope symbols `syntheticsMonitorSavedObjectType` and `id`.

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":238418,"url":"https://github.com/elastic/kibana/pull/238418","title":"[Synthetics] Return 404 status code for monitor not found instead of 500 "},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"sourceCommit":{"sha":"09818f235aa47e1a1228fa6de159eb147f407888"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)