### PR TITLE
[One Workflow]: Move Workflows experimental setting under Workflows settings

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.test.ts
@@ -9,6 +9,7 @@
 
 import { createCoreSetupMock } from '@kbn/core-lifecycle-server-mocks/src/core_setup.mock';
 import {
+  WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID,
   WORKFLOWS_UI_SETTING_ID,
   WORKFLOWS_UI_SHOW_MANAGED_WORKFLOWS_SETTING_ID,
   WORKFLOWS_VERSIONING_SETTING_ID,
@@ -42,6 +43,16 @@ describe('Workflows Management UI Settings', () => {
           name: expect.any(String),
           schema: expect.any(Object),
           value: false,
+          readonly: false,
+          category: ['workflows'],
+        },
+        [WORKFLOWS_EXPERIMENTAL_FEATURES_SETTING_ID]: {
+          description: expect.any(String),
+          name: expect.any(String),
+          schema: expect.any(Object),
+          value: false,
+          experimental: true,
+          requiresPageReload: true,
           readonly: false,
           category: ['workflows'],
         },

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -87,6 +87,7 @@ export const registerUISettings = (
       experimental: true,
       requiresPageReload: true,
       readonly: false,
+      category: ['workflows'],
     },
   });
 


### PR DESCRIPTION
## Summary
- Moves the `workflows:experimentalFeatures` advanced setting into the Workflows category so it appears alongside related Workflows settings.
- Adds unit test coverage for the experimental setting registration metadata.

<img width="1009" height="442" alt="Screenshot 2026-06-28 at 14 46 41" src="https://github.com/user-attachments/assets/be0720da-8252-4e1f-9db9-9965d38b4d25" />
