### PR TITLE
[kbn-code-owners] Add `elastic/security-detection-engineering` team under Security area

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -81,6 +81,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/security-defend-workflows',
     'elastic/security-design',
     'elastic/security-detection-engine',
+    'elastic/security-detection-engineering',
     'elastic/security-detection-platform',
     'elastic/security-detection-rule-management',
     'elastic/security-engineering-productivity',


### PR DESCRIPTION
This PR adds the `elastic/security-detection-engineering` to the `security` code owner <> area mapping. Adding the team here ensures their tests are correctly attributed to the security area by our Scout Reporter.

Made with [Cursor](https://cursor.com)