### PR TITLE
[Synthetics] Fix blank "Errors over time" chart on the Errors overview

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_error_groups.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_error_groups.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getErrorGroups, getErrorGroupsHistogramInterval } from './get_error_groups';
+import { getUptimeESMockClient } from './test_helpers';
+
+describe('getErrorGroupsHistogramInterval', () => {
+  it('targets ~24 buckets across the window (7d -> 7h)', () => {
+    const interval = getErrorGroupsHistogramInterval(
+      '2026-06-20T08:00:00.000Z',
+      '2026-06-27T08:00:00.000Z'
+    );
+    expect(interval).toBe(7 * 60 * 60 * 1000);
+  });
+
+  it('targets ~24 buckets across the window (24h -> 1h)', () => {
+    const interval = getErrorGroupsHistogramInterval(
+      '2026-06-26T08:00:00.000Z',
+      '2026-06-27T08:00:00.000Z'
+    );
+    expect(interval).toBe(60 * 60 * 1000);
+  });
+
+  it('clamps to a 1-minute floor for very short windows', () => {
+    const interval = getErrorGroupsHistogramInterval(
+      '2026-06-27T08:00:00.000Z',
+      '2026-06-27T08:10:00.000Z'
+    );
+    expect(interval).toBe(60_000);
+  });
+
+  it('falls back to 1h when the range cannot be parsed or is inverted', () => {
+    expect(getErrorGroupsHistogramInterval('', '')).toBe(60 * 60 * 1000);
+    expect(getErrorGroupsHistogramInterval('now', 'now-1d')).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('getErrorGroups', () => {
+  const emptyAggsResponse = {
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+    hits: { hits: [], max_score: 0, total: { value: 0, relation: 'eq' as const } },
+    aggregations: { error_groups: { buckets: [] } },
+  };
+
+  // Regression guard for the blank "Errors over time" chart: all error groups
+  // must share ONE aligned time grid. A per-group `auto_date_histogram` gave
+  // short-lived groups a finer interval, collapsing the merged chart's bars to
+  // sub-pixel width. We assert we request a single shared `fixed_interval`
+  // `date_histogram` with `extended_bounds`, and never an `auto_date_histogram`.
+  it('buckets all groups on a single shared fixed_interval grid', async () => {
+    const { esClient, syntheticsEsClient } = getUptimeESMockClient();
+    esClient.search.mockResponseOnce(emptyAggsResponse as any);
+
+    await getErrorGroups({
+      syntheticsEsClient,
+      from: '2026-06-20T08:00:00.000Z',
+      to: '2026-06-27T08:00:00.000Z',
+      spaceId: 'default',
+    });
+
+    const call: any = esClient.search.mock.calls[0][0];
+    const overTime = call.aggs.error_groups.aggs.over_time;
+
+    expect(overTime.auto_date_histogram).toBeUndefined();
+    expect(overTime.date_histogram).toEqual({
+      field: '@timestamp',
+      fixed_interval: `${7 * 60 * 60 * 1000}ms`,
+      min_doc_count: 0,
+      extended_bounds: {
+        min: Date.parse('2026-06-20T08:00:00.000Z'),
+        max: Date.parse('2026-06-27T08:00:00.000Z'),
+      },
+    });
+  });
+
+  it('maps category buckets into error groups with histograms', async () => {
+    const { esClient, syntheticsEsClient } = getUptimeESMockClient();
+    esClient.search.mockResponseOnce({
+      ...emptyAggsResponse,
+      aggregations: {
+        error_groups: {
+          buckets: [
+            {
+              key: 'EOF',
+              doc_count: 1440,
+              error_states: { value: 1 },
+              affected_monitors: { value: 1 },
+              affected_locations: { value: 1 },
+              first_seen: { value_as_string: '2026-01-16T17:06:22.412Z' },
+              last_seen: { value_as_string: '2026-06-27T08:00:00.000Z' },
+              per_state: {
+                buckets: [
+                  {
+                    key: 'state-1',
+                    latest: {
+                      hits: {
+                        hits: [
+                          {
+                            _source: {
+                              '@timestamp': '2026-06-27T08:00:00.000Z',
+                              config_id: 'cfg-1',
+                              monitor: { name: 'tcp-ES', type: 'tcp' },
+                              state: { id: 'state-1', duration_ms: '13965247346' },
+                              observer: { name: 'us-east', geo: { name: 'US East' } },
+                              error: { message: 'EOF' },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              over_time: {
+                buckets: [
+                  { key: 1782547200000, doc_count: 700 },
+                  { key: 1782572400000, doc_count: 720 },
+                  { key: 1782597600000, doc_count: 20 },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const { groups } = await getErrorGroups({
+      syntheticsEsClient,
+      from: '2026-06-20T08:00:00.000Z',
+      to: '2026-06-27T08:00:00.000Z',
+      spaceId: 'default',
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      name: 'EOF',
+      pattern: 'persistent',
+      monitorCount: 1,
+      histogram: [
+        { timestamp: 1782547200000, count: 700 },
+        { timestamp: 1782572400000, count: 720 },
+        { timestamp: 1782597600000, count: 20 },
+      ],
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_error_groups.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_error_groups.ts
@@ -6,6 +6,7 @@
  */
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import DateMath from '@kbn/datemath';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 import {
   EXCLUDE_RUN_ONCE_FILTER,
@@ -42,6 +43,36 @@ function classifyPattern(histogram: ErrorGroupHistogramBucket[]): ErrorGroupPatt
   if (!earlyBucketsHaveErrors) return 'new';
 
   return 'intermittent';
+}
+
+const HISTOGRAM_BUCKET_TARGET = 24;
+const MIN_HISTOGRAM_INTERVAL_MS = 60_000;
+const FALLBACK_HISTOGRAM_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Every error group must share one aligned time grid. The "Errors over time"
+ * chart derives a single bar width from the first group's bucket spacing, then
+ * merges all groups into one series; if a short-lived (intermittent) group has
+ * a finer bucket interval, the merged series ends up with sub-interval spacing
+ * and every bar collapses to sub-pixel width — i.e. the chart renders blank.
+ * A per-group `auto_date_histogram` produced exactly that, so we bucket with a
+ * single window-derived `fixed_interval` shared by all groups instead.
+ */
+export function getErrorGroupsHistogramInterval(from: string, to: string): number {
+  const fromMs = DateMath.parse(from)?.valueOf();
+  const toMs = DateMath.parse(to, { roundUp: true })?.valueOf();
+
+  if (
+    fromMs == null ||
+    toMs == null ||
+    !Number.isFinite(fromMs) ||
+    !Number.isFinite(toMs) ||
+    toMs <= fromMs
+  ) {
+    return FALLBACK_HISTOGRAM_INTERVAL_MS;
+  }
+
+  return Math.max(Math.floor((toMs - fromMs) / HISTOGRAM_BUCKET_TARGET), MIN_HISTOGRAM_INTERVAL_MS);
 }
 
 interface GetErrorGroupsParams {
@@ -103,6 +134,14 @@ export async function getErrorGroups({
     must.push(getQueryFilters(query) as QueryDslQueryContainer);
   }
 
+  const histogramIntervalMs = getErrorGroupsHistogramInterval(from, to);
+  const histogramRangeStart = DateMath.parse(from)?.valueOf();
+  const histogramRangeEnd = DateMath.parse(to, { roundUp: true })?.valueOf();
+  const histogramBounds =
+    histogramRangeStart != null && histogramRangeEnd != null
+      ? { extended_bounds: { min: histogramRangeStart, max: histogramRangeEnd } }
+      : {};
+
   const result = await syntheticsEsClient.search(
     {
       size: 0,
@@ -162,9 +201,11 @@ export async function getErrorGroups({
               },
             },
             over_time: {
-              auto_date_histogram: {
+              date_histogram: {
                 field: '@timestamp',
-                buckets: 24,
+                fixed_interval: `${histogramIntervalMs}ms`,
+                min_doc_count: 0,
+                ...histogramBounds,
               },
             },
           },


### PR DESCRIPTION
## Summary


### Before
<img width="1727" height="845" alt="image" src="https://github.com/user-attachments/assets/151221d0-f00e-4caf-afad-6ad12233e812" />

### After
<img width="1728" height="883" alt="image" src="https://github.com/user-attachments/assets/0117cd9c-3a77-4732-8d2f-70e4c63f53d6" />


On the Synthetics **Errors** overview, the **Errors over time** chart could render blank even though error data existed — most visibly on wider ranges like **Last 7 days**, when a short-lived error burst co-occurred with a long-running outage.

### Root cause

`getErrorGroups` bucketed each error group with its **own** `auto_date_histogram` (nested under `categorize_text`). Each group's interval was sized to that group's own data span, so:

- a persistent / long-running group → coarse interval (e.g. 12h)
- a short intermittent burst → very fine interval (e.g. 30s)

The chart derives a single bar width from the first group's interval, then merges all groups into one series. With a 30s-spaced group in the merged data, the time `BarSeries` bar width collapses to ~30s, so the real (tall) bars render sub-pixel wide on a multi-day axis → the chart looks empty (axis present, no bars).

### Fix

Bucket **all** error groups on one shared, window-derived `fixed_interval` `date_histogram` with `extended_bounds`, so every group returns the same aligned grid and the chart has a single consistent bar width.

- interval = `(to - from) / 24` (floored at 1 minute), so bucket count stays ~24 for any range
- verified live against 24h / 30d / 90d / 1y → single aligned interval, ≤25 buckets, no `search.max_buckets` risk

### Before / after (same data, via the running endpoint)

| window | before (per-group `auto_date_histogram`) | after (shared `fixed_interval`) |
|---|---|---|
| 24h | `{30s, 1h}` → bars collapse to 30s | `1h` for all groups |
| 7d  | `{30s, 12h}` → blank chart | `7h` for all groups |

## Testing

- [x] New unit tests in `get_error_groups.test.ts` (interval helper + asserts a single shared `fixed_interval` `date_histogram`, never `auto_date_histogram`)
- [x] Manually verified in a local Kibana on the Errors tab (Last 7 days): blank before, bars after
- [ ] Reviewer: confirm the "By group" stacked view also renders
