### PR TITLE
[9.4] [Fleet] Align OTel profile integrations with non-ECS ones (#274205)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/epm.ts
@@ -111,6 +111,27 @@ export const dataTypes = {
 // currently identical but may be a subset or otherwise different some day
 export const monitoringTypes = Object.values(dataTypes);
 
+/** Dedicated indices Universal Profiling reads from and the Elasticsearch exporter writes to. */
+export const UNIVERSAL_PROFILING_INDEX_PATTERNS = ['profiling-*', 'profiles-*'] as const;
+
+/**
+ * Data stream types that Fleet must not manage (OTel or dedicated input): no routing transform,
+ * no dataset index templates/data streams, no `<type>-<dataset>-<namespace>` write permissions.
+ * Each maps to the index patterns the data is actually written to.
+ *
+ * `profiles` is owned end-to-end by Universal Profiling — Fleet stamping `data_stream.*` would
+ * misroute data and collapse its streams. See https://github.com/elastic/package-spec/issues/1191.
+ */
+export const FLEET_UNMANAGED_DATA_STREAM_INDEX_PATTERNS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  profiles: UNIVERSAL_PROFILING_INDEX_PATTERNS,
+};
+
+export const FLEET_UNMANAGED_DATA_STREAM_TYPES: readonly string[] = Object.keys(
+  FLEET_UNMANAGED_DATA_STREAM_INDEX_PATTERNS
+);
+
 export const installationStatuses = {
   Installed: 'installed',
   Installing: 'installing',

--- a/x-pack/platform/plugins/shared/fleet/common/constants/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/output.ts
@@ -192,4 +192,5 @@ export const LOGSTASH_API_KEY_INDICES = [
   '.logs-endpoint.action.responses-*',
   'profiling-*',
   '.profiling-*',
+  'profiles-*',
 ];

--- a/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.test.ts
@@ -50,13 +50,14 @@ describe('Fleet - isValidDataStreamType', () => {
     expect(isValidDataStreamType('metrics').valid).toBe(true);
     expect(isValidDataStreamType('traces').valid).toBe(true);
     expect(isValidDataStreamType('synthetics').valid).toBe(true);
-    expect(isValidDataStreamType('profiling').valid).toBe(true);
+    expect(isValidDataStreamType('profiles').valid).toBe(true);
   });
 
   it('returns false for unknown types', () => {
     expect(isValidDataStreamType('bogus').valid).toBe(false);
     expect(isValidDataStreamType('LOGS').valid).toBe(false);
     expect(isValidDataStreamType('').valid).toBe(false);
+    expect(isValidDataStreamType('profiling').valid).toBe(false);
   });
 
   it('returns true for blank when allowBlank is true', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts
@@ -129,7 +129,7 @@ export const VALID_DATA_STREAM_TYPES: readonly PackageDataStreamTypes[] = [
   'metrics',
   'traces',
   'synthetics',
-  'profiling',
+  'profiles',
 ];
 
 export function isValidDataStreamType(

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -2110,13 +2110,20 @@ describe('Fleet - validatePackagePolicyConfig', () => {
       expect(validateDataStreamType('metrics')).toBeNull();
       expect(validateDataStreamType('traces')).toBeNull();
       expect(validateDataStreamType('synthetics')).toBeNull();
-      expect(validateDataStreamType('profiling')).toBeNull();
+      expect(validateDataStreamType('profiles')).toBeNull();
+    });
+
+    it('should return an error for the legacy profiling type', () => {
+      const res = validateDataStreamType('profiling');
+      expect(res).toEqual([
+        'Data stream type must be one of: logs, metrics, traces, synthetics, profiles',
+      ]);
     });
 
     it('should return an error for an unknown type', () => {
       const res = validateDataStreamType('bogus');
       expect(res).toEqual([
-        'Data stream type must be one of: logs, metrics, traces, synthetics, profiling',
+        'Data stream type must be one of: logs, metrics, traces, synthetics, profiles',
       ]);
     });
 
@@ -2133,6 +2140,52 @@ describe('Fleet - validatePackagePolicyConfig', () => {
 
     it('should return null for non-input package type', () => {
       expect(validateDataStreamType('bogus', 'integration')).toBeNull();
+    });
+  });
+
+  describe('additional_datastreams_permissions', () => {
+    const basePolicy: NewPackagePolicy = {
+      name: 'test-policy',
+      namespace: 'default',
+      enabled: true,
+      policy_ids: [],
+      inputs: [],
+      vars: {},
+    };
+    const minimalPackage = {
+      name: 'test-pkg',
+      title: 'Test',
+      version: '0.0.0',
+      description: '',
+      type: 'integration',
+      categories: [],
+      requirement: { kibana: { versions: '' }, elasticsearch: { versions: '' } },
+      format_version: '',
+      download: '',
+      path: '',
+      assets: { kibana: {} },
+      status: installationStatuses.NotInstalled,
+      data_streams: [],
+      policy_templates: [],
+    };
+
+    it('accepts profiles-* as an additional datastreams permission', () => {
+      const result = validatePackagePolicy(
+        { ...basePolicy, additional_datastreams_permissions: ['profiles-generic.otel-default'] },
+        minimalPackage as unknown as PackageInfo,
+        deps
+      );
+      expect(result.additional_datastreams_permissions).toBeNull();
+    });
+
+    it('rejects profiling-* as an additional datastreams permission', () => {
+      const result = validatePackagePolicy(
+        { ...basePolicy, additional_datastreams_permissions: ['profiling-events-default'] },
+        minimalPackage as unknown as PackageInfo,
+        deps
+      );
+      expect(result.additional_datastreams_permissions).not.toBeNull();
+      expect(result.additional_datastreams_permissions![0]).toContain('profiling-events-default');
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -2173,7 +2173,7 @@ describe('Fleet - validatePackagePolicyConfig', () => {
       const result = validatePackagePolicy(
         { ...basePolicy, additional_datastreams_permissions: ['profiles-generic.otel-default'] },
         minimalPackage as unknown as PackageInfo,
-        deps
+        parse
       );
       expect(result.additional_datastreams_permissions).toBeNull();
     });
@@ -2182,7 +2182,7 @@ describe('Fleet - validatePackagePolicyConfig', () => {
       const result = validatePackagePolicy(
         { ...basePolicy, additional_datastreams_permissions: ['profiling-events-default'] },
         minimalPackage as unknown as PackageInfo,
-        deps
+        parse
       );
       expect(result.additional_datastreams_permissions).not.toBeNull();
       expect(result.additional_datastreams_permissions![0]).toContain('profiling-events-default');

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -269,7 +269,7 @@ const isVarRequiredByVarGroup = (
 };
 
 const VALIDATE_DATASTREAMS_PERMISSION_REGEX =
-  /^(logs)|(metrics)|(traces)|(synthetics)|(profiling)-(.*)$/;
+  /^(logs)|(metrics)|(traces)|(synthetics)|(profiles)-(.*)$/;
 
 /*
  * Returns validation information for a given package policy and package info

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/data_stream.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/data_stream.ts
@@ -25,4 +25,4 @@ export interface DataStream {
   } | null;
 }
 
-export type PackageDataStreamTypes = 'logs' | 'metrics' | 'traces' | 'synthetics' | 'profiling';
+export type PackageDataStreamTypes = 'logs' | 'metrics' | 'traces' | 'synthetics' | 'profiles';

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_policy_schema.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_policy_schema.ts
@@ -451,12 +451,12 @@ export const SimplifiedPackagePolicyInputsSchema = schema.maybe(
 );
 
 const VALIDATE_DATASTREAMS_PERMISSION_REGEX =
-  /^(logs)|(metrics)|(traces)|(synthetics)|(profiling)-(.*)$/;
+  /^(logs)|(metrics)|(traces)|(synthetics)|(profiles)-(.*)$/;
 
 function validateAdditionalDatastreamsPermissions(values: string[]) {
   for (const val of values) {
     if (!val.match(VALIDATE_DATASTREAMS_PERMISSION_REGEX)) {
-      return `${val} is not a valid datastream permissions, it should match logs|metrics|traces|synthetics|profiling)-*`;
+      return `${val} is not a valid datastream permissions, it should match logs|metrics|traces|synthetics|profiles)-*`;
     }
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.test.tsx
@@ -11,7 +11,10 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { createFleetTestRendererMock } from '../../../../../../../../mock';
 import type { TestRenderer } from '../../../../../../../../mock';
 import { useAgentless } from '../../../single_page_layout/hooks/setup_technology';
-import { DATA_STREAM_TYPE_VAR_NAME } from '../../../../../../../../../common/constants';
+import {
+  DATASET_VAR_NAME,
+  DATA_STREAM_TYPE_VAR_NAME,
+} from '../../../../../../../../../common/constants';
 
 import type {
   PackageInfo,
@@ -695,6 +698,108 @@ describe('PackagePolicyInputStreamConfig', () => {
 
       await waitFor(() => {
         expect(renderResult.queryByText('Enable Elastic APM Enrichment')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Fleet-unmanaged signal types (e.g. profiles)', () => {
+    // For profiles the type is fixed and the dataset has no effect; both fields are hidden
+    // via FLEET_UNMANAGED_DATA_STREAM_TYPES for both OTel and non-OTel packages.
+    const datasetVar = {
+      name: DATASET_VAR_NAME,
+      type: 'text',
+      title: 'Dataset name',
+      show_user: true,
+    };
+
+    const makeInputPackageInfo = (input: string, type: string): PackageInfo =>
+      ({
+        ...mockPackageInfo,
+        type: 'input',
+        policy_templates: [
+          {
+            name: 'profiling_template',
+            title: 'Profiling Template',
+            description: 'Profiling',
+            input,
+            type,
+            template_path: 'input.yml.hbs',
+            dynamic_signal_types: false,
+            vars: [],
+          },
+        ],
+      } as unknown as PackageInfo);
+
+    const makeInputStream = (
+      input: string,
+      type: string,
+      vars: RegistryStreamWithDataStream['vars'] = []
+    ): RegistryStreamWithDataStream => ({
+      input,
+      title: 'Profiling',
+      template_path: 'stream.yml.hbs',
+      vars,
+      description: 'Collect profiling data',
+      data_stream: {
+        title: 'Profiling Data',
+        release: 'ga',
+        type,
+        package: 'profiling_package',
+        dataset: 'profiling_package.data',
+        path: 'profiling_data',
+        elasticsearch: {},
+        ingest_pipeline: 'default',
+        streams: [],
+      },
+    });
+
+    const makePolicyInputStream = (type: string): NewPackagePolicyInputStream => ({
+      id: 'profiling-stream-1',
+      enabled: true,
+      data_stream: { type, dataset: 'profiling_package.data' },
+      vars: {},
+    });
+
+    // Same behavior for OTel and non-OTel input packages: hiding keys off the signal type.
+    it.each(['otelcol', 'pf-elastic-collector'])(
+      'hides the Data Stream Type selector for the profiles signal (%s input)',
+      async (input) => {
+        render(
+          makeInputStream(input, 'profiles'),
+          makePolicyInputStream('profiles'),
+          makeInputPackageInfo(input, 'profiles')
+        );
+
+        fireEvent.click(renderResult.getByText('Advanced options'));
+
+        await waitFor(() => {
+          expect(renderResult.queryByText('Data Stream Type')).not.toBeInTheDocument();
+          expect(renderResult.queryByTestId('packagePolicyDataStreamType')).not.toBeInTheDocument();
+        });
+      }
+    );
+
+    it('hides the dataset field for the profiles signal', async () => {
+      render(
+        makeInputStream('otelcol', 'profiles', [datasetVar] as any),
+        makePolicyInputStream('profiles'),
+        makeInputPackageInfo('otelcol', 'profiles')
+      );
+
+      await waitFor(() => {
+        expect(renderResult.queryByTestId('datasetComboBox')).not.toBeInTheDocument();
+      });
+    });
+
+    it('keeps the dataset field for managed signal types (e.g. logs)', async () => {
+      render(
+        makeInputStream('otelcol', 'logs', [datasetVar] as any),
+        makePolicyInputStream('logs'),
+        makeInputPackageInfo('otelcol', 'logs')
+      );
+
+      await waitFor(() => {
+        expect(renderResult.getByTestId('datasetComboBox')).toBeInTheDocument();
       });
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -568,10 +568,10 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                                   });
                                 }}
                                 name="dataStreamType"
-                            />
-                          </EuiFormRow>
-                        </EuiFlexItem>
-                      )}
+                              />
+                            </EuiFormRow>
+                          </EuiFlexItem>
+                        )}
                       {advancedVars.map((varDef) => {
                         if (!packagePolicyInputStream.vars) return null;
                         const { name: varName, type: varType } = varDef;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -33,6 +33,7 @@ import { useQuery } from '@kbn/react-query';
 import {
   DATASET_VAR_NAME,
   DATA_STREAM_TYPE_VAR_NAME,
+  FLEET_UNMANAGED_DATA_STREAM_TYPES,
   USE_APM_VAR_NAME,
 } from '../../../../../../../../../common/constants';
 
@@ -144,6 +145,13 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     const customDataStreamTypeVarValue =
       customDataStreamTypeVar?.value || packagePolicyInputStream.data_stream.type || 'logs';
 
+    // For Fleet-unmanaged signal types (e.g. profiles) the type is fixed and the dataset has no
+    // effect; hide both to avoid implying configurability that doesn't exist. Keyed off the signal
+    // type so it applies to both OTel and non-OTel packages. See FLEET_UNMANAGED_DATA_STREAM_TYPES.
+    const isUnmanagedDataStreamType = FLEET_UNMANAGED_DATA_STREAM_TYPES.includes(
+      customDataStreamTypeVarValue
+    );
+
     const dataStreamTypeOptions = useMemo(() => {
       return [
         { id: 'logs', label: 'Logs' },
@@ -219,6 +227,13 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
           : schemaVars;
 
       varsToProcess.forEach((varDef) => {
+        // Hide the dataset field for Fleet-unmanaged signal types (e.g. profiles): the value is
+        // ignored (data goes to dedicated indices, not a `<type>-<dataset>` data stream) and the
+        // "create dedicated index template" affordance would be misleading since none is created.
+        if (isUnmanagedDataStreamType && varDef.name === DATASET_VAR_NAME) {
+          return;
+        }
+
         // Check if var should be shown based on var_group selections
         // Use effective var_groups (stream-level if present, otherwise package-level)
         if (
@@ -244,6 +259,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
       customDataStreamTypeVarValue,
       dynamicSignalTypes,
       isUseAPMVarInSchema,
+      isUnmanagedDataStreamType,
     ]);
 
     // Errors state
@@ -497,54 +513,57 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                   </EuiFlexItem>
                   {isShowingAdvanced ? (
                     <>
-                      {packageInfo.type === 'input' && !dynamicSignalTypes && (
-                        <EuiFlexItem>
-                          <EuiFormRow
-                            label={
-                              <FormattedMessage
-                                id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyDataStreamTypeInputLabel"
-                                defaultMessage="Data Stream Type"
-                              />
-                            }
-                            helpText={
-                              isEditPage ? (
+                      {packageInfo.type === 'input' &&
+                        !dynamicSignalTypes &&
+                        !isUnmanagedDataStreamType && (
+                          <EuiFlexItem>
+                            <EuiFormRow
+                              label={
                                 <FormattedMessage
-                                  id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyInputOnlyEditDataStreamTypeHelpLabel"
-                                  defaultMessage="The data stream type cannot be changed for this integration. Create a new integration policy to use a different input type."
+                                  id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyDataStreamTypeInputLabel"
+                                  defaultMessage="Data Stream Type"
                                 />
-                              ) : (
-                                <FormattedMessage
-                                  id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyDataStreamTypeHelpLabel"
-                                  defaultMessage="Select a data stream type for this policy. This setting changes the name of the integration's data stream. {learnMore}."
-                                  values={{
-                                    learnMore: (
-                                      <EuiLink
-                                        href={docLinks.links.fleet.datastreamsNamingScheme}
-                                        target="_blank"
-                                      >
-                                        {i18n.translate(
-                                          'xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceHelpLearnMoreLabel',
-                                          { defaultMessage: 'Learn more' }
-                                        )}
-                                      </EuiLink>
-                                    ),
-                                  }}
-                                />
-                              )
-                            }
-                          >
-                            <EuiRadioGroup
-                              data-test-subj="packagePolicyDataStreamType"
-                              disabled={isEditPage}
-                              idSelected={customDataStreamTypeVarValue}
-                              options={dataStreamTypeOptions}
-                              onChange={(type: string) => {
-                                updatePackagePolicyInputStream({
-                                  vars: {
-                                    ...packagePolicyInputStream.vars,
-                                    [DATA_STREAM_TYPE_VAR_NAME]: {
-                                      type: 'string',
-                                      value: type,
+                              }
+                              helpText={
+                                isEditPage ? (
+                                  <FormattedMessage
+                                    id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyInputOnlyEditDataStreamTypeHelpLabel"
+                                    defaultMessage="The data stream type cannot be changed for this integration. Create a new integration policy to use a different input type."
+                                  />
+                                ) : (
+                                  <FormattedMessage
+                                    id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyDataStreamTypeHelpLabel"
+                                    defaultMessage="Select a data stream type for this policy. This setting changes the name of the integration's data stream. {learnMore}."
+                                    values={{
+                                      learnMore: (
+                                        <EuiLink
+                                          href={docLinks.links.fleet.datastreamsNamingScheme}
+                                          target="_blank"
+                                        >
+                                          {i18n.translate(
+                                            'xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceHelpLearnMoreLabel',
+                                            { defaultMessage: 'Learn more' }
+                                          )}
+                                        </EuiLink>
+                                      ),
+                                    }}
+                                  />
+                                )
+                              }
+                            >
+                              <EuiRadioGroup
+                                data-test-subj="packagePolicyDataStreamType"
+                                disabled={isEditPage}
+                                idSelected={customDataStreamTypeVarValue}
+                                options={dataStreamTypeOptions}
+                                onChange={(type: string) => {
+                                  updatePackagePolicyInputStream({
+                                    vars: {
+                                      ...packagePolicyInputStream.vars,
+                                      [DATA_STREAM_TYPE_VAR_NAME]: {
+                                        type: 'string',
+                                        value: type,
+                                      },
                                     },
                                   },
                                 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -565,10 +565,9 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                                         value: type,
                                       },
                                     },
-                                  },
-                                });
-                              }}
-                              name="dataStreamType"
+                                  });
+                                }}
+                                name="dataStreamType"
                             />
                           </EuiFormRow>
                         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -1154,7 +1154,7 @@ describe('generateOtelcolConfig', () => {
       expect(metricsPipeline?.processors).not.toContain('elasticapm/default');
     });
 
-    it('should generate transform with multiple signal type statements when dynamic_signal_types is true', () => {
+    it('should generate transform with multiple signal type statements (excluding profiles) when dynamic_signal_types is true', () => {
       const inputs: FullAgentPolicyInput[] = [otelInputWithMultipleSignalTypes];
       const result = generateOtelcolConfig({ inputs, dataOutput: defaultOutput, packageInfoCache });
 
@@ -1197,20 +1197,10 @@ describe('generateOtelcolConfig', () => {
             ],
           },
         ],
-        profile_statements: [
-          {
-            context: 'profile',
-            statements: [
-              'set(attributes["data_stream.type"], "profiles")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
       });
     });
 
-    it('should generate transform with multiple signal type statements when dynamic_signal_types is true and pipelines have simple names', () => {
+    it('should generate transform with multiple signal type statements (excluding profiles) when dynamic_signal_types is true and pipelines have simple names', () => {
       const inputs: FullAgentPolicyInput[] = [otelInputWithMultipleSignalTypes2];
       const result = generateOtelcolConfig({ inputs, dataOutput: defaultOutput, packageInfoCache });
 
@@ -1253,17 +1243,62 @@ describe('generateOtelcolConfig', () => {
             ],
           },
         ],
-        profile_statements: [
+      });
+    });
+
+    it('should not route or generate profile_statements for the profiles signal in a dynamic package', () => {
+      const inputs: FullAgentPolicyInput[] = [otelInputWithMultipleSignalTypes];
+      const result = generateOtelcolConfig({ inputs, dataOutput: defaultOutput, packageInfoCache });
+
+      // profiles is owned end-to-end by Universal Profiling (routing and storage handled by its
+      // Elasticsearch exporter), so Fleet must not stamp data_stream.* for it.
+      expect(
+        result.processors?.['transform/test-multi-signal-stream-id-1-routing']?.profile_statements
+      ).toBeUndefined();
+    });
+
+    it('should not generate a routing transform at all for a profiles-only stream', () => {
+      const profilesOnlyInput: FullAgentPolicyInput = {
+        ...otelInputWithMultipleSignalTypes,
+        streams: [
           {
-            context: 'profile',
-            statements: [
-              'set(attributes["data_stream.type"], "profiles")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
+            id: 'stream-id-1',
+            data_stream: {
+              dataset: 'profilingreceiver',
+              type: 'profiles',
+            },
+            receivers: {
+              profiling: {},
+            },
+            service: {
+              pipelines: {
+                profiles: {
+                  receivers: ['profiling'],
+                },
+              },
+            },
           },
         ],
+      };
+
+      const result = generateOtelcolConfig({
+        inputs: [profilesOnlyInput],
+        dataOutput: defaultOutput,
+        packageInfoCache,
       });
+
+      // No routing transform should be injected, and the profiles pipeline must not
+      // reference one (regression test for elastic/package-spec#1191).
+      const routingKeys = Object.keys(result.processors ?? {}).filter((key) =>
+        key.endsWith('-routing')
+      );
+      expect(routingKeys).toEqual([]);
+
+      const pipeline = result.service?.pipelines?.['profiles/test-multi-signal-stream-id-1'];
+      expect(pipeline).toBeDefined();
+      expect(pipeline?.processors ?? []).not.toContain(
+        'transform/test-multi-signal-stream-id-1-routing'
+      );
     });
 
     it('should generate transform with only specified signal types when pipelines have subset', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../../common/types';
 import {
   dataTypes,
+  FLEET_UNMANAGED_DATA_STREAM_TYPES,
   OTEL_COLLECTOR_INPUT_TYPE,
   outputType,
   USE_APM_VAR_NAME,
@@ -209,8 +210,12 @@ export function generateOtelcolConfig({
         };
 
         // Must run before the APM block below so the aggregated metrics pipeline
-        // does not receive the per-stream routing transform.
-        otelConfig = appendOtelComponents(otelConfig, 'processors', [attributesTransform]);
+        // does not receive the per-stream routing transform. `attributesTransform` is
+        // undefined when the stream only carries Fleet-unmanaged signals (e.g. profiles),
+        // in which case no routing transform is injected.
+        if (attributesTransform) {
+          otelConfig = appendOtelComponents(otelConfig, 'processors', [attributesTransform]);
+        }
 
         if (resolvedOutputId) {
           for (const pipelineId of Object.keys(otelConfig.service?.pipelines ?? {})) {
@@ -363,16 +368,10 @@ function generateOtelTypeTransforms(
           },
         ],
       };
-    case 'profiles':
-      return {
-        profile_statements: [
-          {
-            context: 'profile',
-            statements: buildDataStreamStatements('profiles', dataset, namespace),
-          },
-        ],
-      };
     default:
+      // `profiles` is intentionally absent: it is filtered out before this function is
+      // called (see FLEET_UNMANAGED_DATA_STREAM_TYPES) because the Elasticsearch
+      // exporter — not Fleet — routes it. Any other type here is unexpected.
       throw new FleetError(`unexpected data stream type ${type}`);
   }
 }
@@ -397,18 +396,29 @@ function generateOTelAttributesTransform(
   suffix: string,
   dynamicSignalTypes: boolean,
   signalTypes?: string[]
-): Record<OTelCollectorComponentID, any> {
+): Record<OTelCollectorComponentID, any> | undefined {
   let transformStatements: Record<string, any> = {};
 
   if (dynamicSignalTypes && signalTypes) {
-    signalTypes.forEach((signalType) => {
-      const typeTransforms = generateOtelTypeTransforms(signalType, dataset, namespace);
-      Object.assign(transformStatements, typeTransforms);
-    });
-  } else {
+    signalTypes
+      // Fleet-unmanaged signals (e.g. profiles) are routed by the Elasticsearch exporter,
+      // not by Fleet, so they must not get a data_stream.* routing transform.
+      .filter((signalType) => !FLEET_UNMANAGED_DATA_STREAM_TYPES.includes(signalType))
+      .forEach((signalType) => {
+        const typeTransforms = generateOtelTypeTransforms(signalType, dataset, namespace);
+        Object.assign(transformStatements, typeTransforms);
+      });
+  } else if (!FLEET_UNMANAGED_DATA_STREAM_TYPES.includes(type)) {
     // Default: single signal type from stream.data_stream.type
     transformStatements = generateOtelTypeTransforms(type, dataset, namespace);
   }
+
+  // When every signal type is Fleet-unmanaged (e.g. a profiles-only stream) there is
+  // nothing to route, so do not emit an empty routing transform.
+  if (Object.keys(transformStatements).length === 0) {
+    return undefined;
+  }
+
   return {
     [`transform/${suffix}-routing`]: transformStatements,
   };

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -775,7 +775,7 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
       'package-policy-uuid-test-123': {
         indices: [
           {
-            names: ['profiling-*'],
+            names: ['profiling-*', 'profiles-*'],
             privileges: UNIVERSAL_PROFILING_PERMISSIONS,
           },
         ],
@@ -817,7 +817,56 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
       'package-policy-uuid-test-123': {
         indices: [
           {
-            names: ['profiling-*'],
+            names: ['profiling-*', 'profiles-*'],
+            privileges: UNIVERSAL_PROFILING_PERMISSIONS,
+          },
+        ],
+      },
+    });
+  });
+
+  it('Returns Universal Profiling permissions for a non-dynamic OTel profiles input', async () => {
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-otel-profiles',
+        name: 'profiling-otel-policy',
+        namespace: 'test',
+        enabled: true,
+        package: { name: 'test_package', version: '0.0.0', title: 'Test Package' },
+        inputs: [
+          {
+            type: 'otelcol',
+            enabled: true,
+            streams: [
+              {
+                id: 'otel-profiles',
+                enabled: true,
+                data_stream: { type: 'profiles', dataset: 'profilingreceiver' },
+              },
+            ],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+        policy_ids: [''],
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      'test',
+      packagePolicies
+    );
+    // profiles is owned end-to-end by Universal Profiling, not managed as a profiles-<dataset> data stream.
+    expect(permissions).toMatchObject({
+      'package-policy-otel-profiles': {
+        indices: [
+          {
+            names: ['profiling-*', 'profiles-*'],
             privileges: UNIVERSAL_PROFILING_PERMISSIONS,
           },
         ],
@@ -2470,6 +2519,34 @@ describe('getDataStreamPrivileges()', () => {
     expect(privileges).toMatchObject({
       names: ['logs-*-*'],
       privileges: ['auto_configure', 'create_doc'],
+    });
+  });
+
+  it('targets Universal Profiling index patterns for the profiles signal regardless of dataset/namespace', () => {
+    const dataStream = { type: 'profiles', dataset: 'profilingreceiver' } as DataStreamMeta;
+    const privileges = getDataStreamPrivileges(dataStream, 'namespace');
+
+    // profiles is owned end-to-end by Universal Profiling; permissions cover both legacy
+    // profiling-* custom indices and future profiles-* data streams.
+    expect(privileges).toEqual({
+      names: ['profiling-*', 'profiles-*'],
+      privileges: UNIVERSAL_PROFILING_PERMISSIONS,
+    });
+  });
+
+  it('uses custom privileges for the profiles signal when present', () => {
+    const dataStream = {
+      type: 'profiles',
+      dataset: 'profilingreceiver',
+      elasticsearch: {
+        privileges: { indices: ['create_doc'] },
+      },
+    } as DataStreamMeta;
+    const privileges = getDataStreamPrivileges(dataStream, 'namespace');
+
+    expect(privileges).toEqual({
+      names: ['profiling-*', 'profiles-*'],
+      privileges: ['create_doc'],
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -16,8 +16,10 @@ import {
   FLEET_CONNECTORS_PACKAGE,
   FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE,
   FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE,
+  FLEET_UNMANAGED_DATA_STREAM_INDEX_PATTERNS,
   OTEL_COLLECTOR_INPUT_TYPE,
   OTEL_TEMPLATE_SUFFIX,
+  UNIVERSAL_PROFILING_INDEX_PATTERNS,
   USE_APM_VAR_NAME,
 } from '../../../common/constants';
 
@@ -129,8 +131,10 @@ export function storedPackagePoliciesToAgentPermissions(
       );
     }
 
-    // Special handling for Universal Profiling packages, as it does not use data streams _only_,
-    // but also indices that do not adhere to the convention.
+    // Special handling for Universal Profiling packages: they are `integration` packages with no
+    // data streams, so the generic `profiles` -> UNIVERSAL_PROFILING_INDEX_PATTERNS path in
+    // getDataStreamPrivileges never runs (the empty-data-streams gate below short-circuits first).
+    // Migrating them to `input` packages with a `profiles` template would remove this special case.
     if (
       pkg.name === FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE ||
       pkg.name === FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE
@@ -376,6 +380,18 @@ export function getDataStreamPrivileges(
   dataStream: DataStreamMeta,
   namespace: string = '*'
 ): SecurityIndicesPrivileges {
+  // Fleet-unmanaged signals (e.g. profiles) are routed by their producer/exporter; grant write
+  // permissions to the known destination patterns instead of `<type>-<dataset>-<namespace>`.
+  const unmanagedIndexPatterns = FLEET_UNMANAGED_DATA_STREAM_INDEX_PATTERNS[dataStream.type];
+  if (unmanagedIndexPatterns) {
+    return {
+      names: [...unmanagedIndexPatterns],
+      privileges: dataStream?.elasticsearch?.privileges?.indices?.length
+        ? dataStream.elasticsearch.privileges.indices
+        : UNIVERSAL_PROFILING_PERMISSIONS,
+    };
+  }
+
   let index = dataStream.hidden ? `.${dataStream.type}-` : `${dataStream.type}-`;
 
   // Determine dataset
@@ -405,13 +421,12 @@ export function getDataStreamPrivileges(
 }
 
 function universalProfilingPermissions(packagePolicyId: string): [string, SecurityRoleDescriptor] {
-  const profilingIndexPattern = 'profiling-*';
   return [
     packagePolicyId,
     {
       indices: [
         {
-          names: [profilingIndexPattern],
+          names: [...UNIVERSAL_PROFILING_INDEX_PATTERNS],
           privileges: UNIVERSAL_PROFILING_PERMISSIONS,
         },
       ],

--- a/x-pack/platform/plugins/shared/fleet/server/services/api_keys/logstash_api_keys.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/api_keys/logstash_api_keys.ts
@@ -59,6 +59,7 @@ export async function generateLogstashApiKey(esClient: ElasticsearchClient) {
               '.logs-endpoint.action.responses-*',
               'profiling-*',
               '.profiling-*',
+              'profiles-*',
             ],
             privileges: ['auto_configure', 'create_doc'],
           },

--- a/x-pack/platform/plugins/shared/fleet/server/services/data_streams.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/data_streams.test.ts
@@ -31,7 +31,7 @@ describe('DataStreamService', () => {
       expect(esClient.transport.request).toHaveBeenCalledWith(
         expect.objectContaining({
           method: 'GET',
-          path: '/_data_stream/logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*,profiling-*',
+          path: '/_data_stream/logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*,profiling-*,profiles-*',
           querystring: { filter_path: 'data_streams.name' },
         })
       );

--- a/x-pack/platform/plugins/shared/fleet/server/services/data_streams.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/data_streams.ts
@@ -8,7 +8,8 @@
 import type { IndicesDataStream, IndicesIndexTemplate } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
 
-const DATA_STREAM_INDEX_PATTERN = 'logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*,profiling-*';
+const DATA_STREAM_INDEX_PATTERN =
+  'logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*,profiling-*,profiles-*';
 
 export interface MeteringStatsResponse {
   datastreams: MeteringStats[];

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/data_streams/get.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/data_streams/get.test.ts
@@ -188,4 +188,46 @@ describe('getDataStreams', () => {
       { name: 'logs-elastic_agent-default' },
     ]);
   });
+
+  describe('profiles data stream type', () => {
+    it('includes profiles-* data streams and filters out profiling-* data streams', async () => {
+      const esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+      (dataStreamService.getMatchingDataStreams as jest.Mock).mockResolvedValueOnce([
+        {
+          name: 'profiles-generic.otel-default',
+          timestamp_field: { name: '@timestamp' },
+          indices: [],
+          generation: 1,
+          status: 'GREEN',
+          template: 'profiles-generic.otel',
+          hidden: false,
+          system: false,
+          allow_custom_routing: false,
+          replicated: false,
+        },
+        {
+          name: 'profiling-events-default',
+          timestamp_field: { name: '@timestamp' },
+          indices: [],
+          generation: 1,
+          status: 'GREEN',
+          template: 'profiling-events',
+          hidden: false,
+          system: false,
+          allow_custom_routing: false,
+          replicated: false,
+        },
+      ]);
+
+      const results = await getDataStreams({
+        esClient: esClientMock,
+        sortOrder: 'asc',
+        uncategorisedOnly: false,
+      });
+
+      const names = results.items.map((s) => s.name);
+      expect(names).toContain('profiles-generic.otel-default');
+      expect(names).not.toContain('profiling-events-default');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/data_streams/get.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/data_streams/get.ts
@@ -9,10 +9,9 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import { errors } from '@elastic/elasticsearch';
 
 import type { PackageDataStreamTypes } from '../../../../common/types';
+import { VALID_DATA_STREAM_TYPES } from '../../../../common/services';
 import { dataStreamService } from '../../data_streams';
 import { FleetUnauthorizedError } from '../../../errors';
-
-const VALID_STREAM_TYPES = ['logs', 'metrics', 'traces', 'synthetics', 'profiling'];
 
 export async function getDataStreams(options: {
   esClient: ElasticsearchClient;
@@ -43,7 +42,7 @@ export async function getDataStreams(options: {
     : allDataStreams;
 
   filteredDataStreams = filteredDataStreams.filter((stream) => {
-    const isValidStreamType = VALID_STREAM_TYPES.some((streamType) =>
+    const isValidStreamType = VALID_DATA_STREAM_TYPES.some((streamType) =>
       stream.name.startsWith(streamType)
     );
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.test.ts
@@ -940,6 +940,57 @@ describe('installAssetsForInputPackagePolicy', () => {
       );
     });
 
+    it('should not install any index templates for a profiles input package', async () => {
+      const OTEL_PKG_INFO_PROFILES = {
+        type: 'input',
+        name: 'profiling_otel',
+        version: '1.0.0',
+        policy_templates: [
+          {
+            name: 'profilingreceiver',
+            type: 'profiles',
+            input: 'otelcol',
+          },
+        ],
+      };
+      jest.mocked(getInstalledPackageWithAssets).mockResolvedValue({
+        installation: {
+          name: 'profiling_otel',
+          version: '1.0.0',
+        },
+        packageInfo: OTEL_PKG_INFO_PROFILES,
+        assetsMap: new Map(),
+        paths: [],
+      } as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+
+      await installAssetsForInputPackagePolicy({
+        pkgInfo: OTEL_PKG_INFO_PROFILES as any,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+        packagePolicy: {
+          inputs: [
+            {
+              name: 'profilingreceiver',
+              type: 'otelcol',
+              streams: [
+                {
+                  data_stream: { type: 'profiles' },
+                  vars: { 'data_stream.dataset': { value: 'profilingreceiver' } },
+                },
+              ],
+            },
+          ],
+        } as any,
+      });
+
+      // profiles is owned end-to-end by Universal Profiling; Fleet must not create data streams
+      // for it (elastic/package-spec#1191).
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
+    });
+
     it('should respect data_stream.type var when dynamic_signal_types is true', async () => {
       jest.mocked(getInstalledPackageWithAssets).mockResolvedValue({
         installation: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
@@ -108,13 +108,15 @@ export async function installAssetsForInputPackagePolicy(opts: {
 
   // For OTel packages with dynamic_signal_types, we need to create index templates for all signal types
   const isDynamicSignalTypes = hasDynamicSignalTypes(pkgInfo);
-  const signalTypes: string[] = isDynamicSignalTypes
-    ? ['logs', 'metrics', 'traces']
-    : [
-        packagePolicy.inputs[0].streams[0].vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value ||
-          packagePolicy.inputs[0].streams[0].data_stream?.type ||
-          'logs',
-      ];
+  const signalTypes: string[] = (
+    isDynamicSignalTypes
+      ? ['logs', 'metrics', 'traces']
+      : [
+          packagePolicy.inputs[0].streams[0].vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value ||
+            packagePolicy.inputs[0].streams[0].data_stream?.type ||
+            'logs',
+        ]
+  ).filter((type) => !FLEET_UNMANAGED_DATA_STREAM_TYPES.includes(type));
 
   // Check each signal type and install templates as needed
   for (const dataStreamType of signalTypes) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
@@ -19,6 +19,7 @@ import type {
 import {
   DATASET_VAR_NAME,
   DATA_STREAM_TYPE_VAR_NAME,
+  FLEET_UNMANAGED_DATA_STREAM_TYPES,
   OTEL_COLLECTOR_INPUT_TYPE,
 } from '../../../../common/constants';
 import { PackagePolicyValidationError, PackageNotFoundError, FleetError } from '../../../errors';

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -625,7 +625,7 @@ export const GetInstalledPackagesRequestSchema = {
           schema.literal('metrics'),
           schema.literal('traces'),
           schema.literal('synthetics'),
-          schema.literal('profiling'),
+          schema.literal('profiles'),
         ],
         { meta: { description: 'Filter by data stream type' } }
       )
@@ -662,7 +662,7 @@ export const GetDataStreamsRequestSchema = {
           schema.literal('metrics'),
           schema.literal('traces'),
           schema.literal('synthetics'),
-          schema.literal('profiling'),
+          schema.literal('profiles'),
         ],
         { meta: { description: 'Filter by data stream type' } }
       )
@@ -1085,7 +1085,7 @@ export const CreateCustomIntegrationRequestSchema = {
             schema.literal('metrics'),
             schema.literal('traces'),
             schema.literal('synthetics'),
-            schema.literal('profiling'),
+            schema.literal('profiles'),
           ]),
         }),
         { maxSize: 10 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[Fleet] Align OTel profile integrations with non-ECS ones (#274205)](https://github.com/elastic/kibana/pull/274205)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":274205,"url":"https://github.com/elastic/kibana/pull/274205","title":"[Fleet] Align OTel profile integrations with non-ECS ones"},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"sourceCommit":{"sha":"33b65b023b71f6ba8f4a8b492ccfa79b2236b3ae"}}] BACKPORT-->

All three conflicts resolved as expected:

- `package_policy_input_stream.tsx` imports — added `FLEET_UNMANAGED_DATA_STREAM_TYPES`, left `GENERIC_DATASET_NAME` out
- `package_policy_input_stream.tsx JSX` — `!isUnmanagedDataStreamType &&` was already auto-merged; kept 9.4's closing structure without the `showConditionField` block
- `input_type_packages.ts` — used 9.4's version (function was deleted on 9.4)