### PR TITLE
Filter continuous KI extraction by Significant Events index patterns

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -279,6 +279,7 @@ export { streamsOasDefinitions } from './src/oas_definitions';
 export type { StreamsOasDefinitions } from './src/oas_definitions';
 
 export { streamMatchesIndexPatterns } from './src/helpers/stream_matches_index_patterns';
+export { parseSigEventsIndexPatterns } from './src/helpers/parse_sig_events_index_patterns';
 export { DEFAULT_INDEX_PATTERNS } from './src/helpers/default_index_patterns';
 
 export {

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/parse_sig_events_index_patterns.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/parse_sig_events_index_patterns.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_INDEX_PATTERNS } from './default_index_patterns';
+import { parseSigEventsIndexPatterns } from './parse_sig_events_index_patterns';
+
+describe('parseSigEventsIndexPatterns', () => {
+  it('splits comma-separated patterns and trims whitespace', () => {
+    expect(parseSigEventsIndexPatterns('logs*, metrics* , traces-*')).toEqual([
+      'logs*',
+      'metrics*',
+      'traces-*',
+    ]);
+  });
+
+  it('falls back to the default when undefined', () => {
+    expect(parseSigEventsIndexPatterns(undefined)).toEqual([DEFAULT_INDEX_PATTERNS]);
+  });
+
+  it('falls back to the default when empty', () => {
+    expect(parseSigEventsIndexPatterns('')).toEqual([DEFAULT_INDEX_PATTERNS]);
+  });
+
+  it('falls back to the default when only whitespace', () => {
+    expect(parseSigEventsIndexPatterns('  ,  ')).toEqual([DEFAULT_INDEX_PATTERNS]);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/parse_sig_events_index_patterns.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/parse_sig_events_index_patterns.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_INDEX_PATTERNS } from './default_index_patterns';
+
+/**
+ * Parses the Significant Events index patterns advanced setting value into a
+ * list of glob-style patterns. Falls back to {@link DEFAULT_INDEX_PATTERNS}
+ * when the value is empty or whitespace-only.
+ */
+export function parseSigEventsIndexPatterns(raw: string | undefined): string[] {
+  const patterns = (raw ?? '')
+    .split(',')
+    .map((pattern) => pattern.trim())
+    .filter((pattern) => pattern.length > 0);
+
+  return patterns.length > 0 ? patterns : [DEFAULT_INDEX_PATTERNS];
+}

--- a/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
+++ b/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
@@ -90,7 +90,7 @@ export function registerFeatureFlags(
             value: DEFAULT_INDEX_PATTERNS,
             description: i18n.translate('xpack.streams.sigEventsIndexPatternsSettingsDescription', {
               defaultMessage:
-                'Comma-separated list of index patterns used for Significant Events stream filtering and analysis.',
+                'Comma-separated list of index patterns used for Significant Events stream filtering, analysis, and continuous knowledge indicator extraction.',
             }),
             type: 'string',
             schema: schema.string(),
@@ -153,7 +153,7 @@ export function registerFeatureFlags(
             value: false,
             description: i18n.translate('xpack.streams.continuousKiExtractionEnabledDescription', {
               defaultMessage:
-                'When enabled, knowledge indicator extraction runs automatically on managed streams.',
+                'When enabled, knowledge indicator extraction runs automatically on streams that match Significant Events index patterns, minus any excluded patterns.',
             }),
             type: 'boolean',
             schema: schema.boolean(),
@@ -192,7 +192,7 @@ export function registerFeatureFlags(
               'xpack.streams.continuousKiExtractionExcludedStreamPatternsDescription',
               {
                 defaultMessage:
-                  'Comma-separated list of stream names or glob patterns (e.g. logs.debug.*) to exclude from automatic knowledge indicator extraction.',
+                  'Comma-separated list of stream names or glob patterns (e.g. logs.debug.*) to exclude from automatic knowledge indicator extraction. Streams must also match Significant Events index patterns to be eligible.',
               }
             ),
             type: 'string',

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/reconcile_continuous_ki_extraction_on_startup.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/reconcile_continuous_ki_extraction_on_startup.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, Logger } from '@kbn/core/server';
+import { OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_ENABLED } from '@kbn/management-settings-ids';
+import { reconcileContinuousKiExtractionOnStartup } from './reconcile_continuous_ki_extraction_on_startup';
+
+describe('reconcileContinuousKiExtractionOnStartup', () => {
+  const createDeps = ({
+    enabled = false,
+    ensureWorkflow = jest.fn().mockResolvedValue(undefined),
+  }: {
+    enabled?: boolean;
+    ensureWorkflow?: jest.Mock;
+  } = {}) => {
+    const globalUiSettingsClient = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_ENABLED) {
+          return Promise.resolve(enabled);
+        }
+        return Promise.resolve(undefined);
+      }),
+    };
+
+    const core = {
+      savedObjects: {
+        getUnsafeInternalClient: jest.fn().mockReturnValue({}),
+      },
+      uiSettings: {
+        globalAsScopedToClient: jest.fn().mockReturnValue(globalUiSettingsClient),
+      },
+    } as unknown as CoreStart;
+
+    const continuousKiExtractionWorkflowService = {
+      ensureWorkflow,
+    };
+
+    const taskClient = {};
+
+    const logger = {
+      info: jest.fn(),
+    } as unknown as Logger;
+
+    return { core, continuousKiExtractionWorkflowService, taskClient, logger, ensureWorkflow };
+  };
+
+  it('does nothing when continuous extraction is disabled', async () => {
+    const { core, continuousKiExtractionWorkflowService, taskClient, logger, ensureWorkflow } =
+      createDeps();
+
+    await reconcileContinuousKiExtractionOnStartup({
+      core,
+      continuousKiExtractionWorkflowService,
+      taskClient,
+      logger,
+    });
+
+    expect(ensureWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('creates the extraction workflow when continuous extraction is enabled', async () => {
+    const { core, continuousKiExtractionWorkflowService, taskClient, logger, ensureWorkflow } =
+      createDeps({
+        enabled: true,
+      });
+
+    await reconcileContinuousKiExtractionOnStartup({
+      core,
+      continuousKiExtractionWorkflowService,
+      taskClient,
+      logger,
+    });
+
+    expect(ensureWorkflow).toHaveBeenCalledWith({
+      enabled: true,
+      request: expect.objectContaining({
+        headers: expect.objectContaining({ 'x-elastic-internal-origin': 'kibana' }),
+      }),
+      taskClient,
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      'Reconciled continuous KI extraction workflow on startup'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/reconcile_continuous_ki_extraction_on_startup.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/reconcile_continuous_ki_extraction_on_startup.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, Logger } from '@kbn/core/server';
+import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
+import { OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_ENABLED } from '@kbn/management-settings-ids';
+import type { TaskClient } from '../tasks/task_client';
+import type { ContinuousKiExtractionWorkflowService } from './continuous_extraction_workflow';
+
+/**
+ * Ensures the continuous KI extraction workflow is created when the global
+ * setting is already true (e.g. via kibana.yml globalOverrides) without
+ * requiring a manual toggle through the settings API.
+ */
+export async function reconcileContinuousKiExtractionOnStartup({
+  core,
+  continuousKiExtractionWorkflowService,
+  taskClient,
+  logger,
+}: {
+  core: CoreStart;
+  continuousKiExtractionWorkflowService: ContinuousKiExtractionWorkflowService;
+  taskClient: TaskClient<string>;
+  logger: Logger;
+}): Promise<void> {
+  const soClient = core.savedObjects.getUnsafeInternalClient();
+  const globalUiSettingsClient = core.uiSettings.globalAsScopedToClient(soClient);
+
+  const enabled = await globalUiSettingsClient.get<boolean>(
+    OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_ENABLED,
+    false
+  );
+
+  if (!enabled) {
+    return;
+  }
+
+  const fakeRequest = kibanaRequestFactory({
+    headers: { 'x-elastic-internal-origin': 'kibana' },
+    path: '/internal/streams/_significant_events/settings',
+  });
+
+  await continuousKiExtractionWorkflowService.ensureWorkflow({
+    enabled: true,
+    request: fakeRequest,
+    taskClient,
+  });
+
+  logger.info('Reconciled continuous KI extraction workflow on startup');
+}

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -75,6 +75,7 @@ import {
   createContinuousKiExtractionWorkflowService,
   type ContinuousKiExtractionWorkflowService,
 } from './lib/workflows/continuous_extraction_workflow';
+import { reconcileContinuousKiExtractionOnStartup } from './lib/workflows/reconcile_continuous_ki_extraction_on_startup';
 import { createInferenceResolver } from './lib/streams/assets/query/helpers/inference_availability';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -104,6 +105,8 @@ export class StreamsPlugin
   private statsTelemetryService = new StatsTelemetryService();
   private processorSuggestionsService: ProcessorSuggestionsService;
   private patternExtractionService?: PatternExtractionService;
+  private continuousKiExtractionWorkflowService?: ContinuousKiExtractionWorkflowService;
+  private taskService?: TaskService;
 
   constructor(context: PluginInitializerContext<StreamsConfig>) {
     this.isDev = context.env.mode.dev;
@@ -158,6 +161,7 @@ export class StreamsPlugin
     const contentService = new ContentService(core, this.logger);
     const queryService = new QueryService(core, inferenceResolver, this.logger);
     const taskService = new TaskService(plugins.taskManager);
+    this.taskService = taskService;
     const getScopedClients = async ({
       request,
     }: {
@@ -284,6 +288,7 @@ export class StreamsPlugin
         this.logger,
         plugins.workflowsManagement.management
       );
+      this.continuousKiExtractionWorkflowService = continuousKiExtractionWorkflowService;
     }
 
     const telemetryClient = this.ebtTelemetryService.getClient();
@@ -551,6 +556,30 @@ export class StreamsPlugin
     }
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);
+
+    if (this.continuousKiExtractionWorkflowService && this.taskService) {
+      void (async () => {
+        try {
+          const taskClient = await this.taskService!.getClient(
+            core,
+            plugins.taskManager,
+            this.logger
+          );
+          await reconcileContinuousKiExtractionOnStartup({
+            core,
+            continuousKiExtractionWorkflowService: this.continuousKiExtractionWorkflowService!,
+            taskClient,
+            logger: this.logger,
+          });
+        } catch (err) {
+          this.logger.warn(
+            `Failed to reconcile continuous KI extraction on startup: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      })();
+    }
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/classify_streams.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/classify_streams.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Streams, TaskStatus } from '@kbn/streams-schema';
+import { Streams, streamMatchesIndexPatterns, TaskStatus } from '@kbn/streams-schema';
 import { minimatch } from 'minimatch';
 import type { PersistedTask } from '../../../../lib/tasks/types';
 import type { FeaturesIdentificationTaskParams } from '../../../../lib/tasks/task_definitions/features_identification';
@@ -20,8 +20,10 @@ export interface StreamClassificationResult {
   candidates: StreamCandidate[];
   upToDate: StreamCandidate[];
   excluded: string[];
+  notMatchingIndexPatterns: string[];
   unsupported: string[];
   excludePatterns: string[];
+  indexPatterns: string[];
 }
 
 export const parseExcludePatterns = (raw: string | undefined): string[] =>
@@ -41,17 +43,20 @@ const matchesExcludePatterns = (name: string, patterns: string[]): boolean =>
 export const classifyStreams = ({
   allStreams,
   sortedTasks,
+  indexPatterns,
   excludedStreamPatterns,
   intervalHours,
 }: {
   allStreams: Streams.all.Definition[];
   sortedTasks: Array<PersistedTask<FeaturesIdentificationTaskParams>>;
+  indexPatterns: string[];
   excludedStreamPatterns: string;
   intervalHours: number;
 }): StreamClassificationResult => {
   const excludePatterns = parseExcludePatterns(excludedStreamPatterns);
 
   const excluded: string[] = [];
+  const notMatchingIndexPatterns: string[] = [];
   const unsupported: string[] = [];
   const eligibleNames = new Set<string>();
   for (const stream of allStreams) {
@@ -60,6 +65,10 @@ export const classifyStreams = ({
       !Streams.ClassicStream.Definition.is(stream)
     ) {
       unsupported.push(stream.name);
+      continue;
+    }
+    if (!streamMatchesIndexPatterns(stream.name, indexPatterns)) {
+      notMatchingIndexPatterns.push(stream.name);
       continue;
     }
     if (matchesExcludePatterns(stream.name, excludePatterns)) {
@@ -106,7 +115,9 @@ export const classifyStreams = ({
     candidates: allCandidates,
     upToDate,
     excluded,
+    notMatchingIndexPatterns,
     unsupported,
     excludePatterns,
+    indexPatterns,
   };
 };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/eligible_streams.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/eligible_streams.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { TaskStatus, type Streams } from '@kbn/streams-schema';
+import { DEFAULT_INDEX_PATTERNS, TaskStatus, type Streams } from '@kbn/streams-schema';
 import type { PersistedTask } from '../../../../lib/tasks/types';
 import type { FeaturesIdentificationTaskParams } from '../../../../lib/tasks/task_definitions/features_identification';
 import { classifyStreams, parseExcludePatterns } from './classify_streams';
@@ -82,6 +82,7 @@ describe('classifyStreams', () => {
   const defaultArgs = {
     allStreams: [] as ReturnType<typeof makeStream>[],
     sortedTasks: [] as TaskForTest[],
+    indexPatterns: [DEFAULT_INDEX_PATTERNS],
     excludedStreamPatterns: '',
     intervalHours: 12,
   };
@@ -89,27 +90,93 @@ describe('classifyStreams', () => {
   it('skips unsupported stream types and reports them', () => {
     const result = classifyStreams({
       ...defaultArgs,
-      allStreams: [makeStream('logs'), makeStream('my-query', { query: true })],
+      allStreams: [makeStream('logs.ecs'), makeStream('my-query', { query: true })],
     });
 
-    expect(candidateNames(result)).toEqual(['logs']);
+    expect(candidateNames(result)).toEqual(['logs.ecs']);
     expect(result.unsupported).toEqual(['my-query']);
   });
 
   it('excludes streams matching exclude patterns', () => {
     const result = classifyStreams({
       ...defaultArgs,
-      allStreams: [makeStream('logs'), makeStream('debug-app'), makeStream('test-data')],
-      excludedStreamPatterns: 'debug-*, test-*',
+      allStreams: [
+        makeStream('logs.ecs'),
+        makeStream('logs.debug-app'),
+        makeStream('logs.test-data'),
+      ],
+      excludedStreamPatterns: 'logs.debug-*, logs.test-*',
     });
 
-    expect(result.excluded).toEqual(['debug-app', 'test-data']);
-    expect(candidateNames(result)).toEqual(['logs']);
+    expect(result.excluded).toEqual(['logs.debug-app', 'logs.test-data']);
+    expect(candidateNames(result)).toEqual(['logs.ecs']);
+  });
+
+  it('excludes streams that do not match index patterns', () => {
+    const result = classifyStreams({
+      ...defaultArgs,
+      allStreams: [
+        makeStream('logs.ecs'),
+        makeStream('logs-generic.otel-default'),
+        makeStream('metrics-generic.otel-default'),
+        makeStream('traces-generic.otel-default'),
+      ],
+    });
+
+    expect(result.notMatchingIndexPatterns).toEqual([
+      'metrics-generic.otel-default',
+      'traces-generic.otel-default',
+    ]);
+    expect(candidateNames(result)).toEqual(['logs.ecs', 'logs-generic.otel-default']);
+  });
+
+  it('includes metrics streams when index patterns allow them', () => {
+    const result = classifyStreams({
+      ...defaultArgs,
+      indexPatterns: ['logs*', 'metrics*'],
+      allStreams: [makeStream('logs.ecs'), makeStream('metrics-generic.otel-default')],
+    });
+
+    expect(result.notMatchingIndexPatterns).toEqual([]);
+    expect(candidateNames(result)).toEqual(['logs.ecs', 'metrics-generic.otel-default']);
+  });
+
+  it('applies exclude patterns only within index-pattern matches', () => {
+    const result = classifyStreams({
+      ...defaultArgs,
+      allStreams: [
+        makeStream('logs.ecs'),
+        makeStream('logs.debug.app'),
+        makeStream('metrics-generic.otel-default'),
+      ],
+      excludedStreamPatterns: 'logs.debug.*',
+    });
+
+    expect(result.excluded).toEqual(['logs.debug.app']);
+    expect(result.notMatchingIndexPatterns).toEqual(['metrics-generic.otel-default']);
+    expect(candidateNames(result)).toEqual(['logs.ecs']);
+  });
+
+  it('with default index patterns, never schedules metrics streams', () => {
+    const result = classifyStreams({
+      ...defaultArgs,
+      allStreams: [
+        makeStream('metrics-generic.otel-default'),
+        makeStream('metrics-hostmetricsreceiver.otel-default'),
+      ],
+    });
+
+    expect(candidateNames(result)).toEqual([]);
+    expect(result.notMatchingIndexPatterns).toEqual([
+      'metrics-generic.otel-default',
+      'metrics-hostmetricsreceiver.otel-default',
+    ]);
   });
 
   it('treats streams without a task as never-processed candidates', () => {
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('stream-a'), makeStream('stream-b')],
     });
 
@@ -119,6 +186,7 @@ describe('classifyStreams', () => {
   it('identifies already running (in-progress) tasks', () => {
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('running-stream')],
       sortedTasks: [
         makeTask('running-stream', {
@@ -135,6 +203,7 @@ describe('classifyStreams', () => {
   it('treats BeingCanceled tasks as already running', () => {
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('canceling-stream')],
       sortedTasks: [
         makeTask('canceling-stream', {
@@ -152,6 +221,7 @@ describe('classifyStreams', () => {
     const recentCompletion = new Date().toISOString();
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('fresh-stream')],
       sortedTasks: [makeTask('fresh-stream', { last_completed_at: recentCompletion })],
     });
@@ -166,6 +236,7 @@ describe('classifyStreams', () => {
     const oldCompletion = '2024-01-01T00:00:00Z';
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('old-stream')],
       sortedTasks: [makeTask('old-stream', { last_completed_at: oldCompletion })],
     });
@@ -179,6 +250,7 @@ describe('classifyStreams', () => {
     const recentFailure = new Date().toISOString();
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('failed-stream')],
       sortedTasks: [
         makeTask('failed-stream', {
@@ -198,6 +270,7 @@ describe('classifyStreams', () => {
     const oldCompletion = '2024-01-01T00:00:00Z';
     const result = classifyStreams({
       ...defaultArgs,
+      indexPatterns: ['*'],
       allStreams: [makeStream('old-stream'), makeStream('new-stream')],
       sortedTasks: [makeTask('old-stream', { last_completed_at: oldCompletion })],
     });

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/eligible_streams_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/eligible_streams_route.ts
@@ -10,8 +10,12 @@ import {
   OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_ENABLED,
   OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_INTERVAL_HOURS,
   OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_EXCLUDED_STREAM_PATTERNS,
+  OBSERVABILITY_STREAMS_SIG_EVENTS_INDEX_PATTERNS,
 } from '@kbn/management-settings-ids';
-import { STREAMS_SIG_EVENTS_KI_EXTRACTION_INFERENCE_FEATURE_ID } from '@kbn/streams-schema';
+import {
+  parseSigEventsIndexPatterns,
+  STREAMS_SIG_EVENTS_KI_EXTRACTION_INFERENCE_FEATURE_ID,
+} from '@kbn/streams-schema';
 import { createServerRoute } from '../../../create_server_route';
 import { assertSignificantEventsAccess } from '../../../utils/assert_significant_events_access';
 import {
@@ -39,11 +43,13 @@ export interface EligibleStreamsResponse {
   alreadyRunning: StreamClassificationResult['alreadyRunning'];
   upToDate: StreamCandidate[];
   excluded: string[];
+  notMatchingIndexPatterns: string[];
   unsupported: string[];
   skipped: StreamCandidate[];
   settings: {
     enabled: boolean;
     intervalHours: number;
+    indexPatterns: string[];
     excludePatterns: string[];
   };
   connectorId: string;
@@ -105,13 +111,14 @@ const eligibleStreamsRoute = createServerRoute({
       throw new StatusError('Continuous KI extraction is disabled', 400);
     }
 
-    const [intervalHoursSetting, excludedStreamPatterns] = await Promise.all([
+    const [intervalHoursSetting, excludedStreamPatterns, indexPatternsSetting] = await Promise.all([
       globalUiSettingsClient.get<number>(
         OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_INTERVAL_HOURS
       ),
       globalUiSettingsClient.get<string>(
         OBSERVABILITY_STREAMS_CONTINUOUS_KI_EXTRACTION_EXCLUDED_STREAM_PATTERNS
       ),
+      uiSettingsClient.get<string>(OBSERVABILITY_STREAMS_SIG_EVENTS_INDEX_PATTERNS),
     ]);
 
     const maxStreams = query.maxScheduledStreams ?? MAX_SCHEDULED_STREAMS;
@@ -142,10 +149,19 @@ const eligibleStreamsRoute = createServerRoute({
       query.extractionIntervalHours ?? intervalHoursSetting ?? DEFAULT_EXTRACTION_INTERVAL_HOURS;
 
     const resolvedExcludedPatterns = query.excludedStreamPatterns ?? excludedStreamPatterns ?? '';
+    const resolvedIndexPatterns = parseSigEventsIndexPatterns(indexPatternsSetting);
 
-    const { alreadyRunning, candidates, upToDate, excluded, unsupported } = classifyStreams({
+    const {
+      alreadyRunning,
+      candidates,
+      upToDate,
+      excluded,
+      notMatchingIndexPatterns,
+      unsupported,
+    } = classifyStreams({
       allStreams,
       sortedTasks,
+      indexPatterns: resolvedIndexPatterns,
       excludedStreamPatterns: resolvedExcludedPatterns,
       intervalHours,
     });
@@ -162,11 +178,13 @@ const eligibleStreamsRoute = createServerRoute({
       alreadyRunning,
       upToDate,
       excluded,
+      notMatchingIndexPatterns,
       unsupported,
       skipped,
       settings: {
         enabled,
         intervalHours: intervalHoursSetting ?? DEFAULT_EXTRACTION_INTERVAL_HOURS,
+        indexPatterns: resolvedIndexPatterns,
         excludePatterns: parseExcludePatterns(excludedStreamPatterns),
       },
       connectorId,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/settings/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/settings/tab.tsx
@@ -216,7 +216,7 @@ export function SettingsTab() {
                       'xpack.streams.significantEventsDiscovery.settings.indexPatternsHelp',
                       {
                         defaultMessage:
-                          'Comma-separated list of index patterns to use for feature detection and analysis.',
+                          'Comma-separated list of index patterns to use for feature detection, analysis, and continuous extraction.',
                       }
                     )}{' '}
                     {i18n.translate(
@@ -313,7 +313,7 @@ export function SettingsTab() {
                       'xpack.streams.significantEventsDiscovery.settings.continuousKiExtractionHelp',
                       {
                         defaultMessage:
-                          'When enabled, knowledge indicator extraction runs automatically on managed streams at the configured interval.',
+                          'When enabled, knowledge indicator extraction runs automatically on streams matching the index patterns above, minus any excluded patterns, at the configured interval.',
                       }
                     )}
                   </EuiText>
@@ -376,7 +376,7 @@ export function SettingsTab() {
                     'xpack.streams.significantEventsDiscovery.settings.excludedStreamPatternsHelp',
                     {
                       defaultMessage:
-                        'Comma-separated list of stream names or glob patterns (e.g. logs.debug.*) to skip during continuous extraction.',
+                        'Comma-separated list of stream names or glob patterns (e.g. logs.debug.*) to skip during continuous extraction. Streams must also match the index patterns above to be eligible.',
                     }
                   )}
                 >

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_index_patterns_config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_index_patterns_config.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { streamMatchesIndexPatterns, DEFAULT_INDEX_PATTERNS } from '@kbn/streams-schema';
+import { parseSigEventsIndexPatterns, streamMatchesIndexPatterns } from '@kbn/streams-schema';
 import { OBSERVABILITY_STREAMS_SIG_EVENTS_INDEX_PATTERNS } from '@kbn/management-settings-ids';
 import { useKibana } from './use_kibana';
 
@@ -18,16 +18,10 @@ export function useIndexPatternsConfig() {
 
   const rawValue = core.settings.client.get<string>(
     OBSERVABILITY_STREAMS_SIG_EVENTS_INDEX_PATTERNS,
-    DEFAULT_INDEX_PATTERNS
+    ''
   );
 
-  const indexPatterns = useMemo(() => {
-    const patterns = rawValue
-      .split(',')
-      .map((p) => p.trim())
-      .filter((p) => p.length > 0);
-    return patterns.length > 0 ? patterns : [DEFAULT_INDEX_PATTERNS];
-  }, [rawValue]);
+  const indexPatterns = useMemo(() => parseSigEventsIndexPatterns(rawValue), [rawValue]);
 
   const filterStreamsByIndexPatterns = useMemo(() => {
     return <T extends { stream: { name: string } }>(streamsToFilter: T[]): T[] =>


### PR DESCRIPTION
## Summary

- Continuous KI extraction eligibility now uses the same index pattern filter as Significant Events discovery (`logs*` by default), then applies the exclude list.
- Metrics/traces data streams discovered as unmanaged classic streams are no longer scheduled unless their names match the configured index patterns.
- Adds startup reconciliation so the extraction workflow is created when continuous extraction is pre-enabled via `kibana.yml` global overrides.

## Test plan

- [x] Unit tests: `parse_sig_events_index_patterns.test.ts`
- [x] Unit tests: `eligible_streams.test.ts` (including default `logs*` regression)
- [x] Unit tests: `reconcile_continuous_ki_extraction_on_startup.test.ts`
- [ ] Manual: with default settings, `GET /internal/streams/_extraction/_eligible` returns metrics streams under `notMatchingIndexPatterns`, not `candidates`
- [ ] Manual: adding `metrics*` to index patterns makes metrics streams eligible again