### PR TITLE
[ResponseOps] Teams connector: flag 4xx webhook responses as user errors

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/teams/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/teams/index.test.ts
@@ -18,6 +18,7 @@ import * as utils from '@kbn/actions-plugin/server/lib/axios_utils';
 import type { ActionsConfigurationUtilities } from '@kbn/actions-plugin/server/actions_config';
 import { loggerMock } from '@kbn/logging-mocks';
 import { CONNECTOR_ID } from '@kbn/connector-schemas/teams';
+import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 
 jest.mock('axios');
 jest.mock('@kbn/actions-plugin/server/lib/axios_utils', () => {
@@ -342,5 +343,55 @@ describe('execute()', () => {
         "status": "ok",
       }
     `);
+  });
+
+  const executeWithResponseStatus = async (status: number) => {
+    requestMock.mockRejectedValueOnce({
+      tag: 'err',
+      isAxiosError: true,
+      response: {
+        status,
+        statusText: 'Forbidden',
+      },
+    });
+
+    return connectorType.executor({
+      actionId: 'some-id',
+      services,
+      config: {},
+      secrets: { webhookUrl: 'http://example.com' },
+      params: { message: 'a message' },
+      configurationUtilities,
+      logger: mockedLogger,
+      connectorUsageCollector,
+    });
+  };
+
+  describe('error handling', () => {
+    test.each([401, 402, 403, 404, 407, 409, 412, 413, 417, 422, 423, 429, 451])(
+      'flags %s responses as a user error',
+      async (status) => {
+        const result = await executeWithResponseStatus(status);
+
+        expect(result.status).toBe('error');
+        expect(result.errorSource).toBe(TaskErrorSource.USER);
+        expect(result.serviceMessage).toBe(`[${status}] Forbidden`);
+      }
+    );
+
+    test('retries 5xx responses without a user error source', async () => {
+      const result = await executeWithResponseStatus(503);
+
+      expect(result.status).toBe('error');
+      expect(result.retry).toBe(true);
+      expect(result.errorSource).toBeUndefined();
+    });
+
+    test('does not flag other 4xx responses as a user error', async () => {
+      const result = await executeWithResponseStatus(400);
+
+      expect(result.status).toBe('error');
+      expect(result.errorSource).toBeUndefined();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/teams/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/teams/index.ts
@@ -28,6 +28,7 @@ import {
 } from '@kbn/actions-plugin/common';
 import type { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
+import { httpResponseUserErrorCodes } from '@kbn/actions-plugin/server/lib/create_and_throw_user_error';
 import type {
   ConnectorTypeConfigType,
   ConnectorTypeSecretsType,
@@ -175,7 +176,15 @@ async function teamsExecutor(
         return retryResult(actionId, serviceMessage);
       }
 
-      return errorResultInvalid(actionId, serviceMessage, getErrorSource(error));
+      const errorResult = errorResultInvalid(actionId, serviceMessage, getErrorSource(error));
+
+      // 4xx codes caused by user/configuration mistakes (e.g. a retired webhook
+      // URL) are attributed to the user rather than the framework.
+      if (httpResponseUserErrorCodes.includes(status)) {
+        errorResult.errorSource = TaskErrorSource.USER;
+      }
+
+      return errorResult;
     }
 
     logger.debug(`error on ${actionId} Microsoft Teams action: unexpected error`);


### PR DESCRIPTION
## Summary

The Microsoft Teams connector posts to a user-configured webhook URL. When that POST comes back with a non-5xx HTTP error response, the connector returned its error result **without** an error source. As a result, failures caused by user/configuration problems — most commonly a webhook URL that has been retired or revoked on the Microsoft side — were attributed to the **framework** rather than the **user**.

This PR flags those 4xx responses as user errors, using the shared `httpResponseUserErrorCodes` list (`x-pack/platform/plugins/shared/actions/server/lib/create_and_throw_user_error.ts`) so the Teams connector stays consistent with the `webhook` and `slack` connectors, which already classify the same situation.

**Scope / behavior:**
- Only the **error source classification** changes. Responses whose status is in the shared user-error list are now tagged `user` instead of falling through to `framework`.
- **Retry behavior is unchanged** — these errors are still retried exactly as before; they're just attributed correctly.
- 5xx responses and the rate-limited (200-with-throttle) path are untouched.

### Why

Connector failures caused by user configuration should be surfaced as user errors, not framework errors, so they don't count against framework error rates/SLOs and are actionable by the user. This is the Teams piece of the broader effort in kibana#180960.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Release note

Microsoft Teams connector failures caused by a non-server (4xx) webhook response — for example a retired or revoked webhook URL — are now classified as user errors rather than framework errors.

### Identify risks

- Low risk: classification-only change scoped to the Teams connector's 4xx branch; no change to retry behavior, request handling, or success paths.

Closes part of kibana#180960

Made with [Cursor](https://cursor.com)