### PR TITLE
[9.4] [Fleet] Support data_stream.type variable in simplified policy API (#269895)

### DIFF
--- a/.buildkite/pipelines/storybooks_from_pr.yml
+++ b/.buildkite/pipelines/storybooks_from_pr.yml
@@ -17,7 +17,6 @@ steps:
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      preemptible: true
       diskSizeGb: 105
     timeout_in_minutes: 50
     retry:

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -76,7 +76,7 @@ pageLoadAssetSize:
   files: 6037
   filesManagement: 5208
   fileUpload: 22957
-  fleet: 209495
+  fleet: 213000
   genAiSettings: 6400
   globalSearch: 6890
   globalSearchBar: 26122

--- a/x-pack/platform/plugins/shared/fleet/common/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/index.ts
@@ -87,7 +87,9 @@ export {
   // Package policy helpers
   isValidNamespace,
   isValidDataset,
+  isValidDataStreamType,
   INVALID_NAMESPACE_CHARACTERS,
+  VALID_DATA_STREAM_TYPES,
   getFileMetadataIndexName,
   getFileDataIndexName,
   removeSOAttributes,

--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -28,8 +28,10 @@ export { fullAgentPolicyToYaml } from './full_agent_policy_to_yaml';
 export { isPackageLimited, doesAgentPolicyAlreadyIncludePackage } from './limited_package';
 export {
   isValidDataset,
+  isValidDataStreamType,
   isValidNamespace,
   INVALID_NAMESPACE_CHARACTERS,
+  VALID_DATA_STREAM_TYPES,
 } from './is_valid_namespace';
 export { isDiffPathProtocol } from './is_diff_path_protocol';
 export { LicenseService } from './license';
@@ -48,10 +50,14 @@ export {
   MINIMUM_PRIVILEGE_LEVEL_CHANGE_AGENT_VERSION,
   isAgentEligibleForPrivilegeLevelChange,
 } from './agent_privilege_level_change_helpers';
+export { syncDataStreamTypeFromVar } from './simplified_package_policy_helper';
 export {
   addUseAPMVarIfNotPresent,
   DATA_STREAM_USE_APM_VAR,
   shouldIncludeUseAPMVar,
+  addDataStreamTypeVarIfNotPresent,
+  DATA_STREAM_TYPE_VAR,
+  shouldIncludeDataStreamTypeVar,
   isInputOnlyPolicyTemplate,
   isIntegrationPolicyTemplate,
   getNormalizedInputs,

--- a/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isValidNamespace } from './is_valid_namespace';
+import { isValidNamespace, isValidDataStreamType } from './is_valid_namespace';
 
 describe('Fleet - isValidNamespace', () => {
   it('returns true for valid namespaces', () => {
@@ -41,5 +41,30 @@ describe('Fleet - isValidNamespace', () => {
       ).valid
     ).toBe(false);
     expect(isValidNamespace('default', false, ['test']).valid).toBe(false);
+  });
+});
+
+describe('Fleet - isValidDataStreamType', () => {
+  it('returns true for each valid type', () => {
+    expect(isValidDataStreamType('logs').valid).toBe(true);
+    expect(isValidDataStreamType('metrics').valid).toBe(true);
+    expect(isValidDataStreamType('traces').valid).toBe(true);
+    expect(isValidDataStreamType('synthetics').valid).toBe(true);
+    expect(isValidDataStreamType('profiling').valid).toBe(true);
+  });
+
+  it('returns false for unknown types', () => {
+    expect(isValidDataStreamType('bogus').valid).toBe(false);
+    expect(isValidDataStreamType('LOGS').valid).toBe(false);
+    expect(isValidDataStreamType('').valid).toBe(false);
+  });
+
+  it('returns true for blank when allowBlank is true', () => {
+    expect(isValidDataStreamType('', true).valid).toBe(true);
+    expect(isValidDataStreamType('  ', true).valid).toBe(true);
+  });
+
+  it('returns false for blank when allowBlank is false', () => {
+    expect(isValidDataStreamType('', false).valid).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts
@@ -7,6 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 
+import type { PackageDataStreamTypes } from '../types';
+
 // Namespace string eventually becomes part of an index name. This method partially implements index name rules from
 // https://github.com/elastic/elasticsearch/blob/master/docs/reference/indices/create-index.asciidoc
 // and implements a limit based on https://github.com/elastic/kibana/issues/75846
@@ -121,3 +123,30 @@ function isValidEntity(
 }
 
 export const INVALID_NAMESPACE_CHARACTERS = /[\*\\/\?"<>|\s,#:-]+/;
+
+export const VALID_DATA_STREAM_TYPES: readonly PackageDataStreamTypes[] = [
+  'logs',
+  'metrics',
+  'traces',
+  'synthetics',
+  'profiling',
+];
+
+export function isValidDataStreamType(
+  type: string,
+  allowBlank?: boolean
+): { valid: boolean; error?: string } {
+  if (!type.trim() && allowBlank) {
+    return { valid: true };
+  }
+  if (!VALID_DATA_STREAM_TYPES.includes(type as PackageDataStreamTypes)) {
+    return {
+      valid: false,
+      error: i18n.translate('xpack.fleet.dataStreamTypeValidation.invalidValueErrorMessage', {
+        defaultMessage: 'Data stream type must be one of: {allowedTypes}',
+        values: { allowedTypes: VALID_DATA_STREAM_TYPES.join(', ') },
+      }),
+    };
+  }
+  return { valid: true };
+}

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
@@ -31,6 +31,8 @@ import {
   packagePolicyInputAllowsUndefinedDataStreamType,
   hasDynamicSignalTypes,
   shouldIncludeUseAPMVar,
+  shouldIncludeDataStreamTypeVar,
+  addDataStreamTypeVarIfNotPresent,
 } from './policy_template';
 
 describe('isInputOnlyPolicyTemplate', () => {
@@ -199,6 +201,54 @@ describe('shouldIncludeUseAPMVar', () => {
   });
 });
 
+describe('shouldIncludeDataStreamTypeVar', () => {
+  it('returns true when dynamic_signal_types is false', () => {
+    expect(shouldIncludeDataStreamTypeVar(false)).toBe(true);
+  });
+
+  it('returns false when dynamic_signal_types is true', () => {
+    expect(shouldIncludeDataStreamTypeVar(true)).toBe(false);
+  });
+});
+
+describe('addDataStreamTypeVarIfNotPresent', () => {
+  it('adds the data_stream.type var with the given default when not already present', () => {
+    const result = addDataStreamTypeVarIfNotPresent([], 'metrics');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toEqual('data_stream.type');
+    expect(result[0].default).toEqual('metrics');
+    expect(result[0].show_user).toEqual(false);
+  });
+
+  it('uses empty array when vars is undefined', () => {
+    const result = addDataStreamTypeVarIfNotPresent(undefined, 'logs');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toEqual('data_stream.type');
+  });
+
+  it('does not set a default when defaultType is not provided', () => {
+    const result = addDataStreamTypeVarIfNotPresent([]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toEqual('data_stream.type');
+    expect(result[0].default).toBeUndefined();
+  });
+
+  it('does not add the var when data_stream.type is already present', () => {
+    const existing = {
+      name: 'data_stream.type',
+      type: 'text' as RegistryVarType,
+      title: 'existing',
+      description: 'existing',
+      multi: false,
+      required: false,
+      show_user: true,
+    };
+    const result = addDataStreamTypeVarIfNotPresent([existing], 'metrics');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(existing);
+  });
+});
+
 describe('getNormalizedDataStreams', () => {
   const integrationPkg: PackageInfo = {
     name: 'nginx',
@@ -325,7 +375,88 @@ describe('getNormalizedDataStreams', () => {
     });
     expect(result).toHaveLength(1);
     expect(result[0].streams).toHaveLength(1);
-    expect(result?.[0].streams?.[0]?.vars).toEqual([datasetVar]);
+    const vars = result?.[0].streams?.[0]?.vars;
+    // dataset var should not be duplicated
+    expect(vars?.filter((v) => v.name === 'data_stream.dataset')).toHaveLength(1);
+    expect(vars?.find((v) => v.name === 'data_stream.dataset')).toMatchObject(datasetVar);
+  });
+
+  it('should add synthetic data_stream.type var with policyTemplate.type as default', () => {
+    const result = getNormalizedDataStreams({
+      ...integrationPkg,
+      type: 'input',
+      policy_templates: [
+        {
+          input: 'logfile',
+          type: 'logs',
+          name: 'myinput',
+          template_path: 'some/path.hbl',
+          title: 'My Input',
+          description: 'My Input',
+          vars: [],
+        },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    const vars = result[0].streams![0].vars;
+    const typeVar = vars?.find((v) => v.name === 'data_stream.type');
+    expect(typeVar).toBeDefined();
+    expect(typeVar?.default).toEqual('logs');
+    expect(typeVar?.show_user).toEqual(false);
+  });
+
+  it('should not add data_stream.type var when already declared by the package', () => {
+    const existingTypeVar = {
+      name: 'data_stream.type',
+      type: 'text' as RegistryVarType,
+      title: 'custom type',
+      description: 'custom',
+      multi: false,
+      required: false,
+      show_user: true,
+    };
+    const result = getNormalizedDataStreams({
+      ...integrationPkg,
+      type: 'input',
+      policy_templates: [
+        {
+          input: 'logfile',
+          type: 'logs',
+          name: 'myinput',
+          template_path: 'some/path.hbl',
+          title: 'My Input',
+          description: 'My Input',
+          vars: [existingTypeVar],
+        },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    const vars = result[0].streams![0].vars;
+    const typeVars = vars?.filter((v) => v.name === 'data_stream.type');
+    expect(typeVars).toHaveLength(1);
+    expect(typeVars![0]).toMatchObject(existingTypeVar);
+  });
+
+  it('should not add data_stream.type var when dynamic_signal_types is true', () => {
+    const result = getNormalizedDataStreams({
+      ...integrationPkg,
+      type: 'input',
+      policy_templates: [
+        {
+          input: 'otelcol',
+          name: 'otel-dynamic',
+          template_path: 'some/path.hbl',
+          title: 'OTel Dynamic',
+          description: 'OTel with dynamic signal types',
+          dynamic_signal_types: true,
+          vars: [],
+        },
+      ],
+    } as any);
+    expect(result).toHaveLength(1);
+    const vars = result[0].streams![0].vars;
+    const typeVar = vars?.find((v) => v.name === 'data_stream.type');
+    expect(typeVar).toBeUndefined();
   });
 
   const inputPkg: PackageInfo = {

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 
 import {
   DATASET_VAR_NAME,
+  DATA_STREAM_TYPE_VAR_NAME,
   dataTypes,
   OTEL_COLLECTOR_INPUT_TYPE,
   USE_APM_VAR_NAME,
@@ -41,6 +42,21 @@ const DATA_STREAM_DATASET_VAR: RegistryVarsEntry = {
   multi: false,
   required: true,
   show_user: true,
+};
+
+export const DATA_STREAM_TYPE_VAR: RegistryVarsEntry = {
+  name: DATA_STREAM_TYPE_VAR_NAME,
+  type: 'text',
+  title: i18n.translate('xpack.fleet.policyTemplate.dataStreamTypeVar.title', {
+    defaultMessage: 'Data stream type',
+  }),
+  description: i18n.translate('xpack.fleet.policyTemplate.dataStreamTypeVar.description', {
+    defaultMessage:
+      'Set the type for your data stream. Valid values are logs, metrics, traces, and synthetics.',
+  }),
+  multi: false,
+  required: false,
+  show_user: false,
 };
 
 export const DATA_STREAM_USE_APM_VAR: RegistryVarsEntry = {
@@ -202,6 +218,9 @@ export function getNormalizedDataStreams(
     const dataset = datasetName || createDefaultDatasetName(packageInfo, policyTemplate);
 
     let vars = addDatasetVarIfNotPresent(policyTemplate.vars, policyTemplate.name);
+    if (shouldIncludeDataStreamTypeVar(policyTemplate.dynamic_signal_types === true)) {
+      vars = addDataStreamTypeVarIfNotPresent(vars, policyTemplate.type);
+    }
     if (
       shouldIncludeUseAPMVar(
         policyTemplate.input,
@@ -285,6 +304,26 @@ export const addUseAPMVarIfNotPresent = (vars?: RegistryVarsEntry[]): RegistryVa
     return newVars;
   } else {
     return [...newVars, DATA_STREAM_USE_APM_VAR];
+  }
+};
+
+export const shouldIncludeDataStreamTypeVar = (isDynamicSignalTypes: boolean): boolean =>
+  !isDynamicSignalTypes;
+
+export const addDataStreamTypeVarIfNotPresent = (
+  vars?: RegistryVarsEntry[],
+  defaultType?: string
+): RegistryVarsEntry[] => {
+  const newVars = vars ?? [];
+
+  const isDataStreamTypeVarAlreadyAdded = newVars.find(
+    (varEntry) => varEntry.name === DATA_STREAM_TYPE_VAR_NAME
+  );
+
+  if (isDataStreamTypeVarAlreadyAdded) {
+    return newVars;
+  } else {
+    return [...newVars, { ...DATA_STREAM_TYPE_VAR, ...(defaultType && { default: defaultType }) }];
   }
 };
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -6,6 +6,7 @@
  */
 
 import type { NewPackagePolicy, PackageInfo } from '../../server/types';
+import { PackagePolicyValidationError } from '../errors';
 
 import nginxPackageInfo from '../../server/services/package_policies/fixtures/package_info/nginx_1.5.0.json';
 
@@ -372,6 +373,99 @@ describe('toPackagePolicy', () => {
       const simplified = packagePolicyToSimplifiedPackagePolicy(packagePolicy as any);
 
       expect((simplified as any).var_group_selections).toEqual(varGroupSelections);
+    });
+  });
+
+  describe('With input-only package', () => {
+    const inputPkgInfo: PackageInfo = {
+      name: 'log',
+      type: 'input',
+      title: 'Custom logs',
+      version: '2.4.0',
+      description: 'Collect custom logs with Elastic Agent.',
+      format_version: '3.1.5',
+      owner: { github: '' },
+      assets: {} as any,
+      data_streams: [],
+      policy_templates: [
+        {
+          name: 'logs',
+          type: 'logs',
+          title: 'Custom log file',
+          description: 'Collect logs from custom files.',
+          input: 'logfile',
+          template_path: 'input.yml.hbs',
+          vars: [],
+        },
+      ],
+      latestVersion: '2.4.0',
+      keepPoliciesUpToDate: false,
+      status: 'not_installed',
+    };
+
+    it('should accept data_stream.type via simplified API for input packages', () => {
+      const res = simplifiedPackagePolicytoNewPackagePolicy(
+        {
+          name: 'log-1',
+          namespace: 'default',
+          policy_ids: ['policy123'],
+          inputs: {
+            'logs-logfile': {
+              streams: {
+                'log.logs': {
+                  vars: {
+                    'data_stream.type': 'metrics',
+                  },
+                },
+              },
+            },
+          },
+        },
+        inputPkgInfo
+      );
+
+      const streamVars = res.inputs[0].streams[0].vars;
+      expect(streamVars?.['data_stream.type']?.value).toEqual('metrics');
+      expect(res.inputs[0].streams[0].data_stream.type).toEqual('metrics');
+    });
+
+    it('should reject data_stream.type via simplified API when dynamic_signal_types is true', () => {
+      const dynamicPkgInfo: PackageInfo = {
+        ...inputPkgInfo,
+        policy_templates: [
+          {
+            name: 'otel',
+            title: 'OTel',
+            description: 'OTel input',
+            input: 'otelcol',
+            template_path: 'input.yml.hbs',
+            vars: [],
+            dynamic_signal_types: true,
+          } as any,
+        ],
+      };
+
+      expect(() =>
+        simplifiedPackagePolicytoNewPackagePolicy(
+          {
+            name: 'otel-1',
+            namespace: 'default',
+            policy_ids: ['policy123'],
+            inputs: {
+              'otel-otelcol': {
+                streams: {
+                  'log.otel': {
+                    vars: {
+                      'data_stream.type': 'metrics',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          dynamicPkgInfo
+        )
+      ).toThrow(PackagePolicyValidationError);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/simplified_package_policy_helper.ts
@@ -15,7 +15,7 @@ import type {
   PackageInfo,
   ExperimentalDataStreamFeature,
 } from '../types';
-import { DATASET_VAR_NAME } from '../constants';
+import { DATASET_VAR_NAME, DATA_STREAM_TYPE_VAR_NAME } from '../constants';
 
 import { PackagePolicyValidationError } from '../errors';
 
@@ -159,6 +159,17 @@ function formatStreams(streams: NewPackagePolicy['inputs'][number]['streams']) {
   }, {} as SimplifiedPackagePolicyStreams);
 }
 
+export function syncDataStreamTypeFromVar(packagePolicy: NewPackagePolicy): void {
+  for (const input of packagePolicy.inputs) {
+    for (const stream of input.streams) {
+      const typeVal = stream.vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value;
+      if (typeof typeVal === 'string' && typeVal && typeVal !== stream.data_stream.type) {
+        stream.data_stream.type = typeVal;
+      }
+    }
+  }
+}
+
 function assignVariables(
   userProvidedVars: SimplifiedVars,
   varsRecord?: PackagePolicyConfigRecord,
@@ -293,6 +304,8 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
       }
     });
   });
+
+  syncDataStreamTypeFromVar(packagePolicy);
 
   return packagePolicy;
 }

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -2088,6 +2088,54 @@ describe('Fleet - validatePackagePolicyConfig', () => {
     });
   });
 
+  describe('Data stream type', () => {
+    const validateDataStreamType = (type: string, packageType: string = 'input') => {
+      return validatePackagePolicyConfig(
+        {
+          type: 'text',
+          value: type,
+        },
+        {
+          name: 'data_stream.type',
+          type: 'text',
+        },
+        'data_stream.type',
+        parse,
+        packageType
+      );
+    };
+
+    it('should return null for valid types', () => {
+      expect(validateDataStreamType('logs')).toBeNull();
+      expect(validateDataStreamType('metrics')).toBeNull();
+      expect(validateDataStreamType('traces')).toBeNull();
+      expect(validateDataStreamType('synthetics')).toBeNull();
+      expect(validateDataStreamType('profiling')).toBeNull();
+    });
+
+    it('should return an error for an unknown type', () => {
+      const res = validateDataStreamType('bogus');
+      expect(res).toEqual([
+        'Data stream type must be one of: logs, metrics, traces, synthetics, profiling',
+      ]);
+    });
+
+    it('should return null when value is undefined', () => {
+      const res = validatePackagePolicyConfig(
+        { type: 'text', value: undefined },
+        { name: 'data_stream.type', type: 'text' },
+        'data_stream.type',
+        parse,
+        'input'
+      );
+      expect(res).toBeNull();
+    });
+
+    it('should return null for non-input package type', () => {
+      expect(validateDataStreamType('bogus', 'integration')).toBeNull();
+    });
+  });
+
   describe('URL validation', () => {
     it('should not return an error message for a valid URL', () => {
       const res = validatePackagePolicyConfig(

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -22,7 +22,7 @@ import type {
   RegistryVarGroup,
 } from '../types';
 
-import { DATASET_VAR_NAME } from '../constants';
+import { DATASET_VAR_NAME, DATA_STREAM_TYPE_VAR_NAME } from '../constants';
 
 import {
   isValidNamespace,
@@ -33,7 +33,7 @@ import {
   buildInputKey,
 } from '.';
 import { packageHasNoPolicyTemplates } from './policy_template';
-import { isValidDataset } from './is_valid_namespace';
+import { isValidDataset, isValidDataStreamType } from './is_valid_namespace';
 
 type Errors = string[] | null;
 
@@ -828,6 +828,17 @@ export const validatePackagePolicyConfig = (
       parsedValue.dataset ? parsedValue.dataset : parsedValue,
       false
     );
+    if (!valid && error) {
+      errors.push(error);
+    }
+  }
+
+  if (
+    varName === DATA_STREAM_TYPE_VAR_NAME &&
+    packageType === 'input' &&
+    parsedValue !== undefined
+  ) {
+    const { valid, error } = isValidDataStreamType(parsedValue, false);
     if (!valid && error) {
       errors.push(error);
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -8,7 +8,7 @@
 jest.mock('../epm/packages');
 jest.mock('../app_context');
 
-import { DATASET_VAR_NAME } from '../../../common/constants';
+import { DATA_STREAM_TYPE_VAR_NAME, DATASET_VAR_NAME } from '../../../common/constants';
 import type { PackagePolicy } from '../../types';
 import { PackagePolicyValidationError } from '../../errors';
 
@@ -387,6 +387,30 @@ packageInfoCache.set('elastic_connectors-1.0.0', {
       ml_model: [],
     },
   },
+});
+
+packageInfoCache.set('sql_input-1.0.0', {
+  format_version: '3.1.5',
+  name: 'sql_input',
+  title: 'SQL Input',
+  version: '1.0.0',
+  type: 'input',
+  release: 'ga',
+  policy_templates: [
+    {
+      name: 'mysql',
+      type: 'metrics',
+      title: 'MySQL',
+      description: 'Collect metrics from MySQL.',
+      input: 'sql/metrics',
+      template_path: 'input.yml.hbs',
+      vars: [],
+    },
+  ],
+  data_streams: [],
+  latestVersion: '1.0.0',
+  status: 'not_installed',
+  assets: { kibana: {}, elasticsearch: {} },
 });
 
 packageInfoCache.set('non_dynamic_pkg-1.0.0', {
@@ -2279,6 +2303,58 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
       expect(permissions?.['policy-combined-logfile']?.indices?.[0].names).toEqual([
         'logs-combined_inputs_pkg.app-default',
       ]);
+    });
+
+    it('uses data_stream.type var value for permissions when it overrides stream.data_stream.type', () => {
+      // Simulates a sql_input policy where policyTemplate.type is 'metrics' but the user
+      // overrode data_stream.type to 'logs' via the simplified API. The saved stream retains
+      // data_stream.type = 'metrics' on the stream object; the override lives in the var.
+      const packagePolicies: PackagePolicy[] = [
+        {
+          id: 'sql-logs-override',
+          name: 'sql-logs-override-policy',
+          namespace: 'default',
+          enabled: true,
+          package: { name: 'sql_input', version: '1.0.0', title: 'SQL Input' },
+          inputs: [
+            {
+              type: 'sql/metrics',
+              enabled: true,
+              streams: [
+                {
+                  id: 'stream-1',
+                  enabled: true,
+                  data_stream: {
+                    type: 'metrics',
+                    dataset: 'sql_input.mysql',
+                    elasticsearch: { dynamic_dataset: true, dynamic_namespace: true },
+                  },
+                  vars: {
+                    [DATA_STREAM_TYPE_VAR_NAME]: { value: 'logs' },
+                  },
+                } as any,
+              ],
+            },
+          ],
+          created_at: '',
+          updated_at: '',
+          created_by: '',
+          updated_by: '',
+          revision: 1,
+          policy_id: '',
+          policy_ids: [''],
+        },
+      ];
+
+      const permissions = storedPackagePoliciesToAgentPermissions(
+        packageInfoCache,
+        'default',
+        packagePolicies
+      );
+
+      expect(permissions?.['sql-logs-override']?.indices).toHaveLength(1);
+      // Must use 'logs-*-*', not 'metrics-*-*'
+      expect(permissions?.['sql-logs-override']?.indices?.[0].names).toEqual(['logs-*-*']);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -11,6 +11,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 
 import {
+  DATA_STREAM_TYPE_VAR_NAME,
   FLEET_APM_PACKAGE,
   FLEET_CONNECTORS_PACKAGE,
   FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE,
@@ -232,7 +233,11 @@ export function storedPackagePoliciesToAgentPermissions(
                     return;
                   }
 
-                  if (!stream.data_stream.type) {
+                  const effectiveStreamType =
+                    (stream.vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value as string | undefined) ||
+                    stream.data_stream.type;
+
+                  if (!effectiveStreamType) {
                     if (inputAllowsDynamic) {
                       // Dynamic signal types input — type is resolved at runtime, skip
                       return;
@@ -257,7 +262,7 @@ export function storedPackagePoliciesToAgentPermissions(
                   const datasetIsPrefix = registryDs?.dataset_is_prefix;
 
                   const ds: DataStreamMeta = {
-                    type: stream.data_stream.type,
+                    type: effectiveStreamType,
                     dataset: applyOtelDatasetSuffixIfNeeded(rawDataset, {
                       isOtelInput,
                       dynamicDataset: stream.data_stream.elasticsearch?.dynamic_dataset,

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -12960,6 +12960,14 @@ describe('_applyIndexPrivileges()', () => {
 });
 
 describe('_validateRestrictedFieldsNotModifiedOrThrow()', () => {
+  beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  afterEach(() => {
+    appContextService.stop();
+  });
+
   const pkgInfo = {
     name: 'custom_logs',
     title: 'Custom Logs',
@@ -13082,6 +13090,72 @@ describe('_validateRestrictedFieldsNotModifiedOrThrow()', () => {
         oldPackagePolicy,
         packagePolicyUpdate: newPackagePolicy,
         pkgInfo: { ...pkgInfo, type: 'integration' },
+      })
+    ).not.toThrow();
+  });
+
+  it('should throw if data stream type is modified', () => {
+    const makePolicyWithType = (streamType: string) => ({
+      ...createInputPkgPolicy({ namespace: 'default', dataset: 'custom_logs.logs' }),
+      inputs: [
+        {
+          type: 'logfile',
+          policy_template: 'logs',
+          enabled: true,
+          streams: [
+            {
+              enabled: true,
+              data_stream: { type: 'logs', dataset: 'custom_logs.logs' },
+              vars: {
+                'data_stream.dataset': { type: 'text', value: 'custom_logs.logs' },
+                'data_stream.type': { type: 'text', value: streamType },
+              },
+              id: 'logfile-custom_logs.logs-1',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(() =>
+      _validateRestrictedFieldsNotModifiedOrThrow({
+        oldPackagePolicy: makePolicyWithType('logs'),
+        packagePolicyUpdate: makePolicyWithType('metrics'),
+        pkgInfo,
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Package policy data stream type cannot be modified for input only packages, please create a new package policy."`
+    );
+  });
+
+  it('should not throw if data stream type is unchanged', () => {
+    const makePolicyWithType = (streamType: string) => ({
+      ...createInputPkgPolicy({ namespace: 'default', dataset: 'custom_logs.logs' }),
+      inputs: [
+        {
+          type: 'logfile',
+          policy_template: 'logs',
+          enabled: true,
+          streams: [
+            {
+              enabled: true,
+              data_stream: { type: 'logs', dataset: 'custom_logs.logs' },
+              vars: {
+                'data_stream.dataset': { type: 'text', value: 'custom_logs.logs' },
+                'data_stream.type': { type: 'text', value: streamType },
+              },
+              id: 'logfile-custom_logs.logs-1',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(() =>
+      _validateRestrictedFieldsNotModifiedOrThrow({
+        oldPackagePolicy: makePolicyWithType('logs'),
+        packagePolicyUpdate: makePolicyWithType('logs'),
+        pkgInfo,
       })
     ).not.toThrow();
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -55,6 +55,7 @@ import {
   getInputEffectiveName,
   getRegistryStreamWithDataStreamForInputType,
   validateFleetSavedObjectId,
+  syncDataStreamTypeFromVar,
 } from '../../common/services';
 import {
   SO_SEARCH_LIMIT,
@@ -556,6 +557,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
     this.keepPolicyIdInSync(packagePolicy);
 
+    syncDataStreamTypeFromVar(packagePolicy);
     await preflightCheckPackagePolicy(soClient, packagePolicy, basePkgInfo);
 
     let enrichedPackagePolicy = await packagePolicyService.runExternalCallbacks(
@@ -963,6 +965,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       });
 
       this.keepPolicyIdInSync(packagePolicy);
+      syncDataStreamTypeFromVar(packagePolicy);
       await preflightCheckPackagePolicy(soClient, packagePolicy, basePkgInfo);
     });
 
@@ -4443,7 +4446,7 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
                   }, new val '${JSON.stringify(stream?.vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value)}'`
               );
             throw new PackagePolicyValidationError(
-              i18n.translate('xpack.fleet.updatePackagePolicy.datasetCannotBeModified', {
+              i18n.translate('xpack.fleet.updatePackagePolicy.dataStreamTypeCannotBeModified', {
                 defaultMessage:
                   'Package policy data stream type cannot be modified for input only packages, please create a new package policy.',
               })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Fleet] Support data_stream.type variable in simplified policy API (#269895)](https://github.com/elastic/kibana/pull/269895)

<!--BACKPORT [{"sourcePullRequest":{"number":269895,"url":"https://github.com/elastic/kibana/pull/269895","title":"[Fleet] Support data_stream.type variable in simplified policy API"},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"sourceCommit":{"sha":"80dd0558707ea496c8faac9e7d169e44e5c8f254"}}] BACKPORT-->
