### PR TITLE
[Fleet] fix offline OTel collectors leaking live metrics from re-enrolled collector on same host

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.test.ts
@@ -101,6 +101,99 @@ describe('fetchAndAssignAgentMetrics', () => {
     );
   });
 
+  it('does not assign metrics to non-reporting OPAMP agents (offline, inactive, unenrolled, uninstalled)', async () => {
+    const esClient = {
+      search: jest
+        .fn()
+        .mockResolvedValueOnce({ aggregations: { agents: { buckets: [] } } }) // fleet
+        .mockResolvedValueOnce({
+          aggregations: {
+            agents: {
+              buckets: [
+                {
+                  key: 'my-collector-host',
+                  max_memory_size: { value: 512 },
+                  avg_cpu: { value: 0.5 },
+                },
+              ],
+            },
+          },
+        }), // otel — only the online agent
+    };
+    const agents = [
+      {
+        id: 'online-agent',
+        type: 'OPAMP',
+        status: 'online',
+        non_identifying_attributes: { 'elastic.display.name': 'my-collector-host' },
+      },
+      {
+        id: 'offline-agent',
+        type: 'OPAMP',
+        status: 'offline',
+        non_identifying_attributes: { 'elastic.display.name': 'my-collector-host' },
+      },
+      {
+        id: 'inactive-agent',
+        type: 'OPAMP',
+        status: 'inactive',
+        non_identifying_attributes: { 'elastic.display.name': 'my-collector-host' },
+      },
+      {
+        id: 'unenrolled-agent',
+        type: 'OPAMP',
+        status: 'unenrolled',
+        non_identifying_attributes: { 'elastic.display.name': 'my-collector-host' },
+      },
+    ];
+    const result = await fetchAndAssignAgentMetrics(esClient as any, agents as any);
+
+    // Only the online agent should receive metrics
+    expect(result.find((a) => a.id === 'online-agent')?.metrics).toEqual({
+      cpu_avg: 0.5,
+      memory_size_byte_avg: 512,
+    });
+    expect(result.find((a) => a.id === 'offline-agent')?.metrics).toEqual({
+      cpu_avg: undefined,
+      memory_size_byte_avg: undefined,
+    });
+    expect(result.find((a) => a.id === 'inactive-agent')?.metrics).toEqual({
+      cpu_avg: undefined,
+      memory_size_byte_avg: undefined,
+    });
+    expect(result.find((a) => a.id === 'unenrolled-agent')?.metrics).toEqual({
+      cpu_avg: undefined,
+      memory_size_byte_avg: undefined,
+    });
+
+    // Only the online agent's hostname is queried
+    const otelSearchCall = esClient.search.mock.calls[1][0];
+    expect(otelSearchCall.query.bool.must).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ terms: { 'service.instance.id': ['my-collector-host'] } }),
+      ])
+    );
+  });
+
+  it('skips the ES query entirely when all OPAMP agents are non-reporting', async () => {
+    const esClient = {
+      search: jest.fn().mockResolvedValueOnce({ aggregations: { agents: { buckets: [] } } }), // fleet only
+    };
+    const agents = [
+      {
+        id: 'offline-agent',
+        type: 'OPAMP',
+        status: 'offline',
+        non_identifying_attributes: { 'elastic.display.name': 'my-collector-host' },
+      },
+    ];
+    const result = await fetchAndAssignAgentMetrics(esClient as any, agents as any);
+
+    expect(result[0].metrics).toBeUndefined();
+    // Only the fleet search call fires; no OTel search call
+    expect(esClient.search).toHaveBeenCalledTimes(1);
+  });
+
   it('assigns the same metrics bucket to all agents sharing the same elastic.display.name', async () => {
     const esClient = {
       search: jest

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.ts
@@ -13,6 +13,17 @@ import { DATA_TIERS } from '../../../common/constants';
 
 const AGGREGATION_MAX_SIZE = 1000;
 
+// Agents in these states are not actively reporting OTel telemetry.
+// Excluding them from the hostname-keyed metrics query prevents a newly enrolled collector
+// on the same host from leaking its live metrics to a stale/offline agent entry.
+// See https://github.com/elastic/kibana/issues/274843
+const NON_REPORTING_OPAMP_STATUSES: Array<NonNullable<Agent['status']>> = [
+  'offline',
+  'inactive',
+  'unenrolled',
+  'uninstalled',
+];
+
 export async function fetchAndAssignAgentMetrics(esClient: ElasticsearchClient, agents: Agent[]) {
   const logger = appContextService.getLogger();
   const fleetAgents = agents.filter((agent) => agent.type !== 'OPAMP');
@@ -45,8 +56,15 @@ async function _fetchAndAssignOtelMetrics(esClient: ElasticsearchClient, agents:
   // Map service.instance.id (hostname from elastic.display.name) → agentIds.
   // Multiple agents can share the same display name, and all should receive the same metrics bucket.
   // Collectors report service.instance.id as their hostname, not their Fleet agent ID.
+  //
+  // Only include agents that are actively reporting. Offline/inactive/unenrolled agents must not
+  // be included in the query: they share the same hostname as any newly enrolled collector on the
+  // same host, so they would otherwise receive that collector's live metrics.
   const instanceIdToAgentIds = new Map<string, string[]>();
   for (const agent of agents) {
+    if (agent.status && NON_REPORTING_OPAMP_STATUSES.includes(agent.status)) {
+      continue;
+    }
     const instanceId =
       (agent.non_identifying_attributes?.['elastic.display.name'] as string | undefined) ??
       agent.id;
@@ -58,6 +76,11 @@ async function _fetchAndAssignOtelMetrics(esClient: ElasticsearchClient, agents:
     }
   }
   const instanceIds = Array.from(instanceIdToAgentIds.keys());
+
+  // If no agents are actively reporting, skip the ES query entirely.
+  if (instanceIds.length === 0) {
+    return agents.map(({ id }) => ({ id, metrics: undefined }));
+  }
 
   const res = await esClient.search<
     unknown,

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/list.ts
@@ -313,6 +313,10 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should return metrics for OPAMP agents when called with withMetrics', async () => {
+      const now = Date.now();
+      // last_checkin must be recent so the agent's computed status is 'online' (not 'offline').
+      // Metrics are only assigned to actively-reporting OPAMP agents.
+      const recentCheckin = new Date(now - 60 * 1000).toISOString();
       await es.index({
         id: 'opamp-agent-with-metrics',
         index: '.fleet-agents',
@@ -325,13 +329,11 @@ export default function ({ getService }: FtrProviderContext) {
           local_metadata: { host: { hostname: 'opamp-host' } },
           user_provided_metadata: {},
           enrolled_at: '2022-06-21T12:14:25Z',
-          last_checkin: '2022-06-27T12:27:29Z',
+          last_checkin: recentCheckin,
           tags: ['existingTag'],
           agent: { id: 'opamp-agent-with-metrics', version: '9.2.0' },
         },
       });
-
-      const now = Date.now();
       const threeMinutesAgo = new Date(now - 3 * 60 * 1000);
       threeMinutesAgo.setSeconds(0, 0);
       const twoMinutesAgo = new Date(now - 2 * 60 * 1000);


### PR DESCRIPTION
## Summary

Fixes #274843

OTel collector metrics are stored in `metrics-collectortelemetry.otel-*` indexed by hostname (`service.instance.id` = `elastic.display.name`). When a new collector is enrolled on the same host as an offline/unenrolled one, both share the same hostname, so the stale agent entry was receiving the new collector's live CPU and memory values.

The fix excludes non-reporting agents (`offline`, `inactive`, `unenrolled`, `uninstalled`) from the hostname-keyed ES aggregation query in `_fetchAndAssignOtelMetrics`. These agents get `metrics: undefined` instead of borrowed live metrics. If no OPAMP agents are actively reporting, the ES query is skipped entirely.

## Test plan

- [x] Unit tests pass: `node scripts/jest x-pack/platform/plugins/shared/fleet/server/services/agents/agent_metrics.test.ts`
- [x] Repro: enroll an OTel collector, wait for it to go offline, enroll a new collector on the same host → offline entry should show `—` / N/A for CPU and memory, not the new collector's live values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1722" height="610" alt="image" src="https://github.com/user-attachments/assets/3276b442-3ae5-4e03-929c-3e24e8ec6bf3" />
