### PR TITLE
[ResponseOps] Announce connector creation errors

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/hooks/use_create_connector.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/hooks/use_create_connector.test.tsx
@@ -24,6 +24,7 @@ describe('useCreateConnector', () => {
 
     expect(result.current).toEqual({
       isLoading: false,
+      createConnectorError: null,
       createConnector: expect.anything(),
     });
   });
@@ -78,6 +79,10 @@ describe('useCreateConnector', () => {
       expect(addErrorMock).toHaveBeenCalledWith(error, {
         title: 'Unable to create a connector.',
         toastMessage: 'Internal server error',
+      });
+      expect(result.current.createConnectorError).toEqual({
+        title: 'Unable to create a connector.',
+        message: 'Internal server error',
       });
     });
   });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/hooks/use_create_connector.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/hooks/use_create_connector.tsx
@@ -17,8 +17,14 @@ type CreateConnectorSchema = Pick<
   'actionTypeId' | 'name' | 'config' | 'secrets' | 'id'
 >;
 
+export interface CreateConnectorError {
+  title: string;
+  message: string;
+}
+
 interface UseCreateConnectorReturnValue {
   isLoading: boolean;
+  createConnectorError: CreateConnectorError | null;
   createConnector: (connector: CreateConnectorSchema) => Promise<ActionConnector | undefined>;
 }
 
@@ -29,10 +35,14 @@ export const useCreateConnector = (): UseCreateConnectorReturnValue => {
   } = useKibana().services;
 
   const [isLoading, setIsLoading] = useState(false);
+  const [createConnectorError, setCreateConnectorError] = useState<CreateConnectorError | null>(
+    null
+  );
   const abortCtrlRef = useRef(new AbortController());
   const isMounted = useRef(false);
 
   async function createConnector(connector: CreateConnectorSchema) {
+    setCreateConnectorError(null);
     setIsLoading(true);
     isMounted.current = true;
     abortCtrlRef.current.abort();
@@ -64,17 +74,21 @@ export const useCreateConnector = (): UseCreateConnectorReturnValue => {
         setIsLoading(false);
 
         if (error.name !== 'AbortError') {
+          const title = i18n.translate(
+            'xpack.triggersActionsUI.sections.useCreateConnector.updateErrorNotificationTitle',
+            { defaultMessage: 'Unable to create a connector.' }
+          );
+          const message =
+            error.body?.message ??
+            i18n.translate(
+              'xpack.triggersActionsUI.sections.useCreateConnector.updateErrorNotificationText',
+              { defaultMessage: 'Check the Kibana logs for more information.' }
+            );
+
+          setCreateConnectorError({ title, message });
           toasts.addError(error, {
-            title: i18n.translate(
-              'xpack.triggersActionsUI.sections.useCreateConnector.updateErrorNotificationTitle',
-              { defaultMessage: 'Unable to create a connector.' }
-            ),
-            toastMessage:
-              error.body?.message ??
-              i18n.translate(
-                'xpack.triggersActionsUI.sections.useCreateConnector.updateErrorNotificationText',
-                { defaultMessage: 'Check the Kibana logs for more information.' }
-              ),
+            title,
+            toastMessage: message,
           });
         }
       }
@@ -89,5 +103,5 @@ export const useCreateConnector = (): UseCreateConnectorReturnValue => {
     };
   }, []);
 
-  return { isLoading, createConnector };
+  return { isLoading, createConnectorError, createConnector };
 };

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
@@ -74,7 +74,11 @@ const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
     http,
     uiSettings,
   } = useKibana().services;
-  const { isLoading: isSavingConnector, createConnector } = useCreateConnector();
+  const {
+    isLoading: isSavingConnector,
+    createConnector,
+    createConnectorError,
+  } = useCreateConnector();
 
   const isMounted = useRef(false);
   const [allActionTypes, setAllActionTypes] = useState<ActionTypeIndex | undefined>(undefined);
@@ -464,6 +468,22 @@ const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
                     }
                   )}
                 />
+                <EuiSpacer size="m" />
+              </>
+            )}
+
+            {createConnectorError && (
+              <>
+                <EuiCallOut
+                  announceOnMount
+                  size="s"
+                  color="danger"
+                  iconType="error"
+                  data-test-subj="create-connector-api-error"
+                  title={createConnectorError.title}
+                >
+                  <p>{createConnectorError.message}</p>
+                </EuiCallOut>
                 <EuiSpacer size="m" />
               </>
             )}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242968

## Summary

Errors when creating connectors in the flyout were not previously announced to screen readers. I updated the `use_create_connector` hook to return the error message so it can be rendered in an `EuiCallOut` within the form. This follows an existing pattern. There are other `EuiCallOuts` in the `create_connector_flyout` for similar situations.

## Testing

Enable VoiceOver on Mac. Go to System Settings > Accessibility > VoiceOver.

<img width="757" height="464" alt="Screenshot 2026-06-26 at 10 23 12" src="https://github.com/user-attachments/assets/cc9d12e6-248a-4c4f-abae-71b5725eaf4e" />

Create a connector forcing an error when saving. Bedrock was the one used in the original issue. 

<img width="1713" height="949" alt="Image" src="https://github.com/user-attachments/assets/32a08243-cd8b-4a2d-b52e-10c6171562a3" />

Confirm that the toast title and error message are announced.