### PR TITLE
[Accessibility] Make Core Web Vitals status indicators keyboard focusable

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/ux/core_web_vitals/palette_legends.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/ux/core_web_vitals/palette_legends.tsx
@@ -72,7 +72,7 @@ export function PaletteLegends({ ranks, title, onItemHover, thresholds, isCls }:
             content={getCoreVitalTooltipMessage(thresholds, ind, title, ranks[ind], isCls)}
             position="bottom"
           >
-            <StyledSpan darkMode={darkMode}>
+            <StyledSpan darkMode={darkMode} tabIndex={0}>
               <PaletteLegend color={color}>
                 <EuiText size="xs" data-test-subj={`${labels[ind]}-${ranks?.[ind]}`}>
                   <FormattedMessage


### PR DESCRIPTION
## Summary

Fixes #275360

Core Web Vitals status indicators (Good / Needs improvement / Poor) on the Observability Overview page were not reachable by keyboard — the `Tab` key skipped over them entirely, and their tooltips were mouse-only.

**Root cause:** The `StyledSpan` wrapper inside `EuiToolTip` had no `tabIndex`, making it non-focusable. `EuiToolTip` already injects `onFocus`/`onBlur` listeners into its child internally, so simply making the child focusable is sufficient.

**Fix:** Added `tabIndex={0}` to `StyledSpan`.

## WCAG

Addresses [SC 2.1.1 Keyboard (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).

## Test plan

- [ ] Tab to each status indicator — it should receive focus and show its tooltip.
- [ ] Shift-Tab navigates back through the indicators.
- [ ] Mouse hover still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->