### PR TITLE
[9.4] fix(streams): update default_pipeline on write index when adding processing to a second OTEL metrics stream (#269988)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.test.ts
@@ -467,7 +467,7 @@ describe('translateClassicStreamPipelineActions', () => {
       } as ActionsByType);
     });
 
-    it('upserts only the pipeline if a processors is added', async () => {
+    it('also adds update_default_ingest_pipeline for the new data stream when a processor is added', async () => {
       const actionsByType = emptyActionsByType();
       actionsByType.append_processor_to_ingest_pipeline.push({
         type: 'append_processor_to_ingest_pipeline',
@@ -560,6 +560,15 @@ describe('translateClassicStreamPipelineActions', () => {
                 description:
                   'Streams managed pipeline to connect Classic streams to the Streams layer',
               },
+            },
+          },
+        ],
+        update_default_ingest_pipeline: [
+          {
+            type: 'update_default_ingest_pipeline',
+            request: {
+              name: 'my-other-datastream',
+              pipeline: 'my-template-pipeline',
             },
           },
         ],
@@ -657,6 +666,15 @@ describe('translateClassicStreamPipelineActions', () => {
                 description:
                   'Streams managed pipeline to connect Classic streams to the Streams layer',
               },
+            },
+          },
+        ],
+        update_default_ingest_pipeline: [
+          {
+            type: 'update_default_ingest_pipeline',
+            request: {
+              name: 'my-other-datastream',
+              pipeline: 'my-template-pipeline',
             },
           },
         ],

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.ts
@@ -169,6 +169,18 @@ async function updateExistingStreamsManagedPipeline({
     if (action.type === 'append_processor_to_ingest_pipeline') {
       if (!existingPipelineProcessors.includes(action.processor?.pipeline?.name ?? '')) {
         processors.push(action.processor);
+        // Only set default_pipeline on the write index when this is the first time this stream's
+        // processor is being added (i.e. it wasn't already present in the shared pipeline).
+        // This mirrors what createStreamsManagedPipeline does for the very first stream — without
+        // this, a second (or later) stream sharing the same template pipeline never gets
+        // index.default_pipeline set on its write index and documents bypass processing entirely.
+        actionsByType.update_default_ingest_pipeline.push({
+          type: 'update_default_ingest_pipeline',
+          request: {
+            name: action.dataStream,
+            pipeline: pipelineName,
+          },
+        });
       }
     } else {
       processors = processors.filter(

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
@@ -39,7 +39,7 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./snapshot_restore'));
     loadTestFile(require.resolve('./query_streams'));
     loadTestFile(require.resolve('./deferred_data_stream'));
-    loadTestFile(require.resolve('./draft_streams'));
+    loadTestFile(require.resolve('./otel_metrics_processing'));
     loadTestFile(require.resolve('./otel_metrics_processing'));
   });
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
@@ -39,5 +39,7 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./snapshot_restore'));
     loadTestFile(require.resolve('./query_streams'));
     loadTestFile(require.resolve('./deferred_data_stream'));
+    loadTestFile(require.resolve('./draft_streams'));
+    loadTestFile(require.resolve('./otel_metrics_processing'));
   });
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
@@ -40,6 +40,5 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./query_streams'));
     loadTestFile(require.resolve('./deferred_data_stream'));
     loadTestFile(require.resolve('./otel_metrics_processing'));
-    loadTestFile(require.resolve('./otel_metrics_processing'));
   });
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/otel_metrics_processing.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/otel_metrics_processing.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import type { StreamsSupertestRepositoryClient } from './helpers/repository_client';
+import { createStreamsRepositoryAdminClient } from './helpers/repository_client';
+import {
+  disableStreams,
+  enableStreams,
+  fetchDocument,
+  indexDocument,
+  putIngest,
+} from './helpers/requests';
+
+// OTEL metrics data streams do NOT have a default_pipeline set on their write indices
+// out-of-the-box (unlike logs). Streams must explicitly call updateDefaultIngestPipeline
+// for each new stream.
+//
+// This test reproduces https://github.com/elastic/kibana/issues/269984:
+// when a second classic stream shares the same template-level pipeline (because it matches
+// the same index template), the first stream's setup creates the pipeline and correctly
+// sets default_pipeline on its write index. But the second stream's write index never gets
+// index.default_pipeline set — so documents bypass processing entirely.
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const roleScopedSupertest = getService('roleScopedSupertest');
+  const esClient = getService('es');
+
+  const stream1 = 'metrics-hostmetricsreceiver.otel-default';
+  const stream2 = 'metrics-kubeletstatsreceiver.otel-default';
+
+  let apiClient: StreamsSupertestRepositoryClient;
+
+  describe('OTEL metrics classic streams - processing applied to second stream', () => {
+    before(async () => {
+      apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
+      await enableStreams(apiClient);
+
+      // Seed both streams so their write indices exist before we add processing.
+      // OTEL metrics use resource.attributes.* for resource-level fields.
+      await indexDocument(esClient, stream1, {
+        '@timestamp': new Date().toISOString(),
+        'resource.attributes.host.name': 'node1',
+      });
+      await indexDocument(esClient, stream2, {
+        '@timestamp': new Date().toISOString(),
+        'resource.attributes.host.name': 'node2',
+      });
+    });
+
+    after(async () => {
+      for (const stream of [stream1, stream2]) {
+        await esClient.indices.deleteDataStream({ name: stream }).catch(() => {});
+      }
+      // Remove the Streams-managed ingest pipelines so subsequent runs start clean.
+      // The template-level pipeline persists across disableStreams and would cause
+      // the test to see processors already present, bypassing the update_default_ingest_pipeline
+      // code path that this test exercises.
+      await esClient.ingest
+        .deletePipeline({ id: 'metrics-otel@template-pipeline' })
+        .catch(() => {});
+      await esClient.ingest.deletePipeline({ id: `${stream1}@stream.processing` }).catch(() => {});
+      await esClient.ingest.deletePipeline({ id: `${stream2}@stream.processing` }).catch(() => {});
+      await disableStreams(apiClient);
+    });
+
+    it('applies processing to the second OTEL metrics stream when the template pipeline already exists', async () => {
+      const baseIngest = {
+        lifecycle: { inherit: {} },
+        settings: {},
+        classic: {},
+        failure_store: { inherit: {} },
+      };
+
+      // --- Step 1: add processing to the FIRST stream ---
+      // This creates the shared template-level pipeline (metrics-otel@template-pipeline)
+      // and sets index.default_pipeline on stream1's write index.
+      await putIngest(apiClient, stream1, {
+        ingest: {
+          ...baseIngest,
+          processing: {
+            steps: [{ action: 'set', to: 'attributes.stream_origin', value: 'stream1' }],
+          },
+        },
+      });
+
+      // --- Step 2: add processing to the SECOND stream ---
+      // The template-level pipeline now already exists (streams-managed). Before the fix,
+      // updateExistingStreamsManagedPipeline would NOT emit update_default_ingest_pipeline
+      // for stream2's write index, so the set processor was silently skipped.
+      await putIngest(apiClient, stream2, {
+        ingest: {
+          ...baseIngest,
+          processing: {
+            steps: [{ action: 'set', to: 'attributes.stream_origin', value: 'stream2' }],
+          },
+        },
+      });
+
+      // --- Step 3: index a doc into the SECOND stream and verify the processor ran ---
+      const response = await indexDocument(esClient, stream2, {
+        '@timestamp': new Date().toISOString(),
+        'resource.attributes.host.name': 'node3',
+      });
+
+      const hit = await fetchDocument(esClient, stream2, response._id);
+      const source = hit._source as Record<string, Record<string, unknown>>;
+
+      // If the write index never had default_pipeline set, the field will be absent.
+      // The `set` processor writes into the `attributes` object (OTEL custom namespace).
+      expect(source.attributes?.stream_origin).to.eql('stream2');
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(streams): update default_pipeline on write index when adding processing to a second OTEL metrics stream (#269988)](https://github.com/elastic/kibana/pull/269988)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2026-05-22T10:04:04Z","message":"fix(streams): update default_pipeline on write index when adding processing to a second OTEL metrics stream (#269988)\n\n## Summary\n\nFixes #269984\n\nWhen a second classic stream (e.g. a second OTEL metrics data stream)\nsharing the same template-level ingest pipeline receives its first\nprocessing step, `updateExistingStreamsManagedPipeline` was only\nupdating the shared pipeline's processors. It never pushed\n`update_default_ingest_pipeline` actions for the new stream's current\nwrite index, so `index.default_pipeline` was never set on it and\ndocuments indexed into that stream bypassed processing entirely.\n\nThis did not affect logs data streams because their write indices\nalready have `default_pipeline` set by built-in templates. OTEL metrics\ndata streams do not, so they depend entirely on Streams to set the\n`index.default_pipeline` setting.\n\n## Root cause\n\nIn `translate_classic_stream_pipeline_actions.ts`, the\n`updateExistingStreamsManagedPipeline` path (taken when the template\npipeline already exists as a streams-managed pipeline) was missing the\n`update_default_ingest_pipeline` pushes that\n`createStreamsManagedPipeline` correctly performs for the first stream.\n\n## Fix\n\nFor every `append_processor_to_ingest_pipeline` action processed by\n`updateExistingStreamsManagedPipeline`, emit a matching\n`update_default_ingest_pipeline` action — mirroring what\n`createStreamsManagedPipeline` already does.\n\n## Testing\n\n- Updated the existing unit test\n(`translate_classic_stream_pipeline_actions.test.ts`) to assert\n`update_default_ingest_pipeline` is emitted when\n`updateExistingStreamsManagedPipeline` appends a processor.\n- Added a new FTR API integration test (`otel_metrics_processing.ts`)\nthat:\n  1. Creates two `metrics-*.otel-default` data streams via the ES API\n2. Adds a `set` processor to the first stream via the Streams API\n(creates the template pipeline)\n3. Adds a `set` processor to the second stream via the Streams API\n(exercises the previously-broken path)\n4. Indexes a document into the second stream and verifies that the\nprocessor was actually applied\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"9429056dd34cd63eef08d523f4b78bfa9a8684aa","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-onboarding","backport:version","Feature:Streams","v9.5.0","v9.4.4"],"title":"fix(streams): update default_pipeline on write index when adding processing to a second OTEL metrics stream","number":269988,"url":"https://github.com/elastic/kibana/pull/269988","mergeCommit":{"message":"fix(streams): update default_pipeline on write index when adding processing to a second OTEL metrics stream (#269988)\n\n## Summary\n\nFixes #269984\n\nWhen a second classic stream (e.g. a second OTEL metrics data stream)\nsharing the same template-level ingest pipeline receives its first\nprocessing step, `updateExistingStreamsManagedPipeline` was only\nupdating the shared pipeline's processors. It never pushed\n`update_default_ingest_pipeline` actions for the new stream's current\nwrite index, so `index.default_pipeline` was never set on it and\ndocuments indexed into that stream bypassed processing entirely.\n\nThis did not affect logs data streams because their write indices\nalready have `default_pipeline` set by built-in templates. OTEL metrics\ndata streams do not, so they depend entirely on Streams to set the\n`index.default_pipeline` setting.\n\n## Root cause\n\nIn `translate_classic_stream_pipeline_actions.ts`, the\n`updateExistingStreamsManagedPipeline` path (taken when the template\npipeline already exists as a streams-managed pipeline) was missing the\n`update_default_ingest_pipeline` pushes that\n`createStreamsManagedPipeline` correctly performs for the first stream.\n\n## Fix\n\nFor every `append_processor_to_ingest_pipeline` action processed by\n`updateExistingStreamsManagedPipeline`, emit a matching\n`update_default_ingest_pipeline` action — mirroring what\n`createStreamsManagedPipeline` already does.\n\n## Testing\n\n- Updated the existing unit test\n(`translate_classic_stream_pipeline_actions.test.ts`) to assert\n`update_default_ingest_pipeline` is emitted when\n`updateExistingStreamsManagedPipeline` appends a processor.\n- Added a new FTR API integration test (`otel_metrics_processing.ts`)\nthat:\n  1. Creates two `metrics-*.otel-default` data streams via the ES API\n2. Adds a `set` processor to the first stream via the Streams API\n(creates the template pipeline)\n3. Adds a `set` processor to the second stream via the Streams API\n(exercises the previously-broken path)\n4. Indexes a document into the second stream and verifies that the\nprocessor was actually applied\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"9429056dd34cd63eef08d523f4b78bfa9a8684aa"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269988","number":269988,"mergeCommit":{"message":"fix(streams): update default_pipeline on write index when adding processing to a second OTEL metrics stream (#269988)\n\n## Summary\n\nFixes #269984\n\nWhen a second classic stream (e.g. a second OTEL metrics data stream)\nsharing the same template-level ingest pipeline receives its first\nprocessing step, `updateExistingStreamsManagedPipeline` was only\nupdating the shared pipeline's processors. It never pushed\n`update_default_ingest_pipeline` actions for the new stream's current\nwrite index, so `index.default_pipeline` was never set on it and\ndocuments indexed into that stream bypassed processing entirely.\n\nThis did not affect logs data streams because their write indices\nalready have `default_pipeline` set by built-in templates. OTEL metrics\ndata streams do not, so they depend entirely on Streams to set the\n`index.default_pipeline` setting.\n\n## Root cause\n\nIn `translate_classic_stream_pipeline_actions.ts`, the\n`updateExistingStreamsManagedPipeline` path (taken when the template\npipeline already exists as a streams-managed pipeline) was missing the\n`update_default_ingest_pipeline` pushes that\n`createStreamsManagedPipeline` correctly performs for the first stream.\n\n## Fix\n\nFor every `append_processor_to_ingest_pipeline` action processed by\n`updateExistingStreamsManagedPipeline`, emit a matching\n`update_default_ingest_pipeline` action — mirroring what\n`createStreamsManagedPipeline` already does.\n\n## Testing\n\n- Updated the existing unit test\n(`translate_classic_stream_pipeline_actions.test.ts`) to assert\n`update_default_ingest_pipeline` is emitted when\n`updateExistingStreamsManagedPipeline` appends a processor.\n- Added a new FTR API integration test (`otel_metrics_processing.ts`)\nthat:\n  1. Creates two `metrics-*.otel-default` data streams via the ES API\n2. Adds a `set` processor to the first stream via the Streams API\n(creates the template pipeline)\n3. Adds a `set` processor to the second stream via the Streams API\n(exercises the previously-broken path)\n4. Indexes a document into the second stream and verifies that the\nprocessor was actually applied\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"9429056dd34cd63eef08d523f4b78bfa9a8684aa"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->