### PR TITLE
[Agent Builder] HITL: Remove clarifying title

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -40,9 +40,6 @@ interface RoundLayoutProps {
 const labels = {
   container: i18n.translate('xpack.agentBuilder.round.container', {
     defaultMessage: 'Conversation round',
-  }),
-  askUserQuestionPreamble: i18n.translate('xpack.agentBuilder.round.askUserQuestionPreamble', {
-    defaultMessage: 'I need to clarify a few things first.',
   }),
 };
 
@@ -268,9 +265,6 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
             case AgentPromptType.ask_user_question:
               return (
                 <React.Fragment key={prompt.id}>
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="m">{labels.askUserQuestionPreamble}</EuiText>
-                  </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <AskUserQuestionPrompt
                       promptId={prompt.id}


### PR DESCRIPTION
## Summary

- Removes the "I need to clarify a few things first." preamble text shown before HITL ask-user-question prompts

<img width="702" height="703" alt="image" src="https://github.com/user-attachments/assets/879719ed-b6e5-4927-a860-4faf9fbe0020" />


## References

Epic: https://github.com/elastic/search-team/issues/14202