### PR TITLE
[Entity Store] [POC] Entity store/deterministic source discovery

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -71,6 +71,7 @@ export const ENTITY_STORE_ROUTES = {
     ENTITY_MAINTAINERS_RUN: `${INTERNAL_BASE_ROUTE}/entity_maintainers/run/{id}`,
     ENTITY_MAINTAINERS_GET: `${INTERNAL_BASE_ROUTE}/entity_maintainers`,
     ENTITY_MAINTAINERS_INIT: `${INTERNAL_BASE_ROUTE}/entity_maintainers/init`,
+    DISCOVERED_SOURCES: `${INTERNAL_BASE_ROUTE}/discovered_sources`,
   },
 } as const satisfies Record<string, Record<string, string>>;
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -70,6 +70,7 @@ import {
 } from '../saved_objects';
 import { ENGINE_STATUS } from '../constants';
 import type { EntityType } from '../../../common/domain/definitions/entity_schema';
+import { clearDiscoveredSourceCache } from '../source_discovery';
 
 type MockRemoteLogsExtractionClient = jest.Mocked<
   Pick<RemoteLogsExtractionClient, 'extractToUpdates'>
@@ -1521,6 +1522,142 @@ describe('LogsExtractionClient', () => {
       expect(indexPatterns).not.toContain('-remote_cluster:logs-debug-*');
       // remote includes are also not returned
       expect(indexPatterns).not.toContain('remote_cluster:logs-*');
+    });
+  });
+
+  describe('deterministic source discovery (useDiscoveredIndexSource)', () => {
+    const UPDATES_DATA_STREAM = '.entities.v2.updates.security_default';
+    const ALERTS_INDEX = '.alerts-security.alerts-default';
+
+    describe('FROM replacement when discovered source patterns are supplied', () => {
+      it('builds updates ∪ additional ∪ discovered, skipping the data view (no lookup, no logs-* fallback)', async () => {
+        const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns(
+          ['custom-index'],
+          [],
+          ['logs-okta.system-default', ALERTS_INDEX]
+        );
+
+        expect(localIndexPatterns).toEqual(
+          expect.arrayContaining([
+            UPDATES_DATA_STREAM,
+            'custom-index',
+            'logs-okta.system-default',
+            ALERTS_INDEX,
+          ])
+        );
+        expect(localIndexPatterns).not.toContain('logs-*');
+        expect(mockDataViewsService.get).not.toHaveBeenCalled();
+      });
+
+      it('keeps the alerts index when discovery supplies it (no withoutAlerts stripping)', async () => {
+        const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns(
+          [],
+          [],
+          [ALERTS_INDEX]
+        );
+
+        expect(localIndexPatterns).toContain(ALERTS_INDEX);
+      });
+
+      it('extracts from updates-only when discovery returns no sources (no data view fallback)', async () => {
+        const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns([], [], []);
+
+        expect(localIndexPatterns).toEqual([UPDATES_DATA_STREAM]);
+        expect(mockDataViewsService.get).not.toHaveBeenCalled();
+      });
+
+      it('still appends excluded patterns as trailing negations', async () => {
+        const { localIndexPatterns } = await client.getLocalAndRemoteIndexPatterns(
+          [],
+          ['logs-proxy-*'],
+          ['logs-okta.system-default']
+        );
+
+        const includeIdx = localIndexPatterns.indexOf('logs-okta.system-default');
+        const excludeIdx = localIndexPatterns.indexOf('-logs-proxy-*');
+        expect(includeIdx).toBeGreaterThanOrEqual(0);
+        expect(excludeIdx).toBeGreaterThan(includeIdx);
+      });
+
+      it('routes a cluster-prefixed discovered pattern to the remote set', async () => {
+        const { localIndexPatterns, remoteIndexPatterns } =
+          await client.getLocalAndRemoteIndexPatterns([], [], ['remote_cluster:logs-okta-default']);
+
+        expect(remoteIndexPatterns).toContain('remote_cluster:logs-okta-default');
+        expect(localIndexPatterns).not.toContain('remote_cluster:logs-okta-default');
+      });
+
+      it('getLocalIndexPatterns forwards discovered patterns and returns local-only', async () => {
+        const indexPatterns = await client.getLocalIndexPatterns(
+          [],
+          [],
+          ['logs-okta.system-default', 'remote_cluster:logs-okta-default']
+        );
+
+        expect(indexPatterns).toContain('logs-okta.system-default');
+        expect(indexPatterns).not.toContain('remote_cluster:logs-okta-default');
+        expect(mockDataViewsService.get).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getDiscoveredSources', () => {
+      beforeEach(() => clearDiscoveredSourceCache());
+
+      it('returns enabled:false with empty results and makes no ES calls when the flag is off', async () => {
+        const resolveIndex = jest.fn();
+        const fieldCaps = jest.fn();
+        (mockEsClient as unknown as { indices: unknown }).indices = { resolveIndex };
+        (mockEsClient as unknown as { fieldCaps: unknown }).fieldCaps = fieldCaps;
+
+        const result = await client.getDiscoveredSources();
+
+        expect(result).toEqual({
+          enabled: false,
+          sources: { user: [], host: [], service: [], generic: [] },
+          provenance: [],
+        });
+        expect(resolveIndex).not.toHaveBeenCalled();
+        expect(fieldCaps).not.toHaveBeenCalled();
+      });
+
+      it('returns enabled:false when the store is not installed (global state missing)', async () => {
+        mockGlobalStateClient.find.mockResolvedValueOnce(undefined);
+
+        const result = await client.getDiscoveredSources();
+
+        expect(result.enabled).toBe(false);
+      });
+
+      it('returns discovered sources and provenance when the flag is on', async () => {
+        const dataStream = 'logs-okta.system-default';
+        const backingIndex = '.ds-logs-okta.system-default-2024.01.01-000001';
+        mockGlobalStateClient.find.mockResolvedValue({
+          logsExtraction: LogExtractionConfig.parse({ useDiscoveredIndexSource: true }),
+        } as EntityStoreGlobalState);
+        (mockEsClient as unknown as { indices: unknown }).indices = {
+          resolveIndex: jest.fn().mockResolvedValue({
+            indices: [],
+            aliases: [],
+            data_streams: [{ name: dataStream, backing_indices: [backingIndex] }],
+          }),
+        };
+        (mockEsClient as unknown as { fieldCaps: unknown }).fieldCaps = jest
+          .fn()
+          .mockResolvedValue({
+            indices: [backingIndex],
+            fields: { 'user.email': { keyword: { type: 'keyword', indices: [backingIndex] } } },
+          });
+
+        const result = await client.getDiscoveredSources();
+
+        expect(result.enabled).toBe(true);
+        expect(result.sources.user).toEqual([dataStream]);
+        expect(result.provenance).toContainEqual({
+          entityType: 'user',
+          sourceName: dataStream,
+          matchedFields: ['user.email'],
+        });
+      });
     });
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -1421,6 +1421,125 @@ describe('LogsExtractionClient', () => {
         expect(subWindow3).toContain(effectiveWindowEnd);
       });
     });
+
+    // POC source-discovery watermark gate: while deterministic discovery has not yet
+    // surfaced a real source for a type (empty set, or `.alerts`-only), an empty run
+    // must NOT advance `lastExecutionTimestamp`. Otherwise the per-minute ticks push the
+    // watermark to ~now and, once discovery later observes a real source (cache TTL up to
+    // 15m), its back-dated docs already sit behind the watermark and are never extracted.
+    describe('watermark gate when discovery finds no real sources (POC)', () => {
+      const fixedNow = new Date('2025-06-15T12:00:00.000Z');
+      const effectiveWindowEnd = '2025-06-15T11:59:00.000Z'; // now - 1m delay
+      const heldLastExecution = '2025-06-15T11:00:00.000Z';
+      const ALERTS_INDEX = '.alerts-security.alerts-default';
+
+      beforeEach(() => {
+        clearDiscoveredSourceCache();
+        jest.useFakeTimers({ now: fixedNow.getTime() });
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      // Drives deterministic discovery so that the `user` type resolves to exactly one
+      // source (`sourceName`), qualifying via `user.name` at keyword.
+      const mockUserSourceDiscovery = ({
+        sourceName,
+        asDataStream,
+        backingIndex,
+      }: {
+        sourceName: string;
+        asDataStream: boolean;
+        backingIndex?: string;
+      }) => {
+        const concrete = backingIndex ?? sourceName;
+        (mockEsClient as unknown as { indices: unknown }).indices = {
+          resolveIndex: jest.fn().mockResolvedValue({
+            indices: asDataStream ? [] : [{ name: sourceName }],
+            aliases: [],
+            data_streams: asDataStream ? [{ name: sourceName, backing_indices: [concrete] }] : [],
+          }),
+        };
+        (mockEsClient as unknown as { fieldCaps: unknown }).fieldCaps = jest
+          .fn()
+          .mockResolvedValue({
+            indices: [concrete],
+            fields: { 'user.name': { keyword: { type: 'keyword', indices: [concrete] } } },
+          });
+      };
+
+      const setupDiscoveryOnEngine = (additionalIndexPatterns: string[] = []) => {
+        const globalState = {
+          logsExtraction: LogExtractionConfig.parse({
+            lookbackPeriod: '3h',
+            delay: '1m',
+            maxTimeWindowSize: '999d',
+            useDiscoveredIndexSource: true,
+            additionalIndexPatterns,
+          }),
+        } as EntityStoreGlobalState;
+        mockGlobalStateClient.find.mockResolvedValue(globalState);
+        mockGlobalStateClient.findOrThrow.mockResolvedValue(globalState);
+        mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+          createMockEngineDescriptor('user', {
+            lastExecutionTimestamp: heldLastExecution,
+          }) as Awaited<ReturnType<EngineDescriptorClient['findOrThrow']>>
+        );
+        mockExecuteEsqlQuery.mockResolvedValue(mockLogPaginationCursorProbeEmpty());
+        mockIngestEntities.mockResolvedValue(undefined);
+      };
+
+      it('holds the watermark when the discovered source set is .alerts-only', async () => {
+        setupDiscoveryOnEngine();
+        mockUserSourceDiscovery({ sourceName: ALERTS_INDEX, asDataStream: false });
+
+        const result = await client.extractLogs('user');
+
+        expect(result.success).toBe(true);
+        const finalUpdate = mockEngineDescriptorClient.update.mock.calls.at(-1)!;
+        expect(finalUpdate[1].logExtractionState).toMatchObject({
+          checkpointTimestamp: null,
+          paginationId: null,
+          lastExecutionTimestamp: heldLastExecution,
+        });
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          expect.stringContaining('Holding extraction watermark for entity type "user"')
+        );
+      });
+
+      it('advances the watermark when discovery finds a real (non-alerts) source', async () => {
+        setupDiscoveryOnEngine();
+        mockUserSourceDiscovery({
+          sourceName: 'logs-okta.system-default',
+          asDataStream: true,
+          backingIndex: '.ds-logs-okta.system-default-2025.06.15-000001',
+        });
+
+        const result = await client.extractLogs('user');
+
+        expect(result.success).toBe(true);
+        const finalUpdate = mockEngineDescriptorClient.update.mock.calls.at(-1)!;
+        expect(finalUpdate[1].logExtractionState).toMatchObject({
+          lastExecutionTimestamp: effectiveWindowEnd,
+        });
+      });
+
+      it('advances the watermark when additional patterns are configured, even if discovery is .alerts-only', async () => {
+        setupDiscoveryOnEngine(['custom-logs-*']);
+        mockUserSourceDiscovery({ sourceName: ALERTS_INDEX, asDataStream: false });
+
+        await client.extractLogs('user');
+
+        const finalUpdate = mockEngineDescriptorClient.update.mock.calls.at(-1)!;
+        expect(finalUpdate[1].logExtractionState).toMatchObject({
+          lastExecutionTimestamp: effectiveWindowEnd,
+        });
+        expect(mockLogger.debug).not.toHaveBeenCalledWith(
+          expect.stringContaining('Holding extraction watermark')
+        );
+      });
+    });
   });
 
   describe('getLocalAndRemoteIndexPatterns', () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -49,6 +49,12 @@ import {
   getSecuritySolutionDataViewName,
 } from '../asset_manager/external_indices_contants';
 import {
+  emptySources,
+  getCachedPerTypeSourceIndices,
+  type PerTypeSourceIndices,
+  type PerTypeSourceProvenance,
+} from '../source_discovery';
+import {
   type LogExtractionConfig,
   LogExtractionConfig as LogExtractionConfigSchema,
 } from '../saved_objects';
@@ -96,6 +102,16 @@ interface ExtractedLogsSummaryError {
 }
 
 type ExtractedLogsSummary = ExtractedLogsSummarySuccess | ExtractedLogsSummaryError;
+
+/** Visibility surface for the deterministic source-discovery POC. */
+export interface DiscoveredSourcesResult {
+  /** Whether `useDiscoveredIndexSource` is enabled for this namespace. */
+  enabled: boolean;
+  /** Per-entity-type resolved source patterns (empty when disabled). */
+  sources: PerTypeSourceIndices;
+  /** Why each source qualified for each type (empty when disabled). */
+  provenance: PerTypeSourceProvenance[];
+}
 
 export interface LogsExtractionClientDependencies {
   logger: Logger;
@@ -226,9 +242,11 @@ export class LogsExtractionClient {
   public async getRemainingLogsCount(type: EntityType): Promise<number> {
     try {
       const { config, engineState } = await this.getLogExtractionConfigAndState(type);
+      const discoveredSourcePatterns = await this.resolveDiscoveredSourcePatterns(type, config);
       const indexPatterns = await this.getLocalIndexPatterns(
         config.additionalIndexPatterns,
-        config.excludedIndexPatterns
+        config.excludedIndexPatterns,
+        discoveredSourcePatterns
       );
       const { fromDateISO } = resolveMainExtractionWindow({ config, engineState });
       const toDateISO = moment().utc().toISOString();
@@ -281,9 +299,11 @@ export class LogsExtractionClient {
     logsCapApplied: boolean;
     logsProcessed: number;
   }> {
+    const discoveredSourcePatterns = await this.resolveDiscoveredSourcePatterns(type, config);
     const { localIndexPatterns, remoteIndexPatterns } = await this.getLocalAndRemoteIndexPatterns(
       config.additionalIndexPatterns,
-      config.excludedIndexPatterns
+      config.excludedIndexPatterns,
+      discoveredSourcePatterns
     );
 
     const mainPromise = this.runMainPath({
@@ -946,6 +966,47 @@ export class LogsExtractionClient {
   }
 
   /**
+   * Deterministic source discovery (POC). Returns the per-type discovered source
+   * patterns when `useDiscoveredIndexSource` is enabled, otherwise `undefined` so
+   * callers fall through to the legacy data-view path. The returned array is the
+   * complete source set for `type` (it may legitimately be empty, in which case
+   * the engine extracts from `updates ∪ additional` only — no data-view fallback).
+   */
+  private async resolveDiscoveredSourcePatterns(
+    type: EntityType,
+    config: LogExtractionConfig
+  ): Promise<string[] | undefined> {
+    if (!config.useDiscoveredIndexSource) {
+      return undefined;
+    }
+    const { sources } = await getCachedPerTypeSourceIndices({
+      esClient: this.esClient,
+      namespace: this.namespace,
+      logger: this.logger,
+    });
+    return sources[type];
+  }
+
+  /**
+   * Read-only visibility into deterministic discovery for this namespace: the
+   * resolved per-type sources and why each qualified. Returns `enabled: false`
+   * with empty results when the flag is off or the store is not installed.
+   */
+  public async getDiscoveredSources(): Promise<DiscoveredSourcesResult> {
+    const globalState = await this.globalStateClient.find();
+    const enabled = globalState?.logsExtraction.useDiscoveredIndexSource ?? false;
+    if (!enabled) {
+      return { enabled: false, sources: emptySources(), provenance: [] };
+    }
+    const { sources, provenance } = await getCachedPerTypeSourceIndices({
+      esClient: this.esClient,
+      namespace: this.namespace,
+      logger: this.logger,
+    });
+    return { enabled, sources, provenance };
+  }
+
+  /**
    * Returns local index patterns and remote patterns separately.
    * Cluster-prefixed patterns (`cluster1:logs-*`) go to remote (CCS strategy).
    * Unqualified patterns stay local; CPS strategy reuses local patterns for linked projects.
@@ -953,16 +1014,23 @@ export class LogsExtractionClient {
    */
   public async getLocalAndRemoteIndexPatterns(
     additionalIndexPatterns: string[] = [],
-    excludedIndexPatterns: string[] = []
+    excludedIndexPatterns: string[] = [],
+    discoveredSourcePatterns?: string[]
   ): Promise<{ localIndexPatterns: string[]; remoteIndexPatterns: string[] }> {
-    const all = await this.getAllIndexPatternsIncludingRemote(additionalIndexPatterns);
+    const all = await this.getAllIndexPatternsIncludingRemote(
+      additionalIndexPatterns,
+      discoveredSourcePatterns
+    );
+    // The alerts index is normally stripped here. With deterministic discovery
+    // on, alerts are an intentional, per-type-qualified source, so keep them.
     const alertsIndex = getAlertsIndexName(this.namespace);
-    const withoutAlerts = all.filter((index) => index !== alertsIndex);
+    const candidatePatterns =
+      discoveredSourcePatterns !== undefined ? all : all.filter((index) => index !== alertsIndex);
 
     const localIndexPatterns: string[] = [];
     const remoteIndexPatterns: string[] = [];
 
-    withoutAlerts.forEach((index) => {
+    candidatePatterns.forEach((index) => {
       if (isNonLocalIndexName(index)) {
         remoteIndexPatterns.push(index);
       } else {
@@ -985,11 +1053,13 @@ export class LogsExtractionClient {
 
   public async getLocalIndexPatterns(
     additionalIndexPatterns: string[] = [],
-    excludedIndexPatterns: string[] = []
+    excludedIndexPatterns: string[] = [],
+    discoveredSourcePatterns?: string[]
   ): Promise<string[]> {
     const { localIndexPatterns } = await this.getLocalAndRemoteIndexPatterns(
       additionalIndexPatterns,
-      excludedIndexPatterns
+      excludedIndexPatterns,
+      discoveredSourcePatterns
     );
     return localIndexPatterns;
   }
@@ -998,12 +1068,23 @@ export class LogsExtractionClient {
    * Builds the full list of index patterns (updates, additional, security data view),
    * including cluster-prefixed patterns from the data view, without alerts or
    * local/remote splitting applied.
+   *
+   * When `discoveredSourcePatterns` is provided (deterministic source-discovery
+   * POC), the engine sources from `updates ∪ additional ∪ discovered` only: the
+   * Security Solution data view is intentionally NOT consulted and there is no
+   * `logs-*` fallback.
    */
   private async getAllIndexPatternsIncludingRemote(
-    additionalIndexPatterns: string[] = []
+    additionalIndexPatterns: string[] = [],
+    discoveredSourcePatterns?: string[]
   ): Promise<string[]> {
     const updatesDataStream = getUpdatesEntitiesDataStreamName(this.namespace);
     const indexPatterns: string[] = [updatesDataStream, ...additionalIndexPatterns];
+
+    if (discoveredSourcePatterns !== undefined) {
+      indexPatterns.push(...discoveredSourcePatterns);
+      return indexPatterns;
+    }
 
     try {
       const secSolDataView = await this.dataViewsService.get(

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -181,6 +181,7 @@ export class LogsExtractionClient {
         logsCapDeferred,
         logsCapApplied,
         logsProcessed,
+        hasRealExtractionSources,
       } = await this.runQueryAndIngestDocs({
         type,
         config,
@@ -213,11 +214,26 @@ export class LogsExtractionClient {
           error: remoteError ? { message: remoteError.message, action: 'extractLogs' } : null,
         });
       } else {
+        // POC source-discovery gate: while a type has no real discovered source set
+        // (empty, or `.alerts`-only) and no additional patterns configured, hold the
+        // watermark instead of advancing it. Empty per-minute runs would otherwise push
+        // `lastExecutionTimestamp` to ~now; once discovery later surfaces real sources
+        // (cache TTL up to 15m) their back-dated docs already sit behind the watermark
+        // and are never extracted. Holding it preserves the lookback anchor so the data
+        // is swept on the first run that observes real sources.
+        if (!hasRealExtractionSources) {
+          this.logger.debug(
+            `Holding extraction watermark for entity type "${type}": no real discovered sources yet (empty or .alerts-only).`
+          );
+        }
+
         await this.engineDescriptorClient.update(type, {
           logExtractionState: {
             checkpointTimestamp: null,
             paginationId: null,
-            lastExecutionTimestamp: lastSearchTimestamp || moment().utc().toISOString(),
+            lastExecutionTimestamp: hasRealExtractionSources
+              ? lastSearchTimestamp || moment().utc().toISOString()
+              : engineState.lastExecutionTimestamp,
           },
           error: remoteError ? { message: remoteError.message, action: 'extractLogs' } : null,
         });
@@ -298,8 +314,13 @@ export class LogsExtractionClient {
     logsCapDeferred: boolean;
     logsCapApplied: boolean;
     logsProcessed: number;
+    hasRealExtractionSources: boolean;
   }> {
     const discoveredSourcePatterns = await this.resolveDiscoveredSourcePatterns(type, config);
+    const hasRealExtractionSources = this.hasRealExtractionSources(
+      discoveredSourcePatterns,
+      config.additionalIndexPatterns ?? []
+    );
     const { localIndexPatterns, remoteIndexPatterns } = await this.getLocalAndRemoteIndexPatterns(
       config.additionalIndexPatterns,
       config.excludedIndexPatterns,
@@ -343,6 +364,7 @@ export class LogsExtractionClient {
       isRemote: remoteStrategyIndexPatterns.length > 0,
       indexPatterns: [...localIndexPatterns, ...remoteStrategyIndexPatterns],
       remoteError: remoteResult.error,
+      hasRealExtractionSources,
     };
   }
 
@@ -985,6 +1007,29 @@ export class LogsExtractionClient {
       logger: this.logger,
     });
     return sources[type];
+  }
+
+  /**
+   * POC source-discovery gate helper. Returns whether the engine has at least one
+   * "real" log source to extract from on this run: a discovered source other than the
+   * alerts index, or a user-configured additional index pattern.
+   *
+   * Returns `true` for the legacy path (deterministic discovery disabled — sources are
+   * resolved from the Security data view / `logs-*`) so the gate only engages under
+   * deterministic discovery, where a type can legitimately have no real sources yet.
+   */
+  private hasRealExtractionSources(
+    discoveredSourcePatterns: string[] | undefined,
+    additionalIndexPatterns: string[]
+  ): boolean {
+    if (discoveredSourcePatterns === undefined) {
+      return true;
+    }
+    if (additionalIndexPatterns.length > 0) {
+      return true;
+    }
+    const alertsIndex = getAlertsIndexName(this.namespace);
+    return discoveredSourcePatterns.some((pattern) => pattern !== '' && pattern !== alertsIndex);
   }
 
   /**

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -26,6 +26,15 @@ export type LogExtractionConfig = z.infer<typeof LogExtractionConfig>;
 export const LogExtractionConfig = z.object({
   additionalIndexPatterns: z.array(z.string()).default([]),
   excludedIndexPatterns: z.array(z.string()).default([]),
+  /**
+   * POC feature flag (deterministic source discovery): when true, each engine
+   * sources its `FROM` from the per-entity-type index patterns discovered via
+   * `resolveIndex` + `field_caps` instead of the Security Solution data view.
+   * The data view is NOT used as a source while this is enabled (no silent
+   * fallback). Default `false` keeps behavior byte-identical to a deployment
+   * without this feature.
+   */
+  useDiscoveredIndexSource: z.boolean().default(false),
   fieldHistoryLength: z.number().int().default(10),
   lookbackPeriod: z
     .string()

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/types.ts
@@ -120,11 +120,38 @@ const version3: SavedObjectsFullModelVersion = {
   },
 };
 
+const logExtractionSchemaV4 = logExtractionSchemaV3.extends({
+  useDiscoveredIndexSource: schema.maybe(schema.boolean()),
+});
+
+const globalStateSchemaV4 = globalStateSchemaV3.extends({
+  logsExtraction: logExtractionSchemaV4,
+});
+
+const version4: SavedObjectsFullModelVersion = {
+  changes: [
+    {
+      type: 'data_backfill',
+      backfillFn: () => ({
+        attributes: {
+          logsExtraction: {
+            useDiscoveredIndexSource: false,
+          },
+        },
+      }),
+    },
+  ],
+  schemas: {
+    create: globalStateSchemaV4,
+    forwardCompatibility: globalStateSchemaV4.extends({}, { unknowns: 'ignore' }),
+  },
+};
+
 export const EntityStoreGlobalStateType: SavedObjectsType = {
   name: EntityStoreGlobalStateTypeName,
   hidden: false,
   namespaceType: 'multiple-isolated',
   mappings: EntityStoreGlobalStateTypeMappings,
-  modelVersions: { 1: version1, 2: version2, 3: version3 },
+  modelVersions: { 1: version1, 2: version2, 3: version3, 4: version4 },
   hiddenFromHttpApis: true,
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.test.ts
@@ -74,7 +74,14 @@ describe('discoverPerTypeSourceIndices', () => {
       expect.objectContaining({ name: `logs-*,${ALERTS_INDEX}` })
     );
     expect(esClient.fieldCaps).toHaveBeenCalledWith(
-      expect.objectContaining({ index: ['logs-*', ALERTS_INDEX], types: ['keyword'] })
+      expect.objectContaining({
+        index: ['logs-*', ALERTS_INDEX],
+        types: ['keyword'],
+        // Required for per-index presence: without it ES omits `indices` for
+        // fields that are keyword wherever they exist, and discovery over-
+        // qualifies every source for every entity type.
+        include_unmapped: true,
+      })
     );
   });
 
@@ -162,6 +169,57 @@ describe('discoverPerTypeSourceIndices', () => {
     expect(sources.user).toEqual([dataStream]);
     expect(sources.host).toEqual([dataStream]);
     expect(sources.service).toEqual([]);
+  });
+
+  it('qualifies disjoint sources per entity type so engines do not all scan the same indices', async () => {
+    // Regression for the `include_unmapped: false` bug: when each identity field is
+    // keyword in only a subset of the scope, `field_caps` (with `include_unmapped:
+    // true`) reports per-field `indices`, so each engine must qualify only the
+    // sources that actually carry its identity fields — not every source.
+    const userStream = 'logs-okta.system-default';
+    const userBacking = '.ds-logs-okta.system-default-2024.01.01-000001';
+    const genericStream = 'logs-entityanalytics_okta.entity-default';
+    const genericBacking = '.ds-logs-entityanalytics_okta.entity-default-2024.01.01-000001';
+    const serviceStream = 'logs-apm.service-default';
+    const serviceBacking = '.ds-logs-apm.service-default-2024.01.01-000001';
+    const endpointStream = 'logs-endpoint.events-default';
+    const endpointBacking = '.ds-logs-endpoint.events-default-2024.01.01-000001';
+
+    const esClient = buildEsClient(
+      {
+        data_streams: [
+          { name: userStream, backing_indices: [userBacking] },
+          { name: genericStream, backing_indices: [genericBacking] },
+          { name: serviceStream, backing_indices: [serviceBacking] },
+          { name: endpointStream, backing_indices: [endpointBacking] },
+        ],
+      },
+      {
+        indices: [userBacking, genericBacking, serviceBacking, endpointBacking],
+        fields: {
+          'user.name': { keyword: { type: 'keyword', indices: [userBacking, endpointBacking] } },
+          'host.name': { keyword: { type: 'keyword', indices: [endpointBacking] } },
+          'service.name': { keyword: { type: 'keyword', indices: [serviceBacking] } },
+          'entity.id': { keyword: { type: 'keyword', indices: [genericBacking] } },
+        },
+      }
+    );
+
+    const { sources } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    expect(sources.user).toEqual([userStream, endpointStream]);
+    expect(sources.host).toEqual([endpointStream]);
+    expect(sources.service).toEqual([serviceStream]);
+    expect(sources.generic).toEqual([genericStream]);
+
+    // The bug symptom was all four engines resolving to the identical full set.
+    expect(sources.generic).not.toEqual(sources.service);
+    expect(sources.generic).not.toEqual(sources.user);
+    expect(sources.host).not.toEqual(sources.user);
   });
 
   it('returns empty sources (and logs a warning) when Elasticsearch fails', async () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { getUpdatesEntitiesDataStreamName } from '../asset_manager/updates_data_stream';
+import { discoverPerTypeSourceIndices } from './discover_per_type_source_indices';
+
+const NAMESPACE = 'default';
+const ALERTS_INDEX = '.alerts-security.alerts-default';
+
+interface ResolvePartial {
+  indices?: Array<{ name: string }>;
+  aliases?: Array<{ name: string; indices: string | string[] }>;
+  data_streams?: Array<{ name: string; backing_indices: string | string[] }>;
+}
+
+const buildEsClient = (resolve: ResolvePartial, fieldCaps: unknown): ElasticsearchClient =>
+  ({
+    indices: {
+      resolveIndex: jest.fn().mockResolvedValue({
+        indices: resolve.indices ?? [],
+        aliases: resolve.aliases ?? [],
+        data_streams: resolve.data_streams ?? [],
+      }),
+    },
+    fieldCaps: jest.fn().mockResolvedValue(fieldCaps),
+  } as unknown as ElasticsearchClient);
+
+describe('discoverPerTypeSourceIndices', () => {
+  const logger = loggerMock.create();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('qualifies a logs data stream by its clean name when a backing index carries a keyword identity field', async () => {
+    const dataStream = 'logs-okta.system-default';
+    const backingIndex = '.ds-logs-okta.system-default-2024.01.01-000001';
+    const esClient = buildEsClient(
+      { data_streams: [{ name: dataStream, backing_indices: [backingIndex] }] },
+      {
+        indices: [backingIndex],
+        fields: {
+          'user.email': { keyword: { type: 'keyword', indices: [backingIndex] } },
+        },
+      }
+    );
+
+    const { sources, provenance } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    // The clean data stream name, never the churning `.ds-…` backing index.
+    expect(sources.user).toEqual([dataStream]);
+    expect(sources.host).toEqual([]);
+    expect(provenance).toContainEqual({
+      entityType: 'user',
+      sourceName: dataStream,
+      matchedFields: ['user.email'],
+    });
+  });
+
+  it('scopes both ES calls to `logs-*` + the alerts index and pushes the keyword type gate into field_caps', async () => {
+    const esClient = buildEsClient({}, { indices: [], fields: {} });
+
+    await discoverPerTypeSourceIndices({ esClient, namespace: NAMESPACE, logger });
+
+    expect(esClient.indices.resolveIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ name: `logs-*,${ALERTS_INDEX}` })
+    );
+    expect(esClient.fieldCaps).toHaveBeenCalledWith(
+      expect.objectContaining({ index: ['logs-*', ALERTS_INDEX], types: ['keyword'] })
+    );
+  });
+
+  it('falls back to all matched indices when a field has uniform keyword caps (no per-field indices)', async () => {
+    const dataStream = 'logs-system.auth-default';
+    const backingIndex = '.ds-logs-system.auth-default-2024.01.01-000001';
+    const esClient = buildEsClient(
+      { data_streams: [{ name: dataStream, backing_indices: [backingIndex] }] },
+      {
+        indices: [backingIndex],
+        // No `indices` on the cap → uniform across all matched indices.
+        fields: { 'host.name': { keyword: { type: 'keyword' } } },
+      }
+    );
+
+    const { sources } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    expect(sources.host).toEqual([dataStream]);
+  });
+
+  it('includes the alerts alias as a source, mapping its hidden backing index back to the alias name', async () => {
+    const alertsBackingIndex = '.internal.alerts-security.alerts-default-000001';
+    const esClient = buildEsClient(
+      { aliases: [{ name: ALERTS_INDEX, indices: [alertsBackingIndex] }] },
+      {
+        indices: [alertsBackingIndex],
+        fields: { 'user.name': { keyword: { type: 'keyword', indices: [alertsBackingIndex] } } },
+      }
+    );
+
+    const { sources } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    expect(sources.user).toEqual([ALERTS_INDEX]);
+  });
+
+  it('excludes the entity store updates data stream even if it carries identity fields', async () => {
+    const updatesDataStream = getUpdatesEntitiesDataStreamName(NAMESPACE);
+    const updatesBackingIndex = `.ds-${updatesDataStream}-2024.01.01-000001`;
+    const esClient = buildEsClient(
+      { data_streams: [{ name: updatesDataStream, backing_indices: [updatesBackingIndex] }] },
+      {
+        indices: [updatesBackingIndex],
+        fields: { 'user.name': { keyword: { type: 'keyword', indices: [updatesBackingIndex] } } },
+      }
+    );
+
+    const { sources, provenance } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    expect(sources.user).toEqual([]);
+    expect(provenance).toEqual([]);
+  });
+
+  it('qualifies a single source for multiple entity types', async () => {
+    const dataStream = 'logs-endpoint.events-default';
+    const backingIndex = '.ds-logs-endpoint.events-default-2024.01.01-000001';
+    const esClient = buildEsClient(
+      { data_streams: [{ name: dataStream, backing_indices: [backingIndex] }] },
+      {
+        indices: [backingIndex],
+        fields: {
+          'user.name': { keyword: { type: 'keyword', indices: [backingIndex] } },
+          'host.name': { keyword: { type: 'keyword', indices: [backingIndex] } },
+        },
+      }
+    );
+
+    const { sources } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    expect(sources.user).toEqual([dataStream]);
+    expect(sources.host).toEqual([dataStream]);
+    expect(sources.service).toEqual([]);
+  });
+
+  it('returns empty sources (and logs a warning) when Elasticsearch fails', async () => {
+    const esClient = {
+      indices: { resolveIndex: jest.fn().mockRejectedValue(new Error('cluster down')) },
+      fieldCaps: jest.fn().mockRejectedValue(new Error('cluster down')),
+    } as unknown as ElasticsearchClient;
+
+    const { sources, provenance } = await discoverPerTypeSourceIndices({
+      esClient,
+      namespace: NAMESPACE,
+      logger,
+    });
+
+    expect(sources).toEqual({ user: [], host: [], service: [], generic: [] });
+    expect(provenance).toEqual([]);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { castArray } from 'lodash';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { EntityType } from '../../../common/domain/definitions/entity_schema';
+import { getLatestEntitiesIndexName } from '../../../common/domain/entity_index';
+import { getAlertsIndexName } from '../asset_manager/external_indices_contants';
+import { getUpdatesEntitiesDataStreamName } from '../asset_manager/updates_data_stream';
+import {
+  ALL_IDENTITY_FIELDS,
+  ENTITY_TYPES,
+  ENTITY_TYPE_IDENTITY_FIELDS,
+  SAFE_IDENTITY_FIELD_TYPES,
+  emptySources,
+  type DiscoveredPerTypeSources,
+  type PerTypeSourceProvenance,
+} from './identity_fields';
+import { buildConcreteIndexToSourceNameMap } from './resolve_source_index_map';
+
+/**
+ * POC discovery scope. Intentionally narrow: `logs-*` plus the hand-picked
+ * Security alerts index. The Security Solution data view usually spans more
+ * (e.g. `filebeat-*`, `endgame-*`, custom patterns); widening is a deliberate
+ * follow-up, not an implicit fallback.
+ */
+const LOGS_SOURCE_PATTERN = 'logs-*';
+
+interface DiscoverParams {
+  esClient: ElasticsearchClient;
+  namespace: string;
+  logger: Logger;
+}
+
+/**
+ * Deterministically discovers, per entity type, the set of clean "source" names
+ * (data stream / alias / standalone index) that carry that engine's identity
+ * fields at a safe (`keyword`) type.
+ *
+ * Two Elasticsearch calls, no LLM and no Streams plugin:
+ *  1. `resolveIndex` over the scope → reverse map from the concrete indices
+ *     `field_caps` reports back to clean source names.
+ *  2. `field_caps` (type-gated to `keyword`) over the same scope → which
+ *     concrete indices carry each identity field.
+ *
+ * A source qualifies for an entity type when it carries at least one of that
+ * type's identity fields. Rollover drift is tolerated: a source qualifies if
+ * *any* of its backing indices has the field at `keyword`.
+ *
+ * Resilient by design: any Elasticsearch failure resolves to empty sources so a
+ * background extraction tick degrades to `updates ∪ additional` rather than
+ * throwing.
+ */
+export const discoverPerTypeSourceIndices = async ({
+  esClient,
+  namespace,
+  logger,
+}: DiscoverParams): Promise<DiscoveredPerTypeSources> => {
+  const scope = [LOGS_SOURCE_PATTERN, getAlertsIndexName(namespace)];
+
+  // Sources the entity store manages itself. The updates stream is unioned into
+  // every engine's FROM elsewhere; re-discovering it (or the latest index) as an
+  // input risks a read-your-own-writes feedback loop. Naturally out of `logs-*`
+  // today, but excluded defensively for when the scope widens.
+  const excludedSourceNames = new Set<string>([
+    getUpdatesEntitiesDataStreamName(namespace),
+    getLatestEntitiesIndexName(namespace),
+  ]);
+
+  try {
+    const [resolve, fieldCaps] = await Promise.all([
+      esClient.indices.resolveIndex({
+        name: scope.join(','),
+        expand_wildcards: 'open',
+        ignore_unavailable: true,
+        allow_no_indices: true,
+      }),
+      esClient.fieldCaps({
+        index: scope,
+        fields: [...ALL_IDENTITY_FIELDS],
+        types: [...SAFE_IDENTITY_FIELD_TYPES],
+        include_unmapped: false,
+        ignore_unavailable: true,
+        allow_no_indices: true,
+        expand_wildcards: 'open',
+        // Drop multi-field parents so e.g. `user.name` (text) does not mask its
+        // `user.name.keyword` leaf when only the parent is queried; harmless here.
+        filters: '-parent',
+      }),
+    ]);
+
+    const concreteToSource = buildConcreteIndexToSourceNameMap(resolve);
+    const topLevelConcrete = castArray(fieldCaps.indices ?? []);
+
+    // sourceName -> identity fields present (at keyword) somewhere under it.
+    const presenceBySource = new Map<string, Set<string>>();
+
+    const recordPresence = (concreteIndex: string, field: string) => {
+      const sourceName = concreteToSource.get(concreteIndex) ?? concreteIndex;
+      if (excludedSourceNames.has(sourceName)) {
+        return;
+      }
+      const present = presenceBySource.get(sourceName) ?? new Set<string>();
+      present.add(field);
+      presenceBySource.set(sourceName, present);
+    };
+
+    for (const field of ALL_IDENTITY_FIELDS) {
+      const keywordCap = fieldCaps.fields?.[field]?.keyword;
+      if (!keywordCap) {
+        continue;
+      }
+      // `indices` is omitted when the field has uniform caps across every matched
+      // index — i.e. it is keyword everywhere, so fall back to all matched indices.
+      const concreteIndices =
+        keywordCap.indices !== undefined ? castArray(keywordCap.indices) : topLevelConcrete;
+      for (const concreteIndex of concreteIndices) {
+        recordPresence(concreteIndex, field);
+      }
+    }
+
+    const sourceSets: Record<EntityType, Set<string>> = {
+      user: new Set(),
+      host: new Set(),
+      service: new Set(),
+      generic: new Set(),
+    };
+    const provenance: PerTypeSourceProvenance[] = [];
+
+    for (const [sourceName, presentFields] of presenceBySource) {
+      for (const entityType of ENTITY_TYPES) {
+        const matchedFields = ENTITY_TYPE_IDENTITY_FIELDS[entityType].filter((field) =>
+          presentFields.has(field)
+        );
+        if (matchedFields.length === 0) {
+          continue;
+        }
+        sourceSets[entityType].add(sourceName);
+        provenance.push({ entityType, sourceName, matchedFields });
+      }
+    }
+
+    const sources = {
+      user: Array.from(sourceSets.user),
+      host: Array.from(sourceSets.host),
+      service: Array.from(sourceSets.service),
+      generic: Array.from(sourceSets.generic),
+    };
+
+    logger.debug(
+      () =>
+        `[source_discovery] namespace=${namespace} discovered sources: ${ENTITY_TYPES.map(
+          (type) => `${type}=${sources[type].length}`
+        ).join(' ')}`
+    );
+
+    return { sources, provenance };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      `[source_discovery] deterministic discovery failed for namespace=${namespace}; falling back to updates-only sources: ${reason}`
+    );
+    return { sources: emptySources(), provenance: [] };
+  }
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/discover_per_type_source_indices.ts
@@ -44,8 +44,11 @@ interface DiscoverParams {
  * Two Elasticsearch calls, no LLM and no Streams plugin:
  *  1. `resolveIndex` over the scope → reverse map from the concrete indices
  *     `field_caps` reports back to clean source names.
- *  2. `field_caps` (type-gated to `keyword`) over the same scope → which
- *     concrete indices carry each identity field.
+ *  2. `field_caps` (type-gated to `keyword`, `include_unmapped: true`) over the
+ *     same scope → which concrete indices carry each identity field. The
+ *     `include_unmapped` flag is what makes presence per-index: it forces ES to
+ *     report the exact indices where a field is keyword instead of collapsing to
+ *     "present everywhere" (which would qualify every source for every type).
  *
  * A source qualifies for an entity type when it carries at least one of that
  * type's identity fields. Rollover drift is tolerated: a source qualifies if
@@ -83,7 +86,15 @@ export const discoverPerTypeSourceIndices = async ({
         index: scope,
         fields: [...ALL_IDENTITY_FIELDS],
         types: [...SAFE_IDENTITY_FIELD_TYPES],
-        include_unmapped: false,
+        // Must stay `true`. `field_caps` only fills a type's `indices` array when
+        // the field spans more than one type-family across the scope. With this
+        // `false`, "absent from an index" is not a family, so a field that is
+        // `keyword` wherever it exists looks single-family and ES OMITS `indices`
+        // — indistinguishable from "present everywhere". Discovery then over-
+        // qualifies every source for every type (see the `indices`-omitted
+        // fallback below). `true` adds an `unmapped` family for indices lacking
+        // the field, forcing ES to report exactly the indices where it is keyword.
+        include_unmapped: true,
         ignore_unavailable: true,
         allow_no_indices: true,
         expand_wildcards: 'open',
@@ -114,8 +125,10 @@ export const discoverPerTypeSourceIndices = async ({
       if (!keywordCap) {
         continue;
       }
-      // `indices` is omitted when the field has uniform caps across every matched
-      // index — i.e. it is keyword everywhere, so fall back to all matched indices.
+      // With `include_unmapped: true`, `keyword.indices` is populated whenever the
+      // field is keyword in only a subset of the scope (the rest form the `unmapped`
+      // family). An omitted `indices` therefore genuinely means "keyword in every
+      // in-scope index" — only then is the fall back to all matched indices correct.
       const concreteIndices =
         keywordCap.indices !== undefined ? castArray(keywordCap.indices) : topLevelConcrete;
       for (const concreteIndex of concreteIndices) {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/identity_fields.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/identity_fields.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityType } from '../../../common/domain/definitions/entity_schema';
+
+/**
+ * Identity source fields per entity type — the fields whose presence in an
+ * index source qualifies that source for the corresponding engine.
+ *
+ * These mirror each static engine's identity contract as expressed in the
+ * entity definitions under `common/domain/definitions/`:
+ * - `user`   → `user.{email,id,name,domain}`.
+ * - `host`   → `host.{id,name,hostname}`.
+ * - `service`→ `service.name`.
+ * - `generic`→ `entity.id`.
+ *
+ * Keeping this list here (rather than deriving it from the `euidRanking`
+ * branches at runtime) is deliberate: the ranking branches encode precedence
+ * and composition rules that are irrelevant to "does this source carry any of
+ * this engine's identity fields?". Expanding an engine's identity contract is
+ * an audited change that should update this constant in lockstep.
+ */
+export const ENTITY_TYPE_IDENTITY_FIELDS = {
+  user: ['user.email', 'user.id', 'user.name', 'user.domain'],
+  host: ['host.id', 'host.name', 'host.hostname'],
+  service: ['service.name'],
+  generic: ['entity.id'],
+} as const satisfies Record<EntityType, readonly string[]>;
+
+export const ENTITY_TYPES = Object.keys(ENTITY_TYPE_IDENTITY_FIELDS) as EntityType[];
+
+/** Union of every identity field across all entity types. */
+export const ALL_IDENTITY_FIELDS: readonly string[] = Array.from(
+  new Set(Object.values(ENTITY_TYPE_IDENTITY_FIELDS).flat())
+);
+
+/**
+ * Elasticsearch field types accepted as identity sources. `keyword` is
+ * exact-match and aggregatable, so it is safe to extract/group on; `text` /
+ * `match_only_text` and unmapped fields are intentionally excluded. Pushed into
+ * the `field_caps` `types` filter, and centralized here so the safe set can be
+ * widened later (e.g. `constant_keyword`, `wildcard`, `ip`) without touching
+ * call sites.
+ */
+export const SAFE_IDENTITY_FIELD_TYPES: readonly string[] = ['keyword'];
+
+/** Per-type resolved source index patterns. One array per entity type; deduped, order-stable. */
+export type PerTypeSourceIndices = Record<EntityType, string[]>;
+
+/** Provenance for the visibility surface: which source qualified for which type, and why. */
+export interface PerTypeSourceProvenance {
+  entityType: EntityType;
+  /** The clean source name (data stream / alias / standalone index) that qualified. */
+  sourceName: string;
+  /** The identity fields that caused this source to qualify for `entityType`. */
+  matchedFields: string[];
+}
+
+export interface DiscoveredPerTypeSources {
+  sources: PerTypeSourceIndices;
+  provenance: PerTypeSourceProvenance[];
+}
+
+/** A fresh, fully-keyed empty per-type source map. */
+export const emptySources = (): PerTypeSourceIndices => ({
+  user: [],
+  host: [],
+  service: [],
+  generic: [],
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  ALL_IDENTITY_FIELDS,
+  ENTITY_TYPES,
+  ENTITY_TYPE_IDENTITY_FIELDS,
+  SAFE_IDENTITY_FIELD_TYPES,
+  emptySources,
+  type DiscoveredPerTypeSources,
+  type PerTypeSourceIndices,
+  type PerTypeSourceProvenance,
+} from './identity_fields';
+export { buildConcreteIndexToSourceNameMap } from './resolve_source_index_map';
+export { discoverPerTypeSourceIndices } from './discover_per_type_source_indices';
+export {
+  DISCOVERED_SOURCE_CACHE_TTL_MS,
+  clearDiscoveredSourceCache,
+  getCachedPerTypeSourceIndices,
+} from './source_discovery_cache';

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/resolve_source_index_map.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/resolve_source_index_map.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IndicesResolveIndexResponse } from '@elastic/elasticsearch/lib/api/types';
+import { buildConcreteIndexToSourceNameMap } from './resolve_source_index_map';
+
+const asResolveResponse = (partial: {
+  indices?: Array<{ name: string }>;
+  aliases?: Array<{ name: string; indices: string | string[] }>;
+  data_streams?: Array<{ name: string; backing_indices: string | string[] }>;
+}): IndicesResolveIndexResponse =>
+  ({
+    indices: partial.indices ?? [],
+    aliases: partial.aliases ?? [],
+    data_streams: partial.data_streams ?? [],
+  } as unknown as IndicesResolveIndexResponse);
+
+describe('buildConcreteIndexToSourceNameMap', () => {
+  it('maps every backing index of a data stream to the data stream name', () => {
+    const map = buildConcreteIndexToSourceNameMap(
+      asResolveResponse({
+        data_streams: [
+          {
+            name: 'logs-okta.system-default',
+            backing_indices: [
+              '.ds-logs-okta.system-default-2024.01.01-000001',
+              '.ds-logs-okta.system-default-2024.02.01-000002',
+            ],
+          },
+        ],
+      })
+    );
+
+    expect(map.get('.ds-logs-okta.system-default-2024.01.01-000001')).toBe(
+      'logs-okta.system-default'
+    );
+    expect(map.get('.ds-logs-okta.system-default-2024.02.01-000002')).toBe(
+      'logs-okta.system-default'
+    );
+  });
+
+  it('maps alias member indices to the alias name', () => {
+    const map = buildConcreteIndexToSourceNameMap(
+      asResolveResponse({
+        aliases: [
+          {
+            name: '.alerts-security.alerts-default',
+            indices: ['.internal.alerts-security.alerts-default-000001'],
+          },
+        ],
+      })
+    );
+
+    expect(map.get('.internal.alerts-security.alerts-default-000001')).toBe(
+      '.alerts-security.alerts-default'
+    );
+  });
+
+  it('maps standalone (classic) indices to themselves', () => {
+    const map = buildConcreteIndexToSourceNameMap(
+      asResolveResponse({ indices: [{ name: 'logs-classic-index' }] })
+    );
+
+    expect(map.get('logs-classic-index')).toBe('logs-classic-index');
+  });
+
+  it('prefers the data stream name when an index is reachable as data stream, alias, and standalone', () => {
+    const map = buildConcreteIndexToSourceNameMap(
+      asResolveResponse({
+        indices: [{ name: 'dup-index' }],
+        aliases: [{ name: 'my-alias', indices: ['dup-index'] }],
+        data_streams: [{ name: 'logs-ds', backing_indices: ['dup-index'] }],
+      })
+    );
+
+    expect(map.get('dup-index')).toBe('logs-ds');
+  });
+
+  it('accepts the ES `Indices` shape given as a single string', () => {
+    const map = buildConcreteIndexToSourceNameMap(
+      asResolveResponse({
+        aliases: [{ name: 'an-alias', indices: 'single-alias-member' }],
+        data_streams: [{ name: 'logs-ds', backing_indices: 'single-backing-index' }],
+      })
+    );
+
+    expect(map.get('single-alias-member')).toBe('an-alias');
+    expect(map.get('single-backing-index')).toBe('logs-ds');
+  });
+
+  it('returns an empty map when nothing resolves', () => {
+    expect(buildConcreteIndexToSourceNameMap(asResolveResponse({})).size).toBe(0);
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/resolve_source_index_map.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/resolve_source_index_map.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { castArray } from 'lodash';
+import type { IndicesResolveIndexResponse } from '@elastic/elasticsearch/lib/api/types';
+
+/**
+ * Builds a reverse map from concrete Elasticsearch index names (what
+ * `field_caps` reports in its `indices` arrays) back to the clean "source" name
+ * that belongs in an ESQL `FROM`:
+ *
+ * - a data stream's backing indices (`.ds-…-NNNNNN`) map to the data stream name;
+ * - an alias' member indices map to the alias name;
+ * - standalone (classic) indices map to themselves.
+ *
+ * This is what keeps churning backing-index names out of the `FROM`: the names
+ * we emit come from `resolveIndex`, while `field_caps` is used only as a
+ * presence/type filter.
+ *
+ * Precedence (low → high): standalone, alias, data stream. A concrete index
+ * resolves to itself unless it is an alias member, and an alias member resolves
+ * to its alias unless it is also a data stream backing index (data stream wins,
+ * since that is the only stable name for a `.ds-…` index).
+ */
+export const buildConcreteIndexToSourceNameMap = (
+  resolve: IndicesResolveIndexResponse
+): Map<string, string> => {
+  const map = new Map<string, string>();
+
+  // Standalone indices (lowest precedence): map to themselves.
+  for (const index of resolve.indices) {
+    map.set(index.name, index.name);
+  }
+
+  // Aliases: each member index resolves to the alias name (covers e.g. the
+  // alerts alias whose `field_caps` results are the hidden `.internal.*` indices).
+  for (const alias of resolve.aliases) {
+    for (const member of castArray(alias.indices)) {
+      map.set(member, alias.name);
+    }
+  }
+
+  // Data streams (highest precedence): backing indices resolve to the data
+  // stream name — the only stable name for a rolled-over `.ds-…` index.
+  for (const dataStream of resolve.data_streams) {
+    for (const backingIndex of castArray(dataStream.backing_indices)) {
+      map.set(backingIndex, dataStream.name);
+    }
+  }
+
+  return map;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/source_discovery_cache.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/source_discovery_cache.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { discoverPerTypeSourceIndices } from './discover_per_type_source_indices';
+import type { DiscoveredPerTypeSources } from './identity_fields';
+import {
+  DISCOVERED_SOURCE_CACHE_TTL_MS,
+  clearDiscoveredSourceCache,
+  getCachedPerTypeSourceIndices,
+} from './source_discovery_cache';
+
+jest.mock('./discover_per_type_source_indices');
+const mockDiscover = discoverPerTypeSourceIndices as jest.MockedFunction<
+  typeof discoverPerTypeSourceIndices
+>;
+
+const esClient = {} as ElasticsearchClient;
+const logger = loggerMock.create();
+
+const sourcesNamed = (name: string): DiscoveredPerTypeSources => ({
+  sources: { user: [name], host: [], service: [], generic: [] },
+  provenance: [],
+});
+
+describe('getCachedPerTypeSourceIndices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearDiscoveredSourceCache();
+  });
+
+  it('discovers once and serves later calls from cache within the TTL', async () => {
+    mockDiscover.mockResolvedValue(sourcesNamed('logs-a'));
+    let nowMs = 1_000;
+    const now = () => nowMs;
+
+    const first = await getCachedPerTypeSourceIndices({
+      esClient,
+      namespace: 'default',
+      logger,
+      now,
+    });
+    nowMs += DISCOVERED_SOURCE_CACHE_TTL_MS - 1;
+    const second = await getCachedPerTypeSourceIndices({
+      esClient,
+      namespace: 'default',
+      logger,
+      now,
+    });
+
+    expect(first).toEqual(sourcesNamed('logs-a'));
+    expect(second).toEqual(sourcesNamed('logs-a'));
+    expect(mockDiscover).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-discovers after the TTL expires', async () => {
+    mockDiscover
+      .mockResolvedValueOnce(sourcesNamed('logs-a'))
+      .mockResolvedValueOnce(sourcesNamed('logs-b'));
+    let nowMs = 1_000;
+    const now = () => nowMs;
+
+    await getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger, now });
+    nowMs += DISCOVERED_SOURCE_CACHE_TTL_MS + 1;
+    const second = await getCachedPerTypeSourceIndices({
+      esClient,
+      namespace: 'default',
+      logger,
+      now,
+    });
+
+    expect(second).toEqual(sourcesNamed('logs-b'));
+    expect(mockDiscover).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes concurrent refreshes for the same namespace onto a single discovery', async () => {
+    let resolveDiscovery: (value: DiscoveredPerTypeSources) => void = () => {};
+    mockDiscover.mockReturnValue(
+      new Promise<DiscoveredPerTypeSources>((resolve) => {
+        resolveDiscovery = resolve;
+      })
+    );
+
+    const inFlight = [
+      getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger }),
+      getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger }),
+      getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger }),
+    ];
+    resolveDiscovery(sourcesNamed('logs-a'));
+    const results = await Promise.all(inFlight);
+
+    expect(mockDiscover).toHaveBeenCalledTimes(1);
+    results.forEach((result) => expect(result).toEqual(sourcesNamed('logs-a')));
+  });
+
+  it('keeps independent cache entries per namespace', async () => {
+    mockDiscover.mockImplementation(async ({ namespace }) => sourcesNamed(`logs-${namespace}`));
+
+    const def = await getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger });
+    const space = await getCachedPerTypeSourceIndices({ esClient, namespace: 'space-1', logger });
+
+    expect(def.sources.user).toEqual(['logs-default']);
+    expect(space.sources.user).toEqual(['logs-space-1']);
+    expect(mockDiscover).toHaveBeenCalledTimes(2);
+  });
+
+  it('forces re-discovery after clearDiscoveredSourceCache', async () => {
+    mockDiscover.mockResolvedValue(sourcesNamed('logs-a'));
+
+    await getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger });
+    clearDiscoveredSourceCache('default');
+    await getCachedPerTypeSourceIndices({ esClient, namespace: 'default', logger });
+
+    expect(mockDiscover).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/source_discovery_cache.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/source_discovery/source_discovery_cache.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { discoverPerTypeSourceIndices } from './discover_per_type_source_indices';
+import type { DiscoveredPerTypeSources } from './identity_fields';
+
+/**
+ * POC refresh window. The `extract_entity_task` ticks every minute per entity
+ * type (4 type tasks per namespace), so discovery must not run on every tick.
+ * 15 minutes keeps `resolveIndex` + `field_caps` traffic negligible while still
+ * picking up newly-onboarded sources within a bounded delay.
+ */
+export const DISCOVERED_SOURCE_CACHE_TTL_MS = 15 * 60 * 1000;
+
+interface CacheEntry {
+  expiresAt: number;
+  value: DiscoveredPerTypeSources;
+}
+
+// Module-level, per-namespace. Shared across the type tasks in a Kibana node.
+// Per-node and lost on restart — acceptable for a POC; the productionization
+// path is a dedicated low-frequency discovery task persisting the map.
+const cacheByNamespace = new Map<string, CacheEntry>();
+// In-flight refreshes, so 4 concurrent type-task ticks trigger one discovery.
+const inFlightByNamespace = new Map<string, Promise<DiscoveredPerTypeSources>>();
+
+interface GetCachedParams {
+  esClient: ElasticsearchClient;
+  namespace: string;
+  logger: Logger;
+  /** Injectable clock for deterministic TTL tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Returns the per-type discovered sources for a namespace, refreshing via
+ * {@link discoverPerTypeSourceIndices} only when the cached entry is missing or
+ * expired. Concurrent refreshes for the same namespace are deduped onto a single
+ * in-flight promise. Discovery never throws (it degrades to empty sources), so
+ * this resolver never throws either.
+ */
+export const getCachedPerTypeSourceIndices = async ({
+  esClient,
+  namespace,
+  logger,
+  now = Date.now,
+}: GetCachedParams): Promise<DiscoveredPerTypeSources> => {
+  const cached = cacheByNamespace.get(namespace);
+  if (cached && cached.expiresAt > now()) {
+    return cached.value;
+  }
+
+  const existing = inFlightByNamespace.get(namespace);
+  if (existing) {
+    return existing;
+  }
+
+  const refresh = (async () => {
+    try {
+      const value = await discoverPerTypeSourceIndices({ esClient, namespace, logger });
+      cacheByNamespace.set(namespace, {
+        value,
+        expiresAt: now() + DISCOVERED_SOURCE_CACHE_TTL_MS,
+      });
+      return value;
+    } finally {
+      inFlightByNamespace.delete(namespace);
+    }
+  })();
+
+  inFlightByNamespace.set(namespace, refresh);
+  return refresh;
+};
+
+/** Clears cached discovery state. Pass a namespace to scope the reset; omit to clear all. */
+export const clearDiscoveredSourceCache = (namespace?: string): void => {
+  if (namespace === undefined) {
+    cacheByNamespace.clear();
+    inFlightByNamespace.clear();
+    return;
+  }
+  cacheByNamespace.delete(namespace);
+  inFlightByNamespace.delete(namespace);
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/discovered_sources.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/discovered_sources.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IKibanaResponse } from '@kbn/core-http-server';
+import { API_VERSIONS, ENTITY_STORE_ROUTES } from '../../../common';
+import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
+import type { EntityStorePluginRouter } from '../../types';
+import { wrapMiddlewares } from '../middleware';
+import type { DiscoveredSourcesResult } from '../../domain/logs_extraction/logs_extraction_client';
+
+/**
+ * Read-only visibility into deterministic source discovery (POC): the per-type
+ * source patterns each engine would scope its ESQL `FROM` to, and why each
+ * source qualified. Returns `enabled: false` with empty results when the
+ * `useDiscoveredIndexSource` flag is off or the store is not installed.
+ */
+export type DiscoveredSourcesResponseBody = DiscoveredSourcesResult;
+
+export function registerDiscoveredSources(router: EntityStorePluginRouter) {
+  router.versioned
+    .get({
+      path: ENTITY_STORE_ROUTES.internal.DISCOVERED_SOURCES,
+      access: 'internal',
+      summary: 'Get deterministically discovered entity sources',
+      description:
+        'Return the per-entity-type index source patterns discovered for the current space, along with the identity fields that qualified each source.',
+      options: {
+        tags: ['oas-tag:Security entity store'],
+      },
+      security: {
+        authz: DEFAULT_ENTITY_STORE_PERMISSIONS,
+      },
+      enableQueryVersion: true,
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v2,
+        validate: false,
+      },
+      wrapMiddlewares(
+        async (ctx, req, res): Promise<IKibanaResponse<DiscoveredSourcesResponseBody>> => {
+          const entityStoreCtx = await ctx.entityStore;
+          const { logger, logsExtractionClient } = entityStoreCtx;
+          logger.debug('Discovered sources API invoked');
+
+          const body = await logsExtractionClient.getDiscoveredSources();
+
+          return res.ok({ body });
+        }
+      )
+    );
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
@@ -28,3 +28,4 @@ export { registerGetMaintainers } from './entity_maintainers/get_maintainers';
 export { registerInitMaintainers } from './entity_maintainers/init';
 export { registerRunMaintainer } from './entity_maintainers/run';
 export { registerCheckPrivileges } from './check_privileges';
+export { registerDiscoveredSources } from './discovered_sources';

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
@@ -24,6 +24,7 @@ export const LogExtractionInstallParams = LogExtractionConfig.pick({
   fieldHistoryLength: true,
   additionalIndexPatterns: true,
   excludedIndexPatterns: true,
+  useDiscoveredIndexSource: true,
   lookbackPeriod: true,
   frequency: true,
   delay: true,
@@ -40,6 +41,7 @@ export const LogExtractionUpdateParams = z.object({
   fieldHistoryLength: z.number().int().optional(),
   additionalIndexPatterns: z.array(z.string()).optional(),
   excludedIndexPatterns: z.array(z.string()).optional(),
+  useDiscoveredIndexSource: z.boolean().optional(),
   lookbackPeriod: z
     .string()
     .regex(/[smdh]$/)

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
@@ -29,6 +29,7 @@ import {
   registerResolutionGroup,
   registerUpdate,
   registerCheckPrivileges,
+  registerDiscoveredSources,
 } from './apis';
 import type { EntityStorePluginRouter } from '../types';
 
@@ -41,6 +42,7 @@ export function registerRoutes(router: EntityStorePluginRouter) {
   registerForceRemoteExtractToUpdates(router);
   registerForceHistorySnapshot(router);
   registerCheckPrivileges(router);
+  registerDiscoveredSources(router);
   registerCRUDCreate(router);
   registerCRUDUpdate(router);
   registerCRUDBulkUpdate(router);

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -67,6 +67,7 @@ export const ENTITY_STORE_ROUTES = {
     ENTITY_MAINTAINERS_START: (id: string) => `${INTERNAL_BASE}/entity_maintainers/start/${id}`,
     ENTITY_MAINTAINERS_STOP: (id: string) => `${INTERNAL_BASE}/entity_maintainers/stop/${id}`,
     ENTITY_MAINTAINERS_RUN: (id: string) => `${INTERNAL_BASE}/entity_maintainers/run/${id}`,
+    DISCOVERED_SOURCES: `${INTERNAL_BASE}/discovered_sources`,
   },
 } as const;
 

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/discovered_sources.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/discovered_sources.spec.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+  UPDATES_INDEX,
+} from '../fixtures/constants';
+import { clearEntityStoreIndices } from '../fixtures/helpers';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import type { DiscoveredSourcesResponseBody } from '../../../../server/routes/apis/discovered_sources';
+
+type ApiWorkerFixtures = Parameters<Parameters<typeof apiTest>[2]>[0];
+type ApiClientFixture = ApiWorkerFixtures['apiClient'];
+
+/**
+ * Deterministic source-discovery POC (`useDiscoveredIndexSource`). Unlike the KI
+ * POC, discovery is deterministic, so these tests can seed a real `logs-*` data
+ * stream and assert it surfaces in the discovered `FROM` end-to-end.
+ *
+ * Note: the alerts-index branch (`.alerts-security.alerts-<ns>`) is exercised by
+ * unit tests rather than seeded here — the security alerts index is a
+ * framework-managed system alias and is fragile to fabricate in an API test.
+ */
+apiTest.describe(
+  'Entity Store deterministic source discovery API',
+  { tag: ENTITY_STORE_TAGS },
+  () => {
+    // logs-* data stream carrying a keyword `user.email` — should qualify for the user engine.
+    const LOGS_DATA_STREAM = 'logs-poc.discovery-default';
+    const LOGS_INDEX_TEMPLATE = 'entity-store-poc-discovery-logs';
+    const ALL_TYPES_EMPTY = { user: [], host: [], service: [], generic: [] };
+
+    let defaultHeaders: Record<string, string>;
+    let internalHeaders: Record<string, string>;
+
+    const getDiscoveredSources = (apiClient: ApiClientFixture) =>
+      apiClient.get(ENTITY_STORE_ROUTES.internal.DISCOVERED_SOURCES, {
+        headers: internalHeaders,
+        responseType: 'json',
+      }) as Promise<{ statusCode: number; body: DiscoveredSourcesResponseBody }>;
+
+    const setDiscoveryFlag = (apiClient: ApiClientFixture, enabled: boolean) =>
+      apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { logExtraction: { useDiscoveredIndexSource: enabled } },
+      });
+
+    apiTest.beforeAll(async ({ samlAuth, apiClient, kbnClient, esClient }) => {
+      const credentials = await samlAuth.asInteractiveUser('admin');
+      defaultHeaders = { ...credentials.cookieHeader, ...PUBLIC_HEADERS };
+      internalHeaders = { ...credentials.cookieHeader, ...INTERNAL_HEADERS };
+
+      await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
+
+      // A `logs-*` Security Solution data view. With discovery OFF the engine
+      // sources from this (the literal `logs-*` token). With discovery ON the
+      // data view must be bypassed, so `logs-*` must NOT appear in the FROM.
+      const dataViewResponse = await apiClient.post('/api/data_views/data_view', {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {
+          override: true,
+          data_view: {
+            id: 'security-solution-default',
+            name: 'security-solution-default',
+            title: 'logs-*',
+            timeFieldName: '@timestamp',
+          },
+        },
+      });
+      expect(dataViewResponse.statusCode).toBe(200);
+
+      const installResponse = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+      expect(installResponse.statusCode).toBe(201);
+
+      // Seed a logs-* data stream with a keyword `user.email` BEFORE the first
+      // discovery call so the 15-minute discovery cache is primed with it.
+      await esClient.indices.putIndexTemplate({
+        name: LOGS_INDEX_TEMPLATE,
+        index_patterns: [LOGS_DATA_STREAM],
+        data_stream: {},
+        priority: 500,
+        template: {
+          mappings: {
+            properties: {
+              '@timestamp': { type: 'date' },
+              user: {
+                properties: {
+                  email: { type: 'keyword' },
+                  name: { type: 'keyword' },
+                },
+              },
+            },
+          },
+        },
+      });
+      await esClient.indices.createDataStream({ name: LOGS_DATA_STREAM });
+      await esClient.index({
+        index: LOGS_DATA_STREAM,
+        op_type: 'create',
+        refresh: 'wait_for',
+        body: {
+          '@timestamp': new Date().toISOString(),
+          event: { kind: 'asset', module: 'okta' },
+          user: { email: 'poc-discovery@example.com', name: 'poc-discovery-user' },
+        },
+      });
+    });
+
+    apiTest.afterAll(async ({ apiClient, esClient }) => {
+      await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+      await esClient.indices.deleteDataStream({ name: LOGS_DATA_STREAM }, { ignore: [404] });
+      await esClient.indices.deleteIndexTemplate({ name: LOGS_INDEX_TEMPLATE }, { ignore: [404] });
+      await clearEntityStoreIndices(esClient);
+    });
+
+    apiTest(
+      'returns enabled:false with empty per-type sources when the flag is off',
+      async ({ apiClient }) => {
+        await setDiscoveryFlag(apiClient, false);
+
+        const { statusCode, body } = await getDiscoveredSources(apiClient);
+
+        expect(statusCode).toBe(200);
+        expect(body.enabled).toBe(false);
+        expect(body.sources).toStrictEqual(ALL_TYPES_EMPTY);
+        expect(body.provenance).toStrictEqual([]);
+      }
+    );
+
+    apiTest(
+      'discovers the seeded logs-* data stream (by its clean name) once the flag is on',
+      async ({ apiClient }) => {
+        await setDiscoveryFlag(apiClient, true);
+
+        const { statusCode, body } = await getDiscoveredSources(apiClient);
+
+        expect(statusCode).toBe(200);
+        expect(body.enabled).toBe(true);
+        expect(body.sources.user).toContain(LOGS_DATA_STREAM);
+
+        const userProvenance = body.provenance.find(
+          (entry) => entry.entityType === 'user' && entry.sourceName === LOGS_DATA_STREAM
+        );
+        expect(userProvenance).toBeDefined();
+        expect(userProvenance?.matchedFields).toContain('user.email');
+      }
+    );
+
+    apiTest(
+      'extraction FROM unions updates with discovered sources and bypasses the data view (no logs-* fallback)',
+      async ({ apiClient }) => {
+        await setDiscoveryFlag(apiClient, true);
+
+        const extraction = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('user'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: { fromDateISO: '2026-01-20T11:00:00Z', toDateISO: '2026-01-20T13:00:00Z' },
+          }
+        );
+
+        expect(extraction.statusCode).toBe(200);
+        expect(extraction.body.success).toBe(true);
+
+        const scannedIndices = extraction.body.scannedIndices as string[];
+        // updates union is preserved …
+        expect(scannedIndices).toContain(UPDATES_INDEX);
+        // … the discovered data stream is sourced by its clean name …
+        expect(scannedIndices).toContain(LOGS_DATA_STREAM);
+        // … and the data view's `logs-*` token is gone (no silent fallback).
+        expect(scannedIndices).not.toContain('logs-*');
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Introduces a deterministic source discovery mechanism for the Entity Store's logs extraction. This feature allows the extraction engines to dynamically identify relevant data streams and indices based on the presence of entity identity fields (e.g., `user.email`, `host.name`) and their types (`keyword`).

When enabled via the `useDiscoveredIndexSource` feature flag, this new approach bypasses reliance on the fixed Security Solution data view. Instead, it uses `resolveIndex` and `field_caps` Elasticsearch calls to build a granular, per-entity-type set of source patterns. This enables more precise and adaptable data sourcing.

A new API endpoint (`/internal/entity_store/discovered_sources`) is added to provide read-only visibility into the currently discovered sources and their provenance (which fields qualified them for which entity type). This change lays the groundwork for improved flexibility and accuracy in entity data extraction.## Summary

## Example

### User extraction
```
{
  "success": true,
  "isRemote": false,
  "count": 14614,
  "pages": 2,
  "scannedIndices": [
    ".entities.v2.updates.security_default",
    "logs-1password.item_usages-default",
    "logs-1password.signin_attempts-default",
    "logs-amazon_security_lake.application_activity-default",
    "logs-amazon_security_lake.iam-default",
    "logs-auth0.logs-default",
    "logs-authentik.event-default",
    "logs-authentik.user-default",
    "logs-azure.identity_protection-default",
    "logs-azure.signinlogs-default",
    "logs-beyondinsight_password_safe.managedaccount-default",
    "logs-bitwarden.member-default",
    "logs-box_events.events-default",
    "logs-canva.audit-default",
    "logs-cisco_duo.auth-default",
    "logs-crowdstrike.falcon-default",
    "logs-endpoint.alerts-default",
    "logs-endpoint.events.file-default",
    "logs-endpoint.events.library-default",
    "logs-endpoint.events.network-default",
    "logs-endpoint.events.process-default",
    "logs-endpoint.events.registry-default",
    "logs-endpoint.events.security-default",
    "logs-entityanalytics_ad.user-default",
    "logs-entityanalytics_entra_id.user-default",
    "logs-entityanalytics_okta.user-default",
    "logs-gcp.audit-default",
    "logs-hashicorp_vault.audit-default",
    "logs-island_browser.admin_actions-default",
    "logs-island_browser.audit-default",
    "logs-island_browser.device-default",
    "logs-island_browser.user-default",
    "logs-jamf_pro.events-default",
    "logs-jamf_pro.inventory-default",
    "logs-keeper.audit-default",
    "logs-lastpass.detailed_shared_folder-default",
    "logs-lastpass.event_report-default",
    "logs-lastpass.user-default",
    "logs-lyve_cloud.audit-default",
    "logs-mongodb_atlas.organization-default",
    "logs-okta.system-default",
    "logs-ping_directory.users-default",
    "logs-ping_one.audit-default",
    "logs-slack.audit-default",
    "logs-teleport.audit-default",
    "logs-workday.people-default",
    "logs-zoom.webhook-default",
    "logs-zscaler_zia.web-default",
    ".alerts-security.alerts-default",
    "logs-island_browser_latest.compromised_credential",
    "logs-island_browser_latest.device",
    "logs-island_browser_latest.user",
    "logs-amazon_security_lake.system_activity-default",
    "logs-atlassian_bitbucket.audit-default",
    "logs-atlassian_confluence.audit-default",
    "logs-atlassian_jira.audit-default",
    "logs-authentik.group-default",
    "logs-aws.cloudtrail-default",
    "logs-beyondinsight_password_safe.session-default",
    "logs-beyondinsight_password_safe.useraudit-default",
    "logs-bitwarden.event-default",
    "logs-cloud_asset_inventory.asset_inventory-default",
    "logs-forgerock.am_access-default",
    "logs-forgerock.am_authentication-default",
    "logs-forgerock.idm_access-default",
    "logs-forgerock.idm_authentication-default",
    "logs-github.audit-default",
    "logs-gitlab.api-default",
    "logs-gitlab.audit-default",
    "logs-gitlab.auth-default",
    "logs-mattermost.audit-default",
    "logs-system.security-default",
    "logs-github_latest.dependabot",
    "logs-github_latest.issues",
    "logs-crowdstrike.alert-default",
    "logs-cyberarkpas.audit-default",
    "logs-entityanalytics_ad.device-default",
    "logs-infoblox_nios.log-default",
    "logs-system.auth-default"
  ],
  "lastSearchTimestamp": "2026-06-30T04:35:00Z",
  "logsCapApplied": false,
  "logsProcessed": 83493
}
```

### Host extraction

```
{
  "success": true,
  "isRemote": false,
  "count": 5321,
  "pages": 1,
  "scannedIndices": [
    ".entities.v2.updates.security_default",
    "logs-1password.item_usages-default",
    "logs-1password.signin_attempts-default",
    "logs-amazon_security_lake.application_activity-default",
    "logs-amazon_security_lake.iam-default",
    "logs-auth0.logs-default",
    "logs-authentik.event-default",
    "logs-authentik.user-default",
    "logs-azure.identity_protection-default",
    "logs-azure.signinlogs-default",
    "logs-beyondinsight_password_safe.managedaccount-default",
    "logs-bitwarden.member-default",
    "logs-box_events.events-default",
    "logs-canva.audit-default",
    "logs-cisco_duo.auth-default",
    "logs-crowdstrike.falcon-default",
    "logs-endpoint.alerts-default",
    "logs-endpoint.events.file-default",
    "logs-endpoint.events.library-default",
    "logs-endpoint.events.network-default",
    "logs-endpoint.events.process-default",
    "logs-endpoint.events.registry-default",
    "logs-endpoint.events.security-default",
    "logs-entityanalytics_ad.user-default",
    "logs-entityanalytics_entra_id.user-default",
    "logs-entityanalytics_okta.user-default",
    "logs-gcp.audit-default",
    "logs-hashicorp_vault.audit-default",
    "logs-island_browser.admin_actions-default",
    "logs-island_browser.audit-default",
    "logs-island_browser.device-default",
    "logs-island_browser.user-default",
    "logs-jamf_pro.events-default",
    "logs-jamf_pro.inventory-default",
    "logs-keeper.audit-default",
    "logs-lastpass.detailed_shared_folder-default",
    "logs-lastpass.event_report-default",
    "logs-lastpass.user-default",
    "logs-lyve_cloud.audit-default",
    "logs-mongodb_atlas.organization-default",
    "logs-okta.system-default",
    "logs-ping_directory.users-default",
    "logs-ping_one.audit-default",
    "logs-slack.audit-default",
    "logs-teleport.audit-default",
    "logs-workday.people-default",
    "logs-zoom.webhook-default",
    "logs-zscaler_zia.web-default",
    ".alerts-security.alerts-default",
    "logs-island_browser_latest.device",
    "logs-amazon_security_lake.system_activity-default",
    "logs-atlassian_bitbucket.audit-default",
    "logs-atlassian_confluence.audit-default",
    "logs-atlassian_jira.audit-default",
    "logs-authentik.group-default",
    "logs-aws.cloudtrail-default",
    "logs-beyondinsight_password_safe.session-default",
    "logs-beyondinsight_password_safe.useraudit-default",
    "logs-bitwarden.event-default",
    "logs-cloud_asset_inventory.asset_inventory-default",
    "logs-forgerock.am_access-default",
    "logs-forgerock.am_authentication-default",
    "logs-forgerock.idm_access-default",
    "logs-forgerock.idm_authentication-default",
    "logs-github.audit-default",
    "logs-gitlab.api-default",
    "logs-gitlab.audit-default",
    "logs-gitlab.auth-default",
    "logs-mattermost.audit-default",
    "logs-system.security-default",
    "logs-crowdstrike.alert-default",
    "logs-cyberarkpas.audit-default",
    "logs-entityanalytics_ad.device-default",
    "logs-infoblox_nios.log-default",
    "logs-system.auth-default",
    "logs-amazon_security_lake.discovery-default",
    "logs-amazon_security_lake.findings-default",
    "logs-crowdstrike.host-default",
    "logs-entityanalytics_entra_id.device-default",
    "logs-entityanalytics_okta.device-default",
    "logs-ti_abusech_latest.ja3_fingerprints",
    "logs-ti_abusech_latest.malware",
    "logs-ti_abusech_latest.malwarebazaar",
    "logs-ti_abusech_latest.sslblacklist",
    "logs-ti_abusech_latest.threatfox",
    "logs-ti_abusech_latest.url",
    "logs-amazon_security_lake.network_activity-default",
    "logs-azure.activitylogs-default",
    "logs-azure.application_gateway-default",
    "logs-azure.auditlogs-default",
    "logs-azure.firewall_logs-default",
    "logs-azure.graphactivitylogs-default",
    "logs-azure.platformlogs-default",
    "logs-azure.provisioning-default",
    "logs-azure.springcloudlogs-default",
    "logs-beyondinsight_password_safe.asset-default",
    "logs-beyondinsight_password_safe.managedsystem-default",
    "logs-bitwarden.collection-default",
    "logs-bitwarden.group-default",
    "logs-bitwarden.policy-default",
    "logs-cloudflare_logpush.firewall_event-default",
    "logs-cloudflare_logpush.http_request-default",
    "logs-entityanalytics_entra_id.entity-default",
    "logs-entityanalytics_okta.entity-default",
    "logs-gcp.firewall-default",
    "logs-hashicorp_vault.log-default",
    "logs-jumpcloud.events-default",
    "logs-keycloak.log-default",
    "logs-lumos.activity_logs-default",
    "logs-mongodb_atlas.mongod_audit-default",
    "logs-o365.audit-default",
    "logs-sailpoint_identity_sc.events-default",
    "logs-servicenow.event-default",
    "logs-system.syslog-default",
    "logs-thycotic_ss.logs-default",
    "logs-ti_abusech.malware-default",
    "logs-ti_abusech.url-default",
    "logs-zscaler_zia.firewall-default"
  ],
  "lastSearchTimestamp": "2026-06-30T04:35:00Z",
  "logsCapApplied": false,
  "logsProcessed": 27566
}
```

### Service extraction

```
{
  "success": true,
  "isRemote": false,
  "count": 26,
  "pages": 1,
  "scannedIndices": [
    ".entities.v2.updates.security_default",
    "logs-azure.signinlogs-default",
    "logs-gcp.audit-default",
    "logs-island_browser.audit-default",
    ".alerts-security.alerts-default",
    "logs-forgerock.am_access-default",
    "logs-forgerock.am_authentication-default"
  ],
  "lastSearchTimestamp": "2026-06-30T04:35:00Z",
  "logsCapApplied": false,
  "logsProcessed": 6257
}
```

### Generic extraction

```
{
  "success": true,
  "isRemote": false,
  "count": 3058,
  "pages": 1,
  "scannedIndices": [
    ".entities.v2.updates.security_default",
    "logs-gcp.audit-default",
    ".alerts-security.alerts-default",
    "logs-aws.cloudtrail-default",
    "logs-cloud_asset_inventory.asset_inventory-default"
  ],
  "lastSearchTimestamp": "2026-06-30T04:35:00Z",
  "logsCapApplied": false,
  "logsProcessed": 3058
}
```
