### PR TITLE
[Cases] Use shared app header/menu test infrastructure in redesign header tests

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/all_cases/components/cases_list_app_header.test.tsx
@@ -7,48 +7,27 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
+import { APP_HEADER_TEST_SUBJECTS, APP_MENU_TEST_SUBJECTS } from '@kbn/app-header';
+import { openAppMenuOverflow } from '@kbn/app-header/test_helpers';
 
 import { buildCasesPermissions, renderWithTestingProviders } from '../../../../common/mock';
 import { CasesListAppHeader } from './cases_list_app_header';
 
 jest.mock('../../../../common/navigation/hooks');
 
-jest.mock('@kbn/app-header', () => ({
-  AppHeader: ({
-    title,
-    menu,
-  }: {
-    title: string;
-    menu: {
-      items: Array<{ testId: string }>;
-      primaryActionItem?: { testId: string };
-    };
-  }) => (
-    <div data-test-subj="app-header">
-      <span data-test-subj="app-header-title">{title}</span>
-      <div data-test-subj="app-header-menu">
-        {menu?.items?.map((item) => (
-          <span key={item.testId} data-test-subj={item.testId} />
-        ))}
-        {menu?.primaryActionItem && <span data-test-subj={menu.primaryActionItem.testId} />}
-      </div>
-    </div>
-  ),
-}));
-
 describe('CasesListAppHeader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders the app header with the Cases title and analytics test IDs', () => {
+  it('renders the app header with the Cases title', () => {
     renderWithTestingProviders(<CasesListAppHeader />);
 
-    expect(screen.getByTestId('app-header')).toBeInTheDocument();
-    expect(screen.getByTestId('app-header-title')).toHaveTextContent('Cases');
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.root)).toBeInTheDocument();
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.title)).toHaveTextContent('Cases');
   });
 
