### PR TITLE
[Guided onboarding] Add size limits to route schema validation

### DIFF
--- a/src/platform/plugins/shared/guided_onboarding/server/routes/config_routes.ts
+++ b/src/platform/plugins/shared/guided_onboarding/server/routes/config_routes.ts
@@ -27,7 +27,7 @@ export const registerGetConfigRoute = (router: IRouter, guidesConfig: GuidesConf
       },
       validate: {
         params: schema.object({
-          guideId: schema.string(),
+          guideId: schema.string({ maxLength: 1000 }),
         }),
       },
     },

--- a/src/platform/plugins/shared/guided_onboarding/server/routes/plugin_state_routes.ts
+++ b/src/platform/plugins/shared/guided_onboarding/server/routes/plugin_state_routes.ts
@@ -56,17 +56,18 @@ export const registerPutPluginStateRoute = (router: IRouter) => {
       },
       validate: {
         body: schema.object({
-          status: schema.maybe(schema.string()),
+          status: schema.maybe(schema.string({ maxLength: 1000 })),
           guide: schema.maybe(
             schema.object({
-              status: schema.string(),
-              guideId: schema.string(),
+              status: schema.string({ maxLength: 1000 }),
+              guideId: schema.string({ maxLength: 1000 }),
               isActive: schema.boolean(),
               steps: schema.arrayOf(
                 schema.object({
-                  status: schema.string(),
-                  id: schema.string(),
-                })
+                  status: schema.string({ maxLength: 1000 }),
+                  id: schema.string({ maxLength: 1000 }),
+                }),
+                { maxSize: 1000 }
               ),
               // params are dynamic values
               params: schema.maybe(schema.object({}, { unknowns: 'allow' })),


### PR DESCRIPTION
## Summary

Adds `maxLength` to `schema.string()` and `maxSize` to `schema.arrayOf()` in the guided_onboarding `PUT /internal/guided_onboarding/state` and `GET /internal/guided_onboarding/configs/{guideId}` route validations, so request input size is bounded. Previously these fields were unbounded, allowing an oversized payload to be accepted and processed.

This applies to `8.19` only — the guided_onboarding plugin was removed from `main` in #231084 (9.2.0), so later branches are unaffected.