### PR TITLE
[ResponseOps][Alerting v2] Remove filtered vs total count indicator, only show total

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.test.tsx
@@ -170,11 +170,9 @@ const mockCreateEpisodeActions = jest.mocked(createEpisodeActions);
 
 const mockedUseEpisodesKpisQuery = jest.mocked(useEpisodesKpisQuery);
 
-// The page calls useEpisodesKpisQuery twice: filtered (filterState defined)
-// and total (filterState undefined). Differentiate by that arg.
-const defaultKpisImpl: typeof useEpisodesKpisQuery = ({ filterState }) => ({
+const defaultKpisImpl: typeof useEpisodesKpisQuery = () => ({
   data: {
-    alertsCount: filterState ? 3 : 10,
+    alertsCount: 3,
     firingRules: 0,
     assignedToMe: 0,
     unassigned: 0,
@@ -394,17 +392,16 @@ describe('episode count + reset filters toolbar', () => {
     mockedUseEpisodesKpisQuery.mockImplementation(defaultKpisImpl);
   });
 
-  it('renders "Showing X of Y alerts" with filtered and total counts', async () => {
+  it('renders the episode count', async () => {
     renderPage();
     const node = await screen.findByTestId('alertEpisodesItemCount');
-    expect(node.textContent).toMatch(/^Showing\s+3\s+of\s+10\s+alerts$/);
+    expect(node.textContent).toMatch(/^Showing\s+3\s+episodes$/);
   });
 
-  it('fires useEpisodesKpisQuery both with and without filterState', () => {
+  it('fires useEpisodesKpisQuery only with filterState', () => {
     renderPage();
     const calls = mockedUseEpisodesKpisQuery.mock.calls.map(([args]) => args);
-    expect(calls.some((c) => c.filterState !== undefined)).toBe(true);
-    expect(calls.some((c) => c.filterState === undefined)).toBe(true);
+    expect(calls.every((c) => c.filterState !== undefined)).toBe(true);
   });
 
   it('disables the reset filters button when filter state equals the default', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
@@ -53,7 +53,6 @@ import {
   EpisodeSeverityCell,
 } from '@kbn/alerting-v2-episodes-ui/components/episodes_table_cell_renderers';
 import { AlertEpisodeAssigneeCell } from '@kbn/alerting-v2-episodes-ui/components/assignee_cell';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { ExperimentalBadge } from '../../components/experimental_badge';
 import { paths } from '../../constants';
 import type { AlertEpisodesKibanaServices } from '../../episodes_kibana_services';
@@ -174,14 +173,9 @@ export const AlertEpisodesListPage = () => {
     timeRange,
   });
 
-  const { data: filteredKpis } = useEpisodesKpisQuery({ services, filterState, timeRange });
-  const { data: totalKpis } = useEpisodesKpisQuery({ services, timeRange });
+  const { data: kpis } = useEpisodesKpisQuery({ services, filterState, timeRange });
 
-  const filteredAlertEpisodesCount = filteredKpis?.alertsCount ?? 0;
-  /* The two KPI queries resolve independently; clamping avoids briefly showing an
-  impossible "filtered > total" state when the filtered count updates first.
-  */
-  const totalAlertEpisodesCount = Math.max(totalKpis?.alertsCount ?? 0, filteredAlertEpisodesCount);
+  const alertEpisodesCount = kpis?.alertsCount ?? 0;
 
   const sort: SortOrder[] = useMemo(
     () => [[sortState.sortField, sortState.sortDirection]],
@@ -240,14 +234,7 @@ export const AlertEpisodesListPage = () => {
           >
             <EuiFlexItem grow={false}>
               <EuiText size="xs" data-test-subj="alertEpisodesItemCount">
-                <FormattedMessage
-                  id="xpack.alertingV2.episodes.itemCount"
-                  defaultMessage="Showing {filtered} of {total} {total, plural, one {alert} other {alerts}}"
-                  values={{
-                    filtered: <strong>{filteredAlertEpisodesCount}</strong>,
-                    total: <strong>{totalAlertEpisodesCount}</strong>,
-                  }}
-                />
+                {i18n.EPISODES_LIST_ITEM_COUNT(alertEpisodesCount)}
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -270,13 +257,7 @@ export const AlertEpisodesListPage = () => {
           </EuiFlexGroup>
         ),
       }),
-    [
-      euiTheme.size.s,
-      filteredAlertEpisodesCount,
-      handleClearFilters,
-      hasActiveFilters,
-      totalAlertEpisodesCount,
-    ]
+    [euiTheme.size.s, alertEpisodesCount, handleClearFilters, hasActiveFilters]
   );
 
   const episodeActions: EpisodeAction[] = useMemo(


### PR DESCRIPTION
## 📄 Summary

> [!important]
> Alerting v2 work under feature flag disabled by default. See 🧪 Verification steps > ⚙️ Environment Setup for more information.

Drops the "Showing X of Y alerts" indicator in the episodes list toolbar in favor of a single count ("Showing N episodes"), which matches the value already shown in the first KPI metric. The "X of Y" format was misleading because it implied pagination, which isn't present.

Also removes the extra KPI query that was firing without filters to compute the total, since it's no longer needed.

> 🤖 Co-authored by Claude Code

<details>
<summary>

## 🧪 Verification steps

</summary>

### ⚙️ Environment Setup

Add the following flag to your `kibana.dev.yml`:

```yaml
xpack.alerting_v2.enabled: true
```

Then navigate to Stack Management > Advanced settings > Global, and enable Alerting v2

### ✅ Happy Path

1. Navigate to the Episodes list page.
2. Confirm the toolbar shows "Showing N episodes" (a single count) instead of "Showing X of Y alerts".
3. Apply filters and confirm the count updates to reflect the filtered result set.

### ⚡️ Edge Cases

- With no filters applied, the count shown should match the "total alerts" KPI.
- With filters active, the count updates to match the filtered KPI.

</details>

## ⏪ Backport rationale

Alerting v2 pre-GA work, not backporting.

## 🔗 References

Closes https://github.com/elastic/rna-program/issues/645

## ☑️ Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.