### PR TITLE
fleet: inject data_stream.dataset into templateVars for composable integrations

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -2385,6 +2385,109 @@ describe('Package policy service', () => {
       });
     });
 
+    it('should inject data_stream.dataset into templateVars when absent from stream vars (composable integration)', async () => {
+      const pkgInfo = {
+        name: 'dsvarpkg',
+        version: '1.0.0',
+        type: 'integration',
+        data_streams: [
+          {
+            type: 'logs',
+            dataset: 'dsvarpkg.customds',
+            path: 'customds',
+            streams: [
+              {
+                input: 'log',
+                template_path: 'stream_ds.yml',
+              },
+            ],
+          },
+        ],
+        policy_templates: [{ inputs: [{ type: 'log' }] }],
+      } as unknown as PackageInfo;
+
+      const inputs = await _compilePackagePolicyInputs(
+        pkgInfo,
+        {},
+        [
+          {
+            type: 'log',
+            enabled: true,
+            streams: [
+              {
+                id: 'stream-composable-no-dataset-var',
+                data_stream: { dataset: 'dsvarpkg.customds', type: 'logs' },
+                enabled: true,
+                vars: {
+                  paths: { value: ['/var/log/app.log'], type: 'text' },
+                  // data_stream.dataset intentionally absent — composable integration case
+                },
+              },
+            ],
+          },
+        ],
+        ASSETS_MAP_FIXTURES
+      );
+
+      expect(inputs[0].streams[0].compiled_stream).toEqual({
+        type: 'log',
+        data_stream: { dataset: 'dsvarpkg.customds' },
+        paths: ['/var/log/app.log'],
+      });
+    });
+
+    it('should not overwrite data_stream.dataset in templateVars when already present in stream vars', async () => {
+      const pkgInfo = {
+        name: 'dsvarpkg',
+        version: '1.0.0',
+        type: 'integration',
+        data_streams: [
+          {
+            type: 'logs',
+            dataset: 'dsvarpkg.customds',
+            path: 'customds',
+            streams: [
+              {
+                input: 'log',
+                template_path: 'stream_ds.yml',
+              },
+            ],
+          },
+        ],
+        policy_templates: [{ inputs: [{ type: 'log' }] }],
+      } as unknown as PackageInfo;
+
+      const inputs = await _compilePackagePolicyInputs(
+        pkgInfo,
+        {},
+        [
+          {
+            type: 'log',
+            enabled: true,
+            streams: [
+              {
+                id: 'stream-existing-dataset-var',
+                data_stream: { dataset: 'dsvarpkg.customds', type: 'logs' },
+                enabled: true,
+                vars: {
+                  paths: { value: ['/var/log/app.log'], type: 'text' },
+                  'data_stream.dataset': { value: 'user.custom_dataset', type: 'text' },
+                },
+              },
+            ],
+          },
+        ],
+        ASSETS_MAP_FIXTURES
+      );
+
+      // stream.data_stream.dataset is 'dsvarpkg.customds' but the user-set var should win
+      expect(inputs[0].streams[0].compiled_stream).toEqual({
+        type: 'log',
+        data_stream: { dataset: 'user.custom_dataset' },
+        paths: ['/var/log/app.log'],
+      });
+    });
+
     it('should work with a two level dataset name', async () => {
       const inputs = await _compilePackagePolicyInputs(
         {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -3886,6 +3886,14 @@ function _compilePackageStream(
 
   const datasetPath = packageDataStream.path;
   const templateVars = Object.assign({}, vars, input.vars, stream.vars);
+
+  // Inject data_stream.dataset for composable integrations: the dataset is fixed by the
+  // integration (not user-configurable) so it is absent from stream.vars, but input-package
+  // HBS templates reference {{data_stream.dataset}} and need the value to render correctly.
+  if (!templateVars['data_stream.dataset']) {
+    templateVars['data_stream.dataset'] = { value: stream.data_stream.dataset, type: 'text' };
+  }
+
   const metaVars = getMetaVariables(pkgInfo, input, streamIn, agentVersion);
 
   if (streamFromPkg.template_paths?.length) {


### PR DESCRIPTION
## Summary

Fixes HBS agent template compilation for composable integrations (integrations that import an input package via `requires.input`).

Input packages declare `data_stream.dataset` as a user-facing policy template variable and their HBS agent templates reference it as `{{data_stream.dataset}}`. This flat Handlebars variable is resolved from `stream.vars` via `buildTemplateVariables`, which splits dotted keys so `"data_stream.dataset": { value: "nginx.access" }` becomes `vars.data_stream.dataset = "nginx.access"` in the template context.

For composable integrations the dataset is fixed by the integration (it is always `<package>.<data_stream>`) and must not be user-configurable. The companion elastic-package PR (https://github.com/elastic/elastic-package/pull/3719) intentionally removes `data_stream.dataset` from the bundled stream manifest's `vars` section — Fleet rejects policies that send a var not declared in the package manifest. As a consequence, `stream.vars` no longer carries `data_stream.dataset`, so `{{data_stream.dataset}}` renders as empty in the compiled agent configuration.

The fix: in `_compilePackageStream`, after assembling `templateVars` from `vars + input.vars + stream.vars`, inject `data_stream.dataset` from `stream.data_stream.dataset` when it is not already present. `stream.data_stream.dataset` is always the correct, validated value at this point — it has already been used two lines earlier to look up `packageDataStream` (and throws `StreamNotFoundError` if missing).

The guard (`!templateVars['data_stream.dataset']`) makes this a no-op for any stream that already carries the var, so non-composable integrations are unaffected.

> **Depends on elastic-package companion PR**: https://github.com/elastic/elastic-package/pull/3719
> Without that PR the problem does not surface (the var is present in `stream.vars` so the guard is false and this code is never reached). With that PR alone and without this fix, `{{data_stream.dataset}}` renders empty in the compiled agent config.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **No risk for existing integrations**: the guard ensures the injection only fires when `data_stream.dataset` is absent from `templateVars`. For all current non-composable integrations, `stream.vars` either carries the value already or the HBS template does not reference `{{data_stream.dataset}}` — either way behaviour is unchanged.
- **Composable integrations**: the injected value is sourced from `stream.data_stream.dataset`, which is already validated and is the same value Fleet uses to route data to the correct index. There is no risk of incorrect dataset routing.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->