### PR TITLE
chore: bump securitySolution by 10%

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -166,7 +166,7 @@ pageLoadAssetSize:
   searchQueryRules: 6689
   searchSynonyms: 6371
   security: 79627
-  securitySolution: 171457
+  securitySolution: 188602
   securitySolutionEss: 42592
   securitySolutionServerless: 57290
   serverless: 7412


### PR DESCRIPTION
On merge CI is failing because security solution limit is bypassed. 

```
ERROR Metric overages:
--
  | page load bundle size for securitySolution plugin is greater than the limit of 171457. The current value is 171522.
  | To update the limit, run the following command locally:
  | node scripts/build_kibana_platform_plugins --focus securitySolution --update-limits
```

example: https://buildkite.com/elastic/kibana-on-merge/builds/100635/list?jid=019f043b-c6c8-4559-be69-d8a1642080c0&tab=output