### PR TITLE
[UIAM OAuth] Fix duplicate MCP server URL path

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/oauth_clients/mcp_client_details_content.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback } from 'react';
 import { EuiButtonIcon, EuiCallOut, EuiCopy, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import type { OAuthClient } from '@kbn/agent-builder-common';
-import { MCP_SERVER_PATH, OAuthClientType } from '@kbn/agent-builder-common';
+import { OAuthClientType } from '@kbn/agent-builder-common';
 import fileSaver from 'file-saver';
 import { isEmpty } from 'lodash';
 import useToggle from 'react-use/lib/useToggle';
@@ -28,9 +28,6 @@ const isConfidentialClient = (details: McpClientDetailsData): boolean =>
 
 const maskSecret = (secret: string) => '•'.repeat(secret.length);
 
-const buildMcpServerUrl = (resource: string): string =>
-  `${resource.replace(/\/+$/, '')}${MCP_SERVER_PATH}`;
-
 export interface McpClientDetailsContentProps {
   clientDetails: McpClientDetailsData;
   presentation: McpClientDetailsPresentation;
@@ -42,9 +39,7 @@ export const McpClientDetailsContent = ({
 }: McpClientDetailsContentProps) => {
   const [isSecretVisible, toggleSecretVisibility] = useToggle(false);
 
-  const { client_name: clientName, id, resource } = clientDetails;
-
-  const mcpServerUrl = buildMcpServerUrl(resource);
+  const { client_name: clientName, id, resource: mcpServerUrl } = clientDetails;
   const showSecretField = presentation === 'modal' && hasClientSecret(clientDetails);
   const showSecretRequiredCallout =
     presentation === 'flyout' && isConfidentialClient(clientDetails);

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -836,13 +836,14 @@ describe('ApplicationConnections', () => {
   });
 
   it('opens the client details flyout when the client name is clicked in the list view', async () => {
+    const mcpServerUrl = 'https://cluster.example.com/api/agent_builder/mcp';
     setupHttpResponses(coreStart, {
       clients: {
         clients: [
           {
             id: 'client-a',
             client_name: 'My MCP app',
-            resource: 'https://cluster.example.com',
+            resource: mcpServerUrl,
           },
         ],
       },
@@ -852,7 +853,7 @@ describe('ApplicationConnections', () => {
             id: 'conn-1',
             client_id: 'client-a',
             name: 'Laptop session',
-            resource: 'https://cluster.example.com',
+            resource: mcpServerUrl,
           },
         ],
       },
@@ -870,8 +871,11 @@ describe('ApplicationConnections', () => {
     const flyout = await findByTestId('mcpClientDetailsFlyout');
     expect(within(flyout).getByText('My MCP app')).toBeInTheDocument();
     expect(within(flyout).getByText('client-a')).toBeInTheDocument();
+    expect(within(flyout).getByText(mcpServerUrl)).toBeInTheDocument();
     expect(
-      within(flyout).getByText('https://cluster.example.com/api/agent_builder/mcp')
-    ).toBeInTheDocument();
+      within(flyout).queryByText(
+        'https://cluster.example.com/api/agent_builder/mcp/api/agent_builder/mcp'
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -872,10 +872,5 @@ describe('ApplicationConnections', () => {
     expect(within(flyout).getByText('My MCP app')).toBeInTheDocument();
     expect(within(flyout).getByText('client-a')).toBeInTheDocument();
     expect(within(flyout).getByText(mcpServerUrl)).toBeInTheDocument();
-    expect(
-      within(flyout).queryByText(
-        'https://cluster.example.com/api/agent_builder/mcp/api/agent_builder/mcp'
-      )
-    ).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/config.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.ts
@@ -383,7 +383,7 @@ export const ConfigSchema = schema.object({
             authorization_servers: schema.arrayOf(schema.uri({ scheme: ['https', 'http'] }), {
               minSize: 1,
             }),
-            // Identifier for this protected resource (typically the Kibana public base URL).
+            // Canonical resource identifier for this protected resource (the full MCP server URL).
             resource: schema.uri({ scheme: ['https', 'http'] }),
             // Methods supported for sending bearer tokens. Defaults to ["header"].
             bearer_methods_supported: schema.maybe(

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -19,7 +19,7 @@ import type { InternalAuthenticationServiceStart } from '../../authentication';
 import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
 import { routeDefinitionParamsMock } from '../index.mock';
 
-const RESOURCE = 'https://test-project.kb.us-central1.gcp.elastic.cloud';
+const RESOURCE = 'https://test-project.kb.us-central1.gcp.elastic.cloud/api/agent_builder/mcp';
 const PROJECT_ID = 'mock-project-id';
 
 const mcpConfig = {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/protected_resource.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/protected_resource.test.ts
@@ -25,7 +25,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
         oauth2: {
           metadata: {
             authorization_servers: ['https://auth.example.com'],
-            resource: 'https://kibana.example.com',
+            resource: 'https://kibana.example.com/api/agent_builder/mcp',
           },
         },
       },
@@ -74,7 +74,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
       expect(response.status).toBe(200);
       expect(response.payload).toEqual({
         authorization_servers: ['https://auth.example.com'],
-        resource: 'https://kibana.example.com',
+        resource: 'https://kibana.example.com/api/agent_builder/mcp',
       });
     });
 
@@ -92,7 +92,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
       expect(response.status).toBe(200);
       expect(response.payload).toEqual({
         authorization_servers: ['https://auth.example.com'],
-        resource: 'https://kibana.example.com',
+        resource: 'https://kibana.example.com/api/agent_builder/mcp',
       });
     });
 
@@ -102,7 +102,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
           oauth2: {
             metadata: {
               authorization_servers: ['https://auth1.example.com', 'https://auth2.example.com'],
-              resource: 'https://kibana.example.com',
+              resource: 'https://kibana.example.com/api/agent_builder/mcp',
               bearer_methods_supported: ['header'] as const,
               scopes_supported: ['read', 'write'],
               resource_documentation: 'https://docs.example.com',
@@ -124,7 +124,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
       expect(response.status).toBe(200);
       expect(response.payload).toEqual({
         authorization_servers: ['https://auth1.example.com', 'https://auth2.example.com'],
-        resource: 'https://kibana.example.com',
+        resource: 'https://kibana.example.com/api/agent_builder/mcp',
         bearer_methods_supported: ['header'],
         scopes_supported: ['read', 'write'],
         resource_documentation: 'https://docs.example.com',


### PR DESCRIPTION
## Summary

Fixes #274061.

The MCP connection `resource` is now the canonical full MCP server URL (already ending in `/api/agent_builder/mcp`), but the client details view still re-appended `MCP_SERVER_PATH`, producing a duplicated path like `.../api/agent_builder/mcp/api/agent_builder/mcp`. This PR addresses that.

__Before:__

<img width="2560" height="1320" alt="Screenshot 2026-06-26 at 16 29 27" src="https://github.com/user-attachments/assets/2f8fe00e-373b-4280-9f0c-dc1fee994456" />

__After:__

<img width="2560" height="1318" alt="Screenshot 2026-06-26 at 16 28 15" src="https://github.com/user-attachments/assets/190ba2af-abb8-4744-8077-e64b961cd542" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

