### PR TITLE
[Significant events] Uplift: adding small fine tune design uplifts to the attachment type

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment/significant_event_attachment.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment/significant_event_attachment.test.tsx
@@ -84,7 +84,7 @@ describe('significantEventAttachmentDefinition', () => {
       updateOrigin: jest.fn(),
     };
 
-    it('returns an "Open" SECONDARY button when openCanvas is provided and not in canvas', () => {
+    it('returns an "Open preview" SECONDARY button when openCanvas is provided and not in canvas', () => {
       const openCanvas = jest.fn();
       const buttons =
         significantEventAttachmentDefinition.getActionButtons?.({
@@ -94,7 +94,8 @@ describe('significantEventAttachmentDefinition', () => {
         }) ?? [];
 
       expect(buttons).toHaveLength(1);
-      expect(buttons[0].label).toBe('Open');
+      expect(buttons[0].label).toBe('Open preview');
+      expect(buttons[0].icon).toBe('eye');
       expect(buttons[0].type).toBe(ActionButtonType.SECONDARY);
 
       buttons[0].handler();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment/significant_event_attachment.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_event_attachment/significant_event_attachment.tsx
@@ -18,6 +18,7 @@ import type { ChromeStart } from '@kbn/core/public';
 
 import type { StreamsAppStartDependencies } from '../../../types';
 import { getSigEventStatusColor } from '../significant_events_discovery/components/shared/status_display';
+import { SIG_EVENT_STATUS_LABELS } from '../significant_events_discovery/components/shared/translations';
 import { SigEventDetails } from '../sig_event_details/sig_event_details';
 import type { FocusedSignificantEventService } from '../../../services/significant_events/focused_significant_event_service';
 import { registerSignificantEventAutoAttach } from '../lib/significant_event_auto_attach';
@@ -27,7 +28,7 @@ const labels = {
     defaultMessage: 'Significant event',
   }),
   open: i18n.translate('xpack.streams.significantEventAttachment.openButton', {
-    defaultMessage: 'Open',
+    defaultMessage: 'Open preview',
   }),
 };
 
@@ -39,7 +40,10 @@ export const significantEventAttachmentDefinition: AttachmentUIDefinition<Signif
       icon: 'significantEvents',
       subtitle: labels.fallback,
       badges: [
-        { label: attachment.data.status, color: getSigEventStatusColor(attachment.data.status) },
+        {
+          label: SIG_EVENT_STATUS_LABELS[attachment.data.status] ?? attachment.data.status,
+          color: getSigEventStatusColor(attachment.data.status),
+        },
       ],
     }),
     getActionButtons: ({ openCanvas, isCanvas }) => {
@@ -50,6 +54,7 @@ export const significantEventAttachmentDefinition: AttachmentUIDefinition<Signif
         {
           label: labels.open,
           type: ActionButtonType.SECONDARY,
+          icon: 'eye',
           handler: openCanvas,
         },
       ];


### PR DESCRIPTION
## Summary

Small visual treatment of the significant event attachment:
- Status badge label: render the translated, capitalized status (Promoted, Acknowledged, …) instead of the raw enum value (promoted, acknowledged, …), using the shared `SIG_EVENT_STATUS_LABELS` map to match the events table and flyout.
- "Open preview" action: added an eye icon so the button shows a meaningful glyph in compact mode (≤ 560px header) instead of a blank icon-only square, and provides a clearer affordance at full width.

<img width="3346" height="1702" alt="image" src="https://github.com/user-attachments/assets/f61b30ea-b96c-4648-bd06-007c1c3f405a" />
