### PR TITLE
[Cases][AttachmentsV2] Always register cases-attachments SO

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/utils/saved_object_types.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/saved_object_types.ts
@@ -20,9 +20,6 @@ interface CasesConfigType {
   templates?: {
     enabled?: boolean;
   };
-  attachments?: {
-    enabled?: boolean;
-  };
 }
 
 /**
@@ -35,6 +32,7 @@ export const getSavedObjectsTypes = (config?: Partial<CasesConfigType>): string[
     CASE_USER_ACTION_SAVED_OBJECT,
     CASE_COMMENT_SAVED_OBJECT,
     CASE_CONFIGURE_SAVED_OBJECT,
+    CASE_ATTACHMENT_SAVED_OBJECT,
   ];
 
   const experimentalSOs: string[] = [];
@@ -42,10 +40,6 @@ export const getSavedObjectsTypes = (config?: Partial<CasesConfigType>): string[
   if (config?.templates?.enabled) {
     experimentalSOs.push(CASE_TEMPLATE_SAVED_OBJECT);
     experimentalSOs.push(CASE_FIELD_DEFINITION_SAVED_OBJECT);
-  }
-
-  if (config?.attachments?.enabled) {
-    experimentalSOs.push(CASE_ATTACHMENT_SAVED_OBJECT);
   }
 
   return [...baseSavedObjects, ...experimentalSOs];

--- a/x-pack/platform/plugins/shared/cases/server/authorization/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/authorization/utils.ts
@@ -71,19 +71,14 @@ export const includeFieldsRequiredForAuthentication = (fields?: string[]): strin
 
 /**
  * Returns an authorization filter that covers both the legacy `cases-comments`
- * and the unified `cases-attachments` saved object types based on feature flag
+ * and the unified `cases-attachments` saved object types.
  */
 export const getAttachmentAuthorizationFilter = async (
   authorization: Pick<Authorization, 'getAuthorizationFilter'>,
-  operation: OperationDetails,
-  { isCasesAttachmentsEnabled }: { isCasesAttachmentsEnabled: boolean }
+  operation: OperationDetails
 ): Promise<AuthFilterHelpers> => {
   const { filter, authorizedOwners, ensureSavedObjectsAreAuthorized } =
     await authorization.getAuthorizationFilter(operation);
-
-  if (!isCasesAttachmentsEnabled) {
-    return { filter, authorizedOwners, ensureSavedObjectsAreAuthorized };
-  }
 
   const unifiedFilter = authorizedOwners?.length
     ? getOwnersFilter(CASE_ATTACHMENT_SAVED_OBJECT, authorizedOwners)

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/get.ts
@@ -72,7 +72,6 @@ export const getAllDocumentsAttachedToCase = async (
     authorization,
     services: { attachmentService },
     logger,
-    config,
   } = clientArgs;
 
   try {
@@ -83,9 +82,7 @@ export const getAllDocumentsAttachedToCase = async (
     });
 
     const { filter: authorizationFilter, ensureSavedObjectsAreAuthorized } =
-      await getAttachmentAuthorizationFilter(authorization, Operations.getAlertsAttachedToCase, {
-        isCasesAttachmentsEnabled: config.attachments?.enabled === true,
-      });
+      await getAttachmentAuthorizationFilter(authorization, Operations.getAlertsAttachedToCase);
 
     const filterArray = authorizationFilter ? [authorizationFilter] : [];
     if (filter) filterArray.push(filter);
@@ -127,16 +124,13 @@ export async function find(
     services: { attachmentService },
     logger,
     authorization,
-    config,
   } = clientArgs;
 
   try {
     const queryParams = decodeWithExcessOrThrow(FindAttachmentsQueryParamsRt)(findQueryParams);
 
     const { filter: authorizationFilter, ensureSavedObjectsAreAuthorized } =
-      await getAttachmentAuthorizationFilter(authorization, Operations.findComments, {
-        isCasesAttachmentsEnabled: config.attachments?.enabled === true,
-      });
+      await getAttachmentAuthorizationFilter(authorization, Operations.findComments);
 
     // TODO https://github.com/elastic/security-team/issues/17089
     // include `cases-attachments.attributes.type === 'comment'`
@@ -228,14 +222,12 @@ export async function getAll(
     services: { caseService },
     logger,
     authorization,
-    config,
   } = clientArgs;
 
   try {
     const { filter, ensureSavedObjectsAreAuthorized } = await getAttachmentAuthorizationFilter(
       authorization,
-      Operations.getAllComments,
-      { isCasesAttachmentsEnabled: config.attachments?.enabled === true }
+      Operations.getAllComments
     );
 
     const comments = await caseService.getAllCaseComments({

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/bulk_update.ts
@@ -213,20 +213,18 @@ async function getAlertComments({
     AttachmentType.alert
   );
 
-  const alertFilter = isCasesAttachmentsEnabled
-    ? combineFilters(
-        [
-          legacyAlertFilter,
-          buildFilter({
-            filters: UNIFIED_ALERT_TYPES_ARRAY,
-            field: 'type',
-            operator: 'or',
-            type: CASE_ATTACHMENT_SAVED_OBJECT,
-          }),
-        ],
-        NodeBuilderOperators.or
-      )
-    : legacyAlertFilter;
+  const alertFilter = combineFilters(
+    [
+      legacyAlertFilter,
+      buildFilter({
+        filters: UNIFIED_ALERT_TYPES_ARRAY,
+        field: 'type',
+        operator: 'or',
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+      }),
+    ],
+    NodeBuilderOperators.or
+  );
 
   return (await caseService.getAllCaseComments({
     id: idsOfCasesToSync,

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/get.ts
@@ -104,9 +104,8 @@ export const getCasesByAlertID = async (
 
     /**
      * The authorization filter above is scoped to `cases-comments` (the operation's saved object
-     * type). When the unified attachments feature flag is on we also need to query
-     * `cases-attachments`, so build an equivalent owner-scoped filter for that type using the
-     * same authorized owners.
+     * type). We also query `cases-attachments`, so build an equivalent owner-scoped filter for
+     * that type using the same authorized owners.
      */
     const unifiedAuthorizationFilter =
       authorizedOwners && authorizedOwners.length > 0

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/push.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/push.ts
@@ -76,20 +76,18 @@ const changeAlertsStatusToClose = async (
     AttachmentType.alert
   );
 
-  const alertFilter = isCasesAttachmentsEnabled
-    ? combineFilters(
-        [
-          legacyAlertFilter,
-          buildFilter({
-            filters: UNIFIED_ALERT_TYPES_ARRAY,
-            field: 'type',
-            operator: 'or',
-            type: CASE_ATTACHMENT_SAVED_OBJECT,
-          }),
-        ],
-        NodeBuilderOperators.or
-      )
-    : legacyAlertFilter;
+  const alertFilter = combineFilters(
+    [
+      legacyAlertFilter,
+      buildFilter({
+        filters: UNIFIED_ALERT_TYPES_ARRAY,
+        field: 'type',
+        operator: 'or',
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+      }),
+    ],
+    NodeBuilderOperators.or
+  );
 
   const alertAttachments = await caseService.getAllCaseComments({
     id: [caseId],

--- a/x-pack/platform/plugins/shared/cases/server/client/factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/factory.ts
@@ -310,7 +310,6 @@ export class CasesClientFactory {
         unsecuredSavedObjectsClient,
         savedObjectsSerializer,
         auditLogger,
-        isCasesAttachmentsEnabled: this.options.config.attachments?.enabled === true,
       }),
       attachmentService,
       licensingService,

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/count.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/count.ts
@@ -23,7 +23,6 @@ export class AlertsCount extends SingleCaseBaseHandler {
       authorization,
       services: { attachmentService },
       logger,
-      config,
     } = this.options.clientArgs;
 
     const { casesClient } = this.options;
@@ -37,8 +36,7 @@ export class AlertsCount extends SingleCaseBaseHandler {
 
       const { filter: authorizationFilter } = await getAttachmentAuthorizationFilter(
         authorization,
-        Operations.getAttachmentMetrics,
-        { isCasesAttachmentsEnabled: config.attachments?.enabled === true }
+        Operations.getAttachmentMetrics
       );
 
       const alertsCount = await attachmentService.countAlertsAttachedToCase({

--- a/x-pack/platform/plugins/shared/cases/server/common/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/attachments/index.ts
@@ -33,8 +33,9 @@ export { getCommentContentFromUnifiedPayload, commentAttachmentTransformer } fro
 export { actionsAttachmentTransformer } from './actions';
 export {
   getAttachmentSavedObjectType,
-  resolveAttachmentSavedObjectType,
+  resolveAttachmentSavedObjectTypes,
 } from './saved_object_type';
+export type { ResolvedAttachmentSavedObjectType } from './saved_object_type';
 // Re-exported so existing server call sites keep their `from '.'` import path.
 export { getAttachmentTypeFromAttributes } from '../../../common/utils/attachments';
 

--- a/x-pack/platform/plugins/shared/cases/server/common/attachments/saved_object_type.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/attachments/saved_object_type.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsBulkResponse } from '@kbn/core/server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { CASE_ATTACHMENT_SAVED_OBJECT, CASE_COMMENT_SAVED_OBJECT } from '../../../common/constants';
+import { createUserAttachment } from '../../services/attachments/test_utils';
+import { createErrorSO } from '../../services/test_utils';
+import { resolveAttachmentSavedObjectTypes } from './saved_object_type';
+
+type BulkGetSavedObjects = SavedObjectsBulkResponse['saved_objects'];
+
+const mockBulkGetResponse = (savedObjects: unknown[]): SavedObjectsBulkResponse => ({
+  saved_objects: savedObjects as BulkGetSavedObjects,
+});
+
+describe('resolveAttachmentSavedObjectTypes', () => {
+  const client = savedObjectsClientMock.create();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns [] and skips bulkGet when called with no ids', async () => {
+    await expect(resolveAttachmentSavedObjectTypes(client, [])).resolves.toEqual([]);
+    expect(client.bulkGet).not.toHaveBeenCalled();
+  });
+
+  it('issues a single bulkGet probing both SO types per id', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createUserAttachment(), id: '1', type: CASE_ATTACHMENT_SAVED_OBJECT },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '2' },
+        { ...createUserAttachment(), id: '2', type: CASE_COMMENT_SAVED_OBJECT },
+      ])
+    );
+
+    await resolveAttachmentSavedObjectTypes(client, ['1', '2']);
+
+    expect(client.bulkGet).toHaveBeenCalledTimes(1);
+    expect(client.bulkGet).toHaveBeenCalledWith([
+      { id: '1', type: CASE_ATTACHMENT_SAVED_OBJECT },
+      { id: '1', type: CASE_COMMENT_SAVED_OBJECT },
+      { id: '2', type: CASE_ATTACHMENT_SAVED_OBJECT },
+      { id: '2', type: CASE_COMMENT_SAVED_OBJECT },
+    ]);
+  });
+
+  it('resolves to the unified SO when the unified entry hits', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createUserAttachment(), id: '1', type: CASE_ATTACHMENT_SAVED_OBJECT },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).resolves.toEqual([
+      CASE_ATTACHMENT_SAVED_OBJECT,
+    ]);
+  });
+
+  it('resolves to the legacy SO when only the legacy entry hits', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+        { ...createUserAttachment(), id: '1', type: CASE_COMMENT_SAVED_OBJECT },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).resolves.toEqual([
+      CASE_COMMENT_SAVED_OBJECT,
+    ]);
+  });
+
+  it('resolves to null when both entries 404', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).resolves.toEqual([null]);
+  });
+
+  it('resolves multiple ids in mixed states by id-keyed lookup (not by response order)', async () => {
+    // Respond with the legacy/unified rows in a different order than the request
+    // to confirm the resolver doesn't rely on positional alignment.
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '3' },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '3' },
+        { ...createUserAttachment(), id: '1', type: CASE_ATTACHMENT_SAVED_OBJECT },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '2' },
+        { ...createUserAttachment(), id: '2', type: CASE_COMMENT_SAVED_OBJECT },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1', '2', '3'])).resolves.toEqual([
+      CASE_ATTACHMENT_SAVED_OBJECT,
+      CASE_COMMENT_SAVED_OBJECT,
+      null,
+    ]);
+  });
+
+  it('rejects when the unified entry returns a non-404 error', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT, { statusCode: 503 }), id: '1' },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).rejects.toThrow(
+      `Failed to resolve attachment SO type for ${CASE_ATTACHMENT_SAVED_OBJECT}/1`
+    );
+  });
+
+  it('rejects when the legacy entry returns a non-404 error', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+        { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT, { statusCode: 500 }), id: '1' },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).rejects.toThrow(
+      `Failed to resolve attachment SO type for ${CASE_COMMENT_SAVED_OBJECT}/1`
+    );
+  });
+
+  it('rejects when the unified entry is missing from the bulkGet response', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([{ ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' }])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).rejects.toThrow(
+      /SO bulkGet response missing entry for id="1".*unified=false, legacy=true/
+    );
+  });
+
+  it('rejects when the legacy entry is missing from the bulkGet response', async () => {
+    client.bulkGet.mockResolvedValue(
+      mockBulkGetResponse([
+        { ...createUserAttachment(), id: '1', type: CASE_ATTACHMENT_SAVED_OBJECT },
+      ])
+    );
+
+    await expect(resolveAttachmentSavedObjectTypes(client, ['1'])).rejects.toThrow(
+      /SO bulkGet response missing entry for id="1".*unified=true, legacy=false/
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/common/attachments/saved_object_type.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/attachments/saved_object_type.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { SavedObject, SavedObjectsClientContract } from '@kbn/core/server';
+import type { SavedObjectError } from '@kbn/core-saved-objects-common';
 import { CASE_ATTACHMENT_SAVED_OBJECT, CASE_COMMENT_SAVED_OBJECT } from '../../../common/constants';
 import type { ConfigType } from '../../config';
-import { isSOError } from '../error';
+import { createCaseErrorFromSOError, isSOError } from '../error';
+import type { SOWithErrors } from '../types';
 
 export type ResolvedAttachmentSavedObjectType =
   | typeof CASE_ATTACHMENT_SAVED_OBJECT
@@ -34,9 +36,10 @@ export function getAttachmentSavedObjectType(
  * an id present in neither SO type resolves to `null`. Callers with a single
  * id can pass `[id]` and read `result[0]`.
  *
- * Throws if the saved objects client returns a response whose length does not
- * match the request (i.e. the SO client contract of returning one entry per
- * request in input order is violated).
+ * Errors are handled as follows:
+ *  - `404` on a bucket is treated as "missing" and falls back to the other bucket.
+ *  - Any non-`404` error is re-thrown so callers don't silently mis-route updates.
+ *  - Throws if the SO bulkGet response is missing the unified or legacy entry for an id.
  */
 export async function resolveAttachmentSavedObjectTypes(
   client: SavedObjectsClientContract,
@@ -53,17 +56,44 @@ export async function resolveAttachmentSavedObjectTypes(
     ])
   );
 
-  const expected = savedObjectIds.length * 2;
-  if (response.saved_objects.length !== expected) {
-    throw new Error(
-      `resolveAttachmentSavedObjectTypes: SO bulkGet contract violation. Expected ${expected} entries ` +
-        `(2 per id for ${savedObjectIds.length} ids), received ${response.saved_objects.length}.`
-    );
+  // Index responses by `${type}:${id}` so resolution doesn't rely on the SO
+  // client preserving request order.
+  const keyFor = (type: string, id: string) => `${type}:${id}`;
+  const byKey = new Map<string, SavedObject<unknown> | SOWithErrors<unknown>>();
+  for (const so of response.saved_objects) {
+    byKey.set(keyFor(so.type, so.id), so);
   }
 
-  return savedObjectIds.map((_, idx) => {
-    const unified = response.saved_objects[idx * 2];
-    const legacy = response.saved_objects[idx * 2 + 1];
+  // `bulkGet` always returns `SavedObjectError` (not `DecoratedError`) on its
+  // error entries, so `.statusCode` is the right field to inspect.
+  const statusCodeOf = (so: SOWithErrors<unknown>): number =>
+    (so.error as SavedObjectError).statusCode;
+
+  return savedObjectIds.map((id) => {
+    const unified = byKey.get(keyFor(CASE_ATTACHMENT_SAVED_OBJECT, id));
+    const legacy = byKey.get(keyFor(CASE_COMMENT_SAVED_OBJECT, id));
+    if (!unified || !legacy) {
+      throw new Error(
+        `resolveAttachmentSavedObjectTypes: SO bulkGet response missing entry for id="${id}" ` +
+          `(unified=${unified != null}, legacy=${legacy != null}).`
+      );
+    }
+
+    // Re-throw non-404 errors so transient SO client failures don't get silently
+    // treated as "missing" and route writes to the wrong bucket.
+    if (isSOError(unified) && statusCodeOf(unified) !== 404) {
+      throw createCaseErrorFromSOError(
+        unified.error,
+        `Failed to resolve attachment SO type for ${CASE_ATTACHMENT_SAVED_OBJECT}/${id}`
+      );
+    }
+    if (isSOError(legacy) && statusCodeOf(legacy) !== 404) {
+      throw createCaseErrorFromSOError(
+        legacy.error,
+        `Failed to resolve attachment SO type for ${CASE_COMMENT_SAVED_OBJECT}/${id}`
+      );
+    }
+
     if (!isSOError(unified)) {
       return CASE_ATTACHMENT_SAVED_OBJECT;
     }

--- a/x-pack/platform/plugins/shared/cases/server/common/attachments/saved_object_type.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/attachments/saved_object_type.ts
@@ -8,21 +8,20 @@
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { CASE_ATTACHMENT_SAVED_OBJECT, CASE_COMMENT_SAVED_OBJECT } from '../../../common/constants';
 import type { ConfigType } from '../../config';
-import type { AttachmentPersistedAttributes } from '../types/attachments_v1';
-import type { UnifiedAttachmentAttributes } from '../types/attachments_v2';
+import { isSOError } from '../error';
+
+export type ResolvedAttachmentSavedObjectType =
+  | typeof CASE_ATTACHMENT_SAVED_OBJECT
+  | typeof CASE_COMMENT_SAVED_OBJECT
+  | null;
 
 /**
- * Determines which saved object type should be used for a given attachment type
- * based on the feature flag and migration status.
- *
- * @param config - The cases plugin configuration
- * @param attachmentType - Optional attachment type. If not provided, returns the default SO type.
- * @returns The saved object type to use ('cases-attachments' or 'cases-comments')
+ * Returns the saved object type new attachments should be written to, gated by
+ * the `cases.attachments.enabled` config flag.
  */
 export function getAttachmentSavedObjectType(
   config: ConfigType
 ): typeof CASE_ATTACHMENT_SAVED_OBJECT | typeof CASE_COMMENT_SAVED_OBJECT {
-  // If feature flag is disabled, always use old SO type
   if (config.attachments?.enabled) {
     return CASE_ATTACHMENT_SAVED_OBJECT;
   }
@@ -30,32 +29,47 @@ export function getAttachmentSavedObjectType(
 }
 
 /**
- * Resolves which saved object type contains the attachment by id.
- * Tries the new SO type first, then falls back to the old SO type.
+ * Resolves which saved object type contains each attachment id, using a single
+ * `bulkGet` round trip (2 entries per id). Results are returned in input order;
+ * an id present in neither SO type resolves to `null`. Callers with a single
+ * id can pass `[id]` and read `result[0]`.
  *
- * @param client - The saved objects client
- * @param savedObjectId - Saved object id of the cases attachment to resolve
- * @returns The saved object type where the attachment exists, or null if not found
+ * Throws if the saved objects client returns a response whose length does not
+ * match the request (i.e. the SO client contract of returning one entry per
+ * request in input order is violated).
  */
-export async function resolveAttachmentSavedObjectType(
+export async function resolveAttachmentSavedObjectTypes(
   client: SavedObjectsClientContract,
-  savedObjectId: string
-): Promise<typeof CASE_ATTACHMENT_SAVED_OBJECT | typeof CASE_COMMENT_SAVED_OBJECT | null> {
-  try {
-    await client.get<UnifiedAttachmentAttributes>(CASE_ATTACHMENT_SAVED_OBJECT, savedObjectId);
-    return CASE_ATTACHMENT_SAVED_OBJECT;
-  } catch (error) {
-    const isNotFound =
-      (error as { statusCode?: number })?.statusCode === 404 ||
-      (error as { output?: { statusCode?: number } })?.output?.statusCode === 404;
-    if (isNotFound) {
-      try {
-        await client.get<AttachmentPersistedAttributes>(CASE_COMMENT_SAVED_OBJECT, savedObjectId);
-        return CASE_COMMENT_SAVED_OBJECT;
-      } catch {
-        return null;
-      }
-    }
-    throw error;
+  savedObjectIds: string[]
+): Promise<ResolvedAttachmentSavedObjectType[]> {
+  if (savedObjectIds.length === 0) {
+    return [];
   }
+
+  const response = await client.bulkGet<unknown>(
+    savedObjectIds.flatMap((id) => [
+      { id, type: CASE_ATTACHMENT_SAVED_OBJECT },
+      { id, type: CASE_COMMENT_SAVED_OBJECT },
+    ])
+  );
+
+  const expected = savedObjectIds.length * 2;
+  if (response.saved_objects.length !== expected) {
+    throw new Error(
+      `resolveAttachmentSavedObjectTypes: SO bulkGet contract violation. Expected ${expected} entries ` +
+        `(2 per id for ${savedObjectIds.length} ids), received ${response.saved_objects.length}.`
+    );
+  }
+
+  return savedObjectIds.map((_, idx) => {
+    const unified = response.saved_objects[idx * 2];
+    const legacy = response.saved_objects[idx * 2 + 1];
+    if (!isSOError(unified)) {
+      return CASE_ATTACHMENT_SAVED_OBJECT;
+    }
+    if (!isSOError(legacy)) {
+      return CASE_COMMENT_SAVED_OBJECT;
+    }
+    return null;
+  });
 }

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -127,49 +127,14 @@ describe('Cases Plugin', () => {
       expect(pluginsSetup.features.registerKibanaFeature).not.toHaveBeenCalled();
     });
 
-    it('should register cases-attachments SO when attachments.enabled is true', async () => {
-      context = coreMock.createPluginInitializerContext<ConfigType>(
-        getConfig({ attachments: { enabled: true } })
-      );
-      const pluginWithAttachmentsEnabled = new CasePlugin(context);
-
-      pluginWithAttachmentsEnabled.setup(coreSetup, pluginsSetup);
+    it('should always register cases-attachments SO', async () => {
+      plugin.setup(coreSetup, pluginsSetup);
 
       const registerTypeCalls = coreSetup.savedObjects.registerType.mock.calls;
       const attachmentSOCall = registerTypeCalls.find(
         (call) => call[0]?.name === CASE_ATTACHMENT_SAVED_OBJECT
       );
       expect(attachmentSOCall).toBeDefined();
-    });
-
-    it('should not register cases-attachments SO when attachments.enabled is false', async () => {
-      context = coreMock.createPluginInitializerContext<ConfigType>(
-        getConfig({ attachments: { enabled: false } })
-      );
-      const pluginWithAttachmentsDisabled = new CasePlugin(context);
-
-      pluginWithAttachmentsDisabled.setup(coreSetup, pluginsSetup);
-
-      const registerTypeCalls = coreSetup.savedObjects.registerType.mock.calls;
-      const attachmentSOCall = registerTypeCalls.find(
-        (call) => call[0]?.name === 'cases-attachments'
-      );
-      expect(attachmentSOCall).toBeUndefined();
-    });
-
-    it('should not register cases-attachments SO when attachments is undefined', async () => {
-      context = coreMock.createPluginInitializerContext<ConfigType>(
-        getConfig({ attachments: undefined } as Partial<ConfigType>)
-      );
-      const pluginWithAttachmentsUndefined = new CasePlugin(context);
-
-      pluginWithAttachmentsUndefined.setup(coreSetup, pluginsSetup);
-
-      const registerTypeCalls = coreSetup.savedObjects.registerType.mock.calls;
-      const attachmentSOCall = registerTypeCalls.find(
-        (call) => call[0]?.name === 'cases-attachments'
-      );
-      expect(attachmentSOCall).toBeUndefined();
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/index.ts
@@ -28,12 +28,15 @@ export const createCaseAttachmentSavedObjectType = (): SavedObjectsType => ({
     properties: {
       type: {
         type: 'keyword',
+        ignore_above: 1024,
       },
       attachmentId: {
         type: 'keyword',
+        ignore_above: 1024,
       },
       owner: {
         type: 'keyword',
+        ignore_above: 1024,
       },
       data: {
         properties: {
@@ -41,7 +44,7 @@ export const createCaseAttachmentSavedObjectType = (): SavedObjectsType => ({
             type: 'text',
           },
           /*
-          persistableState: {
+          state: {
             dynamic: false,
             properties: {},
           },
@@ -66,6 +69,7 @@ export const createCaseAttachmentSavedObjectType = (): SavedObjectsType => ({
            */
           username: {
             type: 'keyword',
+            ignore_above: 1024,
           },
         },
       },

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/model_versions/model_version_1.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/model_versions/model_version_1.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import type { SavedObjectsFullModelVersion } from '@kbn/core-saved-objects-server';
+import { MAX_ALERTS_PER_CASE, MAX_COMMENT_LENGTH } from '../../../../common/constants';
 
 // The SO mapping uses `dynamic: false`, so only a subset of attributes is indexed.
 // The `create` schema must declare every indexed field (see
@@ -15,30 +16,47 @@ import type { SavedObjectsFullModelVersion } from '@kbn/core-saved-objects-serve
 // `unknowns: 'allow'` to accommodate the unified payload variations
 // (reference vs value attachments, metadata, pushed_by, updated_by, etc.).
 
+// Bounds reuse existing cases conventions where they exist. `attachmentId`
+// (string): 512 = ES `_id` upper bound, covering every current producer
+// (alert/event ES ids, foreign SO UUIDs). `attachmentId` (array): reuses
+// MAX_ALERTS_PER_CASE. `username`: matches Kibana security plugin routes.
+const MAX_OWNER_LENGTH = 30;
+const MAX_ISO_DATE_LENGTH = 30;
+const MAX_ATTACHMENT_TYPE_LENGTH = 50;
+const MAX_ATTACHMENT_ID_LENGTH = 512;
+const MAX_USERNAME_LENGTH = 1024;
+
 const userSchema = schema.object(
   {
-    username: schema.maybe(schema.nullable(schema.string())),
+    username: schema.maybe(schema.nullable(schema.string({ maxLength: MAX_USERNAME_LENGTH }))),
   },
   { unknowns: 'allow' }
 );
 
 const dataSchema = schema.object(
   {
-    content: schema.maybe(schema.nullable(schema.string())),
+    content: schema.maybe(schema.nullable(schema.string({ maxLength: MAX_COMMENT_LENGTH }))),
   },
   { unknowns: 'allow' }
 );
 
 const createSchema = schema.object(
   {
-    type: schema.string(),
-    attachmentId: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
-    owner: schema.string(),
+    type: schema.string({ maxLength: MAX_ATTACHMENT_TYPE_LENGTH }),
+    attachmentId: schema.maybe(
+      schema.oneOf([
+        schema.string({ maxLength: MAX_ATTACHMENT_ID_LENGTH }),
+        schema.arrayOf(schema.string({ maxLength: MAX_ATTACHMENT_ID_LENGTH }), {
+          maxSize: MAX_ALERTS_PER_CASE,
+        }),
+      ])
+    ),
+    owner: schema.string({ maxLength: MAX_OWNER_LENGTH }),
     data: schema.maybe(schema.nullable(dataSchema)),
-    created_at: schema.string(),
+    created_at: schema.string({ maxLength: MAX_ISO_DATE_LENGTH }),
     created_by: userSchema,
-    pushed_at: schema.maybe(schema.nullable(schema.string())),
-    updated_at: schema.maybe(schema.nullable(schema.string())),
+    pushed_at: schema.maybe(schema.nullable(schema.string({ maxLength: MAX_ISO_DATE_LENGTH }))),
+    updated_at: schema.maybe(schema.nullable(schema.string({ maxLength: MAX_ISO_DATE_LENGTH }))),
   },
   { unknowns: 'allow' }
 );

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/model_versions/model_version_1.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/model_versions/model_version_1.ts
@@ -8,12 +8,46 @@
 import { schema } from '@kbn/config-schema';
 import type { SavedObjectsFullModelVersion } from '@kbn/core-saved-objects-server';
 
+// The SO mapping uses `dynamic: false`, so only a subset of attributes is indexed.
+// The `create` schema must declare every indexed field (see
+// `kbn-check-saved-objects-cli` validateAllMappingsInModelVersion), so we mirror
+// the mapping here while keeping the wrapping objects permissive via
+// `unknowns: 'allow'` to accommodate the unified payload variations
+// (reference vs value attachments, metadata, pushed_by, updated_by, etc.).
+
+const userSchema = schema.object(
+  {
+    username: schema.maybe(schema.nullable(schema.string())),
+  },
+  { unknowns: 'allow' }
+);
+
+const dataSchema = schema.object(
+  {
+    content: schema.maybe(schema.nullable(schema.string())),
+  },
+  { unknowns: 'allow' }
+);
+
+const createSchema = schema.object(
+  {
+    type: schema.string(),
+    attachmentId: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+    owner: schema.string(),
+    data: schema.maybe(schema.nullable(dataSchema)),
+    created_at: schema.string(),
+    created_by: userSchema,
+    pushed_at: schema.maybe(schema.nullable(schema.string())),
+    updated_at: schema.maybe(schema.nullable(schema.string())),
+  },
+  { unknowns: 'allow' }
+);
+
 /** Baseline model version anchoring `cases-attachments`. */
 export const modelVersion1: SavedObjectsFullModelVersion = {
   changes: [],
   schemas: {
-    // Identity passthrough; the SO has no per-mv config-schema yet.
     forwardCompatibility: (attrs) => attrs,
-    create: schema.object({}, { unknowns: 'allow' }),
+    create: createSchema,
   },
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.test.ts
@@ -54,30 +54,35 @@ describe('case export', () => {
     expect(containsIncrementalId).toBeFalsy();
   });
 
-  it('includes cases-attachments when exporting with unified attachments enabled', async () => {
-    const coreSetup = coreMock.createSetup();
+  it.each([
+    ['flag on', { attachments: { enabled: true } } as never],
+    ['flag off', { attachments: { enabled: false } } as never],
+  ])(
+    'includes cases-attachments in the scoped client and export query regardless of the feature flag (%s)',
+    async (_label, configForCase) => {
+      const coreSetup = coreMock.createSetup();
 
-    await handleExport({
-      context: testContext,
-      coreSetup,
-      // @ts-ignore: mock objects are not matching persisted objects
-      objects: testCases,
-      logger,
-      config,
-    });
+      await handleExport({
+        context: testContext,
+        coreSetup,
+        // @ts-ignore: mock objects are not matching persisted objects
+        objects: testCases,
+        logger,
+        config: configForCase,
+      });
 
-    const [coreStart] = await coreSetup.getStartServices();
+      const [coreStart] = await coreSetup.getStartServices();
 
-    expect(coreStart.savedObjects.getScopedClient).toHaveBeenCalledWith(
-      testRequest,
-      expect.objectContaining({
-        includedHiddenTypes: expect.arrayContaining([CASE_ATTACHMENT_SAVED_OBJECT]),
-      })
-    );
-    expect(getAttachmentsAndUserActionsForCases).toHaveBeenCalledWith(
-      expect.anything(),
-      testCases.map((testCase) => testCase.id),
-      true
-    );
-  });
+      expect(coreStart.savedObjects.getScopedClient).toHaveBeenCalledWith(
+        testRequest,
+        expect.objectContaining({
+          includedHiddenTypes: expect.arrayContaining([CASE_ATTACHMENT_SAVED_OBJECT]),
+        })
+      );
+      expect(getAttachmentsAndUserActionsForCases).toHaveBeenCalledWith(
+        expect.anything(),
+        testCases.map((testCase) => testCase.id)
+      );
+    }
+  );
 });

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/export.ts
@@ -64,8 +64,7 @@ export async function handleExport({
     const caseIds = cleanedObjects.map((caseObject) => caseObject.id);
     const attachmentsAndUserActionsForCases = await getAttachmentsAndUserActionsForCases(
       savedObjectsClient,
-      caseIds,
-      config.attachments?.enabled === true
+      caseIds
     );
 
     return [...cleanedObjects, ...attachmentsAndUserActionsForCases.flat()];

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.test.ts
@@ -14,7 +14,7 @@ import {
 import { getAttachmentsAndUserActionsForCases } from './utils';
 
 describe('import_export utils', () => {
-  it('exports attachments from both attachment saved object types when enabled', async () => {
+  it('always exports attachments from both legacy and unified attachment saved object types', async () => {
     const createPointInTimeFinder = jest.fn().mockReturnValue({
       async *find() {
         yield { saved_objects: [] };
@@ -24,7 +24,7 @@ describe('import_export utils', () => {
       createPointInTimeFinder,
     } as unknown as SavedObjectsClientContract;
 
-    await getAttachmentsAndUserActionsForCases(savedObjectsClient, ['case-id'], true);
+    await getAttachmentsAndUserActionsForCases(savedObjectsClient, ['case-id']);
 
     expect(createPointInTimeFinder).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/import_export/utils.ts
@@ -22,8 +22,7 @@ import { defaultSortField } from '../../common/utils';
 
 export async function getAttachmentsAndUserActionsForCases(
   savedObjectsClient: SavedObjectsClientContract,
-  caseIds: string[],
-  includeCaseAttachments = false
+  caseIds: string[]
 ): Promise<
   Array<
     SavedObject<
@@ -31,9 +30,7 @@ export async function getAttachmentsAndUserActionsForCases(
     >
   >
 > {
-  const attachmentTypes = includeCaseAttachments
-    ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
-    : CASE_COMMENT_SAVED_OBJECT;
+  const attachmentTypes = [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT];
 
   const [attachments, userActions] = await Promise.all([
     getAssociatedObjects<AttachmentAttributesWithoutRefs | AttachmentAttributesV2>({

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
@@ -64,8 +64,5 @@ export const registerSavedObjects = ({
     // eslint-disable-next-line @kbn/eslint/no_conditional_saved_object_type_registration -- caseFieldDefinitionSavedObjectType is part of the templates feature which is behind a feature flag
     core.savedObjects.registerType(caseFieldDefinitionSavedObjectType);
   }
-  if (config.attachments?.enabled) {
-    // eslint-disable-next-line @kbn/eslint/no_conditional_saved_object_type_registration -- TODO: remove conditional registration; tracked for follow-up PR
-    core.savedObjects.registerType(createCaseAttachmentSavedObjectType());
-  }
+  core.savedObjects.registerType(createCaseAttachmentSavedObjectType());
 };

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -798,16 +798,36 @@ describe('AttachmentService', () => {
       type: 'cases-comments',
     };
 
+    beforeEach(() => {
+      // `bulkUpdate` resolves the SO type via `resolveAttachmentSavedObjectTypes`
+      // (a single `bulkGet`). Route every id to the legacy bucket so the
+      // existing bulkUpdate tests exercise the legacy update path. Tests that
+      // need different routing override this.
+      unsecuredSavedObjectsClient.bulkGet.mockImplementation((objects) => {
+        const requests = objects as Array<{ id: string; type: string }>;
+        const savedObjects = requests.map(({ id, type }) =>
+          type === CASE_COMMENT_SAVED_OBJECT
+            ? { ...createUserAttachment(), id, type }
+            : { ...createErrorSO(type), id }
+        );
+        return Promise.resolve({
+          saved_objects: savedObjects as unknown as SavedObjectsBulkResponse['saved_objects'],
+        });
+      });
+    });
+
     it('should inject the references to the attributes correctly (persistable state)', async () => {
       unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
-          soClientRes,
+          { ...soClientRes, id: '1' },
           {
             ...soClientRes,
+            id: '2',
             attributes: externalReferenceAttachmentSOAttributesWithoutRefs,
           },
           {
             ...soClientRes,
+            id: '3',
             attributes: externalReferenceAttachmentESAttributes,
           },
         ],
@@ -835,9 +855,9 @@ describe('AttachmentService', () => {
 
       expect(res).toEqual({
         saved_objects: [
-          { ...soClientRes, attributes: persistableStateAttachmentAttributes },
-          { ...soClientRes, attributes: externalReferenceAttachmentSOAttributes },
-          { ...soClientRes, attributes: externalReferenceAttachmentESAttributes },
+          { ...soClientRes, id: '1', attributes: persistableStateAttachmentAttributes },
+          { ...soClientRes, id: '2', attributes: externalReferenceAttachmentSOAttributes },
+          { ...soClientRes, id: '3', attributes: externalReferenceAttachmentESAttributes },
         ],
       });
     });

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -7,6 +7,7 @@
 
 import { unset } from 'lodash';
 
+import type { SavedObjectsBulkResponse } from '@kbn/core/server';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { loggerMock } from '@kbn/logging-mocks';
 import { AttachmentService } from '.';
@@ -42,6 +43,21 @@ describe('AttachmentService', () => {
       log: mockLogger,
       unsecuredSavedObjectsClient,
       config: createAttachmentServiceConfig(),
+    });
+    // Default `bulkGet` mock used by `resolveAttachmentSavedObjectTypes` (called
+    // by `update`/`bulkUpdate`) so tests that don't care about SO-type
+    // resolution always route to the unified bucket. Tests that need different
+    // routing override this.
+    unsecuredSavedObjectsClient.bulkGet.mockImplementation((objects) => {
+      const requests = objects as Array<{ id: string; type: string }>;
+      const savedObjects = requests.map(({ id, type }) =>
+        type === CASE_ATTACHMENT_SAVED_OBJECT
+          ? { ...createUserAttachment(), id, type }
+          : { ...createErrorSO(type), id }
+      );
+      return Promise.resolve({
+        saved_objects: savedObjects as unknown as SavedObjectsBulkResponse['saved_objects'],
+      });
     });
   });
 
@@ -533,7 +549,6 @@ describe('AttachmentService', () => {
         const [soType, persistedAttributes] = unsecuredSavedObjectsClient.create.mock.calls[0];
         expect(soType).toBe(CASE_COMMENT_SAVED_OBJECT);
         expectNoUnifiedOrphans(persistedAttributes);
-        // Sanity: the payload was actually converted to legacy externalReference shape.
         expect(persistedAttributes).toEqual(
           expect.objectContaining({
             type: 'externalReference',
@@ -567,14 +582,14 @@ describe('AttachmentService', () => {
       });
 
       it('update strips attachmentId/metadata/data when writing unified payload to cases-comments', async () => {
-        // `update` first resolves the SO type via `resolveAttachmentSavedObjectType`,
-        // which probes `cases-attachments` then falls back to `cases-comments`.
-        // Simulate the legacy-only state: 404 on the unified type, hit on the legacy type.
-        unsecuredSavedObjectsClient.get.mockImplementation((type: string) => {
-          if (type === CASE_ATTACHMENT_SAVED_OBJECT) {
-            return Promise.reject(Object.assign(new Error('Not found'), { statusCode: 404 }));
-          }
-          return Promise.resolve(createUserAttachment());
+        // `update` resolves the SO type via `resolveAttachmentSavedObjectTypes`,
+        // which probes both types in a single `bulkGet`. Mock it so id '1' 404s
+        // on the unified type and hits on the legacy type.
+        unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
+          saved_objects: [
+            { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+            { ...createUserAttachment(), id: '1', type: CASE_COMMENT_SAVED_OBJECT },
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
         unsecuredSavedObjectsClient.update.mockResolvedValue(createUserAttachment());
@@ -598,6 +613,15 @@ describe('AttachmentService', () => {
       });
 
       it('bulkUpdate strips attachmentId/metadata/data when writing unified payload to cases-comments', async () => {
+        // `bulkUpdate` resolves SO types via a single `bulkGet`. Mock it so id "1"
+        // 404s on the unified type and hits on the legacy type.
+        unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
+          saved_objects: [
+            { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+            { ...createUserAttachment(), id: '1', type: CASE_COMMENT_SAVED_OBJECT },
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
+        });
+
         unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
           saved_objects: [createUserAttachment()],
         });
@@ -637,14 +661,19 @@ describe('AttachmentService', () => {
     };
 
     beforeEach(() => {
-      unsecuredSavedObjectsClient.get.mockImplementation((type: string, id: string) => {
-        if (type === CASE_ATTACHMENT_SAVED_OBJECT) {
-          return Promise.reject(Object.assign(new Error('Not found'), { statusCode: 404 }));
-        }
-        if (type === CASE_COMMENT_SAVED_OBJECT) {
-          return Promise.resolve(createUserAttachment());
-        }
-        return Promise.reject(new Error('Unknown type'));
+      // `update` resolves the SO type via `resolveAttachmentSavedObjectTypes`
+      // (a single `bulkGet`). Route every id to the legacy bucket so the
+      // existing tests exercise the legacy update path.
+      unsecuredSavedObjectsClient.bulkGet.mockImplementation((objects) => {
+        const requests = objects as Array<{ id: string; type: string }>;
+        const savedObjects = requests.map(({ id, type }) =>
+          type === CASE_COMMENT_SAVED_OBJECT
+            ? { ...createUserAttachment(), id, type }
+            : { ...createErrorSO(type), id }
+        );
+        return Promise.resolve({
+          saved_objects: savedObjects as unknown as SavedObjectsBulkResponse['saved_objects'],
+        });
       });
     });
 
@@ -877,9 +906,17 @@ describe('AttachmentService', () => {
         );
       });
 
-      it('throws when the request is missing the attributes.rule.name', async () => {
+      it('throws when the request is missing the attributes.rule.name (legacy bucket)', async () => {
         const invalidAttachment = createAlertAttachment();
         unset(invalidAttachment, 'attributes.rule.name');
+
+        // Force the legacy write path by resolving id '1' to cases-comments.
+        unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
+          saved_objects: [
+            { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+            { ...createAlertAttachment(), id: '1', type: CASE_COMMENT_SAVED_OBJECT },
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
+        });
 
         unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
           saved_objects: [createAlertAttachment()],
@@ -920,6 +957,236 @@ describe('AttachmentService', () => {
         expect(persistedAttributes).not.toHaveProperty('foo');
       });
     });
+
+    describe('per-attachment SO type resolution', () => {
+      // `bulkUpdate` always probes each id and writes to the bucket that owns
+      // it, independent of the `cases.attachments.enabled` flag. Only the
+      // fallback bucket for unknown ids is FF-derived (covered separately).
+      const unifiedCommentAttrs = {
+        type: 'comment',
+        data: { content: 'hello' },
+        owner: SECURITY_SOLUTION_OWNER,
+        created_at: '2024-01-01T00:00:00.000Z',
+        created_by: { username: 'u', full_name: null, email: null },
+        pushed_at: null,
+        pushed_by: null,
+        updated_at: null,
+        updated_by: null,
+      } as const;
+
+      // Mock `bulkGet` so that ids in `unifiedIds` resolve to the unified bucket
+      // and ids in `legacyIds` resolve to the legacy bucket. Anything else is a
+      // not-found error in both buckets.
+      const mockResolveByBucket = (legacyIds: string[], unifiedIds: string[]) => {
+        unsecuredSavedObjectsClient.bulkGet.mockImplementation((objects) => {
+          const requests = objects as Array<{ id: string; type: string }>;
+          const savedObjects = requests.map(({ id, type }) => {
+            if (type === CASE_ATTACHMENT_SAVED_OBJECT && unifiedIds.includes(id)) {
+              return { ...createUserAttachment(), id, type };
+            }
+            if (type === CASE_COMMENT_SAVED_OBJECT && legacyIds.includes(id)) {
+              return { ...createUserAttachment(), id, type };
+            }
+            return { ...createErrorSO(type), id };
+          });
+          return Promise.resolve({
+            saved_objects: savedObjects as unknown as SavedObjectsBulkResponse['saved_objects'],
+          });
+        });
+      };
+
+      it('resolves all SO types in a single bulkGet round trip', async () => {
+        mockResolveByBucket(['legacy-id'], ['unified-id']);
+        unsecuredSavedObjectsClient.bulkUpdate
+          .mockResolvedValueOnce({
+            saved_objects: [
+              {
+                id: 'unified-id',
+                type: CASE_ATTACHMENT_SAVED_OBJECT,
+                attributes: unifiedCommentAttrs,
+                references: [],
+                version: 'v2',
+              },
+            ],
+          })
+          .mockResolvedValueOnce({
+            saved_objects: [{ ...createUserAttachment(), id: 'legacy-id' }],
+          });
+
+        await service.bulkUpdate({
+          comments: [
+            { savedObjectId: 'unified-id', updatedAttributes: unifiedCommentAttrs },
+            {
+              savedObjectId: 'legacy-id',
+              updatedAttributes: createUserAttachment().attributes,
+            },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkGet).toHaveBeenCalledTimes(1);
+        const [bulkGetRequest] = unsecuredSavedObjectsClient.bulkGet.mock.calls[0];
+        expect(bulkGetRequest).toEqual([
+          { id: 'unified-id', type: CASE_ATTACHMENT_SAVED_OBJECT },
+          { id: 'unified-id', type: CASE_COMMENT_SAVED_OBJECT },
+          { id: 'legacy-id', type: CASE_ATTACHMENT_SAVED_OBJECT },
+          { id: 'legacy-id', type: CASE_COMMENT_SAVED_OBJECT },
+        ]);
+      });
+
+      it('writes to both buckets when ids resolve to different SOs', async () => {
+        mockResolveByBucket(['legacy-id'], ['unified-id']);
+        unsecuredSavedObjectsClient.bulkUpdate
+          .mockResolvedValueOnce({
+            saved_objects: [
+              {
+                id: 'unified-id',
+                type: CASE_ATTACHMENT_SAVED_OBJECT,
+                attributes: unifiedCommentAttrs,
+                references: [],
+                version: 'v2',
+              },
+            ],
+          })
+          .mockResolvedValueOnce({
+            saved_objects: [{ ...createUserAttachment(), id: 'legacy-id' }],
+          });
+
+        const res = await service.bulkUpdate({
+          comments: [
+            {
+              savedObjectId: 'unified-id',
+              updatedAttributes: unifiedCommentAttrs,
+            },
+            {
+              savedObjectId: 'legacy-id',
+              updatedAttributes: createUserAttachment().attributes,
+            },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(2);
+        const [unifiedCall, legacyCall] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls;
+        expect(unifiedCall[0]).toEqual([
+          expect.objectContaining({ type: CASE_ATTACHMENT_SAVED_OBJECT, id: 'unified-id' }),
+        ]);
+        expect(legacyCall[0]).toEqual([
+          expect.objectContaining({ type: CASE_COMMENT_SAVED_OBJECT, id: 'legacy-id' }),
+        ]);
+
+        expect(res.saved_objects).toHaveLength(2);
+        expect(res.saved_objects[0].id).toBe('unified-id');
+        expect(res.saved_objects[0].type).toBe(CASE_ATTACHMENT_SAVED_OBJECT);
+        expect(res.saved_objects[1].id).toBe('legacy-id');
+        expect(res.saved_objects[1].type).toBe(CASE_COMMENT_SAVED_OBJECT);
+      });
+
+      it('issues a single bulkUpdate when every id lives in cases-comments', async () => {
+        mockResolveByBucket(['legacy-id'], []);
+        unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+          saved_objects: [{ ...createUserAttachment(), id: 'legacy-id' }],
+        });
+
+        await service.bulkUpdate({
+          comments: [
+            {
+              savedObjectId: 'legacy-id',
+              updatedAttributes: createUserAttachment().attributes,
+            },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+        const [requests] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0];
+        expect(requests).toEqual([
+          expect.objectContaining({ type: CASE_COMMENT_SAVED_OBJECT, id: 'legacy-id' }),
+        ]);
+      });
+
+      it('issues a single bulkUpdate when every id lives in cases-attachments', async () => {
+        mockResolveByBucket([], ['unified-1', 'unified-2']);
+        unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+          saved_objects: [
+            {
+              id: 'unified-1',
+              type: CASE_ATTACHMENT_SAVED_OBJECT,
+              attributes: unifiedCommentAttrs,
+              references: [],
+              version: 'v2',
+            },
+            {
+              id: 'unified-2',
+              type: CASE_ATTACHMENT_SAVED_OBJECT,
+              attributes: unifiedCommentAttrs,
+              references: [],
+              version: 'v2',
+            },
+          ],
+        });
+
+        await service.bulkUpdate({
+          comments: [
+            { savedObjectId: 'unified-1', updatedAttributes: unifiedCommentAttrs },
+            { savedObjectId: 'unified-2', updatedAttributes: unifiedCommentAttrs },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+        const [requests] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0];
+        expect(requests).toEqual([
+          expect.objectContaining({ type: CASE_ATTACHMENT_SAVED_OBJECT, id: 'unified-1' }),
+          expect.objectContaining({ type: CASE_ATTACHMENT_SAVED_OBJECT, id: 'unified-2' }),
+        ]);
+      });
+
+      it('defaults to cases-attachments for unknown ids when attachments FF is on', async () => {
+        const serviceWithFlagOn = new AttachmentService({
+          log: mockLogger,
+          unsecuredSavedObjectsClient,
+          config: createAttachmentServiceConfig(true),
+        });
+        mockResolveByBucket([], []);
+        unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+          saved_objects: [
+            {
+              id: 'missing-id',
+              type: CASE_ATTACHMENT_SAVED_OBJECT,
+              attributes: unifiedCommentAttrs,
+              references: [],
+              version: 'v2',
+            },
+          ],
+        });
+
+        await serviceWithFlagOn.bulkUpdate({
+          comments: [{ savedObjectId: 'missing-id', updatedAttributes: unifiedCommentAttrs }],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+        const [requests] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0];
+        expect(requests).toEqual([
+          expect.objectContaining({ type: CASE_ATTACHMENT_SAVED_OBJECT, id: 'missing-id' }),
+        ]);
+      });
+
+      it('defaults to cases-comments for unknown ids when attachments FF is off', async () => {
+        mockResolveByBucket([], []);
+        unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+          saved_objects: [{ ...createUserAttachment(), id: 'missing-id' }],
+        });
+
+        await service.bulkUpdate({
+          comments: [
+            { savedObjectId: 'missing-id', updatedAttributes: createUserAttachment().attributes },
+          ],
+        });
+
+        expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+        const [requests] = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0];
+        expect(requests).toEqual([
+          expect.objectContaining({ type: CASE_COMMENT_SAVED_OBJECT, id: 'missing-id' }),
+        ]);
+      });
+    });
   });
 
   describe('bulkDelete', () => {
@@ -946,17 +1213,12 @@ describe('AttachmentService', () => {
   });
 
   describe('find', () => {
-    it('uses a single paginated find call when feature flag is enabled', async () => {
-      const serviceWithFlagOn = new AttachmentService({
-        log: mockLogger,
-        unsecuredSavedObjectsClient,
-        config: createAttachmentServiceConfig(true),
-      });
+    it('uses a single paginated find call across both legacy and unified SO types', async () => {
       unsecuredSavedObjectsClient.find.mockResolvedValue(
         createSOFindResponse([{ ...createUserAttachment(), score: 0 }])
       );
 
-      await serviceWithFlagOn.find({
+      await service.find({
         mode: 'legacy',
         options: {
           page: 1,
@@ -969,39 +1231,6 @@ describe('AttachmentService', () => {
         expect.objectContaining({
           page: 1,
           perPage: 10,
-          type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
-        })
-      );
-    });
-
-    it('queries only legacy SO type when feature flag is disabled', async () => {
-      unsecuredSavedObjectsClient.find.mockResolvedValue(
-        createSOFindResponse([{ ...createUserAttachment(), score: 0 }])
-      );
-
-      await service.find({ mode: 'legacy' });
-
-      expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: CASE_COMMENT_SAVED_OBJECT,
-        })
-      );
-    });
-
-    it('queries both legacy and unified comment SO types when feature flag is enabled', async () => {
-      const serviceWithFlagOn = new AttachmentService({
-        log: mockLogger,
-        unsecuredSavedObjectsClient,
-        config: createAttachmentServiceConfig(true),
-      });
-      unsecuredSavedObjectsClient.find.mockResolvedValue(
-        createSOFindResponse([{ ...createUserAttachment(), score: 0 }])
-      );
-
-      await serviceWithFlagOn.find({ mode: 'legacy' });
-
-      expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
-        expect.objectContaining({
           type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
         })
       );
@@ -1169,29 +1398,7 @@ describe('AttachmentService', () => {
       `);
     });
 
-    it('returns the expected total', async () => {
-      const total = 3;
-
-      unsecuredSavedObjectsClient.find.mockResolvedValue(
-        createSOFindResponse(
-          Array(total).fill({ ...createUserAttachment({ foo: 'bar' }), score: 0 })
-        )
-      );
-
-      const res = await service.countPersistableStateAndExternalReferenceAttachments({
-        caseId: 'test-id',
-      });
-
-      expect(res).toBe(total);
-    });
-
-    it('when enabled, sums legacy + unified counts and excludes `file` from the unified type filter', async () => {
-      const serviceWithFlagOn = new AttachmentService({
-        log: mockLogger,
-        unsecuredSavedObjectsClient,
-        config: createAttachmentServiceConfig(true),
-      });
-
+    it('always sums legacy + unified counts and excludes `file` from the unified type filter', async () => {
       unsecuredSavedObjectsClient.find
         .mockResolvedValueOnce(
           createSOFindResponse(Array(2).fill({ ...createUserAttachment({ foo: 'bar' }), score: 0 }))
@@ -1200,7 +1407,7 @@ describe('AttachmentService', () => {
           createSOFindResponse(Array(3).fill({ ...createUserAttachment({ foo: 'bar' }), score: 0 }))
         );
 
-      const res = await serviceWithFlagOn.countPersistableStateAndExternalReferenceAttachments({
+      const res = await service.countPersistableStateAndExternalReferenceAttachments({
         caseId: 'test-id',
       });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -9,6 +9,7 @@ import Boom from '@hapi/boom';
 import type {
   SavedObject,
   SavedObjectsBulkResponse,
+  SavedObjectsBulkUpdateObject,
   SavedObjectsBulkUpdateResponse,
   SavedObjectsFindResponse,
   SavedObjectsFindResult,
@@ -43,7 +44,7 @@ import {
   getAttachmentSavedObjectType,
   getAttachmentTypeFromAttributes,
   getAttachmentTypeTransformers,
-  resolveAttachmentSavedObjectType,
+  resolveAttachmentSavedObjectTypes,
 } from '../../common/attachments';
 
 import { buildFilter, combineFilters } from '../../client/utils';
@@ -158,23 +159,6 @@ export class AttachmentService {
   }
 
   /**
-   * Whether the unified `cases-attachments` saved object type is registered
-   * (gated by the `cases.attachments.enabled` config flag).
-   */
-  public get isUnifiedAttachmentsEnabled(): boolean {
-    return this.context.config.attachments?.enabled === true;
-  }
-
-  private async getAttachmentSavedObjectType(
-    savedObjectId: string
-  ): Promise<typeof CASE_ATTACHMENT_SAVED_OBJECT | typeof CASE_COMMENT_SAVED_OBJECT | null> {
-    return resolveAttachmentSavedObjectType(
-      this.context.unsecuredSavedObjectsClient,
-      savedObjectId
-    );
-  }
-
-  /**
    * Counts the unique number of alerts (deduplicated by id) attached to a case
    * across legacy and unified alert attachments. Honors an optional
    * authorization filter so the metric reflects what the caller can see.
@@ -232,8 +216,6 @@ export class AttachmentService {
     aggType: 'cardinality' | 'value_count';
     extraFilter?: KueryNode;
   }): Promise<number> {
-    const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled === true;
-
     const typeFilters: Array<KueryNode | undefined> = [
       buildFilter({
         filters: [AttachmentType.alert],
@@ -241,39 +223,31 @@ export class AttachmentService {
         operator: 'or',
         type: CASE_COMMENT_SAVED_OBJECT,
       }),
+      buildFilter({
+        filters: UNIFIED_ALERT_TYPES_ARRAY,
+        field: 'type',
+        operator: 'or',
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+      }),
     ];
 
     const aggregations: Record<string, estypes.AggregationsAggregationContainer> = {
       legacyAlerts: {
         [aggType]: { field: `${CASE_COMMENT_SAVED_OBJECT}.attributes.alertId` },
       },
-    };
-
-    if (isCasesAttachmentsEnabled) {
-      typeFilters.push(
-        buildFilter({
-          filters: UNIFIED_ALERT_TYPES_ARRAY,
-          field: 'type',
-          operator: 'or',
-          type: CASE_ATTACHMENT_SAVED_OBJECT,
-        })
-      );
-
-      aggregations.unifiedAlerts = {
+      unifiedAlerts: {
         [aggType]: { field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId` },
-      };
-    }
+      },
+    };
 
     const combinedTypeFilter = combineFilters(typeFilters, 'or');
     const combinedFilter = combineFilters([combinedTypeFilter, extraFilter]);
 
     const response = await this.context.unsecuredSavedObjectsClient.find<
       unknown,
-      { legacyAlerts: { value: number }; unifiedAlerts?: { value: number } }
+      { legacyAlerts: { value: number }; unifiedAlerts: { value: number } }
     >({
-      type: isCasesAttachmentsEnabled
-        ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
-        : CASE_COMMENT_SAVED_OBJECT,
+      type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
       hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
       page: 1,
       perPage: 1,
@@ -349,7 +323,6 @@ export class AttachmentService {
         `Attempting to count persistableState and externalReference attachments for case id ${caseId}`
       );
 
-      const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled === true;
       const legacyTypeFilter = buildFilter({
         filters: [AttachmentType.persistableState, AttachmentType.externalReference],
         field: 'type',
@@ -373,11 +346,6 @@ export class AttachmentService {
         sortField: defaultSortField,
         filter: legacyFilter,
       });
-
-      if (!isCasesAttachmentsEnabled) {
-        const legacyResponse = await legacyFindPromise;
-        return legacyResponse.total;
-      }
 
       const unifiedTypesToCount = [
         ...PERSISTABLE_ATTACHMENT_TYPES_ARRAY,
@@ -634,7 +602,10 @@ export class AttachmentService {
     try {
       this.context.log.debug(`Attempting to UPDATE attachment ${savedObjectId}`);
 
-      const soType = await this.getAttachmentSavedObjectType(savedObjectId);
+      const [soType] = await resolveAttachmentSavedObjectTypes(
+        this.context.unsecuredSavedObjectsClient,
+        [savedObjectId]
+      );
       if (soType === null) {
         throw new Error(`Attachment ${savedObjectId} not found`);
       }
@@ -714,57 +685,57 @@ export class AttachmentService {
         `Attempting to UPDATE attachments ${comments.map((c) => c.savedObjectId).join(', ')}`
       );
 
-      const savedObjectType = getAttachmentSavedObjectType(this.context.config);
+      // Resolve every attachment's SO type in a single bulkGet round trip.
+      // Unknown ids (404 in both types) fall back to the FF-derived default
+      // write target so the subsequent bulkUpdate surfaces a typed not-found
+      // error from the bucket that matches current write routing.
+      const defaultSavedObjectType = getAttachmentSavedObjectType(this.context.config);
+      const perAttachmentTypes = (
+        await resolveAttachmentSavedObjectTypes(
+          this.context.unsecuredSavedObjectsClient,
+          comments.map((c) => c.savedObjectId)
+        )
+      ).map((soType) => soType ?? defaultSavedObjectType);
 
-      if (savedObjectType === CASE_ATTACHMENT_SAVED_OBJECT) {
-        const res =
-          await this.context.unsecuredSavedObjectsClient.bulkUpdate<UnifiedAttachmentAttributes>(
-            comments.map((c) => {
-              const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
-                c.updatedAttributes
-              );
-              const transformer = getTransformerForPatchAttributes(
-                decodedAttributes,
-                requestWithoutType
-              );
-              const unifiedAttributes = transformer.toUnifiedSchema(decodedAttributes);
+      const unifiedRequests: Array<{
+        index: number;
+        payload: SavedObjectsBulkUpdateObject<UnifiedAttachmentAttributes>;
+      }> = [];
+      const legacyRequests: Array<{
+        index: number;
+        payload: SavedObjectsBulkUpdateObject<AttachmentPersistedAttributes>;
+      }> = [];
 
-              return {
-                ...c.options,
-                type: CASE_ATTACHMENT_SAVED_OBJECT,
-                id: c.savedObjectId,
-                attributes: unifiedAttributes,
-              };
-            }),
-            { refresh }
-          );
-        return this.transformAndDecodeBulkUpdateResponse(res, comments, requestWithoutType);
-      }
+      for (let i = 0; i < comments.length; i++) {
+        const c = comments[i];
+        const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(c.updatedAttributes);
+        const transformer = getTransformerForPatchAttributes(decodedAttributes, requestWithoutType);
 
-      const res =
-        await this.context.unsecuredSavedObjectsClient.bulkUpdate<AttachmentPersistedAttributes>(
-          comments.map((c) => {
-            const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
-              c.updatedAttributes
-            );
-            assertAlertAttachmentHasRuleName(decodedAttributes as Record<string, unknown>);
-            const transformer = getTransformerForPatchAttributes(
-              decodedAttributes,
-              requestWithoutType
-            );
-            const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
-            const {
-              attributes: extractedAttributes,
-              references: extractedReferences,
-              didDeleteOperation,
-            } = extractAttachmentSORefsFromAttributes(
-              legacyAttributes,
-              c.options?.references ?? []
-            );
+        if (perAttachmentTypes[i] === CASE_ATTACHMENT_SAVED_OBJECT) {
+          const unifiedAttributes = transformer.toUnifiedSchema(decodedAttributes);
+          unifiedRequests.push({
+            index: i,
+            payload: {
+              ...c.options,
+              type: CASE_ATTACHMENT_SAVED_OBJECT,
+              id: c.savedObjectId,
+              attributes: unifiedAttributes,
+            },
+          });
+        } else {
+          assertAlertAttachmentHasRuleName(decodedAttributes as Record<string, unknown>);
+          const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
+          const {
+            attributes: extractedAttributes,
+            references: extractedReferences,
+            didDeleteOperation,
+          } = extractAttachmentSORefsFromAttributes(legacyAttributes, c.options?.references ?? []);
 
-            const shouldUpdateRefs = extractedReferences.length > 0 || didDeleteOperation;
+          const shouldUpdateRefs = extractedReferences.length > 0 || didDeleteOperation;
 
-            return {
+          legacyRequests.push({
+            index: i,
+            payload: {
               ...c.options,
               type: CASE_COMMENT_SAVED_OBJECT,
               id: c.savedObjectId,
@@ -775,12 +746,61 @@ export class AttachmentService {
                * to prevent this.
                */
               references: shouldUpdateRefs ? extractedReferences : undefined,
-            };
-          }),
-          { refresh }
-        );
+            },
+          });
+        }
+      }
 
-      return this.transformAndDecodeBulkUpdateResponse(res, comments, requestWithoutType);
+      const mergedSavedObjects: Array<
+        SavedObjectsUpdateResponse<
+          AttachmentPersistedAttributes | UnifiedAttachmentPersistedAttributes
+        >
+      > = new Array(comments.length);
+
+      // Issue the two bulkUpdate calls in parallel for the mixed-bucket path.
+      // Skipped buckets resolve to an empty response so the merge logic stays
+      // uniform.
+      const emptyBulkUpdateResponse = <T>(): SavedObjectsBulkUpdateResponse<T> => ({
+        saved_objects: [],
+      });
+      const [unifiedRes, legacyRes] = await Promise.all([
+        unifiedRequests.length > 0
+          ? this.context.unsecuredSavedObjectsClient.bulkUpdate<UnifiedAttachmentAttributes>(
+              unifiedRequests.map((r) => r.payload),
+              { refresh }
+            )
+          : Promise.resolve(emptyBulkUpdateResponse<UnifiedAttachmentAttributes>()),
+        legacyRequests.length > 0
+          ? this.context.unsecuredSavedObjectsClient.bulkUpdate<AttachmentPersistedAttributes>(
+              legacyRequests.map((r) => r.payload),
+              { refresh }
+            )
+          : Promise.resolve(emptyBulkUpdateResponse<AttachmentPersistedAttributes>()),
+      ]);
+
+      const assignBucketResults = <T>(
+        label: string,
+        bucketRequests: Array<{ index: number; payload: SavedObjectsBulkUpdateObject<T> }>,
+        bucketRes: SavedObjectsBulkUpdateResponse<T>
+      ) => {
+        if (bucketRes.saved_objects.length !== bucketRequests.length) {
+          throw new Error(
+            `bulkUpdate SO client contract violation: expected ${bucketRequests.length} ${label} rows, received ${bucketRes.saved_objects.length}.`
+          );
+        }
+        bucketRes.saved_objects.forEach((so, k) => {
+          mergedSavedObjects[bucketRequests[k].index] = so;
+        });
+      };
+
+      assignBucketResults('unified', unifiedRequests, unifiedRes);
+      assignBucketResults('legacy', legacyRequests, legacyRes);
+
+      return this.transformAndDecodeBulkUpdateResponse(
+        { saved_objects: mergedSavedObjects },
+        comments,
+        requestWithoutType
+      );
     } catch (error) {
       this.context.log.error(
         `Error on UPDATE attachments ${comments.map((c) => c.savedObjectId).join(', ')}: ${error}`
@@ -852,13 +872,10 @@ export class AttachmentService {
     try {
       this.context.log.debug(`Attempting to find comments`);
 
-      const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled === true;
       const res = await this.context.unsecuredSavedObjectsClient.find<AttachmentAttributesV2>({
         sortField: defaultSortField,
         ...options,
-        type: isCasesAttachmentsEnabled
-          ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
-          : CASE_COMMENT_SAVED_OBJECT,
+        type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
       });
 
       const validatedAttachments: Array<SavedObjectsFindResult<AttachmentAttributesV2>> = [];

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -788,13 +788,30 @@ export class AttachmentService {
             `bulkUpdate SO client contract violation: expected ${bucketRequests.length} ${label} rows, received ${bucketRes.saved_objects.length}.`
           );
         }
+        // Validate each returned row matches the requested `{id, type}` rather
+        // than relying purely on index ordering.
         bucketRes.saved_objects.forEach((so, k) => {
-          mergedSavedObjects[bucketRequests[k].index] = so;
+          const req = bucketRequests[k];
+          if (so.id !== req.payload.id || so.type !== req.payload.type) {
+            throw new Error(
+              `bulkUpdate SO client contract violation: expected ${label} row {id:${req.payload.id},type:${req.payload.type}}, received {id:${so.id},type:${so.type}}.`
+            );
+          }
+          mergedSavedObjects[req.index] = so;
         });
       };
 
       assignBucketResults('unified', unifiedRequests, unifiedRes);
       assignBucketResults('legacy', legacyRequests, legacyRes);
+
+      // Every comment must end up assigned to exactly one bucket. A hole
+      // indicates a routing/bookkeeping bug.
+      const missingIndex = mergedSavedObjects.findIndex((so) => so == null);
+      if (missingIndex !== -1) {
+        throw new Error(
+          `bulkUpdate internal invariant violated: unassigned slot at index ${missingIndex} for id="${comments[missingIndex].savedObjectId}".`
+        );
+      }
 
       return this.transformAndDecodeBulkUpdateResponse(
         { saved_objects: mergedSavedObjects },

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
@@ -10,7 +10,7 @@ import { unset } from 'lodash';
 import { fromKueryExpression } from '@kbn/es-query';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
-import type { SavedObjectsFindResponse } from '@kbn/core/server';
+import type { SavedObjectsBulkResponse, SavedObjectsFindResponse } from '@kbn/core/server';
 import { loggerMock } from '@kbn/logging-mocks';
 import { AttachmentGetter } from './get';
 import { createAlertAttachment, createFileAttachment, createUserAttachment } from '../test_utils';
@@ -52,24 +52,46 @@ describe('AttachmentService getter', () => {
   describe('bulkGet', () => {
     describe('Decoding', () => {
       it('does not throw when the response has the required fields', async () => {
+        // Production `bulkGet` is called with `[unified, legacy]` per id, so the
+        // mocked response must return matching pairs.
         unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
-          saved_objects: [createUserAttachment()],
+          saved_objects: [
+            createUserAttachment(),
+            { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
         await expect(attachmentGetter.bulkGet(['1'], mode)).resolves.not.toThrow();
       });
 
-      it('does not modified the error saved objects', async () => {
+      it('preserves a single not-found error per id when no SO type hits', async () => {
+        const unifiedNotFoundForId1 = {
+          ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT),
+          id: '1',
+        };
+        const legacyNotFoundForMissing = {
+          ...createErrorSO(CASE_COMMENT_SAVED_OBJECT),
+          id: 'missing-id',
+        };
+        const unifiedNotFoundForMissing = {
+          ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT),
+          id: 'missing-id',
+        };
+        // Production order is interleaved as `[unified, legacy]` per id.
         unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
-          // @ts-expect-error: SO client types are not correct
-          saved_objects: [createUserAttachment(), createErrorSO(CASE_COMMENT_SAVED_OBJECT)],
+          saved_objects: [
+            unifiedNotFoundForId1,
+            createUserAttachment(),
+            unifiedNotFoundForMissing,
+            legacyNotFoundForMissing,
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
-        const res = await attachmentGetter.bulkGet(['1', '2'], mode);
+        const res = await attachmentGetter.bulkGet(['1', 'missing-id'], mode);
 
-        expect(res).toStrictEqual({
-          saved_objects: [createUserAttachment(), createErrorSO(CASE_COMMENT_SAVED_OBJECT)],
-        });
+        // The success at id 1 is kept; the duplicate not-founds at `missing-id`
+        // collapse to a single error response.
+        expect(res.saved_objects).toEqual([createUserAttachment(), unifiedNotFoundForMissing]);
       });
 
       it('Filters successful result over error', async () => {
@@ -102,7 +124,10 @@ describe('AttachmentService getter', () => {
 
       it('strips excess fields', async () => {
         unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
-          saved_objects: [{ ...createUserAttachment({ foo: 'bar' }) }],
+          saved_objects: [
+            { ...createUserAttachment({ foo: 'bar' }) },
+            { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
         const res = await attachmentGetter.bulkGet(['1'], mode);
@@ -112,6 +137,7 @@ describe('AttachmentService getter', () => {
       it('returns migrated legacy events in unified shape when mode=unified', async () => {
         unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
           saved_objects: [
+            { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
             {
               id: '1',
               type: CASE_COMMENT_SAVED_OBJECT,
@@ -133,7 +159,7 @@ describe('AttachmentService getter', () => {
               },
               references: [],
             },
-          ],
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
         const res = await attachmentGetter.bulkGet(['1'], 'unified');
@@ -166,7 +192,10 @@ describe('AttachmentService getter', () => {
         });
 
         unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
-          saved_objects: [legacyFile],
+          saved_objects: [
+            { ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT), id: '1' },
+            legacyFile,
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
         const res = await attachmentGetter.bulkGet(['1'], 'unified');
@@ -199,7 +228,10 @@ describe('AttachmentService getter', () => {
         unset(invalidAttachment, 'attributes.comment');
 
         unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
-          saved_objects: [invalidAttachment],
+          saved_objects: [
+            invalidAttachment,
+            { ...createErrorSO(CASE_COMMENT_SAVED_OBJECT), id: '1' },
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
         });
 
         await expect(
@@ -237,7 +269,7 @@ describe('AttachmentService getter', () => {
         expect(res).toStrictEqual([{ ...createAlertAttachment(), score: 0 }]);
       });
 
-      it('decodes unified event attachments from cases-attachments SO when feature flag is enabled', async () => {
+      it('decodes unified event attachments from cases-attachments SO', async () => {
         const attachmentGetterWithFlagOn = createAttachmentGetter(true);
         const soFindRes = createSOFindResponse([
           {
@@ -297,7 +329,7 @@ describe('AttachmentService getter', () => {
       });
     });
 
-    it('builds an OR group for legacy/unified type filters when attachments FF is enabled', async () => {
+    it('builds an OR group for legacy/unified type filters', async () => {
       const attachmentGetterWithFlagOn = createAttachmentGetter(true);
       mockFinder(createSOFindResponse([]));
 
@@ -486,6 +518,78 @@ describe('AttachmentService getter', () => {
               "type": "cases-comments",
             },
           ],
+          Array [
+            Object {
+              "aggs": Object {
+                "alertIds": Object {
+                  "terms": Object {
+                    "field": "cases-attachments.attributes.attachmentId",
+                    "size": 1000,
+                  },
+                },
+              },
+              "filter": Object {
+                "arguments": Array [
+                  Object {
+                    "arguments": Array [
+                      Object {
+                        "isQuoted": false,
+                        "type": "literal",
+                        "value": "cases-attachments.attributes.type",
+                      },
+                      Object {
+                        "isQuoted": false,
+                        "type": "literal",
+                        "value": "security.alert",
+                      },
+                    ],
+                    "function": "is",
+                    "type": "function",
+                  },
+                  Object {
+                    "arguments": Array [
+                      Object {
+                        "isQuoted": false,
+                        "type": "literal",
+                        "value": "cases-attachments.attributes.type",
+                      },
+                      Object {
+                        "isQuoted": false,
+                        "type": "literal",
+                        "value": "observability.alert",
+                      },
+                    ],
+                    "function": "is",
+                    "type": "function",
+                  },
+                  Object {
+                    "arguments": Array [
+                      Object {
+                        "isQuoted": false,
+                        "type": "literal",
+                        "value": "cases-attachments.attributes.type",
+                      },
+                      Object {
+                        "isQuoted": false,
+                        "type": "literal",
+                        "value": "stack.alert",
+                      },
+                    ],
+                    "function": "is",
+                    "type": "function",
+                  },
+                ],
+                "function": "or",
+                "type": "function",
+              },
+              "hasReference": Object {
+                "id": "test-case",
+                "type": "cases",
+              },
+              "perPage": 0,
+              "type": "cases-attachments",
+            },
+          ],
         ]
       `);
     });
@@ -542,37 +646,10 @@ describe('AttachmentService getter', () => {
         })
       );
     });
-
-    it('does not aggregate on cases-attachments when attachments FF is disabled', async () => {
-      unsecuredSavedObjectsClient.find.mockResolvedValue({
-        aggregations: {
-          legacyEventIds: { buckets: [{ key: 'legacy-event' }] },
-        },
-        saved_objects: [],
-        page: 1,
-        per_page: 0,
-        total: 0,
-      });
-
-      const ids = await attachmentGetter.getAllEventIds({
-        caseId,
-        owner: 'securitySolution',
-      });
-
-      expect(Array.from(ids.values())).toEqual(['legacy-event']);
-      expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: CASE_COMMENT_SAVED_OBJECT,
-          aggs: {
-            legacyEventIds: expect.anything(),
-          },
-        })
-      );
-    });
   });
 
   describe('getCaseAttatchmentStats', () => {
-    it('aggregates unified comment and event totals when feature flag is enabled', async () => {
+    it('aggregates unified comment and event totals from cases-attachments', async () => {
       const attachmentGetterWithFlagOn = createAttachmentGetter(true);
       unsecuredSavedObjectsClient.find
         .mockResolvedValueOnce({
@@ -897,23 +974,10 @@ describe('AttachmentService getter', () => {
   });
 
   describe('getAttachmentIdsForCases', () => {
-    it('queries both SO types when feature flag is disabled', async () => {
+    it('always queries both legacy and unified SO types', async () => {
       mockFinder(createSOFindResponse([{ ...createUserAttachment(), score: 0 }]));
 
       await attachmentGetter.getAttachmentIdsForCases({ caseIds: ['case-1'] });
-
-      expect(unsecuredSavedObjectsClient.createPointInTimeFinder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
-        })
-      );
-    });
-
-    it('queries both SO types when feature flag is enabled', async () => {
-      const attachmentGetterWithFlagOn = createAttachmentGetter(true);
-      mockFinder(createSOFindResponse([{ ...createUserAttachment(), score: 0 }]));
-
-      await attachmentGetterWithFlagOn.getAttachmentIdsForCases({ caseIds: ['case-1'] });
 
       expect(unsecuredSavedObjectsClient.createPointInTimeFinder).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.test.ts
@@ -64,7 +64,7 @@ describe('AttachmentService getter', () => {
         await expect(attachmentGetter.bulkGet(['1'], mode)).resolves.not.toThrow();
       });
 
-      it('preserves a single not-found error per id when no SO type hits', async () => {
+      it('surfaces the legacy not-found error per id when FF is off and no SO type hits', async () => {
         const unifiedNotFoundForId1 = {
           ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT),
           id: '1',
@@ -90,8 +90,33 @@ describe('AttachmentService getter', () => {
         const res = await attachmentGetter.bulkGet(['1', 'missing-id'], mode);
 
         // The success at id 1 is kept; the duplicate not-founds at `missing-id`
-        // collapse to a single error response.
-        expect(res.saved_objects).toEqual([createUserAttachment(), unifiedNotFoundForMissing]);
+        // collapse to a single error. FF is off, so the surfaced error comes
+        // from the legacy (`cases-comments`) bucket to match where new writes go.
+        expect(res.saved_objects).toEqual([createUserAttachment(), legacyNotFoundForMissing]);
+      });
+
+      it('surfaces the unified not-found error per id when FF is on and no SO type hits', async () => {
+        const attachmentGetterWithFlagOn = createAttachmentGetter(true);
+        const legacyNotFoundForMissing = {
+          ...createErrorSO(CASE_COMMENT_SAVED_OBJECT),
+          id: 'missing-id',
+        };
+        const unifiedNotFoundForMissing = {
+          ...createErrorSO(CASE_ATTACHMENT_SAVED_OBJECT),
+          id: 'missing-id',
+        };
+        unsecuredSavedObjectsClient.bulkGet.mockResolvedValue({
+          saved_objects: [
+            unifiedNotFoundForMissing,
+            legacyNotFoundForMissing,
+          ] as unknown as SavedObjectsBulkResponse['saved_objects'],
+        });
+
+        const res = await attachmentGetterWithFlagOn.bulkGet(['missing-id'], mode);
+
+        // FF is on → surfaced error comes from the unified (`cases-attachments`)
+        // bucket since that's where new writes go.
+        expect(res.saved_objects).toEqual([unifiedNotFoundForMissing]);
       });
 
       it('Filters successful result over error', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -73,20 +73,15 @@ export class AttachmentGetter {
         `Attempting to retrieve attachments with ids: ${savedObjectIds.join()}`
       );
 
-      const isCaseAttachmentsEnabled = this.context.config.attachments?.enabled;
       const response =
         await this.context.unsecuredSavedObjectsClient.bulkGet<AttachmentAttributesV2>(
-          savedObjectIds.flatMap((id) =>
-            isCaseAttachmentsEnabled
-              ? [
-                  { id, type: CASE_ATTACHMENT_SAVED_OBJECT },
-                  { id, type: CASE_COMMENT_SAVED_OBJECT },
-                ]
-              : [{ id, type: CASE_COMMENT_SAVED_OBJECT }]
-          )
+          savedObjectIds.flatMap((id) => [
+            { id, type: CASE_ATTACHMENT_SAVED_OBJECT },
+            { id, type: CASE_COMMENT_SAVED_OBJECT },
+          ])
         );
 
-      const merged = this.mergeBulkGetResults(response.saved_objects, isCaseAttachmentsEnabled);
+      const merged = this.mergeBulkGetResults(response.saved_objects);
 
       if (mode === 'legacy') {
         return this.transformAndDecodeBulkGetResponseLegacy(merged);
@@ -101,24 +96,27 @@ export class AttachmentGetter {
   }
 
   private mergeBulkGetResults(
-    savedObjects: Array<SavedObject<AttachmentAttributesV2> | { id: string; error: unknown }>,
-    isCaseAttachmentsEnabled: boolean
+    savedObjects: Array<SavedObject<AttachmentAttributesV2> | { id: string; error: unknown }>
   ): Array<MixSavedObjectResponse> {
-    if (!isCaseAttachmentsEnabled) {
-      return savedObjects;
+    // We query 2 SO types per id (paired in bulkGet input order): one may hit,
+    // one may 404. For ids missing from both types both entries are errors; we
+    // surface a single "not found" so the caller can return it.
+    if (savedObjects.length % 2 !== 0) {
+      throw new Error(
+        `Expected bulkGet response to contain pairs of saved objects, received ${savedObjects.length} entries`
+      );
     }
-    // When FF is on we query 2 SO types per id: one may hit, one may 404. For non-existent ids
-    // both 404. We must preserve one "not found" error per id that has no hits so the client
-    // can return it.
+
     const result: Array<MixSavedObjectResponse> = [];
     for (let i = 0; i < savedObjects.length; i += 2) {
       const pair = [savedObjects[i], savedObjects[i + 1]] as const;
-      const hit = pair.find((so) => !isSOError(so));
-      if (hit) {
-        result.push(hit);
-      } else {
-        result.push(pair[0]);
+      if (pair[0].id !== pair[1].id) {
+        throw new Error(
+          `bulkGet response pair mismatch: expected matching ids, received "${pair[0].id}" and "${pair[1].id}"`
+        );
       }
+      const hit = pair.find((so) => !isSOError(so));
+      result.push(hit ?? pair[0]);
     }
     return result;
   }
@@ -261,7 +259,6 @@ export class AttachmentGetter {
   }: GetAllDocumentsAttachedToCaseArgs): Promise<
     Array<SavedObject<DocumentAttachmentAttributesV2>>
   > {
-    const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled;
     try {
       this.context.log.debug(`Attempting to GET all documents for case id ${caseId}`);
       const legacyDocumentsFilter = buildFilter({
@@ -279,18 +276,13 @@ export class AttachmentGetter {
       });
 
       const combinedFilter = combineFilters([
-        combineFilters(
-          [legacyDocumentsFilter, ...(isCasesAttachmentsEnabled ? [unifiedDocumentsFilter] : [])],
-          NodeBuilderOperators.or
-        ),
+        combineFilters([legacyDocumentsFilter, unifiedDocumentsFilter], NodeBuilderOperators.or),
         filter,
       ]);
 
       const finder =
         this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<AttachmentAttributesV2>({
-          type: isCasesAttachmentsEnabled
-            ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
-            : CASE_COMMENT_SAVED_OBJECT,
+          type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
           hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
           sortField: 'created_at',
           sortOrder: 'asc',
@@ -324,7 +316,6 @@ export class AttachmentGetter {
    * Retrieves all the alerts attached to a case.
    */
   public async getAllAlertIds({ caseId }: { caseId: string }): Promise<Set<string>> {
-    const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled;
     try {
       this.context.log.debug(`Attempting to GET all alerts ids for case id ${caseId}`);
       const legacyFindPromise = this.context.unsecuredSavedObjectsClient.find<
@@ -352,34 +343,35 @@ export class AttachmentGetter {
         },
       });
 
-      const unifiedFindPromise = isCasesAttachmentsEnabled
-        ? this.context.unsecuredSavedObjectsClient.find<unknown, AlertIdsAggsResult>({
-            type: CASE_ATTACHMENT_SAVED_OBJECT,
-            hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
-            filter: buildFilter({
-              filters: UNIFIED_ALERT_TYPES_ARRAY,
-              field: 'type',
-              operator: 'or',
-              type: CASE_ATTACHMENT_SAVED_OBJECT,
-            }),
-            perPage: 0,
-            aggs: {
-              alertIds: {
-                terms: {
-                  field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId`,
-                  size: MAX_ALERTS_PER_CASE,
-                },
-              },
+      const unifiedFindPromise = this.context.unsecuredSavedObjectsClient.find<
+        unknown,
+        AlertIdsAggsResult
+      >({
+        type: CASE_ATTACHMENT_SAVED_OBJECT,
+        hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
+        filter: buildFilter({
+          filters: UNIFIED_ALERT_TYPES_ARRAY,
+          field: 'type',
+          operator: 'or',
+          type: CASE_ATTACHMENT_SAVED_OBJECT,
+        }),
+        perPage: 0,
+        aggs: {
+          alertIds: {
+            terms: {
+              field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId`,
+              size: MAX_ALERTS_PER_CASE,
             },
-          })
-        : Promise.resolve(undefined);
+          },
+        },
+      });
 
       const [legacyRes, unifiedRes] = await Promise.all([legacyFindPromise, unifiedFindPromise]);
 
       const legacyAlertIds =
         legacyRes.aggregations?.alertIds.buckets.map((bucket) => bucket.key) ?? [];
       const unifiedAlertIds =
-        unifiedRes?.aggregations?.alertIds.buckets.map((bucket) => bucket.key) ?? [];
+        unifiedRes.aggregations?.alertIds.buckets.map((bucket) => bucket.key) ?? [];
 
       return new Set([...legacyAlertIds, ...unifiedAlertIds]);
     } catch (error) {
@@ -398,7 +390,6 @@ export class AttachmentGetter {
     caseId: string;
     owner: string;
   }): Promise<Set<string>> {
-    const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled;
     try {
       this.context.log.debug(`Attempting to GET all event ids for case id ${caseId}`);
       const legacyEventsFilter = buildFilter({
@@ -414,14 +405,12 @@ export class AttachmentGetter {
         type: CASE_ATTACHMENT_SAVED_OBJECT,
       });
       const eventsFilter = combineFilters(
-        [legacyEventsFilter, ...(isCasesAttachmentsEnabled ? [unifiedEventsFilter] : [])],
+        [legacyEventsFilter, unifiedEventsFilter],
         NodeBuilderOperators.or
       );
 
       const res = await this.context.unsecuredSavedObjectsClient.find<unknown, EventIdsAggsResult>({
-        type: isCasesAttachmentsEnabled
-          ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
-          : CASE_COMMENT_SAVED_OBJECT,
+        type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
         hasReference: { type: CASE_SAVED_OBJECT, id: caseId },
         sortField: 'created_at',
         sortOrder: 'asc',
@@ -434,23 +423,19 @@ export class AttachmentGetter {
               size: MAX_ALERTS_PER_CASE,
             },
           },
-          ...(isCasesAttachmentsEnabled
-            ? {
-                unifiedEventIds: {
-                  terms: {
-                    field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId`,
-                    size: MAX_ALERTS_PER_CASE,
-                  },
-                },
-              }
-            : {}),
+          unifiedEventIds: {
+            terms: {
+              field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId`,
+              size: MAX_ALERTS_PER_CASE,
+            },
+          },
         },
       });
 
       const legacyEventIds =
         res.aggregations?.legacyEventIds.buckets.map((bucket) => bucket.key) ?? [];
       const unifiedEventIds =
-        res.aggregations?.unifiedEventIds?.buckets.map((bucket) => bucket.key) ?? [];
+        res.aggregations?.unifiedEventIds.buckets.map((bucket) => bucket.key) ?? [];
       const eventIds = [...legacyEventIds, ...unifiedEventIds];
       return new Set(eventIds);
     } catch (error) {
@@ -465,32 +450,24 @@ export class AttachmentGetter {
   }: GetAttachmentArgs): Promise<AttachmentSavedObjectTransformedV2> {
     try {
       this.context.log.debug(`Attempting to GET attachment ${savedObjectId}`);
-      const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled;
 
       let res:
         | SavedObject<UnifiedAttachmentAttributes>
         | SavedObject<AttachmentPersistedAttributes>;
 
-      if (isCasesAttachmentsEnabled) {
-        // if feature flag is enabled, try to fetch unified first
-        try {
-          res = await this.context.unsecuredSavedObjectsClient.get<UnifiedAttachmentAttributes>(
-            CASE_ATTACHMENT_SAVED_OBJECT,
-            savedObjectId
-          );
-        } catch (error) {
-          if (!SavedObjectsErrorHelpers.isNotFoundError(error)) {
-            throw error;
-          }
-          this.context.log.debug(
-            `Attachment ${savedObjectId} not found in ${CASE_ATTACHMENT_SAVED_OBJECT}, falling back to ${CASE_COMMENT_SAVED_OBJECT}`
-          );
-          res = await this.context.unsecuredSavedObjectsClient.get<AttachmentPersistedAttributes>(
-            CASE_COMMENT_SAVED_OBJECT,
-            savedObjectId
-          );
+      // Try unified first; fall back to legacy on 404 to cover unmigrated rows.
+      try {
+        res = await this.context.unsecuredSavedObjectsClient.get<UnifiedAttachmentAttributes>(
+          CASE_ATTACHMENT_SAVED_OBJECT,
+          savedObjectId
+        );
+      } catch (error) {
+        if (!SavedObjectsErrorHelpers.isNotFoundError(error)) {
+          throw error;
         }
-      } else {
+        this.context.log.debug(
+          `Attachment ${savedObjectId} not found in ${CASE_ATTACHMENT_SAVED_OBJECT}, falling back to ${CASE_COMMENT_SAVED_OBJECT}`
+        );
         res = await this.context.unsecuredSavedObjectsClient.get<AttachmentPersistedAttributes>(
           CASE_COMMENT_SAVED_OBJECT,
           savedObjectId
@@ -568,24 +545,22 @@ export class AttachmentGetter {
         return acc;
       }, new Map<string, AttachmentTotals>()) ?? new Map();
 
-    if (this.context.config.attachments?.enabled) {
-      const unifiedStatsByCase = await this.getUnifiedAttachmentStatsByCaseId(caseIds);
-      for (const [caseId, unifiedStats] of unifiedStatsByCase) {
-        const existing = statsMap.get(caseId);
-        if (existing) {
-          statsMap.set(caseId, {
-            ...existing,
-            userComments: existing.userComments + unifiedStats.userComments,
-            alerts: existing.alerts + unifiedStats.alerts,
-            events: existing.events + unifiedStats.events,
-          });
-        } else {
-          statsMap.set(caseId, {
-            userComments: unifiedStats.userComments,
-            alerts: unifiedStats.alerts,
-            events: unifiedStats.events,
-          });
-        }
+    const unifiedStatsByCase = await this.getUnifiedAttachmentStatsByCaseId(caseIds);
+    for (const [caseId, unifiedStats] of unifiedStatsByCase) {
+      const existing = statsMap.get(caseId);
+      if (existing) {
+        statsMap.set(caseId, {
+          ...existing,
+          userComments: existing.userComments + unifiedStats.userComments,
+          alerts: existing.alerts + unifiedStats.alerts,
+          events: existing.events + unifiedStats.events,
+        });
+      } else {
+        statsMap.set(caseId, {
+          userComments: unifiedStats.userComments,
+          alerts: unifiedStats.alerts,
+          events: unifiedStats.events,
+        });
       }
     }
 
@@ -768,7 +743,6 @@ export class AttachmentGetter {
        * array instead of deleting the entire saved object in the situation where the file is attached to multiple cases.
        */
       const references = fileIds.map((id) => ({ id, type: FILE_SO_TYPE }));
-      const isCasesAttachmentsEnabled = this.context.config.attachments?.enabled === true;
 
       /**
        * In the event that we add the ability to attach a file to a case that has already been uploaded we'll run into a
@@ -778,9 +752,7 @@ export class AttachmentGetter {
       const finder = this.context.unsecuredSavedObjectsClient.createPointInTimeFinder<
         AttachmentPersistedAttributes | UnifiedAttachmentAttributes
       >({
-        type: isCasesAttachmentsEnabled
-          ? [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT]
-          : CASE_COMMENT_SAVED_OBJECT,
+        type: [CASE_COMMENT_SAVED_OBJECT, CASE_ATTACHMENT_SAVED_OBJECT],
         hasReference: references,
         sortField: 'created_at',
         sortOrder: 'asc',

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -13,6 +13,7 @@ import {
   toUnifiedAttachmentType,
   UNIFIED_ALERT_TYPES_ARRAY,
 } from '../../../../common/utils/attachments';
+import { getAttachmentSavedObjectType } from '../../../common/attachments';
 import { isSOError } from '../../../common/error';
 import { decodeOrThrow } from '../../../common/runtime_types';
 import type {
@@ -100,13 +101,15 @@ export class AttachmentGetter {
   ): Array<MixSavedObjectResponse> {
     // We query 2 SO types per id (paired in bulkGet input order): one may hit,
     // one may 404. For ids missing from both types both entries are errors; we
-    // surface a single "not found" so the caller can return it.
+    // surface a single "not found" from the FF-derived default write target so
+    // the error message stays consistent with where new writes go.
     if (savedObjects.length % 2 !== 0) {
       throw new Error(
         `Expected bulkGet response to contain pairs of saved objects, received ${savedObjects.length} entries`
       );
     }
 
+    const defaultSavedObjectType = getAttachmentSavedObjectType(this.context.config);
     const result: Array<MixSavedObjectResponse> = [];
     for (let i = 0; i < savedObjects.length; i += 2) {
       const pair = [savedObjects[i], savedObjects[i + 1]] as const;
@@ -116,7 +119,15 @@ export class AttachmentGetter {
         );
       }
       const hit = pair.find((so) => !isSOError(so));
-      result.push(hit ?? pair[0]);
+      if (hit) {
+        result.push(hit);
+      } else {
+        // Both buckets are errors. Surface the one matching the FF-derived
+        // default write target so callers see a consistent "not found"
+        // (cases-comments when FF off, cases-attachments when FF on).
+        const [unifiedSO, legacySO] = pair;
+        result.push(defaultSavedObjectType === CASE_ATTACHMENT_SAVED_OBJECT ? unifiedSO : legacySO);
+      }
     }
     return result;
   }

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
@@ -74,8 +74,7 @@ export interface EventIdsAggsResult {
       key: string;
     }>;
   };
-  /** Present only when `cases-attachments` is included in the find `type` list (attachments feature enabled). */
-  unifiedEventIds?: {
+  unifiedEventIds: {
     buckets: Array<{
       key: string;
     }>;

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
@@ -2342,6 +2342,12 @@ describe('CasesService', () => {
           total: 1,
           per_page: 1,
           page: 1,
+          aggregations: {
+            references: {
+              doc_count: 0,
+              caseIds: { buckets: [] },
+            },
+          },
         });
       });
 
@@ -2375,25 +2381,7 @@ describe('CasesService', () => {
           },
         });
 
-        it('does not query cases-attachments when the unified attachments flag is off', async () => {
-          jest
-            .spyOn(attachmentService, 'isUnifiedAttachmentsEnabled', 'get')
-            .mockReturnValue(false);
-
-          unsecuredSavedObjectsClient.find.mockResolvedValueOnce(buildAggsResponse(['legacy-1']));
-
-          const res = await service.getCaseIdsByAlertId({ alertId: '1' });
-
-          expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledTimes(1);
-          expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'cases-comments' })
-          );
-          expect(CasesService.getCaseIDsFromAlertAggs(res)).toEqual(['legacy-1']);
-        });
-
-        it('runs an additional cases-attachments find when the flag is on and merges deduped case ids', async () => {
-          jest.spyOn(attachmentService, 'isUnifiedAttachmentsEnabled', 'get').mockReturnValue(true);
-
+        it('always issues both cases-comments and cases-attachments finds and merges deduped case ids', async () => {
           unsecuredSavedObjectsClient.find
             .mockResolvedValueOnce(buildAggsResponse(['shared-case', 'legacy-only']))
             .mockResolvedValueOnce(buildAggsResponse(['shared-case', 'unified-only']));
@@ -2404,12 +2392,10 @@ describe('CasesService', () => {
           });
 
           expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledTimes(2);
-          expect(unsecuredSavedObjectsClient.find).toHaveBeenNthCalledWith(
-            1,
+          expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
             expect.objectContaining({ type: 'cases-comments' })
           );
-          expect(unsecuredSavedObjectsClient.find).toHaveBeenNthCalledWith(
-            2,
+          expect(unsecuredSavedObjectsClient.find).toHaveBeenCalledWith(
             expect.objectContaining({ type: 'cases-attachments' })
           );
 

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
@@ -275,9 +275,9 @@ describe('CasesService', () => {
               },
               Object {
                 "error": Object {
-                  "error": "error",
-                  "message": "message",
-                  "statusCode": 500,
+                  "error": "Not Found",
+                  "message": "Saved object not found",
+                  "statusCode": 404,
                 },
                 "id": "1",
                 "references": Array [],

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
@@ -237,29 +237,26 @@ export class CasesService {
     try {
       this.log.debug(`Attempting to GET all cases for alert id ${alertId}`);
 
-      const legacyResponse = await this.findCaseIdsForAlertByType({
-        alertId,
-        soType: CASE_COMMENT_SAVED_OBJECT,
-        alertIdField: 'alertId',
-        filter,
-      });
-
-      if (!this.attachmentService.isUnifiedAttachmentsEnabled) {
-        return legacyResponse;
-      }
-
-      const unifiedResponse = await this.findCaseIdsForAlertByType({
-        alertId,
-        soType: CASE_ATTACHMENT_SAVED_OBJECT,
-        alertIdField: 'attachmentId',
-        extraFilter: buildFilter({
-          filters: UNIFIED_ALERT_TYPES_ARRAY,
-          field: 'type',
-          operator: 'or',
-          type: CASE_ATTACHMENT_SAVED_OBJECT,
+      const [legacyResponse, unifiedResponse] = await Promise.all([
+        this.findCaseIdsForAlertByType({
+          alertId,
+          soType: CASE_COMMENT_SAVED_OBJECT,
+          alertIdField: 'alertId',
+          filter,
         }),
-        filter: unifiedFilter,
-      });
+        this.findCaseIdsForAlertByType({
+          alertId,
+          soType: CASE_ATTACHMENT_SAVED_OBJECT,
+          alertIdField: 'attachmentId',
+          extraFilter: buildFilter({
+            filters: UNIFIED_ALERT_TYPES_ARRAY,
+            field: 'type',
+            operator: 'or',
+            type: CASE_ATTACHMENT_SAVED_OBJECT,
+          }),
+          filter: unifiedFilter,
+        }),
+      ]);
 
       return mergeCaseIdsByAlertIdResponses(legacyResponse, unifiedResponse);
     } catch (error) {

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/types.ts
@@ -25,7 +25,6 @@ export interface GetCaseIdsByAlertIdArgs {
   filter?: KueryNode;
   /**
    * Authorization + owner filter scoped to the unified `cases-attachments` saved object type.
-   * Only used when the unified attachments feature flag is enabled.
    */
   unifiedFilter?: KueryNode;
 }

--- a/x-pack/platform/plugins/shared/cases/server/services/test_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/test_utils.ts
@@ -278,13 +278,16 @@ export const mockPointInTimeFinder =
     });
   };
 
-export const createErrorSO = <T = unknown>(type: string): SOWithErrors<T> => ({
+export const createErrorSO = <T = unknown>(
+  type: string,
+  { statusCode = 404 }: { statusCode?: number } = {}
+): SOWithErrors<T> => ({
   id: '1',
   type,
   error: {
-    error: 'error',
-    message: 'message',
-    statusCode: 500,
+    error: statusCode === 404 ? 'Not Found' : 'error',
+    message: statusCode === 404 ? 'Saved object not found' : 'message',
+    statusCode,
   },
   references: [],
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
@@ -200,31 +200,7 @@ describe('CaseUserActionService', () => {
         },
       } as unknown as SavedObjectsFindResponse;
 
-      it('does not count unified comment type when attachments flag is off', async () => {
-        unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
-
-        const stats = await service.getCaseUserActionStats({ caseId: '123' });
-
-        expect(stats).toEqual({
-          total: 20,
-          total_deletions: 4,
-          total_comments: 4,
-          total_comment_deletions: 1,
-          total_comment_creations: 2,
-          total_hidden_comment_updates: 2,
-          total_other_actions: 16,
-          total_other_action_deletions: 3,
-        });
-      });
-
-      it('counts unified comment type when attachments flag is on', async () => {
-        service = new CaseUserActionService({
-          unsecuredSavedObjectsClient,
-          log: mockLogger,
-          auditLogger: mockAuditLogger,
-          savedObjectsSerializer: soSerializerMock,
-          isCasesAttachmentsEnabled: true,
-        });
+      it('counts both legacy `user` and unified `comment` types as comments', async () => {
         unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
 
         const stats = await service.getCaseUserActionStats({ caseId: '123' });

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
@@ -14,7 +14,7 @@ import type {
 import type { estypes } from '@elastic/elasticsearch';
 import type { KueryNode } from '@kbn/es-query';
 import type { CaseUserActionDeprecatedResponse } from '../../../common/types/api';
-import { AttachmentType, UserActionActions, UserActionTypes } from '../../../common/types/domain';
+import { UserActionActions, UserActionTypes } from '../../../common/types/domain';
 import { decodeOrThrow } from '../../common/runtime_types';
 import {
   CASE_COMMENT_SAVED_OBJECT,
@@ -699,10 +699,6 @@ export class CaseUserActionService {
   }
 
   public async getCaseUserActionStats({ caseId }: { caseId: string }) {
-    const isCasesAttachmentsEnabled = this.context.isCasesAttachmentsEnabled === true;
-    const isComment = (type: string) =>
-      isCasesAttachmentsEnabled ? isCommentAttachmentType(type) : type === AttachmentType.user;
-
     const response = await this.context.unsecuredSavedObjectsClient.find<
       unknown,
       UserActionsStatsAggsResult
@@ -727,19 +723,19 @@ export class CaseUserActionService {
     };
 
     response.aggregations?.totals.buckets.forEach(({ key, doc_count: docCount }) => {
-      if (isComment(key)) {
+      if (isCommentAttachmentType(key)) {
         result.total_comments += docCount;
       }
     });
 
     response.aggregations?.deletions.deletions.buckets.forEach(({ key, doc_count: docCount }) => {
-      if (isComment(key)) {
+      if (isCommentAttachmentType(key)) {
         result.total_comment_deletions += docCount;
       }
     });
 
     response.aggregations?.creations.creations.buckets.forEach(({ key, doc_count: docCount }) => {
-      if (isComment(key)) {
+      if (isCommentAttachmentType(key)) {
         result.total_comment_creations += docCount;
       }
     });
@@ -758,7 +754,7 @@ export class CaseUserActionService {
         const commentTypeBuckets = bucket.reverse?.updates?.byCommentType?.buckets ?? [];
         const userCommentUpdates = commentTypeBuckets.reduce(
           (sum: number, b: { key: string; doc_count: number }) =>
-            isComment(b.key) ? sum + b.doc_count : sum,
+            isCommentAttachmentType(b.key) ? sum + b.doc_count : sum,
           0
         );
         result.total_hidden_comment_updates += userCommentUpdates;

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
@@ -182,7 +182,6 @@ export interface ServiceContext {
   unsecuredSavedObjectsClient: SavedObjectsClientContract;
   savedObjectsSerializer: ISavedObjectsSerializer;
   auditLogger: AuditLogger;
-  isCasesAttachmentsEnabled?: boolean;
 }
 
 export interface PushTimeFrameInfo {


### PR DESCRIPTION
## Summary

Always register the unified `cases-attachments` saved object regardless of the`cases.attachments.enabled` feature flag, and simplify all read paths that previously had to gate on "is the SO registered?". 

Impact on front end: when user turns on the feature flag, attaches some unified attachments, turning off the flag still shows those unified attachments. Previously when flag is off, only legacy attachments are shown.

## What changed
- **SO registration:**`cases-attachments` is registered unconditionally
- **Reads:** both SOs are fetched, ternary based on feature flag removed
- **Authorization:** always combines owner clauses for both SO types
- `AttachmentService.bulkUpdate` correctness fix**
  - Resolves each id's SO type instead of relying on the feature flag. There could be attachments written in either SO type.
  - `AttachmentService.update` uses the same merged resolver.
- `getCaseUserActionStats`: Stats always count both legacy `user` and unified `comment` types as comments

## What is intentionally unchanged
- **Writes still respect `cases.attachments.enabled`:** when the flag is off, all writes continue to target legacy `cases-comments` and produce the byte-for-byte same payload as before this PR. 


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
