### PR TITLE
[Security Solution] Rule chat attachment: type + origin resolve + card (2/N, part of #270250)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -5,7 +5,7 @@ pageLoadAssetSize:
   agentBuilderDashboards: 7786
   agentBuilderPlatform: 15544
   agentBuilderWorkflows: 24405
-  agentContextLayer: 8828
+  agentContextLayer: 7773
   aiAssistantManagementSelection: 11569
   aiops: 15227
   alerting: 22371
@@ -166,7 +166,7 @@ pageLoadAssetSize:
   searchQueryRules: 6689
   searchSynonyms: 6371
   security: 79627
-  securitySolution: 171101
+  securitySolution: 174500
   securitySolutionEss: 42592
   securitySolutionServerless: 57290
   serverless: 7412

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -86,6 +86,21 @@ export interface GetActionButtonsParams<TAttachment extends UnknownAttachment = 
 }
 
 /**
+ * EUI button color values, mirrored here to avoid a direct @elastic/eui dependency
+ * in this shared-common package.
+ */
+export type ActionButtonColor =
+  | 'text'
+  | 'accent'
+  | 'accentSecondary'
+  | 'primary'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'neutral'
+  | 'risk';
+
+/**
  * Action button definition for inline-rendered attachments.
  */
 export interface ActionButton {
@@ -95,6 +110,8 @@ export interface ActionButton {
   icon?: IconType;
   /** Whether this is the primary action button */
   type: ActionButtonType;
+  /** Optional EUI button color override (defaults to 'text') */
+  color?: ActionButtonColor;
   /** Whether the action is currently unavailable */
   disabled?: boolean;
   /** Optional explanation shown when a disabled action remains visible */

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/index.ts
@@ -16,6 +16,7 @@ export type {
   HeaderData,
   HeaderBadge,
   ActionButton,
+  ActionButtonColor,
   AttachmentPreviewState,
   AttachmentLifecycleParams,
 } from './contract';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
@@ -228,21 +228,6 @@ export interface AgentBuilderPluginStart {
     origin: string
   ) => Promise<UpdateOriginResponse>;
   /**
-   * Shallow-merges new data or description into an existing attachment.
-   * Use this to write fields (e.g. a saved rule id) into an attachment after
-   * a save, instead of calling the agent_builder REST API directly.
-   *
-   * @param conversationId - The conversation containing the attachment
-   * @param attachmentId - The ID of the attachment to update
-   * @param input - Fields to merge: `data` (shallow-merged into existing data) and/or `description`
-   * @returns Promise that resolves when the update completes
-   */
-  updateAttachment: (
-    conversationId: string,
-    attachmentId: string,
-    input: { data?: unknown; description?: string }
-  ) => Promise<void>;
-  /**
    * Inline-embeddable conversation component, pre-bound to the plugin's
    * internal services. Render this anywhere in the app to host a fully
    * functional agent_builder chat without the sidebar chrome.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
@@ -228,6 +228,21 @@ export interface AgentBuilderPluginStart {
     origin: string
   ) => Promise<UpdateOriginResponse>;
   /**
+   * Shallow-merges new data or description into an existing attachment.
+   * Use this to write fields (e.g. a saved rule id) into an attachment after
+   * a save, instead of calling the agent_builder REST API directly.
+   *
+   * @param conversationId - The conversation containing the attachment
+   * @param attachmentId - The ID of the attachment to update
+   * @param input - Fields to merge: `data` (shallow-merged into existing data) and/or `description`
+   * @returns Promise that resolves when the update completes
+   */
+  updateAttachment: (
+    conversationId: string,
+    attachmentId: string,
+    input: { data?: unknown; description?: string }
+  ) => Promise<void>;
+  /**
    * Inline-embeddable conversation component, pre-bound to the plugin's
    * internal services. Render this anywhere in the app to host a fully
    * functional agent_builder chat without the sidebar chrome.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
@@ -39,6 +39,7 @@ export { getAgentFromRunContext } from './runner';
 export type {
   ToolHandlerFn,
   ToolHandlerReturn,
+  ToolHandlerStandardReturn,
   ToolHandlerContext,
   ToolHandlerResult,
   BuiltinToolDefinition,
@@ -58,7 +59,13 @@ export type {
   ToolCreateParams,
   ToolUpdateParams,
 } from './tools';
-export { getToolResultId, createErrorResult, createOtherResult, isToolResultId } from './tools';
+export {
+  getToolResultId,
+  createErrorResult,
+  createOtherResult,
+  isToolResultId,
+  isToolHandlerStandardReturn,
+} from './tools';
 export type {
   AgentHandlerParams,
   AgentHandlerContext,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_actions.tsx
@@ -86,7 +86,7 @@ export const AttachmentActions: React.FC<AttachmentActionsProps> = ({
             maybeWrapWithTooltip(
               button,
               <EuiButtonEmpty
-                color="text"
+                color={button.color ?? 'text'}
                 size="s"
                 iconType={button.icon}
                 isDisabled={button.disabled}
@@ -117,7 +117,7 @@ export const AttachmentActions: React.FC<AttachmentActionsProps> = ({
             maybeWrapWithTooltip(
               button,
               <EuiButton
-                color="text"
+                color={button.color ?? 'text'}
                 size="s"
                 iconType={button.icon}
                 isDisabled={button.disabled}

--- a/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
@@ -79,6 +79,7 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
       };
     }),
     addAttachment: jest.fn(),
+    updateAttachment: jest.fn(),
     updateAttachmentOrigin: jest.fn(),
     EmbeddableConversation: () => null,
     EmbeddableConversationInput: () => null,

--- a/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
@@ -79,7 +79,6 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
       };
     }),
     addAttachment: jest.fn(),
-    updateAttachment: jest.fn(),
     updateAttachmentOrigin: jest.fn(),
     EmbeddableConversation: () => null,
     EmbeddableConversationInput: () => null,

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -353,13 +353,6 @@ export class AgentBuilderPlugin
       updateAttachmentOrigin: (conversationId: string, attachmentId: string, origin: string) => {
         return attachmentsService.updateOrigin(conversationId, attachmentId, origin);
       },
-      updateAttachment: (
-        conversationId: string,
-        attachmentId: string,
-        input: { data?: unknown; description?: string }
-      ) => {
-        return attachmentsService.updateAttachment(conversationId, attachmentId, input);
-      },
       EmbeddableConversation: PublicEmbeddableConversation,
       EmbeddableConversationInput: PublicEmbeddableConversationInput,
     };

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -353,6 +353,13 @@ export class AgentBuilderPlugin
       updateAttachmentOrigin: (conversationId: string, attachmentId: string, origin: string) => {
         return attachmentsService.updateOrigin(conversationId, attachmentId, origin);
       },
+      updateAttachment: (
+        conversationId: string,
+        attachmentId: string,
+        input: { data?: unknown; description?: string }
+      ) => {
+        return attachmentsService.updateAttachment(conversationId, attachmentId, input);
+      },
       EmbeddableConversation: PublicEmbeddableConversation,
       EmbeddableConversationInput: PublicEmbeddableConversationInput,
     };

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/attachments/attachements_service.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/attachments/attachements_service.tsx
@@ -90,24 +90,6 @@ export class AttachmentsService {
   }
 
   /**
-   * Shallow-merges new data/description into an existing attachment.
-   * Use when you need to write fields (e.g. ruleId, intent) into the attachment
-   * from outside the plugin without going through a raw HTTP call.
-   */
-  async updateAttachment(
-    conversationId: string,
-    attachmentId: string,
-    input: { data?: unknown; description?: string }
-  ): Promise<void> {
-    await this.http.put(
-      `${publicApiPath}/conversations/${encodeURIComponent(
-        conversationId
-      )}/attachments/${encodeURIComponent(attachmentId)}`,
-      { body: JSON.stringify(input) }
-    );
-  }
-
-  /**
    * Checks all conversation attachments for staleness against their origin snapshots.
    */
   async checkStale(conversationId: string): Promise<CheckStaleAttachmentsResponse> {

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/attachments/attachements_service.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/attachments/attachements_service.tsx
@@ -80,10 +80,30 @@ export class AttachmentsService {
     origin: string
   ): Promise<UpdateOriginResponse> {
     return await this.http.put<UpdateOriginResponse>(
-      `${publicApiPath}/conversations/${conversationId}/attachments/${attachmentId}/origin`,
+      `${publicApiPath}/conversations/${encodeURIComponent(
+        conversationId
+      )}/attachments/${encodeURIComponent(attachmentId)}/origin`,
       {
         body: JSON.stringify({ origin }),
       }
+    );
+  }
+
+  /**
+   * Shallow-merges new data/description into an existing attachment.
+   * Use when you need to write fields (e.g. ruleId, intent) into the attachment
+   * from outside the plugin without going through a raw HTTP call.
+   */
+  async updateAttachment(
+    conversationId: string,
+    attachmentId: string,
+    input: { data?: unknown; description?: string }
+  ): Promise<void> {
+    await this.http.put(
+      `${publicApiPath}/conversations/${encodeURIComponent(
+        conversationId
+      )}/attachments/${encodeURIComponent(attachmentId)}`,
+      { body: JSON.stringify(input) }
     );
   }
 
@@ -92,7 +112,7 @@ export class AttachmentsService {
    */
   async checkStale(conversationId: string): Promise<CheckStaleAttachmentsResponse> {
     return await this.http.get<CheckStaleAttachmentsResponse>(
-      `${publicApiPath}/conversations/${conversationId}/attachments/stale`
+      `${publicApiPath}/conversations/${encodeURIComponent(conversationId)}/attachments/stale`
     );
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/attachments/attachements_service.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/attachments/attachements_service.tsx
@@ -80,9 +80,7 @@ export class AttachmentsService {
     origin: string
   ): Promise<UpdateOriginResponse> {
     return await this.http.put<UpdateOriginResponse>(
-      `${publicApiPath}/conversations/${encodeURIComponent(
-        conversationId
-      )}/attachments/${encodeURIComponent(attachmentId)}/origin`,
+      `${publicApiPath}/conversations/${conversationId}/attachments/${attachmentId}/origin`,
       {
         body: JSON.stringify({ origin }),
       }
@@ -94,7 +92,7 @@ export class AttachmentsService {
    */
   async checkStale(conversationId: string): Promise<CheckStaleAttachmentsResponse> {
     return await this.http.get<CheckStaleAttachmentsResponse>(
-      `${publicApiPath}/conversations/${encodeURIComponent(conversationId)}/attachments/stale`
+      `${publicApiPath}/conversations/${conversationId}/attachments/stale`
     );
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/prepare_conversation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/prepare_conversation.ts
@@ -90,6 +90,7 @@ const mergeInputAttachmentsIntoAttachmentState = async (
           {
             data: input.data,
             ...(input.hidden !== undefined ? { hidden: input.hidden } : {}),
+            ...(input.description !== undefined ? { description: input.description } : {}),
           },
           ATTACHMENT_REF_ACTOR.user
         );

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/helpers.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { RuleResponse } from '../../../../common/api/detection_engine/model/rule_schema';
+import { RULES_PATH } from '../../../../common/constants';
+import {
+  ML_TYPE_DESCRIPTION,
+  EQL_TYPE_DESCRIPTION,
+  QUERY_TYPE_DESCRIPTION,
+  THRESHOLD_TYPE_DESCRIPTION,
+  THREAT_MATCH_TYPE_DESCRIPTION,
+  NEW_TERMS_TYPE_DESCRIPTION,
+  ESQL_TYPE_DESCRIPTION,
+  QUERY_LABEL,
+  EQL_QUERY_LABEL,
+  ESQL_QUERY_LABEL,
+  SAVED_QUERY_LABEL,
+} from './translations';
+
+export type RuleAttachmentIntent = 'create' | 'update';
+
+export type RuleAttachment = Attachment<
+  string,
+  {
+    text: string;
+    attachmentLabel?: string;
+  }
+>;
+
+export const isOnRuleFormPage = (pathname: string): boolean =>
+  pathname.includes(RULES_PATH) && (pathname.includes('/create') || pathname.includes('/edit'));
+
+/** Rule id encoded in a rule edit URL (`…/rules/id/<ruleId>/edit`). */
+export const getRuleIdFromEditFormPath = (pathname: string): string | undefined => {
+  if (!pathname.includes(RULES_PATH) || !pathname.includes('/edit')) {
+    return undefined;
+  }
+  const match = pathname.match(/\/id\/([^/]+)\/edit/);
+  return match ? decodeURIComponent(match[1]) : undefined;
+};
+
+/**
+ * True when the open create/edit form is already showing this saved rule (same id in the URL).
+ * Used to hide redundant "View rule" — not when the form is for a different rule.
+ */
+export const isAttachmentRuleOpenOnFormPage = (
+  attachmentRuleId: string | undefined,
+  pathname: string
+): boolean => {
+  if (!attachmentRuleId || !isOnRuleFormPage(pathname)) {
+    return false;
+  }
+  if (pathname.includes('/create')) {
+    return false;
+  }
+  const formRuleId = getRuleIdFromEditFormPath(pathname);
+  return formRuleId !== undefined && formRuleId === attachmentRuleId;
+};
+
+/** True when the user is already viewing the details page for this specific rule. */
+const isOnRuleDetailsPage = (ruleId: string, pathname: string): boolean => {
+  if (!pathname.includes(RULES_PATH)) return false;
+  const match = pathname.match(/\/id\/([^/]+)/);
+  if (!match) return false;
+  const pathRuleId = decodeURIComponent(match[1]);
+  return pathRuleId === ruleId && !pathname.includes('/edit');
+};
+
+/** Whether "View rule" should appear for an update-intent attachment with this rule id. */
+export const shouldShowViewRuleButton = (
+  attachmentRuleId: string | undefined,
+  pathname: string
+): boolean => {
+  if (!attachmentRuleId) {
+    return false;
+  }
+  return !isOnRuleDetailsPage(attachmentRuleId, pathname);
+};
+
+/**
+ * Saved-rule id from the attachment. Lives in the attachment's top-level `origin` (set after save
+ * and persisted server-side), the single source of truth — used for navigation and the save target.
+ */
+export const getRuleIdFromAttachment = (attachment: RuleAttachment): string | undefined =>
+  attachment.origin ?? undefined;
+
+/**
+ * Effective intent for the button. Driven entirely by `origin`: a saved rule is linked via
+ * `origin` (set after save, persisted, durable across reloads), so origin present means 'update';
+ * absent means 'create'.
+ */
+export const getRuleAttachmentIntent = (attachment: RuleAttachment): RuleAttachmentIntent =>
+  attachment.origin ? 'update' : 'create';
+
+export const parseRuleFromAttachment = (attachment: RuleAttachment): RuleResponse | null => {
+  const text = attachment?.data?.text;
+  if (!text) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as RuleResponse;
+};
+
+export const getRuleName = (attachment: RuleAttachment): string | undefined => {
+  if (attachment?.data?.attachmentLabel) {
+    return attachment.data.attachmentLabel;
+  }
+  return parseRuleFromAttachment(attachment)?.name;
+};
+
+export const getRuleTypeLabel = (ruleType: string): string => {
+  switch (ruleType) {
+    case 'machine_learning':
+      return ML_TYPE_DESCRIPTION;
+    case 'query':
+    case 'saved_query':
+      return QUERY_TYPE_DESCRIPTION;
+    case 'eql':
+      return EQL_TYPE_DESCRIPTION;
+    case 'threshold':
+      return THRESHOLD_TYPE_DESCRIPTION;
+    case 'threat_match':
+      return THREAT_MATCH_TYPE_DESCRIPTION;
+    case 'new_terms':
+      return NEW_TERMS_TYPE_DESCRIPTION;
+    case 'esql':
+      return ESQL_TYPE_DESCRIPTION;
+    default:
+      return ruleType;
+  }
+};
+
+export const getQueryLabel = (rule: RuleResponse): string => {
+  switch (rule.type) {
+    case 'eql':
+      return EQL_QUERY_LABEL;
+    case 'esql':
+      return ESQL_QUERY_LABEL;
+    case 'saved_query':
+      return SAVED_QUERY_LABEL;
+    default:
+      return QUERY_LABEL;
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_action_buttons.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_action_buttons.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { type ActionButton, ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { RULES_UI_EDIT_PRIVILEGE } from '@kbn/security-solution-features/constants';
+import type { AiRuleCreationService } from '../../../detection_engine/common/ai_rule_creation_store';
+import { hasCapabilities } from '../../../common/lib/capabilities';
+import { RULES_PATH, RULES_CREATE_PATH } from '../../../../common/constants';
+import {
+  getEditRuleUrl,
+  getRuleDetailsUrl,
+} from '../../../common/components/link_to/redirect_to_detection_engine';
+import { type RuleAttachmentIntent, getRuleTypeLabel } from './helpers';
+import type { RuleResponse } from '../../../../common/api/detection_engine/model/rule_schema';
+import { getNonEsqlRuleActionDisabledReason } from '../../components/translations';
+
+interface BuildRuleActionButtonsParams {
+  rule: RuleResponse | null;
+  aiRuleCreation: AiRuleCreationService;
+  application: ApplicationStart;
+  uiSettings: IUiSettingsClient;
+  /** Drives the primary button label: 'create' stays "Create rule", 'update' becomes "Update rule". */
+  intent: RuleAttachmentIntent;
+  /** Saved-rule id — PATCH target for update-intent saves and "View rule" link. */
+  ruleId: string | undefined;
+  /** The attachment card id — threaded into save requests and "Open in form" for per-card targeting. */
+  attachmentId: string;
+  /** Whether to show a "View rule" link — true when the rule is saved and not already being viewed. */
+  showViewRule: boolean;
+  /**
+   * Framework callback that links the attachment to its saved rule via `origin` and invalidates
+   * the conversation so the card reflects the saved state in-session. Threaded into the save
+   * request and called once the rule is persisted.
+   */
+  updateOrigin: (origin: string) => Promise<unknown>;
+}
+
+/** Builds action buttons for a rule attachment. Called from `getActionButtons` (not a hook). */
+export const buildRuleActionButtons = ({
+  rule,
+  aiRuleCreation,
+  application,
+  uiSettings,
+  intent,
+  ruleId,
+  attachmentId,
+  showViewRule,
+  updateOrigin,
+}: BuildRuleActionButtonsParams): ActionButton[] => {
+  const canEditRules = hasCapabilities(application.capabilities, RULES_UI_EDIT_PRIVILEGE);
+  if (!rule || !canEditRules || (rule.type === 'esql' && !uiSettings.get(ENABLE_ESQL))) {
+    return [];
+  }
+
+  const isUpdate = intent === 'update';
+  const isEsql = rule.type === 'esql';
+  const disabledReason = isEsql
+    ? undefined
+    : getNonEsqlRuleActionDisabledReason(getRuleTypeLabel(rule.type));
+
+  const buttons: ActionButton[] = [
+    {
+      label: i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.openInForm', {
+        defaultMessage: 'Preview before saving',
+      }),
+      icon: 'pencil',
+      type: ActionButtonType.SECONDARY,
+      handler: () => {
+        aiRuleCreation.setAiCreatedRule(rule, attachmentId);
+        application.navigateToApp('securitySolutionUI', {
+          path: isUpdate && ruleId ? `${RULES_PATH}${getEditRuleUrl(ruleId)}` : RULES_CREATE_PATH,
+        });
+      },
+    },
+    ...(showViewRule && ruleId
+      ? [
+          {
+            label: i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.viewRule', {
+              defaultMessage: 'View rule',
+            }),
+            icon: 'popout' as const,
+            type: ActionButtonType.SECONDARY,
+            handler: () => {
+              application.navigateToApp('securitySolutionUI', {
+                path: `${RULES_PATH}${getRuleDetailsUrl(ruleId)}`,
+              });
+            },
+          },
+        ]
+      : []),
+    isUpdate
+      ? {
+          label: i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.updateRule', {
+            defaultMessage: 'Update rule',
+          }),
+          icon: 'save',
+          type: ActionButtonType.PRIMARY,
+          disabled: !isEsql,
+          disabledReason,
+          handler: () => {
+            // getActionButtons is not reactive to saving$, so guard against double-submit here.
+            if (aiRuleCreation.getIsSaving()) {
+              return;
+            }
+            aiRuleCreation.requestSaveRule(
+              { ...rule, id: ruleId ?? rule.id },
+              { attachmentId, updateOrigin }
+            );
+          },
+        }
+      : {
+          label: i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.createRule', {
+            defaultMessage: 'Create rule',
+          }),
+          icon: 'plusInCircle',
+          type: ActionButtonType.PRIMARY,
+          disabled: !isEsql,
+          disabledReason,
+          handler: () => {
+            if (aiRuleCreation.getIsSaving()) {
+              return;
+            }
+            const { id: _id, ...ruleWithoutId } = rule as RuleResponse & { id?: string };
+            aiRuleCreation.requestSaveRule(ruleWithoutId as RuleResponse, {
+              attachmentId,
+              updateOrigin,
+            });
+          },
+        },
+  ];
+  return buttons;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_attachment.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_attachment.test.ts
@@ -8,15 +8,19 @@
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { AttachmentServiceStartContract } from '@kbn/agent-builder-browser/attachments';
-import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { RULES_FEATURE_LATEST } from '@kbn/security-solution-features/constants';
 import { AiRuleCreationService } from '../../../detection_engine/common/ai_rule_creation_store';
+import type { RuleResponse } from '../../../../common/api/detection_engine/model/rule_schema';
 import {
   createRuleAttachmentDefinition,
+  getRuleIdFromEditFormPath,
+  isAttachmentRuleOpenOnFormPage,
   isOnRuleFormPage,
   registerRuleAttachment,
+  shouldShowViewRuleButton,
 } from './rule_attachment';
+import { buildRuleActionButtons } from './rule_action_buttons';
 import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
 
 const validRule = {
@@ -25,14 +29,6 @@ const validRule = {
   description: 'A test rule',
   severity: 'high',
   risk_score: 73,
-};
-
-const validEsqlRule = {
-  name: 'ES|QL Test Rule',
-  type: 'esql',
-  description: 'An ES|QL test rule',
-  severity: 'medium',
-  risk_score: 50,
 };
 
 const makeAttachment = (ruleJson: string, label?: string) => ({
@@ -61,14 +57,6 @@ const makeUiSettings = (esqlEnabled = true) =>
     }),
   } as unknown as IUiSettingsClient);
 
-const makeActionButtonsParams = (ruleJson: string) => ({
-  attachment: makeAttachment(ruleJson),
-  isSidebar: false,
-  isCanvas: false,
-  updateOrigin: jest.fn(),
-  openSidebarConversation: jest.fn(),
-});
-
 describe('isOnRuleFormPage', () => {
   it('returns true for rule creation path', () => {
     expect(isOnRuleFormPage('/app/security/rules/create')).toBe(true);
@@ -91,19 +79,118 @@ describe('isOnRuleFormPage', () => {
   });
 });
 
+describe('getRuleIdFromEditFormPath', () => {
+  it('extracts the rule id from an edit URL', () => {
+    expect(getRuleIdFromEditFormPath('/app/security/rules/id/my-rule-id/edit')).toBe('my-rule-id');
+  });
+
+  it('returns undefined when not on an edit URL', () => {
+    expect(getRuleIdFromEditFormPath('/app/security/rules/create')).toBeUndefined();
+  });
+});
+
+describe('shouldShowViewRuleButton', () => {
+  it('is false without an attachment rule id', () => {
+    expect(shouldShowViewRuleButton(undefined, '/app/security/rules')).toBe(false);
+  });
+
+  it('is true on the rules list', () => {
+    expect(shouldShowViewRuleButton('rule-b', '/app/security/rules')).toBe(true);
+  });
+
+  it('is true when the edit form is open for the same rule (edit form != details page)', () => {
+    expect(shouldShowViewRuleButton('rule-a', '/app/security/rules/id/rule-a/edit')).toBe(true);
+  });
+
+  it('is true when the edit form is open for a different rule', () => {
+    expect(shouldShowViewRuleButton('rule-b', '/app/security/rules/id/rule-a/edit')).toBe(true);
+  });
+
+  it('is false when on the rule details page for the same rule', () => {
+    expect(shouldShowViewRuleButton('rule-a', '/app/security/rules/id/rule-a')).toBe(false);
+  });
+
+  it('is true on the create form (attachment targets another saved rule)', () => {
+    expect(shouldShowViewRuleButton('rule-b', '/app/security/rules/create')).toBe(true);
+  });
+});
+
+describe('isAttachmentRuleOpenOnFormPage', () => {
+  it('is true only when pathname and attachment rule id match on edit', () => {
+    expect(isAttachmentRuleOpenOnFormPage('rule-a', '/app/security/rules/id/rule-a/edit')).toBe(
+      true
+    );
+    expect(isAttachmentRuleOpenOnFormPage('rule-b', '/app/security/rules/id/rule-a/edit')).toBe(
+      false
+    );
+  });
+});
+
 describe('createRuleAttachmentDefinition', () => {
   let aiRuleCreation: AiRuleCreationService;
-  const originalLocation = window.location;
 
   beforeEach(() => {
     aiRuleCreation = new AiRuleCreationService();
+    jest.spyOn(aiRuleCreation, 'requestSaveRule');
     jest.spyOn(aiRuleCreation, 'setAiCreatedRule');
-    delete (window as { location?: Location }).location;
-    (window as { location: unknown }).location = { pathname: '/' };
   });
 
-  afterAll(() => {
-    (window as { location: unknown }).location = originalLocation;
+  describe('definition shape', () => {
+    it('exposes a static getActionButtons so buttons render on every attachment version', () => {
+      const application = makeApplication(true);
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
+      expect(definition.getActionButtons).toEqual(expect.any(Function));
+    });
+  });
+
+  describe('getActionButtons (intent wiring)', () => {
+    const buildButtons = (
+      attachmentData: Record<string, unknown>,
+      { canEdit = true, origin }: { canEdit?: boolean; origin?: string } = {}
+    ) => {
+      const definition = createRuleAttachmentDefinition({
+        application: makeApplication(canEdit),
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
+      return definition.getActionButtons!({
+        attachment: {
+          id: 'a',
+          type: SecurityAgentBuilderAttachments.rule,
+          data: attachmentData,
+          ...(origin ? { origin } : {}),
+        },
+        isSidebar: false,
+        isCanvas: false,
+        updateOrigin: jest.fn(),
+      } as never);
+    };
+    const primaryLabel = (buttons: ReturnType<typeof buildButtons>) =>
+      buttons.find((b) => b.type === 'primary')?.label;
+
+    beforeEach(() => {
+      window.history.pushState({}, '', '/');
+    });
+
+    it('labels an unsaved attachment "Create rule" (no ruleId, no origin)', () => {
+      expect(primaryLabel(buildButtons({ text: JSON.stringify(validRule) }))).toBe('Create rule');
+    });
+
+    it('labels an attachment with `origin` set "Update rule"', () => {
+      // `origin` is the persisted, reload-safe link to the saved rule and is the source of truth
+      // for the button: once a card is linked to a saved rule it is an update target.
+      expect(
+        primaryLabel(buildButtons({ text: JSON.stringify(validRule) }, { origin: 'rule-1' }))
+      ).toBe('Update rule');
+    });
+
+    it('returns no buttons when the user cannot edit rules', () => {
+      expect(buildButtons({ text: JSON.stringify(validRule) }, { canEdit: false })).toEqual([]);
+    });
   });
 
   describe('registerRuleAttachment', () => {
@@ -165,220 +252,6 @@ describe('createRuleAttachmentDefinition', () => {
     });
   });
 
-  describe('getActionButtons', () => {
-    it('returns empty array when attachment data is not parseable JSON', () => {
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(makeActionButtonsParams('not-json') as never);
-      expect(buttons).toEqual([]);
-    });
-
-    it('returns action buttons for rule without name', () => {
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify({ type: 'query' })) as never
-      );
-      expect(buttons).toHaveLength(1);
-    });
-
-    it('returns empty array when user lacks edit capabilities', () => {
-      const application = makeApplication(false);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validRule)) as never
-      );
-      expect(buttons).toEqual([]);
-    });
-
-    it('returns empty array for esql rule when enableESQL setting is disabled', () => {
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(false),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validEsqlRule)) as never
-      );
-      expect(buttons).toEqual([]);
-    });
-
-    it('returns buttons for esql rule when enableESQL setting is enabled', () => {
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(true),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validEsqlRule)) as never
-      );
-      expect(buttons).toHaveLength(1);
-    });
-
-    it('returns buttons for non-esql rule even when enableESQL setting is disabled', () => {
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(false),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validRule)) as never
-      );
-      expect(buttons).toHaveLength(1);
-    });
-
-    it('returns "Apply to creation" button when not on a rule form page', () => {
-      (window as { location: unknown }).location = { pathname: '/app/security/overview' };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validRule)) as never
-      );
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0].label).toBe('Apply to creation');
-      expect(buttons[0].type).toBe(ActionButtonType.PRIMARY);
-    });
-
-    it('returns "Update rule" button when on a rule creation page', () => {
-      (window as { location: unknown }).location = {
-        pathname: '/app/security/rules/create',
-      };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validRule)) as never
-      );
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0].label).toBe('Update rule');
-    });
-
-    it('returns "Update rule" button when on a rule edit page', () => {
-      (window as { location: unknown }).location = {
-        pathname: '/app/security/rules/abc123/edit',
-      };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validRule)) as never
-      );
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0].label).toBe('Update rule');
-    });
-
-    it('handler calls setAiCreatedRule with the parsed rule', () => {
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const buttons = definition.getActionButtons!(
-        makeActionButtonsParams(JSON.stringify(validRule)) as never
-      );
-
-      buttons[0].handler();
-
-      expect(aiRuleCreation.setAiCreatedRule).toHaveBeenCalledWith(validRule);
-    });
-
-    it('handler navigates to rule creation when not on a rule form page', () => {
-      (window as { location: unknown }).location = { pathname: '/app/security/overview' };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const params = makeActionButtonsParams(JSON.stringify(validRule));
-      const buttons = definition.getActionButtons!(params as never);
-
-      buttons[0].handler();
-
-      expect(application.navigateToApp).toHaveBeenCalledWith('securitySolutionUI', {
-        path: '/rules/create',
-      });
-    });
-
-    it('handler opens sidebar conversation when navigating to rule creation', () => {
-      (window as { location: unknown }).location = { pathname: '/app/security/overview' };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const params = makeActionButtonsParams(JSON.stringify(validRule));
-      const buttons = definition.getActionButtons!(params as never);
-
-      buttons[0].handler();
-
-      expect(params.openSidebarConversation).toHaveBeenCalled();
-    });
-
-    it('handler does not navigate when already on a rule form page', () => {
-      (window as { location: unknown }).location = {
-        pathname: '/app/security/rules/create',
-      };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const params = makeActionButtonsParams(JSON.stringify(validRule));
-      const buttons = definition.getActionButtons!(params as never);
-
-      buttons[0].handler();
-
-      expect(application.navigateToApp).not.toHaveBeenCalled();
-    });
-
-    it('handler does not open sidebar conversation when already on a rule form page', () => {
-      (window as { location: unknown }).location = {
-        pathname: '/app/security/rules/create',
-      };
-      const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({
-        application,
-        aiRuleCreation,
-        uiSettings: makeUiSettings(),
-      });
-      const params = makeActionButtonsParams(JSON.stringify(validRule));
-      const buttons = definition.getActionButtons!(params as never);
-
-      buttons[0].handler();
-
-      expect(params.openSidebarConversation).not.toHaveBeenCalled();
-    });
-  });
-
   describe('getLabel', () => {
     it('returns attachmentLabel when provided', () => {
       const application = makeApplication(true);
@@ -414,5 +287,134 @@ describe('createRuleAttachmentDefinition', () => {
       const label = definition.getLabel(makeAttachment('invalid') as never);
       expect(label).toBe('Security Rule');
     });
+  });
+});
+
+describe('buildRuleActionButtons', () => {
+  let aiRuleCreation: AiRuleCreationService;
+  let baseProps: Parameters<typeof buildRuleActionButtons>[0];
+
+  const primaryButton = (buttons: ReturnType<typeof buildRuleActionButtons>) =>
+    buttons.find((b) => b.type === 'primary');
+  const labels = (buttons: ReturnType<typeof buildRuleActionButtons>) =>
+    buttons.map((b) => b.label);
+
+  beforeEach(() => {
+    aiRuleCreation = new AiRuleCreationService();
+    jest.spyOn(aiRuleCreation, 'requestSaveRule');
+    jest.spyOn(aiRuleCreation, 'setAiCreatedRule');
+    window.history.pushState({}, '', '/');
+    baseProps = {
+      rule: { name: 'Test Rule', type: 'query' } as unknown as RuleResponse,
+      aiRuleCreation,
+      application: makeApplication(true),
+      uiSettings: makeUiSettings(),
+      intent: 'create',
+      ruleId: undefined,
+      attachmentId: 'air:testcard',
+      showViewRule: false,
+      updateOrigin: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns no buttons when the user lacks RULES_UI_EDIT_PRIVILEGE', () => {
+    expect(buildRuleActionButtons({ ...baseProps, application: makeApplication(false) })).toEqual(
+      []
+    );
+  });
+
+  it('returns no buttons for an ES|QL rule when ENABLE_ESQL is disabled', () => {
+    expect(
+      buildRuleActionButtons({
+        ...baseProps,
+        rule: { ...baseProps.rule!, type: 'esql' } as unknown as RuleResponse,
+        uiSettings: makeUiSettings(false),
+      })
+    ).toEqual([]);
+  });
+
+  it('returns a "Create rule" primary action for a create-intent attachment', () => {
+    const buttons = buildRuleActionButtons(baseProps);
+    expect(primaryButton(buttons)?.label).toBe('Create rule');
+    expect(primaryButton(buttons)?.icon).toBe('plusInCircle');
+  });
+
+  it('returns an "Update rule" primary action for an update-intent attachment', () => {
+    const buttons = buildRuleActionButtons({ ...baseProps, intent: 'update', ruleId: 'rule-123' });
+    expect(primaryButton(buttons)?.label).toBe('Update rule');
+    expect(primaryButton(buttons)?.icon).toBe('save');
+  });
+
+  it('requests a save with the ruleId injected for an update-intent attachment', () => {
+    const buttons = buildRuleActionButtons({ ...baseProps, intent: 'update', ruleId: 'rule-123' });
+    primaryButton(buttons)!.handler();
+    expect(aiRuleCreation.requestSaveRule).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rule-123' }),
+      expect.objectContaining({ attachmentId: 'air:testcard' })
+    );
+  });
+
+  it('requests a save with the attachmentId for a create-intent attachment', () => {
+    const buttons = buildRuleActionButtons({ ...baseProps });
+    primaryButton(buttons)!.handler();
+    expect(aiRuleCreation.requestSaveRule).toHaveBeenCalledWith(
+      expect.not.objectContaining({ id: expect.anything() }),
+      expect.objectContaining({ attachmentId: 'air:testcard' })
+    );
+  });
+
+  it('"Preview before saving" calls setAiCreatedRule with the rule and attachmentId', () => {
+    const buttons = buildRuleActionButtons(baseProps);
+    buttons.find((b) => b.label === 'Preview before saving')!.handler();
+    expect(aiRuleCreation.setAiCreatedRule).toHaveBeenCalledWith(baseProps.rule, 'air:testcard');
+  });
+
+  it('guards against a double-submit while a save is already in flight', () => {
+    aiRuleCreation.requestSaveRule({ name: 'in flight' } as unknown as RuleResponse);
+    (aiRuleCreation.requestSaveRule as jest.Mock).mockClear();
+    expect(aiRuleCreation.getIsSaving()).toBe(true);
+
+    primaryButton(buildRuleActionButtons(baseProps))!.handler();
+    expect(aiRuleCreation.requestSaveRule).not.toHaveBeenCalled();
+  });
+
+  it('omits View rule from action buttons when showViewRule is false', () => {
+    expect(labels(buildRuleActionButtons({ ...baseProps, ruleId: 'rule-123' }))).not.toContain(
+      'View rule'
+    );
+  });
+
+  it('navigates to create path for create intent even when a ruleId is present', () => {
+    const application = makeApplication(true);
+    const buttons = buildRuleActionButtons({
+      ...baseProps,
+      application,
+      ruleId: 'rule-123',
+    });
+    buttons.find((b) => b.label === 'Preview before saving')!.handler();
+    expect(application.navigateToApp).toHaveBeenCalledWith('securitySolutionUI', {
+      path: expect.stringContaining('/create'),
+    });
+  });
+
+  it('omits View rule from action buttons when showViewRule is false even for update intent', () => {
+    expect(
+      labels(buildRuleActionButtons({ ...baseProps, intent: 'update', ruleId: 'rule-123' }))
+    ).not.toContain('View rule');
+  });
+
+  it('includes View rule in action buttons when showViewRule is true and ruleId is set', () => {
+    expect(
+      labels(
+        buildRuleActionButtons({
+          ...baseProps,
+          intent: 'update',
+          ruleId: 'rule-123',
+          showViewRule: true,
+        })
+      )
+    ).toContain('View rule');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_attachment.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_attachment.tsx
@@ -8,345 +8,30 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
-  EuiBadge,
-  EuiCallOut,
-  EuiCodeBlock,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-} from '@elastic/eui';
-import type {
-  AttachmentUIDefinition,
-  AttachmentRenderProps,
-  AttachmentServiceStartContract,
+  type AttachmentUIDefinition,
+  type AttachmentServiceStartContract,
 } from '@kbn/agent-builder-browser/attachments';
-import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
-import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
-import { RULES_UI_EDIT_PRIVILEGE } from '@kbn/security-solution-features/constants';
-import { toSimpleRuleSchedule } from '../../../../common/api/detection_engine/model/rule_schema/to_simple_rule_schedule';
-import type { RuleResponse } from '../../../../common/api/detection_engine/model/rule_schema';
 import type { AiRuleCreationService } from '../../../detection_engine/common/ai_rule_creation_store';
-import { RULES_PATH, SecurityAgentBuilderAttachments } from '../../../../common/constants';
-import { hasCapabilities } from '../../../common/lib/capabilities';
-import { FiltersDisplay } from './filters_display';
-import { RuleTypeDetails } from './rule_type_details';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
+import { RuleInlineContent } from './rule_inline_content';
+import { buildRuleActionButtons } from './rule_action_buttons';
+import {
+  type RuleAttachment,
+  getRuleName,
+  getRuleIdFromAttachment,
+  getRuleAttachmentIntent,
+  parseRuleFromAttachment,
+  shouldShowViewRuleButton,
+} from './helpers';
 
-const INDEX_FIELD_LABEL = i18n.translate(
-  'xpack.securitySolution.agentBuilder.ruleAttachment.indexPatternsHeading',
-  { defaultMessage: 'Index patterns' }
-);
-const RULE_TYPE_FIELD_LABEL = i18n.translate(
-  'xpack.securitySolution.agentBuilder.ruleAttachment.ruleTypeLabel',
-  { defaultMessage: 'Rule type' }
-);
-const QUERY_LABEL = i18n.translate('xpack.securitySolution.detectionEngine.createRule.queryLabel', {
-  defaultMessage: 'Custom query',
-});
-const EQL_QUERY_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.eqlQueryLabel',
-  { defaultMessage: 'EQL query' }
-);
-const ESQL_QUERY_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.esqlQueryLabel',
-  { defaultMessage: 'ES|QL query' }
-);
-const SAVED_QUERY_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.savedQueryLabel',
-  { defaultMessage: 'Saved query' }
-);
-const ML_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.mlRuleTypeDescription',
-  { defaultMessage: 'Machine Learning' }
-);
-const EQL_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.eqlRuleTypeDescription',
-  { defaultMessage: 'Event Correlation' }
-);
-const QUERY_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.queryRuleTypeDescription',
-  { defaultMessage: 'Query' }
-);
-const THRESHOLD_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.thresholdRuleTypeDescription',
-  { defaultMessage: 'Threshold' }
-);
-const THREAT_MATCH_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.threatMatchRuleTypeDescription',
-  { defaultMessage: 'Indicator Match' }
-);
-const NEW_TERMS_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.newTermsRuleTypeDescription',
-  { defaultMessage: 'New Terms' }
-);
-const ESQL_TYPE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.esqlRuleTypeDescription',
-  { defaultMessage: 'ES|QL' }
-);
-
-type RuleAttachment = Attachment<string, { text: string; attachmentLabel?: string }>;
-
-const SectionHeading: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <EuiText size="s">
-    <strong>{children}</strong>
-  </EuiText>
-);
-
-const TagsBadgeList: React.FC<{ tags: string[] }> = ({ tags }) => (
-  <EuiFlexGroup responsive={false} gutterSize="xs" wrap>
-    {tags.map((tag) => (
-      <EuiFlexItem grow={false} key={tag}>
-        <EuiBadge color="hollow">{tag}</EuiBadge>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGroup>
-);
-
-export const isOnRuleFormPage = (pathname: string): boolean =>
-  pathname.includes(RULES_PATH) && (pathname.includes('/create') || pathname.includes('/edit'));
-
-const parseRuleFromAttachment = (attachment: RuleAttachment): RuleResponse | null => {
-  try {
-    const parsed = JSON.parse(attachment.data.text);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as RuleResponse;
-  } catch {
-    return null;
-  }
-};
-
-const getRuleName = (attachment: RuleAttachment): string | undefined => {
-  if (attachment?.data?.attachmentLabel) {
-    return attachment.data.attachmentLabel;
-  }
-  return parseRuleFromAttachment(attachment)?.name;
-};
-
-const EmptyRuleContent: React.FC = () => (
-  <EuiCallOut
-    size="s"
-    title={i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.emptyTitle', {
-      defaultMessage: 'New Rule',
-    })}
-    iconType="info"
-    color="primary"
-  >
-    <EuiText size="xs">
-      {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.emptyDescription', {
-        defaultMessage: 'Describe the detection rule you want to create.',
-      })}
-    </EuiText>
-  </EuiCallOut>
-);
-
-const getRuleTypeLabel = (ruleType: string): string => {
-  switch (ruleType) {
-    case 'machine_learning':
-      return ML_TYPE_DESCRIPTION;
-    case 'query':
-    case 'saved_query':
-      return QUERY_TYPE_DESCRIPTION;
-    case 'eql':
-      return EQL_TYPE_DESCRIPTION;
-    case 'threshold':
-      return THRESHOLD_TYPE_DESCRIPTION;
-    case 'threat_match':
-      return THREAT_MATCH_TYPE_DESCRIPTION;
-    case 'new_terms':
-      return NEW_TERMS_TYPE_DESCRIPTION;
-    case 'esql':
-      return ESQL_TYPE_DESCRIPTION;
-    default:
-      return ruleType;
-  }
-};
-
-const ScheduleDisplay: React.FC<{ interval: string; from?: string }> = ({ interval, from }) => {
-  const schedule = toSimpleRuleSchedule({ interval, from: from ?? `now-${interval}`, to: 'now' });
-
-  return (
-    <EuiText size="s">
-      <strong>
-        {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.intervalLabel', {
-          defaultMessage: 'Interval:',
-        })}
-      </strong>{' '}
-      {schedule?.interval ?? interval}
-      {schedule?.lookback && (
-        <>
-          {' | '}
-          <strong>
-            {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.lookbackLabel', {
-              defaultMessage: 'Lookback time:',
-            })}
-          </strong>{' '}
-          {schedule.lookback}
-        </>
-      )}
-    </EuiText>
-  );
-};
-
-const getQueryLabel = (rule: RuleResponse): string => {
-  switch (rule.type) {
-    case 'eql':
-      return EQL_QUERY_LABEL;
-    case 'esql':
-      return ESQL_QUERY_LABEL;
-    case 'saved_query':
-      return SAVED_QUERY_LABEL;
-    default:
-      return QUERY_LABEL;
-  }
-};
-
-const IndexPatterns: React.FC<{ patterns: string[] }> = ({ patterns }) => (
-  <>
-    <SectionHeading>{INDEX_FIELD_LABEL}</SectionHeading>
-    <EuiSpacer size="xs" />
-    <EuiFlexGroup responsive={false} gutterSize="xs" wrap>
-      {patterns.map((pattern) => (
-        <EuiFlexItem grow={false} key={pattern}>
-          <EuiBadge color="hollow">{pattern}</EuiBadge>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGroup>
-  </>
-);
-
-const SeverityRiskScore: React.FC<{
-  severity?: string;
-  riskScore?: number;
-}> = ({ severity, riskScore }) => (
-  <EuiText size="s">
-    {severity && (
-      <>
-        <strong>
-          {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.severityLabel', {
-            defaultMessage: 'Severity:',
-          })}
-        </strong>{' '}
-        {severity.charAt(0).toUpperCase() + severity.slice(1)}
-        {riskScore !== undefined && <>{' | '}</>}
-      </>
-    )}
-    {riskScore !== undefined && (
-      <>
-        <strong>
-          {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.riskScoreLabel', {
-            defaultMessage: 'Risk Score:',
-          })}
-        </strong>{' '}
-        {riskScore}
-      </>
-    )}
-  </EuiText>
-);
-
-const RuleInlineContent: React.FC<AttachmentRenderProps<RuleAttachment>> = ({ attachment }) => {
-  const rule = parseRuleFromAttachment(attachment);
-
-  if (!rule) {
-    return <EmptyRuleContent />;
-  }
-
-  const query = 'query' in rule ? rule.query : undefined;
-  const index = 'index' in rule ? (rule.index as string[] | undefined) : undefined;
-  const filters = 'filters' in rule ? (rule.filters as unknown[] | undefined) : undefined;
-  const interval = 'interval' in rule ? rule.interval : undefined;
-  const from = 'from' in rule ? rule.from : undefined;
-
-  return (
-    <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
-      {rule.type && (
-        <EuiText size="s">
-          <strong>
-            {RULE_TYPE_FIELD_LABEL}
-            {':'}
-          </strong>{' '}
-          {getRuleTypeLabel(rule.type)}
-        </EuiText>
-      )}
-
-      {rule.description && (
-        <>
-          <EuiSpacer size="s" />
-          <SectionHeading>
-            {i18n.translate(
-              'xpack.securitySolution.agentBuilder.ruleAttachment.descriptionHeading',
-              { defaultMessage: 'Description' }
-            )}
-          </SectionHeading>
-          <EuiSpacer size="xs" />
-          <EuiText size="s">{rule.description}</EuiText>
-        </>
-      )}
-
-      {query && (
-        <>
-          <EuiSpacer size="s" />
-          <SectionHeading>{getQueryLabel(rule)}</SectionHeading>
-          <EuiSpacer size="xs" />
-          <EuiCodeBlock
-            language="esql"
-            fontSize="s"
-            paddingSize="s"
-            overflowHeight={150}
-            isCopyable
-          >
-            {query}
-          </EuiCodeBlock>
-        </>
-      )}
-
-      {index && index.length > 0 && (
-        <>
-          <EuiSpacer size="xs" />
-          <IndexPatterns patterns={index} />
-        </>
-      )}
-
-      {filters && filters.length > 0 && (
-        <>
-          <EuiSpacer size="xs" />
-          <FiltersDisplay filters={filters} />
-        </>
-      )}
-
-      <EuiSpacer size="xs" />
-      <RuleTypeDetails rule={rule} />
-
-      {rule.tags && rule.tags.length > 0 && (
-        <>
-          <EuiSpacer size="xs" />
-          <SectionHeading>
-            {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.tagsHeading', {
-              defaultMessage: 'Tags',
-            })}
-          </SectionHeading>
-          <EuiSpacer size="xs" />
-          <TagsBadgeList tags={rule.tags} />
-        </>
-      )}
-
-      <EuiSpacer size="xs" />
-      <SeverityRiskScore severity={rule.severity} riskScore={rule.risk_score} />
-
-      {interval && (
-        <>
-          <EuiSpacer size="xs" />
-          <ScheduleDisplay interval={interval} from={from} />
-        </>
-      )}
-    </EuiPanel>
-  );
-};
+export {
+  getRuleIdFromEditFormPath,
+  isAttachmentRuleOpenOnFormPage,
+  isOnRuleFormPage,
+  shouldShowViewRuleButton,
+} from './helpers';
 
 export const registerRuleAttachment = ({
   attachments,
@@ -380,41 +65,21 @@ export const createRuleAttachmentDefinition = ({
       defaultMessage: 'Security Rule',
     }),
   getIcon: () => 'securityApp',
-  renderInlineContent: (props) => <RuleInlineContent {...props} />,
-  getActionButtons: ({ attachment, openSidebarConversation }) => {
-    const rule = parseRuleFromAttachment(attachment);
-    const canEditRules = hasCapabilities(application.capabilities, RULES_UI_EDIT_PRIVILEGE);
-    if (!rule || !canEditRules) {
-      return [];
-    }
-
-    if (rule.type === 'esql' && !uiSettings.get(ENABLE_ESQL)) {
-      return [];
-    }
-
-    const onRuleForm = isOnRuleFormPage(window.location.pathname);
-
-    return [
-      {
-        label: onRuleForm
-          ? i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.buildRule', {
-              defaultMessage: 'Update rule',
-            })
-          : i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.applyToCreation', {
-              defaultMessage: 'Apply to creation',
-            }),
-        icon: 'plus',
-        type: ActionButtonType.PRIMARY,
-        handler: () => {
-          aiRuleCreation.setAiCreatedRule(rule);
-          if (!onRuleForm) {
-            application.navigateToApp('securitySolutionUI', {
-              path: '/rules/create',
-            });
-            openSidebarConversation?.();
-          }
-        },
-      },
-    ];
+  renderInlineContent: (props) => <RuleInlineContent {...props} aiRuleCreation={aiRuleCreation} />,
+  getActionButtons: ({ attachment, updateOrigin }) => {
+    const intent = getRuleAttachmentIntent(attachment);
+    const ruleId = getRuleIdFromAttachment(attachment) ?? undefined;
+    return buildRuleActionButtons({
+      rule: parseRuleFromAttachment(attachment),
+      aiRuleCreation,
+      application,
+      uiSettings,
+      intent,
+      ruleId,
+      attachmentId: attachment.id,
+      updateOrigin,
+      showViewRule:
+        intent === 'update' && shouldShowViewRuleButton(ruleId, window.location.pathname),
+    });
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_details.test.tsx
@@ -968,13 +968,13 @@ describe('RuleInlineContent integration', () => {
     expect(screen.getByText('test-tag')).toBeInTheDocument();
   });
 
-  it('shows "New Rule" callout when attachment data is not valid JSON', () => {
+  it('renders nothing when attachment data is not valid JSON', () => {
     const aiRuleCreation = new AiRuleCreationService();
     const application = makeApplication();
     const uiSettings = makeUiSettings();
     const definition = createRuleAttachmentDefinition({ application, aiRuleCreation, uiSettings });
     const Renderer = definition.renderInlineContent!;
-    render(
+    const { container } = render(
       <Renderer
         attachment={{
           id: 'test',
@@ -985,7 +985,7 @@ describe('RuleInlineContent integration', () => {
       />
     );
 
-    expect(screen.getByText('New Rule')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('still renders description, query, and other fields when name is missing', () => {
@@ -1003,7 +1003,7 @@ describe('RuleInlineContent integration', () => {
     expect(allText).toContain('*:*');
   });
 
-  it('shows "New Rule" callout when attachment data is a JSON array', () => {
+  it('renders nothing when attachment data is a JSON array', () => {
     const aiRuleCreation = new AiRuleCreationService();
     const application = makeApplication();
     const definition = createRuleAttachmentDefinition({
@@ -1012,7 +1012,7 @@ describe('RuleInlineContent integration', () => {
       uiSettings: makeUiSettings(),
     });
     const Renderer = definition.renderInlineContent!;
-    render(
+    const { container } = render(
       <Renderer
         attachment={{
           id: 'test',
@@ -1023,7 +1023,7 @@ describe('RuleInlineContent integration', () => {
       />
     );
 
-    expect(screen.getByText('New Rule')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('places filters between index patterns and threshold details in DOM order', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_inline_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_inline_content.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AiRuleCreationService } from '../../../detection_engine/common/ai_rule_creation_store';
+import { RuleInlineContent } from './rule_inline_content';
+import type { RuleAttachment } from './helpers';
+
+const rule = { name: 'Test Rule', type: 'esql', query: 'FROM logs-*' };
+
+const makeAttachment = (ruleData: Record<string, unknown>, origin?: string): RuleAttachment =>
+  ({
+    id: 'attachment-1',
+    type: 'security.rule',
+    data: { text: JSON.stringify(ruleData), attachmentLabel: ruleData.name },
+    ...(origin ? { origin } : {}),
+  } as unknown as RuleAttachment);
+
+describe('RuleInlineContent', () => {
+  let aiRuleCreation: AiRuleCreationService;
+
+  beforeEach(() => {
+    aiRuleCreation = new AiRuleCreationService();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  const renderContent = (attachment: RuleAttachment, pathname = '/') => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname },
+      writable: true,
+    });
+    return render(
+      <RuleInlineContent
+        attachment={attachment}
+        aiRuleCreation={aiRuleCreation}
+        isSidebar={false}
+      />
+    );
+  };
+
+  it('renders nothing when the text is not valid JSON', () => {
+    const attachment = {
+      id: 'attachment-1',
+      type: 'security.rule',
+      data: { text: 'not json' },
+    } as unknown as RuleAttachment;
+    const { container } = renderContent(attachment);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the rule content', () => {
+    const { getAllByText } = renderContent(makeAttachment(rule));
+    expect(getAllByText(/ES\|QL/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows the saving spinner while a save is in progress', () => {
+    aiRuleCreation.requestSaveRule({ name: 'Test Rule', type: 'esql' } as never);
+    const { getByText } = renderContent(makeAttachment(rule));
+    expect(getByText('Saving…')).toBeInTheDocument();
+  });
+
+  it('does not show the saving spinner when not saving', () => {
+    const { queryByText } = renderContent(makeAttachment(rule));
+    expect(queryByText('Saving…')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_inline_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/rule_inline_content.tsx
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiBadge,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { type AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
+import type { RuleResponse } from '../../../../common/api/detection_engine/model/rule_schema';
+import { ThreatEuiFlexGroup } from '../../../detection_engine/rule_creation_ui/components/description_step/threat_description';
+import type { AiRuleCreationService } from '../../../detection_engine/common/ai_rule_creation_store';
+import { FiltersDisplay } from './filters_display';
+import { RuleTypeDetails } from './rule_type_details';
+import { ScheduleDisplay } from './schedule_display';
+import { parseRuleFromAttachment, getRuleTypeLabel, getQueryLabel } from './helpers';
+import type { RuleAttachment } from './helpers';
+import { INDEX_FIELD_LABEL, RULE_TYPE_FIELD_LABEL } from './translations';
+
+const SectionHeading: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <EuiText size="s">
+    <strong>{children}</strong>
+  </EuiText>
+);
+
+const TagsBadgeList: React.FC<{ tags: string[] }> = ({ tags }) => (
+  <EuiFlexGroup responsive={false} gutterSize="xs" wrap>
+    {tags.map((tag) => (
+      <EuiFlexItem grow={false} key={tag}>
+        <EuiBadge color="hollow">{tag}</EuiBadge>
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGroup>
+);
+
+const IndexPatterns: React.FC<{ patterns: string[] }> = ({ patterns }) => (
+  <>
+    <SectionHeading>{INDEX_FIELD_LABEL}</SectionHeading>
+    <EuiSpacer size="xs" />
+    <EuiFlexGroup responsive={false} gutterSize="xs" wrap>
+      {patterns.map((pattern) => (
+        <EuiFlexItem grow={false} key={pattern}>
+          <EuiBadge color="hollow">{pattern}</EuiBadge>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  </>
+);
+
+const SeverityRiskScore: React.FC<{
+  severity?: string;
+  riskScore?: number;
+}> = ({ severity, riskScore }) => (
+  <EuiText size="s">
+    {severity && (
+      <>
+        <strong>
+          {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.severityLabel', {
+            defaultMessage: 'Severity:',
+          })}
+        </strong>{' '}
+        {severity.charAt(0).toUpperCase() + severity.slice(1)}
+        {riskScore !== undefined && <>{' | '}</>}
+      </>
+    )}
+    {riskScore !== undefined && (
+      <>
+        <strong>
+          {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.riskScoreLabel', {
+            defaultMessage: 'Risk Score:',
+          })}
+        </strong>{' '}
+        {riskScore}
+      </>
+    )}
+  </EuiText>
+);
+
+const getRuleDisplayFields = (rule: RuleResponse) => ({
+  query: 'query' in rule ? rule.query : undefined,
+  index: 'index' in rule ? (rule.index as string[] | undefined) : undefined,
+  filters: 'filters' in rule ? (rule.filters as unknown[] | undefined) : undefined,
+  interval: 'interval' in rule ? rule.interval : undefined,
+  from: 'from' in rule ? rule.from : undefined,
+});
+
+interface RuleInlineContentProps extends AttachmentRenderProps<RuleAttachment> {
+  aiRuleCreation: AiRuleCreationService;
+}
+
+export const RuleInlineContent: React.FC<RuleInlineContentProps> = ({
+  attachment,
+  aiRuleCreation,
+}) => {
+  const isSaving = useObservable(aiRuleCreation.saving$, false);
+
+  const rule = useMemo(() => parseRuleFromAttachment(attachment), [attachment]);
+
+  if (!rule) {
+    return null;
+  }
+
+  const { query, index, filters, interval, from } = getRuleDisplayFields(rule);
+
+  return (
+    <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
+      {isSaving && (
+        <>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="s" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.savingText', {
+                  defaultMessage: 'Saving…',
+                })}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      {rule.type && (
+        <EuiText size="s">
+          <strong>
+            {RULE_TYPE_FIELD_LABEL}
+            {':'}
+          </strong>{' '}
+          {getRuleTypeLabel(rule.type)}
+        </EuiText>
+      )}
+
+      {rule.description && (
+        <>
+          <EuiSpacer size="s" />
+          <SectionHeading>
+            {i18n.translate(
+              'xpack.securitySolution.agentBuilder.ruleAttachment.descriptionHeading',
+              { defaultMessage: 'Description' }
+            )}
+          </SectionHeading>
+          <EuiSpacer size="xs" />
+          <EuiText size="s">{rule.description}</EuiText>
+        </>
+      )}
+
+      {query && (
+        <>
+          <EuiSpacer size="s" />
+          <SectionHeading>{getQueryLabel(rule)}</SectionHeading>
+          <EuiSpacer size="xs" />
+          <EuiCodeBlock
+            language="esql"
+            fontSize="s"
+            paddingSize="s"
+            overflowHeight={150}
+            isCopyable
+          >
+            {query}
+          </EuiCodeBlock>
+        </>
+      )}
+
+      {index && index.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <IndexPatterns patterns={index} />
+        </>
+      )}
+
+      {filters && filters.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <FiltersDisplay filters={filters} />
+        </>
+      )}
+
+      {[
+        'threshold',
+        'threat_match',
+        'machine_learning',
+        'new_terms',
+        'saved_query',
+        'eql',
+      ].includes(rule.type) && (
+        <>
+          <EuiSpacer size="s" />
+          <RuleTypeDetails rule={rule} />
+        </>
+      )}
+
+      {rule.tags && rule.tags.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <SectionHeading>
+            {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.tagsHeading', {
+              defaultMessage: 'Tags',
+            })}
+          </SectionHeading>
+          <EuiSpacer size="xs" />
+          <TagsBadgeList tags={rule.tags} />
+        </>
+      )}
+
+      {rule.threat && rule.threat.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <SectionHeading>
+            {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.mitreHeading', {
+              defaultMessage: 'MITRE ATT&CK',
+            })}
+          </SectionHeading>
+          <EuiSpacer size="xs" />
+          <EuiFlexGrid columns={2} gutterSize="m" responsive={false}>
+            {rule.threat.map((entry, threatIndex) => (
+              <EuiFlexItem key={threatIndex}>
+                <ThreatEuiFlexGroup threat={[entry]} />
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGrid>
+        </>
+      )}
+
+      <EuiSpacer size="s" />
+      <SeverityRiskScore severity={rule.severity} riskScore={rule.risk_score} />
+
+      {interval && (
+        <>
+          <EuiSpacer size="s" />
+          <ScheduleDisplay interval={interval} from={from} />
+        </>
+      )}
+
+      <EuiSpacer size="s" />
+      <EuiCallOut
+        size="s"
+        color="primary"
+        iconType="info"
+        title={i18n.translate(
+          'xpack.securitySolution.agentBuilder.ruleAttachment.limitationsTitle',
+          { defaultMessage: 'AI rule creation limitations' }
+        )}
+      >
+        <EuiText size="xs">
+          {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.limitationsBody', {
+            defaultMessage:
+              'Only ES|QL rules are supported. Requires existing index data. Severity and risk score default to Low / 21 — ask the assistant to change them.',
+          })}
+        </EuiText>
+      </EuiCallOut>
+    </EuiPanel>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/schedule_display.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/schedule_display.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { toSimpleRuleSchedule } from '../../../../common/api/detection_engine/model/rule_schema/to_simple_rule_schedule';
+
+export const ScheduleDisplay: React.FC<{ interval: string; from?: string }> = ({
+  interval,
+  from,
+}) => {
+  const schedule = toSimpleRuleSchedule({ interval, from: from ?? `now-${interval}`, to: 'now' });
+
+  return (
+    <EuiText size="s">
+      <strong>
+        {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.intervalLabel', {
+          defaultMessage: 'Interval:',
+        })}
+      </strong>{' '}
+      {schedule?.interval ?? interval}
+      {schedule?.lookback && (
+        <>
+          {' | '}
+          <strong>
+            {i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.lookbackLabel', {
+              defaultMessage: 'Lookback time:',
+            })}
+          </strong>{' '}
+          {schedule.lookback}
+        </>
+      )}
+    </EuiText>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule/translations.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const INDEX_FIELD_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.ruleAttachment.indexPatternsHeading',
+  { defaultMessage: 'Index patterns' }
+);
+
+export const RULE_TYPE_FIELD_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.ruleAttachment.ruleTypeLabel',
+  { defaultMessage: 'Rule type' }
+);
+
+export const QUERY_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.queryLabel',
+  { defaultMessage: 'Custom query' }
+);
+
+export const EQL_QUERY_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.eqlQueryLabel',
+  { defaultMessage: 'EQL query' }
+);
+
+export const ESQL_QUERY_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.esqlQueryLabel',
+  { defaultMessage: 'ES|QL query' }
+);
+
+export const SAVED_QUERY_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.savedQueryLabel',
+  { defaultMessage: 'Saved query' }
+);
+
+export const ML_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.mlRuleTypeDescription',
+  { defaultMessage: 'Machine Learning' }
+);
+
+export const EQL_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.eqlRuleTypeDescription',
+  { defaultMessage: 'Event Correlation' }
+);
+
+export const QUERY_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.queryRuleTypeDescription',
+  { defaultMessage: 'Query' }
+);
+
+export const THRESHOLD_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.thresholdRuleTypeDescription',
+  { defaultMessage: 'Threshold' }
+);
+
+export const THREAT_MATCH_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.threatMatchRuleTypeDescription',
+  { defaultMessage: 'Indicator Match' }
+);
+
+export const NEW_TERMS_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.newTermsRuleTypeDescription',
+  { defaultMessage: 'New Terms' }
+);
+
+export const ESQL_TYPE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.esqlRuleTypeDescription',
+  { defaultMessage: 'ES|QL' }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/translations.ts
@@ -20,3 +20,16 @@ export const UPGRADE_TO_ENTERPRISE_TO_USE_AGENT_BUILDER_CHAT = i18n.translate(
     defaultMessage: 'Upgrade your license to use Agent builder chat.',
   }
 );
+
+export const NON_ESQL_RULE_ADD_TO_CHAT_DISABLED_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.agentBuilder.nonEsqlRuleAddToChatDisabledTooltip',
+  {
+    defaultMessage: 'AI rule creation is only supported for ES|QL rules.',
+  }
+);
+
+export const getNonEsqlRuleActionDisabledReason = (ruleTypeLabel: string) =>
+  i18n.translate('xpack.securitySolution.agentBuilder.ruleAttachment.nonEsqlDisabledReason', {
+    defaultMessage: 'AI rule creation is only supported for ES|QL rules. This rule is {ruleType}.',
+    values: { ruleType: ruleTypeLabel },
+  });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/ai_rule_creation_store.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/ai_rule_creation_store.test.ts
@@ -9,7 +9,9 @@ import { firstValueFrom } from 'rxjs';
 import type { RuleResponse } from '../../../common/api/detection_engine/model/rule_schema';
 import { AiRuleCreationService } from './ai_rule_creation_store';
 
-const mockRule = { name: 'Test Rule', type: 'query' } as RuleResponse;
+const mockRule = { name: 'Test Rule', type: 'query', id: 'rule-1' } as RuleResponse;
+const ATT_A = 'air:aaa';
+const ATT_B = 'air:bbb';
 
 describe('AiRuleCreationService', () => {
   let service: AiRuleCreationService;
@@ -18,74 +20,87 @@ describe('AiRuleCreationService', () => {
     service = new AiRuleCreationService();
   });
 
-  describe('aiCreatedRule$', () => {
-    it('initially emits null', async () => {
-      const value = await firstValueFrom(service.aiCreatedRule$);
-      expect(value).toBeNull();
+  describe('saveRuleRequest$', () => {
+    it('emits the rule after requestSaveRule', async () => {
+      const promise = firstValueFrom(service.saveRuleRequest$);
+      service.requestSaveRule(mockRule);
+      const value = await promise;
+      expect(value).toEqual({
+        rule: mockRule,
+        attachmentId: undefined,
+        updateOrigin: undefined,
+      });
     });
 
-    it('emits the rule after setAiCreatedRule', async () => {
-      service.setAiCreatedRule(mockRule);
-      const value = await firstValueFrom(service.aiCreatedRule$);
-      expect(value).toEqual(mockRule);
-    });
-
-    it('emits null after clearAiCreatedRule', async () => {
-      service.setAiCreatedRule(mockRule);
-      service.clearAiCreatedRule();
-      const value = await firstValueFrom(service.aiCreatedRule$);
-      expect(value).toBeNull();
+    it('carries the attachmentId and updateOrigin through requestSaveRule', async () => {
+      const promise = firstValueFrom(service.saveRuleRequest$);
+      const updateOrigin = jest.fn();
+      service.requestSaveRule(mockRule, { attachmentId: ATT_A, updateOrigin });
+      const value = await promise;
+      expect(value).toEqual({ rule: mockRule, attachmentId: ATT_A, updateOrigin });
     });
   });
 
-  describe('formSyncActive$', () => {
-    it('initially emits false', async () => {
-      const value = await firstValueFrom(service.formSyncActive$);
-      expect(value).toBe(false);
+  describe('boundAttachmentId', () => {
+    it('starts null', () => {
+      expect(service.getBoundAttachmentId()).toBeNull();
     });
 
-    it('emits true after activateFormSync', async () => {
-      service.activateFormSync();
-      const value = await firstValueFrom(service.formSyncActive$);
-      expect(value).toBe(true);
+    it('setBoundAttachment updates the bound id', () => {
+      service.setBoundAttachment(ATT_A);
+      expect(service.getBoundAttachmentId()).toBe(ATT_A);
     });
 
-    it('deduplicates consecutive identical values via distinctUntilChanged', () => {
-      const emissions: boolean[] = [];
-      const subscription = service.formSyncActive$.subscribe((v) => emissions.push(v));
+    it('releaseBind sets the bound id back to null', () => {
+      service.setBoundAttachment(ATT_A);
+      service.releaseBind();
+      expect(service.getBoundAttachmentId()).toBeNull();
+    });
 
-      service.activateFormSync();
-      service.activateFormSync();
-      service.activateFormSync();
+    it('setAiCreatedRule with attachmentId sets the bound id', () => {
+      service.setAiCreatedRule(mockRule, ATT_B);
+      expect(service.getBoundAttachmentId()).toBe(ATT_B);
+    });
 
-      subscription.unsubscribe();
-      expect(emissions).toEqual([false, true]);
+    it('setAiCreatedRule without attachmentId does not change the bound id', () => {
+      service.setBoundAttachment(ATT_A);
+      service.setAiCreatedRule(mockRule);
+      expect(service.getBoundAttachmentId()).toBe(ATT_A);
+    });
+
+    it('reset clears the bound id', () => {
+      service.setBoundAttachment(ATT_A);
+      service.reset();
+      expect(service.getBoundAttachmentId()).toBeNull();
+    });
+  });
+
+  describe('session management', () => {
+    it('startSession creates a new session', () => {
+      const session = service.startSession();
+      expect(session.sessionId).toBeDefined();
+      expect(session.applyCount).toBe(0);
+    });
+
+    it('incrementApplyCount increments the apply count', () => {
+      service.startSession();
+      service.incrementApplyCount();
+      service.incrementApplyCount();
+      expect(service.getSession()?.applyCount).toBe(2);
+    });
+
+    it('clearSession sets session to null', () => {
+      service.startSession();
+      service.clearSession();
+      expect(service.getSession()).toBeNull();
     });
   });
 
   describe('reset', () => {
-    it('resets aiCreatedRule$ to null', async () => {
-      service.setAiCreatedRule(mockRule);
+    it('resets session to null', () => {
+      service.startSession();
       service.reset();
-      const value = await firstValueFrom(service.aiCreatedRule$);
-      expect(value).toBeNull();
+      expect(service.getSession()).toBeNull();
     });
-
-    it('resets formSyncActive$ to false', async () => {
-      service.activateFormSync();
-      service.reset();
-      const value = await firstValueFrom(service.formSyncActive$);
-      expect(value).toBe(false);
-    });
-  });
-
-  it('each instance maintains independent state', async () => {
-    const other = new AiRuleCreationService();
-
-    service.setAiCreatedRule(mockRule);
-    service.activateFormSync();
-
-    expect(await firstValueFrom(other.aiCreatedRule$)).toBeNull();
-    expect(await firstValueFrom(other.formSyncActive$)).toBe(false);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/ai_rule_creation_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/ai_rule_creation_store.ts
@@ -6,7 +6,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { BehaviorSubject, distinctUntilChanged } from 'rxjs';
+import { BehaviorSubject, Subject, distinctUntilChanged } from 'rxjs';
 import type { RuleResponse } from '../../../common/api/detection_engine/model/rule_schema';
 
 export interface AiRuleCreationSession {
@@ -15,11 +15,31 @@ export interface AiRuleCreationSession {
   applyCount: number;
 }
 
+/**
+ * Links the attachment to its saved rule via `origin` and invalidates the conversation so the
+ * card reflects the saved state in-session. Supplied by the inline attachment's framework
+ * callback; the save handler calls it once the rule is persisted.
+ */
+export type UpdateAttachmentOriginFn = (origin: string) => Promise<unknown>;
+
+export interface SaveRuleRequest {
+  rule: RuleResponse;
+  attachmentId?: string;
+  updateOrigin?: UpdateAttachmentOriginFn;
+}
+
 export class AiRuleCreationService {
+  private readonly saveRuleSubject = new Subject<SaveRuleRequest>();
+  private readonly savingSubject = new BehaviorSubject<boolean>(false);
   private readonly aiRuleSubject = new BehaviorSubject<RuleResponse | null>(null);
   private readonly formSyncSubject = new BehaviorSubject<boolean>(false);
+  // `null` = form idle (no active bind). Released when a brand-new rule card is minted.
+  // Plain field, not a subject: every consumer reads it imperatively via `getBoundAttachmentId`.
+  private boundAttachmentId: string | null = null;
   private session: AiRuleCreationSession | null = null;
 
+  public readonly saveRuleRequest$ = this.saveRuleSubject.asObservable();
+  public readonly saving$ = this.savingSubject.pipe(distinctUntilChanged());
   public readonly aiCreatedRule$ = this.aiRuleSubject.asObservable();
   public readonly formSyncActive$ = this.formSyncSubject.pipe(distinctUntilChanged());
 
@@ -42,8 +62,46 @@ export class AiRuleCreationService {
     }
   };
 
-  public setAiCreatedRule = (rule: RuleResponse): void => {
+  public requestSaveRule = (
+    rule: RuleResponse,
+    options?: {
+      attachmentId?: string;
+      updateOrigin?: UpdateAttachmentOriginFn;
+    }
+  ): void => {
+    this.savingSubject.next(true);
+    this.saveRuleSubject.next({
+      rule,
+      attachmentId: options?.attachmentId,
+      updateOrigin: options?.updateOrigin,
+    });
+  };
+
+  public clearSaving = (): void => {
+    this.savingSubject.next(false);
+  };
+
+  public getIsSaving = (): boolean => {
+    return this.savingSubject.getValue();
+  };
+
+  public setAiCreatedRule = (rule: RuleResponse, attachmentId?: string): void => {
     this.aiRuleSubject.next(rule);
+    if (attachmentId !== undefined) {
+      this.boundAttachmentId = attachmentId;
+    }
+  };
+
+  public setBoundAttachment = (attachmentId: string): void => {
+    this.boundAttachmentId = attachmentId;
+  };
+
+  public releaseBind = (): void => {
+    this.boundAttachmentId = null;
+  };
+
+  public getBoundAttachmentId = (): string | null => {
+    return this.boundAttachmentId;
   };
 
   public clearAiCreatedRule = (): void => {
@@ -54,13 +112,19 @@ export class AiRuleCreationService {
     this.formSyncSubject.next(true);
   };
 
+  public deactivateFormSync = (): void => {
+    this.formSyncSubject.next(false);
+  };
+
   public clearSession = (): void => {
     this.session = null;
   };
 
   public reset = (): void => {
+    this.savingSubject.next(false);
     this.aiRuleSubject.next(null);
     this.formSyncSubject.next(false);
+    this.boundAttachmentId = null;
     this.session = null;
   };
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
@@ -34,7 +34,7 @@ export const registerAttachments = async (
   agentBuilder.attachments.registerType(createBulkAlertsAttachmentType(core, logger));
   agentBuilder.attachments.registerType(createEntityAttachmentType());
   agentBuilder.attachments.registerType(createEntityAnalyticsDashboardAttachmentType());
-  agentBuilder.attachments.registerType(createRuleAttachmentType());
+  agentBuilder.attachments.registerType(createRuleAttachmentType(core, logger));
   agentBuilder.attachments.registerType(createSiemReadinessAttachmentType());
 
   if (experimentalFeatures.rulePreviewAttachmentEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/rule.ts
@@ -5,30 +5,61 @@
  * 2.0.
  */
 
-import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { Logger } from '@kbn/core/server';
+import type {
+  AttachmentTypeDefinition,
+  AttachmentResolveContext,
+} from '@kbn/agent-builder-server/attachments';
 import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import { platformCoreTools } from '@kbn/agent-builder-common';
 import { z } from '@kbn/zod/v4';
 import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import type { RuleResponse } from '../../../common/api/detection_engine/model/rule_schema';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import { readRules } from '../../lib/detection_engine/rule_management/logic/detection_rules_client/read_rules';
+import { transform } from '../../lib/detection_engine/rule_management/utils/utils';
 import { SECURITY_CREATE_DETECTION_RULE_TOOL_ID, SECURITY_LABS_SEARCH_TOOL_ID } from '../tools';
 
 import { securityAttachmentDataSchema } from './security_attachment_data_schema';
 
 export const ruleAttachmentDataSchema = securityAttachmentDataSchema.extend({
-  text: z.string(),
+  text: z.string().max(500_000),
+  attachmentLabel: z.string().max(1_000).optional(),
 });
 
 const DETECTION_RULE_SKILL_NAME_ID = 'detection-rule-edit';
 
 type RuleAttachmentData = z.infer<typeof ruleAttachmentDataSchema>;
 
-/**
- * Type guard to narrow attachment data to RuleAttachmentData
- */
 const isRuleAttachmentData = (data: unknown): data is RuleAttachmentData => {
   return ruleAttachmentDataSchema.safeParse(data).success;
 };
-export const createRuleAttachmentType = (): AttachmentTypeDefinition => {
+
+/**
+ * Strip server-assigned fields before storing a fetched rule as attachment `text`. `id`/`rule_id`
+ * in the text causes the agent to skip `attachment_id` and mint a new card instead of updating the
+ * existing one; the read-only audit fields are dropped to keep the draft shape consistent with the
+ * save path (`stripServerFields` in `ai_rule_creation_handler.ts`).
+ */
+const stripServerRuleFields = (rule: RuleResponse): Partial<RuleResponse> => {
+  const {
+    id: _id,
+    rule_id: _ruleId,
+    revision: _revision,
+    created_at: _createdAt,
+    created_by: _createdBy,
+    updated_at: _updatedAt,
+    updated_by: _updatedBy,
+    execution_summary: _execSummary,
+    ...spec
+  } = rule as RuleResponse & { rule_id?: string };
+  return spec;
+};
+
+export const createRuleAttachmentType = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): AttachmentTypeDefinition => {
   return {
     id: SecurityAgentBuilderAttachments.rule,
     validate: (input) => {
@@ -40,10 +71,8 @@ export const createRuleAttachmentType = (): AttachmentTypeDefinition => {
       }
     },
     format: (attachment: Attachment<string, unknown>) => {
-      // Extract data to allow proper type narrowing
       const data = attachment.data;
-      // Necessary because we cannot currently use the AttachmentType type as agent is not
-      // registered with enum AttachmentType in agentBuilder attachment_types.ts
+      // AttachmentType enum is not yet registered for security attachments, so we validate manually.
       if (!isRuleAttachmentData(data)) {
         throw new Error(`Invalid rule attachment data for attachment ${attachment.id}`);
       }
@@ -52,6 +81,30 @@ export const createRuleAttachmentType = (): AttachmentTypeDefinition => {
           return { type: 'text', value: formatRuleData(data) };
         },
       };
+    },
+    // By-reference creation: when an attachment is added with `origin` (a saved rule id) and no
+    // `data` — e.g. "add an existing rule to chat" — the framework calls this once to populate the
+    // card from the live rule. `origin` being set is also what drives the "Update" button state.
+    resolve: async (origin: string, context: AttachmentResolveContext) => {
+      try {
+        const [, startPlugins] = await core.getStartServices();
+        const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(context.request);
+        const rule = await readRules({ rulesClient, id: origin, ruleId: undefined });
+        if (!rule) {
+          return undefined;
+        }
+        const transformed = transform(rule);
+        if (!transformed) {
+          return undefined;
+        }
+        return {
+          text: JSON.stringify(stripServerRuleFields(transformed)),
+          attachmentLabel: transformed.name,
+        };
+      } catch (error) {
+        logger.warn(`Failed to resolve rule attachment for origin "${origin}": ${error}`);
+        return undefined;
+      }
     },
     getTools: () => [
       platformCoreTools.generateEsql,


### PR DESCRIPTION
The detection-rule **attachment** — its server type and the in-chat card UI — built origin-native. Slice 2 of the #270250 breakdown.

> ⛓️ **Stacked on #275108** (agent-builder framework primitives). Until that merges, this PR's diff includes #275108's files too — **review just the second commit** here. The diff shrinks to slice-2-only once #275108 merges.

### Changes
- **Server attachment type** (`rule.ts`): `resolve(origin)` fetches the live rule (`getRulesClientWithRequest` → `readRules` → `transform`, server fields stripped) so a rule can be attached by reference. Data schema is `{ text, attachmentLabel }` — **identity lives in the top-level `origin`, not the payload**. `register_attachments` passes `core`/`logger`.
- **Chat rule card** (`rule_inline_content`, `schedule_display`, `rule_action_buttons`, `helpers`, `translations`, `rule_attachment`): renders the rule; the primary button label is driven by `Boolean(origin)` → **"Create rule"** (no origin) vs **"Update rule"** (origin set).
- **`AiRuleCreationService`** store (save requests / saving state, consumed by the card).
- Bundle-limit bump + regenerated i18n.

The attachment type + card are **defined** here; wiring them into the plugin and the save/apply flow is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)