### PR TITLE
[Fleet] Show offline callout on Health tab when OTel collector is not active

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.test.tsx
@@ -28,6 +28,12 @@ const config: OTelCollectorConfig = {
   },
 };
 
+const onlineHealth: ComponentHealth = {
+  healthy: true,
+  status: 'StatusOK',
+  status_time_unix_nano: 1777926000000000000,
+};
+
 describe('CollectorDetailHealth', () => {
   let testRenderer: TestRenderer;
 
@@ -38,6 +44,26 @@ describe('CollectorDetailHealth', () => {
   it('renders no-data message when health is undefined', () => {
     const result = testRenderer.render(<CollectorDetailHealth />);
     expect(result.getByTestId('collectorDetailHealthNoData')).toBeInTheDocument();
+  });
+
+  it.each(['offline', 'inactive', 'unenrolled', 'uninstalled'] as const)(
+    'shows offline callout and hides health data when agentStatus is %s',
+    (status) => {
+      const result = testRenderer.render(
+        <CollectorDetailHealth health={onlineHealth} agentStatus={status} />
+      );
+      expect(result.getByTestId('collectorDetailHealthOffline')).toBeInTheDocument();
+      expect(result.queryByTestId('collectorDetailHealth')).not.toBeInTheDocument();
+      expect(result.queryByText('Healthy')).not.toBeInTheDocument();
+    }
+  );
+
+  it('does not show offline callout when agentStatus is online', () => {
+    const result = testRenderer.render(
+      <CollectorDetailHealth health={onlineHealth} agentStatus="online" />
+    );
+    expect(result.queryByTestId('collectorDetailHealthOffline')).not.toBeInTheDocument();
+    expect(result.getByTestId('collectorDetailHealth')).toBeInTheDocument();
   });
 
   it('renders healthy status', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
@@ -9,6 +9,7 @@ import React, { useMemo } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
+  EuiCallOut,
   EuiDescriptionList,
   EuiFlexGroup,
   EuiFlexItem,
@@ -24,7 +25,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedDate, FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
 
-import type { ComponentHealth, OTelCollectorConfig } from '../../../../../common/types';
+import type { Agent, ComponentHealth, OTelCollectorConfig } from '../../../../../common/types';
 
 import type { OTelComponentType } from '../constants';
 import { COMPONENT_TYPE_LABELS } from '../constants';
@@ -38,9 +39,17 @@ import {
   type ComponentHealthStatus,
 } from '../utils';
 
+const NON_REPORTING_STATUSES: Array<Agent['status']> = [
+  'offline',
+  'inactive',
+  'unenrolled',
+  'uninstalled',
+];
+
 interface CollectorDetailHealthProps {
   health?: ComponentHealth;
   config?: OTelCollectorConfig;
+  agentStatus?: Agent['status'];
   onComponentClick?: (
     componentId: string,
     componentType: OTelComponentType,
@@ -319,6 +328,7 @@ const resolveComponentType = (
 export const CollectorDetailHealth: React.FC<CollectorDetailHealthProps> = ({
   health,
   config,
+  agentStatus,
   onComponentClick,
   selectedComponentId,
 }) => {
@@ -362,6 +372,27 @@ export const CollectorDetailHealth: React.FC<CollectorDetailHealthProps> = ({
   }, [config, health]);
 
   const { euiTheme } = useEuiTheme();
+
+  if (agentStatus && NON_REPORTING_STATUSES.includes(agentStatus)) {
+    return (
+      <EuiCallOut
+        color="warning"
+        iconType="offline"
+        title={i18n.translate('xpack.fleet.otelUi.collectorDetail.health.offlineTitle', {
+          defaultMessage: 'Collector is not active',
+        })}
+        data-test-subj="collectorDetailHealthOffline"
+      >
+        <p>
+          {i18n.translate('xpack.fleet.otelUi.collectorDetail.health.offlineBody', {
+            defaultMessage:
+              'This collector is currently {status}. Health data is only available while the collector is running.',
+            values: { status: agentStatus },
+          })}
+        </p>
+      </EuiCallOut>
+    );
+  }
 
   if (!health) {
     return (

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
@@ -378,6 +378,7 @@ export const CollectorDetailHealth: React.FC<CollectorDetailHealthProps> = ({
       <EuiCallOut
         color="warning"
         iconType="offline"
+        announceOnMount={false}
         title={i18n.translate('xpack.fleet.otelUi.collectorDetail.health.offlineTitle', {
           defaultMessage: 'Collector is not active',
         })}

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_tabs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_tabs.tsx
@@ -129,6 +129,7 @@ export const CollectorDetailTabs: React.FC<CollectorDetailTabsProps> = ({
             <CollectorDetailHealth
               health={health}
               config={config}
+              agentStatus={agent.status}
               onComponentClick={handleComponentClick}
               selectedComponentId={selectedComponent?.componentId}
             />


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/275032

When a collector is `offline`, `inactive`, `unenrolled`, or `uninstalled`, the agent document retains stale health data from its last active session. Previously the Health tab would render that data (e.g. "Health status: Healthy") without any indication that the collector was not currently running.

**Root cause:** `CollectorDetailHealth` received only `agent.health` (the stored health document), with no knowledge of the agent's current status. A collector that was healthy before going offline would always show "Healthy".

**Fix:** Pass `agentStatus` from the agent document into `CollectorDetailHealth`. When the status is non-reporting (`offline` | `inactive` | `unenrolled` | `uninstalled`), render a warning `EuiCallOut` ("Collector is not active") and suppress the stale health data so users are not misled. When the collector is online, behavior is unchanged.

## Test plan

- [x] Unit tests pass: `node scripts/jest --config x-pack/platform/plugins/shared/fleet/jest.config.dev.js x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health`
- [x] Manually: take an online collector → Health tab shows health data normally
- [x] Manually: unenroll/kill the collector so it goes offline → Health tab shows "Collector is not active" callout instead of stale "Healthy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1694" height="1220" alt="image" src="https://github.com/user-attachments/assets/a5b5b22e-94ab-403e-9761-8dcfe83fcea2" />
<img width="1682" height="1167" alt="image" src="https://github.com/user-attachments/assets/e11ff11a-02bd-4f1d-a643-b3ae805ca024" />
