### PR TITLE
[Agent Builder Dashboards] Reassign ownership to Presentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1003,8 +1003,8 @@ x-pack/platform/packages/private/security/ui_components @elastic/kibana-security
 x-pack/platform/packages/private/upgrade-assistant/common @elastic/kibana-management
 x-pack/platform/packages/private/upgrade-assistant/public @elastic/kibana-management
 x-pack/platform/packages/private/upgrade-assistant/server @elastic/kibana-management
-x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common @elastic/appex-ai-infra
-x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards @elastic/appex-ai-infra
+x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common @elastic/kibana-presentation
+x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards @elastic/kibana-presentation
 x-pack/platform/packages/shared/agent-builder/agent-builder-browser @elastic/workchat-eng
 x-pack/platform/packages/shared/agent-builder/agent-builder-common @elastic/workchat-eng
 x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils @elastic/workchat-eng
@@ -1171,7 +1171,7 @@ x-pack/platform/plugins/private/upgrade_assistant @elastic/kibana-management
 x-pack/platform/plugins/private/watcher @elastic/kibana-management
 x-pack/platform/plugins/shared/actions @elastic/response-ops
 x-pack/platform/plugins/shared/agent_builder @elastic/workchat-eng
-x-pack/platform/plugins/shared/agent_builder_dashboards @elastic/appex-ai-infra
+x-pack/platform/plugins/shared/agent_builder_dashboards @elastic/kibana-presentation
 x-pack/platform/plugins/shared/agent_builder_platform @elastic/workchat-eng
 x-pack/platform/plugins/shared/agent_builder_workflows @elastic/workchat-eng @elastic/workflows-eng
 x-pack/platform/plugins/shared/agent_context_layer @elastic/workchat-eng

--- a/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/kibana.jsonc
+++ b/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/agent-builder-dashboards-common",
-  "owner": "@elastic/appex-ai-infra",
+  "owner": "@elastic/kibana-presentation",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/moon.yml
+++ b/x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/agent-builder-dashboards-common'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/appex-ai-infra'
+  defaultOwner: '@elastic/kibana-presentation'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/agent-builder-dashboards-common'
   description: Moon project for @kbn/agent-builder-dashboards-common
   channel: ''
-  owner: '@elastic/appex-ai-infra'
+  owner: '@elastic/kibana-presentation'
   sourceRoot: x-pack/platform/packages/shared/agent-builder-dashboards/agent-builder-dashboards-common
 dependsOn:
   - '@kbn/agent-builder-common'

--- a/x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards/kibana.jsonc
+++ b/x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "functional-tests",
   "id": "@kbn/evals-suite-agent-builder-dashboards",
-  "owner": "@elastic/appex-ai-infra",
+  "owner": "@elastic/kibana-presentation",
   "group": "platform",
   "visibility": "private"
 }

--- a/x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards/moon.yml
+++ b/x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/evals-suite-agent-builder-dashboards'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/appex-ai-infra'
+  defaultOwner: '@elastic/kibana-presentation'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/evals-suite-agent-builder-dashboards'
   description: Moon project for @kbn/evals-suite-agent-builder-dashboards
   channel: ''
-  owner: '@elastic/appex-ai-infra'
+  owner: '@elastic/kibana-presentation'
   sourceRoot: x-pack/platform/packages/shared/agent-builder-dashboards/kbn-evals-suite-agent-builder-dashboards
 dependsOn:
   - '@kbn/evals'

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/agent-builder-dashboards-plugin",
-  "owner": "@elastic/appex-ai-infra",
+  "owner": "@elastic/kibana-presentation",
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/agent-builder-dashboards-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/appex-ai-infra'
+  defaultOwner: '@elastic/kibana-presentation'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/agent-builder-dashboards-plugin'
   description: Moon project for @kbn/agent-builder-dashboards-plugin
   channel: ''
-  owner: '@elastic/appex-ai-infra'
+  owner: '@elastic/kibana-presentation'
   sourceRoot: x-pack/platform/plugins/shared/agent_builder_dashboards
 dependsOn:
   - '@kbn/core'


### PR DESCRIPTION
## Summary
- Reassign the `agent_builder_dashboards` plugin ownership from `@elastic/appex-ai-infra` to `@elastic/kibana-presentation`.
- Reassign ownership for `agent-builder-dashboards-common` and `kbn-evals-suite-agent-builder-dashboards` to `@elastic/kibana-presentation`.
- Regenerate ownership-derived metadata so `moon.yml` and `.github/CODEOWNERS` reflect the new owners.

## Test plan
- [x] Run `node scripts/regenerate_moon_projects.js --update --filter @kbn/agent-builder-dashboards-plugin`
- [x] Run `node scripts/regenerate_moon_projects.js --update --filter @kbn/agent-builder-dashboards-common`
- [x] Run `node scripts/regenerate_moon_projects.js --update --filter @kbn/evals-suite-agent-builder-dashboards`
- [x] Run `node scripts/generate codeowners`

Made with [Cursor](https://cursor.com)