### PR TITLE
[Agent Builder] HITL: Add clarification Q&A to the timeline

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/ask_user_question_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/ask_user_question_flyout.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { AskUserQuestionItem, AskUserQuestionAnswer } from '@kbn/agent-builder-common/agents';
+import { QuestionAnswerList } from './question_answer_list';
+
+const flyoutTitle = i18n.translate('xpack.agentBuilder.conversation.askUserQuestionFlyout.title', {
+  defaultMessage: 'Clarification',
+});
+
+interface AskUserQuestionFlyoutProps {
+  isOpen: boolean;
+  onClose: () => void;
+  questions: AskUserQuestionItem[];
+  answers: AskUserQuestionAnswer[];
+}
+
+export const AskUserQuestionFlyout: React.FC<AskUserQuestionFlyoutProps> = ({
+  isOpen,
+  onClose,
+  questions,
+  answers,
+}) => {
+  if (!isOpen) return null;
+
+  const total = questions.length;
+  const answered = answers.filter((a) => !a.skipped).length;
+  const skipped = answers.filter((a) => a.skipped).length;
+
+  const subtitleText = i18n.translate(
+    'xpack.agentBuilder.conversation.askUserQuestionFlyout.subtitle',
+    {
+      defaultMessage: '{total} questions • {answered} answered • {skipped} skipped',
+      values: { total, answered, skipped },
+    }
+  );
+
+  return (
+    <EuiFlyout
+      onClose={onClose}
+      aria-labelledby="askUserQuestionFlyoutTitle"
+      size="m"
+      ownFocus={false}
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id="askUserQuestionFlyoutTitle">{flyoutTitle}</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s" color="subdued">
+          <p>{subtitleText}</p>
+        </EuiText>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <QuestionAnswerList questions={questions} answers={answers} />
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/question_answer_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/question_answer_list.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment } from 'react';
+import { EuiText, EuiTextColor, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { AskUserQuestionItem, AskUserQuestionAnswer } from '@kbn/agent-builder-common/agents';
+
+const customLabel = i18n.translate('xpack.agentBuilder.roundEvents.askUserQuestionStep.custom', {
+  defaultMessage: 'Custom',
+});
+
+const skippedLabel = i18n.translate('xpack.agentBuilder.roundEvents.askUserQuestionStep.skipped', {
+  defaultMessage: 'Skipped',
+});
+
+interface QuestionAnswerListProps {
+  questions: AskUserQuestionItem[];
+  answers: AskUserQuestionAnswer[];
+}
+
+export const QuestionAnswerList: React.FC<QuestionAnswerListProps> = ({ questions, answers }) => (
+  <>
+    {questions.map((q, i) => {
+      const a = answers[i] ?? {};
+      const isSkipped = !!a.skipped;
+      const choiceText = (a.choice ?? []).map((idx) => q.options[idx].label).join(', ');
+      const hasChoice = choiceText.length > 0;
+      const hasCustom = !!a.custom;
+      const isLast = i === questions.length - 1;
+
+      const primaryText = hasChoice ? choiceText : a.custom ?? '';
+
+      return (
+        <Fragment key={i}>
+          <EuiText size="s">
+            <p>
+              <strong>{q.question}</strong>
+            </p>
+          </EuiText>
+          <EuiSpacer size="s" />
+          {isSkipped ? (
+            <EuiText size="s" color="subdued">
+              <p>
+                <em>{skippedLabel}</em>
+              </p>
+            </EuiText>
+          ) : (
+            <EuiText size="s">
+              <p>
+                {primaryText}
+                {hasCustom && (
+                  <EuiTextColor color="subdued">
+                    {' • '}
+                    {customLabel}
+                  </EuiTextColor>
+                )}
+              </p>
+            </EuiText>
+          )}
+          {!isLast && <EuiSpacer size={isSkipped ? 'm' : 'l'} />}
+        </Fragment>
+      );
+    })}
+  </>
+);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/question_answer_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/question_answer_list.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Fragment } from 'react';
-import { EuiText, EuiTextColor, EuiSpacer } from '@elastic/eui';
+import { EuiText, EuiTextColor, EuiSpacer, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { AskUserQuestionItem, AskUserQuestionAnswer } from '@kbn/agent-builder-common/agents';
 
@@ -23,48 +23,51 @@ interface QuestionAnswerListProps {
   answers: AskUserQuestionAnswer[];
 }
 
-export const QuestionAnswerList: React.FC<QuestionAnswerListProps> = ({ questions, answers }) => (
-  <>
-    {questions.map((q, i) => {
-      const a = answers[i] ?? {};
-      const isSkipped = !!a.skipped;
-      const choiceText = (a.choice ?? []).map((idx) => q.options[idx].label).join(', ');
-      const hasChoice = choiceText.length > 0;
-      const hasCustom = !!a.custom;
-      const isLast = i === questions.length - 1;
+export const QuestionAnswerList: React.FC<QuestionAnswerListProps> = ({ questions, answers }) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <>
+      {questions.map((q, i) => {
+        const a = answers[i] ?? {};
+        const isSkipped = !!a.skipped;
+        const choiceText = (a.choice ?? []).map((idx) => q.options[idx].label).join(', ');
+        const hasChoice = choiceText.length > 0;
+        const hasCustom = !!a.custom;
+        const isLast = i === questions.length - 1;
 
-      const primaryText = hasChoice ? choiceText : a.custom ?? '';
+        const primaryText = hasChoice ? choiceText : a.custom ?? '';
 
-      return (
-        <Fragment key={i}>
-          <EuiText size="s">
-            <p>
-              <strong>{q.question}</strong>
-            </p>
-          </EuiText>
-          <EuiSpacer size="s" />
-          {isSkipped ? (
-            <EuiText size="s" color="subdued">
-              <p>
-                <em>{skippedLabel}</em>
-              </p>
-            </EuiText>
-          ) : (
+        return (
+          <Fragment key={i}>
             <EuiText size="s">
               <p>
-                {primaryText}
-                {hasCustom && (
-                  <EuiTextColor color="subdued">
-                    {' • '}
-                    {customLabel}
-                  </EuiTextColor>
-                )}
+                <strong>{q.question}</strong>
               </p>
             </EuiText>
-          )}
-          {!isLast && <EuiSpacer size={isSkipped ? 'm' : 'l'} />}
-        </Fragment>
-      );
-    })}
-  </>
-);
+            <EuiSpacer size="s" />
+            {isSkipped ? (
+              <EuiText size="s" color="subdued">
+                <p>
+                  <em>{skippedLabel}</em>
+                </p>
+              </EuiText>
+            ) : (
+              <EuiText size="s">
+                <p>
+                  {primaryText}
+                  {hasCustom && (
+                    <EuiTextColor color={euiTheme.colors.textDisabled}>
+                      {' • '}
+                      {customLabel}
+                    </EuiTextColor>
+                  )}
+                </p>
+              </EuiText>
+            )}
+            {!isLast && <EuiSpacer size={isSkipped ? 'm' : 'l'} />}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/question_answer_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/flyouts/question_answer_list.tsx
@@ -30,7 +30,10 @@ export const QuestionAnswerList: React.FC<QuestionAnswerListProps> = ({ question
       {questions.map((q, i) => {
         const a = answers[i] ?? {};
         const isSkipped = !!a.skipped;
-        const choiceText = (a.choice ?? []).map((idx) => q.options[idx].label).join(', ');
+        const choiceText = (a.choice ?? [])
+          .map((idx) => q.options[idx]?.label ?? '')
+          .filter(Boolean)
+          .join(', ');
         const hasChoice = choiceText.length > 0;
         const hasCustom = !!a.custom;
         const isLast = i === questions.length - 1;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/group_steps.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/group_steps.test.ts
@@ -272,7 +272,7 @@ describe('groupSteps', () => {
     ]);
   });
 
-  it('does not flush the tool buffer when an AskUserQuestionStep arrives mid-stream between tool calls', () => {
+  it('flushes the tool buffer when an AskUserQuestionStep arrives and renders it as a step', () => {
     const askUserQuestion: AskUserQuestionStep = {
       type: ConversationRoundStepType.askUserQuestion,
       prompt_id: 'prompt-1',
@@ -284,6 +284,10 @@ describe('groupSteps', () => {
 
     const result = groupSteps([a, b, askUserQuestion, c]);
 
-    expect(result).toEqual([{ kind: 'group', steps: [a, b, c] }]);
+    expect(result).toEqual([
+      { kind: 'group', steps: [a, b] },
+      { kind: 'step', step: askUserQuestion, index: 2 },
+      { kind: 'group', steps: [c] },
+    ]);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/group_steps.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/group_steps.ts
@@ -9,11 +9,7 @@ import type {
   ConversationRoundStep,
   ToolCallStep,
 } from '@kbn/agent-builder-common/chat/conversation';
-import {
-  isToolCallStep,
-  isTodosStep,
-  isAskUserQuestionStep,
-} from '@kbn/agent-builder-common/chat/conversation';
+import { isToolCallStep, isTodosStep } from '@kbn/agent-builder-common/chat/conversation';
 
 export type GroupedStep =
   | { kind: 'step'; step: ConversationRoundStep; index: number }
@@ -34,7 +30,7 @@ export const groupSteps = (steps: ConversationRoundStep[]): GroupedStep[] => {
     const step = steps[i];
     if (isToolCallStep(step)) {
       toolBuffer.push(step);
-    } else if (!isTodosStep(step) && !isAskUserQuestionStep(step)) {
+    } else if (!isTodosStep(step)) {
       flushBuffer();
       result.push({ kind: 'step', step, index: i });
     }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/step_item.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/step_item.tsx
@@ -12,6 +12,7 @@ import {
   isToolCallStep,
   isCompactionStep,
   isBackgroundAgentCompleteStep,
+  isAskUserQuestionStep,
 } from '@kbn/agent-builder-common/chat/conversation';
 import type {
   VersionedAttachment,
@@ -21,6 +22,7 @@ import { ReasoningStep } from './steps/reasoning_step';
 import { ToolCallStep } from './steps/tool_call_step';
 import { CompactionStep } from './steps/compaction_step';
 import { BackgroundAgentStep } from './steps/background_agent_step';
+import { AskUserQuestionStepEvent } from './steps/ask_user_question_step';
 
 interface StepItemProps {
   step: ConversationRoundStep;
@@ -57,6 +59,9 @@ export const StepItem: React.FC<StepItemProps> = ({
   }
   if (isBackgroundAgentCompleteStep(step)) {
     return <BackgroundAgentStep step={step} />;
+  }
+  if (isAskUserQuestionStep(step)) {
+    return <AskUserQuestionStepEvent step={step} />;
   }
   return null;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createAskUserQuestionStep } from '@kbn/agent-builder-common/chat/conversation';
+import type { AskUserQuestionAnswer } from '@kbn/agent-builder-common/agents';
+import { AskUserQuestionStepEvent } from './ask_user_question_step';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <I18nProvider>
+      <EuiProvider>{ui}</EuiProvider>
+    </I18nProvider>
+  );
+
+const makeStep = (answers?: AskUserQuestionAnswer[]) =>
+  createAskUserQuestionStep({
+    prompt_id: 'p1',
+    questions: [
+      {
+        question: 'Pick a color',
+        multi_select: false,
+        options: [{ label: 'Red' }, { label: 'Blue' }],
+      },
+      {
+        question: 'Pick sizes',
+        multi_select: true,
+        options: [{ label: 'S' }, { label: 'M' }, { label: 'L' }],
+      },
+      { question: 'Any notes?', multi_select: false, options: [{ label: 'Yes' }, { label: 'No' }] },
+    ],
+    answers,
+  });
+
+describe('AskUserQuestionStepEvent', () => {
+  it('renders "Clarification • 2 answered, 1 skipped" and flyout is not open by default', () => {
+    renderWithProviders(
+      <AskUserQuestionStepEvent
+        step={makeStep([{ choice: [0] }, { choice: [0] }, { skipped: true }])}
+      />
+    );
+    expect(screen.getByText('Clarification • 2 answered, 1 skipped')).toBeInTheDocument();
+    expect(screen.queryByText('Pick a color')).not.toBeInTheDocument();
+  });
+
+  it('returns null when answers are not defined', () => {
+    const { container } = renderWithProviders(
+      <AskUserQuestionStepEvent step={makeStep(undefined)} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('opens flyout on click and shows question text', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AskUserQuestionStepEvent
+        step={makeStep([{ choice: [0] }, { choice: [0, 1] }, { skipped: true }])}
+      />
+    );
+    await user.click(screen.getByText('Clarification • 2 answered, 1 skipped'));
+    expect(screen.getByText('Pick a color')).toBeInTheDocument();
+    expect(screen.getByText('Clarification')).toBeInTheDocument();
+  });
+
+  it('closes flyout when close button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AskUserQuestionStepEvent
+        step={makeStep([{ choice: [0] }, { choice: [0] }, { skipped: true }])}
+      />
+    );
+    await user.click(screen.getByText('Clarification • 2 answered, 1 skipped'));
+    expect(screen.getByText('Pick a color')).toBeInTheDocument();
+    await user.click(screen.getByTestId('euiFlyoutCloseButton'));
+    expect(screen.queryByText('Pick a color')).not.toBeInTheDocument();
+  });
+
+  describe('answer variants (in flyout)', () => {
+    const openFlyout = async (answers: AskUserQuestionAnswer[]) => {
+      const user = userEvent.setup();
+      const skipped = answers.filter((a) => a.skipped).length;
+      const answered = answers.filter((a) => !a.skipped).length;
+      const step = createAskUserQuestionStep({
+        prompt_id: 'p1',
+        questions: [
+          {
+            question: 'Q1',
+            multi_select: false,
+            options: [{ label: 'Opt A' }, { label: 'Opt B' }],
+          },
+        ],
+        answers,
+      });
+      renderWithProviders(<AskUserQuestionStepEvent step={step} />);
+      const label =
+        skipped > 0
+          ? `Clarification • ${answered} answered, ${skipped} skipped`
+          : `Clarification • ${answered} answered`;
+      await user.click(screen.getByText(label));
+      return user;
+    };
+
+    it('choice only — shows option label', async () => {
+      await openFlyout([{ choice: [0] }]);
+      expect(screen.getByText('Opt A')).toBeInTheDocument();
+    });
+
+    it('custom only — shows "Custom" subdued label and typed text', async () => {
+      const user = userEvent.setup();
+      const step = createAskUserQuestionStep({
+        prompt_id: 'p1',
+        questions: [{ question: 'Q1', multi_select: false, options: [{ label: 'Opt A' }] }],
+        answers: [{ custom: 'my answer' }],
+      });
+      renderWithProviders(<AskUserQuestionStepEvent step={step} />);
+      await user.click(screen.getByText('Clarification • 1 answered'));
+      expect(screen.getByText(/Custom/)).toBeInTheDocument();
+      expect(screen.getByText(/my answer/)).toBeInTheDocument();
+    });
+
+    it('choice + custom — shows choice label with "Custom" badge, no separate custom text', async () => {
+      const user = userEvent.setup();
+      const step = createAskUserQuestionStep({
+        prompt_id: 'p1',
+        questions: [
+          { question: 'Q1', multi_select: true, options: [{ label: 'Opt A' }, { label: 'Opt B' }] },
+        ],
+        answers: [{ choice: [0, 1], custom: 'extra' }],
+      });
+      renderWithProviders(<AskUserQuestionStepEvent step={step} />);
+      await user.click(screen.getByText('Clarification • 1 answered'));
+      expect(screen.getByText(/Opt A, Opt B/)).toBeInTheDocument();
+      expect(screen.getByText(/Custom/)).toBeInTheDocument();
+      expect(screen.queryByText('extra')).not.toBeInTheDocument();
+    });
+
+    it('skipped — shows italic "Skipped" below question heading', async () => {
+      await openFlyout([{ skipped: true }]);
+      expect(screen.getByText('Skipped')).toBeInTheDocument();
+    });
+
+    it('all-skipped — shows italic "Skipped" for each question', async () => {
+      const user = userEvent.setup();
+      const step = createAskUserQuestionStep({
+        prompt_id: 'p1',
+        questions: [
+          { question: 'Q1', multi_select: false, options: [{ label: 'A' }] },
+          { question: 'Q2', multi_select: false, options: [{ label: 'B' }] },
+        ],
+        answers: [{ skipped: true }, { skipped: true }],
+      });
+      renderWithProviders(<AskUserQuestionStepEvent step={step} />);
+      await user.click(screen.getByText('Clarification • 0 answered, 2 skipped'));
+      expect(screen.getAllByText('Skipped')).toHaveLength(2);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { AskUserQuestionStep } from '@kbn/agent-builder-common/chat/conversation';
+import { StepLayout } from '../step_layout';
+import { AskUserQuestionFlyout } from '../flyouts/ask_user_question_flyout';
+
+interface AskUserQuestionStepEventProps {
+  step: AskUserQuestionStep;
+}
+
+export const AskUserQuestionStepEvent: React.FC<AskUserQuestionStepEventProps> = ({ step }) => {
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+  const openFlyout = useCallback(() => setIsFlyoutOpen(true), []);
+  const closeFlyout = useCallback(() => setIsFlyoutOpen(false), []);
+
+  if (!step.answers) return null;
+
+  const answered = step.answers.filter((a) => !a.skipped).length;
+  const skipped = step.answers.filter((a) => a.skipped).length;
+
+  const labelText =
+    skipped > 0
+      ? i18n.translate('xpack.agentBuilder.roundEvents.askUserQuestionStep.labelWithSkipped', {
+          defaultMessage: 'Clarification • {answered} answered, {skipped} skipped',
+          values: { answered, skipped },
+        })
+      : i18n.translate('xpack.agentBuilder.roundEvents.askUserQuestionStep.label', {
+          defaultMessage: 'Clarification • {answered} answered',
+          values: { answered },
+        });
+
+  return (
+    <>
+      <StepLayout
+        label={
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="if" size="m" color="inherit" aria-hidden={true} />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText color="inherit">
+                <p>{labelText}</p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        onClick={openFlyout}
+      />
+      <AskUserQuestionFlyout
+        isOpen={isFlyoutOpen}
+        onClose={closeFlyout}
+        questions={step.questions}
+        answers={step.answers}
+      />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_events/steps/ask_user_question_step.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { useBoolean } from '@kbn/react-hooks';
 import type { AskUserQuestionStep } from '@kbn/agent-builder-common/chat/conversation';
 import { StepLayout } from '../step_layout';
 import { AskUserQuestionFlyout } from '../flyouts/ask_user_question_flyout';
@@ -17,9 +18,7 @@ interface AskUserQuestionStepEventProps {
 }
 
 export const AskUserQuestionStepEvent: React.FC<AskUserQuestionStepEventProps> = ({ step }) => {
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
-  const openFlyout = useCallback(() => setIsFlyoutOpen(true), []);
-  const closeFlyout = useCallback(() => setIsFlyoutOpen(false), []);
+  const [isFlyoutOpen, { on: openFlyout, off: closeFlyout }] = useBoolean();
 
   if (!step.answers) return null;
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/chat_message_text.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/chat_message_text.test.tsx
@@ -133,6 +133,7 @@ describe('chat_message_text', () => {
         setTimeToFirstToken: jest.fn(),
         addPendingPrompt: jest.fn(),
         clearPendingPrompts: jest.fn(),
+        setAskUserQuestionAnswers: jest.fn(),
         clearLastRoundResponse: jest.fn(),
         addBackgroundExecutionCompleteStep: jest.fn(),
         addCompactionStep: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.test.tsx
@@ -62,6 +62,7 @@ jest.mock('./use_conversation_actions', () => ({
     setTimeToFirstToken: jest.fn(),
     addPendingPrompt: jest.fn(),
     clearPendingPrompts: jest.fn(),
+    setAskUserQuestionAnswers: jest.fn(),
     onConversationCreated: jest.fn(),
     addBackgroundExecutionCompleteStep: jest.fn(),
     addOrUpdateTodosStep: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.test.ts
@@ -7,10 +7,16 @@
 
 import { QueryClient } from '@kbn/react-query';
 import type { Conversation } from '@kbn/agent-builder-common';
+import {
+  isAskUserQuestionStep,
+  createAskUserQuestionStep,
+} from '@kbn/agent-builder-common/chat/conversation';
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { AgentPromptType } from '@kbn/agent-builder-common/agents';
+import type { AskUserQuestionPrompt } from '@kbn/agent-builder-common/agents';
 import type { ConversationsService } from '../../../services/conversations';
 import { queryKeys } from '../../query_keys';
-import { createNewConversation } from '../../utils/new_conversation';
+import { createNewConversation, createNewRound } from '../../utils/new_conversation';
 import { createConversationActions } from './use_conversation_actions';
 
 const conversationId = 'conv-1';
@@ -39,6 +45,73 @@ const attachmentFixture = (current: number): VersionedAttachment[] => [
     })),
   },
 ];
+
+const promptId = 'prompt-1';
+const questions = [
+  { question: 'Choose one:', options: [{ label: 'A' }, { label: 'B' }], multi_select: false },
+];
+const answers = [{ choice: [0] }];
+const askUserQuestionResponse = { answers };
+
+const pendingPrompt: AskUserQuestionPrompt = {
+  type: AgentPromptType.ask_user_question,
+  id: promptId,
+  questions,
+};
+
+describe('createConversationActions.setAskUserQuestionAnswers', () => {
+  it('back-fills answers onto an existing AskUserQuestionStep (update-existing)', () => {
+    const { queryClient, actions } = buildActions();
+    const queryKey = queryKeys.conversations.byId(conversationId);
+    const conversation = createNewConversation({ id: conversationId, agentId: 'agent-1' });
+    conversation.rounds.push(
+      createNewRound({ userMessage: 'hello', steps: [createAskUserQuestionStep({ prompt_id: promptId, questions })] })
+    );
+    queryClient.setQueryData<Conversation>(queryKey, conversation);
+
+    actions.setAskUserQuestionAnswers({ [promptId]: askUserQuestionResponse });
+
+    const result = queryClient.getQueryData<Conversation>(queryKey);
+    const step = result?.rounds.at(-1)?.steps.find(isAskUserQuestionStep);
+    expect(step?.answers).toEqual(answers);
+    expect(step?.prompt_id).toBe(promptId);
+    expect(result?.rounds.at(-1)?.steps).toHaveLength(1);
+  });
+
+  it('reconstructs an AskUserQuestionStep from pending_prompts when no step exists (reconstruct-from-pending)', () => {
+    const { queryClient, actions } = buildActions();
+    const queryKey = queryKeys.conversations.byId(conversationId);
+    const conversation = createNewConversation({ id: conversationId, agentId: 'agent-1' });
+    conversation.rounds.push(createNewRound({ userMessage: 'hello' }));
+    queryClient.setQueryData<Conversation>(queryKey, conversation);
+    actions.addPendingPrompt({ prompt: pendingPrompt });
+
+    actions.setAskUserQuestionAnswers({ [promptId]: askUserQuestionResponse });
+
+    const result = queryClient.getQueryData<Conversation>(queryKey);
+    const step = result?.rounds.at(-1)?.steps.find(isAskUserQuestionStep);
+    expect(step).toBeDefined();
+    expect(step?.prompt_id).toBe(promptId);
+    expect(step?.answers).toEqual(answers);
+  });
+
+  it('silently drops answers when pending_prompts are cleared before setAskUserQuestionAnswers (ordering invariant)', () => {
+    const { queryClient, actions } = buildActions();
+    const queryKey = queryKeys.conversations.byId(conversationId);
+    const conversation = createNewConversation({ id: conversationId, agentId: 'agent-1' });
+    conversation.rounds.push(createNewRound({ userMessage: 'hello' }));
+    queryClient.setQueryData<Conversation>(queryKey, conversation);
+    actions.addPendingPrompt({ prompt: pendingPrompt });
+
+    // Wrong order: clear before setting answers — the reconstruct branch cannot find the prompt
+    actions.clearPendingPrompts();
+    actions.setAskUserQuestionAnswers({ [promptId]: askUserQuestionResponse });
+
+    const result = queryClient.getQueryData<Conversation>(queryKey);
+    const step = result?.rounds.at(-1)?.steps.find(isAskUserQuestionStep);
+    expect(step).toBeUndefined();
+  });
+});
 
 describe('createConversationActions.setAttachments', () => {
   it('writes the attachments array onto the cached conversation', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.test.ts
@@ -65,7 +65,10 @@ describe('createConversationActions.setAskUserQuestionAnswers', () => {
     const queryKey = queryKeys.conversations.byId(conversationId);
     const conversation = createNewConversation({ id: conversationId, agentId: 'agent-1' });
     conversation.rounds.push(
-      createNewRound({ userMessage: 'hello', steps: [createAskUserQuestionStep({ prompt_id: promptId, questions })] })
+      createNewRound({
+        userMessage: 'hello',
+        steps: [createAskUserQuestionStep({ prompt_id: promptId, questions })],
+      })
     );
     queryClient.setQueryData<Conversation>(queryKey, conversation);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/use_conversation_actions.ts
@@ -7,7 +7,7 @@
 
 import { useMemo } from 'react';
 import type { QueryClient } from '@kbn/react-query';
-import produce from 'immer';
+import produce, { type Draft } from 'immer';
 import type {
   ConversationRound,
   ReasoningStep,
@@ -27,7 +27,15 @@ import {
   carriedOverTodos,
 } from '@kbn/agent-builder-common';
 import type { TodoItem } from '@kbn/agent-builder-common/chat/conversation';
-import type { PromptRequest } from '@kbn/agent-builder-common/agents';
+import {
+  createAskUserQuestionStep,
+  isAskUserQuestionStep,
+} from '@kbn/agent-builder-common/chat/conversation';
+import type { PromptRequest, PromptResponse } from '@kbn/agent-builder-common/agents';
+import {
+  isAskUserQuestionPrompt,
+  isAskUserQuestionPromptResponse,
+} from '@kbn/agent-builder-common/agents';
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type { AttachmentInput, VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import type { ConversationsService } from '../../../services/conversations';
@@ -71,6 +79,7 @@ export interface ConversationActions {
   setTimeToFirstToken: ({ timeToFirstToken }: { timeToFirstToken: number }) => void;
   addPendingPrompt: ({ prompt }: { prompt: PromptRequest }) => void;
   clearPendingPrompts: () => void;
+  setAskUserQuestionAnswers: (prompts: Record<string, PromptResponse>) => void;
   onConversationCreated: ({ title }: { title: string }) => void;
   addBackgroundExecutionCompleteStep: ({ step }: { step: BackgroundAgentCompleteStep }) => void;
   addOrUpdateTodosStep: ({ todos }: { todos: TodoItem[] }) => void;
@@ -105,7 +114,7 @@ export const createConversationActions = ({
   const setConversation = (updater: (conversation?: Conversation) => Conversation) => {
     queryClient.setQueryData<Conversation>(queryKey, updater);
   };
-  const setCurrentRound = (updater: (conversationRound: ConversationRound) => void) => {
+  const setCurrentRound = (updater: (conversationRound: Draft<ConversationRound>) => void) => {
     setConversation(
       produce((draft) => {
         const round = draft?.rounds?.at(-1);
@@ -318,6 +327,32 @@ export const createConversationActions = ({
       setCurrentRound((round) => {
         round.pending_prompts = undefined;
         round.status = ConversationRoundStatus.inProgress;
+      });
+    },
+    setAskUserQuestionAnswers: (prompts: Record<string, PromptResponse>) => {
+      setCurrentRound((round) => {
+        for (const [promptId, response] of Object.entries(prompts)) {
+          if (!isAskUserQuestionPromptResponse(response)) continue;
+          const existing = round.steps.find(
+            (s) => isAskUserQuestionStep(s) && s.prompt_id === promptId
+          );
+          if (existing && isAskUserQuestionStep(existing)) {
+            existing.answers = response.answers;
+          } else {
+            const pendingPrompt = round.pending_prompts?.find(
+              (p) => isAskUserQuestionPrompt(p) && p.id === promptId
+            );
+            if (pendingPrompt && isAskUserQuestionPrompt(pendingPrompt)) {
+              round.steps.push(
+                createAskUserQuestionStep({
+                  prompt_id: promptId,
+                  questions: pendingPrompt.questions,
+                  answers: response.answers,
+                })
+              );
+            }
+          }
+        }
       });
     },
     onConversationCreated: ({ title }: { title: string }) => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_resume_round_mutation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_resume_round_mutation.ts
@@ -75,6 +75,9 @@ export const useResumeRoundMutation = ({
       const executionId = uuidv4();
       controllersRef.current.set(vars.conversationId, { controller, executionId });
 
+      // Optimistically populate ask_user_question step answers before clearing the prompt —
+      // pending_prompts is needed to reconstruct the step, so this must come first.
+      streamActions.setAskUserQuestionAnswers(vars.prompts);
       // Drop pending prompts from the round — the user has answered, the round is back in progress.
       streamActions.clearPendingPrompts();
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_subscribe_to_chat_events.test.ts
@@ -27,6 +27,7 @@ const buildActionsMock = (): jest.Mocked<ConversationActions> =>
     setTimeToFirstToken: jest.fn(),
     addPendingPrompt: jest.fn(),
     clearPendingPrompts: jest.fn(),
+    setAskUserQuestionAnswers: jest.fn(),
     onConversationCreated: jest.fn(),
     addBackgroundExecutionCompleteStep: jest.fn(),
     addOrUpdateTodosStep: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/ask_user_question.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/ask_user_question.ts
@@ -57,6 +57,8 @@ Once the user has answered all questions, the execution will resume and the resp
 - Do **NOT** call this tool in parallel (with itself or other tools). The tool pauses the execution, and is meant to be called independently so the interrupt state is clean.
 
 - Using a description (in addition to the label) for each option is optional but recommended.
+
+- The "question" field should contain *only* the question itself. Do **NOT** add instructions such as "Pick as many as you like" or "Pick one" — the UI already indicates whether the question is single or multi-choice.
 `;
 
 export const createAskUserQuestionTool = (): BuiltinToolDefinition<typeof schema> => {


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/14824

### Summary

Renders answered `ask_user_question` HITL steps in the conversation timeline.

<img width="688" height="403" alt="image" src="https://github.com/user-attachments/assets/88559022-f63c-43ac-97ab-6bbd59620d07" />

https://github.com/user-attachments/assets/6168a653-6ee8-46f1-ba4c-9bafcb2484ed

### Included
- Flyout with details
- Optimistic update so the Q&As appear right away after submitting the answers

### Not included
- Predicted answers for skipped questions — no data model support yet.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

None


