### PR TITLE
[Task Manager] Defer mget claim hydration & API key decryption to claimed tasks

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_claiming_decrypts_winners_only.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_claiming_decrypts_winners_only.test.ts
@@ -22,9 +22,11 @@ const POLLING_INTERVAL = 500;
 const TASK_TYPE = '_winnersOnlyType';
 
 // The mget claimer over-fetches candidates (4 * capacity) but should only ever hydrate and
-// decrypt the tasks it actually claims. We spy on the private bulkGetDecryptedTaskApiKeys,
-// which is reached exclusively via TaskStore.bulkGet (the claimed-winners re-fetch), and
-// assert it is never handed more ids than the capacity in a single claim cycle.
+// decrypt the tasks it actually claims. The candidate search excludes the apiKey fields from
+// _source, so the candidate-path decryption sees no key and no-ops; the only real decryption
+// happens when the claimed winners are re-fetched in full via TaskStore.bulkGet. We spy on the
+// private bulkGetDecryptedTaskApiKeys and assert it is never handed more ids than the capacity
+// in a single claim cycle.
 const decryptSpy = jest.spyOn(
   TaskStore.prototype as unknown as {
     bulkGetDecryptedTaskApiKeys: (taskIds: string[]) => Promise<Map<string, unknown>>;

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_claiming_decrypts_winners_only.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_claiming_decrypts_winners_only.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { times } from 'lodash';
+import type { TestElasticsearchUtils, TestKibanaUtils } from '@kbn/core-test-helpers-kbn-server';
+import { schema } from '@kbn/config-schema';
+import { TaskStatus, type RunContext } from '../task';
+import type { TaskClaimingOpts } from '../queries/task_claiming';
+import { TaskManagerPlugin, type TaskManagerStartContract } from '../plugin';
+import { TaskStore } from '../task_store';
+import { injectTaskBulk, setupTestServers, retry } from './lib';
+
+// Minimum allowed capacity (see MIN_CAPACITY in config.ts). Normal-cost tasks consume 2
+// capacity each, so at most 2 are claimed per cycle — well below the number of candidates.
+const CAPACITY = 5;
+const POLLING_INTERVAL = 500;
+const TASK_TYPE = '_winnersOnlyType';
+
+// The mget claimer over-fetches candidates (4 * capacity) but should only ever hydrate and
+// decrypt the tasks it actually claims. We spy on the private bulkGetDecryptedTaskApiKeys,
+// which is reached exclusively via TaskStore.bulkGet (the claimed-winners re-fetch), and
+// assert it is never handed more ids than the capacity in a single claim cycle.
+const decryptSpy = jest.spyOn(
+  TaskStore.prototype as unknown as {
+    bulkGetDecryptedTaskApiKeys: (taskIds: string[]) => Promise<Map<string, unknown>>;
+  },
+  'bulkGetDecryptedTaskApiKeys'
+);
+
+const mockRunFn = jest.fn();
+const mockCreateTaskRunner = jest.fn();
+const mockTaskType = {
+  title: 'Winners only decryption test task',
+  description: '',
+  timeout: '1m',
+  maxAttempts: 1,
+  stateSchemaByVersion: {
+    1: {
+      up: (state: Record<string, unknown>) => ({ foo: state.foo || '' }),
+      schema: schema.object({
+        foo: schema.string(),
+      }),
+    },
+  },
+  createTaskRunner: mockCreateTaskRunner.mockImplementation(({ taskInstance }: RunContext) => ({
+    run: async () => mockRunFn(taskInstance),
+  })),
+};
+
+jest.mock('../queries/task_claiming', () => {
+  const actual = jest.requireActual('../queries/task_claiming');
+  return {
+    ...actual,
+    TaskClaiming: jest.fn().mockImplementation((opts: TaskClaimingOpts) => {
+      opts.definitions.registerTaskDefinitions({ [TASK_TYPE]: mockTaskType });
+      return new actual.TaskClaiming(opts);
+    }),
+  };
+});
+
+const taskManagerStartSpy = jest.spyOn(TaskManagerPlugin.prototype, 'start');
+
+describe('Task claiming decrypts and hydrates claimed winners only (integration)', () => {
+  const taskIdsToRemove: string[] = [];
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+  let taskManagerPlugin: TaskManagerStartContract;
+
+  beforeAll(async () => {
+    const setupResult = await setupTestServers({
+      xpack: {
+        task_manager: {
+          claim_strategy: `mget`,
+          capacity: CAPACITY,
+          poll_interval: POLLING_INTERVAL,
+          // Exclude every other registered task type so only our injected tasks are claimed,
+          // keeping the decryption call counts deterministic.
+          unsafe: {
+            exclude_task_types: ['[A-Za-z]*'],
+          },
+        },
+      },
+    });
+    esServer = setupResult.esServer;
+    kibanaServer = setupResult.kibanaServer;
+
+    expect(taskManagerStartSpy).toHaveBeenCalledTimes(1);
+    taskManagerPlugin = taskManagerStartSpy.mock.results[0].value;
+  });
+
+  afterAll(async () => {
+    if (kibanaServer) {
+      await kibanaServer.stop();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+  });
+
+  afterEach(async () => {
+    while (taskIdsToRemove.length > 0) {
+      const id = taskIdsToRemove.pop();
+      await taskManagerPlugin.removeIfExists(id!);
+    }
+  });
+
+  it('decrypts at most "capacity" tasks per claim cycle even when more candidates exist', async () => {
+    decryptSpy.mockClear();
+    mockRunFn.mockClear();
+
+    // Inject many more tasks than can be claimed in a single cycle, each carrying its own
+    // API key + userScope and a sentinel in state. With the old candidate-path decryption a
+    // single call would have received up to `taskCount` ids.
+    const taskCount = 15;
+    const ids: string[] = [];
+    times(taskCount, () => ids.push(uuidV4()));
+
+    const runAt = new Date(Date.now() - 1000);
+    const tasks = ids.map((id) => ({
+      id,
+      taskType: TASK_TYPE,
+      params: {},
+      state: { foo: id },
+      stateVersion: 1,
+      runAt,
+      enabled: true,
+      scheduledAt: new Date(),
+      attempts: 0,
+      status: TaskStatus.Idle,
+      startedAt: null,
+      retryAt: null,
+      ownerId: null,
+      apiKey: Buffer.from(`${id}:api-key-value`).toString('base64'),
+      userScope: {
+        apiKeyId: id,
+        spaceId: 'default',
+        apiKeyCreatedByUser: false,
+      },
+    }));
+    taskIdsToRemove.push(...ids);
+
+    await injectTaskBulk(kibanaServer.coreStart.elasticsearch.client.asInternalUser, tasks);
+
+    // Wait until every task has run (across multiple claim cycles).
+    await retry(async () => {
+      expect(mockRunFn).toHaveBeenCalledTimes(taskCount);
+    });
+
+    // The decryption helper is only reachable through the claimed-winners bulkGet, so no
+    // single invocation should ever see more ids than the per-cycle capacity. If decryption
+    // had stayed in the candidate search path, a call would have received up to `taskCount`.
+    expect(decryptSpy).toHaveBeenCalled();
+    for (const call of decryptSpy.mock.calls) {
+      const [taskIds] = call;
+      expect(taskIds.length).toBeLessThanOrEqual(CAPACITY);
+    }
+
+    // Each claimed task is hydrated in full: the runner receives the sentinel state that the
+    // slim candidate search excludes.
+    for (const call of mockRunFn.mock.calls) {
+      const [taskInstance] = call;
+      expect(taskInstance.state).toEqual({ foo: taskInstance.id });
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.test.ts
@@ -418,7 +418,17 @@ describe('TaskClaiming', () => {
       expect(store.msearch.mock.calls[0][0]?.[0]).toMatchObject({
         size: 40,
         seq_no_primary_term: true,
-        _source: { excludes: ['task.state', 'task.params'] },
+        // candidate search drops unbounded params/state and the API key fields (so msearch skips
+        // decryption); claimed winners are re-fetched in full via bulkGet
+        _source: {
+          excludes: [
+            'task.state',
+            'task.params',
+            'task.apiKey',
+            'task.uiamApiKey',
+            'task.userScope',
+          ],
+        },
       });
       expect(store.getDocVersions).toHaveBeenCalledWith([
         'task:id-1',

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.test.ts
@@ -418,6 +418,7 @@ describe('TaskClaiming', () => {
       expect(store.msearch.mock.calls[0][0]?.[0]).toMatchObject({
         size: 40,
         seq_no_primary_term: true,
+        _source: { excludes: ['task.state', 'task.params'] },
       });
       expect(store.getDocVersions).toHaveBeenCalledWith([
         'task:id-1',

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -12,6 +12,7 @@
 // - if the mget result doesn't match the search result, the task is stale
 // - from the non-stale search results, return as many as we can run based on available
 //   capacity and the cost of each task type to run
+// - only the claimed tasks are re-fetched in full (params, state, decrypted API keys) via bulkGet
 
 import type { Logger } from 'elastic-apm-node';
 import apm from 'elastic-apm-node';
@@ -67,6 +68,9 @@ interface OwnershipClaimingOpts {
 }
 
 const SIZE_MULTIPLIER_FOR_TASK_FETCH = 4;
+
+// params and state are unbounded and only needed for claimed tasks, which bulkGet re-fetches in full
+const CLAIM_SEARCH_SOURCE_EXCLUDES = ['task.state', 'task.params'];
 
 export async function claimAvailableTasksMget(
   opts: TaskClaimerOpts
@@ -343,6 +347,7 @@ async function searchAvailableTasks({
       sort, // note: we could optimize this to not sort on priority, for this case
       size,
       seq_no_primary_term: true,
+      _source: { excludes: CLAIM_SEARCH_SOURCE_EXCLUDES },
     });
   }
 
@@ -370,6 +375,7 @@ async function searchAvailableTasks({
       sort,
       size: capacity * SIZE_MULTIPLIER_FOR_TASK_FETCH,
       seq_no_primary_term: true,
+      _source: { excludes: CLAIM_SEARCH_SOURCE_EXCLUDES },
     });
   }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -7,7 +7,7 @@
 
 // Basic operation of this task claimer:
 // - search for candidate tasks to run, more than we actually can run
-// - initial search returns a slimmer task document for I/O efficiency (no params or state)
+// - initial search returns a slimmer task document for I/O efficiency (no params, state, or API key)
 // - for each task found, do an mget to get the current seq_no and primary_term
 // - if the mget result doesn't match the search result, the task is stale
 // - from the non-stale search results, return as many as we can run based on available
@@ -69,8 +69,16 @@ interface OwnershipClaimingOpts {
 
 const SIZE_MULTIPLIER_FOR_TASK_FETCH = 4;
 
-// params and state are unbounded and only needed for claimed tasks, which bulkGet re-fetches in full
-const CLAIM_SEARCH_SOURCE_EXCLUDES = ['task.state', 'task.params'];
+// The candidate search over-fetches tasks we won't claim. params/state are unbounded and only
+// needed once claimed, and excluding apiKey/userScope means TaskStore.msearch sees no key on these
+// docs and skips decryption. Claimed tasks are re-fetched in full (with key + state) via bulkGet.
+const CLAIM_SEARCH_SOURCE_EXCLUDES = [
+  'task.state',
+  'task.params',
+  'task.apiKey',
+  'task.uiamApiKey',
+  'task.userScope',
+];
 
 export async function claimAvailableTasksMget(
   opts: TaskClaimerOpts

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -34,7 +34,7 @@ import { executionContextServiceMock } from '@kbn/core-execution-context-server-
 import { TaskTypeDictionary } from './task_type_dictionary';
 import { mockLogger } from './test_utils';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
-import { asErr, asOk, isOk } from './lib/result_type';
+import { asErr, asOk } from './lib/result_type';
 import type { UpdateByQueryResponse } from '@elastic/elasticsearch/lib/api/types';
 import { MsearchError } from './lib/errors';
 import { getApiKeyAndUserScope } from './lib/api_key_utils';
@@ -787,7 +787,7 @@ describe('TaskStore', () => {
       });
     });
 
-    test('does NOT decrypt API keys (decryption is deferred to the claimed tasks bulkGet)', async () => {
+    test('should return tasks with decrypted API keys', async () => {
       const { result } = await testMsearch(
         [{}],
         [
@@ -812,13 +812,44 @@ describe('TaskStore', () => {
         startedAt: new Date(mockTask.startedAt),
         state: {},
         params: {},
-        apiKey: 'encryptedKey',
+        apiKey: 'decryptedApiKey',
       });
+    });
+
+    test('does not decrypt API keys when the apiKey field is excluded from _source', async () => {
+      const { result } = await testMsearch(
+        [{ _source: { excludes: ['task.apiKey', 'task.uiamApiKey', 'task.userScope'] } }],
+        [
+          {
+            hits: [
+              {
+                _index: '.kibana_task_manager_8.16.0_001',
+                // apiKey omitted from _source, mirroring the claimer's slim candidate search
+                _source: { task: { ...mockTask, apiKey: undefined } },
+              },
+            ],
+          },
+        ]
+      );
+
+      expect(result.docs[0].apiKey).toBeUndefined();
       expect(esoClient.createPointInTimeFinderDecryptedAsInternalUser).not.toHaveBeenCalled();
     });
 
     test('returns all API keys when first getApiKeys search misses a key, but finds after refresh', async () => {
       const logger = mockLogger();
+      const mockSerializer = savedObjectsServiceMock.createSerializer();
+      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
+      mockSerializer.rawToSavedObject = jest
+        .fn()
+        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
+          id: doc._source?.task?.id ?? 'task1',
+          version: '123',
+          type: 'task',
+          references: [],
+          attributes: doc._source?.task ?? mockTask,
+        }));
+
       const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       const indicesRefreshSpy = jest
         .spyOn(mockEsClient.indices, 'refresh')
@@ -828,7 +859,7 @@ describe('TaskStore', () => {
         logger,
         index: 'tasky',
         taskManagerId: '',
-        serializer,
+        serializer: mockSerializer,
         esClient: mockEsClient,
         definitions: taskDefinitions,
         savedObjectsRepository: savedObjectsClient,
@@ -875,28 +906,35 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      savedObjectsClient.bulkGet.mockResolvedValue({
-        saved_objects: [
+      mockEsClient.msearch.mockResponse({
+        took: 0,
+        responses: [
           {
-            id: 'task1',
-            type: 'task',
-            references: [],
-            attributes: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' },
-          },
-          {
-            id: 'task2',
-            type: 'task',
-            references: [],
-            attributes: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' },
+            hits: {
+              hits: [
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
+                },
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+                },
+              ],
+            },
+            took: 0,
+            _shards: { failed: 0, successful: 1, total: 1 },
+            timed_out: false,
+            status: 200,
           },
         ],
       });
 
-      const result = await refreshStore.bulkGet(['task1', 'task2']);
+      const result = await refreshStore.msearch([{}]);
 
-      expect(result).toHaveLength(2);
-      expect(isOk(result[0]) && result[0].value.apiKey).toBe('decryptedKey1');
-      expect(isOk(result[1]) && result[1].value.apiKey).toBe('decryptedKey2');
+      expect(result.docs).toHaveLength(2);
+      expect(result.docs[0].apiKey).toBe('decryptedKey1');
+      expect(result.docs[1].apiKey).toBe('decryptedKey2');
       expect(indicesRefreshSpy).toHaveBeenCalledWith({ index: 'tasky' });
       expect(esoClient.createPointInTimeFinderDecryptedAsInternalUser).toHaveBeenCalledTimes(2);
       expect(logger.warn).toHaveBeenCalledWith(
@@ -906,6 +944,18 @@ describe('TaskStore', () => {
     });
 
     test('returns partial API keys when first getApiKeys search misses a key, and second search after refresh still does not find it', async () => {
+      const mockSerializer = savedObjectsServiceMock.createSerializer();
+      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
+      mockSerializer.rawToSavedObject = jest
+        .fn()
+        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
+          id: doc._source?.task?.id ?? 'task1',
+          version: '123',
+          type: 'task',
+          references: [],
+          attributes: doc._source?.task ?? mockTask,
+        }));
+
       const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       jest.spyOn(mockEsClient.indices, 'refresh').mockResolvedValue({} as never);
       const logger = mockLogger();
@@ -914,7 +964,7 @@ describe('TaskStore', () => {
         logger,
         index: 'tasky',
         taskManagerId: '',
-        serializer,
+        serializer: mockSerializer,
         esClient: mockEsClient,
         definitions: taskDefinitions,
         savedObjectsRepository: savedObjectsClient,
@@ -954,28 +1004,35 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      savedObjectsClient.bulkGet.mockResolvedValue({
-        saved_objects: [
+      mockEsClient.msearch.mockResponse({
+        took: 0,
+        responses: [
           {
-            id: 'task1',
-            type: 'task',
-            references: [],
-            attributes: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' },
-          },
-          {
-            id: 'task2',
-            type: 'task',
-            references: [],
-            attributes: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' },
+            hits: {
+              hits: [
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
+                },
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+                },
+              ],
+            },
+            took: 0,
+            _shards: { failed: 0, successful: 1, total: 1 },
+            timed_out: false,
+            status: 200,
           },
         ],
       });
 
-      const result = await refreshStore.bulkGet(['task1', 'task2']);
+      const result = await refreshStore.msearch([{}]);
 
-      expect(result).toHaveLength(2);
-      expect(isOk(result[0]) && result[0].value.apiKey).toBe('decryptedKey1');
-      expect(isOk(result[1]) && result[1].value.apiKey).toBe('encryptedKey2');
+      expect(result.docs).toHaveLength(2);
+      expect(result.docs[0].apiKey).toBe('decryptedKey1');
+      expect(result.docs[1].apiKey).toBe('encryptedKey2');
       expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({ index: 'tasky' });
       expect(logger.warn).toHaveBeenCalledWith(
         'Refreshing index to get recently created API keys for tasks'
@@ -986,6 +1043,18 @@ describe('TaskStore', () => {
     });
 
     test('returns partial API keys when refresh fails', async () => {
+      const mockSerializer = savedObjectsServiceMock.createSerializer();
+      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
+      mockSerializer.rawToSavedObject = jest
+        .fn()
+        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
+          id: doc._source?.task?.id ?? 'task1',
+          version: '123',
+          type: 'task',
+          references: [],
+          attributes: doc._source?.task ?? mockTask,
+        }));
+
       const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       jest.spyOn(mockEsClient.indices, 'refresh').mockRejectedValue(new Error('bad refresh'));
       const logger = mockLogger();
@@ -994,7 +1063,7 @@ describe('TaskStore', () => {
         logger,
         index: 'tasky',
         taskManagerId: '',
-        serializer,
+        serializer: mockSerializer,
         esClient: mockEsClient,
         definitions: taskDefinitions,
         savedObjectsRepository: savedObjectsClient,
@@ -1034,28 +1103,35 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      savedObjectsClient.bulkGet.mockResolvedValue({
-        saved_objects: [
+      mockEsClient.msearch.mockResponse({
+        took: 0,
+        responses: [
           {
-            id: 'task1',
-            type: 'task',
-            references: [],
-            attributes: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' },
-          },
-          {
-            id: 'task2',
-            type: 'task',
-            references: [],
-            attributes: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' },
+            hits: {
+              hits: [
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
+                },
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+                },
+              ],
+            },
+            took: 0,
+            _shards: { failed: 0, successful: 1, total: 1 },
+            timed_out: false,
+            status: 200,
           },
         ],
       });
 
-      const result = await refreshStore.bulkGet(['task1', 'task2']);
+      const result = await refreshStore.msearch([{}]);
 
-      expect(result).toHaveLength(2);
-      expect(isOk(result[0]) && result[0].value.apiKey).toBe('decryptedKey1');
-      expect(isOk(result[1]) && result[1].value.apiKey).toBe('encryptedKey2');
+      expect(result.docs).toHaveLength(2);
+      expect(result.docs[0].apiKey).toBe('decryptedKey1');
+      expect(result.docs[1].apiKey).toBe('encryptedKey2');
       expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({ index: 'tasky' });
       expect(logger.warn).toHaveBeenCalledWith(
         'Refreshing index to get recently created API keys for tasks'

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -34,7 +34,7 @@ import { executionContextServiceMock } from '@kbn/core-execution-context-server-
 import { TaskTypeDictionary } from './task_type_dictionary';
 import { mockLogger } from './test_utils';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
-import { asErr, asOk } from './lib/result_type';
+import { asErr, asOk, isOk } from './lib/result_type';
 import type { UpdateByQueryResponse } from '@elastic/elasticsearch/lib/api/types';
 import { MsearchError } from './lib/errors';
 import { getApiKeyAndUserScope } from './lib/api_key_utils';
@@ -787,7 +787,7 @@ describe('TaskStore', () => {
       });
     });
 
-    test('should return tasks with decrypted API keys', async () => {
+    test('does NOT decrypt API keys (decryption is deferred to the claimed tasks bulkGet)', async () => {
       const { result } = await testMsearch(
         [{}],
         [
@@ -812,24 +812,13 @@ describe('TaskStore', () => {
         startedAt: new Date(mockTask.startedAt),
         state: {},
         params: {},
-        apiKey: 'decryptedApiKey',
+        apiKey: 'encryptedKey',
       });
+      expect(esoClient.createPointInTimeFinderDecryptedAsInternalUser).not.toHaveBeenCalled();
     });
 
     test('returns all API keys when first getApiKeys search misses a key, but finds after refresh', async () => {
       const logger = mockLogger();
-      const mockSerializer = savedObjectsServiceMock.createSerializer();
-      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
-      mockSerializer.rawToSavedObject = jest
-        .fn()
-        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
-          id: doc._source?.task?.id ?? 'task1',
-          version: '123',
-          type: 'task',
-          references: [],
-          attributes: doc._source?.task ?? mockTask,
-        }));
-
       const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       const indicesRefreshSpy = jest
         .spyOn(mockEsClient.indices, 'refresh')
@@ -839,7 +828,7 @@ describe('TaskStore', () => {
         logger,
         index: 'tasky',
         taskManagerId: '',
-        serializer: mockSerializer,
+        serializer,
         esClient: mockEsClient,
         definitions: taskDefinitions,
         savedObjectsRepository: savedObjectsClient,
@@ -886,35 +875,28 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      mockEsClient.msearch.mockResponse({
-        took: 0,
-        responses: [
+      savedObjectsClient.bulkGet.mockResolvedValue({
+        saved_objects: [
           {
-            hits: {
-              hits: [
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
-                },
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
-                },
-              ],
-            },
-            took: 0,
-            _shards: { failed: 0, successful: 1, total: 1 },
-            timed_out: false,
-            status: 200,
+            id: 'task1',
+            type: 'task',
+            references: [],
+            attributes: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' },
+          },
+          {
+            id: 'task2',
+            type: 'task',
+            references: [],
+            attributes: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' },
           },
         ],
       });
 
-      const result = await refreshStore.msearch([{}]);
+      const result = await refreshStore.bulkGet(['task1', 'task2']);
 
-      expect(result.docs).toHaveLength(2);
-      expect(result.docs[0].apiKey).toBe('decryptedKey1');
-      expect(result.docs[1].apiKey).toBe('decryptedKey2');
+      expect(result).toHaveLength(2);
+      expect(isOk(result[0]) && result[0].value.apiKey).toBe('decryptedKey1');
+      expect(isOk(result[1]) && result[1].value.apiKey).toBe('decryptedKey2');
       expect(indicesRefreshSpy).toHaveBeenCalledWith({ index: 'tasky' });
       expect(esoClient.createPointInTimeFinderDecryptedAsInternalUser).toHaveBeenCalledTimes(2);
       expect(logger.warn).toHaveBeenCalledWith(
@@ -924,18 +906,6 @@ describe('TaskStore', () => {
     });
 
     test('returns partial API keys when first getApiKeys search misses a key, and second search after refresh still does not find it', async () => {
-      const mockSerializer = savedObjectsServiceMock.createSerializer();
-      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
-      mockSerializer.rawToSavedObject = jest
-        .fn()
-        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
-          id: doc._source?.task?.id ?? 'task1',
-          version: '123',
-          type: 'task',
-          references: [],
-          attributes: doc._source?.task ?? mockTask,
-        }));
-
       const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       jest.spyOn(mockEsClient.indices, 'refresh').mockResolvedValue({} as never);
       const logger = mockLogger();
@@ -944,7 +914,7 @@ describe('TaskStore', () => {
         logger,
         index: 'tasky',
         taskManagerId: '',
-        serializer: mockSerializer,
+        serializer,
         esClient: mockEsClient,
         definitions: taskDefinitions,
         savedObjectsRepository: savedObjectsClient,
@@ -984,35 +954,28 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      mockEsClient.msearch.mockResponse({
-        took: 0,
-        responses: [
+      savedObjectsClient.bulkGet.mockResolvedValue({
+        saved_objects: [
           {
-            hits: {
-              hits: [
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
-                },
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
-                },
-              ],
-            },
-            took: 0,
-            _shards: { failed: 0, successful: 1, total: 1 },
-            timed_out: false,
-            status: 200,
+            id: 'task1',
+            type: 'task',
+            references: [],
+            attributes: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' },
+          },
+          {
+            id: 'task2',
+            type: 'task',
+            references: [],
+            attributes: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' },
           },
         ],
       });
 
-      const result = await refreshStore.msearch([{}]);
+      const result = await refreshStore.bulkGet(['task1', 'task2']);
 
-      expect(result.docs).toHaveLength(2);
-      expect(result.docs[0].apiKey).toBe('decryptedKey1');
-      expect(result.docs[1].apiKey).toBe('encryptedKey2');
+      expect(result).toHaveLength(2);
+      expect(isOk(result[0]) && result[0].value.apiKey).toBe('decryptedKey1');
+      expect(isOk(result[1]) && result[1].value.apiKey).toBe('encryptedKey2');
       expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({ index: 'tasky' });
       expect(logger.warn).toHaveBeenCalledWith(
         'Refreshing index to get recently created API keys for tasks'
@@ -1023,18 +986,6 @@ describe('TaskStore', () => {
     });
 
     test('returns partial API keys when refresh fails', async () => {
-      const mockSerializer = savedObjectsServiceMock.createSerializer();
-      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
-      mockSerializer.rawToSavedObject = jest
-        .fn()
-        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
-          id: doc._source?.task?.id ?? 'task1',
-          version: '123',
-          type: 'task',
-          references: [],
-          attributes: doc._source?.task ?? mockTask,
-        }));
-
       const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       jest.spyOn(mockEsClient.indices, 'refresh').mockRejectedValue(new Error('bad refresh'));
       const logger = mockLogger();
@@ -1043,7 +994,7 @@ describe('TaskStore', () => {
         logger,
         index: 'tasky',
         taskManagerId: '',
-        serializer: mockSerializer,
+        serializer,
         esClient: mockEsClient,
         definitions: taskDefinitions,
         savedObjectsRepository: savedObjectsClient,
@@ -1083,35 +1034,28 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      mockEsClient.msearch.mockResponse({
-        took: 0,
-        responses: [
+      savedObjectsClient.bulkGet.mockResolvedValue({
+        saved_objects: [
           {
-            hits: {
-              hits: [
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
-                },
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
-                },
-              ],
-            },
-            took: 0,
-            _shards: { failed: 0, successful: 1, total: 1 },
-            timed_out: false,
-            status: 200,
+            id: 'task1',
+            type: 'task',
+            references: [],
+            attributes: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' },
+          },
+          {
+            id: 'task2',
+            type: 'task',
+            references: [],
+            attributes: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' },
           },
         ],
       });
 
-      const result = await refreshStore.msearch([{}]);
+      const result = await refreshStore.bulkGet(['task1', 'task2']);
 
-      expect(result.docs).toHaveLength(2);
-      expect(result.docs[0].apiKey).toBe('decryptedKey1');
-      expect(result.docs[1].apiKey).toBe('encryptedKey2');
+      expect(result).toHaveLength(2);
+      expect(isOk(result[0]) && result[0].value.apiKey).toBe('decryptedKey1');
+      expect(isOk(result[1]) && result[1].value.apiKey).toBe('encryptedKey2');
       expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({ index: 'tasky' });
       expect(logger.warn).toHaveBeenCalledWith(
         'Refreshing index to get recently created API keys for tasks'

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -96,6 +96,7 @@ export interface SearchOpts {
   sort?: estypes.Sort;
   query?: estypes.QueryDslQueryContainer;
   seq_no_primary_term?: boolean;
+  _source?: estypes.SearchSourceConfig;
 }
 
 export interface AggregationOpts {
@@ -1114,11 +1115,10 @@ export class TaskStore {
       allTasks = allTasks.concat(this.filterTasks(tasks));
     }
 
+    // API keys are intentionally not decrypted here; the claimer only decrypts the tasks
+    // it claims, via bulkGet. See strategy_mget.ts.
     const allSortedTasks = claimSort(this.definitions, allTasks);
-    const tasksWithDecryptedApiKeys = await this.bulkGetAndMergeTasksWithDecryptedApiKey(
-      allSortedTasks
-    );
-    return { docs: tasksWithDecryptedApiKeys, versionMap };
+    return { docs: allSortedTasks, versionMap };
   }
 
   public async search(opts: SearchOpts = {}, limitResponse: boolean = false): Promise<FetchResult> {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -1115,10 +1115,14 @@ export class TaskStore {
       allTasks = allTasks.concat(this.filterTasks(tasks));
     }
 
-    // API keys are intentionally not decrypted here; the claimer only decrypts the tasks
-    // it claims, via bulkGet. See strategy_mget.ts.
     const allSortedTasks = claimSort(this.definitions, allTasks);
-    return { docs: allSortedTasks, versionMap };
+    // Decryption is driven by the documents: callers that exclude the apiKey/uiamApiKey fields
+    // from _source (e.g. the mget claimer's slim candidate search) yield tasks with no key, so
+    // this is a no-op for them and decryption only happens on fully-fetched tasks.
+    const tasksWithDecryptedApiKeys = await this.bulkGetAndMergeTasksWithDecryptedApiKey(
+      allSortedTasks
+    );
+    return { docs: tasksWithDecryptedApiKeys, versionMap };
   }
 
   public async search(opts: SearchOpts = {}, limitResponse: boolean = false): Promise<FetchResult> {


### PR DESCRIPTION
## Summary

The `mget` claim strategy over-fetches candidates (`4 × capacity`) but only claims/runs `≤ capacity` per cycle. For every over-fetched candidate it still:

- loads the **full** task document, including `task.params` / `task.state` (unbounded — can be MBs), and
- **decrypts its API key**,

even though most candidates are discarded. This PR defers both to the tasks actually claimed by slimming the candidate search's `_source`:

- The candidate `msearch` now excludes `task.params` / `task.state` (so the over-fetch no longer scales with state size) **and** `task.apiKey` / `task.uiamApiKey` / `task.userScope`.
- `TaskStore.msearch` decryption is **data-driven**: it only decrypts tasks whose docs actually carry a key. Because the candidate docs no longer include the key fields, decryption is a no-op for them — it now happens only for the claimed winners, which are re-fetched in full (key + state) via the existing `bulkGet`.

This keeps `TaskStore.msearch`'s public contract intact (a caller that requests full `_source` still gets decrypted keys), so it's safe for current/future callers — the slim/no-decrypt behavior is purely a function of the `_source` the claimer requests. Net effect: `≤ capacity` keys decrypted per cycle instead of ~`4 × capacity`, and candidates no longer carry unbounded `params`/`state`.

Claim atomicity is unchanged — the version-gated `bulkPartialUpdate` is still the source of truth; this only changes what's loaded for candidates that are never claimed.

## Verification

Confirm the new integration test actually guards the optimization by running it **without** the fix:

```bash
# 1. Revert just the production changes (keep the test)
git checkout origin/main -- \
  x-pack/platform/plugins/shared/task_manager/server/task_store.ts \
  x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts

# 2. Run the guard — it FAILS (decryption sees all 15 candidates, not <= capacity 5):
#    expect(received).toBeLessThanOrEqual(expected)  Expected: <= 5  Received: 15
node scripts/jest_integration x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_claiming_decrypts_winners_only.test.ts

# 3. Restore the fix — the test PASSES
git checkout HEAD -- \
  x-pack/platform/plugins/shared/task_manager/server/task_store.ts \
  x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
```

## Test plan

- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/task_manager/tsconfig.json`
- [x] `node scripts/eslint` on changed files
- [x] Unit (`task_store.test.ts`, `strategy_mget.test.ts` — 114 passed): `strategy_mget.test.ts` asserts the candidate `_source` excludes the params/state/apiKey fields; new `task_store.test.ts` case asserts `msearch` does **not** decrypt when `apiKey` is excluded from `_source` (and existing tests still confirm it decrypts when the key is present).
- [x] Integration (real ES): `task_state_validation`, `task_manager_capacity_based_claiming`, `user_profile_enrichment` pass — claimed tasks still get full `state`/`params` and the API-key path works end-to-end.
- [x] New `task_claiming_decrypts_winners_only.test.ts` (see Verification above) — fails without the fix, passes with it.
