### PR TITLE
[ESQL] Reuse suggest for expression" for the primary expression grammar in Completion and MMR

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
@@ -7,14 +7,52 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ISuggestionItem } from '../../../../registry/types';
-import type { FunctionParameterType, FunctionDefinitionTypes } from '../../../types';
-import { getFieldsSuggestions, getFunctionsSuggestions, getLiteralsSuggestions } from '../helpers';
+import type { ESQLControlVariable } from '@kbn/esql-types';
+import type {
+  ICommandCallbacks,
+  ICommandContext,
+  ISuggestionItem,
+} from '../../../../registry/types';
+import { Location } from '../../../../registry/types';
+import type {
+  FunctionParameterType,
+  FunctionDefinitionTypes,
+  SupportedDataType,
+} from '../../../types';
+import { getFieldsSuggestions, withAutoSuggest } from '../helpers';
 import { getOperatorSuggestions } from '../../operators';
+import { getCompatibleLiterals, getDateLiterals } from '../../literals';
+import { filterFunctionDefinitions, getAllFunctions, getFunctionSuggestion } from '../../functions';
 import type { ExpressionContext } from './types';
 import type { PreferredExpressionType } from './types';
 import { commaCompleteItem } from '../../../../registry/complete_items';
 import { shouldSuggestComma, type CommaContext } from './comma_decision_engine';
