### PR TITLE
[9.4] [One Workflow][ES|QL] Integrate es|ql validation feature to elasticsearch.esql.query step (#266673)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1243,6 +1243,7 @@
     "@kbn/workflows-extensions-example": "link:examples/workflows_extensions_example",
     "@kbn/workflows-management-plugin": "link:src/platform/plugins/shared/workflows_management",
     "@kbn/workflows-ui": "link:src/platform/packages/shared/kbn-workflows-ui",
+    "@kbn/workflows-yaml": "link:src/platform/packages/shared/kbn-workflows-yaml",
     "@kbn/workplace-ai-app": "link:x-pack/solutions/workplaceai/plugins/workplace_ai_app",
     "@kbn/xstate-utils": "link:src/platform/packages/shared/kbn-xstate-utils",
     "@kbn/yaml-loader": "link:src/platform/packages/shared/kbn-yaml-loader",

--- a/src/platform/packages/shared/kbn-workflows-yaml/common/yaml/build_workflow_lookup.ts
+++ b/src/platform/packages/shared/kbn-workflows-yaml/common/yaml/build_workflow_lookup.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { YAMLMap, Scalar } from 'yaml';
+
+export interface StepPropInfo {
+  path: string[];
+  keyNode: Scalar<unknown>;
+  valueNode: Scalar<unknown>;
+}
+
+export interface StepInfo {
+  stepId: string;
+  stepType: string;
+  stepYamlNode: YAMLMap<unknown, unknown>;
+  lineStart: number;
+  lineEnd: number;
+  propInfos: Record<string, StepPropInfo>;
+  parentStepId?: string;
+}
+
+export interface WorkflowLookup {
+  steps: Record<string, StepInfo>;
+  triggersLineStart?: number;
+}

--- a/src/platform/packages/shared/kbn-workflows-yaml/index.ts
+++ b/src/platform/packages/shared/kbn-workflows-yaml/index.ts
@@ -7,8 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  WorkflowLookup,
-  StepInfo,
-  StepPropInfo,
-} from './common/yaml/build_workflow_lookup';
+export type { WorkflowLookup, StepInfo, StepPropInfo } from './common/yaml/build_workflow_lookup';

--- a/src/platform/packages/shared/kbn-workflows-yaml/index.ts
+++ b/src/platform/packages/shared/kbn-workflows-yaml/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type {
+  WorkflowLookup,
+  StepInfo,
+  StepPropInfo,
+} from './common/yaml/build_workflow_lookup';

--- a/src/platform/packages/shared/kbn-workflows-yaml/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-workflows-yaml/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/workflows-yaml",
+  "owner": ["@elastic/workflows-eng"],
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/platform/packages/shared/kbn-workflows-yaml/tsconfig.json
+++ b/src/platform/packages/shared/kbn-workflows-yaml/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "kbn_references": [],
+  "exclude": ["target/**/*"]
+}

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -19,6 +19,9 @@ project:
 dependsOn:
   - '@kbn/core'
   - '@kbn/eval-kql'
+  - '@kbn/esql-language'
+  - '@kbn/esql-types'
+  - '@kbn/esql-utils'
   - '@kbn/kibana-react-plugin'
   - '@kbn/i18n'
   - '@kbn/i18n-react'

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.perf.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.perf.test.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 // eslint-disable-next-line import/no-nodejs-modules
 import path from 'path';
 import YAML, { LineCounter } from 'yaml';
+import type { ESQLCallbacks } from '@kbn/esql-types';
 import { collectAllConnectorIds } from './collect_all_connector_ids';
 import { collectAllCustomPropertyItems } from './collect_all_custom_property_items';
 import { collectAllVariables } from './collect_all_variables';
@@ -28,8 +29,11 @@ import { validateWorkflowOutputsInYaml } from './validate_workflow_outputs_in_ya
 import { VARIABLE_REGEX_GLOBAL } from '../../../../common/lib/regex';
 import { getPropertyHandler } from '../../../../common/schema';
 import { performComputation } from '../../../entities/workflows/store/workflow_detail/utils/computation';
+import { validateEsqlSteps } from '../../../widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps';
 
 const WARMUP_ITERATIONS = 5;
