### PR TITLE
[Cases] `cases.pushCases` wokflow step now skips if connector type is `.none`

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/push_cases.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/push_cases.test.ts
@@ -89,6 +89,17 @@ describe('pushCasesStepDefinition', () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  it('skips push and returns the case as-is when a .none connector is configured', async () => {
+    const caseWithoutNoneConnector = { ...createCaseResponseFixture };
+    const get = jest.fn().mockResolvedValue(caseWithoutNoneConnector);
+    const push = jest.fn();
+    const definition = pushCasesStepDefinition(makeCasesClient({ get, push }));
+
+    await definition.handler(createContext({ case_ids: ['case-1'] }));
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it('returns null in the output for a failed case push and logs the error', async () => {
     const push = jest.fn().mockRejectedValue(new Error('push failed'));
     const context = createContext({ case_ids: ['case-1'] });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/push_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/push_cases.ts
@@ -10,6 +10,7 @@ import pRetry from 'p-retry';
 import type { KibanaRequest } from '@kbn/core/server';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { pushCasesStepCommonDefinition } from '../../../common/workflows/steps/push_cases';
+import { ConnectorTypes } from '../../../common/bundled-types.gen';
 import type { CasesClient } from '../../client';
 import { getCasesClientFromStepsContext, safeParseCaseForWorkflowOutput } from './utils';
 
@@ -19,7 +20,7 @@ const pushSingleCase = async (
   logger: { warn(message: string): void }
 ) => {
   const theCase = await client.cases.get({ id: caseId, includeComments: false });
-  if (!theCase.connector) {
+  if (!theCase.connector || theCase.connector.type === ConnectorTypes.enum['.none']) {
     return theCase;
   }
   return pRetry(


### PR DESCRIPTION
## Summary

When the connector type is `.none` the `cases.pushCases` workflow step should skip that case.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->