+
+interface FunctionSuggestionOptions {
+  ignored?: string[];
+  addComma?: boolean;
+  addSpaceAfterFunction?: boolean;
+  constantGeneratingOnly?: boolean;
+  suggestOnlyName?: boolean;
+  functionTypes?: FunctionDefinitionTypes[];
+}
+
+interface GetFunctionsSuggestionsParams {
+  location: Location;
+  types: (SupportedDataType | 'unknown' | 'any')[];
+  options?: FunctionSuggestionOptions;
+  context?: ICommandContext;
+  callbacks?: ICommandCallbacks;
+}
+
+interface LiteralSuggestionsOptions {
+  includeDateLiterals?: boolean;
+  includeCompatibleLiterals?: boolean;
+  addComma?: boolean;
+  advanceCursorAndOpenSuggestions?: boolean;
+  supportsControls?: boolean;
+  variables?: ESQLControlVariable[];
+}
 
 /** Builder pattern to eliminate duplicated field/function/literal suggestion code. */
 export class SuggestionBuilder {
@@ -187,4 +225,103 @@ export class SuggestionBuilder {
 
     return [...new Set([...commandIgnored, ...parentFunctionNames])];
   }
+}
+
+function getFunctionsSuggestions({
+  location,
+  types,
+  options = {},
+  context,
+  callbacks,
+}: GetFunctionsSuggestionsParams): ISuggestionItem[] {
+  const {
+    ignored = [],
+    addComma = false,
+    suggestOnlyName = false,
+    addSpaceAfterFunction = false,
+    constantGeneratingOnly = false,
+    functionTypes,
+  } = options;
+
+  const predicates = {
+    location,
+    returnTypes: types,
+    ignored,
+    isTimeseriesSource: context?.isTimeseriesSource,
+  };
+
+  const hasMinimumLicenseRequired = callbacks?.hasMinimumLicenseRequired;
+  const activeProduct = context?.activeProduct;
+
+  let filteredFunctions = filterFunctionDefinitions(
+    getAllFunctions({ includeOperators: false, type: functionTypes }),
+    predicates,
+    hasMinimumLicenseRequired,
+    activeProduct
+  );
+
+  if (constantGeneratingOnly) {
+    const typeSet = new Set(types);
+    filteredFunctions = filteredFunctions.filter((fn) =>
+      fn.signatures.some((sig) => sig.params.length === 0 && typeSet.has(sig.returnType))
+    );
+  }
+
+  const textSuffix = (addComma ? ',' : '') + (addSpaceAfterFunction ? ' ' : '');
+
+  return filteredFunctions.map((fn) => {
+    const suggestion = getFunctionSuggestion(fn);
+
+    if (suggestOnlyName) {
+      suggestion.text = fn.name.toUpperCase();
+      return suggestion;
+    }
+
+    if (textSuffix) {
+      suggestion.text += textSuffix;
+    }
+
+    return withAutoSuggest(suggestion);
+  });
+}
+
+function getLiteralsSuggestions(
+  types: (SupportedDataType | 'unknown' | 'any')[],
+  location: Location,
+  options: LiteralSuggestionsOptions = {}
+): ISuggestionItem[] {
+  const { includeDateLiterals = true, includeCompatibleLiterals = true } = options;
+
+  const suggestions: ISuggestionItem[] = [];
+
+  if (
+    includeDateLiterals &&
+    (location === Location.WHERE ||
+      location === Location.EVAL ||
+      location === Location.STATS_WHERE) &&
+    types.includes('date')
+  ) {
+    suggestions.push(
+      ...getDateLiterals({
+        addComma: options.addComma,
+        advanceCursorAndOpenSuggestions: options.advanceCursorAndOpenSuggestions,
+      })
+    );
+  }
+
+  if (includeCompatibleLiterals) {
+    suggestions.push(
+      ...getCompatibleLiterals(
+        types,
+        {
+          addComma: options.addComma,
+          advanceCursorAndOpenSuggestions: options.advanceCursorAndOpenSuggestions,
+          supportsControls: options.supportsControls,
+        },
+        options.variables
+      )
+    );
+  }
+
+  return suggestions;
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
@@ -12,7 +12,7 @@ import type { ESQLAstItem, ESQLFunction } from '@elastic/esql/types';
 import { nullCheckOperators, inOperators } from '../../../all_operators';
 import type { ExpressionContext, FunctionParameterContext } from './types';
 import type { ICommandContext, ISuggestionItem } from '../../../../registry/types';
-import { getFunctionDefinition } from '../..';
+import { getFunctionDefinition } from '../../functions';
 import { resolveArgumentTypes } from '../../expressions';
 import type { SupportedDataType } from '../../../types';
 import {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/helpers.ts
@@ -14,18 +14,10 @@ import type {
 import { ESQLVariableType } from '@kbn/esql-types';
 import { i18n } from '@kbn/i18n';
 import { uniqBy } from 'lodash';
-import type {
-  GetColumnsByTypeFn,
-  ICommandCallbacks,
-  ICommandContext,
-  ISuggestionItem,
-} from '../../../registry/types';
-import { Location } from '../../../registry/types';
+import type { GetColumnsByTypeFn, ICommandContext, ISuggestionItem } from '../../../registry/types';
 import type { SupportedDataType } from '../../types';
-import type { FunctionDefinitionTypes } from '../../types';
-import { filterFunctionDefinitions, getAllFunctions, getFunctionSuggestion } from '../functions';
 import { SuggestionCategory } from '../../../../language/autocomplete/utils/sorting/types';
-import { buildConstantsDefinitions, getCompatibleLiterals, getDateLiterals } from '../literals';
+import { buildConstantsDefinitions } from '../literals';
 import { getColumnByName } from '../shared';
 
 export const shouldBeQuotedText = (
@@ -102,134 +94,6 @@ export async function getFieldsSuggestions(
     addComma,
     variableType,
   })) as ISuggestionItem[];
-}
-
-interface FunctionSuggestionOptions {
-  ignored?: string[];
-  addComma?: boolean;
-  addSpaceAfterFunction?: boolean;
-  constantGeneratingOnly?: boolean;
-  suggestOnlyName?: boolean;
-  functionTypes?: FunctionDefinitionTypes[];
-}
-
-interface GetFunctionsSuggestionsParams {
-  location: Location;
-  types: (SupportedDataType | 'unknown' | 'any')[];
-  options?: FunctionSuggestionOptions;
-  context?: ICommandContext;
-  callbacks?: ICommandCallbacks;
-}
-
-export function getFunctionsSuggestions({
-  location,
-  types,
-  options = {},
-  context,
-  callbacks,
-}: GetFunctionsSuggestionsParams): ISuggestionItem[] {
-  const {
-    ignored = [],
-    addComma = false,
-    suggestOnlyName = false,
-    addSpaceAfterFunction = false,
-    constantGeneratingOnly = false,
-    functionTypes,
-  } = options;
-
-  const predicates = {
-    location,
-    returnTypes: types,
-    ignored,
-    isTimeseriesSource: context?.isTimeseriesSource,
-  };
-
-  const hasMinimumLicenseRequired = callbacks?.hasMinimumLicenseRequired;
-  const activeProduct = context?.activeProduct;
-
-  let filteredFunctions = filterFunctionDefinitions(
-    getAllFunctions({ includeOperators: false, type: functionTypes }),
-    predicates,
-    hasMinimumLicenseRequired,
-    activeProduct
-  );
-
-  // Filter for constant-generating functions (functions without parameters)
-  if (constantGeneratingOnly) {
-    const typeSet = new Set(types);
-    filteredFunctions = filteredFunctions.filter((fn) =>
-      fn.signatures.some((sig) => sig.params.length === 0 && typeSet.has(sig.returnType))
-    );
-  }
-
-  const textSuffix = (addComma ? ',' : '') + (addSpaceAfterFunction ? ' ' : '');
-
-  return filteredFunctions.map((fn) => {
-    const suggestion = getFunctionSuggestion(fn);
-
-    if (suggestOnlyName) {
-      suggestion.text = fn.name.toUpperCase();
-      return suggestion;
-    }
-
-    if (textSuffix) {
-      suggestion.text += textSuffix;
-    }
-
-    return withAutoSuggest(suggestion);
-  });
-}
-
-interface LiteralSuggestionsOptions {
-  includeDateLiterals?: boolean;
-  includeCompatibleLiterals?: boolean;
-  // Pass-through options for literal builders
-  addComma?: boolean;
-  advanceCursorAndOpenSuggestions?: boolean;
-  supportsControls?: boolean;
-  variables?: ESQLControlVariable[];
-}
-
-export function getLiteralsSuggestions(
-  types: (SupportedDataType | 'unknown' | 'any')[],
-  location: Location,
-  options: LiteralSuggestionsOptions = {}
-): ISuggestionItem[] {
-  const { includeDateLiterals = true, includeCompatibleLiterals = true } = options;
-
-  const suggestions: ISuggestionItem[] = [];
-
-  // Date literals gated by policy: only WHERE/EVAL/STATS_WHERE and only if types include 'date'
-  if (
-    includeDateLiterals &&
-    (location === Location.WHERE ||
-      location === Location.EVAL ||
-      location === Location.STATS_WHERE) &&
-    types.includes('date')
-  ) {
-    suggestions.push(
-      ...getDateLiterals({
-        addComma: options.addComma,
-        advanceCursorAndOpenSuggestions: options.advanceCursorAndOpenSuggestions,
-      })
-    );
-  }
-
-  if (includeCompatibleLiterals) {
-    suggestions.push(
-      ...getCompatibleLiterals(
-        types,
-        {
-          addComma: options.addComma,
-          advanceCursorAndOpenSuggestions: options.advanceCursorAndOpenSuggestions,
-          supportsControls: options.supportsControls,
-        },
-        options.variables
-      )
-    );
-  }
-
-  return suggestions;
 }
 
 export function getLastNonWhitespaceChar(text: string) {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/index.ts
@@ -9,8 +9,6 @@
 
 export {
   getFieldsSuggestions,
-  getFunctionsSuggestions,
-  getLiteralsSuggestions,
   getControlSuggestionIfSupported,
   getControlSuggestion,
   getSafeInsertText,

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/completion/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/completion/autocomplete.test.ts
@@ -11,13 +11,13 @@ import { autocomplete } from './autocomplete';
 import {
   expectSuggestions,
   getFieldNamesByType,
+  getFunctionSignaturesByReturnType,
   DATE_DIFF_TIME_UNITS,
   suggest as testSuggest,
   mockFieldsWithTypes,
 } from '../../../__tests__/commands/autocomplete';
 import type { ICommandCallbacks } from '../types';
 import { Location } from '../types';
-import { getFunctionsSuggestions } from '../../definitions/utils/autocomplete/helpers';
 import { ESQL_STRING_TYPES } from '../../definitions/types';
 
 interface SuggestionItem {
@@ -62,11 +62,9 @@ const completionExpectSuggestions = async (
 const PROMPT_SUGGESTIONS = [
   ' = ',
   ...getFieldNamesByType(ESQL_STRING_TYPES).map((fieldName) => `${fieldName} `),
-  ...getFunctionsSuggestions({
-    location: Location.COMPLETION,
-    types: ['text', 'keyword', 'unknown'],
-    options: {},
-  }).map(({ text }) => `${text} `),
+  ...getFunctionSignaturesByReturnType(Location.COMPLETION, ['text', 'keyword', 'unknown'], {
+    scalar: true,
+  }).map((text) => `${text} `),
 ];
 
 describe('COMPLETION Autocomplete', () => {
@@ -186,6 +184,27 @@ describe('COMPLETION Autocomplete', () => {
           notContains: ['doubleField '],
         },
         mockCallbacks
+      );
+    });
+
+    it('suggests creating a value control for the prompt expression', async () => {
+      const results = await testSuggest(
+        'FROM a | COMPLETION ',
+        { ...mockContext, supportsControls: true },
+        'completion',
+        mockCallbacks,
+        autocomplete
+      );
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Create control',
+            command: expect.objectContaining({
+              id: 'esql.control.values.create',
+            }),
+          }),
+        ])
       );
     });
   });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/completion/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/completion/autocomplete.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { i18n } from '@kbn/i18n';
