### PR TITLE
Agentless: Add GET and LIST agentless_policy endpoints

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/routes.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/routes.ts
@@ -217,6 +217,8 @@ export const AGENT_API_ROUTES = {
 
 export const AGENTLESS_POLICIES_ROUTES = {
   CREATE_PATTERN: `${API_ROOT}/agentless_policies`,
+  LIST_PATTERN: `${API_ROOT}/agentless_policies`,
+  GET_PATTERN: `${API_ROOT}/agentless_policies/{policyId}`,
   DELETE_PATTERN: `${API_ROOT}/agentless_policies/{policyId}`,
   SYNC_PATTERN: `${INTERNAL_ROOT}/agentless_policies/_sync`,
   BULK_THROUGHPUT_PATTERN: `${INTERNAL_ROOT}/agentless_policies/bulk_throughput`,

--- a/x-pack/platform/plugins/shared/fleet/common/services/routes.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/routes.ts
@@ -228,6 +228,12 @@ export const agentlessPolicyRouteService = {
   getCreatePath: () => {
     return AGENTLESS_POLICIES_ROUTES.CREATE_PATTERN;
   },
+  getListPath: () => {
+    return AGENTLESS_POLICIES_ROUTES.LIST_PATTERN;
+  },
+  getInfoPath: (policyId: string) => {
+    return AGENTLESS_POLICIES_ROUTES.GET_PATTERN.replace('{policyId}', policyId);
+  },
   getDeletePath: (policyId: string) => {
     return AGENTLESS_POLICIES_ROUTES.DELETE_PATTERN.replace('{policyId}', policyId);
   },

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -9,6 +9,12 @@ import { type TypeOf, schema } from '@kbn/config-schema';
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
+import type {
+  GetAgentlessPolicyRequestSchema,
+  ListAgentlessPoliciesRequestSchema,
+  AgentlessPolicyListResponseSchema,
+} from '../../../server/types';
+
 import { SimplifiedCreatePackagePolicyRequestBodySchema } from '../models/package_policy_schema';
 import type { AgentlessPolicyResponseSchema } from '../models/agentless_policy_schema';
 
@@ -187,3 +193,15 @@ export type AgentlessPolicyThroughput = TypeOf<typeof AgentlessPolicyThroughputS
 export type GetBulkAgentlessPolicyThroughputResponse = TypeOf<
   typeof GetBulkAgentlessPolicyThroughputResponseSchema
 >;
+
+export interface GetAgentlessPolicyRequest {
+  params: TypeOf<typeof GetAgentlessPolicyRequestSchema.params>;
+}
+
+export type GetAgentlessPolicyResponse = TypeOf<typeof AgentlessPolicyResponseSchema>;
+
+export interface ListAgentlessPoliciesRequest {
+  query: TypeOf<typeof ListAgentlessPoliciesRequestSchema.query>;
+}
+
+export type ListAgentlessPoliciesResponse = TypeOf<typeof AgentlessPolicyListResponseSchema>;

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -107,6 +107,7 @@ export const DeleteAgentlessPolicyRequestSchema = {
   }),
   params: schema.object({
     policyId: schema.string({
+      maxLength: 256,
       meta: {
         description: 'The ID of the policy to delete.',
       },
@@ -201,6 +202,7 @@ export type GetBulkAgentlessPolicyThroughputResponse = TypeOf<
 export const GetAgentlessPolicyRequestSchema = {
   params: schema.object({
     policyId: schema.string({
+      maxLength: 256,
       meta: {
         description: 'The ID of the agentless policy to retrieve.',
       },
@@ -226,6 +228,7 @@ export const ListAgentlessPoliciesRequestQuerySchema = schema.object({
   ),
   sortField: schema.maybe(
     schema.string({
+      maxLength: 256,
       meta: { description: 'Field to sort results by. Defaults to `updated_at`.' },
     })
   ),
@@ -236,6 +239,7 @@ export const ListAgentlessPoliciesRequestQuerySchema = schema.object({
   ),
   kuery: schema.maybe(
     schema.string({
+      maxLength: 4096,
       meta: { description: 'A KQL query string to filter results.' },
     })
   ),

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -9,14 +9,11 @@ import { type TypeOf, schema } from '@kbn/config-schema';
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import type {
-  GetAgentlessPolicyRequestSchema,
-  ListAgentlessPoliciesRequestSchema,
-  AgentlessPolicyListResponseSchema,
-} from '../../../server/types';
-
 import { SimplifiedCreatePackagePolicyRequestBodySchema } from '../models/package_policy_schema';
 import type { AgentlessPolicyResponseSchema } from '../models/agentless_policy_schema';
+import type { AgentlessPolicy } from '../models/agentless_policy';
+
+import type { ListResult, ListWithKuery } from './common';
 
 export const CreateAgentlessPolicyRequestSchema = {
   body: SimplifiedCreatePackagePolicyRequestBodySchema.extends(
@@ -194,14 +191,33 @@ export type GetBulkAgentlessPolicyThroughputResponse = TypeOf<
   typeof GetBulkAgentlessPolicyThroughputResponseSchema
 >;
 
+/**
+ * Params for the GET-by-id endpoint.
+ *
+ * Inline interface following the Fleet convention (see `GetOneAgentPolicyRequest`):
+ * request/response types live in `common/` while the runtime validation schema
+ * lives in `server/types/rest_spec/agentless_policy.ts`, so `common/` carries no
+ * dependency on `server/`. The two are kept in sync by the API integration tests.
+ */
 export interface GetAgentlessPolicyRequest {
-  params: TypeOf<typeof GetAgentlessPolicyRequestSchema.params>;
+  params: {
+    policyId: string;
+  };
 }
 
 export type GetAgentlessPolicyResponse = TypeOf<typeof AgentlessPolicyResponseSchema>;
 
+/**
+ * Query contract for the LIST endpoint.
+ *
+ * Derived from the shared {@link ListWithKuery} contract (the same source the
+ * service's `ListAgentlessPoliciesOptions` is built from) rather than the
+ * server-side validation schema, so `common/` carries no dependency on
+ * `server/`. The runtime schema in `server/types/rest_spec/agentless_policy.ts`
+ * only adds the server-only `kuery` validator on top of this exact shape.
+ */
 export interface ListAgentlessPoliciesRequest {
-  query: TypeOf<typeof ListAgentlessPoliciesRequestSchema.query>;
+  query: Pick<ListWithKuery, 'page' | 'perPage' | 'sortField' | 'sortOrder' | 'kuery'>;
 }
 
-export type ListAgentlessPoliciesResponse = TypeOf<typeof AgentlessPolicyListResponseSchema>;
+export type ListAgentlessPoliciesResponse = ListResult<AgentlessPolicy>;

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agentless_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { type TypeOf, schema } from '@kbn/config-schema';
+import { schema, type TypeOf } from '@kbn/config-schema';
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
@@ -13,7 +13,7 @@ import { SimplifiedCreatePackagePolicyRequestBodySchema } from '../models/packag
 import type { AgentlessPolicyResponseSchema } from '../models/agentless_policy_schema';
 import type { AgentlessPolicy } from '../models/agentless_policy';
 
-import type { ListResult, ListWithKuery } from './common';
+import type { ListResult } from './common';
 
 export const CreateAgentlessPolicyRequestSchema = {
   body: SimplifiedCreatePackagePolicyRequestBodySchema.extends(
@@ -192,32 +192,57 @@ export type GetBulkAgentlessPolicyThroughputResponse = TypeOf<
 >;
 
 /**
- * Params for the GET-by-id endpoint.
+ * Params validation schema for the GET-by-id endpoint.
  *
- * Inline interface following the Fleet convention (see `GetOneAgentPolicyRequest`):
- * request/response types live in `common/` while the runtime validation schema
- * lives in `server/types/rest_spec/agentless_policy.ts`, so `common/` carries no
- * dependency on `server/`. The two are kept in sync by the API integration tests.
+ * Lives here in `common/` (matching the Create/Delete endpoints in this file) so
+ * `server/` imports it for route registration and `common/` carries no dependency
+ * on `server/`.
  */
-export interface GetAgentlessPolicyRequest {
-  params: {
-    policyId: string;
-  };
-}
+export const GetAgentlessPolicyRequestSchema = {
+  params: schema.object({
+    policyId: schema.string({
+      meta: {
+        description: 'The ID of the agentless policy to retrieve.',
+      },
+    }),
+  }),
+};
 
 export type GetAgentlessPolicyResponse = TypeOf<typeof AgentlessPolicyResponseSchema>;
 
 /**
- * Query contract for the LIST endpoint.
+ * Base query shape for the LIST endpoint.
  *
- * Derived from the shared {@link ListWithKuery} contract (the same source the
- * service's `ListAgentlessPoliciesOptions` is built from) rather than the
- * server-side validation schema, so `common/` carries no dependency on
- * `server/`. The runtime schema in `server/types/rest_spec/agentless_policy.ts`
- * only adds the server-only `kuery` validator on top of this exact shape.
+ * Defined here so the {@link ListAgentlessPoliciesRequest} type can be derived from it via `TypeOf`.
+ * The `kuery` validator is intentionally omitted: it depends on the server-only `validateKuery`,
+ * so `server/types/rest_spec/agentless_policy.ts` `.extends()` this schema to attach it.
  */
+export const ListAgentlessPoliciesRequestQuerySchema = schema.object({
+  // Paging defaults (page=1, perPage=20) are owned by the service layer
+  // (`listAgentlessPolicies`), which is the single source of truth
+  page: schema.maybe(schema.number({ meta: { description: 'Page number. Defaults to `1`.' } })),
+  perPage: schema.maybe(
+    schema.number({ meta: { description: 'Number of results per page. Defaults to `20`.' } })
+  ),
+  sortField: schema.maybe(
+    schema.string({
+      meta: { description: 'Field to sort results by. Defaults to `updated_at`.' },
+    })
+  ),
+  sortOrder: schema.maybe(
+    schema.oneOf([schema.literal('desc'), schema.literal('asc')], {
+      meta: { description: 'Sort order, ascending or descending. Defaults to `desc`.' },
+    })
+  ),
+  kuery: schema.maybe(
+    schema.string({
+      meta: { description: 'A KQL query string to filter results.' },
+    })
+  ),
+});
+
 export interface ListAgentlessPoliciesRequest {
-  query: Pick<ListWithKuery, 'page' | 'perPage' | 'sortField' | 'sortOrder' | 'kuery'>;
+  query: TypeOf<typeof ListAgentlessPoliciesRequestQuerySchema>;
 }
 
 export type ListAgentlessPoliciesResponse = ListResult<AgentlessPolicy>;

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agentless_policy.ts
@@ -16,6 +16,9 @@ import type {
   DeleteAgentlessPolicyRequest,
   DeleteAgentlessPolicyResponse,
   GetBulkAgentlessPolicyThroughputResponse,
+  GetAgentlessPolicyResponse,
+  ListAgentlessPoliciesRequest,
+  ListAgentlessPoliciesResponse,
 } from '../../../common/types/rest_spec/agentless_policy';
 
 import { sendRequestForRq } from './use_request';
@@ -58,4 +61,21 @@ export const useBulkGetAgentlessPolicyThroughput = (policyIds: string[]) => {
       refetchOnWindowFocus: false,
     }
   );
+};
+
+export const sendGetAgentlessPolicy = (policyId: string) => {
+  return sendRequestForRq<GetAgentlessPolicyResponse>({
+    path: agentlessPolicyRouteService.getInfoPath(policyId),
+    method: 'get',
+    version: API_VERSIONS.public.v1,
+  });
+};
+
+export const sendListAgentlessPolicies = (query?: ListAgentlessPoliciesRequest['query']) => {
+  return sendRequestForRq<ListAgentlessPoliciesResponse>({
+    path: agentlessPolicyRouteService.getListPath(),
+    method: 'get',
+    version: API_VERSIONS.public.v1,
+    query,
+  });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
@@ -322,6 +322,10 @@ export const createMockAgentlessPoliciesService = (): jest.Mocked<AgentlessPolic
   return {
     createAgentlessPolicy: jest.fn().mockReturnValue(Promise.resolve()),
     deleteAgentlessPolicy: jest.fn().mockReturnValue(Promise.resolve()),
+    getAgentlessPolicy: jest.fn().mockReturnValue(Promise.resolve(null)),
+    listAgentlessPolicies: jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ items: [], total: 0, page: 1, perPage: 20 })),
   };
 };
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/get_agentless_policy.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/get_agentless_policy.yaml
@@ -1,0 +1,63 @@
+responses:
+  200:
+    description: 'Indicates a successful response'
+    content:
+      application/json:
+        examples:
+          getAgentlessPolicyResponseExample:
+            description: 'Example response for getting an agentless policy by ID'
+            value:
+              item:
+                id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                name: ess_billing-1
+                description: test
+                namespace: default
+                package:
+                  name: ess_billing
+                  title: Elasticsearch Service Billing
+                  version: 1.6.0
+                inputs:
+                  ESS Billing-cel:
+                    enabled: true
+                    vars:
+                      organization_id: '1234'
+                      api_key:
+                        id: QY1sWpoBbWcMW-edr0Ee
+                        isSecretRef: true
+                      url: 'https://billing.elastic-cloud.com'
+                    streams:
+                      ess_billing.billing:
+                        enabled: true
+                        vars:
+                          lookbehind: 365
+                          hide_sensitive: true
+                          http_client_timeout: 30s
+                          tags:
+                            - forwarded
+                            - billing
+                      ess_billing.credits:
+                        enabled: false
+                created_at: '2025-11-06T18:27:43.541Z'
+                created_by: test_user
+                updated_at: '2025-11-06T18:27:43.541Z'
+                updated_by: test_user
+  400:
+    description: 'Bad Request'
+    content:
+      application/json:
+        examples:
+          genericErrorResponseExample:
+            description: 'Example of a generic error response'
+            value:
+              statusCode: 400
+              error: 'Bad Request'
+              message: 'An error message describing what went wrong'
+  404:
+    description: 'Not Found'
+    content:
+      application/json:
+        examples:
+          notFoundErrorResponseExample:
+            description: 'Example of a not found error response'
+            value:
+              message: 'Agentless policy d52a7812-5736-4fdc-aed8-72152afa1ffa not found'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/list_agentless_policies.yaml
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/examples/list_agentless_policies.yaml
@@ -1,0 +1,71 @@
+responses:
+  200:
+    description: 'Indicates a successful response'
+    content:
+      application/json:
+        examples:
+          listAgentlessPoliciesResponseExample:
+            description: 'Example response for listing agentless policies'
+            value:
+              items:
+                - id: d52a7812-5736-4fdc-aed8-72152afa1ffa
+                  name: ess_billing-1
+                  description: test
+                  namespace: default
+                  package:
+                    name: ess_billing
+                    title: Elasticsearch Service Billing
+                    version: 1.6.0
+                  inputs:
+                    ESS Billing-cel:
+                      enabled: true
+                      vars:
+                        organization_id: '1234'
+                        api_key:
+                          id: QY1sWpoBbWcMW-edr0Ee
+                          isSecretRef: true
+                        url: 'https://billing.elastic-cloud.com'
+                      streams:
+                        ess_billing.billing:
+                          enabled: true
+                        ess_billing.credits:
+                          enabled: false
+                  created_at: '2025-11-06T18:27:43.541Z'
+                  created_by: test_user
+                  updated_at: '2025-11-06T18:27:43.541Z'
+                  updated_by: test_user
+                - id: aws-policy-12345
+                  name: cspm-aws-policy
+                  description: CSPM integration for AWS with cloud connector
+                  namespace: default
+                  package:
+                    name: cloud_security_posture
+                    title: Cloud Security Posture Management
+                    version: 3.1.1
+                  inputs:
+                    cspm-cloudbeat/cis_aws:
+                      enabled: true
+                  vars:
+                    posture: cspm
+                    deployment: aws
+                  cloud_connector:
+                    enabled: true
+                    cloud_connector_id: aws-connector-67890
+                  created_at: '2025-11-06T18:27:43.541Z'
+                  created_by: test_user
+                  updated_at: '2025-11-06T18:27:43.541Z'
+                  updated_by: test_user
+              total: 2
+              page: 1
+              perPage: 20
+  400:
+    description: 'Bad Request'
+    content:
+      application/json:
+        examples:
+          genericErrorResponseExample:
+            description: 'Example of a generic error response'
+            value:
+              statusCode: 400
+              error: 'Bad Request'
+              message: 'An error message describing what went wrong'

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -10,10 +10,7 @@ import pMap from 'p-map';
 
 import type { CreateAgentlessPolicyRequestSchema } from '../../../common/types';
 import { appContextService, packagePolicyService } from '../../services';
-import type {
-  FleetRequestHandler,
-  ListAgentlessPoliciesRequestSchema,
-} from '../../types';
+import type { FleetRequestHandler, ListAgentlessPoliciesRequestSchema } from '../../types';
 import { AgentlessPoliciesServiceImpl } from '../../services/agentless/agentless_policies';
 import type {
   DeleteAgentlessPolicyRequestSchema,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -9,14 +9,12 @@ import type { TypeOf } from '@kbn/config-schema';
 import pMap from 'p-map';
 
 import type { CreateAgentlessPolicyRequestSchema } from '../../../common/types';
-import type { FleetRequestHandler } from '../../types';
 import { appContextService, packagePolicyService } from '../../services';
 import type {
   FleetRequestHandler,
   GetAgentlessPolicyRequestSchema,
   ListAgentlessPoliciesRequestSchema,
 } from '../../types';
-import { appContextService } from '../../services';
 import { AgentlessPoliciesServiceImpl } from '../../services/agentless/agentless_policies';
 import type {
   DeleteAgentlessPolicyRequestSchema,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -11,6 +11,12 @@ import pMap from 'p-map';
 import type { CreateAgentlessPolicyRequestSchema } from '../../../common/types';
 import type { FleetRequestHandler } from '../../types';
 import { appContextService, packagePolicyService } from '../../services';
+import type {
+  FleetRequestHandler,
+  GetAgentlessPolicyRequestSchema,
+  ListAgentlessPoliciesRequestSchema,
+} from '../../types';
+import { appContextService } from '../../services';
 import { AgentlessPoliciesServiceImpl } from '../../services/agentless/agentless_policies';
 import type {
   DeleteAgentlessPolicyRequestSchema,
@@ -76,6 +82,71 @@ export const createAgentlessPolicyHandler: FleetRequestHandler<
   return response.ok({
     body: {
       item: agentlessPolicy,
+    },
+  });
+};
+
+export const getAgentlessPolicyHandler: FleetRequestHandler<
+  TypeOf<typeof GetAgentlessPolicyRequestSchema.params>
+> = async (context, request, response) => {
+  const [coreContext, fleetContext] = await Promise.all([context.core, context.fleet]);
+
+  const soClient = coreContext.savedObjects.client;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
+
+  const logger = appContextService.getLogger().get('agentless');
+
+  const agentlessPoliciesService = new AgentlessPoliciesServiceImpl(
+    fleetContext.packagePolicyService.asCurrentUser,
+    soClient,
+    esClient,
+    logger
+  );
+
+  const { policyId } = request.params;
+  const item = await agentlessPoliciesService.getAgentlessPolicy(policyId);
+
+  if (!item) {
+    return response.notFound({
+      body: { message: `Agentless policy ${policyId} not found` },
+    });
+  }
+
+  return response.ok({
+    body: {
+      item,
+    },
+  });
+};
+
+export const listAgentlessPoliciesHandler: FleetRequestHandler<
+  undefined,
+  TypeOf<typeof ListAgentlessPoliciesRequestSchema.query>
+> = async (context, request, response) => {
+  const [coreContext, fleetContext] = await Promise.all([context.core, context.fleet]);
+
+  const soClient = coreContext.savedObjects.client;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
+
+  const logger = appContextService.getLogger().get('agentless');
+
+  const agentlessPoliciesService = new AgentlessPoliciesServiceImpl(
+    fleetContext.packagePolicyService.asCurrentUser,
+    soClient,
+    esClient,
+    logger
+  );
+
+  const { items, total, page, perPage } = await agentlessPoliciesService.listAgentlessPolicies(
+    request.query
+  );
+
+  return response.ok({
+    body: {
+      items,
+      total,
+      page,
+      perPage,
     },
   });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/handler.ts
@@ -12,13 +12,13 @@ import type { CreateAgentlessPolicyRequestSchema } from '../../../common/types';
 import { appContextService, packagePolicyService } from '../../services';
 import type {
   FleetRequestHandler,
-  GetAgentlessPolicyRequestSchema,
   ListAgentlessPoliciesRequestSchema,
 } from '../../types';
 import { AgentlessPoliciesServiceImpl } from '../../services/agentless/agentless_policies';
 import type {
   DeleteAgentlessPolicyRequestSchema,
   GetBulkAgentlessPolicyThroughputRequestSchema,
+  GetAgentlessPolicyRequestSchema,
 } from '../../../common/types/rest_spec/agentless_policy';
 import { syncAgentlessDeployments } from '../../services/agentless/deployment_sync';
 import { agentlessAgentService } from '../../services/agents/agentless_agent';

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -18,13 +18,20 @@ import {
 import { AgentlessPolicyResponseSchema } from '../../../common/types/models/agentless_policy_schema';
 import { AGENTLESS_POLICIES_ROUTES, API_VERSIONS } from '../../../common/constants';
 import type { FleetAuthzRouter } from '../../services/security';
+import {
+  AgentlessPolicyListResponseSchema,
+  GetAgentlessPolicyRequestSchema,
+  ListAgentlessPoliciesRequestSchema,
+} from '../../types';
 import { FLEET_API_PRIVILEGES } from '../../constants/api_privileges';
 
-import { genericErrorResponse } from '../schema/errors';
+import { genericErrorResponse, notFoundResponse } from '../schema/errors';
 
 import {
   createAgentlessPolicyHandler,
   deleteAgentlessPolicyHandler,
+  getAgentlessPolicyHandler,
+  listAgentlessPoliciesHandler,
   syncAgentlessPoliciesHandler,
   getBulkAgentlessPolicyThroughputHandler,
 } from './handler';
@@ -123,6 +130,92 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         },
       },
       createAgentlessPolicyHandler
+    );
+
+  // List
+  router.versioned
+    // @ts-ignore https://github.com/elastic/kibana/issues/203170
+    .get({
+      path: AGENTLESS_POLICIES_ROUTES.LIST_PATTERN,
+      summary: 'Get agentless policies',
+      description: 'List agentless policies',
+      options: {
+        tags: ['oas-tag:Fleet agentless policies'],
+        availability: {
+          since: '9.3.0',
+          stability: 'experimental',
+        },
+      },
+      fleetAuthz: {
+        integrations: { readIntegrationPolicies: true },
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.public.v1,
+        options: {
+          oasOperationObject: () => path.join(__dirname, 'examples/list_agentless_policies.yaml'),
+        },
+        validate: {
+          request: ListAgentlessPoliciesRequestSchema,
+          response: {
+            200: {
+              description: 'OK: A successful request.',
+              body: () => AgentlessPolicyListResponseSchema,
+            },
+            400: {
+              description: 'A bad request.',
+              body: genericErrorResponse,
+            },
+          },
+        },
+      },
+      listAgentlessPoliciesHandler
+    );
+
+  // Get
+  router.versioned
+    // @ts-ignore https://github.com/elastic/kibana/issues/203170
+    .get({
+      path: AGENTLESS_POLICIES_ROUTES.GET_PATTERN,
+      summary: 'Get an agentless policy',
+      description: 'Get an agentless policy by ID',
+      options: {
+        tags: ['oas-tag:Fleet agentless policies'],
+        availability: {
+          since: '9.3.0',
+          stability: 'experimental',
+        },
+      },
+      fleetAuthz: {
+        integrations: { readIntegrationPolicies: true },
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.public.v1,
+        options: {
+          oasOperationObject: () => path.join(__dirname, 'examples/get_agentless_policy.yaml'),
+        },
+        validate: {
+          request: GetAgentlessPolicyRequestSchema,
+          response: {
+            200: {
+              description: 'OK: A successful request.',
+              body: () => AgentlessPolicyResponseSchema,
+            },
+            400: {
+              description: 'A bad request.',
+              body: genericErrorResponse,
+            },
+            404: {
+              description: 'The agentless policy was not found.',
+              body: notFoundResponse,
+            },
+          },
+        },
+      },
+      getAgentlessPolicyHandler
     );
 
   // Delete

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -142,7 +142,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       options: {
         tags: ['oas-tag:Fleet agentless policies'],
         availability: {
-          since: '9.3.0',
+          since: '9.5.0',
           stability: 'experimental',
         },
       },
@@ -183,7 +183,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       options: {
         tags: ['oas-tag:Fleet agentless policies'],
         availability: {
-          since: '9.3.0',
+          since: '9.5.0',
           stability: 'experimental',
         },
       },

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agentless_policy/index.ts
@@ -14,15 +14,12 @@ import {
   DeleteAgentlessPolicyResponseSchema,
   GetBulkAgentlessPolicyThroughputRequestSchema,
   GetBulkAgentlessPolicyThroughputResponseSchema,
+  GetAgentlessPolicyRequestSchema,
 } from '../../../common/types/rest_spec/agentless_policy';
 import { AgentlessPolicyResponseSchema } from '../../../common/types/models/agentless_policy_schema';
 import { AGENTLESS_POLICIES_ROUTES, API_VERSIONS } from '../../../common/constants';
 import type { FleetAuthzRouter } from '../../services/security';
-import {
-  AgentlessPolicyListResponseSchema,
-  GetAgentlessPolicyRequestSchema,
-  ListAgentlessPoliciesRequestSchema,
-} from '../../types';
+import { AgentlessPolicyListResponseSchema, ListAgentlessPoliciesRequestSchema } from '../../types';
 import { FLEET_API_PRIVILEGES } from '../../constants/api_privileges';
 
 import { genericErrorResponse, notFoundResponse } from '../schema/errors';

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -25,6 +25,25 @@ jest.mock('../epm/packages/get');
 
 jest.mock('../agent_policy');
 
+const buildAgentlessPackagePolicy = (overrides: Record<string, any> = {}): any => ({
+  id: 'agentless-policy-id',
+  name: 'Test Agentless Policy',
+  namespace: 'default',
+  description: 'test agentless policy',
+  package: { name: 'test_agentless', title: 'Test Agentless', version: '1.0.0' },
+  inputs: [],
+  vars: {},
+  policy_ids: ['agentless-policy-id'],
+  revision: 1,
+  supports_agentless: true,
+  enabled: true,
+  created_at: '2024-01-01T00:00:00.000Z',
+  created_by: 'system',
+  updated_at: '2024-01-01T00:00:00.000Z',
+  updated_by: 'system',
+  ...overrides,
+});
+
 describe('AgentlessPoliciesService', () => {
   describe('createAgentlessPolicy', () => {
     let packagePolicyService: ReturnType<typeof createPackagePolicyServiceMock>;
@@ -383,6 +402,157 @@ describe('AgentlessPoliciesService', () => {
       ).rejects.toEqual(expect.objectContaining({ output: { statusCode: 500 } }));
 
       expect(jest.mocked(agentPolicyService.delete)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAgentlessPolicy', () => {
+    let packagePolicyService: ReturnType<typeof createPackagePolicyServiceMock>;
+
+    const createService = () =>
+      new AgentlessPoliciesServiceImpl(
+        packagePolicyService,
+        savedObjectsClientMock.create(),
+        elasticsearchServiceMock.createClusterClient().asInternalUser,
+        loggingSystemMock.createLogger()
+      );
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      packagePolicyService = createPackagePolicyServiceMock();
+    });
+
+    it('should return the mapped agentless policy when the package policy supports agentless', async () => {
+      packagePolicyService.get.mockResolvedValueOnce(buildAgentlessPackagePolicy());
+
+      const result = await createService().getAgentlessPolicy('agentless-policy-id');
+
+      expect(packagePolicyService.get).toHaveBeenCalledWith(
+        expect.anything(),
+        'agentless-policy-id'
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'agentless-policy-id',
+          name: 'Test Agentless Policy',
+          namespace: 'default',
+          package: { name: 'test_agentless', title: 'Test Agentless', version: '1.0.0' },
+        })
+      );
+      // Internal Fleet fields must not leak through the agentless contract
+      expect(result).not.toHaveProperty('policy_ids');
+      expect(result).not.toHaveProperty('revision');
+      expect(result).not.toHaveProperty('supports_agentless');
+    });
+
+    it('should return null when the package policy is not agentless', async () => {
+      packagePolicyService.get.mockResolvedValueOnce(
+        buildAgentlessPackagePolicy({ supports_agentless: false })
+      );
+
+      const result = await createService().getAgentlessPolicy('regular-policy-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when packagePolicyService.get resolves null', async () => {
+      packagePolicyService.get.mockResolvedValueOnce(null);
+
+      const result = await createService().getAgentlessPolicy('missing-policy-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when packagePolicyService.get throws a not found error', async () => {
+      packagePolicyService.get.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError('test')
+      );
+
+      const result = await createService().getAgentlessPolicy('missing-policy-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('should rethrow non not-found errors from packagePolicyService.get', async () => {
+      packagePolicyService.get.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(() => createService().getAgentlessPolicy('some-policy-id')).rejects.toThrow(
+        'boom'
+      );
+    });
+  });
+
+  describe('listAgentlessPolicies', () => {
+    let packagePolicyService: ReturnType<typeof createPackagePolicyServiceMock>;
+
+    const createService = () =>
+      new AgentlessPoliciesServiceImpl(
+        packagePolicyService,
+        savedObjectsClientMock.create(),
+        elasticsearchServiceMock.createClusterClient().asInternalUser,
+        loggingSystemMock.createLogger()
+      );
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      packagePolicyService = createPackagePolicyServiceMock();
+      packagePolicyService.list.mockResolvedValue({
+        items: [buildAgentlessPackagePolicy()],
+        total: 1,
+        page: 1,
+        perPage: 20,
+      });
+    });
+
+    it('should scope the query to agentless policies and map the results', async () => {
+      const result = await createService().listAgentlessPolicies();
+
+      expect(packagePolicyService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          kuery: 'fleet-package-policies.supports_agentless:true',
+        })
+      );
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({ id: 'agentless-policy-id', name: 'Test Agentless Policy' })
+      );
+      expect(result.items[0]).not.toHaveProperty('supports_agentless');
+      expect(result).toEqual(expect.objectContaining({ total: 1, page: 1, perPage: 20 }));
+    });
+
+    it('should apply the default paging and sorting contract', async () => {
+      await createService().listAgentlessPolicies();
+
+      expect(packagePolicyService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          page: 1,
+          perPage: 20,
+          sortField: 'updated_at',
+          sortOrder: 'desc',
+        })
+      );
+    });
+
+    it('should forward caller paging, sorting and combine the kuery', async () => {
+      await createService().listAgentlessPolicies({
+        page: 2,
+        perPage: 5,
+        sortField: 'name',
+        sortOrder: 'asc',
+        kuery: 'name:foo',
+      });
+
+      expect(packagePolicyService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          page: 2,
+          perPage: 5,
+          sortField: 'name',
+          sortOrder: 'asc',
+          kuery: '(fleet-package-policies.supports_agentless:true) AND (name:foo)',
+        })
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -550,7 +550,8 @@ describe('AgentlessPoliciesService', () => {
           perPage: 5,
           sortField: 'name',
           sortOrder: 'asc',
-          kuery: '(fleet-package-policies.supports_agentless:true) AND (name:foo)',
+          kuery:
+            '(fleet-package-policies.supports_agentless:true) AND (fleet-package-policies.name: foo)',
         })
       );
     });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -23,9 +23,14 @@ import type {
   AgentlessPolicy,
   AgentlessAgentPolicyConfig,
   PackagePolicy,
+  ListWithKuery,
+  ListResult,
 } from '../../../common/types';
 
-import { AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT } from '../../../common/constants';
+import {
+  AGENTLESS_AGENT_POLICY_INACTIVITY_TIMEOUT,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+} from '../../../common/constants';
 
 import {
   formatInputs,
@@ -48,6 +53,18 @@ import {
 import { agentlessAgentService } from '../agents/agentless_agent';
 import { createAndIntegrateCloudConnector } from '../cloud_connectors';
 
+/**
+ * Options accepted by {@link AgentlessPoliciesService.listAgentlessPolicies}.
+ *
+ * Built from {@link ListWithKuery} but narrowed to the fields the agentless LIST
+ * endpoint actually supports — `fields` and the `HttpFetchQuery` index signature
+ * are intentionally excluded.
+ */
+export type ListAgentlessPoliciesOptions = Pick<
+  ListWithKuery,
+  'page' | 'perPage' | 'sortField' | 'sortOrder' | 'kuery'
+>;
+
 export interface AgentlessPoliciesService {
   createAgentlessPolicy: (
     data: NewAgentlessPolicy,
@@ -61,6 +78,12 @@ export interface AgentlessPoliciesService {
     context?: RequestHandlerContext,
     request?: KibanaRequest
   ) => Promise<void>;
+
+  getAgentlessPolicy: (policyId: string) => Promise<AgentlessPolicy | null>;
+
+  listAgentlessPolicies: (
+    options?: ListAgentlessPoliciesOptions
+  ) => Promise<ListResult<AgentlessPolicy>>;
 }
 
 const getAgentlessAgentPolicyConfig = (
@@ -341,6 +364,64 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
       force: options?.force,
       user,
     });
+  }
+
+  async getAgentlessPolicy(policyId: string): Promise<AgentlessPolicy | null> {
+    this.logger.debug(`Getting agentless policy ${policyId}`);
+
+    let packagePolicy: PackagePolicy | null;
+    try {
+      packagePolicy = await this.packagePolicyService.get(this.soClient, policyId);
+    } catch (error) {
+      // packagePolicyService.get throws (rather than returning null) when the underlying
+      // package policy is missing. Collapse a not-found into a null result so the handler
+      // can return a clean 404 instead of leaking the underlying saved-object error.
+      if (error instanceof FleetNotFoundError || SavedObjectsErrorHelpers.isNotFoundError(error)) {
+        return null;
+      }
+      throw error;
+    }
+
+    // Treat a regular (non-agentless) package policy as not found so this API never
+    // exposes standard Fleet package policies through the agentless contract.
+    if (!packagePolicy || packagePolicy.supports_agentless !== true) {
+      return null;
+    }
+
+    return packagePolicyToAgentlessPolicy(packagePolicy);
+  }
+
+  async listAgentlessPolicies(
+    options: ListAgentlessPoliciesOptions = {}
+  ): Promise<ListResult<AgentlessPolicy>> {
+    // Pin the agentless LIST defaults to our API contract rather than inheriting
+    // whatever packagePolicyService.list happens to default to.
+    const { page = 1, perPage = 20, sortField = 'updated_at', sortOrder = 'desc', kuery } = options;
+
+    // Always scope the result set to agentless package policies. This filter is applied
+    // server-side (and `supports_agentless` is excluded from the allowed kuery fields) so
+    // callers can neither widen the scope to regular package policies nor override it.
+    const agentlessFilter = `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.supports_agentless:true`;
+    const combinedKuery = kuery ? `(${agentlessFilter}) AND (${kuery})` : agentlessFilter;
+
+    this.logger.debug(`Listing agentless policies with kuery [${combinedKuery}]`);
+
+    const result = await this.packagePolicyService.list(this.soClient, {
+      page,
+      perPage,
+      sortField,
+      sortOrder,
+      kuery: combinedKuery,
+    });
+
+    this.logger.debug(`Listed ${result.total} agentless policies`);
+
+    return {
+      items: result.items.map(packagePolicyToAgentlessPolicy),
+      total: result.total,
+      page: result.page,
+      perPage: result.perPage,
+    };
   }
 
   private async deleteOrphanedAgentlessResources(policyId: string, user?: AuthenticatedUser) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -53,6 +53,8 @@ import {
 import { agentlessAgentService } from '../agents/agentless_agent';
 import { createAndIntegrateCloudConnector } from '../cloud_connectors';
 
+import { prefixKueryFieldsWithSavedObjectType } from './kuery_utils';
+
 /**
  * Options accepted by {@link AgentlessPoliciesService.listAgentlessPolicies}.
  *
@@ -402,7 +404,12 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
     // server-side (and `supports_agentless` is excluded from the allowed kuery fields) so
     // callers can neither widen the scope to regular package policies nor override it.
     const agentlessFilter = `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.supports_agentless:true`;
-    const combinedKuery = kuery ? `(${agentlessFilter}) AND (${kuery})` : agentlessFilter;
+    const normalizedKuery = kuery
+      ? prefixKueryFieldsWithSavedObjectType(kuery, PACKAGE_POLICY_SAVED_OBJECT_TYPE)
+      : undefined;
+    const combinedKuery = normalizedKuery
+      ? `(${agentlessFilter}) AND (${normalizedKuery})`
+      : agentlessFilter;
 
     this.logger.debug(`Listing agentless policies with kuery [${combinedKuery}]`);
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/kuery_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/kuery_utils.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { prefixKueryFieldsWithSavedObjectType } from './kuery_utils';
+
+const TYPE = 'fleet-package-policies';
+
+describe('prefixKueryFieldsWithSavedObjectType', () => {
+  it('prefixes a bare field name', () => {
+    expect(prefixKueryFieldsWithSavedObjectType('name:"foo"', TYPE)).toBe(`${TYPE}.name: "foo"`);
+  });
+
+  it('prefixes a nested bare field name', () => {
+    expect(prefixKueryFieldsWithSavedObjectType('package.name:"bar"', TYPE)).toBe(
+      `${TYPE}.package.name: "bar"`
+    );
+  });
+
+  it('does not double-prefix a field that already has the type prefix', () => {
+    expect(prefixKueryFieldsWithSavedObjectType(`${TYPE}.name:"foo"`, TYPE)).toBe(
+      `${TYPE}.name: "foo"`
+    );
+  });
+
+  it('prefixes all fields in an AND expression', () => {
+    expect(prefixKueryFieldsWithSavedObjectType('name:"foo" AND namespace:"default"', TYPE)).toBe(
+      `(${TYPE}.name: "foo" AND ${TYPE}.namespace: "default")`
+    );
+  });
+
+  it('prefixes all fields in an OR expression', () => {
+    expect(prefixKueryFieldsWithSavedObjectType('name:"foo" OR name:"bar"', TYPE)).toBe(
+      `(${TYPE}.name: "foo" OR ${TYPE}.name: "bar")`
+    );
+  });
+
+  it('handles a NOT expression', () => {
+    expect(prefixKueryFieldsWithSavedObjectType('NOT name:"foo"', TYPE)).toBe(
+      `NOT ${TYPE}.name: "foo"`
+    );
+  });
+
+  it('handles nested boolean expressions', () => {
+    expect(
+      prefixKueryFieldsWithSavedObjectType(
+        'name:"foo" AND (namespace:"default" OR package.name:"bar")',
+        TYPE
+      )
+    ).toBe(
+      `(${TYPE}.name: "foo" AND (${TYPE}.namespace: "default" OR ${TYPE}.package.name: "bar"))`
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/kuery_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/kuery_utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KueryNode } from '@kbn/es-query';
+import { fromKueryExpression, toKqlExpression } from '@kbn/es-query';
+
+/**
+ * Rewrites bare field names in a KQL kuery string to be prefixed with the given
+ * saved object type, e.g. `name:"foo"` → `fleet-package-policies.name:"foo"`.
+ *
+ * The core saved objects layer requires all filter fields to be namespaced by
+ * SO type. This lets the public agentless API accept simple field names without
+ * exposing the internal `fleet-package-policies` type to callers.
+ */
+export const prefixKueryFieldsWithSavedObjectType = (
+  kuery: string,
+  savedObjectType: string
+): string => {
+  const rewrite = (node: KueryNode): KueryNode => {
+    const n = node as any;
+    if (n.type === 'function' && (n.function === 'is' || n.function === 'range')) {
+      const [fieldNode, ...rest] = n.arguments;
+      if (
+        fieldNode?.type === 'literal' &&
+        !String(fieldNode.value).startsWith(`${savedObjectType}.`)
+      ) {
+        return {
+          ...n,
+          arguments: [{ ...fieldNode, value: `${savedObjectType}.${fieldNode.value}` }, ...rest],
+        };
+      }
+    }
+    if (n.arguments) {
+      return { ...n, arguments: n.arguments.map(rewrite) };
+    }
+    return node;
+  };
+  return toKqlExpression(rewrite(fromKueryExpression(kuery)));
+};

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ALLOWED_AGENTLESS_POLICY_FILTER_FIELDS,
+  ListAgentlessPoliciesRequestSchema,
+} from './agentless_policy';
+
+describe('ListAgentlessPoliciesRequestSchema', () => {
+  const validateQuery = (query: Record<string, unknown>) =>
+    ListAgentlessPoliciesRequestSchema.query.validate(query);
+
+  it('accepts an empty query (paging defaults are applied by the service layer)', () => {
+    expect(() => validateQuery({})).not.toThrow();
+  });
+
+  it('accepts explicit paging and sorting parameters', () => {
+    const result = validateQuery({
+      page: 2,
+      perPage: 5,
+      sortField: 'name',
+      sortOrder: 'asc',
+    });
+
+    expect(result.page).toBe(2);
+    expect(result.perPage).toBe(5);
+    expect(result.sortField).toBe('name');
+    expect(result.sortOrder).toBe('asc');
+  });
+
+  it('rejects an invalid sortOrder', () => {
+    expect(() => validateQuery({ sortOrder: 'sideways' })).toThrow();
+  });
+
+  it.each(['name:foo', 'namespace:default', 'package.name:test_agentless'])(
+    'accepts a kuery filtering on the allowed field %s',
+    (kuery) => {
+      expect(() => validateQuery({ kuery })).not.toThrow();
+    }
+  );
+
+  it('accepts a kuery combining several allowed fields', () => {
+    expect(() =>
+      validateQuery({ kuery: 'name:foo and namespace:default and package.name:test_agentless' })
+    ).not.toThrow();
+  });
+
+  it.each([
+    'policy_ids:foo',
+    'revision:1',
+    'supports_agentless:true',
+    'package.version:1.0.0',
+    'enabled:true',
+  ])('rejects a kuery filtering on the disallowed field %s', (kuery) => {
+    expect(() => validateQuery({ kuery })).toThrow(/KQLSyntaxError/);
+  });
+
+  it('derives the allowed filter fields from the mapping', () => {
+    expect(ALLOWED_AGENTLESS_POLICY_FILTER_FIELDS).toEqual(['name', 'namespace', 'package.name']);
+  });
+
+  it('returns a self-correcting 400 that enumerates the allowed fields', () => {
+    let message = '';
+    try {
+      validateQuery({ kuery: 'supports_agentless:true' });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    for (const field of ALLOWED_AGENTLESS_POLICY_FILTER_FIELDS) {
+      expect(message).toContain(field);
+    }
+    expect(message).toMatch(/Filtering is only allowed on the following fields/);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
@@ -90,6 +90,7 @@ export const ListAgentlessPoliciesRequestSchema = {
   query: ListAgentlessPoliciesRequestQuerySchema.extends({
     kuery: schema.maybe(
       schema.string({
+        maxLength: 4096,
         meta: {
           description: `A KQL query string to filter results. Filtering is restricted to the following fields: ${ALLOWED_FILTER_FIELDS_LIST}.`,
         },

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
@@ -12,6 +12,7 @@ import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
 } from '../../constants';
 import { AgentlessPolicySchema } from '../../../common/types/models/agentless_policy_schema';
+import { ListAgentlessPoliciesRequestQuerySchema } from '../../../common/types/rest_spec/agentless_policy';
 
 import { validateKuery } from '../../routes/utils/filter_utils';
 import { ListResponseSchema } from '../../routes/schema/utils';
@@ -78,34 +79,15 @@ const ALLOWED_FILTER_FIELDS_LIST = ALLOWED_AGENTLESS_POLICY_FILTER_FIELDS.map(
  */
 export const AgentlessPolicyListResponseSchema = ListResponseSchema(AgentlessPolicySchema);
 
-export const GetAgentlessPolicyRequestSchema = {
-  params: schema.object({
-    policyId: schema.string({
-      meta: {
-        description: 'The ID of the agentless policy to retrieve.',
-      },
-    }),
-  }),
-};
-
+/**
+ * Extends the layering-safe base query shape from `common/` with the server-only
+ * `kuery` validator. The base lives in `common/` so the request TypeScript type
+ * can be derived there; only the validation (which depends on `validateKuery`)
+ * lives here. The override replaces the base `kuery` field with a validating one
+ * of the same type, so the derived `ListAgentlessPoliciesRequest` type stays accurate.
+ */
 export const ListAgentlessPoliciesRequestSchema = {
-  query: schema.object({
-    // Paging defaults (page=1, perPage=20) are owned by the service layer
-    // (`listAgentlessPolicies`), which is the single source of truth
-    page: schema.maybe(schema.number({ meta: { description: 'Page number. Defaults to `1`.' } })),
-    perPage: schema.maybe(
-      schema.number({ meta: { description: 'Number of results per page. Defaults to `20`.' } })
-    ),
-    sortField: schema.maybe(
-      schema.string({
-        meta: { description: 'Field to sort results by. Defaults to `updated_at`.' },
-      })
-    ),
-    sortOrder: schema.maybe(
-      schema.oneOf([schema.literal('desc'), schema.literal('asc')], {
-        meta: { description: 'Sort order, ascending or descending. Defaults to `desc`.' },
-      })
-    ),
+  query: ListAgentlessPoliciesRequestQuerySchema.extends({
     kuery: schema.maybe(
       schema.string({
         meta: {

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
@@ -90,9 +90,11 @@ export const GetAgentlessPolicyRequestSchema = {
 
 export const ListAgentlessPoliciesRequestSchema = {
   query: schema.object({
-    page: schema.maybe(schema.number({ defaultValue: 1, meta: { description: 'Page number' } })),
+    // Paging defaults (page=1, perPage=20) are owned by the service layer
+    // (`listAgentlessPolicies`), which is the single source of truth
+    page: schema.maybe(schema.number({ meta: { description: 'Page number. Defaults to `1`.' } })),
     perPage: schema.maybe(
-      schema.number({ defaultValue: 20, meta: { description: 'Number of results per page' } })
+      schema.number({ meta: { description: 'Number of results per page. Defaults to `20`.' } })
     ),
     sortField: schema.maybe(
       schema.string({

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agentless_policy.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import {
+  LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+} from '../../constants';
+import { AgentlessPolicySchema } from '../../../common/types/models/agentless_policy_schema';
+
+import { validateKuery } from '../../routes/utils/filter_utils';
+import { ListResponseSchema } from '../../routes/schema/utils';
+
+/**
+ * Restricts agentless LIST filtering to the fields exposed by the clean
+ * `AgentlessPolicy` contract. `validateKuery` rejects any field that is not
+ * present in this mapping, so callers cannot filter on the underlying Fleet
+ * package-policy internals (e.g. `policy_ids`, `revision`, `supports_agentless`)
+ * that this API deliberately hides.
+ *
+ * `supports_agentless` is intentionally excluded: the service always ANDs
+ * `supports_agentless:true` onto the query to scope results to agentless
+ * policies, so it must not be something callers can filter (or override).
+ */
+export const AGENTLESS_POLICY_FILTER_MAPPINGS = {
+  properties: {
+    name: { type: 'keyword' },
+    namespace: { type: 'keyword' },
+    package: {
+      properties: {
+        name: { type: 'keyword' },
+      },
+    },
+  },
+} as const;
+
+interface FilterMappingNode {
+  readonly type?: string;
+  readonly properties?: Readonly<Record<string, FilterMappingNode>>;
+}
+
+/**
+ * Walks a mapping's `properties` tree and returns the dotted paths of every leaf
+ * field (e.g. `name`, `package.name`). Used to keep the allowed-filter-field list
+ * single-sourced from {@link AGENTLESS_POLICY_FILTER_MAPPINGS} rather than
+ * duplicating it in the OpenAPI description and the validation error message.
+ */
+const getLeafFieldPaths = (
+  properties: Readonly<Record<string, FilterMappingNode>>,
+  prefix = ''
+): string[] =>
+  Object.entries(properties).flatMap(([key, node]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return node.properties ? getLeafFieldPaths(node.properties, path) : [path];
+  });
+
+/**
+ * The fields a caller may filter on via `kuery`, derived from the filter mapping
+ * so the contract stays in one place.
+ */
+export const ALLOWED_AGENTLESS_POLICY_FILTER_FIELDS = getLeafFieldPaths(
+  AGENTLESS_POLICY_FILTER_MAPPINGS.properties
+);
+
+const ALLOWED_FILTER_FIELDS_LIST = ALLOWED_AGENTLESS_POLICY_FILTER_FIELDS.map(
+  (field) => `\`${field}\``
+).join(', ');
+
+/**
+ * Reuses the shared Fleet list envelope (`{ items, total, page, perPage }` with a
+ * `maxSize` bound on `items`) so the agentless LIST response stays single-sourced
+ * with every other Fleet list endpoint.
+ */
+export const AgentlessPolicyListResponseSchema = ListResponseSchema(AgentlessPolicySchema);
+
+export const GetAgentlessPolicyRequestSchema = {
+  params: schema.object({
+    policyId: schema.string({
+      meta: {
+        description: 'The ID of the agentless policy to retrieve.',
+      },
+    }),
+  }),
+};
+
+export const ListAgentlessPoliciesRequestSchema = {
+  query: schema.object({
+    page: schema.maybe(schema.number({ defaultValue: 1, meta: { description: 'Page number' } })),
+    perPage: schema.maybe(
+      schema.number({ defaultValue: 20, meta: { description: 'Number of results per page' } })
+    ),
+    sortField: schema.maybe(
+      schema.string({
+        meta: { description: 'Field to sort results by. Defaults to `updated_at`.' },
+      })
+    ),
+    sortOrder: schema.maybe(
+      schema.oneOf([schema.literal('desc'), schema.literal('asc')], {
+        meta: { description: 'Sort order, ascending or descending. Defaults to `desc`.' },
+      })
+    ),
+    kuery: schema.maybe(
+      schema.string({
+        meta: {
+          description: `A KQL query string to filter results. Filtering is restricted to the following fields: ${ALLOWED_FILTER_FIELDS_LIST}.`,
+        },
+        validate: (value: string) => {
+          // The filter mapping above already uses unprefixed field names (e.g. `name`,
+          // `package.name`), so the SO-type prefix normalization step must be skipped.
+          const skipNormalization = true;
+          const validationObj = validateKuery(
+            value,
+            [PACKAGE_POLICY_SAVED_OBJECT_TYPE, LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE],
+            AGENTLESS_POLICY_FILTER_MAPPINGS,
+            skipNormalization
+          );
+          if (validationObj?.error) {
+            // Enumerate the allowed fields so the 400 is self-correcting; the list is
+            // derived from the mapping above, never hardcoded.
+            return `${validationObj.error}. Filtering is only allowed on the following fields: ${ALLOWED_FILTER_FIELDS_LIST}.`;
+          }
+        },
+      })
+    ),
+  }),
+};

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/index.ts
@@ -8,6 +8,7 @@
 export * from './common';
 export * from './agent_policy';
 export * from './agent';
+export * from './agentless_policy';
 export * from './package_policy';
 export * from './epm';
 export * from './enrollment_api_key';

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -354,6 +354,224 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
+    describe('Get Agentless Policy', () => {
+      before(async () => {
+        const mockAgentlessApiService = setupMockServer();
+        mockApiServer = await mockAgentlessApiService.listen(8089);
+      });
+
+      after(async () => {
+        await mockApiServer.close();
+      });
+
+      beforeEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanFleetIndices(es);
+        await apiClient.setup();
+      });
+
+      afterEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanFleetIndices(es);
+      });
+
+      it('should return an agentless policy with a clean response shape', async () => {
+        const id = uuidv4();
+        await apiClient.createAgentlessPolicy({
+          id,
+          package: {
+            name: 'test_agentless',
+            version: '1.0.0',
+          },
+          name: `test_agentless-${Date.now()}`,
+          description: 'test agentless policy',
+          namespace: 'default',
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: {
+                api_key: 'TEST_VALUE_API_KEY',
+              },
+              streams: {},
+            },
+          },
+        });
+
+        const { item } = await apiClient.getAgentlessPolicy(id);
+
+        expect(item.id).to.be(id);
+        expect(item.namespace).to.be('default');
+        expect(item.package.name).to.be('test_agentless');
+
+        // The agentless contract must not leak underlying Fleet package-policy internals
+        expect(item).to.not.have.property('policy_ids');
+        expect(item).to.not.have.property('revision');
+        expect(item).to.not.have.property('supports_agentless');
+        expect(item).to.not.have.property('enabled');
+      });
+
+      it('should return 404 for a missing policy id', async () => {
+        await expectToRejectWithNotFound(() => apiClient.getAgentlessPolicy(uuidv4()));
+      });
+
+      it('should return 404 for an existing non-agentless package policy', async () => {
+        const agentPolicyRes = await apiClient.createAgentPolicy(undefined, {
+          name: `standard-policy-${Date.now()}`,
+          namespace: 'default',
+          description: '',
+        });
+
+        const packagePolicyRes = await apiClient.createPackagePolicy(undefined, {
+          package: {
+            name: 'test_agentless',
+            version: '1.0.0',
+          },
+          name: `regular-package-policy-${Date.now()}`,
+          namespace: 'default',
+          policy_ids: [agentPolicyRes.item.id],
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: {
+                api_key: 'TEST_VALUE_API_KEY',
+              },
+              streams: {},
+            },
+          },
+        });
+
+        // The regular package policy exists, but must not be reachable via the agentless API
+        await apiClient.getPackagePolicy(packagePolicyRes.item.id);
+        await expectToRejectWithNotFound(() =>
+          apiClient.getAgentlessPolicy(packagePolicyRes.item.id)
+        );
+      });
+    });
+
+    describe('List Agentless Policies', () => {
+      before(async () => {
+        const mockAgentlessApiService = setupMockServer();
+        mockApiServer = await mockAgentlessApiService.listen(8089);
+      });
+
+      after(async () => {
+        await mockApiServer.close();
+      });
+
+      beforeEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanFleetIndices(es);
+        await apiClient.setup();
+      });
+
+      afterEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanFleetIndices(es);
+      });
+
+      const createAgentlessPolicyWithName = async (name: string) => {
+        const id = uuidv4();
+        await apiClient.createAgentlessPolicy({
+          id,
+          package: {
+            name: 'test_agentless',
+            version: '1.0.0',
+          },
+          name,
+          description: 'test agentless policy',
+          namespace: 'default',
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: {
+                api_key: 'TEST_VALUE_API_KEY',
+              },
+              streams: {},
+            },
+          },
+        });
+        return id;
+      };
+
+      it('should only return agentless policies (scoped) with a clean response shape', async () => {
+        await createAgentlessPolicyWithName(`test_agentless-a-${Date.now()}`);
+        await createAgentlessPolicyWithName(`test_agentless-b-${Date.now()}`);
+
+        // A regular (non-agentless) package policy that must be excluded from the list
+        const agentPolicyRes = await apiClient.createAgentPolicy(undefined, {
+          name: `standard-policy-${Date.now()}`,
+          namespace: 'default',
+          description: '',
+        });
+        await apiClient.createPackagePolicy(undefined, {
+          package: {
+            name: 'test_agentless',
+            version: '1.0.0',
+          },
+          name: `regular-package-policy-${Date.now()}`,
+          namespace: 'default',
+          policy_ids: [agentPolicyRes.item.id],
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: {
+                api_key: 'TEST_VALUE_API_KEY',
+              },
+              streams: {},
+            },
+          },
+        });
+
+        const res = await apiClient.listAgentlessPolicies();
+
+        expect(res.total).to.be(2);
+        expect(res.items.length).to.be(2);
+        expect(res.page).to.be(1);
+        expect(res.perPage).to.be(20);
+
+        for (const item of res.items) {
+          expect(item).to.not.have.property('policy_ids');
+          expect(item).to.not.have.property('revision');
+          expect(item).to.not.have.property('supports_agentless');
+        }
+      });
+
+      it('should respect paging parameters', async () => {
+        await createAgentlessPolicyWithName(`test_agentless-a-${Date.now()}`);
+        await createAgentlessPolicyWithName(`test_agentless-b-${Date.now()}`);
+        await createAgentlessPolicyWithName(`test_agentless-c-${Date.now()}`);
+
+        const firstPage = await apiClient.listAgentlessPolicies({ page: 1, perPage: 2 });
+        expect(firstPage.total).to.be(3);
+        expect(firstPage.items.length).to.be(2);
+
+        const secondPage = await apiClient.listAgentlessPolicies({ page: 2, perPage: 2 });
+        expect(secondPage.total).to.be(3);
+        expect(secondPage.items.length).to.be(1);
+      });
+
+      it('should filter results using an allowed kuery field', async () => {
+        const uniqueName = `test_agentless-unique-${uuidv4()}`;
+        await createAgentlessPolicyWithName(uniqueName);
+        await createAgentlessPolicyWithName(`test_agentless-other-${Date.now()}`);
+
+        const res = await apiClient.listAgentlessPolicies({
+          kuery: `name:"${uniqueName}"`,
+        });
+
+        expect(res.total).to.be(1);
+        expect(res.items.length).to.be(1);
+        expect(res.items[0].name).to.be(uniqueName);
+      });
+
+      it('should reject a kuery filtering on a disallowed field', async () => {
+        await expectToRejectWithError(
+          () => apiClient.listAgentlessPolicies({ kuery: 'supports_agentless:true' }),
+          /400/
+        );
+      });
+    });
+
     describe('Update Agentless Policy', () => {
       let apiCalls: Array<{
         url: string;

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -45,6 +45,9 @@ import type {
   GetSettingsResponse,
   PutSettingsRequest,
   CreateAgentlessPolicyResponse,
+  GetAgentlessPolicyResponse,
+  ListAgentlessPoliciesRequest,
+  ListAgentlessPoliciesResponse,
   PutDownloadSourceRequest,
 } from '@kbn/fleet-plugin/common/types';
 import type {
@@ -150,6 +153,35 @@ export class SpaceTestApiClient {
       .auth(this.auth.username, this.auth.password)
       .set('kbn-xsrf', 'xxxx')
       .send();
+
+    expectStatusCode200(res);
+
+    return res.body;
+  }
+
+  async getAgentlessPolicy(
+    policyId: string,
+    spaceId?: string
+  ): Promise<GetAgentlessPolicyResponse> {
+    const res = await this.supertest
+      .get(`${this.getBaseUrl(spaceId)}/api/fleet/agentless_policies/${policyId}`)
+      .auth(this.auth.username, this.auth.password)
+      .set('kbn-xsrf', 'xxxx');
+
+    expectStatusCode200(res);
+
+    return res.body;
+  }
+
+  async listAgentlessPolicies(
+    query: ListAgentlessPoliciesRequest['query'] = {},
+    spaceId?: string
+  ): Promise<ListAgentlessPoliciesResponse> {
+    const res = await this.supertest
+      .get(`${this.getBaseUrl(spaceId)}/api/fleet/agentless_policies`)
+      .query(query)
+      .auth(this.auth.username, this.auth.password)
+      .set('kbn-xsrf', 'xxxx');
 
     expectStatusCode200(res);
 


### PR DESCRIPTION
## Summary
Adds `GET /agentless_policies/{policyId}` and `GET /agentless_policies` (LIST) endpoints to the Fleet plugin, exposing the clean `AgentlessPolicy` contract without leaking underlying Fleet package-policy internals.
- **GET**: returns a single agentless policy by id; non-agentless package policies and missing ids both resolve to a clean `404`.
- **LIST**: returns the standard `{ items, total, page, perPage }` envelope (via the shared `ListResponseSchema` helper), always scoped server-side to `supports_agentless:true`. KQL filtering is restricted to `name`, `namespace`, `package.name`, with a self-correcting `400` that enumerates the allowed fields.
- Space scoping is inherited from the request-scoped saved-objects client, so callers only see policies in their active space.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




