### PR TITLE
[Fleet] Backport yaml migration fixes to 9.4 (#263437, #265309, #266328, #266774, #271922)

### DIFF
--- a/src/platform/packages/shared/kbn-yaml-loader/moon.yml
+++ b/src/platform/packages/shared/kbn-yaml-loader/moon.yml
@@ -9,8 +9,6 @@ owners:
   defaultOwner: '@elastic/fleet'
 toolchains:
   default: node
-  javascript:
-    rootPackageDependenciesOnly: false
 language: typescript
 project:
   title: '@kbn/yaml-loader'

--- a/src/platform/packages/shared/kbn-yaml-loader/package.json
+++ b/src/platform/packages/shared/kbn-yaml-loader/package.json
@@ -4,8 +4,5 @@
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
   "main": "index.ts",
-  "types": "index.ts",
-  "dependencies": {
-    "yaml": "2.8.1"
-  }
+  "types": "index.ts"
 }

--- a/x-pack/platform/plugins/shared/fleet/common/services/agent_cm_to_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agent_cm_to_yaml.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as yaml from 'yaml';
+
+import type { FullAgentConfigMap } from '../types/models/agent_cm';
+
+import { fullAgentConfigMapToYaml } from './agent_cm_to_yaml';
+
+function makeConfigMap(overrides?: Partial<FullAgentConfigMap>): FullAgentConfigMap {
+  return {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'agent-node-datastreams',
+      namespace: 'kube-system',
+      labels: { 'k8s-app': 'elastic-agent' },
+    },
+    data: {
+      'agent.yml': {} as any,
+    },
+    ...overrides,
+  };
+}
+
+describe('fullAgentConfigMapToYaml', () => {
+  it('serializes a ConfigMap to valid YAML', () => {
+    const cm = makeConfigMap();
+    const result = fullAgentConfigMapToYaml(cm, yaml);
+
+    const parsed = yaml.parse(result);
+    expect(parsed.apiVersion).toBe('v1');
+    expect(parsed.kind).toBe('ConfigMap');
+    expect(parsed.metadata.name).toBe('agent-node-datastreams');
+    expect(parsed.metadata.namespace).toBe('kube-system');
+    expect(parsed.metadata.labels['k8s-app']).toBe('elastic-agent');
+  });
+
+  it('orders top-level keys as apiVersion, kind, metadata, data', () => {
+    // Supply keys in reverse order to confirm sorting is applied
+    const cm = {
+      data: { 'agent.yml': {} as any },
+      metadata: {
+        name: 'agent-node-datastreams',
+        namespace: 'kube-system',
+        labels: { 'k8s-app': 'elastic-agent' },
+      },
+      kind: 'ConfigMap',
+      apiVersion: 'v1',
+    } as FullAgentConfigMap;
+
+    const result = fullAgentConfigMapToYaml(cm, yaml);
+
+    const lines = result.split('\n').filter((l) => /^\w/.test(l));
+    expect(lines[0]).toMatch(/^apiVersion/);
+    expect(lines[1]).toMatch(/^kind/);
+    expect(lines[2]).toMatch(/^metadata/);
+    expect(lines[3]).toMatch(/^data/);
+  });
+
+  it('quotes date-only strings to prevent YAML 1.1 timestamp interpretation by the agent', () => {
+    // The Elastic Agent parses policy YAML with a YAML 1.1 parser, which treats unquoted
+    // YYYY-MM-DD values as timestamps and converts them to RFC3339 (2021-06-01T00:00:00Z).
+    const cm = makeConfigMap({
+      data: {
+        'agent.yml': {
+          state: {
+            assessment_api_version: '2021-06-01',
+            sub_assessment_api_version: '2019-01-01-preview',
+          },
+        } as any,
+      },
+    });
+
+    const result = fullAgentConfigMapToYaml(cm, yaml);
+
+    expect(result).toContain('assessment_api_version: "2021-06-01"');
+    expect(result).toContain('sub_assessment_api_version: 2019-01-01-preview');
+  });
+
+  it('preserves nested agent policy data unchanged', () => {
+    const cm = makeConfigMap({
+      data: {
+        'agent.yml': {
+          id: 'policy-id',
+          outputs: {
+            default: { type: 'elasticsearch', hosts: ['http://localhost:9200'] },
+          },
+          inputs: [{ id: 'input-1', type: 'logfile', streams: [] }],
+        } as any,
+      },
+    });
+
+    const result = fullAgentConfigMapToYaml(cm, yaml);
+    const parsed = yaml.parse(result);
+
+    expect(parsed.data['agent.yml'].id).toBe('policy-id');
+    expect(parsed.data['agent.yml'].outputs.default.type).toBe('elasticsearch');
+    expect(parsed.data['agent.yml'].inputs[0].id).toBe('input-1');
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/common/services/agent_cm_to_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agent_cm_to_yaml.test.ts
@@ -82,6 +82,34 @@ describe('fullAgentConfigMapToYaml', () => {
     expect(result).toContain('sub_assessment_api_version: 2019-01-01-preview');
   });
 
+  it('preserves multi-line strings as YAML literal block scalars (program: |)', () => {
+    const program =
+      '//   It also says that "The data pipeline ingests data at least every 2\n' +
+      '//   minutes." If a package is created every minute on average\n';
+    const cm = makeConfigMap({
+      data: {
+        'agent.yml': {
+          inputs: [
+            {
+              id: 'input-1',
+              type: 'cel',
+              streams: [{ id: 'stream-1', program }],
+            },
+          ],
+        } as any,
+      },
+    });
+
+    const result = fullAgentConfigMapToYaml(cm, yaml);
+
+    // Must use literal block style, not folded (>) or double-quoted
+    expect(result).toContain('program: |');
+    // Lines must be preserved verbatim — no newline-to-space collapse
+    expect(result).toContain('every 2\n');
+    expect(result).toContain('minutes."');
+    expect(result).not.toContain('every 2  //');
+  });
+
   it('preserves nested agent policy data unchanged', () => {
     const cm = makeConfigMap({
       data: {

--- a/x-pack/platform/plugins/shared/fleet/common/services/agent_cm_to_yaml.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agent_cm_to_yaml.ts
@@ -14,5 +14,5 @@ const CM_KEYS_ORDER = ['apiVersion', 'kind', 'metadata', 'data'];
 
 export const fullAgentConfigMapToYaml = (policy: FullAgentConfigMap, yaml: YamlModule): string => {
   const sortCmKeys = createYamlKeysSorter(CM_KEYS_ORDER, yaml);
-  return toYaml(policy, { sortMapEntries: sortCmKeys, strict: false }, yaml);
+  return toYaml(policy, { sortMapEntries: sortCmKeys, strict: false, schema: 'yaml-1.1' }, yaml);
 };

--- a/x-pack/platform/plugins/shared/fleet/common/services/full_agent_policy_to_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/full_agent_policy_to_yaml.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import * as yaml from 'yaml';
+
 import type { FullAgentPolicy } from '../types';
 
 import { fullAgentPolicyToYaml } from './full_agent_policy_to_yaml';
@@ -64,5 +66,38 @@ describe('fullAgentPolicyToYaml', () => {
     expect(result).toMatchInlineSnapshot(
       `"{\\"id\\":\\"1234\\",\\"outputs\\":{\\"default\\":{\\"type\\":\\"elasticsearch\\",\\"hosts\\":[\\"http://localhost:9200\\"]}},\\"inputs\\":[{\\"id\\":\\"test_input-secrets-abcd1234\\",\\"revision\\":1,\\"name\\":\\"secrets-1\\",\\"type\\":\\"test_input\\",\\"data_stream\\":{\\"namespace\\":\\"default\\"},\\"use_output\\":\\"default\\",\\"package_policy_id\\":\\"abcd1234\\",\\"package_var_secret\\":\\"\${SECRET_0}\\",\\"input_var_secret\\":\\"\${SECRET_1}\\",\\"streams\\":[{\\"id\\":\\"test_input-secrets.log-abcd1234\\",\\"data_stream\\":{\\"type\\":\\"logs\\",\\"dataset\\":\\"secrets.log\\"},\\"package_var_secret\\":\\"\${SECRET_0}\\",\\"input_var_secret\\":\\"\${SECRET_1}\\",\\"stream_var_secret\\":\\"\${SECRET_2}\\"}],\\"meta\\":{\\"package\\":{\\"name\\":\\"secrets\\",\\"version\\":\\"1.0.0\\"}}}],\\"secret_references\\":[{\\"id\\":\\"secret-id-1\\"},{\\"id\\":\\"secret-id-2\\"},{\\"id\\":\\"secret-id-3\\"}],\\"revision\\":2,\\"agent\\":{},\\"signed\\":{},\\"output_permissions\\":{},\\"fleet\\":{}}"`
     );
+  });
+
+  it('should quote date-only strings to prevent YAML 1.1 timestamp interpretation by the agent', () => {
+    // Integrations like microsoft_defender_cloud use date-only API versions (e.g. 2021-06-01).
+    // The Elastic Agent parses policy YAML with a YAML 1.1 parser, which treats unquoted
+    // YYYY-MM-DD values as timestamps and converts them to RFC3339 (2021-06-01T00:00:00Z).
+    // The yaml-1.1 schema in Document options forces these values to be quoted.
+    const policy = {
+      id: 'test-policy',
+      outputs: {},
+      inputs: [
+        {
+          id: 'test-input',
+          type: 'cel',
+          streams: [
+            {
+              id: 'test-stream',
+              state: {
+                assessment_api_version: '2021-06-01',
+                sub_assessment_api_version: '2019-01-01-preview',
+              },
+            },
+          ],
+        },
+      ],
+      revision: 1,
+      agent: {},
+    } as unknown as FullAgentPolicy;
+
+    const result = fullAgentPolicyToYaml(policy, yaml);
+
+    expect(result).toContain('assessment_api_version: "2021-06-01"');
+    expect(result).toContain('sub_assessment_api_version: 2019-01-01-preview');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/full_agent_policy_to_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/full_agent_policy_to_yaml.test.ts
@@ -23,6 +23,7 @@ const mockYaml = {
     }
   },
   isScalar: () => true,
+  visit: () => {},
 };
 
 describe('fullAgentPolicyToYaml', () => {
@@ -66,6 +67,34 @@ describe('fullAgentPolicyToYaml', () => {
     expect(result).toMatchInlineSnapshot(
       `"{\\"id\\":\\"1234\\",\\"outputs\\":{\\"default\\":{\\"type\\":\\"elasticsearch\\",\\"hosts\\":[\\"http://localhost:9200\\"]}},\\"inputs\\":[{\\"id\\":\\"test_input-secrets-abcd1234\\",\\"revision\\":1,\\"name\\":\\"secrets-1\\",\\"type\\":\\"test_input\\",\\"data_stream\\":{\\"namespace\\":\\"default\\"},\\"use_output\\":\\"default\\",\\"package_policy_id\\":\\"abcd1234\\",\\"package_var_secret\\":\\"\${SECRET_0}\\",\\"input_var_secret\\":\\"\${SECRET_1}\\",\\"streams\\":[{\\"id\\":\\"test_input-secrets.log-abcd1234\\",\\"data_stream\\":{\\"type\\":\\"logs\\",\\"dataset\\":\\"secrets.log\\"},\\"package_var_secret\\":\\"\${SECRET_0}\\",\\"input_var_secret\\":\\"\${SECRET_1}\\",\\"stream_var_secret\\":\\"\${SECRET_2}\\"}],\\"meta\\":{\\"package\\":{\\"name\\":\\"secrets\\",\\"version\\":\\"1.0.0\\"}}}],\\"secret_references\\":[{\\"id\\":\\"secret-id-1\\"},{\\"id\\":\\"secret-id-2\\"},{\\"id\\":\\"secret-id-3\\"}],\\"revision\\":2,\\"agent\\":{},\\"signed\\":{},\\"output_permissions\\":{},\\"fleet\\":{}}"`
     );
+  });
+
+  it('preserves multi-line strings as YAML literal block scalars (program: |)', () => {
+    const program =
+      '//   It also says that "The data pipeline ingests data at least every 2\n' +
+      '//   minutes." If a package is created every minute on average\n';
+    const policy = {
+      id: 'test-policy',
+      outputs: {},
+      inputs: [
+        {
+          id: 'test-input',
+          type: 'cel',
+          streams: [{ id: 'test-stream', program }],
+        },
+      ],
+      revision: 1,
+      agent: {},
+    } as unknown as FullAgentPolicy;
+
+    const result = fullAgentPolicyToYaml(policy, yaml);
+
+    // Must use literal block style, not folded (>) or double-quoted
+    expect(result).toContain('program: |');
+    // Lines must be preserved verbatim — no newline-to-space collapse
+    expect(result).toContain('every 2\n');
+    expect(result).toContain('minutes."');
+    expect(result).not.toContain('every 2  //');
   });
 
   it('should quote date-only strings to prevent YAML 1.1 timestamp interpretation by the agent', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/full_agent_policy_to_yaml.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/full_agent_policy_to_yaml.ts
@@ -35,7 +35,11 @@ export const fullAgentPolicyToYaml = (
   apiKey?: string
 ): string => {
   const sortYamlKeys = createYamlKeysSorter(POLICY_KEYS_ORDER, yaml);
-  const yamlText = toYaml(policy, { sortMapEntries: sortYamlKeys, strict: false }, yaml);
+  const yamlText = toYaml(
+    policy,
+    { sortMapEntries: sortYamlKeys, strict: false, schema: 'yaml-1.1' },
+    yaml
+  );
   const formattedYml = apiKey ? replaceApiKey(yamlText, apiKey) : yamlText;
 
   if (!policy?.secret_references?.length) return formattedYml;

--- a/x-pack/platform/plugins/shared/fleet/common/services/yaml_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/yaml_utils.ts
@@ -13,6 +13,11 @@
 export interface YamlModule {
   Document: new (data: unknown, options?: any) => { toString(): string };
   isScalar: (node: unknown) => boolean;
+
+  visit: (
+    node: any,
+    visitor: { Scalar(key: unknown, node: { value?: unknown; type?: string }): void }
+  ) => void;
 }
 
 /**
@@ -58,8 +63,20 @@ export function createYamlKeysSorter(
 /**
  * Converts data to YAML string using the yaml package Document API.
  * This is the standard toYaml implementation used across Fleet.
+ *
+ * Multi-line strings are forced to literal block scalar style (`|`) so that
+ * newlines are preserved verbatim. Without this, the yaml package may choose
+ * folded (`>`) or double-quoted style for strings containing embedded newlines,
+ * collapsing lines and corrupting config values like CEL programs or scripts.
  */
 export function toYaml(data: unknown, options: unknown, yaml: YamlModule): string {
   const doc = new yaml.Document(data, options);
+  yaml.visit(doc, {
+    Scalar(_key, node) {
+      if (typeof node.value === 'string' && node.value.includes('\n')) {
+        node.type = 'BLOCK_LITERAL';
+      }
+    },
+  });
   return doc.toString();
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -428,6 +428,100 @@ input: logs
     });
   });
 
+  const rerouteConfigVars = {
+    reroute_config: {
+      type: 'yaml',
+      value: `
+- if:
+    and:
+      - not.has_fields: _conf.dataset
+      - regexp.message: "devid=\\"?FG"
+  then:
+    - add_fields:
+        target: ''
+        fields:
+          _conf.dataset: "fortinet_fortigate.log"
+- if:
+    and:
+      - not.has_fields: _conf.dataset
+      - regexp.message: " CheckPoint [0-9]+ - "
+  then:
+    - add_fields:
+        target: ''
+        fields:
+          _conf.dataset: "checkpoint.firewall"
+          _conf.tz_offset: "UTC"
+      `,
+    },
+  };
+
+  it('should handle deeply nested yaml values without producing compact mappings', () => {
+    const streamTemplate = `
+input: udp
+host: "0.0.0.0:9515"
+reroute_config: {{reroute_config}}
+    `;
+
+    const output = compileTemplate(rerouteConfigVars, getMockedMetaVariable(), streamTemplate);
+    expect(output).toEqual({
+      input: 'udp',
+      host: '0.0.0.0:9515',
+      reroute_config: [
+        {
+          if: {
+            and: [{ 'not.has_fields': '_conf.dataset' }, { 'regexp.message': 'devid="?FG' }],
+          },
+          then: [
+            {
+              add_fields: {
+                target: '',
+                fields: { '_conf.dataset': 'fortinet_fortigate.log' },
+              },
+            },
+          ],
+        },
+        {
+          if: {
+            and: [
+              { 'not.has_fields': '_conf.dataset' },
+              { 'regexp.message': ' CheckPoint [0-9]+ - ' },
+            ],
+          },
+          then: [
+            {
+              add_fields: {
+                target: '',
+                fields: {
+                  '_conf.dataset': 'checkpoint.firewall',
+                  '_conf.tz_offset': 'UTC',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should handle root-level yaml variables with values containing double quotes (syslog_router pattern)', () => {
+    const streamTemplate = `
+input: udp
+host: "0.0.0.0:9515"
+processors:
+- add_locale: ~
+{{#if reroute_config}}
+{{reroute_config}}
+{{/if}}
+    `;
+
+    const output = compileTemplate(rerouteConfigVars, getMockedMetaVariable(), streamTemplate);
+    expect(output.processors).toBeDefined();
+    expect(output.processors).toHaveLength(3);
+    expect(output.processors[0]).toEqual({ add_locale: null });
+    expect(output.processors[1].if.and[1]['regexp.message']).toBe('devid="?FG');
+    expect(output.processors[2].if.and[1]['regexp.message']).toBe(' CheckPoint [0-9]+ - ');
+  });
+
   it('should support $$$$ yaml values at root level', () => {
     const streamTemplate = `
 input: logs

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -113,19 +113,16 @@ export function compileTemplate(
     throw new PackageInvalidArchiveError(`Error while compiling agent template: ${err.message}`);
   }
 
-  compiledTemplate = replaceRootLevelYamlVariables(yamlValues, compiledTemplate);
-
-  // Normalize multi-line double-quoted YAML scalars. The yaml package (unlike
-  // js-yaml) rejects literal newlines inside double-quoted strings. Values that
-  // were JSON-stringified and then had parameters resolved may contain actual
-  // newlines (doubled by handleMultilineStringFormatter). Apply YAML double-quoted
-  // folding semantics: N consecutive newlines become N-1 \n escape sequences,
-  // matching the output that js-yaml.load produced from the multi-line format.
+  // Must run before replaceRootLevelYamlVariables: stringify output may contain
+  // unquoted `"` chars (e.g. regexp patterns) that cause this regex to match
+  // across lines and corrupt the YAML structure.
   compiledTemplate = compiledTemplate.replace(/"(?:[^"\\]|\\.)*"/gs, (match) =>
     match.includes('\n')
       ? match.replace(/\n+/g, (newlines) => '\\n'.repeat(newlines.length - 1))
       : match
   );
+
+  compiledTemplate = replaceRootLevelYamlVariables(yamlValues, compiledTemplate);
 
   try {
     const yamlFromCompiledTemplate = parse(compiledTemplate);
@@ -342,7 +339,7 @@ function replaceRootLevelYamlVariables(yamlVariables: { [k: string]: any }, yaml
   let patchedTemplate = yamlTemplate;
   Object.entries(yamlVariables).forEach(([key, val]) => {
     patchedTemplate = patchedTemplate.replace(new RegExp(`^"${key}"`, 'gm'), () =>
-      val ? stringify(val) : ''
+      val ? stringify(val, { collectionStyle: 'block', lineWidth: 0 }) : ''
     );
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.test.ts
@@ -192,6 +192,40 @@ processors:
     );
   });
 
+  it('serializes multi-line Painless scripts as literal block scalars (source: |)', () => {
+    // yaml.stringify() was producing source: > (folded block) for scripts whose lines
+    // approach the default lineWidth (80 chars), which Elasticsearch's Jackson YAML parser rejects.
+    const pipelineInstall = addCustomPipelineAndLocalRoutingRulesProcessor({
+      contentForInstallation: `processors:
+  - script:
+      lang: painless
+      source: |
+        def splitUnquoted(String input, String sep) {
+          def tokens = [];
+          def startPosition = 0;
+          def isInQuotes = false;
+          char quote = (char)"\\"";
+          for (def currentPosition = 0; currentPosition < input.length(); currentPosition++) {
+            if (input.charAt(currentPosition) == quote) {
+              isInQuotes = !isInQuotes;
+            }
+          }
+          return tokens;
+        }
+`,
+      extension: 'yml',
+      nameForInstallation: 'logs-test-1.0.0',
+      shouldInstallCustomPipelines: true,
+      dataStream: {
+        type: 'logs',
+        dataset: 'test',
+      } as any,
+    });
+
+    expect(pipelineInstall.contentForInstallation).toMatch(/source: \|/);
+    expect(pipelineInstall.contentForInstallation).not.toMatch(/source: >/);
+  });
+
   describe('with local routing rules', () => {
     it('add reroute processor after custom pipeline processor for yaml pipeline', () => {
       const pipelineInstall = addCustomPipelineAndLocalRoutingRulesProcessor({
@@ -231,15 +265,15 @@ processors:
           - pipeline:
               name: global@custom
               ignore_missing_pipeline: true
-              description: '[Fleet] Global pipeline for all data streams'
+              description: \\"[Fleet] Global pipeline for all data streams\\"
           - pipeline:
               name: logs@custom
               ignore_missing_pipeline: true
-              description: '[Fleet] Pipeline for all data streams of type \`logs\`'
+              description: \\"[Fleet] Pipeline for all data streams of type \`logs\`\\"
           - pipeline:
               name: logs-test.access@custom
               ignore_missing_pipeline: true
-              description: '[Fleet] Pipeline for the \`test.access\` dataset'
+              description: \\"[Fleet] Pipeline for the \`test.access\` dataset\\"
           - reroute:
               tag: test.access
               dataset: test.reroute

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.ts
@@ -4,13 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { parse, stringify } from 'yaml';
+import { parse } from 'yaml';
 
 import { ElasticsearchAssetType } from '../../../../types';
 import type { RegistryDataStream } from '../../../../types';
 import { getPathParts } from '../../archive';
 
 import { getPipelineNameForDatastream } from '../../../../../common/services';
+
+import { toYaml } from '../yaml_utils';
 
 import type { PipelineInstall, RewriteSubstitution } from './types';
 
@@ -136,7 +138,7 @@ export function addCustomPipelineAndLocalRoutingRulesProcessor(
     );
     return {
       ...pipeline,
-      contentForInstallation: `---\n${stringify(parsedPipelineContent, { singleQuote: true })}`,
+      contentForInstallation: `---\n${toYaml(parsedPipelineContent)}`,
     };
   }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/meta.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/meta.test.ts
@@ -5,7 +5,57 @@
  * 2.0.
  */
 
-import { getESAssetMetadata } from './meta';
+import { appendMetadataToIngestPipeline, getESAssetMetadata } from './meta';
+
+describe('appendMetadataToIngestPipeline', () => {
+  it('escapes DEL (U+007F) and C1 control characters that the yaml package leaves unescaped', () => {
+    // The yaml package does not escape U+007F in double-quoted scalars; SnakeYAML rejects the raw byte.
+    const result = appendMetadataToIngestPipeline({
+      pipeline: {
+        extension: 'yml',
+        nameForInstallation: 'test-pipeline',
+        // gsub pattern with control characters — mirrors what real Fortinet pipelines contain
+        contentForInstallation: `processors:\n  - gsub:\n      field: message\n      pattern: "[\\x00-\\x1f\\x7f]"\n      replacement: ""\n`,
+      },
+      packageName: 'test',
+    });
+
+    expect(result.contentForInstallation).not.toMatch(/\x7f/);
+    expect(result.contentForInstallation).toContain('\\x7f');
+  });
+
+  it('serializes multi-line Painless scripts as literal block scalars (source: |)', () => {
+    // yaml.stringify() was producing source: > (folded block) for scripts whose lines
+    // approach the default lineWidth (80 chars), which Elasticsearch's Jackson YAML parser rejects.
+    const result = appendMetadataToIngestPipeline({
+      pipeline: {
+        extension: 'yml',
+        nameForInstallation: 'test-pipeline',
+        contentForInstallation: `processors:
+  - script:
+      lang: painless
+      source: |
+        def splitUnquoted(String input, String sep) {
+          def tokens = [];
+          def startPosition = 0;
+          def isInQuotes = false;
+          char quote = (char)"\\"";
+          for (def currentPosition = 0; currentPosition < input.length(); currentPosition++) {
+            if (input.charAt(currentPosition) == quote) {
+              isInQuotes = !isInQuotes;
+            }
+          }
+          return tokens;
+        }
+`,
+      },
+      packageName: 'test',
+    });
+
+    expect(result.contentForInstallation).toMatch(/source: \|/);
+    expect(result.contentForInstallation).not.toMatch(/source: >/);
+  });
+});
 
 describe('getESAssetMetadata', () => {
   describe('with package name', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/meta.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/meta.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import { parse, stringify } from 'yaml';
+import { parse } from 'yaml';
 
 import type { ESAssetMetadata } from '../../../../common/types';
+
 import { PackagePolicyValidationError } from '../../../../common/errors';
+
+import { toYaml } from './yaml_utils';
 
 const MANAGED_BY_DEFAULT = 'fleet';
 
@@ -48,10 +51,9 @@ export function appendMetadataToIngestPipeline({
       // YML and return the resulting YML
       const parsedPipelineContent = parse(pipeline.contentForInstallation);
       parsedPipelineContent._meta = meta;
-
       return {
         ...pipeline,
-        contentForInstallation: `---\n${stringify(parsedPipelineContent)}`,
+        contentForInstallation: `---\n${toYaml(parsedPipelineContent)}`,
       };
     }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/yaml_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/yaml_utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToStringOptions } from 'yaml';
+import { Document, visit } from 'yaml';
+
+/**
+ * Converts a plain object to a YAML string, fixing two serialization issues
+ * that cause Elasticsearch's Jackson/SnakeYAML parser to reject the output:
+ *
+ * 1. Multi-line strings (e.g. Painless scripts) are forced to literal block
+ *    scalars (`source: |`). Without this, the yaml package may choose folded
+ *    block scalars (`source: >`) for long lines.
+ *
+ * 2. Characters U+007F–U+009F are not escaped by the yaml package in
+ *    double-quoted scalars, but SnakeYAML rejects them as raw bytes. They are
+ *    replaced with their `\xNN` YAML escape sequences in the final output.
+ */
+export function toYaml(obj: unknown, opts?: ToStringOptions): string {
+  const doc = new Document(obj);
+  visit(doc, {
+    Scalar(key, node) {
+      if (typeof node.value === 'string' && node.value.includes('\n')) {
+        node.type = 'BLOCK_LITERAL';
+      }
+    },
+  });
+  return escapeUnescapedControlChars(doc.toString(opts));
+}
+
+// The yaml package does not escape U+007F (DEL) or U+0080–U+009F in
+// double-quoted scalars. SnakeYAML rejects these raw bytes with
+// "special characters are not allowed". Replace them with \xNN sequences.
+function escapeUnescapedControlChars(yaml: string): string {
+  return yaml.replace(
+    /[\x7f-\x9f]/g,
+    (c) => `\\x${c.codePointAt(0)!.toString(16).padStart(2, '0')}`
+  );
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_template_inputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_template_inputs.ts
@@ -265,6 +265,13 @@ export async function getTemplateInputs(
       sortMapEntries: _sortYamlKeys as (a: Pair, b: Pair) => number,
       strict: false,
     });
+    yaml.visit(doc, {
+      Scalar(_key, node) {
+        if (typeof node.value === 'string' && node.value.includes('\n')) {
+          node.type = 'BLOCK_LITERAL';
+        }
+      },
+    });
     const yamlStr = doc.toString({ singleQuote: true });
     return addCommentsToYaml(yamlStr, buildIndexedPackage(packageInfo), inputIdsDestinationMap);
   }
@@ -384,6 +391,13 @@ function addCommentsToYaml(
     });
   }
 
+  yaml.visit(doc, {
+    Scalar(_key, node) {
+      if (typeof node.value === 'string' && node.value.includes('\n')) {
+        node.type = 'BLOCK_LITERAL';
+      }
+    },
+  });
   return doc.toString({ singleQuote: true });
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_templates_inputs.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_templates_inputs.test.ts
@@ -447,6 +447,22 @@ describe('Fleet - getTemplateInputs', () => {
     }
   });
 
+  it('preserves multi-line strings as YAML literal block scalars in yml format output (#265122)', async () => {
+    const soMock = savedObjectsClientMock.create();
+    soMock.get.mockResolvedValue({ attributes: {} } as any);
+
+    // The exact two-line CEL comment from the bug report that triggered newline collapse.
+    // Redis has a `program` field in its CEL input streams — use its fixture but override
+    // the compiled stream to include the problematic multi-line content.
+    const template = await getTemplateInputs(soMock, 'redis', '1.18.0', 'yml');
+    const yamlStr = template as unknown as string;
+
+    // The yml output must not contain folded block scalars (>) or escaped newlines (\n)
+    // for any multi-line string values — the fix forces BLOCK_LITERAL style.
+    expect(yamlStr).not.toMatch(/: >\n/); // no folded block scalars
+    expect(yamlStr).not.toMatch(/\\n/); // no escaped newlines in double-quoted strings
+  });
+
   it('should NOT inject wired streams routing processor when disabled', async () => {
     const soMock = savedObjectsClientMock.create();
     soMock.get.mockResolvedValue({ attributes: {} } as any);

--- a/yarn.lock
+++ b/yarn.lock
@@ -36919,11 +36919,6 @@ yaml@2.0.0-1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-1.tgz#8c3029b3ee2028306d5bcf396980623115ff8d18"
   integrity sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==
 
-yaml@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
-  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
-
 yaml@2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"


### PR DESCRIPTION
## Summary

Backports five fixes for the `js-yaml` → `yaml` migration (#252345) to the 9.4 branch.

## Commits

- **#263437** — Remove local `yaml@2.8.1` dependency from `kbn-yaml-loader/package.json` so clean installs no longer fail with `ENOENT` for the local `node_modules/yaml` path.
- **#265309** — Fix date formatting regression: `YYYY-MM-DD` strings in agent policy YAML were being interpreted as timestamps by the Elastic Agent. Adds `schema: 'yaml-1.1'` to `fullAgentPolicyToYaml` and `fullAgentConfigMapToYaml` to restore quoting behaviour.
- **#266328** — Fix ingest pipeline YAML serialization producing folded block scalars (`>`). Elasticsearch's Jackson YAML parser rejects folded scalars containing special characters (e.g. Painless scripts). Adds a `toYaml()` utility that forces `BLOCK_LITERAL` (`|`) on all multi-line scalars.
- **#266774** — Fix root-level variable replacement regression where YAML string values containing quotes were not handled correctly after the migration.
- **#271922** — Fix YAML literal block scalar handling in `toYaml()`: use `yaml.visit()` to force `BLOCK_LITERAL` (`|`) style on every multi-line string scalar, so embedded newlines are preserved verbatim instead of being collapsed by folded (`>`) or double-quoted styles. Prevents corruption of multi-line config values such as CEL programs and scripts.

## Test plan

- [ ] Existing unit tests for the affected files pass
- [x] Integration installation succeeds on Serverless (regression from #266328)
- [x] `syslog_router` package policy creation works (regression from #266774)
- [ ] Agent policy YAML does not convert date strings to RFC3339 (regression from #265309)
- [ ] Multi-line scalars (e.g. CEL programs) serialize as literal block (`|`) with newlines preserved (regression from #271922)

🤖 Generated with [Claude Code](https://claude.com/claude-code)