### PR TITLE
[9.4] Fix scheduled workflow updates for credentials and running tasks (#272702)

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.test.ts
@@ -2693,6 +2693,109 @@ steps:
       );
     });
 
+    it('refreshes scheduled task credentials when editing an enabled scheduled workflow', async () => {
+      const request = {
+        auth: {
+          credentials: { username: 'test-user' },
+        },
+      } as any;
+      const taskScheduler = {
+        updateWorkflowTasks: jest.fn().mockResolvedValue(undefined),
+        unscheduleWorkflowTasks: jest.fn().mockResolvedValue(undefined),
+      };
+      const scheduledDefinition = {
+        name: 'Test Workflow',
+        enabled: true,
+        triggers: [{ type: 'scheduled', with: { every: '30s' } }],
+        steps: [],
+      };
+      const existingDoc = {
+        _id: 'test-workflow-id',
+        _source: {
+          ...mockWorkflowDocument._source,
+          enabled: true,
+          valid: true,
+          triggerTypes: ['scheduled'],
+          definition: scheduledDefinition,
+          yaml: [
+            'name: Test Workflow',
+            'enabled: true',
+            'triggers:',
+            '  - type: scheduled',
+            '    with:',
+            '      every: 30s',
+            'steps: []',
+          ].join('\n'),
+        },
+      };
+      const updatedDoc = {
+        ...existingDoc,
+        _source: {
+          ...existingDoc._source,
+          tags: ['new'],
+          lastUpdatedBy: 'test-user',
+        },
+      };
+
+      service.setTaskScheduler(taskScheduler as any);
+      mockEsClient.search
+        .mockResolvedValueOnce({ hits: { hits: [existingDoc] } } as any)
+        .mockResolvedValueOnce({ hits: { hits: [updatedDoc] } } as any);
+
+      await service.updateWorkflow('test-workflow-id', { tags: ['new'] }, 'default', request);
+
+      expect(taskScheduler.updateWorkflowTasks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-workflow-id',
+          definition: scheduledDefinition,
+        }),
+        'default',
+        request
+      );
+      expect(taskScheduler.unscheduleWorkflowTasks).not.toHaveBeenCalled();
+    });
+
+    it('warns when an enabled scheduled workflow needs scheduler sync but the scheduler is unavailable', async () => {
+      const request = {
+        auth: {
+          credentials: { username: 'test-user' },
+        },
+      } as any;
+      const scheduledDefinition = {
+        name: 'Test Workflow',
+        enabled: true,
+        triggers: [{ type: 'scheduled', with: { every: '30s' } }],
+        steps: [],
+      };
+      const existingDoc = {
+        _id: 'test-workflow-id',
+        _source: {
+          ...mockWorkflowDocument._source,
+          enabled: true,
+          valid: true,
+          triggerTypes: ['scheduled'],
+          definition: scheduledDefinition,
+          yaml: [
+            'name: Test Workflow',
+            'enabled: true',
+            'triggers:',
+            '  - type: scheduled',
+            '    with:',
+            '      every: 30s',
+            'steps: []',
+          ].join('\n'),
+        },
+      };
+
+      mockEsClient.search.mockResolvedValueOnce({ hits: { hits: [existingDoc] } } as any);
+
+      await service.updateWorkflow('test-workflow-id', { tags: ['new'] }, 'default', request);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Skipping scheduler sync for workflow test-workflow-id in space default: task scheduler is unavailable'
+      );
+    });
+
     it('should throw error when workflow not found', async () => {
       mockEsClient.search.mockResolvedValue({ hits: { hits: [] } } as any);
 

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -703,15 +703,31 @@ export class WorkflowsService {
 
   /**
    * Updates or removes scheduled tasks after a workflow document is saved.
-   * Call only when shouldUpdateScheduler is true and taskScheduler is set.
+   * Also refreshes task credentials for enabled scheduled workflows when metadata-only edits keep
+   * the schedule unchanged.
    */
   private async updateSchedulerAfterWorkflowSave(
     id: string,
     spaceId: string,
     request: KibanaRequest,
-    finalData: WorkflowProperties
+    finalData: WorkflowProperties,
+    shouldUpdateScheduler: boolean
   ): Promise<void> {
-    if (!this.taskScheduler) return;
+    const shouldRefreshScheduledTaskCredentials =
+      Boolean(finalData.definition) &&
+      finalData.valid &&
+      finalData.enabled &&
+      hasScheduledTriggers(finalData.definition?.triggers ?? []);
+    if (!shouldUpdateScheduler && !shouldRefreshScheduledTaskCredentials) {
+      return;
+    }
+
+    if (!this.taskScheduler) {
+      this.logger.warn(
+        `Skipping scheduler sync for workflow ${id} in space ${spaceId}: task scheduler is unavailable`
+      );
+      return;
+    }
 
     const workflowIsSchedulable = finalData.definition && finalData.valid && finalData.enabled;
     if (!workflowIsSchedulable) {
@@ -787,9 +803,13 @@ export class WorkflowsService {
         refresh: true,
       });
 
-      if (shouldUpdateScheduler && this.taskScheduler) {
-        await this.updateSchedulerAfterWorkflowSave(id, spaceId, request, finalData);
-      }
+      await this.updateSchedulerAfterWorkflowSave(
+        id,
+        spaceId,
+        request,
+        finalData,
+        shouldUpdateScheduler
+      );
 
       return {
         id,

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts
@@ -18,8 +18,15 @@ import { WorkflowTaskScheduler } from './workflow_task_scheduler';
 
 type FetchReturn = Awaited<ReturnType<TaskManagerStartContract['fetch']>>;
 
-const makeTaskInstance = (id: string): ConcreteTaskInstance =>
-  ({ id } as unknown as ConcreteTaskInstance);
+const makeTaskInstance = (
+  id: string,
+  overrides: Partial<ConcreteTaskInstance> = {}
+): ConcreteTaskInstance =>
+  ({
+    id,
+    scheduledAt: new Date('2030-01-01T00:00:00.000Z'),
+    ...overrides,
+  } as unknown as ConcreteTaskInstance);
 
 const makeFetchResult = (ids: string[]): FetchReturn =>
   ({ docs: ids.map((id) => ({ id })), versionMap: new Map() } as unknown as FetchReturn);
@@ -60,6 +67,7 @@ const makeMockTaskManager = (
 ): jest.Mocked<TaskManagerStartContract> =>
   ({
     schedule: jest.fn().mockResolvedValue(makeTaskInstance('test-task-id')),
+    get: jest.fn().mockResolvedValue(makeTaskInstance('test-task-id')),
     fetch: jest.fn().mockResolvedValue(makeFetchResult([])),
     bulkRemove: jest.fn().mockResolvedValue({ statuses: [] }),
     removeIfExists: jest.fn().mockResolvedValue(undefined),
@@ -219,6 +227,10 @@ describe('WorkflowTaskScheduler', () => {
       conflictError.statusCode = 409;
       const mockTm = makeMockTaskManager();
       mockTm.schedule.mockRejectedValueOnce(conflictError);
+      mockTm.bulkUpdateSchedules.mockResolvedValueOnce({
+        tasks: [makeTaskInstance('workflow:test-workflow:scheduled')],
+        errors: [],
+      });
       const scheduler = new WorkflowTaskScheduler(mockLogger, mockTm);
 
       const result = await scheduler.scheduleWorkflowTasks(makeWorkflow(), 'default', mockRequest);
@@ -227,10 +239,47 @@ describe('WorkflowTaskScheduler', () => {
       expect(mockTm.bulkUpdateSchedules).toHaveBeenCalledWith(
         ['workflow:test-workflow:scheduled'],
         expect.objectContaining({ interval: '30s' }),
-        { request: mockRequest }
+        { request: mockRequest, regenerateApiKey: true }
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining('Updated existing scheduled task')
+      );
+    });
+
+    it('recreates the task when bulkUpdateSchedules skips it', async () => {
+      const conflictError = new Error('Conflict') as Error & { statusCode: number };
+      conflictError.statusCode = 409;
+      const scheduledAt = new Date('2030-01-01T00:00:00.000Z');
+      const mockTm = makeMockTaskManager();
+      mockTm.schedule
+        .mockRejectedValueOnce(conflictError)
+        .mockResolvedValueOnce(makeTaskInstance('workflow:test-workflow:scheduled'));
+      mockTm.get.mockResolvedValueOnce(
+        makeTaskInstance('workflow:test-workflow:scheduled', { scheduledAt })
+      );
+      mockTm.bulkUpdateSchedules.mockResolvedValueOnce({
+        tasks: [],
+        errors: [],
+      });
+      const scheduler = new WorkflowTaskScheduler(mockLogger, mockTm);
+
+      const result = await scheduler.scheduleWorkflowTasks(makeWorkflow(), 'default', mockRequest);
+
+      expect(result).toEqual(['workflow:test-workflow:scheduled']);
+      expect(mockTm.get).toHaveBeenCalledWith('workflow:test-workflow:scheduled');
+      expect(mockTm.removeIfExists).toHaveBeenCalledWith('workflow:test-workflow:scheduled');
+      expect(mockTm.schedule).toHaveBeenCalledTimes(2);
+      expect(mockTm.schedule).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          id: 'workflow:test-workflow:scheduled',
+          schedule: expect.objectContaining({ interval: '30s' }),
+          scheduledAt,
+          runAt: new Date('2030-01-01T00:00:30.000Z'),
+        }),
+        { request: mockRequest }
+      );
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Recreated scheduled task')
       );
     });
 
@@ -247,11 +296,13 @@ describe('WorkflowTaskScheduler', () => {
       expect(mockTm.bulkUpdateSchedules).not.toHaveBeenCalled();
     });
 
-    it('swallows 409 error from bulkUpdateSchedules (concurrent update)', async () => {
+    it('recreates the task after a 409 error from bulkUpdateSchedules', async () => {
       const conflictError = new Error('Conflict') as Error & { statusCode: number };
       conflictError.statusCode = 409;
       const mockTm = makeMockTaskManager();
-      mockTm.schedule.mockRejectedValueOnce(conflictError);
+      mockTm.schedule
+        .mockRejectedValueOnce(conflictError)
+        .mockResolvedValueOnce(makeTaskInstance('workflow:test-workflow:scheduled'));
       mockTm.bulkUpdateSchedules.mockResolvedValueOnce({
         tasks: [],
         errors: [makeBulkError('task-1', 409, 'conflict')],
@@ -261,13 +312,19 @@ describe('WorkflowTaskScheduler', () => {
       const result = await scheduler.scheduleWorkflowTasks(makeWorkflow(), 'default', mockRequest);
 
       expect(result).toEqual(['workflow:test-workflow:scheduled']);
+      expect(mockTm.removeIfExists).toHaveBeenCalledWith('workflow:test-workflow:scheduled');
     });
 
-    it('swallows 404 error from bulkUpdateSchedules (task just removed)', async () => {
+    it('recreates the task after a 404 error from bulkUpdateSchedules', async () => {
       const conflictError = new Error('Conflict') as Error & { statusCode: number };
       conflictError.statusCode = 409;
+      const notFoundError = new Error('Not found') as Error & { statusCode: number };
+      notFoundError.statusCode = 404;
       const mockTm = makeMockTaskManager();
-      mockTm.schedule.mockRejectedValueOnce(conflictError);
+      mockTm.schedule
+        .mockRejectedValueOnce(conflictError)
+        .mockResolvedValueOnce(makeTaskInstance('workflow:test-workflow:scheduled'));
+      mockTm.get.mockRejectedValueOnce(notFoundError);
       mockTm.bulkUpdateSchedules.mockResolvedValueOnce({
         tasks: [],
         errors: [makeBulkError('task-1', 404, 'not found')],
@@ -277,6 +334,8 @@ describe('WorkflowTaskScheduler', () => {
       const result = await scheduler.scheduleWorkflowTasks(makeWorkflow(), 'default', mockRequest);
 
       expect(result).toEqual(['workflow:test-workflow:scheduled']);
+      expect(mockTm.get).toHaveBeenCalledWith('workflow:test-workflow:scheduled');
+      expect(mockTm.removeIfExists).toHaveBeenCalledWith('workflow:test-workflow:scheduled');
     });
 
     it('throws on non-retriable error from bulkUpdateSchedules', async () => {

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.ts
@@ -8,7 +8,10 @@
  */
 
 import type { KibanaRequest, Logger } from '@kbn/core/server';
-import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import {
+  calculateNextRunAtFromSchedule,
+  type TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
 import type { EsWorkflow } from '@kbn/workflows';
 import { getReadableFrequency, getReadableInterval } from '../lib/rrule_logging_utils';
 import type { WorkflowTrigger } from '../lib/schedule_utils';
@@ -64,7 +67,8 @@ export class WorkflowTaskScheduler {
   /**
    * Schedules a single workflow task for a specific trigger.
    * Idempotent: if the task already exists (409 conflict), updates the schedule in place
-   * via bulkUpdateSchedules instead of failing. This handles both interval and RRule schedules.
+   * via bulkUpdateSchedules instead of failing. If Task Manager skips the update, recreates
+   * the deterministic task with the latest schedule and execution credentials.
    */
   async scheduleWorkflowTask(
     workflowId: string,
@@ -113,7 +117,10 @@ export class WorkflowTaskScheduler {
       if ((err as { statusCode?: number }).statusCode === VERSION_CONFLICT_STATUS) {
         // Task already exists — update its schedule in place rather than failing.
         // This handles both interval and RRule schedule types.
-        const result = await this.taskManager.bulkUpdateSchedules([taskId], schedule, { request });
+        const result = await this.taskManager.bulkUpdateSchedules([taskId], schedule, {
+          request,
+          regenerateApiKey: true,
+        });
         if (result.errors.length > 0) {
           const firstError = result.errors[0].error;
           // 409 (concurrent update) and 404 (task was just removed) are non-fatal
@@ -125,6 +132,35 @@ export class WorkflowTaskScheduler {
               `Failed to update schedule for workflow task "${taskId}": ${firstError.message}`
             );
           }
+        }
+        // Task Manager intentionally skips running tasks when updating schedules, and skipped tasks
+        // are not returned in either `tasks` or `errors`. Recreate the deterministic workflow task
+        // so it picks up the latest schedule interval and refreshed execution credentials.
+        if (!result.tasks.some((task) => task.id === taskId)) {
+          const existingTask = await this.taskManager.get(taskId).catch((error) => {
+            if ((error as { statusCode?: number }).statusCode === NOT_FOUND_STATUS) {
+              return undefined;
+            }
+            throw error;
+          });
+          const recreatedTaskInstance = existingTask
+            ? {
+                ...taskInstance,
+                scheduledAt: existingTask.scheduledAt,
+                runAt: new Date(
+                  calculateNextRunAtFromSchedule({
+                    schedule,
+                    startDate: existingTask.scheduledAt,
+                  })
+                ),
+              }
+            : taskInstance;
+          await this.taskManager.removeIfExists(taskId);
+          const scheduledTask = await this.taskManager.schedule(recreatedTaskInstance, { request });
+          this.logger.debug(
+            `Recreated scheduled task for workflow ${workflowId} after in-place update was skipped`
+          );
+          return scheduledTask.id;
         }
         this.logger.debug(
           `Updated existing scheduled task for workflow ${workflowId} (schedule updated in place)`

--- a/x-pack/platform/plugins/shared/task_manager/server/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/index.ts
@@ -36,6 +36,7 @@ export { TaskStatus, TaskPriority, TaskCost, InstanceTaskCost } from './task';
 export type { TaskRegisterDefinition, TaskDefinitionRegistry } from './task_type_dictionary';
 
 export { asInterval } from './lib/intervals';
+export { calculateNextRunAtFromSchedule } from './lib/get_next_run_at';
 export {
   isUnrecoverableError,
   throwUnrecoverableError,

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.ts
@@ -41,7 +41,7 @@ export function calculateNextRunAtFromSchedule({
 }: {
   schedule?: IntervalSchedule | RruleSchedule;
   startDate: Date;
-}) {
+}): number {
   const { rrule, interval } = schedule || {};
 
   let nextRunAt: Date | undefined | null;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts
@@ -909,6 +909,76 @@ describe('TaskScheduling', () => {
       expect(bulkUpdatePayload).toHaveLength(0);
     });
 
+    test('should update task if new schedule is equal to previous and regenerateApiKey is requested', async () => {
+      const task = taskManagerMock.createTask({ id, schedule: { interval: '3h' } });
+      const mockRequest = httpServerMock.createKibanaRequest();
+
+      mockTaskStore.bulkGet.mockResolvedValue([asOk(task)]);
+
+      const taskScheduling = new TaskScheduling(taskSchedulingOpts);
+      await taskScheduling.bulkUpdateSchedules(
+        [id],
+        { interval: '3h' },
+        {
+          request: mockRequest,
+          regenerateApiKey: true,
+        }
+      );
+
+      const bulkUpdatePayload = mockTaskStore.bulkUpdate.mock.calls[0];
+
+      expect(bulkUpdatePayload).toEqual([
+        [task],
+        {
+          validate: false,
+          mergeAttributes: false,
+          options: { request: mockRequest, regenerateApiKey: true },
+        },
+      ]);
+    });
+
+    test('should not update running task if regenerateApiKey is requested', async () => {
+      const task = taskManagerMock.createTask({
+        id,
+        schedule: { interval: '3h' },
+        status: TaskStatus.Running,
+      });
+      const mockRequest = httpServerMock.createKibanaRequest();
+
+      mockTaskStore.bulkGet.mockResolvedValue([asOk(task)]);
+
+      const taskScheduling = new TaskScheduling(taskSchedulingOpts);
+      await taskScheduling.bulkUpdateSchedules(
+        [id],
+        { interval: '3h' },
+        {
+          request: mockRequest,
+          regenerateApiKey: true,
+        }
+      );
+
+      const bulkUpdatePayload = mockTaskStore.bulkUpdate.mock.calls[0][0];
+
+      expect(bulkUpdatePayload).toHaveLength(0);
+    });
+
+    test('should not update running task if regenerateApiKey is not requested', async () => {
+      const task = taskManagerMock.createTask({
+        id,
+        schedule: { interval: '3h' },
+        status: TaskStatus.Running,
+      });
+
+      mockTaskStore.bulkGet.mockResolvedValue([asOk(task)]);
+
+      const taskScheduling = new TaskScheduling(taskSchedulingOpts);
+      await taskScheduling.bulkUpdateSchedules([id], { interval: '5h' });
+
+      const bulkUpdatePayload = mockTaskStore.bulkUpdate.mock.calls[0][0];
+
+      expect(bulkUpdatePayload).toHaveLength(0);
+    });
+
     test('should not update task if new schedule is equal to previous using rrule', async () => {
       const task = taskManagerMock.createTask({
         id,

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
@@ -223,9 +223,9 @@ export class TaskScheduling {
 
   /**
    * Bulk updates schedules for tasks by ids.
-   * Only tasks with `idle` status will be updated, as for the tasks which have `running` status,
-   * `schedule` and `runAt` will be recalculated after task run finishes
-   *
+   * Only tasks with `idle` status will be updated. Running tasks are skipped even when
+   * `regenerateApiKey` is provided, because their `schedule` and `runAt` are recalculated after
+   * the task run finishes.
    * @param {string[]} taskIds  - list of task ids
    * @param {IntervalSchedule | RruleSchedule} schedule  - new schedule
    * @returns {Promise<BulkUpdateTaskResult>}
@@ -235,12 +235,20 @@ export class TaskScheduling {
     schedule: IntervalSchedule | RruleSchedule,
     options?: ApiKeyOptions
   ): Promise<BulkUpdateTaskResult> {
+    const shouldRegenerateApiKey = options?.regenerateApiKey === true;
+
     return retryableBulkUpdate({
       taskIds,
       store: this.store,
       getTasks: async (ids) => await this.bulkGetTasksHelper(ids),
-      filter: (task) => task.status === TaskStatus.Idle && !isEqual(task.schedule, schedule),
+      filter: (task) =>
+        task.status === TaskStatus.Idle &&
+        (shouldRegenerateApiKey || !isEqual(task.schedule, schedule)),
       map: (task) => {
+        if (isEqual(task.schedule, schedule)) {
+          return task;
+        }
+
         const newRunAtInMs = calculateNextRunAtFromSchedule({
           schedule,
           startDate: task.scheduledAt,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [Fix scheduled workflow updates for credentials and running tasks (#272702)](https://github.com/elastic/kibana/pull/272702)

> This backport was resolved manually after the automatic backport failed due to conflicts. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":272702,"url":"https://github.com/elastic/kibana/pull/272702","title":"Fix scheduled workflow updates for credentials and running tasks"},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"sourceCommit":{"sha":"700b8c392e31692e4b56804a799b1bac50f107ef"}}] BACKPORT-->