### PR TITLE
[i18n] Server-side string translation based on per-user language setting

### DIFF
--- a/src/core/packages/http/request-handler-context-server-internal/moon.yml
+++ b/src/core/packages/http/request-handler-context-server-internal/moon.yml
@@ -17,8 +17,11 @@ project:
   owner: '@elastic/kibana-core'
   sourceRoot: src/core/packages/http/request-handler-context-server-internal
 dependsOn:
+  - '@kbn/i18n'
   - '@kbn/core-http-server'
   - '@kbn/core-http-request-handler-context-server'
+  - '@kbn/core-i18n-server'
+  - '@kbn/core-i18n-server-mocks'
   - '@kbn/core-elasticsearch-server-internal'
   - '@kbn/core-saved-objects-server-internal'
   - '@kbn/core-deprecations-server-internal'

--- a/src/core/packages/http/request-handler-context-server-internal/src/core_i18n_route_handler_context.ts
+++ b/src/core/packages/http/request-handler-context-server-internal/src/core_i18n_route_handler_context.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { TranslateArguments } from '@kbn/i18n';
+import type {
+  I18nRequestHandlerContext,
+  I18nServiceStart,
+  RequestI18nClient,
+} from '@kbn/core-i18n-server';
+
+/**
+ * The {@link I18nRequestHandlerContext} implementation.
+ * @internal
+ */
+export class CoreI18nRouteHandlerContext implements I18nRequestHandlerContext {
+  #client?: RequestI18nClient;
+
+  constructor(
+    private readonly i18nStart: I18nServiceStart,
+    private readonly request: KibanaRequest
+  ) {}
+
+  private get client(): RequestI18nClient {
+    if (this.#client == null) {
+      this.#client = this.i18nStart.asScopedToRequest(this.request);
+    }
+    return this.#client;
+  }
+
+  public getLocale(): Promise<string> {
+    return this.client.getLocale();
+  }
+
+  public translate(id: string, args: TranslateArguments): Promise<string> {
+    return this.client.translate(id, args);
+  }
+
+  public formatList(
+    type: 'conjunction' | 'disjunction' | 'unit',
+    value: string[]
+  ): Promise<string> {
+    return this.client.formatList(type, value);
+  }
+}

--- a/src/core/packages/http/request-handler-context-server-internal/src/core_route_handler_context.test.ts
+++ b/src/core/packages/http/request-handler-context-server-internal/src/core_route_handler_context.test.ts
@@ -234,6 +234,46 @@ describe('#security', () => {
   });
 });
 
