### PR TITLE
Fix flaky test: unskip 'should return nothing if no notes have been created by that user'

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/saved_objects/tests/notes.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/saved_objects/tests/notes.ts
@@ -15,6 +15,8 @@ import { createNote, deleteNotes } from '../../utils/notes';
 
 export default function ({ getService }: FtrProviderContextWithSpaces) {
   const utils = getService('securitySolutionUtils');
+  const security = getService('security');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
   let supertest: TestAgent;
 
   describe('Note - Saved Objects', () => {
@@ -399,20 +401,60 @@ export default function ({ getService }: FtrProviderContextWithSpaces) {
         });
       });
 
-      // TODO we need to figure out how to create another user in the test environment
-      it.skip('should return nothing if no notes have been created by that user', async () => {
-        await Promise.all([
-          createNote(supertest, { text: 'first note' }),
-          createNote(supertest, { text: 'second note' }),
-        ]);
+      // Runs in ESS only: serverless does not support interactive login to activate user profiles.
+      describe('@skipInServerless', () => {
+        it('should return nothing if no notes have been created by that user', async () => {
+          // Create a second user who will not create any notes
+          const secondUsername = 'notes_filter_test_user';
+          const secondPassword = 'changeme';
+          await security.user.create(secondUsername, {
+            password: secondPassword,
+            roles: ['kibana_admin'],
+            full_name: 'Notes Filter Test User',
+          });
 
-        const response = await supertest
-          .get(`${NOTE_URL}?createdByFilter=user1`)
-          .set('kbn-xsrf', 'true')
-          .set('elastic-api-version', '2023-10-31');
-        const { totalCount } = response.body as GetNotesResult;
+          try {
+            // Activate the second user's profile by logging in interactively (basic auth
+            // API requests do not activate user profiles; only cookie-based login does).
+            const loginResponse = await supertestWithoutAuth
+              .post('/internal/security/login')
+              .set('kbn-xsrf', 'xxx')
+              .send({
+                providerType: 'basic',
+                providerName: 'basic',
+                currentURL: '/',
+                params: { username: secondUsername, password: secondPassword },
+              })
+              .expect(200);
 
-        expect(totalCount).to.be(0);
+            const rawCookie = loginResponse.headers['set-cookie'][0].split(';')[0];
+
+            // Retrieve the second user's profile UID
+            const profileResponse = await supertestWithoutAuth
+              .get('/internal/security/user_profile')
+              .set('Cookie', rawCookie)
+              .set('kbn-xsrf', 'true')
+              .expect(200);
+            const secondUserUid: string = profileResponse.body.uid;
+
+            // Create notes as the main (default) user — not the second user
+            await Promise.all([
+              createNote(supertest, { text: 'first note' }),
+              createNote(supertest, { text: 'second note' }),
+            ]);
+
+            // Filter notes by the second user's UID; they created no notes so expect 0
+            const response = await supertest
+              .get(`${NOTE_URL}?createdByFilter=${secondUserUid}`)
+              .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31');
+            const { totalCount } = response.body as GetNotesResult;
+
+            expect(totalCount).to.be(0);
+          } finally {
+            await security.user.delete(secondUsername);
+          }
+        });
       });
 
       it('should return error if user does not exist', async () => {


### PR DESCRIPTION
Fixes #270456

## Summary

### 🛑 Problem

The test `"should return nothing if no notes have been created by that user"` in the notes saved-objects integration suite was permanently skipped with a `TODO` comment: the test needed a valid Kibana user profile UID for a second user, but the suite had no established pattern for creating one. The workaround of passing a literal string like `"user1"` would always result in a 500 error from `bulkGet` ("User not found"), not `totalCount === 0`.

### 💡 Solution

Unskip the test by giving it a real second user. The test now creates a `notes_filter_test_user` via the `security` service, logs in interactively via `POST /internal/security/login` (cookie-based login is the only way to activate a Kibana user profile — basic-auth API requests do not activate profiles), retrieves the activated profile UID, creates notes as the main test user, then asserts that filtering by the second user's UID returns zero results. The user is deleted in a `finally` block. The test is wrapped in a `describe('@skipInServerless')` block, consistent with its sibling test, because serverless environments use M2M API keys which do not activate user profiles.

### 🧠 Notes

- The `@skipInServerless` wrapper is intentional and matches the pattern already used by the adjacent `"should retrieve all notes that have been created by a specific user"` test in the same file.
- Interactive login via the internal `POST /internal/security/login` endpoint is the documented FTR pattern for activating user profiles in integration tests; `supertestWithoutAuth` is the right service to use here because the call must be unauthenticated.

### ✅ How to verify

Run the integration suite against an ESS (non-serverless) environment:

```bash
node scripts/functional_tests \
  --config x-pack/solutions/security/test/security_solution_api_integration/config/ess/config.base.basic.ts \
  --grep "should return nothing if no notes have been created by that user"
```

The test should pass (previously it was always skipped). On a serverless config it should be skipped by the `@skipInServerless` tag.

Made with [Cursor](https://cursor.com)