### PR TITLE
remove explicit dry run set to true in version bump

### DIFF
--- a/.buildkite/pipelines/version_bump.yml
+++ b/.buildkite/pipelines/version_bump.yml
@@ -2,7 +2,7 @@ notify:
   - slack:
       channels:
         - '#kibana-operations-alerts'
-      message: "<!subteam^S2XQAJ39Q|kibana-operations-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}"
+      message: '<!subteam^S2XQAJ39Q|kibana-operations-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}'
     if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) &&
       (build.state == 'passed' || build.state == 'failed')
   - slack:
@@ -22,8 +22,6 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-    env:
-      DRY_RUN: 'true'
 
   - wait
 


### PR DESCRIPTION
## Summary 

Remove this constant as it breaks the version bump to always use dry run mode

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->