-import { uniqBy } from 'lodash';
+import { ESQLVariableType } from '@kbn/esql-types';
 import { isFunctionExpression, isLiteral } from '@elastic/esql';
 import type {
   ESQLAstCompletionCommand,
@@ -27,14 +27,8 @@ import {
   withMapCompleteItem,
 } from '../complete_items';
 import {
-  getFieldsSuggestions,
-  getFunctionsSuggestions,
-  getLiteralsSuggestions,
-} from '../../definitions/utils';
-import {
   columnExists,
   createInferenceEndpointToCompletionItem,
-  withAutoSuggest,
   withinQuotes,
 } from '../../definitions/utils/autocomplete/helpers';
 import { buildConstantsDefinitions } from '../../definitions/utils/literals';
@@ -125,46 +119,23 @@ export async function autocomplete(
   switch (position) {
     case CompletionPosition.AFTER_COMPLETION:
     case CompletionPosition.AFTER_TARGET_ASSIGNMENT: {
-      const types = ['text', 'keyword', 'unknown'];
-      const allSuggestions: ISuggestionItem[] = [];
+      const { suggestions: expressionSuggestions } = await suggestForExpression({
+        query,
+        command,
+        cursorPosition,
+        location: Location.COMPLETION,
+        context,
+        callbacks,
+        options: {
+          preferredExpressionType: ['text', 'keyword', 'unknown'],
+          controlType: ESQLVariableType.VALUES,
+        },
+      });
 
-      // Fields
-      allSuggestions.push(
-        ...(await getFieldsSuggestions(types, callbacks?.getByType, {
-          ignoreColumns: [],
-          values: false,
-          addSpaceAfterField: false,
-          openSuggestions: false,
-        }))
-      );
-
-      // Date literals (policy-gated in helpers) with explicit UI options
-      allSuggestions.push(
-        ...getLiteralsSuggestions(types, Location.COMPLETION, {
-          includeDateLiterals: true,
-          includeCompatibleLiterals: false,
-          addComma: false,
-          advanceCursorAndOpenSuggestions: false,
-        })
-      );
-
-      // Functions
-      allSuggestions.push(
-        ...getFunctionsSuggestions({
-          location: Location.COMPLETION,
-          types,
-          options: { ignored: [] },
-          context,
-          callbacks,
-        })
-      );
-
-      const fieldsAndFunctionsSuggestions = uniqBy(allSuggestions, 'label');
-      const suggestions = fieldsAndFunctionsSuggestions.map((suggestion) =>
-        withAutoSuggest({
-          ...suggestion,
-          text: `${suggestion.text} `,
-        })
+      const suggestions = expressionSuggestions.map((suggestion) =>
+        suggestion.kind !== 'Issue' && suggestion.text && !suggestion.text.endsWith(' ')
+          ? { ...suggestion, text: `${suggestion.text} ` }
+          : suggestion
       );
 
       if (!hasTypedFragment) {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/mmr/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/mmr/autocomplete.ts
@@ -9,6 +9,7 @@
 
 import { i18n } from '@kbn/i18n';
 import type { ESQLAstAllCommands, ESQLAstField, ESQLAstMmrCommand } from '@elastic/esql/types';
+import { suggestForExpression } from '../../definitions/utils';
 import type { MapParameters } from '../../definitions/utils/autocomplete/map_expression';
 import { getCommandMapExpressionSuggestions } from '../../definitions/utils/autocomplete/map_expression';
 import { suggestFieldsList } from '../../definitions/utils/autocomplete/fields_list';
@@ -24,12 +25,7 @@ import {
 } from '../complete_items';
 import type { ICommandCallbacks, ICommandContext, ISuggestionItem } from '../types';
 import { Location } from '../types';
-import {
-  getMmrVectorValueSuggestions,
-  getPosition,
-  getVectorFieldSuggestions,
-  MmrPosition,
-} from './utils';
+import { getPosition, getVectorFieldSuggestions, MMR_VECTOR_TYPES, MmrPosition } from './utils';
 
 export async function autocomplete(
   query: string,
@@ -51,11 +47,21 @@ export async function autocomplete(
       const queryVectorExpression = mmrCommand.queryVector;
 
       if (command.args.length === 0) {
-        return [
-          onCompleteItem,
-          mmrQueryVectorSuggestion,
-          ...getMmrVectorValueSuggestions(callbacks, context),
-        ];
+        const { suggestions: queryVectorSuggestions } = await suggestForExpression({
+          query,
+          command,
+          cursorPosition,
+          location: Location.MMR,
+          context,
+          callbacks,
+          options: {
+            preferredExpressionType: MMR_VECTOR_TYPES,
+            suggestFields: false,
+            suggestFunctions: true,
+          },
+        });
+
+        return [onCompleteItem, mmrQueryVectorSuggestion, ...queryVectorSuggestions];
       }
 
       const suggestions = await suggestFieldsList(
@@ -70,7 +76,7 @@ export async function autocomplete(
           afterCompleteSuggestions: [onCompleteItem],
           includePipeAndCommaSuggestions: false,
           allowSingleColumnFields: true,
-          preferredExpressionType: 'dense_vector',
+          preferredExpressionType: MMR_VECTOR_TYPES,
         }
       );
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/mmr/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/mmr/utils.ts
@@ -14,14 +14,8 @@ import type {
   ESQLCommandOption,
 } from '@elastic/esql/types';
 import { isMap, isOptionNode } from '@elastic/esql';
-import {
-  columnExists,
-  getFieldsSuggestions,
-  getFunctionsSuggestions,
-  getLiteralsSuggestions,
-} from '../../definitions/utils/autocomplete/helpers';
+import { columnExists, getFieldsSuggestions } from '../../definitions/utils/autocomplete/helpers';
 import type { ICommandCallbacks, ICommandContext, ISuggestionItem } from '../types';
-import { Location } from '../types';
 
 export enum MmrPosition {
   AFTER_MMR_KEYWORD = 'after_mmr_keyword',
@@ -53,29 +47,6 @@ export const getItemLocation = (
 
   return item.location;
 };
-
-export function getMmrVectorValueSuggestions(
-  callbacks?: ICommandCallbacks,
-  context?: ICommandContext
-): ISuggestionItem[] {
-  return [
-    ...getLiteralsSuggestions(MMR_VECTOR_TYPES, Location.MMR, {
-      includeDateLiterals: false,
-      includeCompatibleLiterals: true,
-      addComma: false,
-      advanceCursorAndOpenSuggestions: false,
-      supportsControls: true,
-      variables: context?.variables,
-    }),
-    ...getFunctionsSuggestions({
-      location: Location.MMR,
-      types: MMR_VECTOR_TYPES,
-      options: {},
-      context,
-      callbacks,
-    }),
-  ];
-}
 
 export async function getVectorFieldSuggestions(
   innerText: string,


### PR DESCRIPTION
## Summary
Friday cleaning

- suggestForExpression for MMR and Completion 
- Move  the function `getFunctionsSuggestions `inside the SuggestForExpression Logic