-  it('displays the create new case menu item when the user has create privileges', () => {
+  it('displays the create new case action when the user has create privileges', () => {
     renderWithTestingProviders(<CasesListAppHeader />, {
       wrapperProps: { permissions: buildCasesPermissions({ create: true }) },
     });
@@ -56,7 +35,7 @@ describe('CasesListAppHeader', () => {
     expect(screen.getByTestId('createNewCaseBtn')).toBeInTheDocument();
   });
 
-  it('does not display the create new case menu item when the user does not have create privileges', () => {
+  it('does not display the create new case action when the user does not have create privileges', () => {
     renderWithTestingProviders(<CasesListAppHeader />, {
       wrapperProps: { permissions: buildCasesPermissions({ create: false }) },
     });
@@ -64,12 +43,14 @@ describe('CasesListAppHeader', () => {
     expect(screen.queryByTestId('createNewCaseBtn')).not.toBeInTheDocument();
   });
 
-  it('displays the configure button when the user has settings privileges', () => {
+  it('displays the configure button when the user has settings privileges', async () => {
     renderWithTestingProviders(<CasesListAppHeader />, {
       wrapperProps: { permissions: buildCasesPermissions({ settings: true }) },
     });
 
-    expect(screen.getByTestId('configure-case-button')).toBeInTheDocument();
+    await openAppMenuOverflow();
+
+    expect(await screen.findByTestId('configure-case-button')).toBeInTheDocument();
   });
 
   it('does not display the configure button when the user does not have settings privileges', () => {
@@ -77,16 +58,20 @@ describe('CasesListAppHeader', () => {
       wrapperProps: { permissions: buildCasesPermissions({ settings: false }) },
     });
 
+    expect(screen.queryByTestId(APP_MENU_TEST_SUBJECTS.overflowButton)).not.toBeInTheDocument();
     expect(screen.queryByTestId('configure-case-button')).not.toBeInTheDocument();
   });
 
-  it('displays both menu items when the user has create and settings privileges', () => {
+  it('displays both the create action and configure button with create and settings privileges', async () => {
     renderWithTestingProviders(<CasesListAppHeader />, {
       wrapperProps: { permissions: buildCasesPermissions({ create: true, settings: true }) },
     });
 
     expect(screen.getByTestId('createNewCaseBtn')).toBeInTheDocument();
-    expect(screen.getByTestId('configure-case-button')).toBeInTheDocument();
+
+    await openAppMenuOverflow();
+
+    expect(await screen.findByTestId('configure-case-button')).toBeInTheDocument();
   });
 
   it('does not display any menu items when the user has no create or settings privileges', () => {
@@ -95,6 +80,6 @@ describe('CasesListAppHeader', () => {
     });
 
     expect(screen.queryByTestId('createNewCaseBtn')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('configure-case-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(APP_MENU_TEST_SUBJECTS.overflowButton)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
+import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
 
 import { CaseDetailsAppHeader } from './case_details_app_header';
 import { renderWithTestingProviders } from '../../../../../common/mock';
@@ -23,15 +24,6 @@ jest.mock('../../../../actions/status/use_status_action');
 jest.mock('../../../../../common/navigation/hooks');
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../case_view/use_on_refresh_case_view_page');
-
-jest.mock('@kbn/app-header', () => ({
-  AppHeader: ({ title, badges, menu }: { title: string; badges: unknown[]; menu: unknown }) => (
-    <div data-test-subj="app-header">
-      <span data-test-subj="app-header-title">{title}</span>
-      <span data-test-subj="app-header-badges">{JSON.stringify(badges)}</span>
-    </div>
-  ),
-}));
 
 jest.mock('../../../../confirm_delete_case', () => ({
   ConfirmDeleteCaseModal: () => <div data-test-subj="confirm-delete-modal" />,
@@ -68,23 +60,21 @@ describe('CaseDetailsAppHeader', () => {
   it('renders the app header with case title', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    expect(await screen.findByTestId('app-header')).toBeInTheDocument();
-    expect(screen.getByTestId('app-header-title')).toHaveTextContent(basicCase.title);
+    expect(await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.root)).toBeInTheDocument();
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.title)).toHaveTextContent(basicCase.title);
   });
 
   it('renders badges in the header', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    const badges = await screen.findByTestId('app-header-badges');
-    expect(badges).toBeInTheDocument();
-    expect(badges.textContent).toContain('case-view-severity-badge');
-    expect(badges.textContent).toContain('case-view-status-badge');
+    expect(await screen.findByTestId('case-view-severity-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('case-view-status-badge')).toBeInTheDocument();
   });
 
   it('does not render delete modal by default', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    await screen.findByTestId('app-header');
+    await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.root);
 
     expect(screen.queryByTestId('confirm-delete-modal')).not.toBeInTheDocument();
   });
@@ -92,7 +82,7 @@ describe('CaseDetailsAppHeader', () => {
   it('does not render settings popover by default', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    await screen.findByTestId('app-header');
+    await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.root);
 
     expect(screen.queryByTestId('case-settings-popover')).not.toBeInTheDocument();
   });
@@ -117,7 +107,7 @@ describe('CaseDetailsAppHeader', () => {
       },
     });
 
-    await screen.findByTestId('app-header');
+    await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.root);
 
     await waitFor(() => {
       expect(screen.queryByTestId('case-settings-popover')).not.toBeInTheDocument();


### PR DESCRIPTION
Follow-up to #274870, which shipped the shared app header/menu test infrastructure.

## Summary

Migrates the Cases redesign header tests to the shared test infrastructure now available in `@kbn/app-header`:

- Removes the hand-rolled `jest.mock('@kbn/app-header', ...)` stubs and renders the real `AppHeader` via the faithful chrome `withProvider` mock.
- Uses the shared `APP_HEADER_TEST_SUBJECTS` / `APP_MENU_TEST_SUBJECTS` constants instead of hardcoded `data-test-subj` strings.
- Uses the `openAppMenuOverflow` helper to assert on overflow-gated menu items, so the tests exercise the actual rendered header behavior.