### PR TITLE
[ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050)

### DIFF
--- a/x-pack/examples/alerting_example/public/alert_types/pattern.tsx
+++ b/x-pack/examples/alerting_example/public/alert_types/pattern.tsx
@@ -13,6 +13,7 @@ import {
   EuiFormRow,
   EuiButton,
   EuiButtonIcon,
+  EuiToolTip,
   EuiSpacer,
   EuiBasicTable,
   EuiCallOut,
@@ -203,12 +204,14 @@ const PatternExpression: React.FunctionComponent<RuleTypeParamsExpressionProps<P
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiFormRow hasEmptyLabelSpace display="rowCompressed">
-                <EuiButtonIcon
-                  iconType="trash"
-                  color="danger"
-                  aria-label={`Remove ${instanceName}`}
-                  onClick={() => removeInstance(instanceName)}
-                />
+                <EuiToolTip content={`Remove ${instanceName}`} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="trash"
+                    color="danger"
+                    aria-label={`Remove ${instanceName}`}
+                    onClick={() => removeInstance(instanceName)}
+                  />
+                </EuiToolTip>
               </EuiFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx
+++ b/x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx
@@ -8,7 +8,7 @@
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFormRow, EuiButtonIcon, EuiTitle } from '@elastic/eui';
+import { EuiFormRow, EuiButtonIcon, EuiToolTip, EuiTitle } from '@elastic/eui';
 import type { RuleConditionsProps, ActionGroupWithCondition } from './rule_conditions';
 
 export type RuleConditionsGroupProps<ConditionProps> = {
@@ -21,6 +21,11 @@ export const RuleConditionsGroup = <ConditionProps extends unknown>({
   children,
   ...otherProps
 }: PropsWithChildren<RuleConditionsGroupProps<ConditionProps>>) => {
+  const removeConditionLabel = i18n.translate(
+    'xpack.triggersActionsUI.sections.ruleForm.conditions.removeConditionLabel',
+    { defaultMessage: 'Remove' }
+  );
+
   if (!actionGroup) {
     return null;
   }
@@ -36,17 +41,14 @@ export const RuleConditionsGroup = <ConditionProps extends unknown>({
       labelAppend={
         onResetConditionsFor &&
         !actionGroup.isRequired && (
-          <EuiButtonIcon
-            iconType="minusCircle"
-            color="danger"
-            aria-label={i18n.translate(
-              'xpack.triggersActionsUI.sections.ruleForm.conditions.removeConditionLabel',
-              {
-                defaultMessage: 'Remove',
-              }
-            )}
-            onClick={() => onResetConditionsFor(actionGroup)}
-          />
+          <EuiToolTip content={removeConditionLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="minusCircle"
+              color="danger"
+              aria-label={removeConditionLabel}
+              onClick={() => onResetConditionsFor(actionGroup)}
+            />
+          </EuiToolTip>
         )
       }
     >

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.tsx
@@ -16,6 +16,7 @@ import {
   EuiSelect,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import * as i18n from './translations';
 import type { DataConditionEntry, DataConditionTypeDescriptor } from './types';
@@ -88,21 +89,25 @@ export const DataConditionPanel = ({
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="pencil"
-              aria-label={i18n.EDIT_DATA_CONDITION_ARIA_LABEL}
-              onClick={() => onChange({ ...entry, confirmed: false })}
-              data-test-subj={`editDataCondition-${entry.id}`}
-            />
+            <EuiToolTip content={i18n.EDIT_DATA_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="pencil"
+                aria-label={i18n.EDIT_DATA_CONDITION_ARIA_LABEL}
+                onClick={() => onChange({ ...entry, confirmed: false })}
+                data-test-subj={`editDataCondition-${entry.id}`}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="trash"
-              color="danger"
-              aria-label={i18n.REMOVE_DATA_CONDITION_ARIA_LABEL}
-              onClick={() => onChange(null)}
-              data-test-subj={`deleteDataCondition-${entry.id}`}
-            />
+            <EuiToolTip content={i18n.REMOVE_DATA_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="trash"
+                color="danger"
+                aria-label={i18n.REMOVE_DATA_CONDITION_ARIA_LABEL}
+                onClick={() => onChange(null)}
+                data-test-subj={`deleteDataCondition-${entry.id}`}
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>
@@ -129,23 +134,27 @@ export const DataConditionPanel = ({
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="check"
-            color="success"
-            display="base"
-            aria-label={i18n.CONFIRM_CONDITION_ARIA_LABEL}
-            onClick={() => onChange({ ...entry, confirmed: true })}
-            isDisabled={!isComplete}
-            data-test-subj={`confirmDataCondition-${entry.id}`}
-          />
+          <EuiToolTip content={i18n.CONFIRM_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="check"
+              color="success"
+              display="base"
+              aria-label={i18n.CONFIRM_CONDITION_ARIA_LABEL}
+              onClick={() => onChange({ ...entry, confirmed: true })}
+              isDisabled={!isComplete}
+              data-test-subj={`confirmDataCondition-${entry.id}`}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="cross"
-            aria-label={i18n.REMOVE_DATA_CONDITION_ARIA_LABEL}
-            onClick={() => onChange(null)}
-            data-test-subj={`removeDataCondition-${entry.id}`}
-          />
+          <EuiToolTip content={i18n.REMOVE_DATA_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="cross"
+              aria-label={i18n.REMOVE_DATA_CONDITION_ARIA_LABEL}
+              onClick={() => onChange(null)}
+              data-test-subj={`removeDataCondition-${entry.id}`}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="s" />

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/snooze_duration_picker.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/snooze_duration_picker.tsx
@@ -17,6 +17,7 @@ import {
   EuiFormRow,
   EuiSelect,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { CustomDurationState, CustomSnoozeMode, SnoozeUnit } from './types';
 import { SNOOZE_UNIT_OPTIONS, CUSTOM_MODE_BUTTONS } from './constants';
@@ -105,12 +106,14 @@ export const SnoozeDurationPicker = ({
             </EuiFlexItem>
             {dateTime !== null && (
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType="cross"
-                  onClick={() => onChange({ dateTime: null })}
-                  aria-label={i18n.CLEAR_DATETIME_ARIA_LABEL}
-                  data-test-subj="dateTimeClear"
-                />
+                <EuiToolTip content={i18n.CLEAR_DATETIME_ARIA_LABEL} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="cross"
+                    onClick={() => onChange({ dateTime: null })}
+                    aria-label={i18n.CLEAR_DATETIME_ARIA_LABEL}
+                    data-test-subj="dateTimeClear"
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             )}
           </EuiFlexGroup>

--- a/x-pack/platform/packages/shared/response-ops/alert-snooze/components/time_condition_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alert-snooze/components/time_condition_panel.tsx
@@ -16,6 +16,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { CustomDurationState, SnoozeUnit } from './types';
 import { SnoozeDurationPicker } from './snooze_duration_picker';
@@ -68,21 +69,25 @@ export const TimeConditionPanel = ({
             <EuiBadge color="hollow">{chipLabel}</EuiBadge>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="pencil"
-              aria-label={i18n.EDIT_TIME_CONDITION_ARIA_LABEL}
-              onClick={() => onChange({ ...value, status: 'editing' })}
-              data-test-subj="editTimeCondition"
-            />
+            <EuiToolTip content={i18n.EDIT_TIME_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="pencil"
+                aria-label={i18n.EDIT_TIME_CONDITION_ARIA_LABEL}
+                onClick={() => onChange({ ...value, status: 'editing' })}
+                data-test-subj="editTimeCondition"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="trash"
-              color="danger"
-              aria-label={i18n.REMOVE_TIME_CONDITION_ARIA_LABEL}
-              onClick={() => onChange(null)}
-              data-test-subj="removeTimeCondition"
-            />
+            <EuiToolTip content={i18n.REMOVE_TIME_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="trash"
+                color="danger"
+                aria-label={i18n.REMOVE_TIME_CONDITION_ARIA_LABEL}
+                onClick={() => onChange(null)}
+                data-test-subj="removeTimeCondition"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>
@@ -102,23 +107,27 @@ export const TimeConditionPanel = ({
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="check"
-              color="success"
-              display="base"
-              aria-label={i18n.CONFIRM_CONDITION_ARIA_LABEL}
-              onClick={() => onChange({ ...value, status: 'confirmed' })}
-              isDisabled={isConditionInvalid}
-              data-test-subj="confirmTimeCondition"
-            />
+            <EuiToolTip content={i18n.CONFIRM_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="check"
+                color="success"
+                display="base"
+                aria-label={i18n.CONFIRM_CONDITION_ARIA_LABEL}
+                onClick={() => onChange({ ...value, status: 'confirmed' })}
+                isDisabled={isConditionInvalid}
+                data-test-subj="confirmTimeCondition"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="cross"
-              aria-label={i18n.REMOVE_TIME_CONDITION_ARIA_LABEL}
-              onClick={() => onChange(null)}
-              data-test-subj="removeTimeCondition"
-            />
+            <EuiToolTip content={i18n.REMOVE_TIME_CONDITION_ARIA_LABEL} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label={i18n.REMOVE_TIME_CONDITION_ARIA_LABEL}
+                onClick={() => onChange(null)}
+                data-test-subj="removeTimeCondition"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="s" />

--- a/x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx
@@ -14,6 +14,7 @@ import {
   EuiHorizontalRule,
   EuiPanel,
   EuiText,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -309,14 +310,16 @@ const Operator = ({ operator, onDelete }: OperatorProps) => {
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          iconType="trash"
-          aria-label={DELETE_OPERAND_LABEL}
-          onClick={onDelete}
-          iconSize="s"
-          color="text"
-          data-test-subj={DELETE_OPERAND_BUTTON_SUBJ}
-        />
+        <EuiToolTip content={DELETE_OPERAND_LABEL} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="trash"
+            aria-label={DELETE_OPERAND_LABEL}
+            onClick={onDelete}
+            iconSize="s"
+            color="text"
+            data-test-subj={DELETE_OPERAND_BUTTON_SUBJ}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx
@@ -14,7 +14,7 @@ import { AlertsDataGrid } from './alerts_data_grid';
 import type { AlertsDataGridProps, BulkActionsState } from '../types';
 import type { AdditionalContext, RenderContext } from '../types';
 import type { EuiDataGridColumnCellAction } from '@elastic/eui';
-import { EuiButton, EuiButtonIcon, EuiFlexItem } from '@elastic/eui';
+import { EuiButton, EuiButtonIcon, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { testQueryClientConfig } from '@kbn/alerts-ui-shared/src/common/test_utils/test_query_client_config';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
@@ -241,24 +241,28 @@ describe('AlertsDataGrid', () => {
               renderActionsCell: () => (
                 <>
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="analyzeEvent"
-                      color="primary"
-                      onClick={() => {}}
-                      size="s"
-                      data-test-subj="testAction"
-                      aria-label="testActionLabel"
-                    />
+                    <EuiToolTip content="testActionLabel" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        iconType="analyzeEvent"
+                        color="primary"
+                        onClick={() => {}}
+                        size="s"
+                        data-test-subj="testAction"
+                        aria-label="testActionLabel"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="analyzeEvent"
-                      color="primary"
-                      onClick={() => {}}
-                      size="s"
-                      data-test-subj="testAction2"
-                      aria-label="testActionLabel2"
-                    />
+                    <EuiToolTip content="testActionLabel2" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        iconType="analyzeEvent"
+                        color="primary"
+                        onClick={() => {}}
+                        size="s"
+                        data-test-subj="testAction2"
+                        aria-label="testActionLabel2"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 </>
               ),

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import React, { useState, memo, useCallback } from 'react';
 
 import type { EsQuerySnapshot } from '@kbn/alerting-types';
@@ -53,15 +53,16 @@ const AlertsQueryInspectorComponent: React.FC<InspectButtonProps> = ({
 
   return (
     <>
-      <EuiButtonIcon
-        className={BUTTON_CLASS}
-        aria-label={i18n.INSPECT}
-        data-test-subj="inspect-icon-button"
-        iconSize="m"
-        iconType="inspect"
-        title={i18n.INSPECT}
-        onClick={onOpenModal}
-      />
+      <EuiToolTip content={i18n.INSPECT} disableScreenReaderOutput>
+        <EuiButtonIcon
+          className={BUTTON_CLASS}
+          aria-label={i18n.INSPECT}
+          data-test-subj="inspect-icon-button"
+          iconSize="m"
+          iconType="inspect"
+          onClick={onOpenModal}
+        />
+      </EuiToolTip>
       {isShowingModal && (
         <AlertsQueryInspectorModal
           closeModal={onCloseModal}

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx
@@ -11,7 +11,7 @@ import { AlertsField } from '../types';
 import type { AdditionalContext, RenderContext } from '../types';
 import { createCasesServiceMock, getCasesMapMock } from './cases.mock';
 import { getMaintenanceWindowsMock } from './maintenance_windows.mock';
-import { EuiButtonIcon, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import React from 'react';
 import { identity } from 'lodash';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
@@ -159,14 +159,16 @@ export const mockRenderContext = createPartialObjectMock<RenderContext<Additiona
   }),
   renderActionsCell: () => (
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="analyzeEvent"
-        color="primary"
-        onClick={() => {}}
-        size="s"
-        data-test-subj="testAction"
-        aria-label="Test action"
-      />
+      <EuiToolTip content="Test action" disableScreenReaderOutput>
+        <EuiButtonIcon
+          iconType="analyzeEvent"
+          color="primary"
+          onClick={() => {}}
+          size="s"
+          data-test-subj="testAction"
+          aria-label="Test action"
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   ),
   services: {

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx
@@ -671,21 +671,29 @@ export const RuleActionsItem = (props: RuleActionsItemProps) => {
         `,
       }}
       extraAction={
-        <EuiButtonIcon
-          data-test-subj="ruleActionsItemDeleteButton"
-          style={{
-            marginRight: euiTheme.size.l,
-          }}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
-            {
-              defaultMessage: 'delete action',
-            }
+            { defaultMessage: 'delete action' }
           )}
-          iconType="trash"
-          color="danger"
-          onClick={() => onDelete(action.uuid!)}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="ruleActionsItemDeleteButton"
+            style={{
+              marginRight: euiTheme.size.l,
+            }}
+            aria-label={i18n.translate(
+              'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
+              {
+                defaultMessage: 'delete action',
+              }
+            )}
+            iconType="trash"
+            color="danger"
+            onClick={() => onDelete(action.uuid!)}
+          />
+        </EuiToolTip>
       }
       buttonContentClassName="eui-fullWidth"
       buttonContent={

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx
@@ -252,21 +252,29 @@ export const RuleActionsSystemActionsItem = (props: RuleActionsSystemActionsItem
         `,
       }}
       extraAction={
-        <EuiButtonIcon
-          data-test-subj="ruleActionsSystemActionsItemDeleteActionButton"
-          style={{
-            marginRight: euiTheme.size.l,
-          }}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
-            {
-              defaultMessage: 'delete action',
-            }
+            { defaultMessage: 'delete action' }
           )}
-          iconType="trash"
-          color="danger"
-          onClick={() => onDelete(action.uuid!)}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="ruleActionsSystemActionsItemDeleteActionButton"
+            style={{
+              marginRight: euiTheme.size.l,
+            }}
+            aria-label={i18n.translate(
+              'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
+              {
+                defaultMessage: 'delete action',
+              }
+            )}
+            iconType="trash"
+            color="danger"
+            onClick={() => onDelete(action.uuid!)}
+          />
+        </EuiToolTip>
       }
       buttonContentClassName="eui-fullWidth"
       buttonContent={

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx
@@ -14,6 +14,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 import React from 'react';
 import {
@@ -32,12 +33,14 @@ export const RuleFlyoutSelectConnector = ({ onClose }: RuleFlyoutSelectConnector
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="chevronSingleLeft"
-              onClick={onClose}
-              aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
-              color="text"
-            />
+            <EuiToolTip content={RULE_FLYOUT_HEADER_BACK_TEXT} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="chevronSingleLeft"
+                onClick={onClose}
+                aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
+                color="text"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="xs" data-test-subj="ruleFlyoutSelectConnectorTitle">

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import {
@@ -41,12 +42,14 @@ export const RuleFlyoutShowRequest = ({ onClose }: RuleFlyoutShowRequestProps) =
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="chevronSingleLeft"
-              onClick={onClose}
-              aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
-              color="text"
-            />
+            <EuiToolTip content={RULE_FLYOUT_HEADER_BACK_TEXT} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="chevronSingleLeft"
+                onClick={onClose}
+                aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
+                color="text"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="xs" data-test-subj="ruleFlyoutShowRequestTitle">

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx
@@ -15,6 +15,7 @@ import {
   EuiFlexItem,
   useEuiTheme,
   EuiFormRow,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   RULE_NAME_ARIA_LABEL_TEXT,
@@ -112,13 +113,15 @@ export const RulePageNameInput = () => {
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            color="primary"
-            iconType="check"
-            size="m"
-            onClick={onCancelEdit}
-            aria-label={RULE_NAME_INPUT_BUTTON_ARIA_LABEL}
-          />
+          <EuiToolTip content={RULE_NAME_INPUT_BUTTON_ARIA_LABEL} disableScreenReaderOutput>
+            <EuiButtonIcon
+              color="primary"
+              iconType="check"
+              size="m"
+              onClick={onCancelEdit}
+              aria-label={RULE_NAME_INPUT_BUTTON_ARIA_LABEL}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
     );


### PR DESCRIPTION
## Summary

Fixes all 21 `@elastic/eui/tooltip-button-icon-wrap` ESLint violations across 14 `@elastic/response-ops` files by wrapping every `EuiButtonIcon` with `EuiToolTip`.

Closes #275050

## Changes

Each `EuiButtonIcon` is wrapped with `<EuiToolTip content={ariaLabel} disableScreenReaderOutput>` where the tooltip `content` matches the button's `aria-label`. `disableScreenReaderOutput` prevents duplicate screen reader announcements. The native `title` prop was removed from `alerts_query_inspector.tsx` where it was present.

## PR checklist

- [x] Read and applied [`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)
- [x] Added label `a11y:agent-pr`
- [x] Fixed all files (or documented skips in the PR body)

## Files fixed

- `x-pack/examples/alerting_example/public/alert_types/pattern.tsx`
- `x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx`
- `x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.tsx`
- `x-pack/platform/packages/shared/response-ops/alert-snooze/components/snooze_duration_picker.tsx`
- `x-pack/platform/packages/shared/response-ops/alert-snooze/components/time_condition_panel.tsx`
- `x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx`
- `x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx`
- `x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx`
- `x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx`
- `x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx`
- `x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx`
- `x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx`
- `x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx`
- `x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->