### PR TITLE
[UIAM OAuth] Improve Application Connections UX for clients with zero connections

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -95,7 +95,7 @@ describe('ApplicationConnections', () => {
     expect(getByTestId('applicationConnectionsTable')).toBeInTheDocument();
   }, 15_000);
 
-  it('hides clients that have zero connections (falls back to the empty prompt when all clients are empty)', async () => {
+  it('shows clients that have zero connections in the grouped view', async () => {
     setupHttpResponses(coreStart, {
       clients: {
         clients: [
@@ -109,13 +109,40 @@ describe('ApplicationConnections', () => {
       connections: { connections: [] },
     });
 
-    const { findByText, queryByText, queryByTestId } = renderPage(coreStart);
+    const { findByText, findByTestId, queryByText, queryByTestId } = renderPage(coreStart);
 
-    expect(await findByText(/No application connections/)).toBeInTheDocument();
-    expect(queryByText('Unused MCP app')).not.toBeInTheDocument();
+    expect(await findByText('Unused MCP app')).toBeInTheDocument();
     expect(
-      queryByTestId('applicationConnectionsListRow-client-without-conn')
-    ).not.toBeInTheDocument();
+      await findByTestId('applicationConnectionsListRow-client-without-conn')
+    ).toBeInTheDocument();
+    expect(await findByTestId('applicationConnectionsCount-client-without-conn')).toHaveTextContent(
+      '0'
+    );
+    expect(queryByTestId('expandRow-client-without-conn')).not.toBeInTheDocument();
+    expect(queryByText(/No application connections/)).not.toBeInTheDocument();
+  });
+
+  it('excludes clients with zero connections from the flat list view', async () => {
+    setupHttpResponses(coreStart, {
+      clients: {
+        clients: [
+          { id: 'client-with-conn', client_name: 'Connected app', resource: 'cluster:elastic' },
+          { id: 'client-without-conn', client_name: 'Unused MCP app', resource: 'cluster:elastic' },
+        ],
+      },
+      connections: {
+        connections: [{ id: 'conn-1', client_id: 'client-with-conn', resource: 'cluster:elastic' }],
+      },
+    });
+
+    const { findByText, findByTestId, getByTestId, queryByText } = renderPage(coreStart);
+
+    expect(await findByText('Unused MCP app')).toBeInTheDocument();
+
+    fireEvent.click(getByTestId('applicationConnectionsViewModeList'));
+
+    expect(await findByTestId('applicationConnectionsListViewRow-conn-1')).toBeInTheDocument();
+    expect(queryByText('Unused MCP app')).not.toBeInTheDocument();
   });
 
   it('renders clients grouped with their connections', async () => {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections.test.tsx
@@ -145,6 +145,54 @@ describe('ApplicationConnections', () => {
     expect(queryByText('Unused MCP app')).not.toBeInTheDocument();
   });
 
+  it('hides clients with zero connections when a status filter is applied', async () => {
+    setupHttpResponses(coreStart, {
+      clients: {
+        clients: [
+          { id: 'client-with-conn', client_name: 'Connected app', resource: 'cluster:elastic' },
+          { id: 'client-without-conn', client_name: 'Unused MCP app', resource: 'cluster:elastic' },
+        ],
+      },
+      connections: {
+        connections: [{ id: 'conn-1', client_id: 'client-with-conn', resource: 'cluster:elastic' }],
+      },
+    });
+
+    const { findByText, findByRole, getByRole, getByText, queryByText } = renderPage(coreStart);
+
+    expect(await findByText('Unused MCP app')).toBeInTheDocument();
+    expect(await findByText('Connected app')).toBeInTheDocument();
+
+    fireEvent.click(getByRole('button', { name: /Status Selection/ }));
+    fireEvent.click(await findByRole('option', { name: /Connected/ }));
+
+    await waitFor(() => {
+      expect(queryByText('Unused MCP app')).not.toBeInTheDocument();
+    });
+    expect(getByText('Connected app')).toBeInTheDocument();
+  });
+
+  it('disables selection for clients with zero connections with an explanatory message', async () => {
+    setupHttpResponses(coreStart, {
+      clients: {
+        clients: [
+          { id: 'client-with-conn', client_name: 'Connected app', resource: 'cluster:elastic' },
+          { id: 'client-without-conn', client_name: 'Unused MCP app', resource: 'cluster:elastic' },
+        ],
+      },
+      connections: {
+        connections: [{ id: 'conn-1', client_id: 'client-with-conn', resource: 'cluster:elastic' }],
+      },
+    });
+
+    const { findByText, getByLabelText } = renderPage(coreStart);
+
+    expect(await findByText('Unused MCP app')).toBeInTheDocument();
+
+    const emptyClientCheckbox = getByLabelText('This client has no connections yet');
+    expect(emptyClientCheckbox).toBeDisabled();
+  });
+
   it('renders clients grouped with their connections', async () => {
     setupHttpResponses(coreStart, {
       clients: {

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table_columns.tsx
@@ -81,7 +81,8 @@ export const useApplicationConnectionsTableColumns = ({
       width: '40px',
       align: 'right',
       isExpander: true,
-      render: ({ client }) => {
+      render: ({ client, connections }) => {
+        if (connections.length === 0) return null;
         const isOpen = expandedRows.has(client.id);
         return (
           <EuiToolTip

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table_search.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/application_connections_table_search.tsx
@@ -136,6 +136,9 @@ export const useApplicationConnectionsTableSearch = ({
           applicationConnectionsMatchesFreeText(applicationConnection, searchQuery)
         )
         .flatMap((applicationConnection) => {
+          if (applicationConnection.connections.length === 0) {
+            return statusFilter.length === 0 ? [applicationConnection] : [];
+          }
           const matchingConnections = applicationConnection.connections.filter((connection) =>
             applicationConnectionMatchesStatus(
               { client: applicationConnection.client, connection },

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connections_by_client_table.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/application_connections_table/connections_by_client_table.tsx
@@ -92,10 +92,14 @@ export const ConnectionsByClientTable = ({
     () => ({
       selected: selectedClientRows,
       selectable: (row) => (selectableConnectionsByClient[row.client.id]?.length ?? 0) > 0,
-      selectableMessage: (selectable, row) =>
-        selectable
-          ? labels.groupedColumns.selectClientLabel(row.client.client_name ?? row.client.id)
-          : labels.groupedColumns.allRevokedClientLabel,
+      selectableMessage: (selectable, row) => {
+        if (selectable) {
+          return labels.groupedColumns.selectClientLabel(row.client.client_name ?? row.client.id);
+        }
+        return row.connections.length === 0
+          ? labels.groupedColumns.noConnectionsClientLabel
+          : labels.groupedColumns.allRevokedClientLabel;
+      },
       onSelectionChange: (nextSelection) => {
         const nextIds = new Set(nextSelection.map((row) => row.client.id));
         const prevIds = new Set(selectedClientRows.map((row) => row.client.id));

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/constants/i18n.ts
@@ -99,6 +99,10 @@ export const labels = {
       'xpack.security.management.applicationConnections.columns.allRevokedClientLabel',
       { defaultMessage: 'All connections for this client are already revoked' }
     ),
+    noConnectionsClientLabel: i18n.translate(
+      'xpack.security.management.applicationConnections.columns.noConnectionsClientLabel',
+      { defaultMessage: 'This client has no connections yet' }
+    ),
   },
   connectionColumns: {
     connectionName: i18n.translate(

--- a/x-pack/platform/plugins/shared/security/public/management/application_connections/hooks/use_application_connections.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/application_connections/hooks/use_application_connections.ts
@@ -22,9 +22,7 @@ export const useApplicationConnections = () => {
     if (!clients || !connections) return EMPTY_ROWS;
 
     const byClient = groupBy(connections, (connection) => connection.client_id);
-    return clients
-      .map((client) => ({ client, connections: byClient[client.id] ?? [] }))
-      .filter((row) => row.connections.length > 0);
+    return clients.map((client) => ({ client, connections: byClient[client.id] ?? [] }));
   }, [clients, connections]);
 
   return {


### PR DESCRIPTION
## Summary

Surfaces OAuth clients that have zero connections in the "Group by Client" view of the Application Connections page instead of hiding them. Previously such clients were filtered out entirely, which made newly registered apps invisible and fell back to the empty prompt when no client had any connections. 

### Demo

__Group by client__

<img width="2560" height="1319" alt="Screenshot 2026-06-26 at 17 29 38" src="https://github.com/user-attachments/assets/1d313c60-c7e9-49ff-9e07-94dd5e66d998" />

__List view: Remains omitted as intended__

<img width="2560" height="1318" alt="Screenshot 2026-06-26 at 17 30 16" src="https://github.com/user-attachments/assets/67d9ce4b-2d4e-4006-bf0c-f50a46752657" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