+
+const stubEsqlCallbacks: ESQLCallbacks = {};
 
 interface BenchmarkConfig {
   iterations: number;
@@ -248,6 +252,10 @@ async function runE2EBenchmark(yamlContent: string, config: BenchmarkConfig) {
       start = performance.now();
       validateIfConditions(workflowLookup, lc);
       record('validateIfConditions', performance.now() - start);
+
+      start = performance.now();
+      await validateEsqlSteps(workflowLookup, lc, model, stubEsqlCallbacks);
+      record('validateEsqlSteps', performance.now() - start);
     }
 
     if (workflowGraph && workflowDefinition) {

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.test.ts
@@ -11,6 +11,21 @@ import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { monaco } from '@kbn/monaco';
+
+const mockValidateEsqlSteps = jest.fn().mockResolvedValue([]);
+
+jest.mock('../../../widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps', () => ({
+  validateEsqlSteps: (...args: unknown[]) => mockValidateEsqlSteps(...args),
+}));
+
+jest.mock(
+  '../../../widgets/workflow_yaml_editor/lib/esql_validation/use_workflow_esql_callbacks',
+  () => ({
+    useWorkflowEsqlCallbacks: () => ({}),
+  })
+);
+
+import type { WorkflowLookup } from '@kbn/workflows-yaml';
 import { useYamlValidation } from './use_yaml_validation';
 import { selectDetail } from '../../../entities/workflows/store';
 import { createWorkflowsStore } from '../../../entities/workflows/store/store';
@@ -18,9 +33,14 @@ import {
   setActiveTab,
   setYamlString,
 } from '../../../entities/workflows/store/workflow_detail/slice';
-import { createStartServicesMock } from '../../../mocks';
+import { useKibana } from '../../../hooks/use_kibana';
+import { createStartServicesMock, createUseKibanaMockValue } from '../../../mocks';
 
-jest.mock('../../../hooks/use_kibana');
+const mockKibanaValue = createUseKibanaMockValue();
+
+jest.mock('../../../hooks/use_kibana', () => ({
+  useKibana: jest.fn(() => mockKibanaValue),
+}));
 
 // Mock Monaco editor
 const createMockEditor = (value: string) => {
@@ -46,6 +66,20 @@ const createMockEditor = (value: string) => {
 // Mock Monaco setModelMarkers
 const mockSetModelMarkers = jest.fn();
 (monaco.editor as any).setModelMarkers = mockSetModelMarkers;
+
+const getBatchedMarkerCalls = () =>
+  mockSetModelMarkers.mock.calls.filter((call) => call[1] === 'custom-yaml-validation');
+
+const waitForBatchedMarkers = async () => {
+  await waitFor(() => {
+    expect(getBatchedMarkerCalls().length).toBeGreaterThan(0);
+  });
+};
+
+const getLastBatchedMarkers = (): unknown[] => {
+  const batchedCalls = getBatchedMarkerCalls();
+  return batchedCalls[batchedCalls.length - 1][2];
+};
 
 // Mock schema functions
 jest.mock('../../../../common/schema', () => ({
@@ -99,6 +133,7 @@ describe('useYamlValidation - Step Name Uniqueness', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    jest.mocked(useKibana).mockReturnValue(mockKibanaValue);
   });
 
   afterEach(() => {
@@ -147,19 +182,11 @@ steps:
       expect(result.current.error).toBeNull();
     });
 
-    // Wait for Monaco markers to be set
-    await waitFor(() => {
-      expect(mockSetModelMarkers).toHaveBeenCalled();
-    });
+    await waitForBatchedMarkers();
 
-    // All custom markers are batched under 'custom-yaml-validation';
-    // filter the last batched call's markers by source
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
+    const stepNameMarkers = getLastBatchedMarkers().filter(
+      (m: any) => m.source === 'step-name-validation'
     );
-    expect(batchedCalls.length).toBeGreaterThan(0);
-    const allMarkers = batchedCalls[batchedCalls.length - 1][2];
-    const stepNameMarkers = allMarkers.filter((m: any) => m.source === 'step-name-validation');
     expect(stepNameMarkers).toEqual([]);
   });
 
@@ -186,18 +213,12 @@ steps:
     // Fast-forward through the debounced computation
     jest.advanceTimersByTime(500);
 
-    // Wait for validation to complete
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    // All custom markers are batched; filter by source
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
-    const allMarkers = batchedCalls[0][2];
-    const markers = allMarkers.filter((m: any) => m.source === 'step-name-validation');
+    const markers = getLastBatchedMarkers().filter((m: any) => m.source === 'step-name-validation');
     expect(markers).toHaveLength(2); // Two errors for the duplicate "step1"
 
     markers.forEach((marker: any) => {
@@ -226,16 +247,12 @@ steps:
     // Fast-forward through the debounced computation
     jest.advanceTimersByTime(500);
 
-    // Wait for validation to complete
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
-    const markers = batchedCalls[0][2].filter((m: any) => m.source === 'step-name-validation');
+    const markers = getLastBatchedMarkers().filter((m: any) => m.source === 'step-name-validation');
     expect(markers).toHaveLength(2); // Two errors for the duplicate "nested_step"
 
     markers.forEach((marker: any) => {
@@ -264,16 +281,12 @@ steps:
     // Fast-forward through the debounced computation
     jest.advanceTimersByTime(500);
 
-    // Wait for validation to complete
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
-    const markers = batchedCalls[0][2].filter((m: any) => m.source === 'step-name-validation');
+    const markers = getLastBatchedMarkers().filter((m: any) => m.source === 'step-name-validation');
     expect(markers).toHaveLength(2); // Two errors for the duplicate "duplicate_name"
 
     markers.forEach((marker: any) => {
@@ -302,16 +315,12 @@ steps:
     // Fast-forward through the debounced computation
     jest.advanceTimersByTime(500);
 
-    // Wait for validation to complete
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
-    const markers = batchedCalls[0][2].filter((m: any) => m.source === 'step-name-validation');
+    const markers = getLastBatchedMarkers().filter((m: any) => m.source === 'step-name-validation');
     expect(markers).toHaveLength(2); // Two errors for the duplicate "branch_step"
 
     markers.forEach((marker: any) => {
@@ -350,16 +359,12 @@ steps:
     // Fast-forward through the debounced computation
     jest.advanceTimersByTime(500);
 
-    // Wait for validation to complete
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
-    const markers = batchedCalls[0][2].filter((m: any) => m.source === 'step-name-validation');
+    const markers = getLastBatchedMarkers().filter((m: any) => m.source === 'step-name-validation');
 
     // Should have 5 errors: 3 for "root_step", 2 for "inner_step"
     expect(markers).toHaveLength(5);
@@ -384,6 +389,7 @@ describe('useYamlValidation - Marker Batching', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    jest.mocked(useKibana).mockReturnValue(mockKibanaValue);
   });
 
   afterEach(() => {
@@ -417,18 +423,12 @@ steps:
     jest.advanceTimersByTime(500);
 
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    await waitFor(() => {
-      expect(mockSetModelMarkers).toHaveBeenCalled();
-    });
-
-    // All custom validations should be batched into exactly one call
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
+    // All custom validations should be batched into exactly one call per validation run
+    expect(getBatchedMarkerCalls()).toHaveLength(1);
   });
 
   it('should include markers from all validation sources in the batched call', async () => {
@@ -452,23 +452,83 @@ steps:
     jest.advanceTimersByTime(500);
 
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(false);
     });
+    await waitForBatchedMarkers();
 
-    await waitFor(() => {
-      expect(mockSetModelMarkers).toHaveBeenCalled();
-    });
-
-    // The batched call's markers should carry individual source names
-    const batchedCalls = mockSetModelMarkers.mock.calls.filter(
-      (call) => call[1] === 'custom-yaml-validation'
-    );
-    expect(batchedCalls).toHaveLength(1);
+    expect(getBatchedMarkerCalls()).toHaveLength(1);
 
     // Verify no individual owner calls were made (only batched)
     const individualOwnerCalls = mockSetModelMarkers.mock.calls.filter(
       (call) => call[1] !== 'custom-yaml-validation'
     );
     expect(individualOwnerCalls).toHaveLength(0);
+  });
+});
+
+describe('useYamlValidation - ES|QL step wiring', () => {
+  beforeEach(() => {
+    jest.mocked(useKibana).mockReturnValue(mockKibanaValue);
+    mockValidateEsqlSteps.mockReset();
+    mockValidateEsqlSteps.mockResolvedValue([]);
+  });
+
+  it('calls validateEsqlSteps when the workflow has an elasticsearch.esql.query step', async () => {
+    const yamlContent = `
+version: "1"
+name: "ES|QL Workflow"
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+steps:
+  - name: esql_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM logs-* | LIMIT 10
+`;
+    const mockEditor = createMockEditor(yamlContent);
+    renderHookWithProviders(mockEditor as any, yamlContent);
+
+    await waitFor(
+      () => {
+        expect(mockValidateEsqlSteps).toHaveBeenCalled();
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it('validateEsqlSteps early-outs when no elasticsearch.esql.query step exists', async () => {
+    mockValidateEsqlSteps.mockImplementation(async (workflowLookup: WorkflowLookup) => {
+      const hasEsqlStep = Object.values(workflowLookup.steps).some(
+        (step) => step.stepType === 'elasticsearch.esql.query'
+      );
+      expect(hasEsqlStep).toBe(false);
+      return [];
+    });
+
+    const yamlContent = `
+version: "1"
+name: "No ES|QL Workflow"
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+steps:
+  - name: log_step
+    type: console
+    with:
+      message: "elasticsearch.esql.query is documented in the guide"
+`;
+    const mockEditor = createMockEditor(yamlContent);
+    renderHookWithProviders(mockEditor as any, yamlContent);
+
+    await waitFor(
+      () => {
+        expect(mockValidateEsqlSteps).toHaveBeenCalled();
+      },
+      { timeout: 3000 }
+    );
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
@@ -35,6 +35,8 @@ import {
   selectYamlLineCounter,
 } from '../../../entities/workflows/store/workflow_detail/selectors';
 import { useKibana } from '../../../hooks/use_kibana';
+import { useWorkflowEsqlCallbacks } from '../../../widgets/workflow_yaml_editor/lib/esql_validation/use_workflow_esql_callbacks';
+import { validateEsqlSteps } from '../../../widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps';
 import { MarkerSeverity } from '../../../widgets/workflow_yaml_editor/lib/utils';
 import {
   BATCHED_CUSTOM_MARKER_OWNER,
@@ -85,9 +87,22 @@ export function useYamlValidation(
   const isWorkflowTab = useSelector(selectIsWorkflowTab);
   const connectors = useSelector(selectConnectors);
   const workflows = useSelector(selectWorkflows);
-  const { application } = useKibana().services;
+  const { application, http, data, licensing } = useKibana().services;
+  const esqlCallbacks = useWorkflowEsqlCallbacks({
+    http,
+    application,
+    data,
+    licensing,
+  });
+  // Held in a ref so the effect below doesn't re-fire just because the
+  // memo identity rebuilt (it does on every render in tests where the kibana
+  // mock returns fresh service objects).
+  const esqlCallbacksRef = useRef(esqlCallbacks);
+  esqlCallbacksRef.current = esqlCallbacks;
 
   useEffect(() => {
+    const esqlAbortController = new AbortController();
+
     async function validateYaml() {
       if (!editor) {
         return;
@@ -145,11 +160,21 @@ export function useYamlValidation(
         ...validateConnectorIds(connectorIdItems, dynamicConnectorTypes, connectorsManagementUrl),
         ...validateWorkflowOutputsInYaml(yamlDocument, model, workflowDefinition?.outputs),
         ...(customPropertyItems ? await validateCustomProperties(customPropertyItems) : []),
+        // Lookup-backed validators run sequentially (each await blocks the next).
+        // ES|QL runs after custom-property validation so property errors surface first
+        // and we avoid overlapping cluster calls from validateQuery with property handlers.
         ...(workflowLookup && lineCounter
           ? [
               ...validateDeprecatedStepTypes(workflowLookup, lineCounter),
               ...validateWorkflowInputs(workflowLookup, workflows, lineCounter),
               ...validateIfConditions(workflowLookup, lineCounter),
+              ...(await validateEsqlSteps(
+                workflowLookup,
+                lineCounter,
+                model,
+                esqlCallbacksRef.current,
+                esqlAbortController.signal
+              ).catch(() => [])),
             ]
           : []),
       ];
@@ -188,6 +213,10 @@ export function useYamlValidation(
     }
 
     validateYaml();
+
+    return () => {
+      esqlAbortController.abort();
+    };
   }, [
     editor,
     lineCounter,

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/model/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/model/types.ts
@@ -152,6 +152,12 @@ export type CustomPropertyValidationResult =
   | YamlValidationResultCustomPropertyError
   | YamlValidationResultCustomPropertyValid;
 
+interface YamlValidationResultEsql extends YamlValidationResultBase {
+  severity: YamlValidationErrorSeverity;
+  message: string;
+  owner: 'esql-validation';
+}
+
 interface YamlValidationResultWorkflowInputsError extends YamlValidationResultBase {
   severity: YamlValidationErrorSeverity;
   message: string;
@@ -170,6 +176,7 @@ export const CUSTOM_YAML_VALIDATION_MARKER_OWNERS = [
   'workflow-output-validation',
   'if-condition-validation',
   'deprecated-step-validation',
+  'esql-validation',
 ] as const;
 
 export const BATCHED_CUSTOM_MARKER_OWNER = 'custom-yaml-validation';
@@ -197,7 +204,8 @@ export type YamlValidationResult =
   | YamlValidationResultTriggerConditionError
   | YamlValidationResultWorkflowOutput
   | YamlValidationResultIfConditionError
-  | YamlValidationResultDeprecatedStep;
+  | YamlValidationResultDeprecatedStep
+  | YamlValidationResultEsql;
 
 export function validationResultFingerprint(r: YamlValidationResult): string {
   return `${r.owner}\0${r.severity}\0${r.startLineNumber}:${r.startColumn}\0${r.endLineNumber}:${r.endColumn}\0${r.message}`;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/classify_liquid_position.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/classify_liquid_position.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  applyLiquidMask,
+  classifyLiquidPosition,
+  isOffsetInsideMaskedRange,
+} from './classify_liquid_position';
+
+describe('classifyLiquidPosition', () => {
+  it('returns safe with no masks for plain ES|QL', () => {
+    const result = classifyLiquidPosition('FROM logs-* | LIMIT 10');
+    expect(result.kind).toBe('safe');
+    if (result.kind === 'safe') {
+      expect(result.maskedRanges).toEqual([]);
+    }
+  });
+
+  it('returns safe with no masks for empty input', () => {
+    const result = classifyLiquidPosition('');
+    expect(result.kind).toBe('safe');
+    if (result.kind === 'safe') {
+      expect(result.maskedRanges).toEqual([]);
+    }
+  });
+
+  it('classifies a {{ … }} span inside a double-quoted string as maskable', () => {
+    const text = 'FROM logs-* | WHERE host == "{{ inputs.host }}"';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+    if (result.kind === 'safe') {
+      expect(result.maskedRanges).toEqual([
+        { start: text.indexOf('{{'), end: text.indexOf('}}') + 2 },
+      ]);
+    }
+  });
+
+  it('classifies multiple in-string spans as maskable', () => {
+    const text = 'WHERE a == "{{ x }}" AND b == "{{ y }}"';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+    if (result.kind === 'safe') {
+      expect(result.maskedRanges).toHaveLength(2);
+    }
+  });
+
+  it('classifies a {{ … }} span in identifier position as structural', () => {
+    expect(classifyLiquidPosition('FROM logs-{{ inputs.env }}-*').kind).toBe('has-structural');
+  });
+
+  it('classifies `{% … %}` outside a string as structural', () => {
+    expect(classifyLiquidPosition('{%- if env -%} FROM logs {%- endif -%}').kind).toBe(
+      'has-structural'
+    );
+  });
+
+  it('treats `{# … #}` as maskable even outside a string (Liquid comments are inert)', () => {
+    const text = 'FROM logs-* {# pick the right index #} | LIMIT 10';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+    if (result.kind === 'safe') {
+      expect(result.maskedRanges).toEqual([
+        { start: text.indexOf('{#'), end: text.indexOf('#}') + 2 },
+      ]);
+    }
+  });
+
+  it('still classifies as structural when a structural span sits alongside in-string spans', () => {
+    expect(classifyLiquidPosition('FROM logs-{{ env }}-* | WHERE x == "{{ y }}"').kind).toBe(
+      'has-structural'
+    );
+  });
+
+  it('classifies a Liquid span inside `"""…"""` as maskable', () => {
+    const text = 'WHERE x == """foo {{ bar }} baz"""';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+    if (result.kind === 'safe') {
+      expect(result.maskedRanges).toEqual([
+        { start: text.indexOf('{{'), end: text.indexOf('}}') + 2 },
+      ]);
+    }
+  });
+
+  it('respects ES|QL string escapes (\\" does not close the string)', () => {
+    // The `"` inside the string is escaped; the cursor is still in-string when
+    // it reaches `{{ env }}`, so the span must be classified as in-string.
+    const text = 'WHERE x == "a \\"quoted\\" {{ env }} tail"';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+  });
+
+  it('classifies Liquid inside an ES|QL line comment as maskable', () => {
+    const text = 'FROM logs-* // {{ debug }}\n| LIMIT 10';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+  });
+
+  it('classifies Liquid inside an ES|QL block comment as maskable', () => {
+    const text = 'FROM logs-* /* note: {{ debug }} */ | LIMIT 10';
+    const result = classifyLiquidPosition(text);
+    expect(result.kind).toBe('safe');
+  });
+
+  it('returns has-structural for an unclosed `{{` outside a string', () => {
+    expect(classifyLiquidPosition('FROM logs-* | LIMIT {{ nope').kind).toBe('has-structural');
+  });
+
+  it('returns has-structural for an unclosed `{#` outside a string', () => {
+    expect(classifyLiquidPosition('FROM logs-* {# unclosed').kind).toBe('has-structural');
+  });
+});
+
+describe('applyLiquidMask', () => {
+  it('returns the input unchanged when ranges is empty', () => {
+    expect(applyLiquidMask('FROM logs-*', [])).toBe('FROM logs-*');
+  });
+
+  it('replaces each range with whitespace of the same length', () => {
+    const text = 'WHERE host == "{{ env }}"';
+    const ranges = [{ start: text.indexOf('{{'), end: text.indexOf('}}') + 2 }];
+    const masked = applyLiquidMask(text, ranges);
+    expect(masked).toHaveLength(text.length);
+    expect(masked).toBe('WHERE host == "         "');
+  });
+
+  it('handles multiple non-overlapping ranges', () => {
+    const text = 'a "{{ x }}" "{{ y }}" b';
+    const ranges = [
+      { start: text.indexOf('{{ x'), end: text.indexOf('}}') + 2 },
+      { start: text.lastIndexOf('{{'), end: text.lastIndexOf('}}') + 2 },
+    ];
+    const masked = applyLiquidMask(text, ranges);
+    expect(masked).toHaveLength(text.length);
+    expect(masked.includes('{{')).toBe(false);
+    expect(masked.includes('}}')).toBe(false);
+  });
+});
+
+describe('isOffsetInsideMaskedRange', () => {
+  const ranges = [
+    { start: 10, end: 20 },
+    { start: 30, end: 40 },
+  ];
+
+  it('is true for offsets inside a range', () => {
+    expect(isOffsetInsideMaskedRange(15, ranges)).toBe(true);
+    expect(isOffsetInsideMaskedRange(35, ranges)).toBe(true);
+  });
+
+  it('treats range end as exclusive', () => {
+    expect(isOffsetInsideMaskedRange(20, ranges)).toBe(false);
+    expect(isOffsetInsideMaskedRange(40, ranges)).toBe(false);
+  });
+
+  it('is false for offsets outside any range', () => {
+    expect(isOffsetInsideMaskedRange(0, ranges)).toBe(false);
+    expect(isOffsetInsideMaskedRange(25, ranges)).toBe(false);
+    expect(isOffsetInsideMaskedRange(50, ranges)).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/classify_liquid_position.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/classify_liquid_position.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Classifies how Liquid expressions sit inside an ES|QL query string.
+ *
+ * Workflow authors interpolate Liquid into ES|QL — most often inside a quoted
+ * string literal (`WHERE host == "{{ inputs.host }}"`), occasionally as a
+ * structural fragment of the query itself (`FROM logs-{{ inputs.env }}-*`).
+ * The latter cannot be validated honestly at edit time: replacing the Liquid
+ * span with whitespace leaves the ES|QL parser staring at gaps where it
+ * expected an identifier, keyword, or numeric literal, and it dutifully
+ * reports false-positive syntax errors that the workflow author can't act on.
+ *
+ * This classifier walks the query once with awareness of:
+ *   - double-quoted strings (`"…"`),
+ *   - triple-quoted strings (`"""…"""`),
+ *   - ES|QL line comments (`// …`),
+ *   - ES|QL block comments (`/* … *​/`),
+ *
+ * and decides whether every Liquid span sits in a "safe" position (inside a
+ * string or comment, or itself a Liquid comment `{# … #}`) or whether at
+ * least one span is structural. The validator skips the entire region in the
+ * structural case, mirroring the policy KQL validation already uses for
+ * `triggers[].on.condition` and step `if` conditions.
+ */
+
+export interface LiquidMaskedRange {
+  start: number;
+  end: number;
+}
+
+export type LiquidPositionClass =
+  | { kind: 'safe'; maskedRanges: ReadonlyArray<LiquidMaskedRange> }
+  | { kind: 'has-structural' };
+
+const TRIPLE_QUOTE = '"""';
+const LINE_COMMENT_OPEN = '//';
+const BLOCK_COMMENT_OPEN = '/*';
+const BLOCK_COMMENT_CLOSE = '*/';
+const LIQUID_VAR_OPEN = '{{';
+const LIQUID_VAR_CLOSE = '}}';
+const LIQUID_TAG_OPEN = '{%';
+const LIQUID_TAG_CLOSE = '%}';
+const LIQUID_COMMENT_OPEN = '{#';
+const LIQUID_COMMENT_CLOSE = '#}';
+
+type ScannerState = 'normal' | 'string-double' | 'string-triple' | 'line-comment' | 'block-comment';
+
+export function classifyLiquidPosition(text: string): LiquidPositionClass {
+  if (!text || (!text.includes('{{') && !text.includes('{%') && !text.includes('{#'))) {
+    return { kind: 'safe', maskedRanges: [] };
+  }
+
+  const masked: LiquidMaskedRange[] = [];
+  let state: ScannerState = 'normal';
+  let i = 0;
+
+  while (i < text.length) {
+    const step = scanLiquidStep(text, i, state);
+    if (step.hasStructural) {
+      return { kind: 'has-structural' };
+    }
+    if (step.maskedRange) {
+      masked.push(step.maskedRange);
+    }
+    state = step.nextState;
+    i = step.nextIndex;
+  }
+
+  return { kind: 'safe', maskedRanges: masked };
+}
+
+interface ScanStep {
+  nextState: ScannerState;
+  nextIndex: number;
+  maskedRange?: LiquidMaskedRange;
+  hasStructural?: boolean;
+}
+
+function scanLiquidStep(text: string, i: number, state: ScannerState): ScanStep {
+  switch (state) {
+    case 'normal':
+      return scanNormalState(text, i);
+    case 'string-double':
+      return scanDoubleQuotedStringState(text, i);
+    case 'string-triple':
+      if (startsAt(text, i, TRIPLE_QUOTE)) {
+        return { nextState: 'normal', nextIndex: i + TRIPLE_QUOTE.length };
+      }
+      return maskLiquidOrAdvance(text, i, 'string-triple');
+    case 'line-comment':
+      if (text[i] === '\n') {
+        return { nextState: 'normal', nextIndex: i + 1 };
+      }
+      return maskLiquidOrAdvance(text, i, 'line-comment');
+    case 'block-comment':
+      if (startsAt(text, i, BLOCK_COMMENT_CLOSE)) {
+        return { nextState: 'normal', nextIndex: i + BLOCK_COMMENT_CLOSE.length };
+      }
+      return maskLiquidOrAdvance(text, i, 'block-comment');
+  }
+}
+
+function scanNormalState(text: string, i: number): ScanStep {
+  if (startsAt(text, i, TRIPLE_QUOTE)) {
+    return { nextState: 'string-triple', nextIndex: i + TRIPLE_QUOTE.length };
+  }
+  if (text[i] === '"') {
+    return { nextState: 'string-double', nextIndex: i + 1 };
+  }
+  if (startsAt(text, i, LINE_COMMENT_OPEN)) {
+    return { nextState: 'line-comment', nextIndex: i + LINE_COMMENT_OPEN.length };
+  }
+  if (startsAt(text, i, BLOCK_COMMENT_OPEN)) {
+    return { nextState: 'block-comment', nextIndex: i + BLOCK_COMMENT_OPEN.length };
+  }
+  if (startsAt(text, i, LIQUID_VAR_OPEN) || startsAt(text, i, LIQUID_TAG_OPEN)) {
+    return { nextState: 'normal', nextIndex: i, hasStructural: true };
+  }
+  if (startsAt(text, i, LIQUID_COMMENT_OPEN)) {
+    const close = text.indexOf(LIQUID_COMMENT_CLOSE, i + LIQUID_COMMENT_OPEN.length);
+    if (close === -1) {
+      return { nextState: 'normal', nextIndex: i, hasStructural: true };
+    }
+    const end = close + LIQUID_COMMENT_CLOSE.length;
+    return {
+      nextState: 'normal',
+      nextIndex: end,
+      maskedRange: { start: i, end },
+    };
+  }
+  return { nextState: 'normal', nextIndex: i + 1 };
+}
+
+function scanDoubleQuotedStringState(text: string, i: number): ScanStep {
+  if (text[i] === '\\' && i + 1 < text.length) {
+    return { nextState: 'string-double', nextIndex: i + 2 };
+  }
+  if (text[i] === '"') {
+    return { nextState: 'normal', nextIndex: i + 1 };
+  }
+  return maskLiquidOrAdvance(text, i, 'string-double');
+}
+
+function maskLiquidOrAdvance(text: string, i: number, state: ScannerState): ScanStep {
+  const close = matchLiquidOpen(text, i);
+  if (close !== -1) {
+    return {
+      nextState: state,
+      nextIndex: close,
+      maskedRange: { start: i, end: close },
+    };
+  }
+  return { nextState: state, nextIndex: i + 1 };
+}
+
+/**
+ * Replaces every span in `ranges` with a run of spaces of identical length so
+ * line/column offsets in the surrounding ES|QL stay valid for the parser.
+ * Caller is responsible for having computed the ranges (typically via
+ * {@link classifyLiquidPosition}).
+ */
+export function applyLiquidMask(text: string, ranges: ReadonlyArray<LiquidMaskedRange>): string {
+  if (ranges.length === 0) {
+    return text;
+  }
+  let out = text;
+  for (const range of ranges) {
+    const len = range.end - range.start;
+    out = out.slice(0, range.start) + ' '.repeat(len) + out.slice(range.end);
+  }
+  return out;
+}
+
+/** True if `offset` lies inside any of `ranges` (end-exclusive). */
+export function isOffsetInsideMaskedRange(
+  offset: number,
+  ranges: ReadonlyArray<LiquidMaskedRange>
+): boolean {
+  for (const range of ranges) {
+    if (offset >= range.start && offset < range.end) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function startsAt(text: string, pos: number, marker: string): boolean {
+  if (pos + marker.length > text.length) {
+    return false;
+  }
+  for (let k = 0; k < marker.length; k++) {
+    if (text[pos + k] !== marker[k]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function matchLiquidOpen(text: string, pos: number): number {
+  if (startsAt(text, pos, LIQUID_VAR_OPEN)) {
+    const close = text.indexOf(LIQUID_VAR_CLOSE, pos + LIQUID_VAR_OPEN.length);
+    return close === -1 ? -1 : close + LIQUID_VAR_CLOSE.length;
+  }
+  if (startsAt(text, pos, LIQUID_TAG_OPEN)) {
+    const close = text.indexOf(LIQUID_TAG_CLOSE, pos + LIQUID_TAG_OPEN.length);
+    return close === -1 ? -1 : close + LIQUID_TAG_CLOSE.length;
+  }
+  if (startsAt(text, pos, LIQUID_COMMENT_OPEN)) {
+    const close = text.indexOf(LIQUID_COMMENT_CLOSE, pos + LIQUID_COMMENT_OPEN.length);
+    return close === -1 ? -1 : close + LIQUID_COMMENT_CLOSE.length;
+  }
+  return -1;
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/extract_esql_region.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/extract_esql_region.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { LineCounter, parseDocument } from 'yaml';
+import { collectEsqlRegionsFromLookup } from './extract_esql_region';
+import { buildWorkflowLookup } from '../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
+
+function regionsFromText(text: string) {
+  const lineCounter = new LineCounter();
+  const document = parseDocument(text, { lineCounter, keepSourceTokens: true });
+  const workflowLookup = buildWorkflowLookup(document, lineCounter);
+  return collectEsqlRegionsFromLookup(workflowLookup, text);
+}
+
+describe('collectEsqlRegionsFromLookup', () => {
+  it('returns one region per elasticsearch.esql.query step', () => {
+    const text = `steps:
+  - name: esql_a
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM logs-* | LIMIT 10
+  - type: elasticsearch.search
+    with:
+      index: other
+  - name: esql_b
+    type: elasticsearch.esql.query
+    with:
+      query: "FROM events | KEEP id"
+`;
+    const regions = regionsFromText(text);
+    expect(regions).toHaveLength(2);
+    expect(regions[0].scalarStyle).toBe('BLOCK_LITERAL');
+    expect(regions[0].esql.includes('FROM logs-* | LIMIT 10')).toBe(true);
+    expect(regions[1].scalarStyle).toBe('QUOTE_DOUBLE');
+    expect(regions[1].esql).toBe('FROM events | KEEP id');
+  });
+
+  it('finds nested ES|QL steps inside loops', () => {
+    const text = `steps:
+  - type: foreach
+    foreach: '[1,2,3]'
+    steps:
+      - name: nested_esql
+        type: elasticsearch.esql.query
+        with:
+          query: |
+            FROM logs-*
+`;
+    const regions = regionsFromText(text);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].esql.includes('FROM logs-*')).toBe(true);
+  });
+
+  it('skips steps with no query value yet', () => {
+    const text = `steps:
+  - name: esql_step
+    type: elasticsearch.esql.query
+    with:
+      query:
+`;
+    expect(regionsFromText(text)).toHaveLength(0);
+  });
+
+  it('returns [] for unrelated step types', () => {
+    const text = `steps:
+  - type: elasticsearch.search
+    with:
+      query:
+        match_all: {}
+`;
+    expect(regionsFromText(text)).toHaveLength(0);
+  });
+
+  it('does not treat a comment substring as an ES|QL step', () => {
+    const text = `steps:
+  - name: log_step
+    type: console
+    with:
+      message: "elasticsearch.esql.query is documented here"
+`;
+    expect(regionsFromText(text)).toHaveLength(0);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/extract_esql_region.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/extract_esql_region.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Scalar } from 'yaml';
+import { isScalar } from 'yaml';
+import type { WorkflowLookup } from '../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
+
+export const ESQL_QUERY_STEP_TYPE = 'elasticsearch.esql.query' as const;
+
+export type EsqlScalarStyle =
+  | 'BLOCK_LITERAL'
+  | 'BLOCK_FOLDED'
+  | 'QUOTE_DOUBLE'
+  | 'QUOTE_SINGLE'
+  | 'PLAIN';
+
+export interface EsqlStepRegion {
+  /** Raw ES|QL substring sliced from the source — preserves indent / quotes. */
+  esql: string;
+  /** Inclusive offset in the source where `esql` begins. */
+  contentStartInFile: number;
+  /** Exclusive offset in the source where `esql` ends. */
+  contentEndInFile: number;
+  /** YAML scalar style used by the author. */
+  scalarStyle: EsqlScalarStyle;
+}
+
+/**
+ * Collects one `EsqlStepRegion` per `elasticsearch.esql.query` step from the
+ * store-built workflow lookup (same source as other YAML validators).
+ */
+export function collectEsqlRegionsFromLookup(
+  workflowLookup: WorkflowLookup,
+  modelText: string
+): EsqlStepRegion[] {
+  const out: EsqlStepRegion[] = [];
+  for (const step of Object.values(workflowLookup.steps)) {
+    if (step.stepType === ESQL_QUERY_STEP_TYPE) {
+      const queryProp = step.propInfos['with.query'];
+      if (queryProp?.valueNode) {
+        const region = extractEsqlRegionFromScalar(queryProp.valueNode, modelText);
+        if (region && region.esql.trim().length > 0) {
+          out.push(region);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Maps a `with.query` YAML scalar to the ES|QL substring and file offsets used
+ * for validation markers.
+ */
+export function extractEsqlRegionFromScalar(
+  valueNode: Scalar,
+  modelText: string
+): EsqlStepRegion | null {
+  if (!isScalar(valueNode) || !valueNode.range) {
+    return null;
+  }
+  const [r0, , r2] = valueNode.range;
+  if (r0 < 0 || r2 < r0 || r2 > modelText.length) {
+    return null;
+  }
+  const sourceSlice = modelText.slice(r0, r2);
+  const style = scalarTypeToStyle(valueNode.type);
+
+  if (style === 'BLOCK_LITERAL' || style === 'BLOCK_FOLDED') {
+    const newlineIdx = sourceSlice.indexOf('\n');
+    if (newlineIdx === -1) {
+      return null;
+    }
+    const contentStart = r0 + newlineIdx + 1;
+    const trailingWs = sourceSlice.length - sourceSlice.trimEnd().length;
+    const contentEnd = Math.max(contentStart, r2 - trailingWs);
+    return {
+      esql: modelText.slice(contentStart, contentEnd),
+      contentStartInFile: contentStart,
+      contentEndInFile: contentEnd,
+      scalarStyle: style,
+    };
+  }
+
+  if (style === 'QUOTE_DOUBLE' || style === 'QUOTE_SINGLE') {
+    const quote = style === 'QUOTE_DOUBLE' ? '"' : "'";
+    const firstQuote = sourceSlice.indexOf(quote);
+    const lastQuote = sourceSlice.lastIndexOf(quote);
+    if (firstQuote === -1 || lastQuote <= firstQuote) {
+      return null;
+    }
+    const contentStart = r0 + firstQuote + 1;
+    const contentEnd = r0 + lastQuote;
+    return {
+      esql: modelText.slice(contentStart, contentEnd),
+      contentStartInFile: contentStart,
+      contentEndInFile: contentEnd,
+      scalarStyle: style,
+    };
+  }
+
+  const leading = sourceSlice.length - sourceSlice.trimStart().length;
+  const trailing = sourceSlice.length - sourceSlice.trimEnd().length;
+  const contentStart = r0 + leading;
+  const contentEnd = Math.max(contentStart, r2 - trailing);
+  return {
+    esql: modelText.slice(contentStart, contentEnd),
+    contentStartInFile: contentStart,
+    contentEndInFile: contentEnd,
+    scalarStyle: 'PLAIN',
+  };
+}
+
+function scalarTypeToStyle(type: Scalar['type']): EsqlScalarStyle {
+  switch (type) {
+    case 'BLOCK_LITERAL':
+      return 'BLOCK_LITERAL';
+    case 'BLOCK_FOLDED':
+      return 'BLOCK_FOLDED';
+    case 'QUOTE_DOUBLE':
+      return 'QUOTE_DOUBLE';
+    case 'QUOTE_SINGLE':
+      return 'QUOTE_SINGLE';
+    default:
+      return 'PLAIN';
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/integration.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Drives the *real* `@kbn/esql-language` validator end-to-end against the
+// scenario matrix in the plan. Each row of the table in the plan is locked
+// in here so any future regression in mask/skip behaviour fails loudly.
+
+import { LineCounter, parseDocument } from 'yaml';
+import type { ESQLCallbacks } from '@kbn/esql-types';
+import type { monaco } from '@kbn/monaco';
+import { validateEsqlSteps } from './validate_esql_steps';
+import { buildWorkflowLookup } from '../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
+
+function createTextModel(content: string): monaco.editor.ITextModel {
+  return {
+    getValue: () => content,
+    getValueLength: () => content.length,
+    getPositionAt: (offset: number) => {
+      const safe = Math.max(0, Math.min(offset, content.length));
+      const before = content.slice(0, safe);
+      const lines = before.split('\n');
+      return {
+        lineNumber: lines.length,
+        column: lines[lines.length - 1].length + 1,
+      } as monaco.Position;
+    },
+  } as monaco.editor.ITextModel;
+}
+
+function buildStep(query: string): string {
+  const body = query
+    .split('\n')
+    .map((line) => `        ${line}`)
+    .join('\n');
+  return `steps:
+  - name: esql_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+${body}
+`;
+}
+
+const stubCallbacks: ESQLCallbacks = {
+  getSources: async () => [
+    { name: 'logs-app-*', hidden: false, type: 'Index' },
+    { name: 'metrics-*', hidden: false, type: 'Index' },
+  ],
+  getColumnsFor: async () => [
+    { name: '@timestamp', type: 'date', userDefined: false },
+    { name: 'message', type: 'text', userDefined: false },
+    { name: 'host.name', type: 'keyword', userDefined: false },
+  ],
+  getPolicies: async () => [],
+  getPreferences: async () => ({ histogramBarTarget: 50 }),
+  getLicense: async () => ({ hasAtLeast: () => true }),
+};
+
+async function validate(query: string) {
+  const text = buildStep(query);
+  const lineCounter = new LineCounter();
+  const document = parseDocument(text, { lineCounter, keepSourceTokens: true });
+  const workflowLookup = buildWorkflowLookup(document, lineCounter);
+  const model = createTextModel(text);
+  return validateEsqlSteps(workflowLookup, lineCounter, model, stubCallbacks);
+}
+
+describe('end-to-end ES|QL validation — Liquid policy (real validateQuery)', () => {
+  describe('mask path (no false positives, real diagnostics still surface)', () => {
+    it('row 1: Liquid in a string literal does not trip the validator', async () => {
+      const markers = await validate('FROM logs-app-* | WHERE host.name == "{{ inputs.host }}"');
+      expect(markers).toEqual([]);
+    });
+
+    it('row 8: a `{# … #}` Liquid comment is masked transparently', async () => {
+      const markers = await validate('FROM logs-app-* {# pick the env #} | LIMIT 10');
+      expect(markers).toEqual([]);
+    });
+
+    it('row 10: a real ES|QL typo on a non-Liquid step still surfaces', async () => {
+      const markers = await validate('FROM logs-app-* | KEEPP @timestamp');
+      expect(markers.length).toBeGreaterThan(0);
+      // The marker must land on the query body line (after adding `name:` on its own line).
+      expect(markers[0].startLineNumber).toBe(6);
+      expect(markers[0].owner).toBe('esql-validation');
+    });
+
+    it('clean valid query produces zero diagnostics', async () => {
+      const markers = await validate('FROM logs-app-* | KEEP @timestamp, message | LIMIT 10');
+      expect(markers).toEqual([]);
+    });
+  });
+
+  describe('skip path (zero false positives by skipping)', () => {
+    const cases: Array<{ row: number; description: string; query: string }> = [
+      { row: 2, description: 'Liquid in index pattern', query: 'FROM logs-{{ env }}-*' },
+      { row: 3, description: 'Liquid as entire source', query: 'FROM {{ source }}' },
+      {
+        row: 4,
+        description: 'Liquid as pipe command',
+        query: 'FROM logs-app-* | {{ cmd }} count',
+      },
+      {
+        row: 5,
+        description: 'Liquid in function arg list',
+        query: 'FROM logs-app-* | EVAL x = TO_INT({{ field }})',
+      },
+      {
+        row: 6,
+        description: 'Liquid as numeric literal',
+        query: 'FROM logs-app-* | LIMIT {{ n }}',
+      },
+      { row: 7, description: 'Liquid wraps the whole query', query: '{{ query }}' },
+      {
+        row: 9,
+        description: 'Liquid `{% raw %}` block outside a string',
+        query: '{% raw %}FROM logs-* | LIMIT 1{% endraw %}',
+      },
+    ];
+
+    for (const { row, description, query } of cases) {
+      it(`row ${row}: ${description} produces no diagnostics`, async () => {
+        const markers = await validate(query);
+        expect(markers).toEqual([]);
+      });
+    }
+  });
+
+  describe('multi-step independence', () => {
+    it('skips a Liquid-templated step and still flags a real typo on another', async () => {
+      const text = `steps:
+  - name: liquid_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM logs-{{ env }}-*
+  - name: typo_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM logs-app-* | KEEPP @timestamp
+`;
+      const lineCounter = new LineCounter();
+      const document = parseDocument(text, { lineCounter, keepSourceTokens: true });
+      const workflowLookup = buildWorkflowLookup(document, lineCounter);
+      const model = createTextModel(text);
+      const markers = await validateEsqlSteps(workflowLookup, lineCounter, model, stubCallbacks);
+      expect(markers.length).toBeGreaterThan(0);
+      // The marker must point at the second step's body (line 10), not the first.
+      expect(markers.every((m) => m.startLineNumber >= 10)).toBe(true);
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/use_workflow_esql_callbacks.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/use_workflow_esql_callbacks.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo, useRef } from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ESQLCallbacks } from '@kbn/esql-types';
+import { getEsqlColumns, getEsqlPolicies, getESQLSources } from '@kbn/esql-utils';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import type { ILicense } from '@kbn/licensing-types';
+import { useObservable } from '@kbn/use-observable';
+
+export interface UseWorkflowEsqlCallbacksOptions {
+  http: CoreStart['http'];
+  application: CoreStart['application'];
+  data: DataPublicPluginStart;
+  licensing: LicensingPluginStart;
+}
+
+/**
+ * Builds the minimal `ESQLCallbacks` shape needed for ES|QL autocomplete
+ * inside a workflow YAML editor:
+ *
+ *   - `getSources` powers `FROM` completions.
+ *   - `getColumnsFor` powers field completions in WHERE / KEEP / STATS …
+ *   - `getPolicies` powers ENRICH completions.
+ *   - `getPreferences` is supplied so the language tooling has a stable
+ *     histogram bucket target without round-tripping to advanced settings.
+ *   - `getLicense` is supplied so license-gated commands gracefully filter.
+ *
+ * Other callbacks (variables, join indices, inference endpoints, fields
+ * metadata) are intentionally omitted — they belong to richer Discover/Lens
+ * features and would surface data the workflow author didn't ask for.
+ */
+export function useWorkflowEsqlCallbacks({
+  http,
+  application,
+  data,
+  licensing,
+}: UseWorkflowEsqlCallbacksOptions): ESQLCallbacks {
+  const license = useObservable(licensing.license$);
+  const licenseRef = useRef(license);
+  licenseRef.current = license;
+
+  return useMemo(() => {
+    const getLicense = async (): Promise<ILicense | undefined> => licenseRef.current;
+
+    return {
+      getSources: () => getESQLSources({ http, application }, getLicense),
+      getColumnsFor: async (ctx) => {
+        const query = ctx?.query;
+        if (!query) {
+          return [];
+        }
+        return getEsqlColumns({
+          esqlQuery: query,
+          search: data.search.search.bind(data.search),
+          timeRange: data.query.timefilter.timefilter.getTime(),
+        });
+      },
+      getPolicies: () => getEsqlPolicies(http),
+      getPreferences: async () => ({ histogramBarTarget: 50 }),
+      getLicense,
+    } satisfies ESQLCallbacks;
+  }, [http, application, data]);
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps.test.ts
@@ -1,0 +1,377 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { LineCounter, parseDocument } from 'yaml';
+import type { ESQLCallbacks } from '@kbn/esql-types';
+import type { monaco } from '@kbn/monaco';
+import { validateEsqlSteps } from './validate_esql_steps';
+import { buildWorkflowLookup } from '../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
+
+const mockValidate = jest.fn();
+
+jest.mock('@kbn/esql-language', () => ({
+  __esModule: true,
+  validateQuery: (...args: unknown[]) => mockValidate(...args),
+}));
+
+function createTextModel(content: string): monaco.editor.ITextModel {
+  return {
+    getValue: () => content,
+    getValueLength: () => content.length,
+    getPositionAt: (offset: number) => {
+      const safe = Math.max(0, Math.min(offset, content.length));
+      const before = content.slice(0, safe);
+      const lines = before.split('\n');
+      return {
+        lineNumber: lines.length,
+        column: lines[lines.length - 1].length + 1,
+      } as monaco.Position;
+    },
+  } as monaco.editor.ITextModel;
+}
+
+const stubCallbacks: ESQLCallbacks = {};
+
+async function validateEsqlFromText(text: string, callbacks: ESQLCallbacks, signal?: AbortSignal) {
+  const lineCounter = new LineCounter();
+  const document = parseDocument(text, { lineCounter, keepSourceTokens: true });
+  const workflowLookup = buildWorkflowLookup(document, lineCounter);
+  const model = createTextModel(text);
+  return validateEsqlSteps(workflowLookup, lineCounter, model, callbacks, signal);
+}
+
+function buildStep(query: string): string {
+  // Indent matches what the YAML parser would extract for a `|` block scalar.
+  const body = query
+    .split('\n')
+    .map((line) => `        ${line}`)
+    .join('\n');
+  return `steps:
+  - name: esql_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+${body}
+`;
+}
+
+describe('validateEsqlSteps — Liquid policy', () => {
+  beforeEach(() => mockValidate.mockReset());
+
+  it('returns [] when no ES|QL step is present', async () => {
+    const text = `steps:
+  - type: elasticsearch.search
+    with:
+      index: test
+`;
+    const markers = await validateEsqlFromText(text, stubCallbacks);
+    expect(markers).toEqual([]);
+    expect(mockValidate).not.toHaveBeenCalled();
+  });
+
+  it('row 10: runs validateQuery on plain ES|QL and surfaces real diagnostics', async () => {
+    const text = buildStep('FROM logs-* | KEEPP @timestamp');
+    mockValidate.mockResolvedValue({
+      errors: [
+        {
+          type: 'error',
+          text: 'Unknown command "KEEPP"',
+          location: { min: 16, max: 20 },
+          code: 'esql.unknownCommand',
+        },
+      ],
+      warnings: [],
+    });
+    const markers = await validateEsqlFromText(text, stubCallbacks);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].owner).toBe('esql-validation');
+    expect(markers[0].severity).toBe('error');
+    expect(markers[0].message).toBe('Unknown command "KEEPP"');
+  });
+
+  describe('mask path: Liquid only inside string literals', () => {
+    it('row 1: passes a whitespace-masked query to validateQuery', async () => {
+      const text = buildStep('WHERE host == "{{ inputs.host }}"');
+      mockValidate.mockResolvedValue({ errors: [], warnings: [] });
+      await validateEsqlFromText(text, stubCallbacks);
+      expect(mockValidate).toHaveBeenCalledTimes(1);
+      const [maskedQuery] = mockValidate.mock.calls[0];
+      // No `{{` survives the mask.
+      expect(maskedQuery).not.toMatch(/\{\{/);
+      // Length is preserved so offsets stay aligned with the original text.
+      expect(maskedQuery).toHaveLength('        WHERE host == "{{ inputs.host }}"'.length);
+    });
+
+    it('drops a diagnostic that lands fully inside the masked region', async () => {
+      const text = buildStep('WHERE host == "{{ inputs.host }}"');
+      const queryStartInLine = '        '.length;
+      const innerStringStart = queryStartInLine + 'WHERE host == "'.length;
+      const innerStringEnd = innerStringStart + '{{ inputs.host }}'.length;
+      mockValidate.mockResolvedValue({
+        errors: [
+          {
+            type: 'error',
+            text: 'noise inside the mask',
+            location: { min: innerStringStart, max: innerStringEnd - 1 },
+            code: 'esql.spurious',
+          },
+        ],
+        warnings: [],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      expect(markers).toEqual([]);
+    });
+
+    it('keeps a diagnostic that touches the mask boundary but extends outside', async () => {
+      const text = buildStep('WHERE host == "{{ x }}" | LIMIT abc');
+      // Diagnostic on the `LIMIT abc` token — well outside the mask.
+      const limitStart = text.indexOf('LIMIT abc') - text.indexOf('WHERE');
+      mockValidate.mockResolvedValue({
+        errors: [
+          {
+            type: 'error',
+            text: 'expected number',
+            location: { min: limitStart + 6, max: limitStart + 8 },
+            code: 'esql.syntax',
+          },
+        ],
+        warnings: [],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      expect(markers).toHaveLength(1);
+      expect(markers[0].message).toBe('expected number');
+    });
+  });
+
+  describe('skip path: Liquid in structural position', () => {
+    // Numbers reference the scenario matrix in the plan
+    // (`/Users/marcoliberati/.claude/plans/you-are-a-very-fancy-waffle.md`).
+    const cases: Array<{ row: number | string; description: string; query: string }> = [
+      { row: 2, description: 'Liquid in index pattern', query: 'FROM logs-{{ env }}-*' },
+      { row: 3, description: 'Liquid as the entire source', query: 'FROM {{ source }}' },
+      {
+        row: 4,
+        description: 'Liquid as a pipe command',
+        query: 'FROM logs-* | {{ cmd }} count',
+      },
+      {
+        row: 5,
+        description: 'Liquid in a function arg list',
+        query: 'FROM logs-* | EVAL x = TO_INT({{ field }})',
+      },
+      {
+        row: 6,
+        description: 'Liquid as a numeric literal',
+        query: 'FROM logs-* | LIMIT {{ n }}',
+      },
+      { row: 7, description: 'Liquid wraps the whole query', query: '{{ query }}' },
+      {
+        row: 9,
+        description: 'Liquid `{% raw %}` block outside a string',
+        query: '{% raw %}FROM logs-* | LIMIT 1{% endraw %}',
+      },
+      {
+        row: 'extra',
+        description: 'Liquid `{% if %}` tag outside any string',
+        query: '{%- if env -%} FROM logs {%- endif -%}',
+      },
+    ];
+
+    for (const { row, description, query } of cases) {
+      it(`row ${row}: skips validation for ${description}`, async () => {
+        const text = buildStep(query);
+        const markers = await validateEsqlFromText(text, stubCallbacks);
+        expect(markers).toEqual([]);
+        expect(mockValidate).not.toHaveBeenCalled();
+      });
+    }
+  });
+
+  describe('Liquid comments and ES|QL comments stay on the mask path', () => {
+    it('row 8: a `{# … #}` Liquid comment outside any string is masked, not skipped', async () => {
+      const text = buildStep('FROM logs-* {# pick the env #} | LIMIT 10');
+      mockValidate.mockResolvedValue({ errors: [], warnings: [] });
+      await validateEsqlFromText(text, stubCallbacks);
+      expect(mockValidate).toHaveBeenCalledTimes(1);
+      const [maskedQuery] = mockValidate.mock.calls[0];
+      expect(maskedQuery).not.toMatch(/\{#/);
+      expect(maskedQuery).toMatch(/FROM logs-\*/);
+    });
+
+    it('Liquid inside an ES|QL line comment is masked', async () => {
+      const text = buildStep('FROM logs-* // {{ debug }}\n        | LIMIT 10');
+      mockValidate.mockResolvedValue({ errors: [], warnings: [] });
+      await validateEsqlFromText(text, stubCallbacks);
+      expect(mockValidate).toHaveBeenCalledTimes(1);
+    });
+
+    it('Liquid inside an ES|QL block comment is masked', async () => {
+      const text = buildStep('FROM logs-* /* note: {{ debug }} */ | LIMIT 10');
+      mockValidate.mockResolvedValue({ errors: [], warnings: [] });
+      await validateEsqlFromText(text, stubCallbacks);
+      expect(mockValidate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('multi-step robustness', () => {
+    it('skips one step on Liquid and validates another', async () => {
+      const text = `steps:
+  - name: liquid_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM logs-{{ env }}-*
+  - name: typo_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM logs-* | KEEPP foo
+`;
+      mockValidate.mockResolvedValue({
+        errors: [
+          {
+            type: 'error',
+            text: 'Unknown command',
+            location: { min: 13, max: 18 },
+            code: 'esql.unknownCommand',
+          },
+        ],
+        warnings: [],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      // The first step is skipped (structural Liquid); only the second runs.
+      expect(mockValidate).toHaveBeenCalledTimes(1);
+      expect(markers).toHaveLength(1);
+      expect(markers[0].message).toBe('Unknown command');
+    });
+
+    it('a thrown validateQuery on one step does not stop the next', async () => {
+      const text = `steps:
+  - name: bad_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM bad
+  - name: good_step
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        FROM good | LIMIT 5
+`;
+      mockValidate.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({
+        errors: [
+          { type: 'error', text: 'second error', location: { min: 0, max: 4 }, code: 'esql.x' },
+        ],
+        warnings: [],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      expect(mockValidate).toHaveBeenCalledTimes(2);
+      expect(markers).toHaveLength(1);
+      expect(markers[0].message).toBe('second error');
+    });
+
+    it('an aborted signal returns [] early', async () => {
+      const text = buildStep('FROM x');
+      const controller = new AbortController();
+      controller.abort();
+      mockValidate.mockResolvedValue({ errors: [], warnings: [] });
+      const markers = await validateEsqlFromText(text, stubCallbacks, controller.signal);
+      expect(markers).toEqual([]);
+    });
+  });
+
+  describe('warnings', () => {
+    it('emits warnings as warning-severity validation results', async () => {
+      const text = buildStep('FROM logs-* | LIMIT 1000000');
+      mockValidate.mockResolvedValue({
+        errors: [],
+        warnings: [
+          {
+            type: 'warning',
+            text: 'large LIMIT',
+            location: { min: 0, max: 4 },
+            code: 'esql.largeLimit',
+          },
+        ],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      expect(markers).toHaveLength(1);
+      expect(markers[0].severity).toBe('warning');
+    });
+
+    it('clamps an out-of-bounds column so the marker stays inside the ES|QL region', async () => {
+      // The query body is a single line `FROM x` (6 chars). A diagnostic that
+      // claims `endColumn: 999` must not be allowed to push the marker offset
+      // past the line into the surrounding YAML.
+      const text = buildStep('FROM x');
+      const queryStartInFile = text.indexOf('FROM x');
+      const queryEndInFile = queryStartInFile + 'FROM x'.length;
+      const model = createTextModel(text);
+      mockValidate.mockResolvedValue({
+        errors: [
+          {
+            message: 'runaway range',
+            code: 'esql.runaway',
+            severity: 'error',
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 999,
+          },
+        ],
+        warnings: [],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      expect(markers).toHaveLength(1);
+      const marker = markers[0];
+      // Reconstruct the marker's end offset and confirm it doesn't escape the
+      // region — the bug allowed it to land deep in the YAML below.
+      const endOffset =
+        model
+          .getValue()
+          .split('\n')
+          .slice(0, marker.endLineNumber - 1)
+          .join('\n').length +
+        (marker.endLineNumber > 1 ? 1 : 0) +
+        (marker.endColumn - 1);
+      expect(endOffset).toBeLessThanOrEqual(queryEndInFile);
+    });
+
+    it('maps Monaco numeric severities (Warning=4, Info=2) on EditorError diagnostics', async () => {
+      const text = buildStep('FROM logs-* | LIMIT 1000000');
+      mockValidate.mockResolvedValue({
+        errors: [],
+        warnings: [
+          {
+            message: 'large LIMIT',
+            code: 'esql.largeLimit',
+            severity: 4,
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 5,
+          },
+          {
+            message: 'hint about projection',
+            code: 'esql.projectionHint',
+            severity: 2,
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 5,
+          },
+        ],
+      });
+      const markers = await validateEsqlFromText(text, stubCallbacks);
+      expect(markers).toHaveLength(2);
+      expect(markers[0].severity).toBe('warning');
+      expect(markers[1].severity).toBe('info');
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/esql_validation/validate_esql_steps.ts
@@ -1,0 +1,322 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EditorError } from '@elastic/esql/types';
+import type { LineCounter } from 'yaml';
+import { validateQuery } from '@kbn/esql-language';
+import type { ESQLCallbacks } from '@kbn/esql-types';
+import type { monaco } from '@kbn/monaco';
+import {
+  applyLiquidMask,
+  classifyLiquidPosition,
+  isOffsetInsideMaskedRange,
+  type LiquidMaskedRange,
+} from './classify_liquid_position';
+import { collectEsqlRegionsFromLookup, type EsqlStepRegion } from './extract_esql_region';
+import type { WorkflowLookup } from '../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
+import type { YamlValidationResult } from '../../../../features/validate_workflow_yaml/model/types';
+
+type EsqlValidationDiagnostic = Awaited<ReturnType<typeof validateQuery>>['errors'][number];
+
+/**
+ * Runs `validateQuery` against every `elasticsearch.esql.query` step in the
+ * workflow lookup and returns workflow-style `YamlValidationResult`s in YAML
+ * coordinates. The host pipeline (`useYamlValidation`) batches these into
+ * markers and feeds the bottom-bar accordion alongside every other validator.
+ *
+ * Liquid handling matches the policy used elsewhere in the editor:
+ *
+ *   - When every Liquid span sits inside a quoted string literal or a
+ *     comment, we mask each span with same-length whitespace and let the
+ *     ES|QL parser run normally. Diagnostics that fall *entirely* inside a
+ *     mask are suppressed (the parser can't say anything actionable about a
+ *     run of spaces standing in for a string literal).
+ *   - When at least one Liquid span occupies a structural position
+ *     (identifier, keyword, numeric literal, …), we skip the entire region.
+ *     We can't honestly validate something whose runtime substitution we
+ *     don't know, and false positives in editor diagnostics are worse than
+ *     missing ones — they train authors to ignore squigglies.
+ *
+ * Mirrors the KQL/if-condition policy in [validate_trigger_conditions.ts]
+ * and [validate_if_conditions.ts] which also bail out on Liquid presence.
+ */
+export async function validateEsqlSteps(
+  workflowLookup: WorkflowLookup,
+  _lineCounter: LineCounter,
+  model: monaco.editor.ITextModel,
+  callbacks: ESQLCallbacks,
+  signal?: AbortSignal
+): Promise<YamlValidationResult[]> {
+  const modelText = model.getValue();
+  const regions = collectEsqlRegionsFromLookup(workflowLookup, modelText);
+  if (regions.length === 0) {
+    return [];
+  }
+
+  const out: YamlValidationResult[] = [];
+  for (let regionIdx = 0; regionIdx < regions.length; regionIdx++) {
+    if (signal?.aborted) {
+      return [];
+    }
+    const regionResults = await validateRegion(
+      regions[regionIdx],
+      regionIdx,
+      model,
+      callbacks,
+      signal
+    );
+    if (signal?.aborted) {
+      return [];
+    }
+    out.push(...regionResults);
+  }
+  return out;
+}
+
+async function validateRegion(
+  region: EsqlStepRegion,
+  regionIdx: number,
+  model: monaco.editor.ITextModel,
+  callbacks: ESQLCallbacks,
+  signal: AbortSignal | undefined
+): Promise<YamlValidationResult[]> {
+  const classification = classifyLiquidPosition(region.esql);
+  if (classification.kind === 'has-structural') {
+    return [];
+  }
+
+  const maskedRanges = classification.maskedRanges;
+  const maskedQuery = applyLiquidMask(region.esql, maskedRanges);
+
+  const result = await safeValidate(maskedQuery, callbacks);
+  if (signal?.aborted || !result) {
+    return [];
+  }
+
+  const out: YamlValidationResult[] = [];
+  let diagnosticIdx = 0;
+  for (const error of result.errors) {
+    const v = toValidationResult(
+      error,
+      region,
+      maskedRanges,
+      model,
+      'error',
+      regionIdx,
+      diagnosticIdx++
+    );
+    if (v) {
+      out.push(v);
+    }
+  }
+  for (const warning of result.warnings) {
+    const v = toValidationResult(
+      warning,
+      region,
+      maskedRanges,
+      model,
+      'warning',
+      regionIdx,
+      diagnosticIdx++
+    );
+    if (v) {
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+async function safeValidate(
+  query: string,
+  callbacks: ESQLCallbacks
+): Promise<Awaited<ReturnType<typeof validateQuery>> | null> {
+  try {
+    return await validateQuery(query, callbacks);
+  } catch {
+    return null;
+  }
+}
+
+function toValidationResult(
+  diagnostic: EsqlValidationDiagnostic,
+  region: EsqlStepRegion,
+  maskedRanges: ReadonlyArray<LiquidMaskedRange>,
+  model: monaco.editor.ITextModel,
+  fallbackSeverity: 'error' | 'warning',
+  regionIdx: number,
+  diagnosticIdx: number
+): YamlValidationResult | null {
+  const innerRange = extractInnerRange(diagnostic, region.esql);
+  if (!innerRange) {
+    return null;
+  }
+  if (rangeFullyInsideMask(innerRange, maskedRanges)) {
+    return null;
+  }
+
+  const startOffset = region.contentStartInFile + innerRange.start;
+  const endOffset = region.contentStartInFile + innerRange.end;
+  if (startOffset < 0 || endOffset < startOffset) {
+    return null;
+  }
+
+  const maxOffset = model.getValueLength();
+  const safeStart = Math.min(startOffset, maxOffset);
+  const safeEnd = Math.min(Math.max(endOffset, safeStart + 1), maxOffset);
+  const startPos = model.getPositionAt(safeStart);
+  const endPos = model.getPositionAt(safeEnd);
+
+  const { message, code } = extractMessageAndCode(diagnostic);
+  const severity = resolveSeverity(diagnostic, fallbackSeverity);
+
+  return {
+    id: `esql-validation-${regionIdx}-${diagnosticIdx}-${code}`,
+    severity,
+    message,
+    owner: 'esql-validation',
+    source: 'esql',
+    startLineNumber: startPos.lineNumber,
+    startColumn: startPos.column,
+    endLineNumber: endPos.lineNumber,
+    endColumn: endPos.column,
+    hoverMessage: null,
+  };
+}
+
+function isEsqlMessage(
+  diagnostic: EsqlValidationDiagnostic
+): diagnostic is EsqlValidationDiagnostic & {
+  type: 'error' | 'warning';
+  text: string;
+  location: { min: number; max: number };
+  code: string;
+} {
+  return (
+    'location' in diagnostic &&
+    typeof diagnostic.location === 'object' &&
+    diagnostic.location !== null &&
+    'min' in diagnostic.location &&
+    'max' in diagnostic.location
+  );
+}
+
+function isEditorError(diagnostic: EsqlValidationDiagnostic): diagnostic is EditorError {
+  return (
+    'startLineNumber' in diagnostic &&
+    typeof diagnostic.startLineNumber === 'number' &&
+    typeof diagnostic.startColumn === 'number'
+  );
+}
+
+function extractInnerRange(
+  diagnostic: EsqlValidationDiagnostic,
+  esql: string
+): { start: number; end: number } | null {
+  if (isEsqlMessage(diagnostic)) {
+    return { start: diagnostic.location.min, end: diagnostic.location.max + 1 };
+  }
+  if (isEditorError(diagnostic)) {
+    const start = lineColToOffset(esql, diagnostic.startLineNumber, diagnostic.startColumn);
+    const end = lineColToOffset(esql, diagnostic.endLineNumber, diagnostic.endColumn);
+    if (start === null || end === null) {
+      return null;
+    }
+    return { start, end: Math.max(start + 1, end) };
+  }
+  return null;
+}
+
+function lineColToOffset(text: string, line: number, column: number): number | null {
+  if (line < 1 || column < 1) {
+    return null;
+  }
+  let offset = 0;
+  let currentLine = 1;
+  while (currentLine < line) {
+    const idx = text.indexOf('\n', offset);
+    if (idx === -1) {
+      return null;
+    }
+    offset = idx + 1;
+    currentLine += 1;
+  }
+  const nextNewline = text.indexOf('\n', offset);
+  const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+  const clampedColumn = Math.min(column - 1, lineEnd - offset);
+  return offset + clampedColumn;
+}
+
+function rangeFullyInsideMask(
+  range: { start: number; end: number },
+  masks: ReadonlyArray<LiquidMaskedRange>
+): boolean {
+  for (const mask of masks) {
+    if (range.start >= mask.start && range.end <= mask.end) {
+      return true;
+    }
+  }
+  if (range.end === range.start + 1 && isOffsetInsideMaskedRange(range.start, masks)) {
+    return true;
+  }
+  return false;
+}
+
+function extractMessageAndCode(diagnostic: EsqlValidationDiagnostic): {
+  message: string;
+  code: string;
+} {
+  if (isEsqlMessage(diagnostic)) {
+    return {
+      message: diagnostic.text,
+      code: diagnostic.code,
+    };
+  }
+  if (isEditorError(diagnostic)) {
+    return {
+      message: diagnostic.message,
+      code: diagnostic.code,
+    };
+  }
+  return {
+    message: 'ES|QL validation error',
+    code: 'esql.invalid',
+  };
+}
+
+function resolveSeverity(
+  diagnostic: EsqlValidationDiagnostic,
+  fallback: 'error' | 'warning'
+): 'error' | 'warning' | 'info' {
+  if (isEsqlMessage(diagnostic)) {
+    if (diagnostic.type === 'warning') {
+      return 'warning';
+    }
+    return 'error';
+  }
+  if (isEditorError(diagnostic)) {
+    const raw: string | number = diagnostic.severity;
+    if (typeof raw === 'number') {
+      if (raw === 4) {
+        return 'warning';
+      }
+      if (raw === 2 || raw === 1) {
+        return 'info';
+      }
+      return 'error';
+    }
+    if (raw === 'warning') {
+      return 'warning';
+    }
+    if (raw === 'info') {
+      return 'info';
+    }
+    return 'error';
+  }
+  return fallback;
+}

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -17,6 +17,9 @@
   "kbn_references": [
     "@kbn/core",
     "@kbn/eval-kql",
+    "@kbn/esql-language",
+    "@kbn/esql-types",
+    "@kbn/esql-utils",
     "@kbn/kibana-react-plugin",
     "@kbn/i18n",
     "@kbn/i18n-react",

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -29,6 +29,7 @@
     "@kbn/config-schema",
     "@kbn/workflows",
     "@kbn/workflows-ui",
+    "@kbn/workflows-yaml",
     "@kbn/zod",
     "@kbn/code-editor",
     "@kbn/monaco",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2642,6 +2642,8 @@
       "@kbn/workflows-management-plugin/*": ["src/platform/plugins/shared/workflows_management/*"],
       "@kbn/workflows-ui": ["src/platform/packages/shared/kbn-workflows-ui"],
       "@kbn/workflows-ui/*": ["src/platform/packages/shared/kbn-workflows-ui/*"],
+      "@kbn/workflows-yaml": ["src/platform/packages/shared/kbn-workflows-yaml"],
+      "@kbn/workflows-yaml/*": ["src/platform/packages/shared/kbn-workflows-yaml/*"],
       "@kbn/workplace-ai-app": ["x-pack/solutions/workplaceai/plugins/workplace_ai_app"],
       "@kbn/workplace-ai-app/*": ["x-pack/solutions/workplaceai/plugins/workplace_ai_app/*"],
       "@kbn/workspaces": ["src/platform/packages/shared/kbn-workspaces"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9818,6 +9818,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/workflows-yaml@link:src/platform/packages/shared/kbn-workflows-yaml":
+  version "0.0.0"
+  uid ""
+
 "@kbn/workflows@link:src/platform/packages/shared/kbn-workflows":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[One Workflow][ES|QL] Integrate es|ql validation feature to elasticsearch.esql.query step (#266673)](https://github.com/elastic/kibana/pull/266673)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-26T09:04:17Z","message":"[One Workflow][ES|QL] Integrate es|ql validation feature to elasticsearch.esql.query step (#266673)\n\n## Summary\n\nIntegrate existing ES|QL validation utilities into the workflows editor.\n\n<img width=\"765\" height=\"538\" alt=\"Screenshot 2026-04-30 at 12 11 10\"\nsrc=\"https://github.com/user-attachments/assets/7a798c78-8537-460d-8376-c0c8ffaf8571\"\n/>\n\n## LiquidJS in ES|QL\n\nWhat happens when a Liquidjs variable is injected into an esql query?\nHere's the summary of it:\n\n| # | Pattern | After this PR |\n|---|---|---|\n| 1 | `WHERE host == \"{{ host }}\"` | ✅ no diagnostic (mask path) |\n| 2 | `FROM logs-{{ env }}-*` | ✅ skipped (structural Liquid) |\n| 3 | `FROM {{ source }}` | ✅ skipped |\n| 4 | `… \\| {{ cmd }} count` | ✅ skipped |\n| 5 | `EVAL x = TO_INT({{ field }})` | ✅ skipped |\n| 6 | `… \\| LIMIT {{ n }}` | ✅ skipped |\n| 7 | `{{ query }}` (whole body) | ✅ skipped |\n| 8 | `FROM logs {# comment #}` | ✅ extended regex masks; mask path |\n| 9 | `{% raw %}{{ literal }}{% endraw %}` | ✅ extended regex masks;\nskipped |\n| 10 | Real typo on a non-Liquid step | ✅ surfaces (validator still\nruns) |\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba48b2cf69aa158d37f7328050110bf6cf4d7429","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:One Workflow","v9.5.0"],"title":"[One Workflow][ES|QL] Integrate es|ql validation feature to elasticsearch.esql.query step","number":266673,"url":"https://github.com/elastic/kibana/pull/266673","mergeCommit":{"message":"[One Workflow][ES|QL] Integrate es|ql validation feature to elasticsearch.esql.query step (#266673)\n\n## Summary\n\nIntegrate existing ES|QL validation utilities into the workflows editor.\n\n<img width=\"765\" height=\"538\" alt=\"Screenshot 2026-04-30 at 12 11 10\"\nsrc=\"https://github.com/user-attachments/assets/7a798c78-8537-460d-8376-c0c8ffaf8571\"\n/>\n\n## LiquidJS in ES|QL\n\nWhat happens when a Liquidjs variable is injected into an esql query?\nHere's the summary of it:\n\n| # | Pattern | After this PR |\n|---|---|---|\n| 1 | `WHERE host == \"{{ host }}\"` | ✅ no diagnostic (mask path) |\n| 2 | `FROM logs-{{ env }}-*` | ✅ skipped (structural Liquid) |\n| 3 | `FROM {{ source }}` | ✅ skipped |\n| 4 | `… \\| {{ cmd }} count` | ✅ skipped |\n| 5 | `EVAL x = TO_INT({{ field }})` | ✅ skipped |\n| 6 | `… \\| LIMIT {{ n }}` | ✅ skipped |\n| 7 | `{{ query }}` (whole body) | ✅ skipped |\n| 8 | `FROM logs {# comment #}` | ✅ extended regex masks; mask path |\n| 9 | `{% raw %}{{ literal }}{% endraw %}` | ✅ extended regex masks;\nskipped |\n| 10 | Real typo on a non-Liquid step | ✅ surfaces (validator still\nruns) |\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba48b2cf69aa158d37f7328050110bf6cf4d7429"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266673","number":266673,"mergeCommit":{"message":"[One Workflow][ES|QL] Integrate es|ql validation feature to elasticsearch.esql.query step (#266673)\n\n## Summary\n\nIntegrate existing ES|QL validation utilities into the workflows editor.\n\n<img width=\"765\" height=\"538\" alt=\"Screenshot 2026-04-30 at 12 11 10\"\nsrc=\"https://github.com/user-attachments/assets/7a798c78-8537-460d-8376-c0c8ffaf8571\"\n/>\n\n## LiquidJS in ES|QL\n\nWhat happens when a Liquidjs variable is injected into an esql query?\nHere's the summary of it:\n\n| # | Pattern | After this PR |\n|---|---|---|\n| 1 | `WHERE host == \"{{ host }}\"` | ✅ no diagnostic (mask path) |\n| 2 | `FROM logs-{{ env }}-*` | ✅ skipped (structural Liquid) |\n| 3 | `FROM {{ source }}` | ✅ skipped |\n| 4 | `… \\| {{ cmd }} count` | ✅ skipped |\n| 5 | `EVAL x = TO_INT({{ field }})` | ✅ skipped |\n| 6 | `… \\| LIMIT {{ n }}` | ✅ skipped |\n| 7 | `{{ query }}` (whole body) | ✅ skipped |\n| 8 | `FROM logs {# comment #}` | ✅ extended regex masks; mask path |\n| 9 | `{% raw %}{{ literal }}{% endraw %}` | ✅ extended regex masks;\nskipped |\n| 10 | Real typo on a non-Liquid step | ✅ surfaces (validator still\nruns) |\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba48b2cf69aa158d37f7328050110bf6cf4d7429"}}]}] BACKPORT-->