### PR TITLE
[8.19] [Synthetics] Fix label deletion not persisting on monitor edit (#274404)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
@@ -78,7 +78,8 @@ describe('syncEditedMonitor', () => {
       '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d',
       expect.objectContaining({
         enabled: true,
-      })
+      }),
+      { mergeAttributes: false }
     );
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.test.ts
@@ -278,6 +278,72 @@ describe('MonitorConfigRepository', () => {
     });
   });
 
+  describe('update', () => {
+    it('fully replaces attributes (mergeAttributes: false) so removed map-field keys are deleted', async () => {
+      const id = 'test-id';
+      const decryptedPreviousMonitor = {
+        id,
+        type: syntheticsMonitorSavedObjectType,
+        namespaces: ['default'],
+        attributes: {
+          name: 'Test Monitor',
+          [ConfigKey.LABELS]: { a: '1', b: '2', team: 'obs' },
+        },
+        references: [],
+      } as any;
+
+      // New attributes drop the `a` and `b` labels, keeping only `team`. A deep-merge
+      // would silently restore the removed keys (see #274387).
+      const data = {
+        name: 'Test Monitor',
+        [ConfigKey.LABELS]: { team: 'obs' },
+        spaces: ['default'],
+      } as any;
+
+      const mockUpdatedMonitor = {
+        id,
+        attributes: data,
+        type: syntheticsMonitorSavedObjectType,
+        references: [],
+      };
+      soClient.update.mockResolvedValue(mockUpdatedMonitor as any);
+
+      const result = await repository.update(id, data, decryptedPreviousMonitor);
+
+      expect(soClient.update).toHaveBeenCalledWith(syntheticsMonitorSavedObjectType, id, data, {
+        mergeAttributes: false,
+      });
+      expect(result).toBe(mockUpdatedMonitor);
+    });
+
+    it('recreates the saved object when spaces change instead of updating', async () => {
+      const id = 'test-id';
+      const decryptedPreviousMonitor = {
+        id,
+        type: syntheticsMonitorSavedObjectType,
+        namespaces: ['default'],
+        attributes: {},
+        references: [],
+      } as any;
+      const data = { name: 'Test Monitor', spaces: ['space-2'] } as any;
+
+      soClient.delete.mockResolvedValue({} as any);
+      const mockCreated = { id, attributes: data, type: syntheticsMonitorSavedObjectType };
+      soClient.create.mockResolvedValue(mockCreated as any);
+
+      const result = await repository.update(id, data, decryptedPreviousMonitor);
+
+      expect(soClient.delete).toHaveBeenCalledWith(syntheticsMonitorSavedObjectType, id, {
+        force: true,
+      });
+      expect(soClient.create).toHaveBeenCalledWith(syntheticsMonitorSavedObjectType, data, {
+        id,
+        initialNamespaces: ['space-2'],
+      });
+      expect(result).toBe(mockCreated);
+    });
+  });
+
   describe('bulkUpdate', () => {
     it('should update multiple monitors in bulk', async () => {
       const monitors = [
@@ -323,11 +389,13 @@ describe('MonitorConfigRepository', () => {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-1',
           attributes: { name: 'Updated Monitor 1' },
+          mergeAttributes: false,
         },
         {
           type: 'synthetics-monitor',
           id: 'test-id-2',
           attributes: { name: 'Updated Monitor 2' },
+          mergeAttributes: false,
         },
       ]);
 
@@ -394,11 +462,13 @@ describe('MonitorConfigRepository', () => {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-1',
           attributes: { name: 'Updated Monitor 1', spaces: ['default'] },
+          mergeAttributes: false,
         },
         {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-2',
           attributes: { name: 'Updated Monitor 2', spaces: ['default'] },
+          mergeAttributes: false,
         },
       ]);
 
@@ -535,6 +605,7 @@ describe('MonitorConfigRepository', () => {
           type: syntheticsMonitorSavedObjectType,
           id: 'test-id-2',
           attributes: { name: 'Updated Monitor 2', spaces: ['default'] },
+          mergeAttributes: false,
         },
       ]);
       expect(result).toEqual({

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_config_repository.ts
@@ -177,7 +177,12 @@ export class MonitorConfigRepository {
     const spaces = (data.spaces || []).sort();
     // If the spaces have changed, we need to delete the saved object and recreate it
     if (isEqual(prevSpaces, spaces)) {
-      return this.soClient.update<MonitorFields>(soType, id, data);
+      // `mergeAttributes: false` fully replaces the attributes. The default deep-merge
+      // keeps stale keys in top-level map fields that aren't mapped as `flattened`
+      // (notably `labels`), making it impossible to delete individual entries. See #274387.
+      return this.soClient.update<MonitorFields>(soType, id, data, {
+        mergeAttributes: false,
+      });
     } else {
       await this.soClient.delete(soType, id, { force: true });
       return await this.soClient.create(syntheticsMonitorSavedObjectType, data, {
@@ -209,6 +214,7 @@ export class MonitorConfigRepository {
       id: string;
       attributes: MonitorFields;
       namespace?: string;
+      mergeAttributes?: boolean;
     }> = [];
 
     for (const monitor of monitors) {
@@ -225,6 +231,8 @@ export class MonitorConfigRepository {
         id,
         attributes,
         namespace,
+        // See `update` above: avoid deep-merging so removed map-field keys are deleted.
+        mergeAttributes: false,
       });
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [[Synthetics] Fix label deletion not persisting on monitor edit (#274404)](https://github.com/elastic/kibana/pull/274404)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

## 8.19 adaptations

- **Scout API test omitted**: The Scout API harness (`test/scout/api/`) does not exist on 8.19 — only Scout UI tests are present. The unit tests in `monitor_config_repository.test.ts` cover the fix.
- **`bulkUpdate` `mergeAttributes`**: Supported on 8.19 (`SavedObjectsBulkUpdateObject.mergeAttributes` in `@kbn/core-saved-objects-api-server`). Applied to both `update` and `bulkUpdate`.
- **`references` omitted**: 8.19's `MonitorConfigRepository.update`/`bulkUpdate` do not accept `references` (unlike `main`); only `mergeAttributes: false` was added.
- **Independent of #274996**: Conflicts resolved against current 8.19 code without depending on the open #238418 backport (#274996).

<!--BACKPORT [{"sourcePullRequest":{"number":274404,"url":"https://github.com/elastic/kibana/pull/274404","title":"[Synthetics] Fix label deletion not persisting on monitor edit"},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"sourceCommit":{"sha":"afc11918e181abf339c0ce5cde80d2402689bb61"}}] BACKPORT-->

Made with [Cursor](https://cursor.com)