### PR TITLE
[Security Solution] Adding realtime support for getListItems

### DIFF
--- a/x-pack/solutions/security/plugins/lists/server/services/items/delete_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/delete_list_item.ts
@@ -41,7 +41,12 @@ export const deleteListItem = async ({
 
     if (response.deleted) {
       const checkIfListItemDeleted = async (): Promise<void> => {
-        const deletedListItem = await getListItem({ esClient, id, listItemIndex, realtime: false });
+        const deletedListItem = await getListItem({
+          esClient,
+          esRealtime: false,
+          id,
+          listItemIndex,
+        });
         if (deletedListItem !== null) {
           throw Error(
             'List item was deleted, but the change was not propagated in the expected time interval.'

--- a/x-pack/solutions/security/plugins/lists/server/services/items/delete_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/delete_list_item.ts
@@ -41,7 +41,7 @@ export const deleteListItem = async ({
 
     if (response.deleted) {
       const checkIfListItemDeleted = async (): Promise<void> => {
-        const deletedListItem = await getListItem({ esClient, id, listItemIndex });
+        const deletedListItem = await getListItem({ esClient, id, listItemIndex, realtime: false });
         if (deletedListItem !== null) {
           throw Error(
             'List item was deleted, but the change was not propagated in the expected time interval.'

--- a/x-pack/solutions/security/plugins/lists/server/services/items/delete_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/delete_list_item.ts
@@ -43,7 +43,6 @@ export const deleteListItem = async ({
       const checkIfListItemDeleted = async (): Promise<void> => {
         const deletedListItem = await getListItem({
           esClient,
-          esRealtime: false,
           id,
           listItemIndex,
         });

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.test.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.test.ts
@@ -5,18 +5,15 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 
 import { getListItemResponseMock } from '../../../common/schemas/response/list_item_schema.mock';
+import { LIST_INDEX, LIST_ITEM_ID } from '../../../common/constants.mock';
 import {
-  DATE_NOW,
-  LIST_ID,
-  LIST_INDEX,
-  META,
-  TIE_BREAKER,
-  USER,
-} from '../../../common/constants.mock';
-import { getSearchListItemMock } from '../../schemas/elastic_response/search_es_list_item_schema.mock';
+  getSearchEsListItemMock,
+  getSearchEsListItemsAsAllUndefinedMock,
+} from '../../schemas/elastic_response/search_es_list_item_schema.mock';
 
 import { getListItem } from './get_list_item';
 
@@ -30,61 +27,57 @@ describe('get_list_item', () => {
   });
 
   test('it returns a list item as expected if the list item is found', async () => {
-    const data = getSearchListItemMock();
     const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
-    esClient.search.mockResponse(data);
-    const list = await getListItem({ esClient, id: LIST_ID, listItemIndex: LIST_INDEX });
+    esClient.get.mockResolvedValue({
+      _id: LIST_ITEM_ID,
+      _index: LIST_INDEX,
+      _source: getSearchEsListItemMock(),
+      found: true,
+    });
+    const list = await getListItem({ esClient, id: LIST_ITEM_ID, listItemIndex: LIST_INDEX });
     const expected = getListItemResponseMock();
     expect(list).toEqual(expected);
   });
 
-  test('it returns null if the search is empty', async () => {
-    const data = getSearchListItemMock();
-    data.hits.hits = [];
+  test('it returns null if the document is not found (404)', async () => {
     const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
-    esClient.search.mockResponse(data);
-    const list = await getListItem({ esClient, id: LIST_ID, listItemIndex: LIST_INDEX });
+    esClient.get.mockRejectedValue(
+      new errors.ResponseError({
+        body: { error: { type: 'not_found' } },
+        headers: {},
+        meta: {} as never,
+        statusCode: 404,
+        warnings: [],
+      })
+    );
+    const list = await getListItem({ esClient, id: LIST_ITEM_ID, listItemIndex: LIST_INDEX });
     expect(list).toEqual(null);
   });
 
   test('it returns null if all the values underneath the source type is undefined', async () => {
-    const data = getSearchListItemMock();
-    data.hits.hits[0]._source = {
-      '@timestamp': DATE_NOW,
-      binary: undefined,
-      boolean: undefined,
-      byte: undefined,
-      created_at: DATE_NOW,
-      created_by: USER,
-      date: undefined,
-      date_nanos: undefined,
-      date_range: undefined,
-      double: undefined,
-      double_range: undefined,
-      float: undefined,
-      float_range: undefined,
-      geo_point: undefined,
-      geo_shape: undefined,
-      half_float: undefined,
-      integer: undefined,
-      integer_range: undefined,
-      ip: undefined,
-      ip_range: undefined,
-      keyword: undefined,
-      list_id: LIST_ID,
-      long: undefined,
-      long_range: undefined,
-      meta: META,
-      shape: undefined,
-      short: undefined,
-      text: undefined,
-      tie_breaker_id: TIE_BREAKER,
-      updated_at: DATE_NOW,
-      updated_by: USER,
-    };
     const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
-    esClient.search.mockResponse(data);
-    const list = await getListItem({ esClient, id: LIST_ID, listItemIndex: LIST_INDEX });
+    esClient.get.mockResolvedValue({
+      _id: LIST_ITEM_ID,
+      _index: LIST_INDEX,
+      _source: getSearchEsListItemsAsAllUndefinedMock(),
+      found: true,
+    });
+    const list = await getListItem({ esClient, id: LIST_ITEM_ID, listItemIndex: LIST_INDEX });
     expect(list).toEqual(null);
+  });
+
+  test('it re-throws non-404 errors', async () => {
+    const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+    const serverError = new errors.ResponseError({
+      body: { error: { type: 'internal_server_error' } },
+      headers: {},
+      meta: {} as never,
+      statusCode: 500,
+      warnings: [],
+    });
+    esClient.get.mockRejectedValue(serverError);
+    await expect(
+      getListItem({ esClient, id: LIST_ITEM_ID, listItemIndex: LIST_INDEX })
+    ).rejects.toThrow(serverError);
   });
 });

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.test.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.test.ts
@@ -66,6 +66,35 @@ describe('get_list_item', () => {
     expect(list).toEqual(null);
   });
 
+  test('it forwards esRealtime: true to the esClient.get call', async () => {
+    const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+    esClient.get.mockResolvedValue({
+      _id: LIST_ITEM_ID,
+      _index: LIST_INDEX,
+      _source: getSearchEsListItemMock(),
+      found: true,
+    });
+    await getListItem({
+      esClient,
+      esRealtime: true,
+      id: LIST_ITEM_ID,
+      listItemIndex: LIST_INDEX,
+    });
+    expect(esClient.get).toHaveBeenCalledWith(expect.objectContaining({ realtime: true }));
+  });
+
+  test('it returns null if _source is undefined', async () => {
+    const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
+    esClient.get.mockResolvedValue({
+      _id: LIST_ITEM_ID,
+      _index: LIST_INDEX,
+      _source: undefined,
+      found: true,
+    });
+    const list = await getListItem({ esClient, id: LIST_ITEM_ID, listItemIndex: LIST_INDEX });
+    expect(list).toEqual(null);
+  });
+
   test('it re-throws non-404 errors', async () => {
     const esClient = elasticsearchClientMock.createScopedClusterClient().asCurrentUser;
     const serverError = new errors.ResponseError({

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Id, ListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import { encodeHitVersion } from '@kbn/securitysolution-es-utils';
 
-import { transformElasticToListItem } from '../utils';
-import { findSourceType } from '../utils/find_source_type';
+import { ErrorWithStatusCode } from '../../error_with_status_code';
 import type { SearchEsListItemSchema } from '../../schemas/elastic_response';
+import { findSourceType } from '../utils/find_source_type';
+import { findSourceValue } from '../utils/find_source_value';
+import { convertDateNumberToString } from '../utils/convert_date_number_to_string';
 
 interface GetListItemOptions {
   id: Id;
@@ -23,30 +27,42 @@ export const getListItem = async ({
   esClient,
   listItemIndex,
 }: GetListItemOptions): Promise<ListItemSchema | null> => {
-  // Note: This typing of response = await esClient<SearchResponse<SearchEsListSchema>>
-  // is because when you pass in seq_no_primary_term: true it does a "fall through" type and you have
-  // to explicitly define the type <T>.
-  const listItemES = await esClient.search<SearchEsListItemSchema>({
-    ignore_unavailable: true,
-    index: listItemIndex,
-    query: {
-      term: {
-        _id: id,
-      },
-    },
-    seq_no_primary_term: true,
-  });
+  try {
+    const response = await esClient.get<SearchEsListItemSchema>({
+      id,
+      index: listItemIndex,
+    });
 
-  if (listItemES.hits.hits.length) {
-    // @ts-expect-error @elastic/elasticsearch _source is optional
-    const type = findSourceType(listItemES.hits.hits[0]._source);
-    if (type != null) {
-      const listItems = transformElasticToListItem({ response: listItemES, type });
-      return listItems[0];
-    } else {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const source = response._source!;
+    const type = findSourceType(source);
+    if (type == null) {
       return null;
     }
-  } else {
-    return null;
+
+    const value = findSourceValue(source);
+    if (value == null) {
+      throw new ErrorWithStatusCode(`Was expected ${type} to not be null/undefined`, 400);
+    }
+
+    return {
+      '@timestamp': convertDateNumberToString(source['@timestamp']),
+      _version: encodeHitVersion(response),
+      created_at: source.created_at,
+      created_by: source.created_by,
+      id: response._id,
+      list_id: source.list_id,
+      meta: source.meta ?? undefined,
+      tie_breaker_id: source.tie_breaker_id,
+      type,
+      updated_at: source.updated_at,
+      updated_by: source.updated_by,
+      value,
+    };
+  } catch (e) {
+    if (e instanceof errors.ResponseError && e.statusCode === 404) {
+      return null;
+    }
+    throw e;
   }
 };

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
@@ -20,22 +20,23 @@ interface GetListItemOptions {
   id: Id;
   esClient: ElasticsearchClient;
   listItemIndex: string;
-  // Set to false when polling for segment-visible state (e.g. waitUntilDocumentIndexed
-  // callbacks). Defaults to true (translog realtime reads) for direct HTTP read paths.
-  realtime?: boolean;
+  // Maps to the ES Get API `realtime` parameter. Set to false in waitUntilDocumentIndexed
+  // poll callbacks so the read only resolves after a segment refresh (search-consistent).
+  // Defaults to true for direct HTTP read paths.
+  esRealtime?: boolean;
 }
 
 export const getListItem = async ({
   id,
   esClient,
   listItemIndex,
-  realtime = true,
+  esRealtime = true,
 }: GetListItemOptions): Promise<ListItemSchema | null> => {
   try {
     const response = await esClient.get<SearchEsListItemSchema>({
       id,
       index: listItemIndex,
-      realtime,
+      realtime: esRealtime,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
@@ -20,9 +20,9 @@ interface GetListItemOptions {
   id: Id;
   esClient: ElasticsearchClient;
   listItemIndex: string;
-  // Maps to the ES Get API `realtime` parameter. Set to false in waitUntilDocumentIndexed
-  // poll callbacks so the read only resolves after a segment refresh (search-consistent).
-  // Defaults to true for direct HTTP read paths.
+  // Maps to the ES Get API `realtime` parameter. Defaults to false (segment-visible,
+  // matching the previous esClient.search behavior). Set to true on read paths that need
+  // immediate visibility after a refresh:false write (translog reads).
   esRealtime?: boolean;
 }
 
@@ -30,7 +30,7 @@ export const getListItem = async ({
   id,
   esClient,
   listItemIndex,
-  esRealtime = true,
+  esRealtime = false,
 }: GetListItemOptions): Promise<ListItemSchema | null> => {
   try {
     const response = await esClient.get<SearchEsListItemSchema>({

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
@@ -20,17 +20,22 @@ interface GetListItemOptions {
   id: Id;
   esClient: ElasticsearchClient;
   listItemIndex: string;
+  // Set to false when polling for segment-visible state (e.g. waitUntilDocumentIndexed
+  // callbacks). Defaults to true (translog realtime reads) for direct HTTP read paths.
+  realtime?: boolean;
 }
 
 export const getListItem = async ({
   id,
   esClient,
   listItemIndex,
+  realtime = true,
 }: GetListItemOptions): Promise<ListItemSchema | null> => {
   try {
     const response = await esClient.get<SearchEsListItemSchema>({
       id,
       index: listItemIndex,
+      realtime,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/get_list_item.ts
@@ -39,8 +39,11 @@ export const getListItem = async ({
       realtime: esRealtime,
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const source = response._source!;
+    const { _source: source } = response;
+    if (source == null) {
+      return null;
+    }
+
     const type = findSourceType(source);
     if (type == null) {
       return null;

--- a/x-pack/solutions/security/plugins/lists/server/services/items/update_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/update_list_item.ts
@@ -109,9 +109,9 @@ export const updateListItem = async ({
         const checkIfListUpdated = async (): Promise<void> => {
           const updatedListItem = await getListItem({
             esClient,
+            esRealtime: false,
             id,
             listItemIndex,
-            realtime: false,
           });
           if (updatedListItem?._version === listItem._version) {
             throw Error('List item has not been re-indexed in time');

--- a/x-pack/solutions/security/plugins/lists/server/services/items/update_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/update_list_item.ts
@@ -107,7 +107,12 @@ export const updateListItem = async ({
       let updatedOCCVersion: string | undefined;
       if (response.updated) {
         const checkIfListUpdated = async (): Promise<void> => {
-          const updatedListItem = await getListItem({ esClient, id, listItemIndex });
+          const updatedListItem = await getListItem({
+            esClient,
+            id,
+            listItemIndex,
+            realtime: false,
+          });
           if (updatedListItem?._version === listItem._version) {
             throw Error('List item has not been re-indexed in time');
           }

--- a/x-pack/solutions/security/plugins/lists/server/services/items/update_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/items/update_list_item.ts
@@ -109,7 +109,6 @@ export const updateListItem = async ({
         const checkIfListUpdated = async (): Promise<void> => {
           const updatedListItem = await getListItem({
             esClient,
-            esRealtime: false,
             id,
             listItemIndex,
           });


### PR DESCRIPTION
> Note: this is WIP

## Summary

Relates to: https://github.com/elastic/kibana/issues/266239

Replaces `esClient.search` with `esClient.get` in `getListItem` for fetching a single list item by its document `_id`.

* [ES document get operation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get)
* [ES search operation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search)

`esClient.search` with `term: { _id }` is functionally correct but I think semantically we could do a single-document retrieval using `esClient.get`, as it seems to be the right API for this access pattern.

**What changed:**
- `getListItem` now calls `esClient.get` instead of `esClient.search`
- Not-found is handled via a caught 404 `ResponseError` instead of checking `hits.hits.length === 0`
- `ListItemSchema` is constructed inline from building blocks (`findSourceType`, `findSourceValue`, `encodeHitVersion`, `convertDateNumberToString`) that `transformElasticToListItem` calls internally (all 12 fields verified field-by-field) A new `esRealtime` option is added to `GetListItemOptions` (maps directly to the ES Get API `realtime` parameter). It defaults to `false` (segment-visible reads, matching the prior `esClient.search` behavior) so all existing callers are unaffected. Callers that need immediate visibility after a `refresh: false` write opt in with `esRealtime: true`

**No behavioral change for callers.** Return type `Promise<ListItemSchema | null>` is unchanged. No caller needed modification.

## Context

`waitUntilDocumentIndexed` was introduced in #162508 (lists data stream migration) because `update_by_query` and `delete_by_query`(as it was required for mutations on data streams, validate with @vitaliidm ) only support `refresh: true/false`, not `refresh: wait_for`. The polling loop fills that gap by retrying `getListItem` until the change is visible.

Before this PR, the poll used `esClient.search` (near-real-time), which implicitly guaranteed the document was in a refreshed Lucene segment. `esClient.get` defaults to realtime translog reads, which would have broken that guarantee. This is avoided by defaulting `esRealtime` to `false`, so all poll callbacks (and all unmodified callers) continue to see segment-visible state.

## Motivation
Part of the epic https://github.com/elastic/kibana/issues/266239, we are suggesting performance improvements for IaC (Infrastructure as Code) clients, these clients currently use `refresh: wait_for` in all of the request as default behavior, which causes ~second-long responses for individual CRUD operations on value list items.
 
- **This PR helps unblock the usage `refresh: false` write patterns, by allowing translog reads**. Allows clients to have consistent realtime reads on items mutated with `refresh: false`, and  avoid the ~1s-per-item `wait_for` bottleneck that makes large-scale IaC deployments long-running wall times.

**Otherwise**, with the old `esClient.search` implementation, an immediate read-back after a `refresh: false` write would return `null` (if done before the ES index refresh). `esClient.get` [reads from the translog by default](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-get).

- **Possibly better semantics**. `esClient.get` is the intended API for fetching a document by `_id`; using `esClient.search` with `term: { _id }` uses the full query layer to do a document-level operation. In return this also- **Lower overhead** — skips query parsing, shard fan-out, scoring, and the two-phase query/fetch coordination; routes directly to the shard that owns the document

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3b1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- **`waitUntilDocumentIndexed` polling consistency** — *Low.* `esClient.get` with `realtime: true` resolves from the translog before a Lucene refresh, which would allow the poll to signal "done" while concurrent search callers still see stale data. Mitigated by defaulting `esRealtime` to `false`, so all poll callbacks (and all callers that don't explicitly opt in) get segment-visible reads identical to the old `esClient.search` behavior.
- **`index_not_found_exception` masking** — *Very low.* The old `esClient.search` with `ignore_unavailable: true` silently returned `null` for a missing index. The new code catches any 404 `ResponseError` (including `index_not_found_exception`) and also returns `null`. Callers see identical behavior; the only difference is that a missing-index condition is no longer distinguishable from a missing-document condition at this layer.
