### PR TITLE
Add experience-docs as code owner for docs/release-notes, docset.yml and redirects.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3593,6 +3593,7 @@ oas_docs/scripts                              @elastic/kibana-core
 # Documentation settings files
 docs/settings-gen                             @elastic/experience-docs
 docs/reference                                @elastic/experience-docs
+docs/release-notes                            @elastic/experience-docs
 
 # Side navigation title glossary
 src/platform/packages/shared/shared-ux/label_formatter/src/to_sentence_case.ts @elastic/experience-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3594,6 +3594,8 @@ oas_docs/scripts                              @elastic/kibana-core
 docs/settings-gen                             @elastic/experience-docs
 docs/reference                                @elastic/experience-docs
 docs/release-notes                            @elastic/experience-docs
+docs/docset.yml                               @elastic/experience-docs
+docs/redirects.yml                            @elastic/experience-docs
 
 # Side navigation title glossary
 src/platform/packages/shared/shared-ux/label_formatter/src/to_sentence_case.ts @elastic/experience-docs


### PR DESCRIPTION
## Summary

Adds `@elastic/experience-docs` as the code owner for several previously-unowned documentation paths in `.github/CODEOWNERS`, matching the existing ownership of `docs/reference` and `docs/settings-gen`.

The following lines are added to the **Documentation settings files** section:

```
docs/release-notes                            @elastic/experience-docs
docs/docset.yml                               @elastic/experience-docs
docs/redirects.yml                            @elastic/experience-docs
```

- `docs/release-notes` — release notes content (`breaking-changes.md`, `deprecations.md`, `index.md`, `known-issues.md`, `toc.yml`)
- `docs/docset.yml` — docs build configuration
- `docs/redirects.yml` — docs redirects configuration

These paths previously had no code owner, so changes to them did not automatically request review from the docs team.

Other `docs/` paths remain intentionally out of scope for this PR (`docs/changelog`, `docs/development`, `docs/releases`, most of `docs/extend`).

### Checklist

- [x] This change only updates `.github/CODEOWNERS`; no code, tests, or user-facing text are affected.

### Identify risks

- [x] Low risk. This only adds review ownership for documentation files and does not change any product behavior.