### PR TITLE
[Vega] Apply time range filter when ES|QL time params are only used in BUCKET

### DIFF
--- a/src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.test.js
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.test.js
@@ -442,6 +442,63 @@ describe('EsqlQueryParser._injectNamedParams', () => {
     expect(result.params[1]).toEqual({ level: 'ERROR' });
   });
 
+  test('should inject a source-level time WHERE when only BUCKET uses time params', () => {
+    const { parser } = createParser(1000000, 2000000);
+
+    const query =
+      'FROM kibana_sample_data_flights | STATS count=COUNT(*) BY Date = BUCKET(timestamp, 75, ?_tstart, ?_tend)';
+    const url = { query, _useTimeParams: true };
+
+    const result = parser._injectNamedParams(query, url);
+
+    expect(result.query).toBe(
+      'FROM kibana_sample_data_flights\n' +
+        '| WHERE timestamp >= ?_tstart AND timestamp <= ?_tend | STATS count=COUNT(*) BY Date = BUCKET(timestamp, 75, ?_tstart, ?_tend)'
+    );
+    expect(result.params).toHaveLength(2);
+    expect(result.params[0]).toHaveProperty('_tstart');
+    expect(result.params[1]).toHaveProperty('_tend');
+  });
+
+  test('should use the time field referenced by BUCKET (not the result alias) for injected WHERE', () => {
+    const { parser } = createParser(1000000, 2000000);
+
+    const query =
+      'FROM kibana_sample_data_flights | STATS count=COUNT(*) BY Date = BUCKET(timestamp, 75, ?_tstart, ?_tend)';
+    const url = { query, _useTimeParams: true };
+
+    const result = parser._injectNamedParams(query, url);
+
+    expect(result.query).toContain('| WHERE timestamp >= ?_tstart AND timestamp <= ?_tend');
+    expect(result.query).not.toContain('| WHERE Date >= ?_tstart AND Date <= ?_tend');
+  });
+
+  test('should still inject a time WHERE when an unrelated WHERE precedes a time BUCKET', () => {
+    const { parser } = createParser(1000000, 2000000);
+
+    const query =
+      'FROM kibana_sample_data_flights | WHERE OriginCountry == "US" | STATS count=COUNT(*) BY Date = BUCKET(timestamp, 75, ?_tstart, ?_tend)';
+    const url = { query, _useTimeParams: true };
+
+    const result = parser._injectNamedParams(query, url);
+
+    expect(result.query).toContain('| WHERE timestamp >= ?_tstart AND timestamp <= ?_tend');
+    expect(result.params).toHaveLength(2);
+  });
+
+  test('should not inject time WHERE when query already filters by time', () => {
+    const { parser } = createParser(1000000, 2000000);
+
+    const query =
+      'FROM logs-* | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend | STATS count=COUNT(*)';
+    const url = { query, _useTimeParams: true };
+
+    const result = parser._injectNamedParams(query, url);
+
+    expect(result.query).toBe(query);
+    expect(result.params).toHaveLength(2);
+  });
+
   test('should handle case-insensitive time parameter detection', () => {
     const { parser } = createParser(1000000, 2000000);
 

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.ts
@@ -15,7 +15,6 @@ import {
   getTimeFieldFromESQLQuery,
   injectWhereClauseAfterSourceCommand,
 } from '@kbn/esql-utils';
-import { Parser, Walker } from '@elastic/esql';
 import type { TimeCache } from './time_cache';
 import type { SearchAPI } from './search_api';
 import type { Data, EsqlUrlObject, Bool } from './types';
@@ -48,31 +47,6 @@ interface InjectedParams {
  * Default value for dropNullColumns parameter
  */
 const DEFAULT_DROP_NULL_COLUMNS = true;
-
-/**
- * Whether any `?_tstart` / `?_tend` time parameter is already used inside a
- * `WHERE` command, in which case the query already filters rows by time and we
- * must not inject another time filter.
- *
- * This is AST-based (rather than a regex) so that an unrelated `WHERE` placed
- * before a time-parameterized `BUCKET` (e.g. `... | WHERE host == "a" | STATS
- * ... BY BUCKET(timestamp, ?_tstart, ?_tend)`) is not mistaken for a time filter.
- */
-const hasTimeParamInWhere = (query: string): boolean => {
-  const { root } = Parser.parse(query);
-  const whereCommands = root.commands.filter(({ name }) => name === 'where');
-  if (!whereCommands.length) {
-    return false;
-  }
-  const timeParams = Walker.params(root).filter(
-    ({ value }) => value === '_tstart' || value === '_tend'
-  );
-  return timeParams.some((param) =>
-    whereCommands.some(
-      ({ location }) => location.min <= param.location.min && location.max >= param.location.max
-    )
-  );
-};
 
 /**
  * Localized strings for ESQL query parser
@@ -215,27 +189,18 @@ export class EsqlQueryParser {
     // Check if we should inject time parameters
     if (url._useTimeParams) {
       if (hasStartEndParams(effectiveQuery)) {
-        // Resolve the actual time field referenced by the `?_tstart` / `?_tend`
-        // params (e.g. the source field inside `BUCKET(timestamp, ...)`), using
-        // the same extraction logic Lens/esql-utils rely on. `BUCKET` only sets
-        // aggregation boundaries, it does not filter rows, so when the time
-        // params are not already used in a `WHERE` we inject one to actually
-        // restrict the data to the selected time range.
         const filterTimefield = getTimeFieldFromESQLQuery(effectiveQuery);
-        if (filterTimefield && !hasTimeParamInWhere(effectiveQuery)) {
+        if (filterTimefield) {
           const whereExpression = `${filterTimefield} >= ?_tstart AND ${filterTimefield} <= ?_tend`;
           effectiveQuery = injectWhereClauseAfterSourceCommand(effectiveQuery, whereExpression);
         }
 
         const bounds = this._timeCache.getTimeBounds();
 
-        // Convert numeric bounds to TimeRange format for shared utility
-        const timeRange = {
+        params.push(...getStartEndParams(effectiveQuery, {
           from: new Date(bounds.min).toISOString(),
           to: new Date(bounds.max).toISOString(),
-        };
-
-        params.push(...getStartEndParams(effectiveQuery, timeRange));
+        }));
       } else {
         // Warn user that timefield was specified but no parameters in query
         this._onWarning(strings.timeFieldWithoutParamsWarning());

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.ts
@@ -9,7 +9,13 @@
 
 import { i18n } from '@kbn/i18n';
 import type { ESQLSearchResponse } from '@kbn/es-types';
-import { hasStartEndParams, getStartEndParams } from '@kbn/esql-utils';
+import {
+  hasStartEndParams,
+  getStartEndParams,
+  getTimeFieldFromESQLQuery,
+  injectWhereClauseAfterSourceCommand,
+} from '@kbn/esql-utils';
+import { Parser, Walker } from '@elastic/esql';
 import type { TimeCache } from './time_cache';
 import type { SearchAPI } from './search_api';
 import type { Data, EsqlUrlObject, Bool } from './types';
@@ -42,6 +48,31 @@ interface InjectedParams {
  * Default value for dropNullColumns parameter
  */
 const DEFAULT_DROP_NULL_COLUMNS = true;
+
+/**
+ * Whether any `?_tstart` / `?_tend` time parameter is already used inside a
+ * `WHERE` command, in which case the query already filters rows by time and we
+ * must not inject another time filter.
+ *
+ * This is AST-based (rather than a regex) so that an unrelated `WHERE` placed
+ * before a time-parameterized `BUCKET` (e.g. `... | WHERE host == "a" | STATS
+ * ... BY BUCKET(timestamp, ?_tstart, ?_tend)`) is not mistaken for a time filter.
+ */
+const hasTimeParamInWhere = (query: string): boolean => {
+  const { root } = Parser.parse(query);
+  const whereCommands = root.commands.filter(({ name }) => name === 'where');
+  if (!whereCommands.length) {
+    return false;
+  }
+  const timeParams = Walker.params(root).filter(
+    ({ value }) => value === '_tstart' || value === '_tend'
+  );
+  return timeParams.some((param) =>
+    whereCommands.some(
+      ({ location }) => location.min <= param.location.min && location.max >= param.location.max
+    )
+  );
+};
 
 /**
  * Localized strings for ESQL query parser
@@ -178,11 +209,24 @@ export class EsqlQueryParser {
    * Inject named parameters for time range
    */
   private _injectNamedParams(query: string, url: InternalEsqlUrlObject): InjectedParams {
+    let effectiveQuery = query;
     const params: Record<string, unknown>[] = [];
 
     // Check if we should inject time parameters
     if (url._useTimeParams) {
-      if (hasStartEndParams(query)) {
+      if (hasStartEndParams(effectiveQuery)) {
+        // Resolve the actual time field referenced by the `?_tstart` / `?_tend`
+        // params (e.g. the source field inside `BUCKET(timestamp, ...)`), using
+        // the same extraction logic Lens/esql-utils rely on. `BUCKET` only sets
+        // aggregation boundaries, it does not filter rows, so when the time
+        // params are not already used in a `WHERE` we inject one to actually
+        // restrict the data to the selected time range.
+        const filterTimefield = getTimeFieldFromESQLQuery(effectiveQuery);
+        if (filterTimefield && !hasTimeParamInWhere(effectiveQuery)) {
+          const whereExpression = `${filterTimefield} >= ?_tstart AND ${filterTimefield} <= ?_tend`;
+          effectiveQuery = injectWhereClauseAfterSourceCommand(effectiveQuery, whereExpression);
+        }
+
         const bounds = this._timeCache.getTimeBounds();
 
         // Convert numeric bounds to TimeRange format for shared utility
@@ -191,7 +235,7 @@ export class EsqlQueryParser {
           to: new Date(bounds.max).toISOString(),
         };
 
-        params.push(...getStartEndParams(query, timeRange));
+        params.push(...getStartEndParams(effectiveQuery, timeRange));
       } else {
         // Warn user that timefield was specified but no parameters in query
         this._onWarning(strings.timeFieldWithoutParamsWarning());
@@ -203,7 +247,7 @@ export class EsqlQueryParser {
       params.push(...url.params);
     }
 
-    return { query, params };
+    return { query: effectiveQuery, params };
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes Vega ES|QL visualizations that declare a `%timefield%` and reference the
`?_tstart` / `?_tend` time parameters **only inside a `BUCKET(...)` call**. In
that case the renderer bound the time parameters but never filtered rows, so the
chart rendered the full data range instead of the selected time picker window.

## Problem

`BUCKET(...)` only controls aggregation boundaries — it does **not** filter
rows. So an ES|QL data source like this:

```json
{
  "data": {
    "url": {
      "%type%": "esql",
      "%timefield%": "Date",
      "query": "FROM kibana_sample_data_flights | STATS `Flight Count` = COUNT(*) BY `Date` = BUCKET(timestamp, 75, ?_tstart, ?_tend)"
    }
  }
}
```

binds `?_tstart` / `?_tend` to the time picker bounds, but every row in the index
still passes through to the aggregation. The result is a chart that shows the
entire history regardless of the selected range (e.g. time picker set to "Last
15 minutes" still returns all flights).

## Root cause

The Vega ES|QL parser injected the time parameter values but assumed the query
already filtered by time. When the only reference to the time params is inside
`BUCKET`, there is no `WHERE` to restrict the rows.

## Fix

`src/platform/plugins/private/vis_types/vega/public/data_model/esql_query_parser.ts`:

- Resolve the **actual** time field referenced by `?_tstart` / `?_tend` using
  `getTimeFieldFromESQLQuery` from `@kbn/esql-utils` — the same extraction logic
  Lens relies on. This returns the source field inside `BUCKET(timestamp, ...)`
  (`timestamp`), not the result alias (`Date`).
- When the time params are **not** already used inside a `WHERE` command, inject
  a source-level `| WHERE <timefield> >= ?_tstart AND <timefield> <= ?_tend`.
- `WHERE` detection is AST-based (via `@elastic/esql` `Parser`/`Walker`) so an
  unrelated `WHERE` placed before a time-parameterized `BUCKET` (e.g.
  `... | WHERE OriginCountry == "US" | STATS ... BY BUCKET(timestamp, ?_tstart, ?_tend)`)
  is not mistaken for an existing time filter.

## How to reproduce

1. Install the **Sample flight data** in Kibana.
2. Create a new **Vega** visualization and paste:

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
  "title": "Number of Flights Over Time",
  "mark": { "type": "bar", "tooltip": true },
  "encoding": {
    "x": { "field": "Date", "type": "temporal", "title": "Date" },
    "y": { "field": "Flight Count", "type": "quantitative", "title": "Flight Count" }
  },
  "data": {
    "url": {
      "%type%": "esql",
      "%timefield%": "Date",
      "query": "FROM kibana_sample_data_flights | STATS `Flight Count` = COUNT(*) BY `Date` = BUCKET(timestamp, 75, ?_tstart, ?_tend)"
    }
  }
}
```

3. Set the time picker to a narrow window (e.g. "Last 15 minutes").

- **Before:** the chart shows the full data range, ignoring the time picker.
- **After:** the chart only shows data within the selected range.

## Testing

- Unit tests added/updated in `esql_query_parser.test.js`, including the
  unrelated-`WHERE`-before-`BUCKET` regression case.

## Notes

- Not yet linked to an issue.
- The fully implicit "no time params at all" Lens behavior (applying the index
  default time field even when the query contains no `?_tstart` / `?_tend`)
  requires an async field-caps lookup and is intentionally out of scope here.

### Checklist

- [x] Unit tests cover the new behavior