+describe('#i18n', () => {
+  test('delegates to the client returned by coreStart.i18n.asScopedToRequest', async () => {
+    const request = httpServerMock.createKibanaRequest();
+    const coreStart = createCoreRouteHandlerContextParamsMock();
+    const context = new CoreRouteHandlerContext(coreStart, request);
+
+    await context.i18n.getLocale();
+    const client = coreStart.i18n.asScopedToRequest.mock.results[0].value;
+
+    expect(coreStart.i18n.asScopedToRequest).toHaveBeenCalledWith(request);
+    expect(client.getLocale).toHaveBeenCalledTimes(1);
+  });
+
+  test('lazily created', () => {
+    const request = httpServerMock.createKibanaRequest();
+    const coreStart = createCoreRouteHandlerContextParamsMock();
+    const context = new CoreRouteHandlerContext(coreStart, request);
+
+    expect(coreStart.i18n.asScopedToRequest).not.toHaveBeenCalled();
+    const i18n = context.i18n;
+    expect(i18n).toBeDefined();
+    // The scoped client is only built when a method is first invoked.
+    expect(coreStart.i18n.asScopedToRequest).not.toHaveBeenCalled();
+    context.i18n.getLocale();
+    expect(coreStart.i18n.asScopedToRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('only creates one scoped client across calls', async () => {
+    const request = httpServerMock.createKibanaRequest();
+    const coreStart = createCoreRouteHandlerContextParamsMock();
+    const context = new CoreRouteHandlerContext(coreStart, request);
+
+    await context.i18n.getLocale();
+    await context.i18n.translate('id', { defaultMessage: 'Hello' });
+    await context.i18n.formatList('conjunction', ['a', 'b']);
+
+    expect(coreStart.i18n.asScopedToRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('#userProfile', () => {
   describe('getCurrent', () => {
     test('calls coreStart.userProfile.getCurrent with the correct parameters', () => {

--- a/src/core/packages/http/request-handler-context-server-internal/src/core_route_handler_context.ts
+++ b/src/core/packages/http/request-handler-context-server-internal/src/core_route_handler_context.ts
@@ -35,6 +35,8 @@ import {
 } from '@kbn/core-user-profile-server-internal';
 import { CoreFeatureFlagsRouteHandlerContext } from '@kbn/core-feature-flags-server-internal';
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-server';
+import type { I18nServiceStart } from '@kbn/core-i18n-server';
+import { CoreI18nRouteHandlerContext } from './core_i18n_route_handler_context';
 
 /**
  * Subset of `InternalCoreStart` used by {@link CoreRouteHandlerContext}
@@ -48,6 +50,7 @@ export interface CoreRouteHandlerContextParams {
   deprecations: InternalDeprecationsServiceStart;
   security: InternalSecurityServiceStart;
   userProfile: InternalUserProfileServiceStart;
+  i18n: I18nServiceStart;
 }
 
 /**
@@ -63,6 +66,7 @@ export class CoreRouteHandlerContext implements CoreRequestHandlerContext {
   #deprecations?: CoreDeprecationsRouteHandlerContext;
   #security?: CoreSecurityRouteHandlerContext;
   #userProfile?: CoreUserProfileRouteHandlerContext;
+  #i18n?: CoreI18nRouteHandlerContext;
 
   constructor(
     private readonly coreStart: CoreRouteHandlerContextParams,
@@ -133,5 +137,12 @@ export class CoreRouteHandlerContext implements CoreRequestHandlerContext {
       );
     }
     return this.#userProfile;
+  }
+
+  public get i18n() {
+    if (!this.#i18n) {
+      this.#i18n = new CoreI18nRouteHandlerContext(this.coreStart.i18n, this.request);
+    }
+    return this.#i18n;
   }
 }

--- a/src/core/packages/http/request-handler-context-server-internal/src/test_helpers/core_route_handler_context_params.mock.ts
+++ b/src/core/packages/http/request-handler-context-server-internal/src/test_helpers/core_route_handler_context_params.mock.ts
@@ -14,6 +14,7 @@ import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 import { deprecationsServiceMock } from '@kbn/core-deprecations-server-mocks';
 import { securityServiceMock } from '@kbn/core-security-server-mocks';
 import { userProfileServiceMock } from '@kbn/core-user-profile-server-mocks';
+import { i18nServiceMock } from '@kbn/core-i18n-server-mocks';
 
 export const createCoreRouteHandlerContextParamsMock = () => {
   return {
@@ -24,5 +25,6 @@ export const createCoreRouteHandlerContextParamsMock = () => {
     deprecations: deprecationsServiceMock.createInternalStartContract(),
     security: securityServiceMock.createInternalStart(),
     userProfile: userProfileServiceMock.createInternalStart(),
+    i18n: i18nServiceMock.createStartContract(),
   };
 };

--- a/src/core/packages/http/request-handler-context-server-internal/tsconfig.json
+++ b/src/core/packages/http/request-handler-context-server-internal/tsconfig.json
@@ -11,8 +11,11 @@
     "**/*.ts",
   ],
   "kbn_references": [
+    "@kbn/i18n",
     "@kbn/core-http-server",
     "@kbn/core-http-request-handler-context-server",
+    "@kbn/core-i18n-server",
+    "@kbn/core-i18n-server-mocks",
     "@kbn/core-elasticsearch-server-internal",
     "@kbn/core-saved-objects-server-internal",
     "@kbn/core-deprecations-server-internal",

--- a/src/core/packages/http/request-handler-context-server/moon.yml
+++ b/src/core/packages/http/request-handler-context-server/moon.yml
@@ -25,6 +25,7 @@ dependsOn:
   - '@kbn/core-security-server'
   - '@kbn/core-user-profile-server'
   - '@kbn/core-feature-flags-server'
+  - '@kbn/core-i18n-server'
 tags:
   - shared-server
   - package

--- a/src/core/packages/http/request-handler-context-server/src/request_handler_context.ts
+++ b/src/core/packages/http/request-handler-context-server/src/request_handler_context.ts
@@ -15,6 +15,7 @@ import type { UiSettingsRequestHandlerContext } from '@kbn/core-ui-settings-serv
 import type { SecurityRequestHandlerContext } from '@kbn/core-security-server';
 import type { UserProfileRequestHandlerContext } from '@kbn/core-user-profile-server';
 import type { FeatureFlagsRequestHandlerContext } from '@kbn/core-feature-flags-server';
+import type { I18nRequestHandlerContext } from '@kbn/core-i18n-server';
 
 /**
  * The `core` context provided to route handler.
@@ -59,6 +60,12 @@ export interface CoreRequestHandlerContext {
    * {@link UserProfileRequestHandlerContext}
    */
   userProfile: UserProfileRequestHandlerContext;
+  /**
+   * {@link I18nRequestHandlerContext} - translates strings into the locale
+   * resolved for the current request (profile → cookie → Accept-Language on
+   * serverless → `i18n.defaultLocale`).
+   */
+  i18n: I18nRequestHandlerContext;
 }
 
 /**

--- a/src/core/packages/http/request-handler-context-server/tsconfig.json
+++ b/src/core/packages/http/request-handler-context-server/tsconfig.json
@@ -18,7 +18,8 @@
     "@kbn/core-ui-settings-server",
     "@kbn/core-security-server",
     "@kbn/core-user-profile-server",
-    "@kbn/core-feature-flags-server"
+    "@kbn/core-feature-flags-server",
+    "@kbn/core-i18n-server"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/i18n/server-internal/index.ts
+++ b/src/core/packages/i18n/server-internal/index.ts
@@ -9,6 +9,8 @@
 
 export type { I18nConfigType, InternalI18nServicePreboot } from './src';
 export { config, I18nService } from './src';
+export { resolveLocale, buildKbnLocaleCookie } from './src';
+export type { ResolveLocaleArgs, ResolveLocaleResult, BuildKbnLocaleCookieArgs } from './src';
 export {
   discoverAllTranslationPaths,
   getKibanaTranslationFiles,

--- a/src/core/packages/i18n/server-internal/moon.yml
+++ b/src/core/packages/i18n/server-internal/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/core-i18n-server'
   - '@kbn/core-http-server'
   - '@kbn/core-http-server-internal'
+  - '@kbn/core-user-settings-server-internal'
   - '@kbn/repo-info'
   - '@kbn/config-mocks'
   - '@kbn/core-base-server-mocks'

--- a/src/core/packages/i18n/server-internal/src/i18n_service.start.test.ts
+++ b/src/core/packages/i18n/server-internal/src/i18n_service.start.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  getAllKibanaTranslationFilesMock,
+  groupFilesByLocaleMock,
+  computeLocaleFileHashMock,
+} from './i18n_service.test.mocks';
+
+import { BehaviorSubject } from 'rxjs';
+import { i18nLoader } from '@kbn/i18n';
+import { configServiceMock } from '@kbn/config-mocks';
+import { mockCoreContext } from '@kbn/core-base-server-mocks';
+import { httpServiceMock, httpServerMock } from '@kbn/core-http-server-mocks';
+import type { InternalUserSettingsServiceSetup } from '@kbn/core-user-settings-server-internal';
+
+import { I18nService } from './i18n_service';
+
+const getConfigService = (defaultLocale = 'en', locales: string[] = ['en', 'fr-FR', 'ja-JP']) => {
+  const configService = configServiceMock.create();
+  configService.atPath.mockImplementation((path) => {
+    if (path === 'i18n') {
+      return new BehaviorSubject({ defaultLocale, locales });
+    }
+    return new BehaviorSubject({});
+  });
+  return configService;
+};
+
+const createUserSettings = (
+  locale: string | undefined
+): jest.Mocked<InternalUserSettingsServiceSetup> => ({
+  getUserSettingDarkMode: jest.fn().mockResolvedValue(undefined),
+  getUserSettingLocale: jest.fn().mockResolvedValue(locale),
+  getUserSettingRememberSelectedSpace: jest.fn().mockResolvedValue(true),
+});
+
+describe('I18nService#start', () => {
+  let service: I18nService;
+  let configService: ReturnType<typeof configServiceMock.create>;
+  let httpPreboot: ReturnType<typeof httpServiceMock.createInternalPrebootContract>;
+  let httpSetup: ReturnType<typeof httpServiceMock.createInternalSetupContract>;
+  let coreContext: ReturnType<typeof mockCoreContext.create>;
+  let getTranslationsByLocaleSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    getAllKibanaTranslationFilesMock.mockResolvedValue([]);
+    groupFilesByLocaleMock.mockReturnValue({});
+    computeLocaleFileHashMock.mockResolvedValue('mock-file-hash');
+
+    getTranslationsByLocaleSpy = jest
+      .spyOn(i18nLoader, 'getTranslationsByLocale')
+      .mockResolvedValue({ locale: 'fr-FR', messages: { greeting: 'Bonjour' } });
+
+    configService = getConfigService();
+    coreContext = mockCoreContext.create({ configService });
+    service = new I18nService(coreContext);
+
+    httpPreboot = httpServiceMock.createInternalPrebootContract();
+    httpPreboot.registerRoutes.mockImplementation((type, callback) =>
+      callback(httpServiceMock.createRouter())
+    );
+    httpSetup = httpServiceMock.createInternalSetupContract();
+
+    await service.preboot({ pluginPaths: [], http: httpPreboot });
+    await service.setup({ pluginPaths: [], http: httpSetup });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws if called before setup', () => {
+    const freshService = new I18nService(mockCoreContext.create({ configService }));
+    expect(() => freshService.start({ userSettings: createUserSettings('fr-FR') })).toThrow(
+      'I18nService#start called before #setup'
+    );
+  });
+
+  it('does not build any translator until a request method is called', () => {
+    const { asScopedToRequest } = service.start({ userSettings: createUserSettings('fr-FR') });
+
+    // Creating the scoped client must not resolve the locale or load files.
+    asScopedToRequest(httpServerMock.createKibanaRequest());
+
+    expect(getTranslationsByLocaleSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves the user profile locale and translates from that locale file', async () => {
+    const userSettings = createUserSettings('fr-FR');
+    const { asScopedToRequest } = service.start({ userSettings });
+
+    const client = asScopedToRequest(httpServerMock.createKibanaRequest());
+
+    await expect(client.getLocale()).resolves.toBe('fr-FR');
+    await expect(client.translate('greeting', { defaultMessage: 'Hello' })).resolves.toBe(
+      'Bonjour'
+    );
+    expect(userSettings.getUserSettingLocale).toHaveBeenCalledTimes(1);
+    expect(getTranslationsByLocaleSpy).toHaveBeenCalledWith('fr-FR');
+  });
+
+  it('reuses the cached translator across requests for the same locale', async () => {
+    const { asScopedToRequest } = service.start({ userSettings: createUserSettings('fr-FR') });
+
+    const first = asScopedToRequest(httpServerMock.createKibanaRequest());
+    const second = asScopedToRequest(httpServerMock.createKibanaRequest());
+
+    await first.translate('greeting', { defaultMessage: 'Hello' });
+    await second.translate('greeting', { defaultMessage: 'Hello' });
+
+    // The translator for 'fr-FR' is built once and shared across requests.
+    expect(getTranslationsByLocaleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('memoises the resolved locale per request', async () => {
+    const userSettings = createUserSettings('fr-FR');
+    const { asScopedToRequest } = service.start({ userSettings });
+
+    const client = asScopedToRequest(httpServerMock.createKibanaRequest());
+
+    await client.getLocale();
+    await client.translate('greeting', { defaultMessage: 'Hello' });
+    await client.formatList('conjunction', ['a', 'b']);
+
+    // The (async) profile lookup happens at most once per request.
+    expect(userSettings.getUserSettingLocale).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the singleton messages for the default locale without hitting the loader', async () => {
+    const { asScopedToRequest } = service.start({ userSettings: createUserSettings('en') });
+
+    const client = asScopedToRequest(httpServerMock.createKibanaRequest());
+
+    await expect(client.getLocale()).resolves.toBe('en');
+    // No file in the test, so the default-locale translator falls back to the
+    // provided defaultMessage — and crucially never calls the loader.
+    await expect(client.translate('greeting', { defaultMessage: 'Hello' })).resolves.toBe('Hello');
+    expect(getTranslationsByLocaleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/packages/i18n/server-internal/src/i18n_service.ts
+++ b/src/core/packages/i18n/server-internal/src/i18n_service.ts
@@ -9,15 +9,25 @@
 
 import { firstValueFrom } from 'rxjs';
 import { createHash } from 'crypto';
-import { i18n, getLocaleLabel, type AvailableLocale } from '@kbn/i18n';
+import {
+  i18n,
+  i18nLoader,
+  getLocaleLabel,
+  createScopedTranslator,
+  type AvailableLocale,
+  type ScopedTranslator,
+  type TranslationInput,
+} from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
 import type { IConfigService } from '@kbn/config';
 import type { CoreContext } from '@kbn/core-base-server-internal';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type {
   InternalHttpServicePreboot,
   InternalHttpServiceSetup,
 } from '@kbn/core-http-server-internal';
-import type { I18nServiceSetup } from '@kbn/core-i18n-server';
+import type { I18nServiceSetup, I18nServiceStart, RequestI18nClient } from '@kbn/core-i18n-server';
+import type { InternalUserSettingsServiceSetup } from '@kbn/core-user-settings-server-internal';
 import type { I18nConfigType } from './i18n_config';
 import { config as i18nConfigDef } from './i18n_config';
 import {
@@ -27,6 +37,7 @@ import {
 } from './get_kibana_translation_files';
 import { initTranslations } from './init_translations';
 import { registerRoutes } from './routes';
+import { resolveLocale } from './resolve_locale';
 
 export interface PrebootDeps {
   http: InternalHttpServicePreboot;
@@ -36,6 +47,17 @@ export interface PrebootDeps {
 export interface SetupDeps {
   http: InternalHttpServiceSetup;
   pluginPaths: string[];
+}
+
+export interface StartDeps {
+  userSettings: InternalUserSettingsServiceSetup;
+}
+
+interface LocaleResolutionConfig {
+  defaultLocale: string;
+  locales: readonly string[];
+  translationHashes: Record<string, string>;
+  allowLocaleCookie: boolean;
 }
 
 export interface InternalI18nServicePreboot {
@@ -48,6 +70,8 @@ export interface InternalI18nServicePreboot {
 export class I18nService {
   private readonly log: Logger;
   private readonly configService: IConfigService;
+  private localeResolutionConfig?: LocaleResolutionConfig;
+  private readonly translatorCache = new Map<string, ScopedTranslator>();
 
   constructor(private readonly coreContext: CoreContext) {
     this.log = coreContext.logger.get('i18n');
@@ -104,6 +128,14 @@ export class I18nService {
       localeFileMap,
     });
 
+    // Capture the inputs `start` needs to resolve a locale per request.
+    this.localeResolutionConfig = {
+      defaultLocale,
+      locales,
+      translationHashes,
+      allowLocaleCookie,
+    };
+
     return {
       getLocale: () => defaultLocale,
       getLocales: () => locales,
@@ -113,6 +145,66 @@ export class I18nService {
       getTranslationHashes: () => translationHashes,
       allowLocaleCookie,
     };
+  }
+
+  public start({ userSettings }: StartDeps): I18nServiceStart {
+    const localeConfig = this.localeResolutionConfig;
+    if (!localeConfig) {
+      throw new Error('I18nService#start called before #setup');
+    }
+
+    const isServerless = this.coreContext.env.packageInfo.buildFlavor === 'serverless';
+
+    return {
+      asScopedToRequest: (request: KibanaRequest): RequestI18nClient => {
+        // Resolve the locale and its translator at most once per request; the
+        // first call pays the async profile lookup, the rest reuse the result.
+        let resolved: Promise<{ locale: string; translator: ScopedTranslator }> | undefined;
+        const resolve = () => {
+          if (!resolved) {
+            resolved = (async () => {
+              const userSettingLocale = await userSettings.getUserSettingLocale(request);
+              const { locale } = resolveLocale({
+                request,
+                userSettingLocale,
+                configLocale: localeConfig.defaultLocale,
+                configuredLocales: localeConfig.locales,
+                translationHashes: localeConfig.translationHashes,
+                isServerless,
+                allowLocaleCookie: localeConfig.allowLocaleCookie,
+              });
+              const translator = await this.getTranslator(locale, localeConfig.defaultLocale);
+              return { locale, translator };
+            })();
+          }
+          return resolved;
+        };
+
+        return {
+          getLocale: async () => (await resolve()).locale,
+          translate: async (id, args) => (await resolve()).translator.translate(id, args),
+          formatList: async (type, value) => (await resolve()).translator.formatList(type, value),
+        };
+      },
+    };
+  }
+
+  private async getTranslator(locale: string, defaultLocale: string): Promise<ScopedTranslator> {
+    const cached = this.translatorCache.get(locale);
+    if (cached) {
+      return cached;
+    }
+
+    // Default locale reuses the singleton's boot-loaded messages; other locales
+    // load from disk via the loader's internal file cache.
+    const translationInput: TranslationInput =
+      locale === defaultLocale
+        ? extractSingletonTranslation()
+        : await i18nLoader.getTranslationsByLocale(locale);
+
+    const translator = createScopedTranslator(translationInput);
+    this.translatorCache.set(locale, translator);
+    return translator;
   }
 
   private async initTranslations(pluginPaths: string[]) {
@@ -164,4 +256,11 @@ export class I18nService {
 
 const computeHash = (serialized: string) => {
   return createHash('sha256').update(serialized).digest('hex').slice(0, 12);
+};
+
+// Reuse the singleton's boot-loaded default-locale messages, avoiding a
+// redundant disk read / JSON parse via the loader.
+const extractSingletonTranslation = (): TranslationInput => {
+  const { messages, locale, formats } = i18n.getTranslation();
+  return { messages, locale, formats };
 };

--- a/src/core/packages/i18n/server-internal/src/index.ts
+++ b/src/core/packages/i18n/server-internal/src/index.ts
@@ -11,3 +11,9 @@ export { config } from './i18n_config';
 export type { I18nConfigType } from './i18n_config';
 export { I18nService } from './i18n_service';
 export type { InternalI18nServicePreboot } from './i18n_service';
+export { resolveLocale, buildKbnLocaleCookie } from './resolve_locale';
+export type {
+  ResolveLocaleArgs,
+  ResolveLocaleResult,
+  BuildKbnLocaleCookieArgs,
+} from './resolve_locale';

--- a/src/core/packages/i18n/server-internal/src/resolve_locale.test.ts
+++ b/src/core/packages/i18n/server-internal/src/resolve_locale.test.ts
@@ -10,6 +10,7 @@
 import type { KibanaRequest } from '@kbn/core-http-server';
 import {
   KBN_LOCALE_COOKIE_NAME,
+  buildKbnLocaleCookie,
   pickFromAcceptLanguage,
   readCookie,
   resolveLocale,
@@ -41,7 +42,6 @@ const baseArgs = (overrides: Partial<ResolveLocaleArgs> = {}): ResolveLocaleArgs
   configuredLocales: ['en', 'fr-FR', 'ja-JP'],
   translationHashes: { en: 'h1', 'fr-FR': 'h2', 'ja-JP': 'h3' },
   isServerless: false,
-  serverBasePath: '',
   allowLocaleCookie: true,
   ...overrides,
 });
@@ -183,46 +183,64 @@ describe('resolveLocale', () => {
       expect(result.locale).toBe('en');
     });
   });
+});
 
-  describe('Set-Cookie header', () => {
-    it('always emits a Set-Cookie value matching the resolved locale', () => {
-      const result = resolveLocale(baseArgs());
-      expect(result.setCookieHeader).toContain(`${KBN_LOCALE_COOKIE_NAME}=en`);
+describe('buildKbnLocaleCookie', () => {
+  it('emits a Set-Cookie value matching the provided locale', () => {
+    const cookie = buildKbnLocaleCookie({
+      locale: 'en',
+      request: buildRequest(),
+      serverBasePath: '',
     });
+    expect(cookie).toContain(`${KBN_LOCALE_COOKIE_NAME}=en`);
+  });
 
-    it('includes Path, Max-Age, SameSite=Lax, and HttpOnly', () => {
-      const result = resolveLocale(baseArgs({ serverBasePath: '/abc' }));
-      expect(result.setCookieHeader).toContain('Path=/abc');
-      expect(result.setCookieHeader).toContain('Max-Age=31536000');
-      expect(result.setCookieHeader).toContain('SameSite=Lax');
-      expect(result.setCookieHeader).toContain('HttpOnly');
+  it('includes Path, Max-Age, SameSite=Lax, and HttpOnly', () => {
+    const cookie = buildKbnLocaleCookie({
+      locale: 'en',
+      request: buildRequest(),
+      serverBasePath: '/abc',
     });
+    expect(cookie).toContain('Path=/abc');
+    expect(cookie).toContain('Max-Age=31536000');
+    expect(cookie).toContain('SameSite=Lax');
+    expect(cookie).toContain('HttpOnly');
+  });
 
-    it('uses Path=/ when serverBasePath is empty', () => {
-      const result = resolveLocale(baseArgs({ serverBasePath: '' }));
-      expect(result.setCookieHeader).toContain('Path=/');
+  it('uses Path=/ when serverBasePath is empty', () => {
+    const cookie = buildKbnLocaleCookie({
+      locale: 'en',
+      request: buildRequest(),
+      serverBasePath: '',
     });
+    expect(cookie).toContain('Path=/');
+  });
 
-    it('adds Secure on HTTPS', () => {
-      const result = resolveLocale(baseArgs({ request: buildRequest({ protocol: 'https:' }) }));
-      expect(result.setCookieHeader).toContain('; Secure');
+  it('adds Secure on HTTPS', () => {
+    const cookie = buildKbnLocaleCookie({
+      locale: 'en',
+      request: buildRequest({ protocol: 'https:' }),
+      serverBasePath: '',
     });
+    expect(cookie).toContain('; Secure');
+  });
 
-    it('omits Secure on HTTP', () => {
-      const result = resolveLocale(baseArgs({ request: buildRequest({ protocol: 'http:' }) }));
-      expect(result.setCookieHeader).not.toContain('Secure');
+  it('omits Secure on HTTP', () => {
+    const cookie = buildKbnLocaleCookie({
+      locale: 'en',
+      request: buildRequest({ protocol: 'http:' }),
+      serverBasePath: '',
     });
+    expect(cookie).not.toContain('Secure');
+  });
 
-    it('URL-encodes non-ASCII locale ids defensively', () => {
-      const result = resolveLocale(
-        baseArgs({
-          configLocale: 'a-Ω',
-          translationHashes: { 'a-Ω': 'h' },
-          configuredLocales: ['a-Ω'],
-        })
-      );
-      expect(result.setCookieHeader).toContain(`${KBN_LOCALE_COOKIE_NAME}=a-%CE%A9`);
+  it('URL-encodes non-ASCII locale ids defensively', () => {
+    const cookie = buildKbnLocaleCookie({
+      locale: 'a-Ω',
+      request: buildRequest(),
+      serverBasePath: '',
     });
+    expect(cookie).toContain(`${KBN_LOCALE_COOKIE_NAME}=a-%CE%A9`);
   });
 });
 

--- a/src/core/packages/i18n/server-internal/src/resolve_locale.ts
+++ b/src/core/packages/i18n/server-internal/src/resolve_locale.ts
@@ -35,11 +35,9 @@ export interface ResolveLocaleArgs {
    * deterministic for existing users.
    */
   isServerless: boolean;
-  /** Server-wide base path for the cookie's Path attribute. */
-  serverBasePath: string;
   /**
-   * When false, the `KBN_LOCALE` cookie is neither read from the request nor
-   * written to the response. Controlled by `i18n.allowLocaleCookie`.
+   * When false, the `KBN_LOCALE` cookie is not consulted during resolution.
+   * Controlled by `i18n.allowLocaleCookie`.
    */
   allowLocaleCookie: boolean;
 }
@@ -47,19 +45,17 @@ export interface ResolveLocaleArgs {
 export interface ResolveLocaleResult {
   /** Locale id Kibana should render the response in. */
   locale: string;
-  /**
-   * Ready-to-use Set-Cookie header value (e.g. `KBN_LOCALE=fr-FR; Path=/; ...`).
-   * Always present — the cookie is rewritten on every render.
-   */
-  setCookieHeader: string;
 }
 
 /**
- * Resolves the effective locale for a render using the following priority chain:
+ * Resolves the effective locale for a request using the following priority chain:
  *   1. User profile setting (when value is in `translationHashes`)
  *   2. KBN_LOCALE cookie (only when `allowLocaleCookie` is `true` and value is in `translationHashes`)
  *   3. Accept-Language header (serverless only; strict match against `configuredLocales`)
  *   4. `configLocale`
+ *
+ * Pure resolution only — writing the `KBN_LOCALE` cookie is handled separately
+ * by {@link buildKbnLocaleCookie}.
  */
 export const resolveLocale = (args: ResolveLocaleArgs): ResolveLocaleResult => {
   const {
@@ -69,18 +65,17 @@ export const resolveLocale = (args: ResolveLocaleArgs): ResolveLocaleResult => {
     configuredLocales,
     translationHashes,
     isServerless,
-    serverBasePath,
     allowLocaleCookie,
   } = args;
 
   if (userSettingLocale && translationHashes[userSettingLocale]) {
-    return finalize(userSettingLocale, request, serverBasePath);
+    return { locale: userSettingLocale };
   }
 
   if (allowLocaleCookie) {
     const cookieLocale = readCookie(getHeader(request, 'cookie'), KBN_LOCALE_COOKIE_NAME);
     if (cookieLocale && translationHashes[cookieLocale]) {
-      return finalize(cookieLocale, request, serverBasePath);
+      return { locale: cookieLocale };
     }
   }
 
@@ -92,11 +87,42 @@ export const resolveLocale = (args: ResolveLocaleArgs): ResolveLocaleResult => {
     // Match the profile/cookie paths above: only return a header-derived
     // locale if we can actually serve translations for it.
     if (headerLocale && translationHashes[headerLocale]) {
-      return finalize(headerLocale, request, serverBasePath);
+      return { locale: headerLocale };
     }
   }
 
-  return finalize(configLocale, request, serverBasePath);
+  return { locale: configLocale };
+};
+
+export interface BuildKbnLocaleCookieArgs {
+  /** The resolved locale to persist in the cookie. */
+  locale: string;
+  request: KibanaRequest;
+  /** Server-wide base path for the cookie's Path attribute. */
+  serverBasePath: string;
+}
+
+/**
+ * Builds the `Set-Cookie` header value (e.g. `KBN_LOCALE=fr-FR; Path=/; ...`)
+ * that persists the resolved locale in the browser. Only called by rendering,
+ * which rewrites the cookie on every render so it tracks the resolved locale.
+ */
+export const buildKbnLocaleCookie = ({
+  locale,
+  request,
+  serverBasePath,
+}: BuildKbnLocaleCookieArgs): string => {
+  const isHttps = request.url.protocol === 'https:';
+  const path = serverBasePath || '/';
+  const parts = [
+    `${KBN_LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}`,
+    `Path=${path}`,
+    `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
+    'SameSite=Lax',
+    'HttpOnly',
+  ];
+  if (isHttps) parts.push('Secure');
+  return parts.join('; ');
 };
 
 const getHeader = (request: KibanaRequest, name: string): string => {
@@ -172,25 +198,4 @@ export const pickFromAcceptLanguage = (
     if (match) return match;
   }
   return undefined;
-};
-
-const finalize = (
-  locale: string,
-  request: KibanaRequest,
-  serverBasePath: string
-): ResolveLocaleResult => {
-  const isHttps = request.url.protocol === 'https:';
-  const path = serverBasePath || '/';
-  const parts = [
-    `${KBN_LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}`,
-    `Path=${path}`,
-    `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
-    'SameSite=Lax',
-    'HttpOnly',
-  ];
-  if (isHttps) parts.push('Secure');
-  return {
-    locale,
-    setCookieHeader: parts.join('; '),
-  };
 };

--- a/src/core/packages/i18n/server-internal/tsconfig.json
+++ b/src/core/packages/i18n/server-internal/tsconfig.json
@@ -18,6 +18,7 @@
     "@kbn/core-i18n-server",
     "@kbn/core-http-server",
     "@kbn/core-http-server-internal",
+    "@kbn/core-user-settings-server-internal",
     "@kbn/repo-info",
     "@kbn/config-mocks",
     "@kbn/core-base-server-mocks",

--- a/src/core/packages/i18n/server-mocks/src/i18n_service.mock.ts
+++ b/src/core/packages/i18n/server-mocks/src/i18n_service.mock.ts
@@ -9,7 +9,7 @@
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { I18nService, InternalI18nServicePreboot } from '@kbn/core-i18n-server-internal';
-import type { I18nServiceSetup } from '@kbn/core-i18n-server';
+import type { I18nServiceSetup, I18nServiceStart, RequestI18nClient } from '@kbn/core-i18n-server';
 import { lazyObject } from '@kbn/lazy-object';
 
 const MOCK_TRANSLATION_HASHES: Record<string, string> = { en: 'MOCK_HASH' };
@@ -29,6 +29,33 @@ const createSetupContractMock = () => {
   });
 
   return { ...base, allowLocaleCookie: true } as jest.Mocked<I18nServiceSetup>;
+};
+
+const createRequestClientMock = (): jest.Mocked<RequestI18nClient> => {
+  const mock: jest.Mocked<RequestI18nClient> = {
+    getLocale: jest.fn(),
+    translate: jest.fn(),
+    formatList: jest.fn(),
+  };
+
+  mock.getLocale.mockResolvedValue('en');
+  // Fall back to the provided defaultMessage, like the real client.
+  mock.translate.mockImplementation(async (_id, args) =>
+    typeof args.defaultMessage === 'string' ? args.defaultMessage : ''
+  );
+  mock.formatList.mockResolvedValue('');
+
+  return mock;
+};
+
+const createStartContractMock = (): jest.Mocked<I18nServiceStart> => {
+  const mock: jest.Mocked<I18nServiceStart> = {
+    asScopedToRequest: jest.fn(),
+  };
+
+  mock.asScopedToRequest.mockImplementation(() => createRequestClientMock());
+
+  return mock;
 };
 
 const createInternalPrebootMock = () => {
@@ -53,6 +80,7 @@ const createMock = () => {
   const mock: jest.Mocked<I18nServiceContract> = lazyObject({
     preboot: jest.fn(),
     setup: jest.fn().mockResolvedValue(createSetupContractMock()),
+    start: jest.fn().mockReturnValue(createStartContractMock()),
   });
 
   return mock;
@@ -61,5 +89,7 @@ const createMock = () => {
 export const i18nServiceMock = {
   create: createMock,
   createSetupContract: createSetupContractMock,
+  createStartContract: createStartContractMock,
+  createRequestClient: createRequestClientMock,
   createInternalPrebootContract: createInternalPrebootMock,
 };

--- a/src/core/packages/i18n/server/index.ts
+++ b/src/core/packages/i18n/server/index.ts
@@ -7,4 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { I18nServiceSetup, I18nServiceStart, RequestI18nClient } from './src/types';
+export type {
+  I18nServiceSetup,
+  I18nServiceStart,
+  RequestI18nClient,
+  I18nRequestHandlerContext,
+} from './src/types';

--- a/src/core/packages/i18n/server/index.ts
+++ b/src/core/packages/i18n/server/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { I18nServiceSetup } from './src/types';
+export type { I18nServiceSetup, I18nServiceStart, RequestI18nClient } from './src/types';

--- a/src/core/packages/i18n/server/moon.yml
+++ b/src/core/packages/i18n/server/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: src/core/packages/i18n/server
 dependsOn:
   - '@kbn/i18n'
+  - '@kbn/core-http-server'
 tags:
   - shared-server
   - package

--- a/src/core/packages/i18n/server/src/types.ts
+++ b/src/core/packages/i18n/server/src/types.ts
@@ -42,6 +42,14 @@ export interface I18nServiceStart {
 }
 
 /**
+ * Core's `i18n` request handler context. Exposed as `context.core.i18n`, it
+ * translates strings into the locale resolved for the current request.
+ *
+ * @public
+ */
+export type I18nRequestHandlerContext = RequestI18nClient;
+
+/**
  * @public
  */
 export interface I18nServiceSetup {

--- a/src/core/packages/i18n/server/src/types.ts
+++ b/src/core/packages/i18n/server/src/types.ts
@@ -7,7 +7,39 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AvailableLocale } from '@kbn/i18n';
+import type { AvailableLocale, TranslateArguments } from '@kbn/i18n';
+import type { KibanaRequest } from '@kbn/core-http-server';
+
+/**
+ * A request-scoped i18n client that translates strings into the locale Kibana
+ * resolved for the current request (profile → cookie → Accept-Language on
+ * serverless → `i18n.defaultLocale`).
+ *
+ * The methods are asynchronous because resolving the locale for the request may
+ * require an awaited user-profile lookup on the first call. The resolved locale
+ * is memoised on the client, so subsequent calls do no additional I/O.
+ *
+ * @public
+ */
+export interface RequestI18nClient {
+  /** Returns the locale resolved for the current request. */
+  getLocale(): Promise<string>;
+  /** Translates a message by id into the request's resolved locale. */
+  translate(id: string, args: TranslateArguments): Promise<string>;
+  /** Formats a list of values using the request's resolved locale. */
+  formatList(type: 'conjunction' | 'disjunction' | 'unit', value: string[]): Promise<string>;
+}
+
+/**
+ * @public
+ */
+export interface I18nServiceStart {
+  /**
+   * Returns a {@link RequestI18nClient} scoped to the given request's resolved
+   * locale.
+   */
+  asScopedToRequest(request: KibanaRequest): RequestI18nClient;
+}
 
 /**
  * @public

--- a/src/core/packages/i18n/server/tsconfig.json
+++ b/src/core/packages/i18n/server/tsconfig.json
@@ -15,5 +15,6 @@
   ],
   "kbn_references": [
     "@kbn/i18n",
+    "@kbn/core-http-server",
   ]
 }

--- a/src/core/packages/lifecycle/server-internal/src/internal_core_start.ts
+++ b/src/core/packages/lifecycle/server-internal/src/internal_core_start.ts
@@ -16,6 +16,7 @@ import type { InternalElasticsearchServiceStart } from '@kbn/core-elasticsearch-
 import type { InternalExecutionContextStart } from '@kbn/core-execution-context-server-internal';
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-server';
 import type { InternalHttpServiceStart } from '@kbn/core-http-server-internal';
+import type { I18nServiceStart } from '@kbn/core-i18n-server';
 import type { InternalMetricsServiceStart } from '@kbn/core-metrics-server-internal';
 import type { InternalSavedObjectsServiceStart } from '@kbn/core-saved-objects-server-internal';
 import type { InternalUiSettingsServiceStart } from '@kbn/core-ui-settings-server-internal';
@@ -38,6 +39,7 @@ export interface InternalCoreStart {
   featureFlags: FeatureFlagsStart;
   docLinks: DocLinksServiceStart;
   http: InternalHttpServiceStart;
+  i18n: I18nServiceStart;
   metrics: InternalMetricsServiceStart;
   savedObjects: InternalSavedObjectsServiceStart;
   uiSettings: InternalUiSettingsServiceStart;

--- a/src/core/packages/lifecycle/server-mocks/src/internal_core_start.mock.ts
+++ b/src/core/packages/lifecycle/server-mocks/src/internal_core_start.mock.ts
@@ -14,6 +14,7 @@ import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { executionContextServiceMock } from '@kbn/core-execution-context-server-mocks';
 import { httpServiceMock } from '@kbn/core-http-server-mocks';
+import { i18nServiceMock } from '@kbn/core-i18n-server-mocks';
 import { metricsServiceMock } from '@kbn/core-metrics-server-mocks';
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
@@ -37,6 +38,7 @@ export function createInternalCoreStartMock() {
     elasticsearch: elasticsearchServiceMock.createInternalStart(),
     featureFlags: coreFeatureFlagsMock.createStart(),
     http: httpServiceMock.createInternalStartContract(),
+    i18n: i18nServiceMock.createStartContract(),
     metrics: metricsServiceMock.createInternalStartContract(),
     savedObjects: savedObjectsServiceMock.createInternalStartContract(),
     uiSettings: uiSettingsServiceMock.createStartContract(),

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -21,6 +21,7 @@ import type { UiPlugins } from '@kbn/core-plugins-base-server-internal';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import type { UserStorageServiceStart } from '@kbn/core-user-storage-server';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import { resolveLocale, buildKbnLocaleCookie } from '@kbn/core-i18n-server-internal';
 import {
   type DarkModeValue,
   type ThemeName,
@@ -48,7 +49,6 @@ import {
   getScriptPaths,
   getBrowserLoggingConfig,
 } from './render_utils';
-import { resolveLocale } from './resolve_locale';
 import { filterUiPlugins } from './filter_ui_plugins';
 import { getApmConfig } from './get_apm_config';
 import type { InternalRenderingRequestHandlerContext } from './internal_types';
@@ -291,14 +291,13 @@ export class RenderingService {
     const translationHashes = i18n.getTranslationHashes();
     const availableLocales = i18n.getAvailableLocales();
     const isServerless = this.coreContext.env.packageInfo.buildFlavor === 'serverless';
-    const { locale: effectiveLocale, setCookieHeader } = resolveLocale({
+    const { locale: effectiveLocale } = resolveLocale({
       request,
       userSettingLocale,
       configLocale,
       configuredLocales: availableLocales.map((entry) => entry.id),
       translationHashes,
       isServerless,
-      serverBasePath,
       allowLocaleCookie: i18n.allowLocaleCookie,
     });
     // When the effective locale is English, the browser's pre-allocated `intl`
@@ -415,7 +414,7 @@ export class RenderingService {
     };
 
     const cookieHeaders: Record<string, string> = i18n.allowLocaleCookie
-      ? { 'set-cookie': setCookieHeader }
+      ? { 'set-cookie': buildKbnLocaleCookie({ locale: effectiveLocale, request, serverBasePath }) }
       : {};
 
     return {

--- a/src/core/packages/root/server-internal/src/server.ts
+++ b/src/core/packages/root/server-internal/src/server.ts
@@ -107,6 +107,7 @@ export class Server {
   private readonly docLinks: DocLinksService;
   private readonly customBranding: CustomBrandingService;
   private readonly userSettingsService: UserSettingsService;
+  private userSettingsServiceSetup?: ReturnType<UserSettingsService['setup']>;
   private readonly security: SecurityService;
   private readonly userProfile: UserProfileService;
   private readonly injection: CoreInjectionService;
@@ -429,7 +430,8 @@ export class Server {
     });
 
     const customBrandingSetup = this.customBranding.setup();
-    const userSettingsServiceSetup = this.userSettingsService.setup();
+    const userSettingsServiceSetup = (this.userSettingsServiceSetup =
+      this.userSettingsService.setup());
     const featureFlagsSetup = this.featureFlags.setup({
       http: httpSetup,
     });
@@ -624,6 +626,12 @@ export class Server {
       userStorage: userStorageStart,
     });
 
+    if (!this.userSettingsServiceSetup) {
+      // #setup always runs before #start, so this should be unreachable.
+      throw new Error('UserSettingsService#setup must run before Server#start');
+    }
+    const i18nServiceStart = this.i18n.start({ userSettings: this.userSettingsServiceSetup });
+
     this.coreStart = {
       analytics: analyticsStart,
       capabilities: capabilitiesStart,
@@ -633,6 +641,7 @@ export class Server {
       executionContext: executionContextStart,
       featureFlags: featureFlagsStart,
       http: httpStart,
+      i18n: i18nServiceStart,
       metrics: metricsStart,
       savedObjects: savedObjectsStart,
       uiSettings: uiSettingsStart,

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -22,6 +22,7 @@ import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 import { coreLifecycleMock, coreInternalLifecycleMock } from '@kbn/core-lifecycle-server-mocks';
 import { securityServiceMock } from '@kbn/core-security-server-mocks';
 import { userProfileServiceMock } from '@kbn/core-user-profile-server-mocks';
+import { i18nServiceMock } from '@kbn/core-i18n-server-mocks';
 import type { SharedGlobalConfig, PluginInitializerContext } from '@kbn/core-plugins-server';
 import { coreFeatureFlagsMock } from '@kbn/core-feature-flags-server-mocks';
 
@@ -142,6 +143,7 @@ function createCoreRequestHandlerContextMock() {
     },
     security: securityServiceMock.createRequestHandlerContext(),
     userProfile: userProfileServiceMock.createRequestHandlerContext(),
+    i18n: i18nServiceMock.createRequestClient(),
   };
 }
 

--- a/src/platform/packages/shared/kbn-i18n/index.ts
+++ b/src/platform/packages/shared/kbn-i18n/index.ts
@@ -51,7 +51,8 @@ const i18nLoader = {
 
 export type { Translation, TranslationInput } from './src/translation';
 export type { Formats, TranslateArguments } from './src/core';
-export { EN_LOCALE } from './src/core';
+export { EN_LOCALE, createScopedTranslator } from './src/core';
+export type { ScopedTranslator } from './src/core';
 export {
   SUPPORTED_LOCALE_IDS,
   getLocaleLabel,

--- a/src/platform/packages/shared/kbn-i18n/src/core/formatter.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/formatter.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createIntl, createIntlCache } from '@formatjs/intl';
+import type { Formatters, IntlConfig, IntlShape, MessageDescriptor } from '@formatjs/intl';
+
+import type { TranslationInput } from '../translation';
+import { handleIntlError } from './error_handler';
+import { defaultEnFormats } from './formats';
+import type { FormatXMLElementFn, PrimitiveType } from './types';
+
+export const EN_LOCALE = 'en';
+
+/**
+ * Normalizes locale to make it consistent with IntlMessageFormat locales
+ * @param locale
+ */
+const normalizeLocale = (locale: string): string => {
+  return locale.toLowerCase();
+};
+
+type MessageFormatters = Pick<
+  Formatters,
+  'getNumberFormat' | 'getDateTimeFormat' | 'getPluralRules'
+>;
+
+export interface TranslateArguments {
+  /**
+   * Will be used unless translation was successful
+   */
+  defaultMessage: MessageDescriptor['defaultMessage'];
+  /**
+   * Message description, used by translators and other devs to understand the message context.
+   */
+  description?: MessageDescriptor['description'];
+  /**
+   * values to pass into translation
+   */
+  values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>;
+  /**
+   * Whether to treat HTML/XML tags as string literal
+   * instead of parsing them as tag token.
+   * When this is false we only allow simple tags without
+   * any attributes
+   */
+  ignoreTag?: boolean;
+  /**
+   * Custom formatters to override the default intl formatters
+   */
+  formatters?: MessageFormatters;
+}
+
+/**
+ * Builds an isolated `IntlShape` for the given translation input. Mirrors the
+ * configuration used by the `@kbn/i18n` singleton, but returns a fresh instance
+ * with its own cache so callers can format messages for a specific locale
+ * without mutating shared state.
+ */
+export const createTranslationIntl = (newTranslation: TranslationInput): IntlShape<string> => {
+  if (!newTranslation.locale || typeof newTranslation.locale !== 'string') {
+    throw new Error('[I18n] A `locale` must be a non-empty string to add messages.');
+  }
+
+  const config: IntlConfig<string> = {
+    locale: normalizeLocale(newTranslation.locale),
+    messages: newTranslation.messages,
+    defaultFormats: defaultEnFormats,
+    defaultLocale: EN_LOCALE,
+    onError: handleIntlError,
+  };
+
+  // formatJS differentiates between `formats: undefined` and unset `formats`.
+  if (newTranslation.formats) {
+    config.formats = newTranslation.formats;
+  }
+
+  const cache = createIntlCache();
+  return createIntl(config, cache);
+};
+
+/**
+ * Translates a message by id against the supplied `intl` instance.
+ * @param intl - the formatter instance to use
+ * @param id - translation id to be translated
+ * @param [options] - see {@link TranslateArguments}
+ */
+export const formatMessage = (
+  intl: IntlShape<string>,
+  id: string,
+  { values = {}, description, defaultMessage, ignoreTag, formatters }: TranslateArguments
+): string => {
+  if (!id || typeof id !== 'string') {
+    throw new Error('[I18n] An `id` must be a non-empty string to translate a message.');
+  }
+
+  try {
+    if (!defaultMessage) {
+      throw new Error('Missing `defaultMessage`.');
+    }
+
+    return intl.formatMessage(
+      {
+        id,
+        defaultMessage,
+        description,
+      },
+      values,
+      // @ts-expect-error - There’s a small mismatch between @formatjs type and Intl API that only applies to the date function, we’re ignoring that
+      { ignoreTag, shouldParseSkeletons: true, formatters }
+    );
+  } catch (e) {
+    throw new Error(`[I18n] Error formatting the default message for: "${id}".\n${e}`);
+  }
+};
+
+/**
+ * Formats a list of values using the supplied `intl` instance.
+ * @param intl - the formatter instance to use
+ * @param type - The type of list formatting (e.g., 'conjunction', 'disjunction', 'unit').
+ * @param value - The array of string values to format.
+ * @returns The formatted list string.
+ */
+export const formatList = (
+  intl: IntlShape<string>,
+  type: 'conjunction' | 'disjunction' | 'unit',
+  value: string[]
+): string => {
+  try {
+    return intl.formatList(value, { type });
+  } catch (e) {
+    throw new Error(`[I18n] Error formatting list ${JSON.stringify(value)}: ${e}`);
+  }
+};

--- a/src/platform/packages/shared/kbn-i18n/src/core/i18n.test.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/i18n.test.ts
@@ -11,6 +11,7 @@ import type * as i18nModule from './i18n';
 import type { Translation, TranslationInput } from '../translation';
 import type { Formats } from './formats';
 import { defaultEnFormats } from './formats';
+import { createScopedTranslator } from './scoped_translator';
 
 const createExpectedTranslations = (
   locale: string,
@@ -756,5 +757,75 @@ describe('i18n.initDefault', () => {
       i18n.initDefault();
     }).not.toThrow();
     expect(i18n.getIsInitialized()).toBe(true);
+  });
+});
+
+// Scoped translators own their own `intl` instance, so they translate
+// successful messages without depending on the singleton's init lifecycle or
+// the error-throwing behavior gated by the skipped block above.
+describe('createScopedTranslator', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('translates a message using the provided locale messages', () => {
+    const translator = createScopedTranslator({
+      locale: 'fr',
+      messages: { 'a.b.c': 'Bonjour {name}' },
+    });
+
+    expect(
+      translator.translate('a.b.c', {
+        defaultMessage: 'Hello {name}',
+        values: { name: 'Marie' },
+      })
+    ).toBe('Bonjour Marie');
+  });
+
+  test('falls back to the defaultMessage when the id is missing', () => {
+    const translator = createScopedTranslator({ locale: 'fr', messages: {} });
+
+    expect(translator.translate('missing.id', { defaultMessage: 'Hello' })).toBe('Hello');
+  });
+
+  test('reports the normalized locale', () => {
+    const translator = createScopedTranslator({ locale: 'fr-FR', messages: {} });
+
+    expect(translator.getLocale()).toBe('fr-fr');
+  });
+
+  test('throws if the locale is empty', () => {
+    expect(() =>
+      createScopedTranslator({ locale: '', messages: {} })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"[I18n] A \`locale\` must be a non-empty string to add messages."`
+    );
+  });
+
+  test('keeps messages isolated between two translators', () => {
+    const fr = createScopedTranslator({ locale: 'fr', messages: { greeting: 'Bonjour' } });
+    const ja = createScopedTranslator({ locale: 'ja', messages: { greeting: 'こんにちは' } });
+
+    expect(fr.translate('greeting', { defaultMessage: 'Hello' })).toBe('Bonjour');
+    expect(ja.translate('greeting', { defaultMessage: 'Hello' })).toBe('こんにちは');
+    // Interleave calls to confirm neither instance bleeds into the other.
+    expect(fr.translate('greeting', { defaultMessage: 'Hello' })).toBe('Bonjour');
+    expect(ja.translate('greeting', { defaultMessage: 'Hello' })).toBe('こんにちは');
+  });
+
+  test('formats a list using the translator locale', () => {
+    const translator = createScopedTranslator({ locale: 'en', messages: {} });
+
+    expect(translator.formatList('conjunction', ['a', 'b', 'c'])).toBe('a, b, and c');
+  });
+
+  test('does not affect the i18n singleton', () => {
+    const i18n = jest.requireActual('./i18n') as typeof i18nModule;
+
+    createScopedTranslator({ locale: 'fr', messages: { greeting: 'Bonjour' } });
+
+    expect(i18n.getLocale()).toBe('en');
+    expect(i18n.getTranslation().messages).toEqual({});
   });
 });

--- a/src/platform/packages/shared/kbn-i18n/src/core/i18n.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/i18n.ts
@@ -7,15 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createIntl, createIntlCache } from '@formatjs/intl';
-import type { MessageDescriptor, Formatters, IntlConfig, IntlShape } from '@formatjs/intl';
-import { handleIntlError } from './error_handler';
+import { createIntl } from '@formatjs/intl';
+import type { IntlShape } from '@formatjs/intl';
 
 import type { Translation, TranslationInput } from '../translation';
 import { defaultEnFormats } from './formats';
-import type { FormatXMLElementFn, PrimitiveType } from './types';
+import {
+  EN_LOCALE,
+  createTranslationIntl,
+  formatList as formatListWithIntl,
+  formatMessage as formatMessageWithIntl,
+} from './formatter';
+import type { TranslateArguments } from './formatter';
 
-export const EN_LOCALE = 'en';
+export { EN_LOCALE } from './formatter';
+export type { TranslateArguments } from './formatter';
+
 const defaultLocale = EN_LOCALE;
 
 /**
@@ -26,6 +33,9 @@ const defaultLocale = EN_LOCALE;
  * This pattern has several limitations and can cause unexpected bugs. The main limitation
  * is that we cannot server multiple locales on the server side based on the user requested
  * locale.
+ *
+ * For request-scoped, per-locale translation that avoids this shared mutable
+ * state, use `createScopedTranslator` instead.
  */
 let intl: IntlShape<string>;
 let isInitialized = false;
@@ -48,36 +58,12 @@ intl = createIntl({
 export const getIsInitialized = () => {
   return isInitialized;
 };
-/**
- * Normalizes locale to make it consistent with IntlMessageFormat locales
- * @param locale
- */
-function normalizeLocale(locale: string) {
-  return locale.toLowerCase();
-}
 
 /**
  * Provides a way to register translations with the engine
  */
 export function activateTranslation(newTranslation: TranslationInput) {
-  if (!newTranslation.locale || typeof newTranslation.locale !== 'string') {
-    throw new Error('[I18n] A `locale` must be a non-empty string to add messages.');
-  }
-  const config: IntlConfig<string> = {
-    locale: normalizeLocale(newTranslation.locale),
-    messages: newTranslation.messages,
-    defaultFormats: defaultEnFormats,
-    defaultLocale,
-    onError: handleIntlError,
-  };
-
-  // formatJS differentiates between `formats: undefined` and unset `formats`.
-  if (newTranslation.formats) {
-    config.formats = newTranslation.formats;
-  }
-
-  const cache = createIntlCache();
-  intl = createIntl(config, cache);
+  intl = createTranslationIntl(newTranslation);
 }
 
 /**
@@ -101,37 +87,6 @@ export function getLocale() {
   return intl.locale;
 }
 
-type MessageFormatters = Pick<
-  Formatters,
-  'getNumberFormat' | 'getDateTimeFormat' | 'getPluralRules'
->;
-
-export interface TranslateArguments {
-  /**
-   * Will be used unless translation was successful
-   */
-  defaultMessage: MessageDescriptor['defaultMessage'];
-  /**
-   * Message description, used by translators and other devs to understand the message context.
-   */
-  description?: MessageDescriptor['description'];
-  /**
-   * values to pass into translation
-   */
-  values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>;
-  /**
-   * Whether to treat HTML/XML tags as string literal
-   * instead of parsing them as tag token.
-   * When this is false we only allow simple tags without
-   * any attributes
-   */
-  ignoreTag?: boolean;
-  /**
-   * Custom formatters to override the default intl formatters
-   */
-  formatters?: MessageFormatters;
-}
-
 /**
  * Translate message by id
  * @param id - translation id to be translated
@@ -142,32 +97,8 @@ export interface TranslateArguments {
  * @param [options.ignoreTag] - Whether to treat HTML/XML tags as string literal instead of parsing them as tag token. When this is false we only allow simple tags without any attributes
  * @param [options.formatters] - Custom formatters to override the default intl formatters
  */
-export function translate(
-  id: string,
-  { values = {}, description, defaultMessage, ignoreTag, formatters }: TranslateArguments
-): string {
-  if (!id || typeof id !== 'string') {
-    throw new Error('[I18n] An `id` must be a non-empty string to translate a message.');
-  }
-
-  try {
-    if (!defaultMessage) {
-      throw new Error('Missing `defaultMessage`.');
-    }
-
-    return intl.formatMessage(
-      {
-        id,
-        defaultMessage,
-        description,
-      },
-      values,
-      // @ts-expect-error - There’s a small mismatch between @formatjs type and Intl API that only applies to the date function, we’re ignoring that
-      { ignoreTag, shouldParseSkeletons: true, formatters }
-    );
-  } catch (e) {
-    throw new Error(`[I18n] Error formatting the default message for: "${id}".\n${e}`);
-  }
+export function translate(id: string, args: TranslateArguments): string {
+  return formatMessageWithIntl(intl, id, args);
 }
 
 /**
@@ -177,11 +108,7 @@ export function translate(
  * @returns The formatted list string.
  */
 export function formatList(type: 'conjunction' | 'disjunction' | 'unit', value: string[]): string {
-  try {
-    return intl.formatList(value, { type });
-  } catch (e) {
-    throw new Error(`[I18n] Error formatting list ${JSON.stringify(value)}: ${e}`);
-  }
+  return formatListWithIntl(intl, type, value);
 }
 
 /**

--- a/src/platform/packages/shared/kbn-i18n/src/core/index.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/index.ts
@@ -21,4 +21,6 @@ export {
   getIsInitialized,
 } from './i18n';
 export type { TranslateArguments } from './i18n';
+export { createScopedTranslator } from './scoped_translator';
+export type { ScopedTranslator } from './scoped_translator';
 export { handleIntlError } from './error_handler';

--- a/src/platform/packages/shared/kbn-i18n/src/core/scoped_translator.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/scoped_translator.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TranslationInput } from '../translation';
+import {
+  createTranslationIntl,
+  formatList as formatListWithIntl,
+  formatMessage as formatMessageWithIntl,
+} from './formatter';
+import type { TranslateArguments } from './formatter';
+
+/**
+ * A request-scoped translator bound to a single locale. Unlike the `@kbn/i18n`
+ * singleton, each instance owns its own `intl` formatter, so multiple locales
+ * can be translated concurrently without any shared mutable state.
+ */
+export interface ScopedTranslator {
+  /** Returns the (normalized) locale this translator was built for. */
+  getLocale(): string;
+  /** Translates a message by id. See {@link TranslateArguments}. */
+  translate(id: string, args: TranslateArguments): string;
+  /** Formats a list of values using this translator's locale. */
+  formatList(type: 'conjunction' | 'disjunction' | 'unit', value: string[]): string;
+}
+
+/**
+ * Builds a {@link ScopedTranslator} for the provided translation input. The
+ * underlying `intl` instance is private to the returned translator — building
+ * or using a scoped translator never mutates the `@kbn/i18n` singleton.
+ */
+export const createScopedTranslator = (translationInput: TranslationInput): ScopedTranslator => {
+  const intl = createTranslationIntl(translationInput);
+
+  return {
+    getLocale: () => intl.locale,
+    translate: (id, args) => formatMessageWithIntl(intl, id, args),
+    formatList: (type, value) => formatListWithIntl(intl, type, value),
+  };
+};

--- a/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.test.ts
@@ -21,7 +21,7 @@ import { sessionMock } from '../../session_management/session.mock';
 import type { SecurityRequestHandlerContext, SecurityRouter } from '../../types';
 import type { UserProfileServiceStartInternal } from '../../user_profile';
 import { userProfileServiceMock } from '../../user_profile/user_profile_service.mock';
-import { routeDefinitionParamsMock } from '../index.mock';
+import { routeDefinitionParamsMock, securityRequestHandlerContextMock } from '../index.mock';
 
 function getMockContext() {
   return {
@@ -443,6 +443,34 @@ describe('Update profile routes', () => {
       ).resolves.toEqual(expect.objectContaining({ status: 200, payload: undefined }));
 
       expect(userProfileService.update).toBeCalledTimes(1);
+    });
+
+    it('rejects a locale that is not enabled with a request-scoped translated error.', async () => {
+      session.get.mockResolvedValue({
+        error: null,
+        value: sessionMock.createValue({ userProfileId: 'u_some_id' }),
+      });
+      authc.getCurrentUser.mockReturnValue(mockAuthenticatedUser());
+
+      const context = securityRequestHandlerContextMock.create();
+      const { i18n: i18nClient } = await context.core;
+
+      await expect(
+        routeHandler(
+          context,
+          httpServerMock.createKibanaRequest({ body: { userSettings: { locale: 'fr-FR' } } }),
+          kibanaResponseFactory
+        )
+      ).resolves.toEqual(expect.objectContaining({ status: 400 }));
+
+      expect(i18nClient.translate).toHaveBeenCalledWith(
+        'xpack.security.userProfile.localeNotEnabled',
+        {
+          defaultMessage: 'Locale "{locale}" is not enabled for this deployment',
+          values: { locale: 'fr-FR' },
+        }
+      );
+      expect(userProfileService.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.ts
@@ -152,8 +152,12 @@ export function defineUpdateUserProfileDataRoute({
       if (requestedLocale) {
         const allowedLocales = i18nService.getLocales();
         if (!allowedLocales.includes(requestedLocale)) {
+          const { i18n: i18nClient } = await context.core;
           return response.customError({
-            body: `Locale "${requestedLocale}" is not enabled for this deployment`,
+            body: await i18nClient.translate('xpack.security.userProfile.localeNotEnabled', {
+              defaultMessage: 'Locale "{locale}" is not enabled for this deployment',
+              values: { locale: requestedLocale },
+            }),
             statusCode: 400,
           });
         }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/3497

## Summary

* Request-scoped server-side i18n: a `context.core.i18n.translate(...)` client that resolves each user's locale (profile → cookie → Accept-Language on serverless → default) and translates HTTP responses accordingly.
* `@kbn/i18n` gains a non-singleton `createScopedTranslator`, leaving the existing singleton untouched.
* `I18nService.start()` lazily builds and caches one translator per requested locale, reusing boot-loaded default messages and the loader's file cache.
* Locale resolution is split out of rendering into a shared, pure `resolveLocale`.
* A new route-handler context plumbs the per-request client through core.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



