### PR TITLE
[9.3] [Security] Fix flaky account_management_page test timeout (#274679)

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/account_management/account_management_page.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/account_management/account_management_page.test.tsx
@@ -16,10 +16,17 @@ import * as UserProfileImports from './user_profile/user_profile';
 import { UserProfileAPIClient } from './user_profile/user_profile_api_client';
 import type { UserProfileData } from '../../common';
 import { mockAuthenticatedUser } from '../../common/model/authenticated_user.mock';
+import { Breadcrumb } from '../components/breadcrumb';
 import { UserAPIClient } from '../management';
 import { securityMock } from '../mocks';
 
-const UserProfileMock = jest.spyOn(UserProfileImports, 'UserProfile');
+const UserProfileMock = jest
+  .spyOn(UserProfileImports, 'UserProfile')
+  .mockImplementation(({ user }) => (
+    <Breadcrumb text={user.username}>
+      <form aria-label="user profile" />
+    </Breadcrumb>
+  ));
 
 describe('<AccountManagementPage>', () => {
   const coreStart = coreMock.createStart();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security] Fix flaky account_management_page test timeout (#274679)](https://github.com/elastic/kibana/pull/274679)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-06-26T16:02:45Z","message":"[Security] Fix flaky account_management_page test timeout (#274679)\n\n## Summary\n\nFixes the flaky Jest test reported in #268139:\n\n> Failing test: `Jest\nTests.x-pack/platform/plugins/shared/security/public/account_management`\n- should render user profile form and set breadcrumbs\n\nThe single test in `account_management_page.test.tsx` spied on\n`UserProfile` with a bare `jest.spyOn(...)` (no `mockImplementation`),\nso the **real** `UserProfile` rendered — the full Formik + EUI tree\n(color picker, button groups, locale select, multiple\n`EuiDescribedFormGroup`s, `KibanaPageTemplate`). The single assertion\ngate `await findByRole('form')` inherits Jest's default 5000 ms timeout,\nand on loaded CI agents that render budget was intermittently exceeded,\nproducing the `Exceeded timeout of 5000 ms for a test` signature in the\nissue.\n\nThis was aggravated by #260835, which added the `usePrimeUserLocale`\nhook (`useEffect → update() → http.post`) inside `UserProfile`, adding\nanother async re-render to the tree the test waits on.\n\n## Fix\n\nGive the `UserProfile` spy a lightweight `mockImplementation` that\nrenders just a `Breadcrumb` wrapping a native `<form>`:\n\n```tsx\nconst UserProfileMock = jest\n  .spyOn(UserProfileImports, 'UserProfile')\n  .mockImplementation(({ user }) => (\n    <Breadcrumb text={user.username}>\n      <form aria-label=\"user profile\" />\n    </Breadcrumb>\n  ));\n```\n\nThis keeps every existing assertion green without rendering the heavy\nform tree:\n- `findByRole('form')` resolves immediately (the `<form>` has an\naccessible name via `aria-label`).\n- The `setBreadcrumbs` assertion still fires because the inner\n`<Breadcrumb text={user.username}>` produces the expected `{ text:\n'user' }` crumb.\n- `expect(UserProfileMock).toHaveBeenCalledWith(...)` still holds — a\nspy with `mockImplementation` still records calls.\n\nWith `UserProfile` mocked, the defensive\n`coreStart.http.post.mockReset().mockResolvedValue(undefined)` added in\n`beforeEach` for `usePrimeUserLocale` is now dead code (the hook never\nruns), so it has been removed.\n\n`UserProfile` itself remains independently covered by the 19 tests in\n`user_profile.test.tsx`, so this test doesn't need to re-render it for\nreal.\n\n## Notes\n\n- This triage is based on the [Failed Test Investigator\nanalysis](https://github.com/elastic/kibana/issues/268139#issuecomment-4630575689),\nverified against the code.\n- Opened as **draft** so CI can run the Jest test + typecheck (the dev\nenvironment was not bootstrapped here).\n\nCloses #268139\n\n---\n🔗 Slack thread:\nhttps://elastic.slack.com/archives/GRBCBLNEQ/p1782244044150879\n\n---\n_Generated by [Claude\nCode](https://claude.ai/code/session_01FBmN7Nfu1TgcKGL4tEztph)_\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"2a78076d8534fd5f42ccbc19cd2e9d0335552633","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.5.0"],"title":"[Security] Fix flaky account_management_page test timeout","number":274679,"url":"https://github.com/elastic/kibana/pull/274679","mergeCommit":{"message":"[Security] Fix flaky account_management_page test timeout (#274679)\n\n## Summary\n\nFixes the flaky Jest test reported in #268139:\n\n> Failing test: `Jest\nTests.x-pack/platform/plugins/shared/security/public/account_management`\n- should render user profile form and set breadcrumbs\n\nThe single test in `account_management_page.test.tsx` spied on\n`UserProfile` with a bare `jest.spyOn(...)` (no `mockImplementation`),\nso the **real** `UserProfile` rendered — the full Formik + EUI tree\n(color picker, button groups, locale select, multiple\n`EuiDescribedFormGroup`s, `KibanaPageTemplate`). The single assertion\ngate `await findByRole('form')` inherits Jest's default 5000 ms timeout,\nand on loaded CI agents that render budget was intermittently exceeded,\nproducing the `Exceeded timeout of 5000 ms for a test` signature in the\nissue.\n\nThis was aggravated by #260835, which added the `usePrimeUserLocale`\nhook (`useEffect → update() → http.post`) inside `UserProfile`, adding\nanother async re-render to the tree the test waits on.\n\n## Fix\n\nGive the `UserProfile` spy a lightweight `mockImplementation` that\nrenders just a `Breadcrumb` wrapping a native `<form>`:\n\n```tsx\nconst UserProfileMock = jest\n  .spyOn(UserProfileImports, 'UserProfile')\n  .mockImplementation(({ user }) => (\n    <Breadcrumb text={user.username}>\n      <form aria-label=\"user profile\" />\n    </Breadcrumb>\n  ));\n```\n\nThis keeps every existing assertion green without rendering the heavy\nform tree:\n- `findByRole('form')` resolves immediately (the `<form>` has an\naccessible name via `aria-label`).\n- The `setBreadcrumbs` assertion still fires because the inner\n`<Breadcrumb text={user.username}>` produces the expected `{ text:\n'user' }` crumb.\n- `expect(UserProfileMock).toHaveBeenCalledWith(...)` still holds — a\nspy with `mockImplementation` still records calls.\n\nWith `UserProfile` mocked, the defensive\n`coreStart.http.post.mockReset().mockResolvedValue(undefined)` added in\n`beforeEach` for `usePrimeUserLocale` is now dead code (the hook never\nruns), so it has been removed.\n\n`UserProfile` itself remains independently covered by the 19 tests in\n`user_profile.test.tsx`, so this test doesn't need to re-render it for\nreal.\n\n## Notes\n\n- This triage is based on the [Failed Test Investigator\nanalysis](https://github.com/elastic/kibana/issues/268139#issuecomment-4630575689),\nverified against the code.\n- Opened as **draft** so CI can run the Jest test + typecheck (the dev\nenvironment was not bootstrapped here).\n\nCloses #268139\n\n---\n🔗 Slack thread:\nhttps://elastic.slack.com/archives/GRBCBLNEQ/p1782244044150879\n\n---\n_Generated by [Claude\nCode](https://claude.ai/code/session_01FBmN7Nfu1TgcKGL4tEztph)_\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"2a78076d8534fd5f42ccbc19cd2e9d0335552633"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274679","number":274679,"mergeCommit":{"message":"[Security] Fix flaky account_management_page test timeout (#274679)\n\n## Summary\n\nFixes the flaky Jest test reported in #268139:\n\n> Failing test: `Jest\nTests.x-pack/platform/plugins/shared/security/public/account_management`\n- should render user profile form and set breadcrumbs\n\nThe single test in `account_management_page.test.tsx` spied on\n`UserProfile` with a bare `jest.spyOn(...)` (no `mockImplementation`),\nso the **real** `UserProfile` rendered — the full Formik + EUI tree\n(color picker, button groups, locale select, multiple\n`EuiDescribedFormGroup`s, `KibanaPageTemplate`). The single assertion\ngate `await findByRole('form')` inherits Jest's default 5000 ms timeout,\nand on loaded CI agents that render budget was intermittently exceeded,\nproducing the `Exceeded timeout of 5000 ms for a test` signature in the\nissue.\n\nThis was aggravated by #260835, which added the `usePrimeUserLocale`\nhook (`useEffect → update() → http.post`) inside `UserProfile`, adding\nanother async re-render to the tree the test waits on.\n\n## Fix\n\nGive the `UserProfile` spy a lightweight `mockImplementation` that\nrenders just a `Breadcrumb` wrapping a native `<form>`:\n\n```tsx\nconst UserProfileMock = jest\n  .spyOn(UserProfileImports, 'UserProfile')\n  .mockImplementation(({ user }) => (\n    <Breadcrumb text={user.username}>\n      <form aria-label=\"user profile\" />\n    </Breadcrumb>\n  ));\n```\n\nThis keeps every existing assertion green without rendering the heavy\nform tree:\n- `findByRole('form')` resolves immediately (the `<form>` has an\naccessible name via `aria-label`).\n- The `setBreadcrumbs` assertion still fires because the inner\n`<Breadcrumb text={user.username}>` produces the expected `{ text:\n'user' }` crumb.\n- `expect(UserProfileMock).toHaveBeenCalledWith(...)` still holds — a\nspy with `mockImplementation` still records calls.\n\nWith `UserProfile` mocked, the defensive\n`coreStart.http.post.mockReset().mockResolvedValue(undefined)` added in\n`beforeEach` for `usePrimeUserLocale` is now dead code (the hook never\nruns), so it has been removed.\n\n`UserProfile` itself remains independently covered by the 19 tests in\n`user_profile.test.tsx`, so this test doesn't need to re-render it for\nreal.\n\n## Notes\n\n- This triage is based on the [Failed Test Investigator\nanalysis](https://github.com/elastic/kibana/issues/268139#issuecomment-4630575689),\nverified against the code.\n- Opened as **draft** so CI can run the Jest test + typecheck (the dev\nenvironment was not bootstrapped here).\n\nCloses #268139\n\n---\n🔗 Slack thread:\nhttps://elastic.slack.com/archives/GRBCBLNEQ/p1782244044150879\n\n---\n_Generated by [Claude\nCode](https://claude.ai/code/session_01FBmN7Nfu1TgcKGL4tEztph)_\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"2a78076d8534fd5f42ccbc19cd2e9d0335552633"}}]}] BACKPORT-->