### PR TITLE
fix(workflows): give managed workflows human-readable display names

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/detection.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/detection.yaml
@@ -1,5 +1,5 @@
 version: "1"
-name: ".significant-events-detection"
+name: "Significant Events Detection"
 description: "Detects statistically significant changes in alert firing patterns per rule using the Elasticsearch change_point aggregation."
 enabled: true
 tags:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/discovery.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/discovery.yaml
@@ -1,5 +1,5 @@
 version: '1'
-name: '.significant-events-discovery'
+name: 'Significant Events Discovery'
 description: 'Correlates unhandled detections into discoveries using an investigator agent and propagates rule-level resolutions.'
 enabled: true
 settings:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/orchestrator.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/orchestrator.yaml
@@ -1,5 +1,5 @@
 version: "1"
-name: ".significant-events-orchestrator"
+name: "Significant Events Orchestrator"
 description: "Sequences detection, discovery, and triage. Each workflow handles its own idle-skip logic."
 enabled: true
 tags:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/triage.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/significant_events/triage.yaml
@@ -1,5 +1,5 @@
 version: '1'
-name: '.significant-events-triage'
+name: 'Significant Events Triage'
 description: 'Analyses unreviewed discoveries with a judge agent and creates significant events.'
 enabled: true
 tags:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/continuous_onboarding.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/continuous_onboarding.yaml
@@ -16,7 +16,7 @@
 # disabled and enabled/disabled via the continuous KI extraction setting.
 
 version: "1"
-name: ".streams-continuous-ki-onboarding"
+name: "Continuous KI Onboarding"
 enabled: false
 description: "This workflow is used by the system and should not be modified."
 tags:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/features_identification.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/features_identification.yaml
@@ -13,7 +13,7 @@
 # for a given stream at any time; overlapping triggers are dropped.
 
 version: "1"
-name: ".streams-ki-features-identification"
+name: "KI Features Identification"
 enabled: true
 description: "Identifies KI features in a stream using LLM analysis and computed KI features."
 tags:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/onboarding.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/onboarding.yaml
@@ -6,7 +6,7 @@
 #   3. Queries generation (optional, skippable — persistence handled by the child workflow)
 
 version: "1"
-name: ".streams-ki-onboarding"
+name: "KI Onboarding"
 enabled: true
 description: "Orchestrates KI feature identification and query generation for a stream."
 tags:

--- a/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/queries_generation.yaml
+++ b/src/platform/packages/shared/kbn-workflows/managed/definitions/streams_ki/queries_generation.yaml
@@ -11,7 +11,7 @@
 # for a given stream at any time; overlapping triggers are dropped.
 
 version: "1"
-name: ".streams-ki-queries-generation"
+name: "KI Queries Generation"
 enabled: true
 description: "Generates KI queries for a stream using LLM inference."
 tags:


### PR DESCRIPTION
## Summary

The `sig_events` and `streams_ki` managed workflow definitions were using dot-prefixed technical identifiers as their display names (e.g. `.significant-events-detection`, `.streams-ki-onboarding`), while the `streams_memory` and `streams_investigation` workflows already had proper human-readable titles like `Memory Synthesis` or `Investigation`.

This PR makes all managed workflows consistent with descriptive, user-facing names:

**`sig_events/`**
- `.significant-events-detection` → `Significant Events Detection`
- `.significant-events-discovery` → `Significant Events Discovery`
- `.significant-events-orchestrator` → `Significant Events Orchestrator`
- `.significant-events-triage` → `Significant Events Triage`

**`streams_ki/`**
- `.streams-continuous-ki-onboarding` → `Continuous KI Onboarding`
- `.streams-ki-features-identification` → `KI Features Identification`
- `.streams-ki-onboarding` → `KI Onboarding`
- `.streams-ki-queries-generation` → `KI Queries Generation`

## Before

<img width="825" height="979" alt="Screenshot 2026-06-26 at 11 58 42" src="https://github.com/user-attachments/assets/011ededc-32f6-410b-b07f-dbc68a2703e7" />


## Test plan

- [ ] Open the Workflows list in the UI and verify all managed workflows show their descriptive title instead of the dot-prefixed identifier.