### PR TITLE
Fix flaky synonyms rule edit test

### DIFF
--- a/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
+++ b/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
@@ -205,13 +205,14 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
           throw new Error(`Badge with index ${index} not found`);
         }
         const expectedCount = initialBadges.length - 1;
+        const deleteButton = await initialBadges[index].findByTagName('button');
+        await deleteButton.click();
 
         const badges = await testSubjects.findAll(this.TEST_IDS.FLYOUT_FROM_BADGE);
         if (badges.length === expectedCount) {
           return;
         }
-        const deleteButton = await badges[index].findByTagName('button');
-        await deleteButton.click();
+
         throw new Error(
           `Clicked remove on badge ${index}, waiting for badge count to drop to ${expectedCount}`
         );

--- a/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
+++ b/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
@@ -190,8 +190,12 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
         FLYOUT_FROM_BADGE: 'searchSynonymsSynonymsRuleFlyoutFromTermBadge',
       },
       async addFromSynonym(synonym: string) {
-        await testSubjects.setValue(this.TEST_IDS.FLYOUT_FROM_INPUT, synonym);
-        await testSubjects.setValue(this.TEST_IDS.FLYOUT_FROM_INPUT, '\uE007');
+        const comboBox = await testSubjects.find(this.TEST_IDS.FLYOUT_FROM_INPUT);
+        const input = await comboBox.findByCssSelector('[role="combobox"]');
+        await input.click();
+        await input.clearValue();
+        await input.type(synonym);
+        await input.pressKeys(browser.keys.ENTER);
       },
       async addMapTo(synonym: string) {
         await testSubjects.setValue(this.TEST_IDS.FLYOUT_MAPTO_INPUT, synonym);
@@ -204,16 +208,27 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
         if (index >= initialBadges.length) {
           throw new Error(`Badge with index ${index} not found`);
         }
-        const expectedCount = initialBadges.length - 1;
+        const initialTerms = await Promise.all(
+          initialBadges.map(async (badge) => (await badge.getVisibleText()).trim())
+        );
+        const termToRemove = initialTerms[index];
+        const expectedTerms = initialTerms.filter((_, termIndex) => termIndex !== index);
+
+        const deleteButton = await initialBadges[index].findByTagName('button');
+        await deleteButton.click();
+
         await retry.try(async () => {
           const badges = await testSubjects.findAll(this.TEST_IDS.FLYOUT_FROM_BADGE);
-          if (badges.length === expectedCount) {
+          const terms = await Promise.all(
+            badges.map(async (badge) => (await badge.getVisibleText()).trim())
+          );
+          if (terms.join(',') === expectedTerms.join(',')) {
             return;
           }
-          const deleteButton = await badges[index].findByTagName('button');
-          await deleteButton.click();
           throw new Error(
-            `Clicked remove on badge ${index}, waiting for badge count to drop to ${expectedCount}`
+            `Clicked remove on badge "${termToRemove}", waiting for terms to be ${expectedTerms.join(
+              ','
+            )}; got ${terms.join(',')}`
           );
         });
       },

--- a/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
+++ b/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
@@ -205,17 +205,16 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
           throw new Error(`Badge with index ${index} not found`);
         }
         const expectedCount = initialBadges.length - 1;
-        await retry.try(async () => {
-          const badges = await testSubjects.findAll(this.TEST_IDS.FLYOUT_FROM_BADGE);
-          if (badges.length === expectedCount) {
-            return;
-          }
-          const deleteButton = await badges[index].findByTagName('button');
-          await deleteButton.click();
-          throw new Error(
-            `Clicked remove on badge ${index}, waiting for badge count to drop to ${expectedCount}`
-          );
-        });
+
+        const badges = await testSubjects.findAll(this.TEST_IDS.FLYOUT_FROM_BADGE);
+        if (badges.length === expectedCount) {
+          return;
+        }
+        const deleteButton = await badges[index].findByTagName('button');
+        await deleteButton.click();
+        throw new Error(
+          `Clicked remove on badge ${index}, waiting for badge count to drop to ${expectedCount}`
+        );
       },
     },
   };

--- a/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
+++ b/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
@@ -190,12 +190,8 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
         FLYOUT_FROM_BADGE: 'searchSynonymsSynonymsRuleFlyoutFromTermBadge',
       },
       async addFromSynonym(synonym: string) {
-        const comboBox = await testSubjects.find(this.TEST_IDS.FLYOUT_FROM_INPUT);
-        const input = await comboBox.findByCssSelector('[role="combobox"]');
-        await input.click();
-        await input.clearValue();
-        await input.type(synonym);
-        await input.pressKeys(browser.keys.ENTER);
+        await testSubjects.setValue(this.TEST_IDS.FLYOUT_FROM_INPUT, synonym);
+        await testSubjects.setValue(this.TEST_IDS.FLYOUT_FROM_INPUT, '\uE007');
       },
       async addMapTo(synonym: string) {
         await testSubjects.setValue(this.TEST_IDS.FLYOUT_MAPTO_INPUT, synonym);
@@ -208,27 +204,16 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
         if (index >= initialBadges.length) {
           throw new Error(`Badge with index ${index} not found`);
         }
-        const initialTerms = await Promise.all(
-          initialBadges.map(async (badge) => (await badge.getVisibleText()).trim())
-        );
-        const termToRemove = initialTerms[index];
-        const expectedTerms = initialTerms.filter((_, termIndex) => termIndex !== index);
-
-        const deleteButton = await initialBadges[index].findByTagName('button');
-        await deleteButton.click();
-
+        const expectedCount = initialBadges.length - 1;
         await retry.try(async () => {
           const badges = await testSubjects.findAll(this.TEST_IDS.FLYOUT_FROM_BADGE);
-          const terms = await Promise.all(
-            badges.map(async (badge) => (await badge.getVisibleText()).trim())
-          );
-          if (terms.join(',') === expectedTerms.join(',')) {
+          if (badges.length === expectedCount) {
             return;
           }
+          const deleteButton = await badges[index].findByTagName('button');
+          await deleteButton.click();
           throw new Error(
-            `Clicked remove on badge "${termToRemove}", waiting for terms to be ${expectedTerms.join(
-              ','
-            )}; got ${terms.join(',')}`
+            `Clicked remove on badge ${index}, waiting for badge count to drop to ${expectedCount}`
           );
         });
       },


### PR DESCRIPTION
## Summary

Fixes a flaky Search Synonyms FTR page object interaction by targeting the EUI combobox input directly and making synonym badge removal a single-click action that waits for the exact remaining terms.

## Testing

- node scripts/eslint x-pack/solutions/search/test/page_objects/search_synonyms_page.ts