### PR TITLE
[Discover][Logs] Skip resource badges for array-wrapped empty values

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_available_resource_fields.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_available_resource_fields.test.ts
@@ -133,4 +133,47 @@ describe('getAvailableResourceFields', () => {
     // Arrays are not extracted, returned as field names
     expect(fields).toEqual(['service.name']);
   });
+
+  it('should ignore an array containing only an empty string', () => {
+    const fields = getAvailableResourceFields({
+      'service.name': [''],
+    });
+    expect(fields).toEqual([]);
+  });
+
+  it('should ignore an array containing only empty strings', () => {
+    const fields = getAvailableResourceFields({
+      'service.name': ['', ''],
+    });
+    expect(fields).toEqual([]);
+  });
+
+  it('should ignore an array containing only null values', () => {
+    const fields = getAvailableResourceFields({
+      'service.name': [null],
+    });
+    expect(fields).toEqual([]);
+  });
+
+  it('should ignore an empty array', () => {
+    const fields = getAvailableResourceFields({
+      'service.name': [],
+    });
+    expect(fields).toEqual([]);
+  });
+
+  it('should fall through to a populated field when an earlier field in the group is an empty array', () => {
+    const fields = getAvailableResourceFields({
+      'kubernetes.container.name': [''],
+      'container.name': 'my-container',
+    });
+    expect(fields).toEqual(['container.name']);
+  });
+
+  it('should keep an array that contains at least one non-empty value', () => {
+    const fields = getAvailableResourceFields({
+      'service.name': ['', 'my-service'],
+    });
+    expect(fields).toEqual(['service.name']);
+  });
 });

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_available_resource_fields.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_available_resource_fields.ts
@@ -35,16 +35,20 @@ const AVAILABLE_RESOURCE_FIELDS: Array<Array<keyof ResourceFields>> = [
   ],
 ];
 
+const isEmptyScalar = (value: unknown): boolean =>
+  value === undefined || value === null || value === '';
+
+// In Classic mode the `fields` API returns values wrapped in arrays, so a blank
+// field arrives as `['']`. Treat empty arrays and arrays containing only
+// empty/null values as empty, consistent with how scalar null/'' are handled.
+const isEmptyResourceValue = (value: unknown): boolean =>
+  Array.isArray(value) ? value.every(isEmptyScalar) : isEmptyScalar(value);
+
 export const getAvailableResourceFields = (resourceDoc: Record<string, unknown>): string[] =>
   AVAILABLE_RESOURCE_FIELDS.reduce<string[]>((acc, fields) => {
     for (const fieldName of fields) {
       const result = getFieldValueWithFallback(resourceDoc, fieldName);
-      if (
-        result.field &&
-        result.value !== undefined &&
-        result.value !== null &&
-        result.value !== ''
-      ) {
+      if (result.field && !isEmptyResourceValue(result.value)) {
         acc.push(result.field);
         break;
       }


### PR DESCRIPTION
## Summary

Closes #275134

In Discover Classic mode, the `fields` API returns field values wrapped in arrays. When a resource field is an empty string, it arrives as `['']`, which bypassed the existing scalar-only empty check in `getAvailableResourceFields` and caused a misleading `(blank)` resource badge to render.

This change treats empty arrays and arrays whose elements are all empty/null the same way as scalar `null`, `undefined`, and `''`: the field is excluded and no badge is shown. Arrays with at least one non-empty value (e.g. `['service1', 'service2']` or `['', 'my-service']`) continue to produce a badge, preserving existing behavior.

## How to reproduce

- Manual verification in Discover (Classic mode, Observability space):
  1. Ingest a log document with an empty `service.name` into a `logs-*` data stream:
     ```json
     POST logs-repro.test-default/_bulk?refresh=true
     { "create": {} }
     { "@timestamp": "2026-06-29T10:00:00.000Z", "message": "empty service.name", "service": { "name": "" }, "data_stream": { "type": "logs", "dataset": "repro.test", "namespace": "default" } }
     ```
  2. Open Discover with data view `logs-*` and filter with `data_stream.dataset: "repro.test"`.
  3. Confirm the empty-service row shows **no** `(blank)` resource badge.
  4. Confirm a row with a valid `service.name` still shows the expected badge.

## Screenshots

| Before | After |
|--------|-------|
| <img width="2110" height="1158" alt="Before: resource badge shows (blank) for empty service.name" src="https://github.com/user-attachments/assets/9d6beb6c-28d1-4a4e-b1e2-c990fe96f62c" /> | <img width="2250" height="1290" alt="After: no resource badge for empty service.name" src="https://github.com/user-attachments/assets/60ce5090-45f7-42f7-ad2e-5ac7eee9c89d" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->