### PR TITLE
[CI] fix securitySolution limits.yml breach

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,7 +1,7 @@
 pageLoadAssetSize:
   actions: 20500
   advancedSettings: 6196
-  agentBuilder: 65830
+  agentBuilder: 52317
   agentBuilderDashboards: 7786
   agentBuilderPlatform: 15544
   agentBuilderWorkflows: 24405
@@ -116,7 +116,7 @@ pageLoadAssetSize:
   logstash: 15882
   maintenanceWindows: 8775
   management: 14304
-  maps: 36281
+  maps: 36005
   mapsEms: 6734
   metricsDataAccess: 44950
   ml: 99842
@@ -166,7 +166,7 @@ pageLoadAssetSize:
   searchQueryRules: 6689
   searchSynonyms: 6371
   security: 79627
-  securitySolution: 171457
+  securitySolution: 188674
   securitySolutionEss: 42592
   securitySolutionServerless: 57290
   serverless: 7412


### PR DESCRIPTION
## Summary
Limits were breached under the radar through small, competing changes. This PR increases the limits for `securitySolution` (and adjusts the rest).

Fixes: https://github.com/elastic/kibana-operations/issues/543