### PR TITLE
[Cases] Address preview feedback and refine table columns

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/search.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/search.tsx
@@ -9,6 +9,7 @@ import { EuiFieldSearch } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import * as i18n from './translations';
 import type { FilterOptions } from '../../containers/types';
+import { KibanaServices } from '../../common/lib/kibana';
 
 interface TableSearchComponentProps {
   filterOptionsSearch: string;
@@ -20,6 +21,7 @@ const TableSearchComponent: React.FC<TableSearchComponentProps> = ({
   onFilterOptionsChange,
 }) => {
   const [search, setSearch] = useState(filterOptionsSearch);
+  const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
 
   const onSearch = useCallback(
     (newSearch: string) => {
@@ -30,13 +32,17 @@ const TableSearchComponent: React.FC<TableSearchComponentProps> = ({
     [onFilterOptionsChange]
   );
 
+  const placeholder = isTemplatesV2Enabled
+    ? i18n.SEARCH_PLACEHOLDER_TEMPLATES_V2
+    : i18n.SEARCH_PLACEHOLDER;
+
   return (
     <EuiFieldSearch
       aria-label={i18n.SEARCH_CASES}
       data-test-subj="search-cases"
       fullWidth
       incremental={false}
-      placeholder={i18n.SEARCH_PLACEHOLDER}
+      placeholder={placeholder}
       onChange={(e) => setSearch(e.target.value)}
       onSearch={onSearch}
       value={search}

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/search.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/search.tsx
@@ -9,7 +9,7 @@ import { EuiFieldSearch } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import * as i18n from './translations';
 import type { FilterOptions } from '../../containers/types';
-import { KibanaServices } from '../../common/lib/kibana';
+import { useCasesConfig } from '../../common/lib/kibana';
 
 interface TableSearchComponentProps {
   filterOptionsSearch: string;
@@ -21,7 +21,7 @@ const TableSearchComponent: React.FC<TableSearchComponentProps> = ({
   onFilterOptionsChange,
 }) => {
   const [search, setSearch] = useState(filterOptionsSearch);
-  const isTemplatesV2Enabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
+  const { templatesEnabled } = useCasesConfig();
 
   const onSearch = useCallback(
     (newSearch: string) => {
@@ -32,7 +32,7 @@ const TableSearchComponent: React.FC<TableSearchComponentProps> = ({
     [onFilterOptionsChange]
   );
 
-  const placeholder = isTemplatesV2Enabled
+  const placeholder = templatesEnabled
     ? i18n.SEARCH_PLACEHOLDER_TEMPLATES_V2
     : i18n.SEARCH_PLACEHOLDER;
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
@@ -107,8 +107,7 @@ export const SEARCH_PLACEHOLDER = i18n.translate('xpack.cases.caseTable.searchPl
 export const SEARCH_PLACEHOLDER_TEMPLATES_V2 = i18n.translate(
   'xpack.cases.caseTable.searchPlaceholderTemplatesV2',
   {
-    defaultMessage:
-      'Free text, field label, or field:value. Use "" for multi-word, e.g. network Priority:high "Start date":01/01/2025',
+    defaultMessage: 'Search by text, field label, or field:value',
   }
 );
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
@@ -101,9 +101,16 @@ export const INCIDENT_MANAGEMENT_SYSTEM = i18n.translate('xpack.cases.caseTable.
 });
 
 export const SEARCH_PLACEHOLDER = i18n.translate('xpack.cases.caseTable.searchPlaceholder', {
-  defaultMessage:
-    'Free text, field label, or field:value. Use "" for multi-word, e.g. network Priority:high "Start date":01/01/2025',
+  defaultMessage: 'Search cases',
 });
+
+export const SEARCH_PLACEHOLDER_TEMPLATES_V2 = i18n.translate(
+  'xpack.cases.caseTable.searchPlaceholderTemplatesV2',
+  {
+    defaultMessage:
+      'Free text, field label, or field:value. Use "" for multi-word, e.g. network Priority:high "Start date":01/01/2025',
+  }
+);
 
 export const CLOSED = i18n.translate('xpack.cases.caseTable.closed', {
   defaultMessage: 'Closed',

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_metrics.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_metrics.tsx
@@ -25,6 +25,9 @@ import { ATTC_DESCRIPTION, ATTC_STAT, ATTC_STAT_INFO_ARIA_LABEL } from '../trans
 const PRETTY_MS_OPTIONS = { compact: true, verbose: false } as const;
 const MTTR_MULTIPLIER = 1000;
 
+// TODO: This stats bar currently shows unfiltered totals. It should be made responsive
+// to the active table filters (status, severity, tags, etc.) so the counts reflect the
+// filtered data set.
 const CasesMetricsComponent: React.FC = () => {
   const { euiTheme } = useEuiTheme();
   const { data: { mttr, status } = { mttr: 0 }, isLoading: isCasesMetricsLoading } =

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_metrics.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_metrics.tsx
@@ -27,7 +27,7 @@ const MTTR_MULTIPLIER = 1000;
 
 // TODO: This stats bar currently shows unfiltered totals. It should be made responsive
 // to the active table filters (status, severity, tags, etc.) so the counts reflect the
-// filtered data set.
+// filtered data set. https://github.com/elastic/security-team/issues/18001
 const CasesMetricsComponent: React.FC = () => {
   const { euiTheme } = useEuiTheme();
   const { data: { mttr, status } = { mttr: 0 }, isLoading: isCasesMetricsLoading } =

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { renderWithTestingProviders } from '../../../../../common/mock';
 import { CaseListItem } from './case_list_item';
@@ -15,6 +16,15 @@ import { suggestionUserProfiles } from '../../../../../containers/user_profiles/
 import { CaseSeverity } from '../../../../../../common/types/domain';
 import { CaseStatuses } from '@kbn/cases-components';
 import * as i18n from '../../translations';
+
+const mockNavigateToCaseView = jest.fn();
+jest.mock('../../../../../common/navigation/hooks', () => ({
+  ...jest.requireActual('../../../../../common/navigation/hooks'),
+  useCaseViewNavigation: () => ({
+    navigateToCaseView: mockNavigateToCaseView,
+    getCaseViewUrl: jest.fn().mockReturnValue('/cases/test-id'),
+  }),
+}));
 
 jest.mock('../../../../all_cases/use_actions', () => ({
   ...jest.requireActual('../../../../all_cases/use_actions'),
@@ -168,5 +178,21 @@ describe('CaseListItem', () => {
     renderWithTestingProviders(<CaseListItem {...defaultProps} />);
 
     expect(screen.getByTestId('mock-action-column')).toBeInTheDocument();
+  });
+
+  it('navigates to case view when the card is clicked', async () => {
+    renderWithTestingProviders(<CaseListItem {...defaultProps} />);
+
+    await userEvent.click(screen.getByTestId('cases-list-item-reporter'));
+
+    expect(mockNavigateToCaseView).toHaveBeenCalledWith({ detailName: mockCase.id });
+  });
+
+  it('does not navigate when the action button is clicked', async () => {
+    renderWithTestingProviders(<CaseListItem {...defaultProps} />);
+
+    await userEvent.click(screen.getByTestId('mock-action-column'));
+
+    expect(mockNavigateToCaseView).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithTestingProviders } from '../../../../../common/mock';
 import { CaseListItem } from './case_list_item';
-import { basicCase } from '../../../../../containers/mock';
+import { basicCase, basicPush } from '../../../../../containers/mock';
 import { suggestionUserProfiles } from '../../../../../containers/user_profiles/api.mock';
 import { CaseSeverity } from '../../../../../../common/types/domain';
 import { CaseStatuses } from '@kbn/cases-components';
@@ -196,6 +196,38 @@ describe('CaseListItem', () => {
     const actionButton = screen.getByTestId('mock-action-column');
 
     expect(link.contains(actionButton)).toBe(false);
+  });
+
+  it('renders optional fields outside the stretched link', () => {
+    renderWithTestingProviders(
+      <CaseListItem
+        {...defaultProps}
+        selectedFields={[{ field: 'tags', name: i18n.TAGS, isChecked: true }]}
+      />
+    );
+
+    const link = screen.getByTestId(`cases-list-item-clickable-${mockCase.id}`);
+    const optionalFields = screen.getByTestId('cases-list-item-optional-fields');
+
+    expect(link.contains(optionalFields)).toBe(false);
+  });
+
+  it('renders external incident link outside the stretched link when pushed', () => {
+    renderWithTestingProviders(
+      <CaseListItem
+        {...defaultProps}
+        theCase={{ ...mockCase, externalService: basicPush }}
+        selectedFields={[
+          { field: 'externalIncident', name: i18n.EXTERNAL_INCIDENT, isChecked: true },
+        ]}
+      />
+    );
+
+    const link = screen.getByTestId(`cases-list-item-clickable-${mockCase.id}`);
+    const externalLink = screen.getByTestId('cases-list-item-field-external-link');
+
+    expect(link.contains(externalLink)).toBe(false);
+    expect(externalLink).toHaveAttribute('href', basicPush.externalUrl);
   });
 
   it('navigates to case view when the link content is clicked', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
@@ -180,7 +180,7 @@ describe('CaseListItem', () => {
     expect(screen.getByTestId('mock-action-column')).toBeInTheDocument();
   });
 
-  it('renders as a real anchor with href and aria-label', () => {
+  it('renders the link with href and aria-label inside the card', () => {
     renderWithTestingProviders(<CaseListItem {...defaultProps} />);
 
     const link = screen.getByTestId(`cases-list-item-clickable-${mockCase.id}`);
@@ -189,7 +189,16 @@ describe('CaseListItem', () => {
     expect(link).toHaveAttribute('aria-label', `click to visit case with title ${mockCase.title}`);
   });
 
-  it('navigates to case view when the card is clicked', async () => {
+  it('renders the action button as a sibling outside the link', () => {
+    renderWithTestingProviders(<CaseListItem {...defaultProps} />);
+
+    const link = screen.getByTestId(`cases-list-item-clickable-${mockCase.id}`);
+    const actionButton = screen.getByTestId('mock-action-column');
+
+    expect(link.contains(actionButton)).toBe(false);
+  });
+
+  it('navigates to case view when the link content is clicked', async () => {
     renderWithTestingProviders(<CaseListItem {...defaultProps} />);
 
     await userEvent.click(screen.getByTestId('cases-list-item-reporter'));

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.test.tsx
@@ -180,6 +180,15 @@ describe('CaseListItem', () => {
     expect(screen.getByTestId('mock-action-column')).toBeInTheDocument();
   });
 
+  it('renders as a real anchor with href and aria-label', () => {
+    renderWithTestingProviders(<CaseListItem {...defaultProps} />);
+
+    const link = screen.getByTestId(`cases-list-item-clickable-${mockCase.id}`);
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/cases/test-id');
+    expect(link).toHaveAttribute('aria-label', `click to visit case with title ${mockCase.title}`);
+  });
+
   it('navigates to case view when the card is clicked', async () => {
     renderWithTestingProviders(<CaseListItem {...defaultProps} />);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -232,8 +232,8 @@ export const CaseListItem: React.FC<{
                 </EuiFlexItem>
               )}
             </EuiFlexGroup>
-            <ListItemOptionalFields theCase={theCase} selectedFields={selectedFields} />
           </EuiLink>
+          <ListItemOptionalFields theCase={theCase} selectedFields={selectedFields} />
         </EuiFlexItem>
 
         <EuiFlexItem grow={false} css={styles.actions}>

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -47,19 +47,9 @@ export const CaseListItem: React.FC<{
 
   const caseUrl = getCaseViewUrl({ detailName: theCase.id });
 
-  const handleCardClick = useCallback(
-    (e: React.MouseEvent | React.KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.closest('button')) {
-        if ('button' in e) {
-          e.preventDefault();
-        }
-        return;
-      }
-      if ('key' in e && e.key !== 'Enter' && e.key !== ' ') {
-        return;
-      }
-      if ('button' in e && (e.button === 1 || e.metaKey || e.ctrlKey)) {
+  const handleLinkClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button === 1 || e.metaKey || e.ctrlKey) {
         return;
       }
       e.preventDefault();
@@ -70,11 +60,21 @@ export const CaseListItem: React.FC<{
 
   const styles = useMemo(
     () => ({
-      mainFlexGroup: css`
-        height: 100%;
+      panel: css`
+        position: relative;
+        isolation: isolate;
+        min-height: ${LIST_ITEM_HEIGHT}px;
+        border-radius: ${euiTheme.border.radius.medium};
+        transition: background-color 150ms ease-in-out;
+
+        &:hover {
+          background-color: ${euiTheme.colors.backgroundBaseSubdued};
+        }
       `,
-      cardLink: css`
+      stretchedLink: css`
         display: block;
+        flex: 1;
+        min-width: 0;
         text-decoration: none;
         color: inherit;
 
@@ -83,16 +83,16 @@ export const CaseListItem: React.FC<{
           text-decoration: none;
           color: inherit;
         }
-      `,
-      panel: css`
-        min-height: ${LIST_ITEM_HEIGHT}px;
-        border-radius: ${euiTheme.border.radius.medium};
-        transition: background-color 150ms ease-in-out;
-        cursor: pointer;
 
-        &:hover {
-          background-color: ${euiTheme.colors.backgroundBaseSubdued};
+        &::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          cursor: pointer;
         }
+      `,
+      actions: css`
+        position: relative;
       `,
       title: css`
         font-size: ${euiTheme.size.base};
@@ -120,29 +120,22 @@ export const CaseListItem: React.FC<{
   const reporterName = theCase.createdBy.fullName ?? theCase.createdBy.username ?? i18n.UNKNOWN;
 
   return (
-    <EuiLink
-      href={caseUrl}
-      onClick={handleCardClick}
-      onKeyDown={handleCardClick}
-      css={styles.cardLink}
-      aria-label={CASE_DETAILS_LINK_ARIA(theCase.title)}
-      data-test-subj={`cases-list-item-clickable-${theCase.id}`}
+    <EuiPanel
+      hasBorder
+      hasShadow={false}
+      paddingSize="m"
+      data-test-subj={`cases-list-item-${theCase.id}`}
+      css={styles.panel}
     >
-      <EuiPanel
-        hasBorder
-        hasShadow={false}
-        paddingSize="m"
-        data-test-subj={`cases-list-item-${theCase.id}`}
-        css={styles.panel}
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
-          responsive={false}
-          wrap={false}
-          css={styles.mainFlexGroup}
-        >
-          <EuiFlexItem grow>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+        <EuiFlexItem grow>
+          <EuiLink
+            href={caseUrl}
+            onClick={handleLinkClick}
+            css={styles.stretchedLink}
+            aria-label={CASE_DETAILS_LINK_ARIA(theCase.title)}
+            data-test-subj={`cases-list-item-clickable-${theCase.id}`}
+          >
             <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
               {theCase.incrementalId != null && (
                 <EuiFlexItem grow={false}>
@@ -240,27 +233,27 @@ export const CaseListItem: React.FC<{
               )}
             </EuiFlexGroup>
             <ListItemOptionalFields theCase={theCase} selectedFields={selectedFields} />
-          </EuiFlexItem>
+          </EuiLink>
+        </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <EuiBadge
-                  color={euiTheme.colors.backgroundLightText}
-                  iconType="comment"
-                  data-test-subj="cases-list-item-comments-badge"
-                >
-                  {String(theCase.totalComment)}
-                </EuiBadge>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <ActionColumn theCase={theCase} disableActions={disableActions} />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
-    </EuiLink>
+        <EuiFlexItem grow={false} css={styles.actions}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiBadge
+                color={euiTheme.colors.backgroundLightText}
+                iconType="comment"
+                data-test-subj="cases-list-item-comments-badge"
+              >
+                {String(theCase.totalComment)}
+              </EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ActionColumn theCase={theCase} disableActions={disableActions} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
   );
 });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -12,6 +12,7 @@ import {
   EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiPanel,
   EuiText,
   useEuiTheme,
@@ -29,6 +30,7 @@ import { FormattedRelativePreferenceDate } from '../../../../formatted_date';
 import { useCaseViewNavigation } from '../../../../../common/navigation/hooks';
 import { ActionColumnComponent as ActionColumn } from '../../../../all_cases/use_actions';
 import { severities } from '../../../../severity/config';
+import { CASE_DETAILS_LINK_ARIA } from '../../../../links/translations';
 import * as i18n from '../../translations';
 
 const LIST_ITEM_HEIGHT = 80;
@@ -41,15 +43,20 @@ export const CaseListItem: React.FC<{
   selectedFields: CasesColumnSelection[];
 }> = React.memo(({ theCase, userProfiles, disableActions, selectedFields }) => {
   const { euiTheme } = useEuiTheme();
-  const { navigateToCaseView } = useCaseViewNavigation();
+  const { navigateToCaseView, getCaseViewUrl } = useCaseViewNavigation();
+
+  const caseUrl = getCaseViewUrl({ detailName: theCase.id });
 
   const handleCardClick = useCallback(
     (e: React.MouseEvent | React.KeyboardEvent) => {
       const target = e.target as HTMLElement;
-      if (target.closest('a') || target.closest('button')) {
+      if (target.closest('button')) {
         return;
       }
       if ('key' in e && e.key !== 'Enter' && e.key !== ' ') {
+        return;
+      }
+      if ('button' in e && (e.button === 1 || e.metaKey || e.ctrlKey)) {
         return;
       }
       e.preventDefault();
@@ -110,12 +117,12 @@ export const CaseListItem: React.FC<{
   const reporterName = theCase.createdBy.fullName ?? theCase.createdBy.username ?? i18n.UNKNOWN;
 
   return (
-    <div
-      role="link"
-      tabIndex={0}
+    <EuiLink
+      href={caseUrl}
       onClick={handleCardClick}
       onKeyDown={handleCardClick}
       css={styles.cardLink}
+      aria-label={CASE_DETAILS_LINK_ARIA(theCase.title)}
       data-test-subj={`cases-list-item-clickable-${theCase.id}`}
     >
       <EuiPanel
@@ -250,7 +257,7 @@ export const CaseListItem: React.FC<{
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>
-    </div>
+    </EuiLink>
   );
 });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -51,6 +51,9 @@ export const CaseListItem: React.FC<{
     (e: React.MouseEvent | React.KeyboardEvent) => {
       const target = e.target as HTMLElement;
       if (target.closest('button')) {
+        if ('button' in e) {
+          e.preventDefault();
+        }
         return;
       }
       if ('key' in e && e.key !== 'Enter' && e.key !== ' ') {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiAvatar,
@@ -26,7 +26,7 @@ import { UserToolTip } from '../../../../user_profiles/user_tooltip';
 import { SmallUserAvatar } from '../../../../user_profiles/small_user_avatar';
 import { useAssignees } from '../../../../../containers/user_profiles/use_assignees';
 import { FormattedRelativePreferenceDate } from '../../../../formatted_date';
-import { CaseDetailsLink } from '../../../../links';
+import { useCaseViewNavigation } from '../../../../../common/navigation/hooks';
 import { ActionColumnComponent as ActionColumn } from '../../../../all_cases/use_actions';
 import { severities } from '../../../../severity/config';
 import * as i18n from '../../translations';
@@ -41,16 +41,44 @@ export const CaseListItem: React.FC<{
   selectedFields: CasesColumnSelection[];
 }> = React.memo(({ theCase, userProfiles, disableActions, selectedFields }) => {
   const { euiTheme } = useEuiTheme();
+  const { navigateToCaseView } = useCaseViewNavigation();
+
+  const handleCardClick = useCallback(
+    (e: React.MouseEvent | React.KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('a') || target.closest('button')) {
+        return;
+      }
+      if ('key' in e && e.key !== 'Enter' && e.key !== ' ') {
+        return;
+      }
+      e.preventDefault();
+      navigateToCaseView({ detailName: theCase.id });
+    },
+    [navigateToCaseView, theCase.id]
+  );
 
   const styles = useMemo(
     () => ({
       mainFlexGroup: css`
         height: 100%;
       `,
+      cardLink: css`
+        display: block;
+        text-decoration: none;
+        color: inherit;
+
+        &:hover,
+        &:focus {
+          text-decoration: none;
+          color: inherit;
+        }
+      `,
       panel: css`
         min-height: ${LIST_ITEM_HEIGHT}px;
         border-radius: ${euiTheme.border.radius.medium};
         transition: background-color 150ms ease-in-out;
+        cursor: pointer;
 
         &:hover {
           background-color: ${euiTheme.colors.backgroundBaseSubdued};
@@ -82,140 +110,147 @@ export const CaseListItem: React.FC<{
   const reporterName = theCase.createdBy.fullName ?? theCase.createdBy.username ?? i18n.UNKNOWN;
 
   return (
-    <EuiPanel
-      hasBorder
-      hasShadow={false}
-      paddingSize="m"
-      data-test-subj={`cases-list-item-${theCase.id}`}
-      css={styles.panel}
+    <div
+      role="link"
+      tabIndex={0}
+      onClick={handleCardClick}
+      onKeyDown={handleCardClick}
+      css={styles.cardLink}
+      data-test-subj={`cases-list-item-clickable-${theCase.id}`}
     >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
-        responsive={false}
-        wrap={false}
-        css={styles.mainFlexGroup}
+      <EuiPanel
+        hasBorder
+        hasShadow={false}
+        paddingSize="m"
+        data-test-subj={`cases-list-item-${theCase.id}`}
+        css={styles.panel}
       >
-        <EuiFlexItem grow>
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
-            {theCase.incrementalId != null && (
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
+          responsive={false}
+          wrap={false}
+          css={styles.mainFlexGroup}
+        >
+          <EuiFlexItem grow>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+              {theCase.incrementalId != null && (
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s" color="subdued" data-test-subj="cases-list-item-id">
+                    {'#'}
+                    {theCase.incrementalId}
+                  </EuiText>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={false}>
-                <EuiText size="s" color="subdued" data-test-subj="cases-list-item-id">
-                  {'#'}
-                  {theCase.incrementalId}
-                </EuiText>
-              </EuiFlexItem>
-            )}
-            <EuiFlexItem grow={false}>
-              <CaseDetailsLink detailName={theCase.id} title={theCase.title}>
                 <EuiText size="s" data-test-subj="cases-list-item-title" css={styles.title}>
                   {theCase.title}
                 </EuiText>
-              </CaseDetailsLink>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBadge
-                color={severities[theCase.severity].badgeColor}
-                data-test-subj={`case-severity-badge-${theCase.severity}`}
-              >
-                {severities[theCase.severity].label}
-              </EuiBadge>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <Status status={theCase.status} />
-            </EuiFlexItem>
-            {theCase.totalAlerts > 0 && (
+              </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiBadge
-                  color="danger"
-                  iconType="warning"
-                  data-test-subj="cases-list-item-alerts-badge"
+                  color={severities[theCase.severity].badgeColor}
+                  data-test-subj={`case-severity-badge-${theCase.severity}`}
                 >
-                  {theCase.totalAlerts}
+                  {severities[theCase.severity].label}
                 </EuiBadge>
               </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-            responsive={false}
-            wrap={false}
-            css={styles.metaRow}
-          >
-            {allAssignees.length > 0 && (
               <EuiFlexItem grow={false}>
-                <EuiFlexGroup
-                  gutterSize="xs"
-                  alignItems="center"
-                  responsive={false}
-                  data-test-subj="cases-list-item-assignees"
-                >
-                  {allAssignees.slice(0, MAX_VISIBLE_ASSIGNEES).map((assignee) => (
-                    <EuiFlexItem grow={false} key={assignee.uid}>
-                      <UserToolTip userInfo={assignee.profile}>
-                        <SmallUserAvatar userInfo={assignee.profile} />
-                      </UserToolTip>
-                    </EuiFlexItem>
-                  ))}
-                  {allAssignees.length > MAX_VISIBLE_ASSIGNEES && (
-                    <EuiFlexItem grow={false}>
-                      <EuiAvatar
-                        name={`+${allAssignees.length - MAX_VISIBLE_ASSIGNEES}`}
-                        initials={`+${allAssignees.length - MAX_VISIBLE_ASSIGNEES}`}
-                        initialsLength={2}
-                        size="s"
-                        color="subdued"
-                        data-test-subj="cases-list-item-assignees-overflow"
-                      />
-                    </EuiFlexItem>
-                  )}
-                </EuiFlexGroup>
+                <Status status={theCase.status} />
               </EuiFlexItem>
-            )}
-            <EuiFlexItem grow={false}>
-              <EuiText size="xs" color="subdued" data-test-subj="cases-list-item-reporter">
-                <span css={styles.labelSpan}>
-                  {i18n.LIST_REPORTED_BY}
-                  {':'}
-                </span>{' '}
-                {reporterName}
-              </EuiText>
-            </EuiFlexItem>
-            {theCase.updatedAt && (
+              {theCase.totalAlerts > 0 && (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge
+                    color="danger"
+                    iconType="warning"
+                    data-test-subj="cases-list-item-alerts-badge"
+                  >
+                    {theCase.totalAlerts}
+                  </EuiBadge>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              responsive={false}
+              wrap={false}
+              css={styles.metaRow}
+            >
+              {allAssignees.length > 0 && (
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup
+                    gutterSize="xs"
+                    alignItems="center"
+                    responsive={false}
+                    data-test-subj="cases-list-item-assignees"
+                  >
+                    {allAssignees.slice(0, MAX_VISIBLE_ASSIGNEES).map((assignee) => (
+                      <EuiFlexItem grow={false} key={assignee.uid}>
+                        <UserToolTip userInfo={assignee.profile}>
+                          <SmallUserAvatar userInfo={assignee.profile} />
+                        </UserToolTip>
+                      </EuiFlexItem>
+                    ))}
+                    {allAssignees.length > MAX_VISIBLE_ASSIGNEES && (
+                      <EuiFlexItem grow={false}>
+                        <EuiAvatar
+                          name={`+${allAssignees.length - MAX_VISIBLE_ASSIGNEES}`}
+                          initials={`+${allAssignees.length - MAX_VISIBLE_ASSIGNEES}`}
+                          initialsLength={2}
+                          size="s"
+                          color="subdued"
+                          data-test-subj="cases-list-item-assignees-overflow"
+                        />
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={false}>
-                <EuiText size="xs" color="subdued" data-test-subj="cases-list-item-updated-at">
+                <EuiText size="xs" color="subdued" data-test-subj="cases-list-item-reporter">
                   <span css={styles.labelSpan}>
-                    {i18n.LIST_LAST_UPDATE}
+                    {i18n.LIST_REPORTED_BY}
                     {':'}
                   </span>{' '}
-                  <FormattedRelativePreferenceDate value={theCase.updatedAt} stripMs />
+                  {reporterName}
                 </EuiText>
               </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-          <ListItemOptionalFields theCase={theCase} selectedFields={selectedFields} />
-        </EuiFlexItem>
+              {theCase.updatedAt && (
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued" data-test-subj="cases-list-item-updated-at">
+                    <span css={styles.labelSpan}>
+                      {i18n.LIST_LAST_UPDATE}
+                      {':'}
+                    </span>{' '}
+                    <FormattedRelativePreferenceDate value={theCase.updatedAt} stripMs />
+                  </EuiText>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+            <ListItemOptionalFields theCase={theCase} selectedFields={selectedFields} />
+          </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiBadge
-                color={euiTheme.colors.backgroundLightText}
-                iconType="comment"
-                data-test-subj="cases-list-item-comments-badge"
-              >
-                {theCase.totalComment}
-              </EuiBadge>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <ActionColumn theCase={theCase} disableActions={disableActions} />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiBadge
+                  color={euiTheme.colors.backgroundLightText}
+                  iconType="comment"
+                  data-test-subj="cases-list-item-comments-badge"
+                >
+                  {String(theCase.totalComment)}
+                </EuiBadge>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <ActionColumn theCase={theCase} disableActions={disableActions} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </div>
   );
 });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/case_list_item.tsx
@@ -49,7 +49,7 @@ export const CaseListItem: React.FC<{
 
   const handleLinkClick = useCallback(
     (e: React.MouseEvent) => {
-      if (e.button === 1 || e.metaKey || e.ctrlKey) {
+      if (e.button !== 0 || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
         return;
       }
       e.preventDefault();

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/field_content_getters.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/field_content_getters.tsx
@@ -101,17 +101,17 @@ const listItemFieldContentGetters: Record<
         },
   totalComment: (theCase) => ({
     label: i18n.COMMENTS,
-    content: i18n.LIST_FIELD_COMMENTS(theCase.totalComment),
+    content: String(theCase.totalComment),
     testSubj: 'cases-list-item-field-comments',
   }),
   totalAlerts: (theCase) => ({
     label: i18n.ALERTS,
-    content: i18n.LIST_FIELD_ALERTS(theCase.totalAlerts ?? 0),
+    content: String(theCase.totalAlerts ?? 0),
     testSubj: 'cases-list-item-field-alerts',
   }),
   totalEvents: (theCase) => ({
     label: i18n.EVENTS,
-    content: i18n.LIST_FIELD_EVENTS(theCase.totalEvents ?? 0),
+    content: String(theCase.totalEvents ?? 0),
     testSubj: 'cases-list-item-field-events',
   }),
   createdAt: (theCase) => ({

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
@@ -53,8 +53,7 @@ export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
     <EuiFlexGroup
       alignItems="center"
       gutterSize="s"
-      responsive={false}
-      wrap={false}
+      wrap
       data-test-subj="cases-list-item-optional-fields"
       css={styles.container}
     >

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/list_view/list_item_optional_fields/list_item_optional_fields.tsx
@@ -22,6 +22,7 @@ export const ListItemOptionalFields: React.FC<ListItemOptionalFieldsProps> = ({
   const styles = useMemo(
     () => ({
       container: css`
+        position: relative;
         margin-top: ${euiTheme.size.s};
       `,
     }),

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.test.tsx
@@ -83,7 +83,7 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
@@ -97,10 +97,10 @@ describe('useCasesColumns ', () => {
           },
           Object {
             "field": "tags",
-            "minWidth": "4em",
+            "minWidth": "8em",
             "name": "Tags",
             "render": [Function],
-            "width": "10em",
+            "width": "14em",
           },
           Object {
             "align": "right",
@@ -204,7 +204,7 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
@@ -218,10 +218,10 @@ describe('useCasesColumns ', () => {
           },
           Object {
             "field": "tags",
-            "minWidth": "4em",
+            "minWidth": "8em",
             "name": "Tags",
             "render": [Function],
-            "width": "10em",
+            "width": "14em",
           },
           Object {
             "align": "right",
@@ -319,7 +319,7 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
@@ -384,7 +384,7 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
@@ -449,7 +449,7 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
@@ -534,17 +534,17 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
           },
           Object {
             "field": "tags",
-            "minWidth": "4em",
+            "minWidth": "8em",
             "name": "Tags",
             "render": [Function],
-            "width": "10em",
+            "width": "14em",
           },
           Object {
             "align": "right",
@@ -656,17 +656,17 @@ describe('useCasesColumns ', () => {
         "columns": Array [
           Object {
             "field": "title",
-            "minWidth": "16em",
+            "minWidth": "12em",
             "name": "Name",
             "render": [Function],
             "sortable": true,
           },
           Object {
             "field": "tags",
-            "minWidth": "4em",
+            "minWidth": "8em",
             "name": "Tags",
             "render": [Function],
-            "width": "10em",
+            "width": "14em",
           },
           Object {
             "align": "right",

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/hooks/use_cases_columns.tsx
@@ -12,6 +12,8 @@ import {
   EuiBadgeGroup,
   EuiBadge,
   EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiLink,
   EuiIcon,
   EuiToolTip,
@@ -103,7 +105,7 @@ export const useCasesColumns = ({
         field: casesColumnsConfig.title.field,
         name: casesColumnsConfig.title.name,
         sortable: true,
-        minWidth: '16em',
+        minWidth: '12em',
         render: (_: string, theCase: CaseUI) => {
           if (theCase.id == null || theCase.title == null) {
             return getEmptyCellValue();
@@ -114,14 +116,18 @@ export const useCasesColumns = ({
           }
 
           return (
-            <div>
-              <CaseDetailsLink detailName={theCase.id} title={theCase.title}>
-                <TruncatedText text={theCase.title} />
-              </CaseDetailsLink>
+            <EuiFlexGroup gutterSize="s" alignItems="baseline" responsive={false} wrap={false}>
               {typeof theCase.incrementalId === 'number' && (
-                <IncrementalIdText incrementalId={theCase.incrementalId} />
+                <EuiFlexItem grow={false}>
+                  <IncrementalIdText incrementalId={theCase.incrementalId} />
+                </EuiFlexItem>
               )}
-            </div>
+              <EuiFlexItem grow={false}>
+                <CaseDetailsLink detailName={theCase.id} title={theCase.title}>
+                  <TruncatedText text={theCase.title} />
+                </CaseDetailsLink>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           );
         },
       },
@@ -137,8 +143,8 @@ export const useCasesColumns = ({
       tags: {
         field: casesColumnsConfig.tags.field,
         name: casesColumnsConfig.tags.name,
-        width: '10em',
-        minWidth: '4em',
+        width: '14em',
+        minWidth: '8em',
         render: (tags: CaseUI['tags']) => {
           if (tags != null && tags.length > 0) {
             const clampedBadges = (

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/translations.ts
@@ -64,24 +64,6 @@ export const LIST_FIELD_CLOSED = i18n.translate('xpack.cases.casesRedesign.listV
   defaultMessage: 'Closed',
 });
 
-export const LIST_FIELD_COMMENTS = (count: number) =>
-  i18n.translate('xpack.cases.casesRedesign.listView.fieldComments', {
-    values: { count },
-    defaultMessage: '{count} {count, plural, one {comment} other {comments}}',
-  });
-
-export const LIST_FIELD_ALERTS = (count: number) =>
-  i18n.translate('xpack.cases.casesRedesign.listView.fieldAlerts', {
-    values: { count },
-    defaultMessage: '{count} {count, plural, one {alert} other {alerts}}',
-  });
-
-export const LIST_FIELD_EVENTS = (count: number) =>
-  i18n.translate('xpack.cases.casesRedesign.listView.fieldEvents', {
-    values: { count },
-    defaultMessage: '{count} {count, plural, one {event} other {events}}',
-  });
-
 export const SORT_NEWEST_FIRST = i18n.translate(
   'xpack.cases.casesRedesign.tableFilters.newestFirst',
   {

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -22,7 +22,7 @@ describe('config validation', () => {
           },
           "casesRedesign": Object {
             "details": false,
-            "list": true,
+            "list": false,
             "settings": false,
           },
           "enabled": true,

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -22,7 +22,7 @@ describe('config validation', () => {
           },
           "casesRedesign": Object {
             "details": false,
-            "list": false,
+            "list": true,
             "settings": false,
           },
           "enabled": true,

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -67,7 +67,7 @@ export const ConfigSchema = schema.object({
   // Temporary feature flag for the Cases UX redesign (elastic/security-team#17398).
   // Once the redesigned UI fully replaces the current one, this config block will be removed.
   casesRedesign: schema.object({
-    list: schema.boolean({ defaultValue: true }),
+    list: schema.boolean({ defaultValue: false }),
     details: schema.boolean({ defaultValue: false }),
     settings: schema.boolean({ defaultValue: false }),
   }),

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -67,7 +67,7 @@ export const ConfigSchema = schema.object({
   // Temporary feature flag for the Cases UX redesign (elastic/security-team#17398).
   // Once the redesigned UI fully replaces the current one, this config block will be removed.
   casesRedesign: schema.object({
-    list: schema.boolean({ defaultValue: false }),
+    list: schema.boolean({ defaultValue: true }),
     details: schema.boolean({ defaultValue: false }),
     settings: schema.boolean({ defaultValue: false }),
   }),


### PR DESCRIPTION
## What & Why
Enables the Cases redesign list view for testing purposes  (`casesRedesign.list: true`) - this will be removed before merging. Adjusts the table layout: the incremental case ID (`#123`) now renders inline before the case title instead of below it, the title column is narrower (`12em`), and the tags column is wider (`14em`) to better accommodate multi-tag display. 
Address comments from testing. 

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)