### PR TITLE
[9.3] [Synthetics] Fix label deletion not persisting on monitor edit (#274404)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
@@ -78,7 +78,8 @@ describe('syncEditedMonitor', () => {
       '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d',
       expect.objectContaining({
         enabled: true,
-      })
+      }),
+      { mergeAttributes: false }
     );
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.test.ts
@@ -277,6 +277,72 @@ describe('MonitorConfigRepository', () => {
     });
   });
 
+  describe('update', () => {
+    it('fully replaces attributes (mergeAttributes: false) so removed map-field keys are deleted', async () => {
+      const id = 'test-id';
+      const decryptedPreviousMonitor = {
+        id,
+        type: syntheticsMonitorSavedObjectType,
+        namespaces: ['default'],
+        attributes: {
+          name: 'Test Monitor',
+          [ConfigKey.LABELS]: { a: '1', b: '2', team: 'obs' },
+        },
+        references: [],
+      } as any;
+
+      // New attributes drop the `a` and `b` labels, keeping only `team`. A deep-merge
+      // would silently restore the removed keys (see #274387).
+      const data = {
+        name: 'Test Monitor',
+        [ConfigKey.LABELS]: { team: 'obs' },
+        spaces: ['default'],
+      } as any;
+
+      const mockUpdatedMonitor = {
+        id,
+        attributes: data,
+        type: syntheticsMonitorSavedObjectType,
+        references: [],
+      };
+      soClient.update.mockResolvedValue(mockUpdatedMonitor as any);
+
+      const result = await repository.update(id, data, decryptedPreviousMonitor);
+
+      expect(soClient.update).toHaveBeenCalledWith(syntheticsMonitorSavedObjectType, id, data, {
+        mergeAttributes: false,
+      });
+      expect(result).toBe(mockUpdatedMonitor);
+    });
+
+    it('recreates the saved object when spaces change instead of updating', async () => {
+      const id = 'test-id';
+      const decryptedPreviousMonitor = {
+        id,
+        type: syntheticsMonitorSavedObjectType,
+        namespaces: ['default'],
+        attributes: {},
+        references: [],
+      } as any;
+      const data = { name: 'Test Monitor', spaces: ['space-2'] } as any;
+
+      soClient.delete.mockResolvedValue({} as any);
+      const mockCreated = { id, attributes: data, type: syntheticsMonitorSavedObjectType };
+      soClient.create.mockResolvedValue(mockCreated as any);
+
+      const result = await repository.update(id, data, decryptedPreviousMonitor);
+
+      expect(soClient.delete).toHaveBeenCalledWith(syntheticsMonitorSavedObjectType, id, {
+        force: true,
+      });
+      expect(soClient.create).toHaveBeenCalledWith(syntheticsMonitorSavedObjectType, data, {
+        id,
+        initialNamespaces: ['space-2'],
+      });
+      expect(result).toBe(mockCreated);
+    });
+  });
+
   describe('bulkUpdate', () => {
     it('should update multiple monitors in bulk', async () => {
       const monitors = [
@@ -322,11 +388,13 @@ describe('MonitorConfigRepository', () => {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-1',
           attributes: { name: 'Updated Monitor 1' },
+          mergeAttributes: false,
         },
         {
           type: 'synthetics-monitor',
           id: 'test-id-2',
           attributes: { name: 'Updated Monitor 2' },
+          mergeAttributes: false,
         },
       ]);
 
@@ -393,11 +461,13 @@ describe('MonitorConfigRepository', () => {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-1',
           attributes: { name: 'Updated Monitor 1', spaces: ['default'] },
+          mergeAttributes: false,
         },
         {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-2',
           attributes: { name: 'Updated Monitor 2', spaces: ['default'] },
+          mergeAttributes: false,
         },
       ]);
 
@@ -534,6 +604,7 @@ describe('MonitorConfigRepository', () => {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-2',
           attributes: { name: 'Updated Monitor 2', spaces: ['default'] },
+          mergeAttributes: false,
         },
       ]);
       expect(result).toEqual({

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
@@ -183,7 +183,12 @@ export class MonitorConfigRepository {
     const spaces = (data.spaces || []).sort();
     // If the spaces have changed, we need to delete the saved object and recreate it
     if (isEqual(prevSpaces, spaces)) {
-      return this.soClient.update<MonitorFields>(soType, id, data);
+      // `mergeAttributes: false` fully replaces the attributes. The default deep-merge
+      // keeps stale keys in top-level map fields that aren't mapped as `flattened`
+      // (notably `labels`), making it impossible to delete individual entries. See #274387.
+      return this.soClient.update<MonitorFields>(soType, id, data, {
+        mergeAttributes: false,
+      });
     } else {
       await this.soClient.delete(soType, id, { force: true });
       return await this.soClient.create(syntheticsMonitorSavedObjectType, data, {
@@ -215,6 +220,7 @@ export class MonitorConfigRepository {
       id: string;
       attributes: MonitorFields;
       namespace?: string;
+      mergeAttributes?: boolean;
     }> = [];
 
     for (const monitor of monitors) {
@@ -231,6 +237,8 @@ export class MonitorConfigRepository {
         id,
         attributes,
         namespace,
+        // See `update` above: avoid deep-merging so removed map-field keys are deleted.
+        mergeAttributes: false,
       });
     }
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts
@@ -156,9 +156,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         ...savedMonitor,
         [ConfigKey.LABELS]: { team: 'obs' },
         [ConfigKey.REQUEST_HEADERS_CHECK]: { sampleHeader: 'sampleHeaderValue' },
-      };
+      } as any;
 
-      await editMonitor(toUpdate as MonitorFields, monitorId);
+      await editMonitor(toUpdate, monitorId);
 
       const updatedResponse = await monitorTestService.getMonitor(monitorId, {
         internal: true,

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts
@@ -133,6 +133,44 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       );
     });
 
+    it('persists deletion of label and header keys instead of deep-merging them', async () => {
+      // Regression test for #274387. `labels` is a top-level map attribute, so a
+      // deep-merging saved-object update silently kept removed keys and they could
+      // never be deleted. Headers live in the encrypted `secrets` string (replaced
+      // wholesale), so they already worked; asserting them here guards that the
+      // full-attribute replacement keeps round-tripping secrets. The edit *response*
+      // is built from the in-memory monitor and looks correct even when persistence
+      // is broken, so this asserts a subsequent GET.
+      const savedMonitor = await saveMonitor({
+        ...(httpMonitorJson as MonitorFields),
+        name: 'monitor with maps to prune',
+        [ConfigKey.LABELS]: { team: 'obs', env: 'prod' },
+        [ConfigKey.REQUEST_HEADERS_CHECK]: {
+          sampleHeader: 'sampleHeaderValue',
+          extra: 'extraValue',
+        },
+      });
+      const monitorId = savedMonitor[ConfigKey.CONFIG_ID];
+
+      const toUpdate = {
+        ...savedMonitor,
+        [ConfigKey.LABELS]: { team: 'obs' },
+        [ConfigKey.REQUEST_HEADERS_CHECK]: { sampleHeader: 'sampleHeaderValue' },
+      };
+
+      await editMonitor(toUpdate as MonitorFields, monitorId);
+
+      const updatedResponse = await monitorTestService.getMonitor(monitorId, {
+        internal: true,
+        user: editorUser,
+      });
+
+      expect(updatedResponse.body[ConfigKey.LABELS]).eql({ team: 'obs' });
+      expect(updatedResponse.body[ConfigKey.REQUEST_HEADERS_CHECK]).eql({
+        sampleHeader: 'sampleHeaderValue',
+      });
+    });
+
     it('strips unknown keys from monitor edits', async () => {
       const newMonitor = { ...httpMonitorJson, name: 'yet another' };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[Synthetics] Fix label deletion not persisting on monitor edit (#274404)](https://github.com/elastic/kibana/pull/274404)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

## Manual backport adaptations for 9.3

- **Scout API test omitted**: The Scout API test harness (`test/scout/api/`) is absent on 9.3. The regression assertion was ported to the existing deployment-agnostic FTR test at `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts` instead.
- **`mergeAttributes` support**: Confirmed supported on 9.3 for both `SavedObjectsClient.update` options and per-item `SavedObjectsBulkUpdateObject.mergeAttributes`. Applied to both `update` and `bulkUpdate`.
- **9.3 API differences**: The 9.3 `MonitorConfigRepository.update` method does not accept a `references` parameter (unlike main); the fix passes only `{ mergeAttributes: false }`.

<!--BACKPORT [{"sourcePullRequest":{"number":274404,"url":"https://github.com/elastic/kibana/pull/274404","title":"[Synthetics] Fix label deletion not persisting on monitor edit"},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"sourceCommit":{"sha":"afc11918e181abf339c0ce5cde80d2402689bb61"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)