### PR TITLE
[Unified search] Introduces a new fast mode component

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -541,7 +541,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       queryDsl: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/querydsl`,
       queryESQL: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql`,
       queryESQLExamples: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql`,
-      queryESQLKibana: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana`,
+      queryESQLApproximateResults: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana`,
       queryESQLMultiValueControls: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana#esql-multi-values-controls`,
       queryESQLMvIntersects: `${ELASTIC_DOCS}reference/query-languages/esql/functions-operators/mv-functions/mv_intersects`,
     },

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -541,7 +541,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       queryDsl: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/querydsl`,
       queryESQL: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql`,
       queryESQLExamples: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql`,
-      queryESQLApproximateResults: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana`,
+      queryESQLApproximateResults: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana#approximation-fast-mode`,
       queryESQLMultiValueControls: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana#esql-multi-values-controls`,
       queryESQLMvIntersects: `${ELASTIC_DOCS}reference/query-languages/esql/functions-operators/mv-functions/mv_intersects`,
     },

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -541,6 +541,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       queryDsl: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/querydsl`,
       queryESQL: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql`,
       queryESQLExamples: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql`,
+      queryESQLKibana: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana`,
       queryESQLMultiValueControls: `${ELASTIC_DOCS}explore-analyze/query-filter/languages/esql-kibana#esql-multi-values-controls`,
       queryESQLMvIntersects: `${ELASTIC_DOCS}reference/query-languages/esql/functions-operators/mv-functions/mv_intersects`,
     },

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -397,7 +397,7 @@ export interface DocLinks {
     readonly queryDsl: string;
     readonly queryESQL: string;
     readonly queryESQLExamples: string;
-    readonly queryESQLKibana: string;
+    readonly queryESQLApproximateResults: string;
     readonly queryESQLMultiValueControls: string;
     readonly queryESQLMvIntersects: string;
   };

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -397,6 +397,7 @@ export interface DocLinks {
     readonly queryDsl: string;
     readonly queryESQL: string;
     readonly queryESQLExamples: string;
+    readonly queryESQLKibana: string;
     readonly queryESQLMultiValueControls: string;
     readonly queryESQLMvIntersects: string;
   };

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.test.tsx
@@ -23,7 +23,7 @@ const mockServices = {
   docLinks: {
     links: {
       query: {
-        queryESQLKibana: 'https://elastic.co/docs/esql-kibana',
+        queryESQLApproximateResults: 'https://elastic.co/docs/esql-kibana',
       },
     },
   },

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EuiThemeProvider } from '@elastic/eui';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { coreMock } from '@kbn/core/public/mocks';
+import { EsqlApproximationToggle } from './esql_approximation_toggle';
+
+const startMock = coreMock.createStart();
+
+const mockServices = {
+  ...startMock,
+  docLinks: {
+    links: {
+      query: {
+        queryESQLKibana: 'https://elastic.co/docs/esql-kibana',
+      },
+    },
+  },
+};
+
+const renderToggle = (props: React.ComponentProps<typeof EsqlApproximationToggle>) =>
+  render(
+    <EuiThemeProvider>
+      <I18nProvider>
+        <KibanaContextProvider services={mockServices}>
+          <EsqlApproximationToggle {...props} />
+        </KibanaContextProvider>
+      </I18nProvider>
+    </EuiThemeProvider>
+  );
+
+describe('EsqlApproximationToggle', () => {
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the bolt button with OFF aria-label when useApproximation is false', () => {
+    renderToggle({ useApproximation: false, onChange });
+    expect(screen.getByLabelText('Fast mode: OFF')).toBeInTheDocument();
+  });
+
+  it('renders the bolt button with ON aria-label when useApproximation is true', () => {
+    renderToggle({ useApproximation: true, onChange });
+    expect(screen.getByLabelText('Fast mode: ON')).toBeInTheDocument();
+  });
+
+  it('opens the popover with switch and description on button click', async () => {
+    renderToggle({ useApproximation: false, onChange });
+    await userEvent.click(screen.getByTestId('esqlApproximationToggleButton'));
+    await waitFor(() => {
+      expect(screen.getByTestId('esqlApproximationToggleSwitch')).toBeInTheDocument();
+      expect(screen.getByText(/Get faster results/)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onChange when the switch is toggled', async () => {
+    renderToggle({ useApproximation: false, onChange });
+    await userEvent.click(screen.getByTestId('esqlApproximationToggleButton'));
+    await waitFor(() => screen.getByRole('switch'));
+    await userEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders additionalText inside the popover when provided', async () => {
+    renderToggle({ useApproximation: false, onChange, additionalText: 'Index has 10M+ docs' });
+    await userEvent.click(screen.getByTestId('esqlApproximationToggleButton'));
+    await waitFor(() => expect(screen.getByText('Index has 10M+ docs')).toBeInTheDocument());
+  });
+
+  describe('disabled state', () => {
+    beforeEach(() => {
+      renderToggle({ useApproximation: false, onChange, disabled: true });
+    });
+
+    it('renders the button as disabled', () => {
+      expect(screen.getByTestId('esqlApproximationToggleButton')).toBeDisabled();
+    });
+
+    it('has unavailable aria-label', () => {
+      expect(screen.getByLabelText('Fast mode unavailable')).toBeInTheDocument();
+    });
+
+    it('does not open the popover', async () => {
+      await userEvent.click(screen.getByTestId('esqlApproximationToggleButton'), {
+        pointerEventsCheck: 0,
+      });
+      expect(screen.queryByTestId('esqlApproximationToggleSwitch')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.tsx
@@ -100,7 +100,7 @@ export const EsqlApproximationToggle = ({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { euiTheme } = useEuiTheme();
   const { services } = useKibana<IUnifiedSearchPluginServices>();
-  const learnMoreUrl = services.docLinks.links.query.queryESQLKibana;
+  const learnMoreUrl = services.docLinks.links.query.queryESQLApproximateResults;
 
   const { tooltipContent, ariaLabel, switchLabel } = getLabels(
     disabled,

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButtonIcon,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiLink,
+  EuiPopover,
+  EuiSwitch,
+  EuiText,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { IUnifiedSearchPluginServices } from '../types';
+
+const POPOVER_WIDTH = 320;
+
+const getLabels = (
+  disabled: boolean | undefined,
+  useApproximation: boolean,
+  additionalText?: string
+) => {
+  if (disabled) {
+    const ariaLabel = i18n.translate('unifiedSearch.esqlApproximationToggle.unavailable', {
+      defaultMessage: 'Fast mode unavailable',
+    });
+    return {
+      tooltipContent: (
+        <>
+          <strong>{ariaLabel}</strong>
+          {additionalText && (
+            <>
+              <br />
+              <br />
+              {additionalText}
+            </>
+          )}
+        </>
+      ),
+      ariaLabel,
+      switchLabel: i18n.translate('unifiedSearch.esqlApproximationToggle.switch.off', {
+        defaultMessage: 'OFF',
+      }),
+    };
+  }
+
+  if (useApproximation) {
+    return {
+      tooltipContent: i18n.translate('unifiedSearch.esqlApproximationToggle.button.tooltip.on', {
+        defaultMessage: 'Fast mode: ON',
+      }),
+      ariaLabel: i18n.translate('unifiedSearch.esqlApproximationToggle.button.ariaLabel.on', {
+        defaultMessage: 'Fast mode: ON',
+      }),
+      switchLabel: i18n.translate('unifiedSearch.esqlApproximationToggle.switch.on', {
+        defaultMessage: 'ON',
+      }),
+    };
+  }
+
+  return {
+    tooltipContent: i18n.translate('unifiedSearch.esqlApproximationToggle.button.tooltip.off', {
+      defaultMessage: 'Fast mode: OFF',
+    }),
+    ariaLabel: i18n.translate('unifiedSearch.esqlApproximationToggle.button.ariaLabel.off', {
+      defaultMessage: 'Fast mode: OFF',
+    }),
+    switchLabel: i18n.translate('unifiedSearch.esqlApproximationToggle.switch.off', {
+      defaultMessage: 'OFF',
+    }),
+  };
+};
+
+interface EsqlApproximationToggleProps {
+  useApproximation: boolean;
+  onChange: (useApproximation: boolean) => void;
+  additionalText?: string;
+  disabled?: boolean;
+}
+
+export const EsqlApproximationToggle = ({
+  useApproximation,
+  onChange,
+  additionalText,
+  disabled,
+}: EsqlApproximationToggleProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const { euiTheme } = useEuiTheme();
+  const { services } = useKibana<IUnifiedSearchPluginServices>();
+  const learnMoreUrl = services.docLinks.links.query.queryESQLKibana;
+
+  const { tooltipContent, ariaLabel, switchLabel } = getLabels(
+    disabled,
+    useApproximation,
+    additionalText
+  );
+
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiPopover
+        button={
+          <EuiToolTip content={tooltipContent} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="bolt"
+              aria-label={ariaLabel}
+              size="s"
+              color={useApproximation ? 'success' : 'text'}
+              display={useApproximation ? 'base' : 'empty'}
+              disabled={disabled}
+              data-test-subj="esqlApproximationToggleButton"
+              onClick={() => setIsPopoverOpen((open) => !open)}
+            />
+          </EuiToolTip>
+        }
+        isOpen={isPopoverOpen}
+        closePopover={() => setIsPopoverOpen(false)}
+        panelPaddingSize="m"
+        panelStyle={{ width: POPOVER_WIDTH }}
+        anchorPosition="downRight"
+        aria-label={i18n.translate('unifiedSearch.esqlApproximationToggle.popover.ariaLabel', {
+          defaultMessage: 'Fast mode options',
+        })}
+      >
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem>
+            <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="m">
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiIcon type="bolt" size="m" aria-hidden={true} />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="s">
+                      {i18n.translate('unifiedSearch.esqlApproximationToggle.fastMode.label', {
+                        defaultMessage: 'Fast mode',
+                      })}
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  label={switchLabel}
+                  checked={useApproximation}
+                  onChange={(e) => onChange(e.target.checked)}
+                  data-test-subj="esqlApproximationToggleSwitch"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiHorizontalRule margin="s" />
+          <EuiFlexItem>
+            <EuiText size="s">
+              <FormattedMessage
+                id="unifiedSearch.esqlApproximationToggle.description"
+                defaultMessage="Get faster results by using approximation on large datasets. This is especially useful for exploring trends, or similar cases where you don't need exact results. {learnMore}"
+                values={{
+                  learnMore: (
+                    <EuiLink href={learnMoreUrl} target="_blank" external>
+                      {i18n.translate('unifiedSearch.esqlApproximationToggle.learnMore', {
+                        defaultMessage: 'Learn more',
+                      })}
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </EuiText>
+          </EuiFlexItem>
+          {additionalText && (
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued" css={{ paddingTop: euiTheme.size.s }}>
+                {additionalText}
+              </EuiText>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiPopover>
+    </EuiFlexItem>
+  );
+};

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/esql_approximation_toggle.tsx
@@ -118,7 +118,7 @@ export const EsqlApproximationToggle = ({
               aria-label={ariaLabel}
               size="s"
               color={useApproximation ? 'success' : 'text'}
-              display={useApproximation ? 'base' : 'empty'}
+              display="base"
               disabled={disabled}
               data-test-subj="esqlApproximationToggleButton"
               onClick={() => setIsPopoverOpen((open) => !open)}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -67,6 +67,7 @@ import { AddFilterPopover } from './add_filter_popover';
 import type { DataViewPickerProps } from '../dataview_picker';
 import { DataViewPicker } from '../dataview_picker';
 import { NoDataPopover } from './no_data_popover';
+import { EsqlApproximationToggle } from './esql_approximation_toggle';
 import type { IUnifiedSearchPluginServices, UnifiedSearchDraft } from '../types';
 import { shallowEqual } from '../utils/shallow_equal';
 import { FilterBarToggleButton } from '../filter_bar/filter_bar_toggle_button';
@@ -258,6 +259,15 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
    * the flag is disabled, the legacy picker is always used.
    */
   enableDateRangePicker?: boolean;
+  /**
+   * When provided, renders the ES|QL approximate execution toggle (bolt icon) before the date picker.
+   */
+  esqlApproximation?: {
+    useApproximation: boolean;
+    onChange: (useApproximation: boolean) => void;
+    additionalText?: string;
+    disabled?: boolean;
+  };
 }
 
 export const SharingMetaFields = React.memo(function SharingMetaFields({
@@ -1041,6 +1051,14 @@ export const QueryBarTopRow = React.memo(
               {shouldRenderESQLUi ? (
                 <>
                   {shouldRenderUpdateButton() ? button : null}
+                  {props.esqlApproximation && (
+                    <EsqlApproximationToggle
+                      useApproximation={props.esqlApproximation.useApproximation}
+                      onChange={props.esqlApproximation.onChange}
+                      additionalText={props.esqlApproximation.additionalText}
+                      disabled={props.esqlApproximation.disabled}
+                    />
+                  )}
                   {shouldRenderDatePicker() ? renderDatePicker() : null}
                 </>
               ) : (
@@ -1300,6 +1318,14 @@ export const QueryBarTopRow = React.memo(
                 {renderQueryInput()}
                 {props.renderQueryInputAppend?.()}
                 {shouldShowDatePickerAsBadge() && props.filterBar}
+                {props.esqlApproximation && (
+                  <EsqlApproximationToggle
+                    useApproximation={props.esqlApproximation.useApproximation}
+                    onChange={props.esqlApproximation.onChange}
+                    additionalText={props.esqlApproximation.additionalText}
+                    disabled={props.esqlApproximation.disabled}
+                  />
+                )}
                 {renderDatePickerWithUpdateBtn()}
               </EuiFlexGroup>
               {!shouldShowDatePickerAsBadge() && props.filterBar}

--- a/src/platform/plugins/shared/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/create_search_bar.tsx
@@ -309,6 +309,7 @@ export function createSearchBar({
             esqlQueryStats={props.esqlQueryStats}
             enableResourceBrowser={props.enableResourceBrowser}
             enableDateRangePicker={props.enableDateRangePicker}
+            esqlApproximation={props.esqlApproximation}
           />
         </core.i18n.Context>
       </KibanaContextProvider>

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -155,6 +155,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
   submitOnBlur?: boolean;
 
   renderQueryInputAppend?: () => React.ReactNode;
+  esqlApproximation?: QueryBarTopRowProps['esqlApproximation'];
   onESQLDocsFlyoutVisibilityChanged?: QueryBarTopRowProps['onESQLDocsFlyoutVisibilityChanged'];
   /**
    * Optional configuration for ES|QL variables.
@@ -798,6 +799,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
           submitOnBlur={this.props.submitOnBlur}
           suggestionsAbstraction={this.props.suggestionsAbstraction}
           renderQueryInputAppend={this.props.renderQueryInputAppend}
+          esqlApproximation={this.props.esqlApproximation}
           disableExternalPadding={this.props.displayStyle === 'withBorders'}
           onESQLDocsFlyoutVisibilityChanged={this.props.onESQLDocsFlyoutVisibilityChanged}
           bubbleSubmitEvent={this.props.bubbleSubmitEvent}


### PR DESCRIPTION
## Summary

Introduces a new component, fast mode icon button with a popover that is going to be used in Discover ES|QL and Dashboards to allow the users to toggle the approximate results. (currently not visible)

Part of https://github.com/elastic/kibana/issues/275303


**Disabled**
<img width="1096" height="520" alt="image (4)" src="https://github.com/user-attachments/assets/05464fd0-2810-470f-8172-48882e109738" />


**ON**
<img width="1006" height="688" alt="image (3)" src="https://github.com/user-attachments/assets/e75e8201-67f9-48b3-963b-3fba1c00c25a" />


**OFF**
<img width="1432" height="646" alt="image (2)" src="https://github.com/user-attachments/assets/13e89f9c-56b8-4d56-9872-9731c658339d" />



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




