### PR TITLE
[Fleet] Fix OTel collector Platform field always showing '-'

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_info.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_info.test.tsx
@@ -32,6 +32,7 @@ const makeAgent = (overrides?: Partial<Agent>): Agent =>
       'elastic.display.name': 'prod-west-gateway',
       'host.arch': 'x86_64',
       'os.type': 'linux',
+      'os.description': 'Ubuntu 22.04.4 LTS',
       'elastic.collector.group': 'production-west',
     },
     capabilities: ['logs', 'metrics', 'traces'],
@@ -65,6 +66,7 @@ describe('CollectorDetailInfo', () => {
     expect(panel.textContent).toContain('collector-prod-west-1');
     expect(panel.textContent).toContain('x86_64');
     expect(panel.textContent).toContain('linux');
+    expect(panel.textContent).toContain('Ubuntu 22.04.4 LTS');
     expect(panel.textContent).toContain('production-west');
     expect(panel.textContent).toContain('logs, metrics, traces');
   });

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_info.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_info.tsx
@@ -125,10 +125,7 @@ export const CollectorDetailInfo: React.FC<CollectorDetailInfoProps> = ({ agent,
           title: i18n.translate('xpack.fleet.otelUi.collectorDetail.info.platform', {
             defaultMessage: 'Platform',
           }),
-          description:
-            typeof agent.local_metadata?.os?.platform === 'string'
-              ? agent.local_metadata.os.platform
-              : '-',
+          description: nonIdentifying?.['os.description'] ?? '-',
         },
         {
           title: i18n.translate('xpack.fleet.otelUi.collectorDetail.info.collectorGroup', {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/275038

- The **Platform** field in the OTel collector info panel was always displaying `-` for OPAMP collectors.
- Root cause: the code read `agent.local_metadata?.os?.platform`, which is populated by fleet-server only for classic Elastic Agents — never for OPAMP collectors.
- Fix: read `non_identifying_attributes['os.description']` instead, which carries the human-readable OS description (e.g. `"Ubuntu 22.04.4 LTS"`) reported by the OTel SDK over the OpAMP protocol.

## Test plan

- [x] Unit tests pass: `node scripts/jest --config x-pack/platform/plugins/shared/fleet/jest.config.dev.js x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_info`
- [x] Manually verify the Platform field on the collector details Info tab shows the OS description (e.g. "Ubuntu 22.04.4 LTS") instead of `-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1225" height="1073" alt="image" src="https://github.com/user-attachments/assets/b8196165-40e5-4678-b589-31497a4341d9" />
