### PR TITLE
[Fleet] Hide Diagnostics tab for OTel collectors

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.test.tsx
@@ -115,6 +115,18 @@ describe('AgentDetailsPage', () => {
     expect(result.queryByText('AgentDetailsContent')).toBeNull();
   });
 
+  it('should not show Diagnostics tab for OPAMP collector', async () => {
+    setupMocks({ agent: mockAgent({ type: 'OPAMP' }), enableOtelUI: true });
+    const result = await render();
+    expect(result.queryByText('Diagnostics')).toBeNull();
+  });
+
+  it('should show Diagnostics tab for non-collector agents', async () => {
+    setupMocks({ agent: mockAgent({ type: 'PERMANENT' }), enableOtelUI: true });
+    const result = await render();
+    expect(result.queryByText('Diagnostics')).not.toBeNull();
+  });
+
   it('should render AgentDetailsContent for non-OPAMP agent', async () => {
     setupMocks({ agent: mockAgent({ type: 'PERMANENT' }), enableOtelUI: true });
     const result = await render();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -241,14 +241,18 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         href: getHref('agent_details_logs', { agentId, tabId: 'logs' }),
         isSelected: tabId === 'logs',
       },
-      {
-        id: 'diagnostics',
-        name: i18n.translate('xpack.fleet.agentDetails.subTabs.diagnosticsTab', {
-          defaultMessage: 'Diagnostics',
-        }),
-        href: getHref('agent_details_diagnostics', { agentId, tabId: 'diagnostics' }),
-        isSelected: tabId === 'diagnostics',
-      },
+      ...(!isCollector
+        ? [
+            {
+              id: 'diagnostics',
+              name: i18n.translate('xpack.fleet.agentDetails.subTabs.diagnosticsTab', {
+                defaultMessage: 'Diagnostics',
+              }),
+              href: getHref('agent_details_diagnostics', { agentId, tabId: 'diagnostics' }),
+              isSelected: tabId === 'diagnostics',
+            },
+          ]
+        : []),
       {
         id: 'settings',
         name: i18n.translate('xpack.fleet.agentDetails.subTabs.settingsTab', {
@@ -355,12 +359,14 @@ const AgentDetailsPageContent: React.FunctionComponent<{
           return <AgentLogs agent={agent} agentPolicy={agentPolicy} />;
         }}
       />
-      <Route
-        path={FLEET_ROUTING_PATHS.agent_details_diagnostics}
-        render={() => {
-          return <AgentDiagnosticsTab agent={agent} />;
-        }}
-      />
+      {!isCollector && (
+        <Route
+          path={FLEET_ROUTING_PATHS.agent_details_diagnostics}
+          render={() => {
+            return <AgentDiagnosticsTab agent={agent} />;
+          }}
+        />
+      )}
       <Route
         path={FLEET_ROUTING_PATHS.agent_details_settings}
         render={() => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/274504

The Diagnostics tab exposes agent diagnostics (request diagnostics files) that is only applicable to classic Elastic Agents, not to OTel collectors enrolled via OpAMP.

**Changes:**
- Exclude the Diagnostics tab from `headerTabs` when `isCollector` is true (OPAMP agent + `enableOtelUI` feature flag)
- Guard the diagnostics route in `AgentDetailsPageContent` so that a collector navigating directly to `/agents/:id/diagnostics` falls through to the details route rather than rendering `AgentDiagnosticsTab`

## Test plan

- [x] Unit tests pass: `node scripts/jest --config x-pack/platform/plugins/shared/fleet/jest.config.dev.js x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/index.test`
- [x] Manually verify: open an OTel collector's agent details page — Diagnostics tab should not appear
- [x] Manually verify: classic Elastic Agent details page still shows the Diagnostics tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1698" height="807" alt="image" src="https://github.com/user-attachments/assets/d70ca31c-2f56-4586-ac99-5321a9270174" />
<img width="1834" height="472" alt="image" src="https://github.com/user-attachments/assets/481a5171-4874-41e7-9863-145fdffa6942" />
