### PR TITLE
[Scout] Trigger Scout Reviewer on TypeScript changes only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3694,6 +3694,8 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.github/agents/scout-reviewer.md @elastic/appex-qa
 /.github/workflows/reviewer-scout.md @elastic/appex-qa
 /.github/workflows/reviewer-scout.lock.yml @elastic/appex-qa
+/.github/workflows/label-scout-prs.yml @elastic/appex-qa
+/.github/labeler-scout.yml @elastic/appex-qa
 
 # Kibana Localization
 /src/dev/i18n_tools/  @elastic/kibana-localization @elastic/kibana-core

--- a/.github/labeler-scout.yml
+++ b/.github/labeler-scout.yml
@@ -1,5 +1,5 @@
 'reviewer:scout':
   - changed-files:
       - any-glob-to-any-file:
-          - '**/test/scout*/**'
-          - '**/kbn-scout*/**'
+          - '**/test/scout*/**/*.ts'
+          - '**/kbn-scout*/**/*.ts'


### PR DESCRIPTION
I noticed we're running the Scout Test Reviewer on PRs that don't really need a Scout review, e.g., Scout manifest file updates (https://github.com/elastic/kibana/pull/275284). This PR fixes this by scoping down the globs down to `*.ts`.