### PR TITLE
[Temp] Enable ES|QL by default in Discover

### DIFF
--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -76,7 +76,6 @@ import type { DiscoverEBTManager } from './ebt_manager';
 import {
   CASCADE_LAYOUT_ENABLED_FEATURE_FLAG_KEY,
   EMBEDDABLE_TRANSFORMS_FEATURE_FLAG_KEY,
-  IS_ESQL_DEFAULT_FEATURE_FLAG_KEY,
 } from './constants';
 import { EmbeddableEditorService } from './plugin_imports/embeddable_editor_service';
 
@@ -213,8 +212,7 @@ export const buildServices = ({
     discoverFeatureFlags: {
       getCascadeLayoutEnabled: () =>
         core.featureFlags.getBooleanValue(CASCADE_LAYOUT_ENABLED_FEATURE_FLAG_KEY, true),
-      getIsEsqlDefault: () =>
-        core.featureFlags.getBooleanValue(IS_ESQL_DEFAULT_FEATURE_FLAG_KEY, false),
+      getIsEsqlDefault: () => true,
       getEmbeddableTransformsEnabled: () =>
         core.featureFlags.getBooleanValue(EMBEDDABLE_TRANSFORMS_FEATURE_FLAG_KEY, true),
     },

--- a/src/platform/test/functional/apps/discover/ccs_compatibility/_cancel_results.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/_cancel_results.ts
@@ -16,12 +16,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const toasts = getService('toasts');
-  const { common, discover, header, timePicker } = getPageObjects([
-    'common',
-    'discover',
-    'header',
-    'timePicker',
-  ]);
+  const { discover, header, timePicker } = getPageObjects(['discover', 'header', 'timePicker']);
   const dataViews = getService('dataViews');
   const monacoEditor = getService('monacoEditor');
 
@@ -39,7 +34,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
-      await discover.setQueryMode('classic', 'esql');
     });
 
     after(async () => {
@@ -56,7 +50,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('classic mode', () => {
       it('should show warning and results', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await dataViews.createFromSearchBar({
           name: 'ftr-remote:logstash-*,logstash-*',
           hasTimeField: false,
@@ -119,7 +113,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('esql mode', () => {
       it('should show warning and results', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await timePicker.setDefaultAbsoluteRange();
         await monacoEditor.setCodeEditorValue(`FROM logstash-*, ftr-remote:logstash-* METADATA _index

--- a/src/platform/test/functional/apps/discover/ccs_compatibility/_data_view_editor.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/_data_view_editor.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const security = getService('security');
   const config = getService('config');
-  const { common, discover, timePicker } = getPageObjects(['common', 'discover', 'timePicker']);
+  const { discover, timePicker } = getPageObjects(['discover', 'timePicker']);
   const defaultIndexPatternString = config.get('esTestCluster.ccs')
     ? 'ftr-remote:logstash-*'
     : 'logstash-*';
@@ -44,8 +44,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.importExport.load(kbnDirectory);
       await kibanaServer.uiSettings.replace(defaultSettings);
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
-      await discover.setQueryMode('classic', 'esql');
-      await common.navigateToApp('discover');
+      // A non-empty `_a` bypasses the persisted-query-mode check (which requires
+      // localStorage, unavailable on a brand new session's `data:` origin) and
+      // lands on the classic default query, same as `navigateToApp('classic')`.
+      await discover.navigateToActualUrl(undefined, '_a=(columns:!())');
     });
 
     after(async () => {

--- a/src/platform/test/functional/apps/discover/ccs_compatibility/_saved_queries.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/_saved_queries.ts
@@ -87,9 +87,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esNode.load('src/platform/test/functional/fixtures/es_archiver/logstash_functional');
 
       await kibanaServer.uiSettings.replace(defaultSettings);
-      await discover.setQueryMode('classic', 'esql');
       log.debug('discover');
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
     });
 
     after(async () => {

--- a/src/platform/test/functional/apps/discover/ccs_compatibility/_search_errors.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/_search_errors.ts
@@ -17,7 +17,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const dataViews = getService('dataViews');
-  const { common, discover, timePicker } = getPageObjects(['common', 'discover', 'timePicker']);
+  const { discover, timePicker } = getPageObjects(['discover', 'timePicker']);
 
   const isCcsTest = config.get('esTestCluster.ccs');
   const archiveDirectory = isCcsTest
@@ -35,7 +35,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esNode.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
-      await discover.setQueryMode('classic', 'esql');
     });
 
     after(async () => {
@@ -44,7 +43,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('exception on single shard shows warning and results', async () => {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await dataViews.switchToAndValidate(defaultIndex);
       await timePicker.setDefaultAbsoluteRange();
       await retry.try(async () => {
@@ -77,7 +76,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('exception on all shards shows error', async () => {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await dataViews.switchToAndValidate(defaultIndex);
       await timePicker.setDefaultAbsoluteRange();
       await retry.try(async () => {

--- a/src/platform/test/functional/apps/discover/ccs_compatibility/_timeout_results.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/_timeout_results.ts
@@ -16,12 +16,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const toasts = getService('toasts');
-  const { common, discover, header, timePicker } = getPageObjects([
-    'common',
-    'discover',
-    'header',
-    'timePicker',
-  ]);
+  const { discover, header, timePicker } = getPageObjects(['discover', 'header', 'timePicker']);
   const dataViews = getService('dataViews');
   const monacoEditor = getService('monacoEditor');
 
@@ -40,7 +35,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/kbn_archiver/discover.json'
       );
       await kibanaServer.uiSettings.update({ 'search:timeout': 3000 });
-      await discover.setQueryMode('classic', 'esql');
     });
 
     after(async () => {
@@ -58,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('bfetch enabled', () => {
       it('timeout on single shard shows warning and results with bfetch enabled', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await dataViews.createFromSearchBar({
           name: 'ftr-remote:logstash-*,logstash-*',
           hasTimeField: false,
@@ -128,7 +122,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('timeout on single shard shows warning and results', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await dataViews.createFromSearchBar({
           name: 'ftr-remote:logstash-*,logstash-*',
           hasTimeField: false,
@@ -190,7 +184,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('with esql', () => {
       it('should show warning and results', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await monacoEditor.setCodeEditorValue(`FROM logstash-*, ftr-remote:logstash-* METADATA _index
   | EVAL buckets = DATE_TRUNC(5 minute, @timestamp), delay = TO_STRING(CASE(STARTS_WITH(_index, "ftr-remote"), DELAY(10ms), false))

--- a/src/platform/test/functional/apps/discover/context_awareness/_framework.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/_framework.ts
@@ -61,7 +61,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('data view mode', () => {
       describe('custom context', () => {
         it('should render formatted record in doc viewer using formatter from custom context', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await discover.waitUntilSearchingHasFinished();

--- a/src/platform/test/functional/apps/discover/context_awareness/_profile_state.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/_profile_state.ts
@@ -226,7 +226,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     {
       name: 'classic',
       loadDefaultProfile: async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await discover.waitUntilTabIsLoaded();

--- a/src/platform/test/functional/apps/discover/context_awareness/_telemetry.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/_telemetry.ts
@@ -48,7 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should set EBT context for telemetry events with default profile', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await discover.waitUntilSearchingHasFinished();
         await monacoEditor.setCodeEditorValue('from my-example-* | sort @timestamp desc');
@@ -68,7 +68,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should set EBT context for telemetry events when example profile and reset', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await discover.waitUntilSearchingHasFinished();
         await monacoEditor.setCodeEditorValue('from my-example-logs | sort @timestamp desc');
@@ -142,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should send EBT events when a different data source profile gets resolved', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await discover.waitUntilSearchingHasFinished();
         await monacoEditor.setCodeEditorValue('from my-example-logs | sort @timestamp desc');
@@ -196,7 +196,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should send EBT events when a different document profile gets resolved', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await monacoEditor.setCodeEditorValue('from my-example-* | sort @timestamp desc');
         await testSubjects.click('querySubmitButton');
@@ -225,7 +225,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('field usage events', () => {
       beforeEach(async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await header.waitUntilLoadingHasFinished();
         await discover.waitUntilSearchingHasFinished();
       });
@@ -509,7 +509,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('trackTabs telemetry', () => {
       beforeEach(async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.waitUntilTabIsLoaded();
         await ebtUIHelper.setOptIn(true);
       });

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_additional_cell_actions.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_additional_cell_actions.ts
@@ -119,7 +119,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render additional cell actions for logs data source', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -149,7 +149,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render incompatible cell action for message column', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -165,7 +165,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render cell actions for incompatible data source', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-metrics');

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_cell_renderers.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_cell_renderers.ts
@@ -87,7 +87,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('data view mode', () => {
       describe('root profile', () => {
         it('should render custom @timestamp', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await dataViews.switchTo('my-example-*');
@@ -101,7 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       describe('data source profile', () => {
         it('should render custom @timestamp but not custom log.level', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await dataViews.switchTo('my-example-*');
@@ -117,7 +117,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it('should render custom @timestamp and custom log.level', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await dataViews.switchTo('my-example-logs');

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_default_ad_hoc_data_views.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_default_ad_hoc_data_views.ts
@@ -13,11 +13,7 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const { common, discover, unifiedFieldList } = getPageObjects([
-    'common',
-    'discover',
-    'unifiedFieldList',
-  ]);
+  const { discover, unifiedFieldList } = getPageObjects(['discover', 'unifiedFieldList']);
   const testSubjects = getService('testSubjects');
   const dataViews = getService('dataViews');
   const dataGrid = getService('dataGrid');
@@ -32,7 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should show the profile data view', async () => {
-      await common.navigateToActualUrl('discover', undefined, {
+      await discover.navigateToActualUrl('classic', undefined, {
         ensureCurrentUrl: false,
       });
       expect(await dataViews.getSelectedName()).not.to.be('Example profile data view');
@@ -101,7 +97,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await kibanaServer.importExport.unload(
           'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
         );
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         expect(await dataViews.getSelectedName()).to.be('Example profile data view');
@@ -124,7 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await esArchiver.unload(
           'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
         );
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         expect(await testSubjects.exists('kbnNoDataPage')).to.be(true);

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_default_app_state.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_default_app_state.ts
@@ -144,7 +144,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render default state', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await header.waitUntilLoadingHasFinished();
@@ -160,7 +160,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render default state when switching data views', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await header.waitUntilLoadingHasFinished();
@@ -183,7 +183,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should reset default state when clicking "New"', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await header.waitUntilLoadingHasFinished();
@@ -211,7 +211,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await kibanaServer.uiSettings.update({
           defaultColumns: ['bad_column', 'data_stream.type', 'message'],
         });
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await header.waitUntilLoadingHasFinished();

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_doc_viewer.ts
@@ -164,7 +164,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should not render custom doc viewer view', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-*');
@@ -178,7 +178,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render custom doc viewer view', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -194,7 +194,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render custom doc viewer header', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -207,7 +207,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render custom doc viewer footer', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -220,7 +220,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render restorable state doc viewer and preserve counter state in data view mode', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_pagination_config.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_pagination_config.ts
@@ -62,7 +62,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render single page pagination without page numbers', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs,logstash*');
@@ -73,7 +73,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render default pagination with page numbers', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.createFromSearchBar({

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_recommended_fields.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_recommended_fields.ts
@@ -64,7 +64,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should show recommended fields section for matching profile', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await header.waitUntilLoadingHasFinished();
@@ -89,7 +89,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not show recommended fields for non-matching profile', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await header.waitUntilLoadingHasFinished();

--- a/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_row_additional_leading_controls.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/extensions/_get_row_additional_leading_controls.ts
@@ -58,7 +58,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render logs controls for logs data source', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await unifiedTabs.closeTabPreviewWithEsc();
         await dataViews.switchTo('my-example-logs');
         await discover.waitUntilSearchingHasFinished();
@@ -78,7 +78,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render logs controls for non-logs data source', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await unifiedTabs.closeTabPreviewWithEsc();
         await dataViews.switchTo('my-example-metrics');
         await discover.waitUntilSearchingHasFinished();

--- a/src/platform/test/functional/apps/discover/context_awareness/index.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/index.ts
@@ -9,10 +9,9 @@
 
 import type { FtrProviderContext } from '../ftr_provider_context';
 
-export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
+export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const { discover } = getPageObjects(['discover']);
 
   const from = '2024-06-10T14:00:00.000Z';
   const to = '2024-06-10T16:30:00.000Z';
@@ -31,10 +30,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await kibanaServer.uiSettings.update({
         'timepicker:timeDefaults': `{ "from": "${from}", "to": "${to}"}`,
       });
-    });
-
-    beforeEach(async () => {
-      await discover.setQueryMode('classic', 'esql');
     });
 
     loadTestFile(require.resolve('./_framework'));

--- a/src/platform/test/functional/apps/discover/esql_2/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql_2/_esql_view.ts
@@ -97,8 +97,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render esql view correctly', async function () {
-        await discover.setQueryMode('classic', 'esql');
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
 

--- a/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
+++ b/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
@@ -19,12 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const filterBar = getService('filterBar');
   const retry = getService('retry');
-  const { common, discover, header, timePicker } = getPageObjects([
-    'common',
-    'discover',
-    'header',
-    'timePicker',
-  ]);
+  const { discover, header, timePicker } = getPageObjects(['discover', 'header', 'timePicker']);
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
@@ -110,14 +105,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     beforeEach(async function () {
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await kibanaServer.uiSettings.update(defaultSettings);
-      await discover.setQueryMode('classic', 'esql');
-      await common.navigateToApp('discover');
+      // A non-empty `_a` bypasses the persisted-query-mode check (which requires
+      // localStorage, unavailable on a brand new session's `data:` origin) and
+      // lands on the classic default query, same as `navigateToApp('classic')`.
+      await discover.navigateToActualUrl(undefined, '_a=(columns:!())');
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();
-    });
-
-    afterEach(async function () {
-      await discover.resetQueryMode();
     });
 
     it('should show histogram by default', async () => {

--- a/src/platform/test/functional/apps/management/group2/_scripted_fields.ts
+++ b/src/platform/test/functional/apps/management/group2/_scripted_fields.ts
@@ -51,7 +51,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
       await kibanaServer.uiSettings.replace({});
-      await PageObjects.discover.setQueryMode('classic', 'esql');
       // Navigate once to capture the actual data view ID (importExport may assign a new UUID).
       await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickKibanaIndexPatterns();
@@ -143,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it('should see scripted field value in Discover', async function () {
-          await PageObjects.common.navigateToApp('discover');
+          await PageObjects.discover.navigateToApp('classic');
 
           await retry.try(async function () {
             await PageObjects.unifiedFieldList.clickFieldListItemAdd(scriptedPainlessFieldName);
@@ -245,7 +244,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should see scripted field value in Discover', async function () {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
 
         await retry.try(async function () {
           await PageObjects.unifiedFieldList.clickFieldListItemAdd(scriptedPainlessFieldName2);
@@ -346,7 +345,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should see scripted field value in Discover', async function () {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
 
         await retry.try(async function () {
           await PageObjects.unifiedFieldList.clickFieldListItemAdd(scriptedPainlessFieldName2);
@@ -440,7 +439,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should see scripted field value in Discover', async function () {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
 
         await retry.try(async function () {
           await PageObjects.unifiedFieldList.clickFieldListItemAdd(scriptedPainlessFieldName2);

--- a/src/platform/test/functional/apps/management/group3/_handle_alias.ts
+++ b/src/platform/test/functional/apps/management/group3/_handle_alias.ts
@@ -45,7 +45,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should be able to discover and verify no of hits for alias1', async function () {
       const expectedHitCount = '4';
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await retry.try(async function () {
         expect(await PageObjects.discover.getHitCount()).to.be(expectedHitCount);
       });
@@ -65,7 +65,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should be able to discover and verify no of hits for alias2', async function () {
         const expectedHitCount = '5';
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.discover.selectIndexPattern('alias2*');
 
         await retry.waitForWithTimeout('expected hit count to be 5', 30000, async () => {

--- a/src/platform/test/functional/apps/visualize/group3/_linked_saved_searches.ts
+++ b/src/platform/test/functional/apps/visualize/group3/_linked_saved_searches.ts
@@ -33,7 +33,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       before(async () => {
         await visualize.initTests();
         await timePicker.setDefaultAbsoluteRangeViaUiSettings();
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await filterBar.addFilter({ field: 'extension.raw', operation: 'is', value: 'jpg' });
         await header.waitUntilLoadingHasFinished();
         await discover.saveSearch(savedSearchName);

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -41,8 +41,30 @@ export class DiscoverPageObject extends FtrService {
 
   public readonly APP_ID = 'discover';
 
-  public async navigateToApp() {
+  /**
+   * Navigates to Discover, optionally pinning the query mode (classic vs ES|QL)
+   * for this load.
+   */
+  public async navigateToApp(queryMode?: string) {
+    if (queryMode) {
+      await this.setQueryMode(queryMode, 'esql');
+    }
     await this.common.navigateToApp(this.APP_ID);
+  }
+
+  /**
+   * Navigates to Discover via an explicit rison-encoded app-state URL (e.g. to seed
+   * ES|QL query state directly), optionally pinning the query mode for this load.
+   */
+  public async navigateToActualUrl(
+    queryMode: string | undefined,
+    hash?: string,
+    options?: { basePath?: string; ensureCurrentUrl?: boolean; shouldLoginIfPrompted?: boolean }
+  ) {
+    if (queryMode) {
+      await this.setQueryMode(queryMode, 'esql');
+    }
+    await this.common.navigateToActualUrl(this.APP_ID, hash, options);
   }
 
   /** Ensures that navigation to discover has completed */

--- a/src/platform/test/plugin_functional/test_suites/data_plugin/session.ts
+++ b/src/platform/test/plugin_functional/test_suites/data_plugin/session.ts
@@ -50,7 +50,7 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
   describe('Session management', function describeSessionManagementTests() {
     describe('Discover', () => {
       before(async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.waitUntilTabIsLoaded();
         await discover.selectIndexPattern('All logs');
         await discover.waitUntilTabIsLoaded();

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/common/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/common/ui/fixtures/page_objects/index.ts
@@ -66,7 +66,7 @@ export const extendPageObjects = (
     episodeDetails: createLazyPageObject(EpisodeDetailsPage, page, kbnUrl),
     executionHistory: createLazyPageObject(ExecutionHistoryPage, page, kbnUrl),
     ruleBuilder: createLazyPageObject(RuleBuilderPage, page),
-    ruleForm: createLazyPageObject(RuleFormPage, page, discoverAppMenu),
+    ruleForm: createLazyPageObject(RuleFormPage, page, discoverAppMenu, pageObjects.discover),
     rulesList: createLazyPageObject(RulesListPage, page),
     thresholdBuilder: createLazyPageObject(ThresholdBuilderPage, page),
   };

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/common/ui/fixtures/page_objects/rule_form_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/common/ui/fixtures/page_objects/rule_form_page.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Locator, ScoutPage } from '@kbn/scout';
+import type { DiscoverApp, Locator, ScoutPage } from '@kbn/scout';
 import { KibanaCodeEditorWrapper } from '@kbn/scout';
 import type { DiscoverAppMenu } from './discover_app_menu';
 
@@ -30,7 +30,11 @@ export class RuleFormPage {
 
   private readonly codeEditor: KibanaCodeEditorWrapper;
 
-  constructor(private readonly page: ScoutPage, private readonly discoverAppMenu: DiscoverAppMenu) {
+  constructor(
+    private readonly page: ScoutPage,
+    private readonly discoverAppMenu: DiscoverAppMenu,
+    private readonly discover: DiscoverApp
+  ) {
     this.codeEditor = new KibanaCodeEditorWrapper(page);
 
     this.nameInput = this.page.testSubj.locator('ruleNameInput');
@@ -60,7 +64,7 @@ export class RuleFormPage {
   }
 
   async gotoDiscover() {
-    await this.page.gotoApp('discover');
+    await this.discover.goto({ queryMode: 'classic' });
   }
 
   /**

--- a/x-pack/platform/test/functional/apps/discover/group1/reporting.ts
+++ b/x-pack/platform/test/functional/apps/discover/group1/reporting.ts
@@ -25,9 +25,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const browser = getService('browser');
   const retry = getService('retry');
-  const { reporting, common, discover, timePicker, exports } = getPageObjects([
+  const { reporting, discover, timePicker, exports } = getPageObjects([
     'reporting',
-    'common',
     'discover',
     'timePicker',
     'share',
@@ -151,8 +150,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       before(async () => {
         await esArchiver.emptyKibanaIndex();
         await reportingAPI.initEcommerce();
-        await discover.setQueryMode('classic', 'esql');
-        await common.navigateToApp('discover');
+        // A non-empty `_a` bypasses the persisted-query-mode check (which requires
+        // localStorage, unavailable on a brand new session's `data:` origin) and
+        // lands on the classic default query, same as `navigateToApp('classic')`.
+        // This is the first Discover navigation in the config, so no other page
+        // has been loaded yet to establish a real origin.
+        await discover.navigateToActualUrl(undefined, '_a=(columns:!())');
         await discover.waitUntilTabIsLoaded();
         await discover.selectIndexPattern('ecommerce');
         await discover.waitUntilTabIsLoaded();
@@ -201,8 +204,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       beforeEach(async () => {
-        await discover.setQueryMode('classic', 'esql');
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.waitUntilTabIsLoaded();
         await discover.selectIndexPattern('ecommerce');
         await discover.waitUntilTabIsLoaded();
@@ -390,8 +392,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           dateSubstractUnit: 'days',
         });
         await reportingAPI.initLogs();
-        await discover.setQueryMode('classic', 'esql');
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.waitUntilTabIsLoaded();
         await discover.loadSavedSearch('Sparse Columns');
         await discover.waitUntilTabIsLoaded();
@@ -437,8 +438,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       before(async () => {
         await reportingAPI.initEcommerce();
-        await discover.setQueryMode('classic', 'esql');
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.waitUntilTabIsLoaded();
         await discover.selectIndexPattern('ecommerce');
         await discover.waitUntilTabIsLoaded();

--- a/x-pack/platform/test/functional/apps/discover/group1/reporting_embeddable.ts
+++ b/x-pack/platform/test/functional/apps/discover/group1/reporting_embeddable.ts
@@ -18,16 +18,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const retry = getService('retry');
-  const { reporting, common, discover, timePicker, header, dashboard, unifiedFieldList } =
-    getPageObjects([
-      'reporting',
-      'common',
-      'discover',
-      'timePicker',
-      'header',
-      'dashboard',
-      'unifiedFieldList',
-    ]);
+  const { reporting, discover, timePicker, header, dashboard, unifiedFieldList } = getPageObjects([
+    'reporting',
+    'discover',
+    'timePicker',
+    'header',
+    'dashboard',
+    'unifiedFieldList',
+  ]);
   const monacoEditor = getService('monacoEditor');
   const queryBar = getService('queryBar');
   const testSubjects = getService('testSubjects');
@@ -113,8 +111,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/kbn_archiver/discover'
       );
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
-      await discover.setQueryMode('classic', 'esql');
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();
       await discover.selectIndexPattern('logstash-*');

--- a/x-pack/platform/test/functional/apps/discover/group3/esql_starred.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/esql_starred.ts
@@ -11,8 +11,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const monacoEditor = getService('monacoEditor');
-  const { common, discover, header, unifiedFieldList, security } = getPageObjects([
-    'common',
+  const { discover, header, unifiedFieldList, security } = getPageObjects([
     'discover',
     'header',
     'unifiedFieldList',
@@ -73,7 +72,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should star a query from the editor query history', async () => {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await discover.selectTextBaseLang();
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();
@@ -104,7 +103,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should select a query from the starred and submit it', async () => {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await discover.selectTextBaseLang();
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();
@@ -121,7 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should delete a query from the starred queries tab', async () => {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await discover.selectTextBaseLang();
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();

--- a/x-pack/platform/test/functional/apps/discover/group3/rule_creation.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/rule_creation.ts
@@ -11,7 +11,7 @@ import { openDiscoverSearchThresholdRuleFlyout } from '../open_search_threshold_
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('Discover rule creation', function () {
-    const { common } = getPageObjects(['common', 'settings', 'shareSavedObjectsToSpace']);
+    const { discover } = getPageObjects(['discover', 'settings', 'shareSavedObjectsToSpace']);
     const testSubjects = getService('testSubjects');
     const retry = getService('retry');
     const esArchiver = getService('esArchiver');
@@ -29,7 +29,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('navigate to Discover', () => {
-      return common.navigateToApp('discover');
+      return discover.navigateToApp('classic');
     });
 
     it('begin creating rule', async () => {

--- a/x-pack/platform/test/functional/apps/discover/group3/saved_queries.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/saved_queries.ts
@@ -12,8 +12,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const spaces = getService('spaces');
-  const { common, settings, shareSavedObjectsToSpace } = getPageObjects([
+  const { common, discover, settings, shareSavedObjectsToSpace } = getPageObjects([
     'common',
+    'discover',
     'settings',
     'shareSavedObjectsToSpace',
   ]);
@@ -48,8 +49,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('Manage saved queries', () => {
       it('delete saved query shared in multiple spaces', async () => {
-        // Navigate to Discover & create a saved query
-        await common.navigateToApp('discover');
+        // Navigate to Discover & create a saved query. A non-empty `_a` bypasses
+        // the persisted-query-mode check (which requires localStorage, unavailable
+        // on a brand new session's `data:` origin) and lands on the classic default
+        // query, same as `navigateToApp('classic')`. This is the first Discover
+        // navigation in the config, so no other page has established an origin yet.
+        await discover.navigateToActualUrl(undefined, '_a=(columns:!())');
         await queryBar.setQuery('response:200');
         await queryBar.submitQuery();
         await savedQueryManagementComponent.saveNewQuery(savedQueryName, '', true, false);
@@ -66,7 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await shareSavedObjectsToSpace.saveShare();
 
         // Navigate back to Discover and delete the query
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await savedQueryManagementComponent.deleteSavedQuery(savedQueryName);
 
         // Refresh to ensure the object is actually deleted
@@ -78,7 +83,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const name = `${savedQueryName}-update`;
 
         // Navigate to Discover & create a saved query
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await queryBar.setQuery('response:200');
         await queryBar.submitQuery();
         await savedQueryManagementComponent.saveNewQuery(name, '', true, false);
@@ -91,7 +96,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await savedQueryManagementComponent.updateCurrentlyLoadedQuery('', true, false);
 
         // Navigate to Discover ensure updated query exists
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await savedQueryManagementComponent.savedQueryExistOrFail(name);
         await savedQueryManagementComponent.closeSavedQueryManagementComponent();
         await savedQueryManagementComponent.deleteSavedQuery(name);

--- a/x-pack/platform/test/functional/apps/discover/group3/saved_searches.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/saved_searches.ts
@@ -77,7 +77,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it(`should unselect saved search when navigating to a 'new'`, async function () {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await discover.selectIndexPattern('ecommerce');
       await filterBar.addFilter({ field: 'category', operation: 'is', value: `Men's Shoes` });
       await queryBar.setQuery('customer_gender:MALE');

--- a/x-pack/platform/test/functional/apps/discover/group3/value_suggestions.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/value_suggestions.ts
@@ -14,8 +14,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const queryBar = getService('queryBar');
   const filterBar = getService('filterBar');
   const dataGrid = getService('dataGrid');
-  const { common, timePicker, settings, context } = getPageObjects([
+  const { common, discover, timePicker, settings, context } = getPageObjects([
     'common',
+    'discover',
     'timePicker',
     'settings',
     'context',
@@ -51,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       beforeEach(async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
       });
 
       describe('discover', () => {
@@ -109,7 +110,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       beforeEach(async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
       });
 
       afterEach(async () => {

--- a/x-pack/platform/test/functional/apps/discover/group3/value_suggestions_non_timebased.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/value_suggestions_non_timebased.ts
@@ -11,7 +11,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const queryBar = getService('queryBar');
-  const { common } = getPageObjects(['common']);
+  const { discover } = getPageObjects(['discover']);
 
   describe('value suggestions non time based', function describeIndexTests() {
     before(async function () {
@@ -34,7 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('shows all autosuggest options for a filter in discover context app', async () => {
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await queryBar.setQuery('type.keyword : ');
       await queryBar.expectSuggestions({ count: 1, contains: '"apache"' });
     });

--- a/x-pack/platform/test/functional/apps/discover/group3/visualize_field.ts
+++ b/x-pack/platform/test/functional/apps/discover/group3/visualize_field.ts
@@ -19,8 +19,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const retry = getService('retry');
   const kibanaServer = getService('kibanaServer');
   const dataViews = getService('dataViews');
-  const { common, discover, timePicker, lens, header, unifiedFieldList } = getPageObjects([
-    'common',
+  const { discover, timePicker, lens, header, unifiedFieldList } = getPageObjects([
     'discover',
     'timePicker',
     'lens',
@@ -61,8 +60,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await discover.setQueryMode('classic', 'esql');
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
       await header.waitUntilLoadingHasFinished();
       await discover.waitUntilSearchingHasFinished();
       await setDiscoverTimeRange();

--- a/x-pack/platform/test/functional/apps/maps/group4/discover.js
+++ b/x-pack/platform/test/functional/apps/maps/group4/discover.js
@@ -35,8 +35,7 @@ export default function ({ getService, getPageObjects }) {
         'global_visualize_read',
       ]);
       await common.setTime({ from, to });
-      await discover.setQueryMode('classic', 'esql');
-      await common.navigateToApp('discover');
+      await discover.navigateToApp('classic');
     });
 
     after(async () => {

--- a/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/search_source_alert.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/search_source_alert.ts
@@ -228,7 +228,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   const openAlertResults = async (value: string, type: 'id' | 'name' = 'name') => {
-    await PageObjects.common.navigateToApp('discover');
+    await PageObjects.discover.navigateToApp('classic');
     await PageObjects.header.waitUntilLoadingHasFinished();
     await PageObjects.discover.clickNewSearchButton(); // reset params
 
@@ -355,7 +355,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('Search source Alert', () => {
     before(async () => {
       await security.testUser.setRoles(['discover_alert']);
-      await PageObjects.discover.setQueryMode('classic', 'esql');
 
       log.debug('create source indices');
       await createSourceIndex();
@@ -420,7 +419,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should show time field validation error', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await dataViews.switchToAndValidate(SOURCE_DATA_VIEW);
       await PageObjects.timePicker.setCommonlyUsedTime('Last_15 minutes');
@@ -574,7 +573,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should navigate to alert results via link provided in notification using adhoc data view', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await dataViews.createFromSearchBar({
         name: 'search-source-',

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/_framework.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/_framework.ts
@@ -67,7 +67,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('data view mode', () => {
       describe('custom context', () => {
         it('should render formatted record in doc viewer using formatter from custom context', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await discover.waitUntilSearchingHasFinished();

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_additional_cell_actions.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_additional_cell_actions.ts
@@ -122,7 +122,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render additional cell actions for logs data source', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -152,7 +152,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render incompatible cell action for message column', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');
@@ -168,7 +168,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render cell actions for incompatible data source', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-metrics');

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_cell_renderers.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_cell_renderers.ts
@@ -84,7 +84,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('data view mode', () => {
       describe('root profile', () => {
         it('should not render custom @timestamp', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await dataViews.switchTo('my-example-*');
@@ -96,7 +96,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       describe('data source profile', () => {
         it('should not render custom @timestamp or log.level', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await dataViews.switchTo('my-example-*');
@@ -110,7 +110,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it('should not render custom @timestamp but should render custom log.level', async () => {
-          await common.navigateToActualUrl('discover', undefined, {
+          await discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await dataViews.switchTo('my-example-logs');

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_default_ad_hoc_data_views.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_default_ad_hoc_data_views.ts
@@ -11,8 +11,7 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const { common, discover, unifiedFieldList, svlCommonPage } = getPageObjects([
-    'common',
+  const { discover, unifiedFieldList, svlCommonPage } = getPageObjects([
     'discover',
     'unifiedFieldList',
     'svlCommonPage',
@@ -35,7 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should show the profile data view', async () => {
-      await common.navigateToActualUrl('discover', undefined, {
+      await discover.navigateToActualUrl('classic', undefined, {
         ensureCurrentUrl: false,
       });
       expect(await dataViews.getSelectedName()).not.to.be('Example profile data view');
@@ -102,7 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await kibanaServer.importExport.unload(
           'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
         );
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         expect(await dataViews.getSelectedName()).to.be('Example profile data view');
@@ -121,7 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await esArchiver.unload(
           'src/platform/test/functional/fixtures/es_archiver/discover/context_awareness'
         );
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         expect(await testSubjects.exists('kbnNoDataPage')).to.be(true);

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_default_app_state.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_default_app_state.ts
@@ -147,7 +147,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render default state', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.header.waitUntilLoadingHasFinished();
@@ -163,7 +163,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render default state when switching data views', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.header.waitUntilLoadingHasFinished();
@@ -186,7 +186,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should reset default state when clicking "New"', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.header.waitUntilLoadingHasFinished();
@@ -215,7 +215,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await kibanaServer.uiSettings.update({
           defaultColumns: ['bad_column', 'data_stream.type', 'message'],
         });
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.header.waitUntilLoadingHasFinished();

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_doc_viewer.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_doc_viewer.ts
@@ -100,7 +100,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should not render custom doc viewer view', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-*');
@@ -113,7 +113,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render custom doc viewer view', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs');

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_pagination_config.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_pagination_config.ts
@@ -73,7 +73,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render single page pagination without page numbers', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs,logstash*');
@@ -84,7 +84,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render default pagination with page numbers', async () => {
-        await common.navigateToActualUrl('discover', undefined, {
+        await discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
 

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_recommended_fields.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_recommended_fields.ts
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should show recommended fields section for matching profile', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await header.waitUntilLoadingHasFinished();
         await discover.waitUntilSearchingHasFinished();
         await dataViews.switchToAndValidate('my-example-logs');
@@ -94,7 +94,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not show recommended fields for non-matching profile', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await header.waitUntilLoadingHasFinished();
         await discover.waitUntilSearchingHasFinished();
         await dataViews.switchToAndValidate('my-example-*');

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_row_additional_leading_controls.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/extensions/_get_row_additional_leading_controls.ts
@@ -51,7 +51,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render logs controls for logs data source', async () => {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await dataViews.switchTo('my-example-logs');
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await testSubjects.existOrFail('exampleLogsControl_chartBarVerticalStack');
@@ -70,7 +70,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render logs controls for non-logs data source', async () => {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await dataViews.switchTo('my-example-metrics');
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await testSubjects.missingOrFail('exampleLogsControl_chartBarVerticalStack');

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/index.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/context_awareness/index.ts
@@ -10,7 +10,7 @@ import type { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage', 'discover']);
+  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage']);
   const from = '2024-06-10T14:00:00.000Z';
   const to = '2024-06-10T16:30:00.000Z';
 
@@ -37,10 +37,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
         'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
       );
       await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-    });
-
-    beforeEach(async () => {
-      await PageObjects.discover.setQueryMode('classic', 'esql');
     });
 
     loadTestFile(require.resolve('./_framework'));

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/embeddable/_saved_search_embeddable.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/embeddable/_saved_search_embeddable.ts
@@ -83,7 +83,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     const createNonLogsSavedSearch = async () => {
-      await common.navigateToActualUrl('discover', undefined, {
+      await discover.navigateToActualUrl('classic', undefined, {
         ensureCurrentUrl: false,
       });
       await dataViews.createFromSearchBar({

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
@@ -79,8 +79,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render esql view correctly', async function () {
-        await PageObjects.discover.setQueryMode('classic', 'esql');
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
@@ -333,8 +332,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('inspector', () => {
       beforeEach(async () => {
-        await PageObjects.discover.setQueryMode('classic', 'esql');
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         await PageObjects.discover.waitUntilTabIsLoaded();
@@ -363,8 +361,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('query history', () => {
       beforeEach(async () => {
-        await PageObjects.discover.setQueryMode('classic', 'esql');
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         await PageObjects.discover.waitUntilTabIsLoaded();

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group1/_discover.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group1/_discover.ts
@@ -45,7 +45,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
       await kibanaServer.uiSettings.replace(defaultSettings);
       await PageObjects.svlCommonPage.loginWithPrivilegedRole();
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.timePicker.setDefaultAbsoluteRange();
     });
     after(async () => {
@@ -217,7 +217,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('time zone switch', () => {
       it('should show bars in the correct time zone after switching', async function () {
         await kibanaServer.uiSettings.update({ 'dateFormat:tz': 'America/Phoenix' });
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.header.awaitKibanaChrome();
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.timePicker.setDefaultAbsoluteRange();
@@ -253,7 +253,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('managing fields', function () {
       it('should add a field, sort by it, remove it and also sorting by it', async function () {
         await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.clickFieldListItemAdd('_score');
         await PageObjects.discover.waitUntilTabIsLoaded();
@@ -268,7 +268,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       it('should add a field with customLabel, sort by it, display it correctly', async function () {
         await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.clickFieldListItemAdd('referer');
         await PageObjects.discover.waitUntilTabIsLoaded();

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group1/_discover_histogram.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group1/_discover_histogram.ts
@@ -52,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.uiSettings.replace(defaultSettings);
       await PageObjects.svlCommonPage.loginAsAdmin();
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
     });
     after(async () => {
       await esArchiver.unload(
@@ -65,7 +65,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     async function prepareTest(time: TimeStrings, interval?: string) {
       await PageObjects.common.setTime(time);
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       if (interval) {
         await PageObjects.discover.setChartInterval(interval);
@@ -74,7 +74,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     }
 
     it('should modify the time range when the histogram is brushed', async function () {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await elasticChart.waitForRenderComplete();
       let prevRowData = '';
@@ -101,7 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should update correctly when switching data views and brushing the histogram', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await PageObjects.discover.selectIndexPattern('logstash-*');
       await PageObjects.discover.waitUntilSearchingHasFinished();
@@ -118,7 +118,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.uiSettings.update({
         'timepicker:timeDefaults': '{  "from": "2015-09-18T19:37:13.000Z",  "to": "now"}',
       });
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.header.awaitKibanaChrome();
       const initialTimeString = await PageObjects.discover.getChartTimespan();
       await queryBar.clickQuerySubmitButton();
@@ -263,7 +263,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.header.waitUntilLoadingHasFinished();
 
       // go to discover
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.header.waitUntilLoadingHasFinished();
       canvasExists = await elasticChart.canvasExists();
       expect(canvasExists).to.be(true);
@@ -277,7 +277,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should recover from broken query search when clearing the query bar', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       // Make sure the chart is visible
       await PageObjects.discover.toggleChartVisibility();
@@ -297,7 +297,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should reset all histogram state when resetting the saved search', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await PageObjects.timePicker.setDefaultAbsoluteRange();

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group2/_data_grid_doc_navigation.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group2/_data_grid_doc_navigation.ts
@@ -42,7 +42,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     beforeEach(async function () {
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await kibanaServer.uiSettings.update(defaultSettings);
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
     });
 
     it('should open the doc view of the selected document', async function () {

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/x_pack_visualize_field/visualize_field.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/x_pack_visualize_field/visualize_field.ts
@@ -19,7 +19,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const dataViews = getService('dataViews');
   const PageObjects = getPageObjects([
-    'common',
     'svlCommonPage',
     'discover',
     'timePicker',
@@ -50,8 +49,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await PageObjects.discover.setQueryMode('classic', 'esql');
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await setDiscoverTimeRange();

--- a/x-pack/platform/test/serverless/functional/test_suites/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover_ml_uptime/discover/search_source_alert.ts
@@ -267,7 +267,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   const openAlertResults = async (value: string, type: 'id' | 'name' = 'name') => {
-    await PageObjects.common.navigateToApp('discover');
+    await PageObjects.discover.navigateToApp('classic');
     await PageObjects.header.waitUntilLoadingHasFinished();
     await PageObjects.discover.clickNewSearchButton(); // reset params
     await dataViews.switchToAndValidate(OUTPUT_DATA_VIEW);
@@ -402,7 +402,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await security.testUser.setRoles(['discover_alert']);
       await PageObjects.svlCommonPage.loginAsAdmin();
-      await PageObjects.discover.setQueryMode('classic', 'esql');
 
       log.debug('create source indices');
       await createSourceIndex();
@@ -456,7 +455,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should show time field validation error', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await dataViews.switchToAndValidate(SOURCE_DATA_VIEW);
       await PageObjects.timePicker.setCommonlyUsedTime('Last_15 minutes');
@@ -601,7 +600,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should navigate to alert results via link provided in notification using adhoc data view', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await dataViews.createFromSearchBar({
         name: 'search-source-',

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_cell_renderers.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_cell_renderers.ts
@@ -181,7 +181,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('data view mode', () => {
       describe('Log Level Badge Cell', () => {
         it('should render log.level badge cell', async () => {
-          await PageObjects.common.navigateToActualUrl('discover', undefined, {
+          await PageObjects.discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await PageObjects.header.waitUntilLoadingHasFinished();
@@ -226,7 +226,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it("should not render log.level badge cell if it's not a logs data source", async () => {
-          await PageObjects.common.navigateToActualUrl('discover', undefined, {
+          await PageObjects.discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await PageObjects.header.waitUntilLoadingHasFinished();
@@ -265,7 +265,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       describe('Service Name Cell', () => {
         it('should render service.name cell', async () => {
-          await PageObjects.common.navigateToActualUrl('discover', undefined, {
+          await PageObjects.discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await PageObjects.header.waitUntilLoadingHasFinished();
@@ -297,7 +297,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it("should not render service.name cell if it's not a logs data source", async () => {
-          await PageObjects.common.navigateToActualUrl('discover', undefined, {
+          await PageObjects.discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await PageObjects.header.waitUntilLoadingHasFinished();
@@ -327,7 +327,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       describe('Summary column', () => {
         it('should render a summary of the log entry replacing the original document', async () => {
-          await PageObjects.common.navigateToActualUrl('discover', undefined, {
+          await PageObjects.discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await PageObjects.header.waitUntilLoadingHasFinished();
@@ -340,7 +340,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it('should NOT render the summary column if the source does not match logs', async () => {
-          await PageObjects.common.navigateToActualUrl('discover', undefined, {
+          await PageObjects.discover.navigateToActualUrl('classic', undefined, {
             ensureCurrentUrl: false,
           });
           await PageObjects.header.waitUntilLoadingHasFinished();

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_doc_viewer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_doc_viewer.ts
@@ -54,7 +54,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should render logs overview tab for logs data source', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.discover.waitUntilTabIsLoaded();
@@ -94,7 +94,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not render logs overview tab for non-logs data source', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.discover.waitUntilTabIsLoaded();

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_pagination_config.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_pagination_config.ts
@@ -72,7 +72,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('data view mode', () => {
       it('should render default pagination with page numbers', async () => {
         const defaultPageLimit = 500;
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await dataViews.switchTo('my-example-logs,logstash*');

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_recommended_fields.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_recommended_fields.ts
@@ -60,7 +60,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('data view mode', () => {
       it('should show recommended fields section for matching profile', async () => {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataViews.switchToAndValidate('my-example-logs');
@@ -69,7 +69,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should not show recommended fields for non-matching profile', async () => {
-        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.navigateToApp('classic');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataViews.switchToAndValidate('my-example-*');

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_row_indicator_provider.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/_get_row_indicator_provider.ts
@@ -99,7 +99,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should render log.level row indicators on Surrounding documents page', async () => {
-      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.navigateToApp('classic');
       await dataViews.switchTo('my-example-logs,logstash*');
       await PageObjects.discover.waitUntilSearchingHasFinished();
       await dataGrid.clickRowToggle({ rowIndex: 0 });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/index.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/index.ts
@@ -10,7 +10,7 @@ import type { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage', 'discover']);
+  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage']);
   const from = '2024-06-10T14:00:00.000Z';
   const to = '2024-06-10T16:30:00.000Z';
 
@@ -37,10 +37,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
         'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
       );
       await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-    });
-
-    beforeEach(async () => {
-      await PageObjects.discover.setQueryMode('classic', 'esql');
     });
 
     loadTestFile(require.resolve('./_get_row_indicator_provider'));

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/telemetry/_telemetry.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/telemetry/_telemetry.ts
@@ -49,7 +49,7 @@ export default function ({ getService, getPageObjects }: ObservabilityTelemetryF
       });
 
       it('should set EBT context for telemetry events with o11y root profile', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await discover.waitUntilTabIsLoaded();
         await monacoEditor.setCodeEditorValue('from my-example-* | sort @timestamp desc');
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }: ObservabilityTelemetryF
       });
 
       it('should set EBT context for telemetry events when logs data source profile and reset', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await discover.waitUntilTabIsLoaded();
         await monacoEditor.setCodeEditorValue('from my-example-logs | sort @timestamp desc');
@@ -150,7 +150,7 @@ export default function ({ getService, getPageObjects }: ObservabilityTelemetryF
       });
 
       it('should send EBT events when a different data source profile gets resolved', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await discover.waitUntilSearchingHasFinished();
         await monacoEditor.setCodeEditorValue('from my-example-logs | sort @timestamp desc');
@@ -211,7 +211,7 @@ export default function ({ getService, getPageObjects }: ObservabilityTelemetryF
       });
 
       it('should send EBT events when a different document profile gets resolved', async () => {
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await discover.selectTextBaseLang();
         await monacoEditor.setCodeEditorValue('from my-example-logs | sort @timestamp desc');
         await ebtUIHelper.setOptIn(true); // starts the recording of events from this moment
@@ -247,7 +247,7 @@ export default function ({ getService, getPageObjects }: ObservabilityTelemetryF
     describe('events', () => {
       beforeEach(async () => {
         await svlCommonPage.loginAsAdmin();
-        await common.navigateToApp('discover');
+        await discover.navigateToApp('classic');
         await header.waitUntilLoadingHasFinished();
         await discover.waitUntilSearchingHasFinished();
       });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/telemetry/index.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/context_awareness/telemetry/index.ts
@@ -14,7 +14,7 @@ export default function ({
 }: ObservabilityTelemetryFtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage', 'discover']);
+  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage']);
   const from = '2024-06-10T14:00:00.000Z';
   const to = '2024-06-10T16:30:00.000Z';
 
@@ -39,10 +39,6 @@ export default function ({
         'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
       );
       await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-    });
-
-    beforeEach(async () => {
-      await PageObjects.discover.setQueryMode('classic', 'esql');
     });
 
     loadTestFile(require.resolve('./_telemetry'));

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/landing/redirects.ts
@@ -48,6 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       ]);
 
       await PageObjects.svlCommonPage.loginWithPrivilegedRole();
+      await PageObjects.discover.setQueryMode('classic', 'esql');
       await PageObjects.common.navigateToApp('landingPage');
 
       await retry.tryForTime(60 * 1000, async () => {

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/role_management/custom_role_access.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/role_management/custom_role_access.ts
@@ -10,7 +10,13 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 import type { RoleCredentials } from '../../services';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
-  const pageObjects = getPageObjects(['svlCommonPage', 'timePicker', 'common', 'header']);
+  const pageObjects = getPageObjects([
+    'svlCommonPage',
+    'timePicker',
+    'common',
+    'header',
+    'discover',
+  ]);
   const samlAuth = getService('samlAuth');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const esArchiver = getService('esArchiver');
@@ -86,7 +92,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should access Discover app', async () => {
-      await pageObjects.common.navigateToApp('discover');
+      await pageObjects.discover.navigateToApp('classic');
       await pageObjects.timePicker.setDefaultAbsoluteRange();
       await pageObjects.header.waitUntilLoadingHasFinished();
       expect(await testSubjects.exists('unifiedHistogramChart')).to.be(true);

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/default_dataview.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/default_dataview.ts
@@ -13,6 +13,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const svlCommonNavigation = getPageObject('svlCommonNavigation');
   const svlCommonPage = getPageObject('svlCommonPage');
+  const discover = getPageObject('discover');
   const dataViewApi = getService('dataViewApi');
   const samlAuth = getService('samlAuth');
   let roleAuthc: RoleCredentials;
@@ -33,6 +34,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
     });
 
     it('should show discover but with no data', async () => {
+      await discover.setQueryMode('classic', 'esql');
       await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'discover' });
       await testSubjects.existOrFail('discover-dataView-switch-link');
       await testSubjects.click('discover-dataView-switch-link');

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
@@ -24,11 +24,13 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const retry = getService('retry');
   const esArchiver = getService('esArchiver');
   const common = getPageObject('common');
+  const discover = getPageObject('discover');
 
   describe('navigation', function () {
     before(async () => {
       await esArchiver.load(archiveEmptyIndex);
       await svlCommonPage.loginWithRole('admin');
+      await discover.setQueryMode('classic', 'esql');
       await svlSearchNavigation.navigateToElasticsearchHome();
     });
     after(async () => {

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/cell_renderer.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/cell_renderer.ts
@@ -40,7 +40,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('DataView mode', () => {
       it('should render alert workflow status badge', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
         await PageObjects.discover.selectIndexPattern(SECURITY_SOLUTION_DATA_VIEW);

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/default_state.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/default_state.ts
@@ -66,7 +66,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('DataView mode', () => {
       it('should have correct list of columns', async () => {
-        await PageObjects.common.navigateToActualUrl('discover', undefined, {
+        await PageObjects.discover.navigateToActualUrl('classic', undefined, {
           ensureCurrentUrl: false,
         });
 

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/index.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/index.ts
@@ -14,7 +14,7 @@ import { SECURITY_ES_ARCHIVES_DIR } from '../../../constants';
 export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage', 'discover']);
+  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage']);
   const detectionsApi = getService('detectionsApi');
   const retry = getService('retry');
   const es = getService('es');
@@ -83,10 +83,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
 
       await esArchiver.unload(path.join(SECURITY_ES_ARCHIVES_DIR, 'auditbeat_single'));
-    });
-
-    beforeEach(async () => {
-      await PageObjects.discover.setQueryMode('classic', 'esql');
     });
 
     loadTestFile(require.resolve('./default_state'));

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/row_indicator.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover/context_awareness/row_indicator.ts
@@ -32,7 +32,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         describe('DataView mode', () => {
           it('should have row indicator for both event and alert', async () => {
-            await PageObjects.common.navigateToActualUrl('discover', undefined, {
+            await PageObjects.discover.navigateToActualUrl('classic', undefined, {
               ensureCurrentUrl: false,
             });
             await PageObjects.discover.selectIndexPattern(SECURITY_SOLUTION_DATA_VIEW);


### PR DESCRIPTION
## Summary

**TEMP - DON'T MERGE**

Temporarily enabling ES|QL by default in Discover to see what fails in CI.