### PR TITLE
[9.1] [Synthetics] Return 404 status code for monitor not found instead of 500 (#238418)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
@@ -15,7 +15,7 @@ import {
   selectEncryptedSyntheticsSavedMonitors,
   selectMonitorListState,
   selectorMonitorDetailsState,
-  selectorError,
+  selectSyntheticsMonitorError,
 } from '../../../state';
 import { useGetUrlParams } from '../../../hooks';
 
@@ -37,7 +37,7 @@ export const useSelectedMonitor = ({
     () => monitorsList.find((monitor) => monitor[ConfigKey.CONFIG_ID] === monitorId) ?? null,
     [monitorId, monitorsList]
   );
-  const error = useSelector(selectorError);
+  const error = useSelector(selectSyntheticsMonitorError);
   const { lastRefresh, refreshInterval } = useSyntheticsRefreshContext();
   const { syntheticsMonitor, syntheticsMonitorLoading, syntheticsMonitorDispatchedAt } =
     useSelector(selectorMonitorDetailsState);

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
@@ -18,6 +18,7 @@ import { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-plugin
 import { withApmSpan } from '@kbn/apm-data-access-plugin/server/utils/with_apm_span';
 import { isEmpty, isEqual } from 'lodash';
 import { Logger } from '@kbn/logging';
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { MONITOR_SEARCH_FIELDS } from '../routes/common';
 import {
   legacyMonitorAttributes,
@@ -63,7 +64,10 @@ export class MonitorConfigRepository {
     ]);
     const resolved = results.saved_objects.find((obj) => obj?.attributes);
     if (!resolved) {
-      throw new Error('Monitor not found');
+      throw SavedObjectsErrorHelpers.createGenericNotFoundError(
+        syntheticsMonitorSavedObjectType,
+        id
+      );
     }
     return resolved;
   }


### PR DESCRIPTION
# Backport

Manual backport of #238418 to `9.1` (auto-backport failed with merge conflicts in Oct 2025).

This will backport the following commits from `main` to `9.1`:
- [[Synthetics] Return 404 status code for monitor not found instead of 500 (#238418)](https://github.com/elastic/kibana/pull/238418)

## Summary

- **Server (`monitor_config_repository.ts`)**: throw `SavedObjectsErrorHelpers.createGenericNotFoundError(syntheticsMonitorSavedObjectType, id)` instead of `new Error('Monitor not found')` so missing monitors return HTTP 404.
- **Public (`use_selected_monitor.tsx`)**: use `selectSyntheticsMonitorError` instead of the generic `selectorError` so 404 responses are handled and the page does not spin indefinitely.

## 9.1 adaptations

- Cherry-pick conflict in `monitor_config_repository.ts` imports only: kept 9.1's value import for `Logger` (`import { Logger } from '@kbn/logging'`) and added the `SavedObjectsErrorHelpers` import; the not-found throw and public selector change applied cleanly otherwise.

> This backport was generated manually after the auto-backport bot failed. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":238418,"url":"https://github.com/elastic/kibana/pull/238418","title":"[Synthetics] Return 404 status code for monitor not found instead of 500 "},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"sourceCommit":{"sha":"09818f235aa47e1a1228fa6de159eb147f407888"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)