### PR TITLE
[Cloud Security][Graph API] Add maxSize to graph schema array params

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { graphRequestSchema } from './v1';
+
+const baseQuery = {
+  start: 'now-1d',
+  end: 'now',
+};
+
+describe('graph request schema', () => {
+  describe('originEventIds maxSize (1000)', () => {
+    const buildOriginEventIds = (length: number) =>
+      Array.from({ length }, (_, index) => ({ id: `event-${index}`, isAlert: false }));
+
+    it('accepts up to 1000 originEventIds', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, originEventIds: buildOriginEventIds(1000) },
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects more than 1000 originEventIds', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, originEventIds: buildOriginEventIds(1001) },
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('entityIds maxSize (5000)', () => {
+    const buildEntityIds = (length: number) =>
+      Array.from({ length }, (_, index) => ({ id: `entity-${index}`, isOrigin: false }));
+
+    it('accepts up to 5000 entityIds', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, entityIds: buildEntityIds(5000) },
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects more than 5000 entityIds', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, entityIds: buildEntityIds(5001) },
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('indexPatterns maxSize (100)', () => {
+    const buildIndexPatterns = (length: number) =>
+      Array.from({ length }, (_, index) => `logs-${index}-*`);
+
+    it('accepts up to 100 indexPatterns', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, indexPatterns: buildIndexPatterns(100) },
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects more than 100 indexPatterns', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, indexPatterns: buildIndexPatterns(101) },
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('esQuery bool clause maxSize (100)', () => {
+    const buildClauses = (length: number) =>
+      Array.from({ length }, (_, index) => ({
+        match_phrase: { 'event.action': `action-${index}` },
+      }));
+
+    it('accepts up to 100 clauses per bool section', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, esQuery: { bool: { filter: buildClauses(100) } } },
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects more than 100 clauses in a bool section', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, esQuery: { bool: { must: buildClauses(101) } } },
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('pinnedIds maxSize (1024)', () => {
+    const buildPinnedIds = (length: number) => Array.from({ length }, (_, index) => `id-${index}`);
+
+    it('accepts up to 1024 pinnedIds', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, pinnedIds: buildPinnedIds(1024) },
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects more than 1024 pinnedIds', () => {
+      expect(() =>
+        graphRequestSchema.validate({
+          query: { ...baseQuery, pinnedIds: buildPinnedIds(1025) },
+        })
+      ).toThrow();
+    });
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph/v1.ts
@@ -9,7 +9,66 @@ import { schema } from '@kbn/config-schema';
 
 export const INDEX_PATTERN_REGEX = /^[^A-Z^\\/?"<>|\s#,]+$/;
 
+// ---------------------------------------------------------------------------
+// Array size ceilings (`maxSize`) for `schema.arrayOf` — DoS protection.
+// Every value is derived from the ES|QL execution limits of the graph queries so
+// validation never rejects an input/output the queries can legitimately produce,
+// while still rejecting abusive payloads (flagged by GitHub Advanced Security as
+// `js/kibana/unbounded-array-in-schema`).
+// ---------------------------------------------------------------------------
+
+// ES|QL caps a single query result at 10,000 rows by default
+// (`esql.query.result_truncation_max_size`). This is the hard upper bound for any
+// collection assembled from one query result.
+const ESQL_MAX_RESULT_ROWS = 10_000;
+
+// The events graph query applies an explicit `LIMIT 1000`, and queries without an
+// explicit LIMIT (e.g. relationships) fall back to the ES|QL default of 1,000
+// rows. This bounds how many event/alert rows — and the IPs/country codes
+// aggregated from them — can feed a single graph.
+const ESQL_DEFAULT_ROW_LIMIT = 1_000;
+
+// Entity IDs accepted for relationship/enrichment lookups. Enrichment is chunked
+// at 1,000 IDs per ES|QL query (`fetch_entity_enrichment.ts`); 5,000 caps the
+// request at five chunks.
+const ENTITY_IDS_MAX_SIZE = 5_000;
+
+// Origin event IDs that seed graph traversal — bounded by the number of events a
+// single graph can display (the events query `LIMIT 1000`).
+const ORIGIN_EVENT_IDS_MAX_SIZE = ESQL_DEFAULT_ROW_LIMIT;
+
+// Pinned node IDs preserved across graph refreshes.
 const PINNED_IDS_MAX_SIZE = 1024;
+
+// Index patterns fanned into a single `FROM idx1,idx2,...` ES|QL source.
+export const INDEX_PATTERNS_MAX_SIZE = 100;
+
+// Boolean clauses per section (filter/must/should/must_not) of the user ES query.
+const ES_QUERY_CLAUSES_MAX_SIZE = 100;
+
+// IPs aggregated onto a single node/entity/event via `VALUES()`, bounded by the
+// default ES|QL row limit of contributing event rows.
+export const IPS_MAX_SIZE = ESQL_DEFAULT_ROW_LIMIT;
+
+// ISO 3166-1 alpha-2 country codes (~249 currently assigned); 250 covers the set.
+export const COUNTRY_CODES_MAX_SIZE = 250;
+
+// Documents aggregated onto a single graph node, bounded by the events query limit.
+const DOCUMENTS_DATA_MAX_SIZE = ESQL_DEFAULT_ROW_LIMIT;
+
+// Nodes/edges in a graph response. The events (`LIMIT 1000`) and relationship
+// (default 1,000) queries each emit at most `ESQL_DEFAULT_ROW_LIMIT` rows, each
+// contributing a bounded number of node/edge references; the ES|QL hard cap of
+// 10,000 rows is a safe ceiling for the deduplicated result.
+const GRAPH_NODES_MAX_SIZE = ESQL_MAX_RESULT_ROWS;
+const GRAPH_EDGES_MAX_SIZE = ESQL_MAX_RESULT_ROWS;
+
+// Informational status messages (currently only `REACHED_NODES_LIMIT`).
+const GRAPH_MESSAGES_MAX_SIZE = 100;
+
+// Detail endpoints (events/entities) are server-paginated; a response page holds
+// at most this many records (matches the `page.size` ceiling).
+export const DETAIL_PAGE_SIZE_MAX = 100;
 
 /**
  * CPS project routing expressions accepted by the Graph API.
@@ -38,7 +97,9 @@ export const graphRequestSchema = schema.object({
     pinnedIds: schema.maybe(schema.arrayOf(schema.string(), { maxSize: PINNED_IDS_MAX_SIZE })),
     // Origin event IDs - optional, may be empty when opening from entity flyout
     originEventIds: schema.maybe(
-      schema.arrayOf(schema.object({ id: schema.string(), isAlert: schema.boolean() }))
+      schema.arrayOf(schema.object({ id: schema.string(), isAlert: schema.boolean() }), {
+        maxSize: ORIGIN_EVENT_IDS_MAX_SIZE,
+      })
     ),
     // TODO: use zod for range validation instead of config schema
     start: schema.oneOf([schema.number(), schema.string()]),
@@ -53,21 +114,37 @@ export const graphRequestSchema = schema.object({
             }
           },
         }),
-        { minSize: 1 }
+        { minSize: 1, maxSize: INDEX_PATTERNS_MAX_SIZE }
       )
     ),
     esQuery: schema.maybe(
       schema.object({
         bool: schema.object({
-          filter: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
-          must: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
-          should: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
-          must_not: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
+          filter: schema.maybe(
+            schema.arrayOf(schema.object({}, { unknowns: 'allow' }), {
+              maxSize: ES_QUERY_CLAUSES_MAX_SIZE,
+            })
+          ),
+          must: schema.maybe(
+            schema.arrayOf(schema.object({}, { unknowns: 'allow' }), {
+              maxSize: ES_QUERY_CLAUSES_MAX_SIZE,
+            })
+          ),
+          should: schema.maybe(
+            schema.arrayOf(schema.object({}, { unknowns: 'allow' }), {
+              maxSize: ES_QUERY_CLAUSES_MAX_SIZE,
+            })
+          ),
+          must_not: schema.maybe(
+            schema.arrayOf(schema.object({}, { unknowns: 'allow' }), {
+              maxSize: ES_QUERY_CLAUSES_MAX_SIZE,
+            })
+          ),
         }),
       })
     ),
     // Entity IDs for fetching relationships from entity store (optional, may be empty when opening from events flyout)
-    entityIds: schema.maybe(schema.arrayOf(entityIdSchema)),
+    entityIds: schema.maybe(schema.arrayOf(entityIdSchema, { maxSize: ENTITY_IDS_MAX_SIZE })),
     // CPS project routing applied only to logs/events queries.
     // Alerts and entity-store enrichment are always pinned to the origin project.
     projectRouting: schema.maybe(
@@ -94,7 +171,7 @@ export const entitySchema = schema.object({
   ),
   host: schema.maybe(
     schema.object({
-      ip: schema.maybe(schema.arrayOf(schema.string())),
+      ip: schema.maybe(schema.arrayOf(schema.string(), { maxSize: IPS_MAX_SIZE })),
     })
   ),
   availableInEntityStore: schema.maybe(schema.boolean()),
@@ -132,10 +209,15 @@ export const graphResponseSchema = () =>
         groupNodeDataSchema,
         labelNodeDataSchema,
         relationshipNodeDataSchema,
-      ])
+      ]),
+      { maxSize: GRAPH_NODES_MAX_SIZE }
     ),
-    edges: schema.arrayOf(edgeDataSchema),
-    messages: schema.maybe(schema.arrayOf(schema.oneOf([schema.literal(REACHED_NODES_LIMIT)]))),
+    edges: schema.arrayOf(edgeDataSchema, { maxSize: GRAPH_EDGES_MAX_SIZE }),
+    messages: schema.maybe(
+      schema.arrayOf(schema.oneOf([schema.literal(REACHED_NODES_LIMIT)]), {
+        maxSize: GRAPH_MESSAGES_MAX_SIZE,
+      })
+    ),
   });
 
 export const nodeColorSchema = schema.oneOf([
@@ -181,9 +263,13 @@ export const entityNodeDataSchema = schema.allOf([
     ]),
     tag: schema.maybe(schema.string()),
     count: schema.maybe(schema.number()),
-    ips: schema.maybe(schema.arrayOf(schema.string())),
-    countryCodes: schema.maybe(schema.arrayOf(schema.string())),
-    documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
+    ips: schema.maybe(schema.arrayOf(schema.string(), { maxSize: IPS_MAX_SIZE })),
+    countryCodes: schema.maybe(
+      schema.arrayOf(schema.string(), { maxSize: COUNTRY_CODES_MAX_SIZE })
+    ),
+    documentsData: schema.maybe(
+      schema.arrayOf(nodeDocumentDataSchema, { maxSize: DOCUMENTS_DATA_MAX_SIZE })
+    ),
   }),
 ]);
 
@@ -200,12 +286,16 @@ export const labelNodeDataSchema = schema.allOf([
     shape: schema.literal('label'),
     parentId: schema.maybe(schema.string()),
     color: nodeColorSchema,
-    ips: schema.maybe(schema.arrayOf(schema.string())),
+    ips: schema.maybe(schema.arrayOf(schema.string(), { maxSize: IPS_MAX_SIZE })),
     count: schema.maybe(schema.number()),
     uniqueEventsCount: schema.maybe(schema.number()),
     uniqueAlertsCount: schema.maybe(schema.number()),
-    countryCodes: schema.maybe(schema.arrayOf(schema.string())),
-    documentsData: schema.maybe(schema.arrayOf(nodeDocumentDataSchema)),
+    countryCodes: schema.maybe(
+      schema.arrayOf(schema.string(), { maxSize: COUNTRY_CODES_MAX_SIZE })
+    ),
+    documentsData: schema.maybe(
+      schema.arrayOf(nodeDocumentDataSchema, { maxSize: DOCUMENTS_DATA_MAX_SIZE })
+    ),
   }),
 ]);
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_entities/v1.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_entities/v1.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { entitiesRequestSchema } from './v1';
+import { entitiesRequestSchema, entityItemSchema } from './v1';
 
 describe('graph entities schema', () => {
   it('accepts a page size up to 100', () => {
@@ -62,5 +62,71 @@ describe('graph entities schema', () => {
         },
       })
     ).toThrow();
+  });
+
+  it('accepts up to 100 index patterns', () => {
+    const indexPatterns = Array.from({ length: 100 }, (_, index) => `logs-${index}-*`);
+
+    expect(() =>
+      entitiesRequestSchema.validate({
+        page: { index: 0, size: 10 },
+        query: {
+          entityIds: ['entity-1'],
+          start: 'now-1d',
+          end: 'now',
+          indexPatterns,
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects more than 100 index patterns', () => {
+    const indexPatterns = Array.from({ length: 101 }, (_, index) => `logs-${index}-*`);
+
+    expect(() =>
+      entitiesRequestSchema.validate({
+        page: { index: 0, size: 10 },
+        query: {
+          entityIds: ['entity-1'],
+          start: 'now-1d',
+          end: 'now',
+          indexPatterns,
+        },
+      })
+    ).toThrow();
+  });
+
+  describe('entityItemSchema', () => {
+    it('accepts up to 1000 ips and rejects more', () => {
+      expect(() =>
+        entityItemSchema.validate({
+          id: 'entity-1',
+          ips: Array.from({ length: 1000 }, (_, index) => `10.0.0.${index}`),
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        entityItemSchema.validate({
+          id: 'entity-1',
+          ips: Array.from({ length: 1001 }, (_, index) => `10.0.0.${index}`),
+        })
+      ).toThrow();
+    });
+
+    it('accepts up to 250 country codes and rejects more', () => {
+      expect(() =>
+        entityItemSchema.validate({
+          id: 'entity-1',
+          countryCodes: Array.from({ length: 250 }, (_, index) => `c-${index}`),
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        entityItemSchema.validate({
+          id: 'entity-1',
+          countryCodes: Array.from({ length: 251 }, (_, index) => `c-${index}`),
+        })
+      ).toThrow();
+    });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_entities/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_entities/v1.ts
@@ -6,7 +6,13 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { INDEX_PATTERN_REGEX } from '../graph/v1';
+import {
+  COUNTRY_CODES_MAX_SIZE,
+  DETAIL_PAGE_SIZE_MAX,
+  INDEX_PATTERN_REGEX,
+  INDEX_PATTERNS_MAX_SIZE,
+  IPS_MAX_SIZE,
+} from '../graph/v1';
 
 // ============================================
 // ENTITIES ENDPOINT: /internal/cloud_security_posture/graph/entities
@@ -28,14 +34,14 @@ export const entityItemSchema = schema.object({
       ip: schema.maybe(schema.string()),
     })
   ),
-  ips: schema.maybe(schema.arrayOf(schema.string())),
-  countryCodes: schema.maybe(schema.arrayOf(schema.string())),
+  ips: schema.maybe(schema.arrayOf(schema.string(), { maxSize: IPS_MAX_SIZE })),
+  countryCodes: schema.maybe(schema.arrayOf(schema.string(), { maxSize: COUNTRY_CODES_MAX_SIZE })),
 });
 
 export const entitiesRequestSchema = schema.object({
   page: schema.object({
     index: schema.number({ min: 0 }),
-    size: schema.number({ min: 1, max: 100 }),
+    size: schema.number({ min: 1, max: DETAIL_PAGE_SIZE_MAX }),
   }),
   query: schema.object({
     entityIds: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 5000 }),
@@ -51,7 +57,7 @@ export const entitiesRequestSchema = schema.object({
             }
           },
         }),
-        { minSize: 1 }
+        { minSize: 1, maxSize: INDEX_PATTERNS_MAX_SIZE }
       )
     ),
   }),
@@ -59,6 +65,6 @@ export const entitiesRequestSchema = schema.object({
 
 export const entitiesResponseSchema = () =>
   schema.object({
-    entities: schema.arrayOf(entityItemSchema),
+    entities: schema.arrayOf(entityItemSchema, { maxSize: DETAIL_PAGE_SIZE_MAX }),
     totalRecords: schema.number(),
   });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_events/v1.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_events/v1.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { eventsRequestSchema } from './v1';
+import { eventsRequestSchema, eventOrAlertItemSchema } from './v1';
 
 describe('graph events schema', () => {
   it('accepts a page size up to 100', () => {
@@ -62,5 +62,75 @@ describe('graph events schema', () => {
         },
       })
     ).toThrow();
+  });
+
+  it('accepts up to 100 index patterns', () => {
+    const indexPatterns = Array.from({ length: 100 }, (_, index) => `logs-${index}-*`);
+
+    expect(() =>
+      eventsRequestSchema.validate({
+        page: { index: 0, size: 10 },
+        query: {
+          eventIds: ['event-1'],
+          start: 'now-1d',
+          end: 'now',
+          indexPatterns,
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects more than 100 index patterns', () => {
+    const indexPatterns = Array.from({ length: 101 }, (_, index) => `logs-${index}-*`);
+
+    expect(() =>
+      eventsRequestSchema.validate({
+        page: { index: 0, size: 10 },
+        query: {
+          eventIds: ['event-1'],
+          start: 'now-1d',
+          end: 'now',
+          indexPatterns,
+        },
+      })
+    ).toThrow();
+  });
+
+  describe('eventOrAlertItemSchema', () => {
+    it('accepts up to 1000 ips and rejects more', () => {
+      expect(() =>
+        eventOrAlertItemSchema.validate({
+          id: 'event-1',
+          isAlert: false,
+          ips: Array.from({ length: 1000 }, (_, index) => `10.0.0.${index}`),
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        eventOrAlertItemSchema.validate({
+          id: 'event-1',
+          isAlert: false,
+          ips: Array.from({ length: 1001 }, (_, index) => `10.0.0.${index}`),
+        })
+      ).toThrow();
+    });
+
+    it('accepts up to 250 country codes and rejects more', () => {
+      expect(() =>
+        eventOrAlertItemSchema.validate({
+          id: 'event-1',
+          isAlert: false,
+          countryCodes: Array.from({ length: 250 }, (_, index) => `c-${index}`),
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        eventOrAlertItemSchema.validate({
+          id: 'event-1',
+          isAlert: false,
+          countryCodes: Array.from({ length: 251 }, (_, index) => `c-${index}`),
+        })
+      ).toThrow();
+    });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_events/v1.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/schema/graph_events/v1.ts
@@ -6,7 +6,13 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { INDEX_PATTERN_REGEX } from '../graph/v1';
+import {
+  COUNTRY_CODES_MAX_SIZE,
+  DETAIL_PAGE_SIZE_MAX,
+  INDEX_PATTERN_REGEX,
+  INDEX_PATTERNS_MAX_SIZE,
+  IPS_MAX_SIZE,
+} from '../graph/v1';
 
 // ============================================
 // SHARED AUXILIARY SCHEMAS (not exported)
@@ -30,14 +36,14 @@ export const eventOrAlertItemSchema = schema.object({
   action: schema.maybe(schema.string()),
   actor: schema.maybe(actorOrTargetSchema),
   target: schema.maybe(actorOrTargetSchema),
-  ips: schema.maybe(schema.arrayOf(schema.string())),
-  countryCodes: schema.maybe(schema.arrayOf(schema.string())),
+  ips: schema.maybe(schema.arrayOf(schema.string(), { maxSize: IPS_MAX_SIZE })),
+  countryCodes: schema.maybe(schema.arrayOf(schema.string(), { maxSize: COUNTRY_CODES_MAX_SIZE })),
 });
 
 export const eventsRequestSchema = schema.object({
   page: schema.object({
     index: schema.number({ min: 0 }),
-    size: schema.number({ min: 1, max: 100 }),
+    size: schema.number({ min: 1, max: DETAIL_PAGE_SIZE_MAX }),
   }),
   query: schema.object({
     eventIds: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 5000 }),
@@ -53,7 +59,7 @@ export const eventsRequestSchema = schema.object({
             }
           },
         }),
-        { minSize: 1 }
+        { minSize: 1, maxSize: INDEX_PATTERNS_MAX_SIZE }
       )
     ),
   }),
@@ -61,6 +67,6 @@ export const eventsRequestSchema = schema.object({
 
 export const eventsResponseSchema = () =>
   schema.object({
-    events: schema.arrayOf(eventOrAlertItemSchema),
+    events: schema.arrayOf(eventOrAlertItemSchema, { maxSize: DETAIL_PAGE_SIZE_MAX }),
     totalRecords: schema.number(),
   });


### PR DESCRIPTION
Closes #275267

## Summary

GitHub Advanced Security (CodeQL js/kibana/unbounded-array-in-schema) flagged numerous schema.arrayOf() calls in the Graph API route schemas with no maxSize, an unbounded-input DoS vector.

Add a maxSize ceiling to every arrayOf in the graph, graph_entities, and graph_events schemas. Limits are derived from the ES|QL execution constraints of the underlying queries and documented inline:
- events query LIMIT 1000 / default 1000-row limit
- result_truncation_max_size hard cap of 10,000
- enrichment chunking (5,000 IDs)
- ips bounded by the event-row limit; countryCodes by ISO 3166-1 (~250)
- detail responses bounded by the page.size ceiling (100)

Add Jest schema unit tests covering boundary-accepted and over-limit-rejected cases for the new limits.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


### How to test

1. Start Kibana: `yarn start`
2. Load the archives:
   - `node scripts/es_archiver load x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/logs_gcp_audit --es-url http://elastic:changeme@localhost:9200 --kibana-url http://elastic:changeme@localhost:5601`
   - `node scripts/es_archiver load x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/entity_store_v2 --es-url http://elastic:changeme@localhost:9200 --kibana-url http://elastic:changeme@localhost:5601`
3. Go to Explore → host/service/user -> expand some events -> observe graph is rendered correctly under visualizations tab -> apply some filters to check graph shows correctly.
4. Navigate to entity analytics page -> expand same entities -> observe graph is rendered correctly under visualizations tab -> apply some filters to check graph shows correctly.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



