### PR TITLE
[Cases] Add inline title editing and reporter metadata to case details header

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
@@ -99,8 +99,9 @@ describe('CaseDetailsAppHeader', () => {
   it('renders badges in the header', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    expect(await screen.findByTestId('case-view-severity-badge')).toBeInTheDocument();
-    expect(screen.getByTestId('case-view-status-badge')).toBeInTheDocument();
+    const badgesEl = await screen.findByTestId('app-header-badges');
+    expect(badgesEl.textContent).toContain('case-view-severity-badge');
+    expect(badgesEl.textContent).toContain('case-view-status-badge');
   });
 
   it('does not render delete modal by default', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
@@ -25,6 +25,30 @@ jest.mock('../../../../../common/navigation/hooks');
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../case_view/use_on_refresh_case_view_page');
 
+jest.mock('@kbn/app-header', () => ({
+  APP_HEADER_TEST_SUBJECTS: {
+    root: 'app-header',
+    title: 'app-header-title',
+  },
+  AppHeader: ({
+    title,
+    badges,
+    metadata,
+  }: {
+    title: string | { text: string };
+    badges: unknown[];
+    metadata: unknown;
+  }) => (
+    <div data-test-subj="app-header">
+      <span data-test-subj="app-header-title">
+        {typeof title === 'string' ? title : title.text}
+      </span>
+      <span data-test-subj="app-header-badges">{JSON.stringify(badges)}</span>
+      <span data-test-subj="app-header-metadata">{JSON.stringify(metadata)}</span>
+    </div>
+  ),
+}));
+
 jest.mock('../../../../confirm_delete_case', () => ({
   ConfirmDeleteCaseModal: () => <div data-test-subj="confirm-delete-modal" />,
 }));
@@ -62,6 +86,14 @@ describe('CaseDetailsAppHeader', () => {
 
     expect(await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.root)).toBeInTheDocument();
     expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.title)).toHaveTextContent(basicCase.title);
+  });
+
+  it('renders metadata with reporter name', async () => {
+    renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
+
+    const metadata = await screen.findByTestId('app-header-metadata');
+    expect(metadata.textContent).toContain('Reported by');
+    expect(metadata.textContent).toContain(basicCase.createdBy.fullName!);
   });
 
   it('renders badges in the header', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.test.tsx
@@ -25,30 +25,6 @@ jest.mock('../../../../../common/navigation/hooks');
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../case_view/use_on_refresh_case_view_page');
 
-jest.mock('@kbn/app-header', () => ({
-  APP_HEADER_TEST_SUBJECTS: {
-    root: 'app-header',
-    title: 'app-header-title',
-  },
-  AppHeader: ({
-    title,
-    badges,
-    metadata,
-  }: {
-    title: string | { text: string };
-    badges: unknown[];
-    metadata: unknown;
-  }) => (
-    <div data-test-subj="app-header">
-      <span data-test-subj="app-header-title">
-        {typeof title === 'string' ? title : title.text}
-      </span>
-      <span data-test-subj="app-header-badges">{JSON.stringify(badges)}</span>
-      <span data-test-subj="app-header-metadata">{JSON.stringify(metadata)}</span>
-    </div>
-  ),
-}));
-
 jest.mock('../../../../confirm_delete_case', () => ({
   ConfirmDeleteCaseModal: () => <div data-test-subj="confirm-delete-modal" />,
 }));
@@ -91,7 +67,7 @@ describe('CaseDetailsAppHeader', () => {
   it('renders metadata with reporter name', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    const metadata = await screen.findByTestId('app-header-metadata');
+    const metadata = await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.metadata);
     expect(metadata.textContent).toContain('Reported by');
     expect(metadata.textContent).toContain(basicCase.createdBy.fullName!);
   });
@@ -99,9 +75,8 @@ describe('CaseDetailsAppHeader', () => {
   it('renders badges in the header', async () => {
     renderWithTestingProviders(<CaseDetailsAppHeader {...defaultProps} />);
 
-    const badgesEl = await screen.findByTestId('app-header-badges');
-    expect(badgesEl.textContent).toContain('case-view-severity-badge');
-    expect(badgesEl.textContent).toContain('case-view-status-badge');
+    expect(await screen.findByTestId('case-view-severity-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('case-view-status-badge')).toBeInTheDocument();
   });
 
   it('does not render delete modal by default', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/case_details_app_header.tsx
@@ -35,6 +35,7 @@ export const CaseDetailsAppHeader: FC<CaseDetailsAppHeaderProps> = ({
 
   const {
     headerTitle,
+    metadata,
     backHref,
     badges,
     menu,
@@ -44,14 +45,7 @@ export const CaseDetailsAppHeader: FC<CaseDetailsAppHeaderProps> = ({
     isSettingsOpen,
     setIsSettingsOpen,
     settingsAnchor,
-  } = useCaseViewHeader({ caseData, onStatusChanged });
-
-  const onCaseNameChange = useCallback(
-    (newName: string) => {
-      onUpdateField({ key: 'title', value: newName });
-    },
-    [onUpdateField]
-  );
+  } = useCaseViewHeader({ caseData, onStatusChanged, onUpdateField });
 
   const onSyncAlertsChanged = useCallback(
     (checked: boolean) =>
@@ -69,6 +63,8 @@ export const CaseDetailsAppHeader: FC<CaseDetailsAppHeaderProps> = ({
         back={{ href: backHref, label: PAGE_TITLE }}
         badges={badges}
         menu={menu}
+        metadata={metadata}
+        sticky={false}
       />
       {closeCaseModal}
       {isDeleteModalVisible && (
@@ -85,7 +81,6 @@ export const CaseDetailsAppHeader: FC<CaseDetailsAppHeaderProps> = ({
           onSyncAlertsChange={onSyncAlertsChanged}
           showMetrics={showMetrics}
           onShowMetricsChange={onShowMetricsChange}
-          onCaseNameChange={onCaseNameChange}
           isOpen={isSettingsOpen}
           onClose={() => setIsSettingsOpen(false)}
           anchorElement={settingsAnchor}

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts
@@ -48,22 +48,106 @@ describe('useCaseViewHeader', () => {
     (useShouldDisableStatus as jest.Mock).mockReturnValue(() => false);
   });
 
-  it('returns a formatted title with incremental ID', () => {
+  it('returns an editable title with incremental ID when user has update permissions', () => {
     const caseWithId: CaseUI = { ...basicCase, incrementalId: 42 };
     const { result } = renderHook(
       () => useCaseViewHeader({ ...defaultArgs, caseData: caseWithId }),
       { wrapper }
     );
 
-    expect(result.current.headerTitle).toBe(`#42 ${basicCase.title}`);
+    expect(result.current.headerTitle).toEqual(
+      expect.objectContaining({ text: `#42 ${basicCase.title}` })
+    );
   });
 
-  it('returns title without prefix when incrementalId is undefined', () => {
+  it('returns an editable title without prefix when incrementalId is undefined', () => {
     const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
       wrapper,
     });
 
+    expect(result.current.headerTitle).toEqual(expect.objectContaining({ text: basicCase.title }));
+  });
+
+  it('returns a plain string title when user lacks update permissions', () => {
+    const readOnlyWrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        TestProviders,
+        {
+          permissions: {
+            all: false,
+            create: true,
+            read: true,
+            update: false,
+            delete: false,
+            push: false,
+            connectors: false,
+            settings: false,
+            reopenCase: false,
+            createComment: false,
+            assign: false,
+            manageTemplates: false,
+          },
+        } as React.ComponentProps<typeof TestProviders>,
+        children
+      );
+
+    const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
+      wrapper: readOnlyWrapper,
+    });
+
+    expect(typeof result.current.headerTitle).toBe('string');
     expect(result.current.headerTitle).toBe(basicCase.title);
+  });
+
+  it('calls onUpdateField when editable title is saved', async () => {
+    const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
+      wrapper,
+    });
+
+    const title = result.current.headerTitle;
+    expect(typeof title).not.toBe('string');
+    if (typeof title !== 'string') {
+      await act(async () => {
+        await title.onSave('New Title');
+      });
+      expect(onUpdateField).toHaveBeenCalledWith({ key: 'title', value: 'New Title' });
+    }
+  });
+
+  it('strips incremental ID prefix when saving title', async () => {
+    const caseWithId: CaseUI = { ...basicCase, incrementalId: 42 };
+    const { result } = renderHook(
+      () => useCaseViewHeader({ ...defaultArgs, caseData: caseWithId }),
+      { wrapper }
+    );
+
+    const title = result.current.headerTitle;
+    if (typeof title !== 'string') {
+      await act(async () => {
+        await title.onSave('#42 Updated Title');
+      });
+      expect(onUpdateField).toHaveBeenCalledWith({ key: 'title', value: 'Updated Title' });
+    }
+  });
+
+  it('returns metadata with reporter name and created date', () => {
+    const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
+      wrapper,
+    });
+
+    expect(result.current.metadata).toBeDefined();
+    expect(result.current.metadata[0]).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        label: expect.stringContaining(basicCase.createdBy.fullName!),
+      })
+    );
+    expect(result.current.metadata[1]).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        'data-test-subj': 'case-view-created-at',
+      })
+    );
   });
 
   it('returns a backHref', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.test.ts
@@ -48,19 +48,7 @@ describe('useCaseViewHeader', () => {
     (useShouldDisableStatus as jest.Mock).mockReturnValue(() => false);
   });
 
-  it('returns an editable title with incremental ID when user has update permissions', () => {
-    const caseWithId: CaseUI = { ...basicCase, incrementalId: 42 };
-    const { result } = renderHook(
-      () => useCaseViewHeader({ ...defaultArgs, caseData: caseWithId }),
-      { wrapper }
-    );
-
-    expect(result.current.headerTitle).toEqual(
-      expect.objectContaining({ text: `#42 ${basicCase.title}` })
-    );
-  });
-
-  it('returns an editable title without prefix when incrementalId is undefined', () => {
+  it('returns an editable title with case name only', () => {
     const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
       wrapper,
     });
@@ -99,6 +87,20 @@ describe('useCaseViewHeader', () => {
     expect(result.current.headerTitle).toBe(basicCase.title);
   });
 
+  it('rejects empty title on save', async () => {
+    const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
+      wrapper,
+    });
+
+    const title = result.current.headerTitle;
+    expect(typeof title).not.toBe('string');
+    if (typeof title !== 'string') {
+      const error = await act(async () => title.onSave(''));
+      expect(error).toBeDefined();
+      expect(onUpdateField).not.toHaveBeenCalled();
+    }
+  });
+
   it('calls onUpdateField when editable title is saved', async () => {
     const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
       wrapper,
@@ -114,20 +116,31 @@ describe('useCaseViewHeader', () => {
     }
   });
 
-  it('strips incremental ID prefix when saving title', async () => {
+  it('includes incremental ID in metadata when present', () => {
     const caseWithId: CaseUI = { ...basicCase, incrementalId: 42 };
     const { result } = renderHook(
       () => useCaseViewHeader({ ...defaultArgs, caseData: caseWithId }),
       { wrapper }
     );
 
-    const title = result.current.headerTitle;
-    if (typeof title !== 'string') {
-      await act(async () => {
-        await title.onSave('#42 Updated Title');
-      });
-      expect(onUpdateField).toHaveBeenCalledWith({ key: 'title', value: 'Updated Title' });
-    }
+    expect(result.current.metadata[0]).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        label: '#42',
+        'data-test-subj': 'case-view-incremental-id',
+      })
+    );
+  });
+
+  it('does not include incremental ID in metadata when undefined', () => {
+    const { result } = renderHook(() => useCaseViewHeader(defaultArgs), {
+      wrapper,
+    });
+
+    const incrementalIdItem = result.current.metadata.find(
+      (m) => m?.['data-test-subj'] === 'case-view-incremental-id'
+    );
+    expect(incrementalIdItem).toBeUndefined();
   });
 
   it('returns metadata with reporter name and created date', () => {
@@ -136,16 +149,24 @@ describe('useCaseViewHeader', () => {
     });
 
     expect(result.current.metadata).toBeDefined();
-    expect(result.current.metadata[0]).toEqual(
+
+    const reportedBy = result.current.metadata.find(
+      (m) => m?.['data-test-subj'] === 'case-view-reported-by'
+    );
+    expect(reportedBy).toEqual(
       expect.objectContaining({
         type: 'text',
-        label: expect.stringContaining(basicCase.createdBy.fullName!),
+        label: `Reported by: ${basicCase.createdBy.fullName!}`,
       })
     );
-    expect(result.current.metadata[1]).toEqual(
+
+    const createdAt = result.current.metadata.find(
+      (m) => m?.['data-test-subj'] === 'case-view-created-at'
+    );
+    expect(createdAt).toEqual(
       expect.objectContaining({
         type: 'text',
-        'data-test-subj': 'case-view-created-at',
+        label: expect.stringContaining('on: '),
       })
     );
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
@@ -20,7 +20,12 @@ import { useGetCaseConnectors } from '../../../../../../containers/use_get_case_
 import { useDeleteCases } from '../../../../../../containers/use_delete_cases';
 import { useShouldDisableStatus } from '../../../../../actions/status/use_should_disable_status';
 import * as commonI18n from '../../../../../../common/translations';
-import { REPORTED_BY, CREATED_ON, EDIT_CASE_NAME_ARIA } from '../../../../translations';
+import {
+  REPORTED_BY,
+  CREATED_ON,
+  UNKNOWN_REPORTER,
+  EDIT_CASE_NAME_ARIA,
+} from '../../../../translations';
 import { getBadges } from '../utils/header_badges';
 import { getMenu } from '../utils/header_menu';
 
@@ -56,45 +61,53 @@ export const useCaseViewHeader = ({
 
   // Title
   const headerTitle = useMemo((): AppHeaderTitle => {
-    const prefix = typeof caseData.incrementalId === 'number' ? `#${caseData.incrementalId} ` : '';
-    const displayTitle = `${prefix}${caseData.title}`;
-
     if (!permissions.update) {
-      return displayTitle;
+      return caseData.title;
     }
 
     return {
-      text: displayTitle,
-      onSave: async (nextTitle: string) => {
-        const titleValue = nextTitle.startsWith(prefix)
-          ? nextTitle.slice(prefix.length)
-          : nextTitle;
-        if (!titleValue) {
+      text: caseData.title,
+      onSave: (nextTitle: string) => {
+        if (!nextTitle.trim()) {
           return commonI18n.TITLE_REQUIRED;
         }
-        onUpdateField({ key: 'title', value: titleValue });
+        onUpdateField({ key: 'title', value: nextTitle.trim() });
       },
       ariaLabel: EDIT_CASE_NAME_ARIA,
     };
-  }, [caseData.incrementalId, caseData.title, permissions.update, onUpdateField]);
+  }, [caseData.title, permissions.update, onUpdateField]);
 
   // Metadata
   const metadata = useMemo((): AppHeaderMetadataItems => {
-    const reporterName = caseData.createdBy.fullName ?? caseData.createdBy.username ?? '';
+    const reporterName =
+      caseData.createdBy.fullName ?? caseData.createdBy.username ?? UNKNOWN_REPORTER;
     const formattedDate = moment.tz(caseData.createdAt, timeZone).format(dateFormat);
-    return [
-      {
-        type: 'text' as const,
-        label: `${REPORTED_BY}: ${reporterName}`,
-        'data-test-subj': 'case-view-reported-by',
-      },
-      {
-        type: 'text' as const,
-        label: `${CREATED_ON}: ${formattedDate}`,
-        'data-test-subj': 'case-view-created-at',
-      },
-    ];
-  }, [caseData.createdBy, caseData.createdAt, timeZone, dateFormat]);
+
+    const reportedByItem = {
+      type: 'text' as const,
+      label: REPORTED_BY(reporterName),
+      'data-test-subj': 'case-view-reported-by',
+    };
+    const createdAtItem = {
+      type: 'text' as const,
+      label: CREATED_ON(formattedDate),
+      'data-test-subj': 'case-view-created-at',
+    };
+
+    if (typeof caseData.incrementalId === 'number') {
+      return [
+        {
+          type: 'text' as const,
+          label: `#${caseData.incrementalId}`,
+          'data-test-subj': 'case-view-incremental-id',
+        },
+        reportedByItem,
+        createdAtItem,
+      ];
+    }
+
+    return [reportedByItem, createdAtItem];
+  }, [caseData.incrementalId, caseData.createdBy, caseData.createdAt, timeZone, dateFormat]);
 
   // Back
   const backHref = useMemo(() => getAllCasesUrl(), [getAllCasesUrl]);

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
@@ -6,25 +6,35 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
+import moment from 'moment-timezone';
+import type { AppHeaderMetadataItems, AppHeaderTitle } from '@kbn/app-header';
 import type { CaseStatuses } from '../../../../../../../common/types/domain';
 import type { CaseUI } from '../../../../../../../common';
+import type { OnUpdateFields } from '../../../../../case_view/types';
 import { useAllCasesNavigation } from '../../../../../../common/navigation';
 import { useCasesContext } from '../../../../../cases_context/use_cases_context';
 import { useCasesToast } from '../../../../../../common/use_cases_toast';
+import { useDateFormat, useTimeZone } from '../../../../../../common/lib/kibana';
 import { useRefreshCaseViewPage } from '../../../../../case_view/use_on_refresh_case_view_page';
 import { useGetCaseConnectors } from '../../../../../../containers/use_get_case_connectors';
 import { useDeleteCases } from '../../../../../../containers/use_delete_cases';
 import { useShouldDisableStatus } from '../../../../../actions/status/use_should_disable_status';
 import * as commonI18n from '../../../../../../common/translations';
+import { REPORTED_BY, CREATED_ON, EDIT_CASE_NAME_ARIA } from '../../../../translations';
 import { getBadges } from '../utils/header_badges';
 import { getMenu } from '../utils/header_menu';
 
 interface UseCaseViewHeaderArgs {
   caseData: CaseUI;
   onStatusChanged: (status: CaseStatuses) => void;
+  onUpdateField: (args: OnUpdateFields) => void;
 }
 
-export const useCaseViewHeader = ({ caseData, onStatusChanged }: UseCaseViewHeaderArgs) => {
+export const useCaseViewHeader = ({
+  caseData,
+  onStatusChanged,
+  onUpdateField,
+}: UseCaseViewHeaderArgs) => {
   const { permissions } = useCasesContext();
   const { getAllCasesUrl, navigateToAllCases } = useAllCasesNavigation();
   const { showSuccessToast, showErrorToast } = useCasesToast();
@@ -41,11 +51,50 @@ export const useCaseViewHeader = ({ caseData, onStatusChanged }: UseCaseViewHead
     return shouldDisableStatusFn([caseData]);
   }, [caseData, shouldDisableStatusFn]);
 
+  const dateFormat = useDateFormat();
+  const timeZone = useTimeZone();
+
   // Title
-  const headerTitle = useMemo(() => {
+  const headerTitle = useMemo((): AppHeaderTitle => {
     const prefix = typeof caseData.incrementalId === 'number' ? `#${caseData.incrementalId} ` : '';
-    return `${prefix}${caseData.title}`;
-  }, [caseData.incrementalId, caseData.title]);
+    const displayTitle = `${prefix}${caseData.title}`;
+
+    if (!permissions.update) {
+      return displayTitle;
+    }
+
+    return {
+      text: displayTitle,
+      onSave: async (nextTitle: string) => {
+        const titleValue = nextTitle.startsWith(prefix)
+          ? nextTitle.slice(prefix.length)
+          : nextTitle;
+        if (!titleValue) {
+          return commonI18n.TITLE_REQUIRED;
+        }
+        onUpdateField({ key: 'title', value: titleValue });
+      },
+      ariaLabel: EDIT_CASE_NAME_ARIA,
+    };
+  }, [caseData.incrementalId, caseData.title, permissions.update, onUpdateField]);
+
+  // Metadata
+  const metadata = useMemo((): AppHeaderMetadataItems => {
+    const reporterName = caseData.createdBy.fullName ?? caseData.createdBy.username ?? '';
+    const formattedDate = moment.tz(caseData.createdAt, timeZone).format(dateFormat);
+    return [
+      {
+        type: 'text' as const,
+        label: `${REPORTED_BY}: ${reporterName}`,
+        'data-test-subj': 'case-view-reported-by',
+      },
+      {
+        type: 'text' as const,
+        label: `${CREATED_ON}: ${formattedDate}`,
+        'data-test-subj': 'case-view-created-at',
+      },
+    ];
+  }, [caseData.createdBy, caseData.createdAt, timeZone, dateFormat]);
 
   // Back
   const backHref = useMemo(() => getAllCasesUrl(), [getAllCasesUrl]);
@@ -113,6 +162,7 @@ export const useCaseViewHeader = ({ caseData, onStatusChanged }: UseCaseViewHead
 
   return {
     headerTitle,
+    metadata,
     backHref,
     badges,
     menu,

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_details_header/hooks/use_case_view_header.tsx
@@ -80,7 +80,7 @@ export const useCaseViewHeader = ({
   // Metadata
   const metadata = useMemo((): AppHeaderMetadataItems => {
     const reporterName =
-      caseData.createdBy.fullName ?? caseData.createdBy.username ?? UNKNOWN_REPORTER;
+      caseData.createdBy.fullName || caseData.createdBy.username || UNKNOWN_REPORTER;
     const formattedDate = moment.tz(caseData.createdAt, timeZone).format(dateFormat);
 
     const reportedByItem = {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_settings_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_settings_popover.test.tsx
@@ -42,7 +42,6 @@ describe('CaseSettingsPopover', () => {
     onSyncAlertsChange: jest.fn(),
     showMetrics: true,
     onShowMetricsChange: jest.fn(),
-    onCaseNameChange: jest.fn(),
     isOpen: true,
     onClose: jest.fn(),
     anchorElement,
@@ -114,58 +113,6 @@ describe('CaseSettingsPopover', () => {
     });
   });
 
-  it('renders edit case name link', async () => {
-    renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} />);
-
-    expect(await screen.findByTestId('case-settings-change-name')).toBeInTheDocument();
-  });
-
-  it('opens rename modal when edit case name is clicked', async () => {
-    renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} />);
-
-    await userEvent.click(await screen.findByTestId('case-settings-change-name'));
-
-    expect(await screen.findByTestId('case-rename-modal')).toBeInTheDocument();
-    expect(defaultProps.onClose).toHaveBeenCalled();
-  });
-
-  it('submits new name and closes modal', async () => {
-    renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} />);
-
-    await userEvent.click(await screen.findByTestId('case-settings-change-name'));
-
-    const input = await screen.findByTestId('case-rename-input');
-    await userEvent.clear(input);
-    await userEvent.type(input, 'New case name');
-
-    await userEvent.click(await screen.findByTestId('case-rename-submit'));
-
-    await waitFor(() => {
-      expect(defaultProps.onCaseNameChange).toHaveBeenCalledWith('New case name');
-    });
-  });
-
-  it('disables submit when name is same as current', async () => {
-    renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} />);
-
-    await userEvent.click(await screen.findByTestId('case-settings-change-name'));
-
-    const submitButton = await screen.findByTestId('case-rename-submit');
-    expect(submitButton).toBeDisabled();
-  });
-
-  it('disables submit when name is empty', async () => {
-    renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} />);
-
-    await userEvent.click(await screen.findByTestId('case-settings-change-name'));
-
-    const input = await screen.findByTestId('case-rename-input');
-    await userEvent.clear(input);
-
-    const submitButton = await screen.findByTestId('case-rename-submit');
-    expect(submitButton).toBeDisabled();
-  });
-
   it('does not render popover content when isOpen is false', () => {
     renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} isOpen={false} />);
 
@@ -219,5 +166,12 @@ describe('CaseSettingsPopover', () => {
     await screen.findByTestId('case-settings-popover');
 
     expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not render edit case name link', async () => {
+    renderWithTestingProviders(<CaseSettingsPopover {...defaultProps} />);
+
+    await screen.findByTestId('case-settings-popover');
+    expect(screen.queryByTestId('case-settings-change-name')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_settings_popover.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/case_settings_popover.tsx
@@ -8,18 +8,8 @@
 import type { FC } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  EuiButton,
-  EuiButtonEmpty,
   EuiComboBox,
-  EuiFieldText,
   EuiFormRow,
-  EuiHorizontalRule,
-  EuiLink,
-  EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
   EuiPopoverTitle,
   EuiSpacer,
   EuiSwitch,
@@ -35,7 +25,7 @@ import { useGetTemplate } from '../../../templates_v2/hooks/use_get_template';
 import { KibanaServices } from '../../../../common/lib/kibana';
 import * as i18n from '../../../case_view/translations';
 import * as commonI18n from '../../../../common/translations';
-import { SHOW_METRICS, EDIT_CASE_NAME, NEW_CASE_NAME_LABEL } from '../../translations';
+import { SHOW_METRICS } from '../../translations';
 
 interface CaseSettingsPopoverProps {
   caseData: CaseUI;
@@ -43,7 +33,6 @@ interface CaseSettingsPopoverProps {
   onSyncAlertsChange: (enabled: boolean) => void;
   showMetrics: boolean;
   onShowMetricsChange: (enabled: boolean) => void;
-  onCaseNameChange: (newName: string) => void;
   isOpen: boolean;
   onClose: () => void;
   anchorElement: HTMLElement;
@@ -55,7 +44,6 @@ export const CaseSettingsPopover: FC<CaseSettingsPopoverProps> = ({
   onSyncAlertsChange,
   showMetrics,
   onShowMetricsChange,
-  onCaseNameChange,
   isOpen,
   onClose,
   anchorElement,
@@ -64,8 +52,6 @@ export const CaseSettingsPopover: FC<CaseSettingsPopoverProps> = ({
   const { isSyncAlertsEnabled, metricsFeatures } = useCasesFeatures();
   const hasMetrics = metricsFeatures.length > 0;
   const isTemplatesEnabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
-  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
-  const [newCaseName, setNewCaseName] = useState(caseData.title);
 
   const { data: templatesData, isLoading: isLoadingTemplates } = useGetTemplates({
     queryParams: { page: 1, perPage: 10000, owner, isEnabled: true },
@@ -119,111 +105,57 @@ export const CaseSettingsPopover: FC<CaseSettingsPopoverProps> = ({
     setSelectedTemplateId(selected[0]?.value ?? '');
   }, []);
 
-  const openRenameModal = useCallback(() => {
-    setNewCaseName(caseData.title);
-    setIsRenameModalOpen(true);
-    onClose();
-  }, [caseData.title, onClose]);
-
-  const closeRenameModal = useCallback(() => {
-    setIsRenameModalOpen(false);
-  }, []);
-
-  const onSubmitRename = useCallback(() => {
-    const trimmed = newCaseName.trim();
-    if (trimmed && trimmed !== caseData.title) {
-      onCaseNameChange(trimmed);
-    }
-    setIsRenameModalOpen(false);
-  }, [newCaseName, caseData.title, onCaseNameChange]);
-
   return (
-    <>
-      <EuiWrappingPopover
-        button={anchorElement}
-        isOpen={isOpen}
-        closePopover={onClose}
-        anchorPosition="downRight"
-        panelPaddingSize="m"
-        aria-label={i18n.CASE_SETTINGS}
-        data-test-subj="case-settings-popover"
-      >
-        <EuiPopoverTitle>{i18n.CASE_SETTINGS}</EuiPopoverTitle>
-        {isTemplatesEnabled && (
-          <>
-            <EuiFormRow label={commonI18n.APPLY_TEMPLATE_MODAL_TEMPLATE_LABEL} fullWidth>
-              <EuiComboBox
-                fullWidth
-                singleSelection={{ asPlainText: true }}
-                options={options}
-                selectedOptions={selectedOptions}
-                onChange={onTemplateChange}
-                isLoading={isLoadingTemplates}
-                placeholder={commonI18n.APPLY_TEMPLATE_MODAL_TEMPLATE_PLACEHOLDER}
-                data-test-subj="case-settings-template-select"
-                compressed
-              />
-            </EuiFormRow>
-            <EuiSpacer size="m" />
-          </>
-        )}
-        {isSyncAlertsEnabled && (
-          <>
-            <EuiSwitch
-              label={i18n.SYNC_ALERTS}
-              checked={syncAlerts}
-              onChange={(e) => onSyncAlertsChange(e.target.checked)}
+    <EuiWrappingPopover
+      button={anchorElement}
+      isOpen={isOpen}
+      closePopover={onClose}
+      anchorPosition="downRight"
+      panelPaddingSize="m"
+      aria-label={i18n.CASE_SETTINGS}
+      data-test-subj="case-settings-popover"
+    >
+      <EuiPopoverTitle>{i18n.CASE_SETTINGS}</EuiPopoverTitle>
+      {isTemplatesEnabled && (
+        <>
+          <EuiFormRow label={commonI18n.APPLY_TEMPLATE_MODAL_TEMPLATE_LABEL} fullWidth>
+            <EuiComboBox
+              fullWidth
+              singleSelection={{ asPlainText: true }}
+              options={options}
+              selectedOptions={selectedOptions}
+              onChange={onTemplateChange}
+              isLoading={isLoadingTemplates}
+              placeholder={commonI18n.APPLY_TEMPLATE_MODAL_TEMPLATE_PLACEHOLDER}
+              data-test-subj="case-settings-template-select"
               compressed
-              data-test-subj="case-settings-sync-alerts-switch"
             />
-            <EuiSpacer size="m" />
-          </>
-        )}
-        {hasMetrics && (
-          <>
-            <EuiSwitch
-              label={SHOW_METRICS}
-              checked={showMetrics}
-              onChange={(e) => onShowMetricsChange(e.target.checked)}
-              compressed
-              data-test-subj="case-settings-show-metrics-switch"
-            />
-            <EuiHorizontalRule margin="m" />
-          </>
-        )}
-        <EuiLink onClick={openRenameModal} data-test-subj="case-settings-change-name">
-          {EDIT_CASE_NAME}
-        </EuiLink>
-      </EuiWrappingPopover>
-      {isRenameModalOpen && (
-        <EuiModal onClose={closeRenameModal} data-test-subj="case-rename-modal">
-          <EuiModalHeader>
-            <EuiModalHeaderTitle>{EDIT_CASE_NAME}</EuiModalHeaderTitle>
-          </EuiModalHeader>
-          <EuiModalBody>
-            <EuiFormRow label={NEW_CASE_NAME_LABEL} fullWidth>
-              <EuiFieldText
-                fullWidth
-                value={newCaseName}
-                onChange={(e) => setNewCaseName(e.target.value)}
-                data-test-subj="case-rename-input"
-              />
-            </EuiFormRow>
-          </EuiModalBody>
-          <EuiModalFooter>
-            <EuiButtonEmpty onClick={closeRenameModal}>{commonI18n.CANCEL}</EuiButtonEmpty>
-            <EuiButton
-              fill
-              onClick={onSubmitRename}
-              isDisabled={!newCaseName.trim() || newCaseName.trim() === caseData.title}
-              data-test-subj="case-rename-submit"
-            >
-              {commonI18n.SAVE}
-            </EuiButton>
-          </EuiModalFooter>
-        </EuiModal>
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+        </>
       )}
-    </>
+      {isSyncAlertsEnabled && (
+        <>
+          <EuiSwitch
+            label={i18n.SYNC_ALERTS}
+            checked={syncAlerts}
+            onChange={(e) => onSyncAlertsChange(e.target.checked)}
+            compressed
+            data-test-subj="case-settings-sync-alerts-switch"
+          />
+          <EuiSpacer size="m" />
+        </>
+      )}
+      {hasMetrics && (
+        <EuiSwitch
+          label={SHOW_METRICS}
+          checked={showMetrics}
+          onChange={(e) => onShowMetricsChange(e.target.checked)}
+          compressed
+          data-test-subj="case-settings-show-metrics-switch"
+        />
+      )}
+    </EuiWrappingPopover>
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
@@ -33,13 +33,24 @@ export const SHOW_METRICS = i18n.translate('xpack.cases.casesRedesign.details.sh
   defaultMessage: 'Show metrics',
 });
 
-export const REPORTED_BY = i18n.translate('xpack.cases.casesRedesign.details.reportedBy', {
-  defaultMessage: 'Reported by',
-});
+export const REPORTED_BY = (name: string) =>
+  i18n.translate('xpack.cases.casesRedesign.details.reportedBy', {
+    defaultMessage: 'Reported by: {name}',
+    values: { name },
+  });
 
-export const CREATED_ON = i18n.translate('xpack.cases.casesRedesign.details.createdOn', {
-  defaultMessage: 'on',
-});
+export const CREATED_ON = (date: string) =>
+  i18n.translate('xpack.cases.casesRedesign.details.createdOn', {
+    defaultMessage: 'on: {date}',
+    values: { date },
+  });
+
+export const UNKNOWN_REPORTER = i18n.translate(
+  'xpack.cases.casesRedesign.details.unknownReporter',
+  {
+    defaultMessage: 'Unknown',
+  }
+);
 
 export const EDIT_CASE_NAME_ARIA = i18n.translate(
   'xpack.cases.casesRedesign.details.editCaseNameAria',

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/translations.ts
@@ -33,13 +33,17 @@ export const SHOW_METRICS = i18n.translate('xpack.cases.casesRedesign.details.sh
   defaultMessage: 'Show metrics',
 });
 
-export const EDIT_CASE_NAME = i18n.translate('xpack.cases.casesRedesign.details.editCaseName', {
-  defaultMessage: 'Edit case name',
+export const REPORTED_BY = i18n.translate('xpack.cases.casesRedesign.details.reportedBy', {
+  defaultMessage: 'Reported by',
 });
 
-export const NEW_CASE_NAME_LABEL = i18n.translate(
-  'xpack.cases.casesRedesign.details.newCaseNameLabel',
+export const CREATED_ON = i18n.translate('xpack.cases.casesRedesign.details.createdOn', {
+  defaultMessage: 'on',
+});
+
+export const EDIT_CASE_NAME_ARIA = i18n.translate(
+  'xpack.cases.casesRedesign.details.editCaseNameAria',
   {
-    defaultMessage: 'Case name',
+    defaultMessage: 'Edit case name',
   }
 );


### PR DESCRIPTION
## What & Why
Moves case title editing from the settings popover modal into the `AppHeader` via inline click-to-edit, and adds "Reported by" / creation date metadata to the case details header. This removes the rename modal from `CaseSettingsPopover`, reducing indirection for the most common rename flow and surfacing case provenance information at a glance.
<img width="1470" height="173" alt="image" src="https://github.com/user-attachments/assets/d7859354-2ec3-4243-8267-6429a3b31b02" />

## How to Test
1. Open a case detail page — verify the title is click-to-edit (click the title text, modify, press Enter to save).
2. Confirm "Reported by: {name}" and "on: {date}" metadata appear below the title.
3. Open the settings gear — confirm "Edit case name" link and rename modal are gone.
4. Switch to a read-only user — verify the title is plain text (not editable) and metadata still renders.

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)