### PR TITLE
[AlertingV2][Execution History] Filter out unrelated results when using the search bar in the Action Policy Execution History

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/action_policy_execution_history_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/action_policy_execution_history_client.test.ts
@@ -437,6 +437,40 @@ describe('ActionPolicyExecutionHistoryClient', () => {
 
         expect(result.searchMatches).toBeNull();
       });
+
+      it('only emits rows for rule ids that matched the search, not all rules sharing the event', async () => {
+        const { client, eventLogService, actionPolicyClient, rulesClient } = createMocks();
+
+        (actionPolicyClient.findActionPolicies as jest.Mock).mockResolvedValue({
+          items: [],
+          total: 0,
+          page: 1,
+          perPage: 500,
+        });
+        (rulesClient.findRules as jest.Mock)
+          .mockResolvedValueOnce({
+            items: [{ id: 'rule-A' } as any],
+            total: 1,
+            page: 1,
+            perPage: 500,
+          })
+          .mockResolvedValueOnce(
+            buildFindRulesResponse([buildRule('rule-A', 'Rule A'), buildRule('rule-B', 'Rule B')])
+          );
+
+        eventLogService.findActionPolicyExecutionEvents.mockResolvedValue({
+          events: [buildEvent({ policyId: 'policy-1', ruleIds: ['rule-A', 'rule-B'] })],
+          page: 1,
+          perPage: 100,
+          total: 1,
+        } as any);
+
+        const request = httpServerMock.createKibanaRequest();
+        const result = await client.listExecutionHistory({ request, search: 'rule-A' });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].rule.id).toBe('rule-A');
+      });
     });
 
     describe('partial failures in name resolution', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/action_policy_execution_history_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/action_policy_execution_history_client.ts
@@ -17,6 +17,7 @@ import {
   type RuleResponse,
   type PolicyExecutionOutcome,
   type PolicyExecutionOutcomeFilter,
+  SearchMatchCounts,
 } from '@kbn/alerting-v2-schemas';
 import { ActionPolicyClient } from '../action_policy_client';
 import { RulesClient } from '../rules_client';
@@ -29,7 +30,7 @@ import {
 } from '../services/logger_service/logger_service';
 import { ALERTING_V2_LOG_CODES, type AlertingV2LogCode } from '../errors/error_codes';
 import type { AlertingServerStartDependencies } from '../../types';
-import { collectIdsFromEvents, denormalizeEvent, type NameMaps } from './denormalize_event';
+import { collectIdsFromEvents, denormalizeEvent, ResolvedSearchIds, type NameMaps } from './denormalize_event';
 
 const TIME_WINDOW_HOURS = 24;
 const DEFAULT_PAGE = 1;
@@ -51,12 +52,6 @@ export interface ListExecutionHistoryParams {
   outcome?: PolicyExecutionOutcomeFilter;
 }
 
-export interface SearchMatchCounts {
-  policies: number;
-  rules: number;
-  cap: number;
-}
-
 export interface ListExecutionHistoryResult {
   items: PolicyExecutionHistoryItem[];
   page: number;
@@ -76,13 +71,6 @@ export interface CountNewEventsSinceResult {
   count: number;
 }
 
-interface ResolvedSearchIds {
-  policyIds: string[];
-  ruleIds: string[];
-  hasMatches: boolean;
-  matches: SearchMatchCounts | null;
-}
-
 @injectable()
 export class ActionPolicyExecutionHistoryClient {
   constructor(
@@ -94,7 +82,7 @@ export class ActionPolicyExecutionHistoryClient {
     @inject(PluginStart<AlertingServerStartDependencies['spaces']>('spaces'))
     private readonly spaces: AlertingServerStartDependencies['spaces'],
     @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract
-  ) {}
+  ) { }
 
   public async listExecutionHistory({
     request,
@@ -105,11 +93,12 @@ export class ActionPolicyExecutionHistoryClient {
   }: ListExecutionHistoryParams): Promise<ListExecutionHistoryResult> {
     const startDate = new Date(Date.now() - TIME_WINDOW_HOURS * 60 * 60 * 1000).toISOString();
     const spaceId = this.spaces.spacesService.getSpaceId(request);
+    const searchIsActive = search !== undefined && search.trim() !== '';
 
-    const searchIds = await this.resolveSearchIds(search);
+    const matchingSearchIds = await this.resolveSearchIds(search);
 
-    if (search !== undefined && !searchIds.hasMatches) {
-      return { items: [], page, perPage, totalEvents: 0, searchMatches: searchIds.matches };
+    if (searchIsActive && !matchingSearchIds.hasMatches) {
+      return { items: [], page, perPage, totalEvents: 0, searchMatches: matchingSearchIds.matches };
     }
 
     const result = await this.eventLogService.findActionPolicyExecutionEvents({
@@ -118,19 +107,24 @@ export class ActionPolicyExecutionHistoryClient {
       page,
       perPage,
       outcome: toOutcomeForService(outcome),
-      policyIds: searchIds.policyIds,
-      ruleIds: searchIds.ruleIds,
+      policyIds: matchingSearchIds.policyIds,
+      ruleIds: matchingSearchIds.ruleIds,
     });
 
     const nameMaps = await this.resolveNames(result.events, spaceId);
-    const items = result.events.flatMap((event) => denormalizeEvent(event, nameMaps));
+    const items = result.events.flatMap(
+      (event) => denormalizeEvent(
+        event,
+        nameMaps,
+        searchIsActive ? matchingSearchIds : undefined)
+    );
 
     return {
       items,
       page: result.page,
       perPage: result.perPage,
       totalEvents: result.total,
-      searchMatches: searchIds.matches,
+      searchMatches: matchingSearchIds.matches,
     };
   }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/action_policy_execution_history_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/action_policy_execution_history_client.ts
@@ -17,7 +17,7 @@ import {
   type RuleResponse,
   type PolicyExecutionOutcome,
   type PolicyExecutionOutcomeFilter,
-  SearchMatchCounts,
+  type SearchMatchCounts,
 } from '@kbn/alerting-v2-schemas';
 import { ActionPolicyClient } from '../action_policy_client';
 import { RulesClient } from '../rules_client';
@@ -30,7 +30,8 @@ import {
 } from '../services/logger_service/logger_service';
 import { ALERTING_V2_LOG_CODES, type AlertingV2LogCode } from '../errors/error_codes';
 import type { AlertingServerStartDependencies } from '../../types';
-import { collectIdsFromEvents, denormalizeEvent, ResolvedSearchIds, type NameMaps } from './denormalize_event';
+import type { ResolvedSearchIds } from './denormalize_event';
+import { collectIdsFromEvents, denormalizeEvent, type NameMaps } from './denormalize_event';
 
 const TIME_WINDOW_HOURS = 24;
 const DEFAULT_PAGE = 1;
@@ -82,7 +83,7 @@ export class ActionPolicyExecutionHistoryClient {
     @inject(PluginStart<AlertingServerStartDependencies['spaces']>('spaces'))
     private readonly spaces: AlertingServerStartDependencies['spaces'],
     @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract
-  ) { }
+  ) {}
 
   public async listExecutionHistory({
     request,
@@ -112,11 +113,8 @@ export class ActionPolicyExecutionHistoryClient {
     });
 
     const nameMaps = await this.resolveNames(result.events, spaceId);
-    const items = result.events.flatMap(
-      (event) => denormalizeEvent(
-        event,
-        nameMaps,
-        searchIsActive ? matchingSearchIds : undefined)
+    const items = result.events.flatMap((event) =>
+      denormalizeEvent(event, nameMaps, searchIsActive ? matchingSearchIds : undefined)
     );
 
     return {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.test.ts
@@ -23,15 +23,15 @@ const EMPTY_NAME_MAPS: NameMaps = {
 };
 
 const buildEvent = (overrides: Partial<NonNullable<IValidatedEvent>> = {}): IValidatedEvent =>
-  ({
-    '@timestamp': '2026-05-05T10:00:00.000Z',
-    event: { action: ACTION_POLICY_EVENT_ACTIONS.DISPATCHED, provider: 'alerting_v2' },
-    kibana: {
-      saved_objects: [{ type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' }],
-      alerting_v2: { dispatcher: {} },
-    },
-    ...overrides,
-  } as IValidatedEvent);
+({
+  '@timestamp': '2026-05-05T10:00:00.000Z',
+  event: { action: ACTION_POLICY_EVENT_ACTIONS.DISPATCHED, provider: 'alerting_v2' },
+  kibana: {
+    saved_objects: [{ type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' }],
+    alerting_v2: { dispatcher: {} },
+  },
+  ...overrides,
+} as IValidatedEvent);
 
 describe('isString', () => {
   it('returns true for strings', () => {
@@ -321,5 +321,68 @@ describe('denormalizeEvent', () => {
     expect(rows[0].episode_count).toBe(0);
     expect(rows[0].action_group_count).toBe(0);
     expect(rows[0].workflows).toEqual([]);
+  });
+
+  describe('when search is not active', () => {
+    it('returns all rule ids when matchingSearchIds is undefined', () => {
+      const event = buildEvent({
+        kibana: {
+          saved_objects: [
+            { type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-a' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-b' },
+          ],
+          alerting_v2: { dispatcher: {} },
+        },
+      });
+      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, undefined);
+      expect(rows.map((r) => r.rule.id)).toEqual(['rule-a', 'rule-b']);
+    });
+  });
+
+  describe('when search is active', () => {
+    it('returns [] when search is active but there are no matches', () => {
+      const event = buildEvent({
+        kibana: {
+          saved_objects: [
+            { type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-a' },
+          ],
+          alerting_v2: { dispatcher: {} },
+        },
+      });
+      expect(denormalizeEvent(event, EMPTY_NAME_MAPS, { policyIds: [], ruleIds: [], hasMatches: false, matches: null })).toEqual([]);
+    });
+
+    it('returns all rule ids if policy is in search matches', () => {
+      const event = buildEvent({
+        kibana: {
+          saved_objects: [
+            { type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-a' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-b' },
+          ],
+          alerting_v2: { dispatcher: {} },
+        },
+      });
+      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, { policyIds: ['policy-1'], ruleIds: [], hasMatches: true, matches: null });
+      expect(rows.map((r) => r.rule.id)).toEqual(['rule-a', 'rule-b']);
+    });
+
+    it('returns only matching rule ids if policy is not in search matches', () => {
+      const event = buildEvent({
+        kibana: {
+          saved_objects: [
+            { type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-a' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-b' },
+            { type: RULE_SAVED_OBJECT_TYPE, id: 'rule-c' },
+          ],
+          alerting_v2: { dispatcher: {} },
+        },
+      });
+      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, { policyIds: ['policy-2'], ruleIds: ['rule-a', 'rule-c'], hasMatches: true, matches: null });
+      expect(rows.map((r) => r.rule.id)).toEqual(['rule-a', 'rule-c']);
+    })
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.test.ts
@@ -23,15 +23,15 @@ const EMPTY_NAME_MAPS: NameMaps = {
 };
 
 const buildEvent = (overrides: Partial<NonNullable<IValidatedEvent>> = {}): IValidatedEvent =>
-({
-  '@timestamp': '2026-05-05T10:00:00.000Z',
-  event: { action: ACTION_POLICY_EVENT_ACTIONS.DISPATCHED, provider: 'alerting_v2' },
-  kibana: {
-    saved_objects: [{ type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' }],
-    alerting_v2: { dispatcher: {} },
-  },
-  ...overrides,
-} as IValidatedEvent);
+  ({
+    '@timestamp': '2026-05-05T10:00:00.000Z',
+    event: { action: ACTION_POLICY_EVENT_ACTIONS.DISPATCHED, provider: 'alerting_v2' },
+    kibana: {
+      saved_objects: [{ type: ACTION_POLICY_SAVED_OBJECT_TYPE, id: 'policy-1' }],
+      alerting_v2: { dispatcher: {} },
+    },
+    ...overrides,
+  } as IValidatedEvent);
 
 describe('isString', () => {
   it('returns true for strings', () => {
@@ -351,7 +351,14 @@ describe('denormalizeEvent', () => {
           alerting_v2: { dispatcher: {} },
         },
       });
-      expect(denormalizeEvent(event, EMPTY_NAME_MAPS, { policyIds: [], ruleIds: [], hasMatches: false, matches: null })).toEqual([]);
+      expect(
+        denormalizeEvent(event, EMPTY_NAME_MAPS, {
+          policyIds: [],
+          ruleIds: [],
+          hasMatches: false,
+          matches: null,
+        })
+      ).toEqual([]);
     });
 
     it('returns all rule ids if policy is in search matches', () => {
@@ -365,7 +372,12 @@ describe('denormalizeEvent', () => {
           alerting_v2: { dispatcher: {} },
         },
       });
-      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, { policyIds: ['policy-1'], ruleIds: [], hasMatches: true, matches: null });
+      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, {
+        policyIds: ['policy-1'],
+        ruleIds: [],
+        hasMatches: true,
+        matches: null,
+      });
       expect(rows.map((r) => r.rule.id)).toEqual(['rule-a', 'rule-b']);
     });
 
@@ -381,8 +393,13 @@ describe('denormalizeEvent', () => {
           alerting_v2: { dispatcher: {} },
         },
       });
-      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, { policyIds: ['policy-2'], ruleIds: ['rule-a', 'rule-c'], hasMatches: true, matches: null });
+      const rows = denormalizeEvent(event, EMPTY_NAME_MAPS, {
+        policyIds: ['policy-2'],
+        ruleIds: ['rule-a', 'rule-c'],
+        hasMatches: true,
+        matches: null,
+      });
       expect(rows.map((r) => r.rule.id)).toEqual(['rule-a', 'rule-c']);
-    })
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.ts
@@ -6,7 +6,7 @@
  */
 
 import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
-import type { PolicyExecutionHistoryItem, PolicyExecutionOutcome } from '@kbn/alerting-v2-schemas';
+import type { PolicyExecutionHistoryItem, PolicyExecutionOutcome, SearchMatchCounts } from '@kbn/alerting-v2-schemas';
 import { ACTION_POLICY_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
 import { ACTION_POLICY_EVENT_ACTIONS } from '../dispatcher/steps/constants';
 
@@ -16,6 +16,13 @@ export interface NameMaps {
   policyNames: Map<string, string>;
   ruleNames: Map<string, string>;
   workflowNames: Map<string, string>;
+}
+
+export interface ResolvedSearchIds {
+  policyIds: string[];
+  ruleIds: string[];
+  hasMatches: boolean;
+  matches: SearchMatchCounts | null;
 }
 
 export const isString = (v: unknown): v is string => typeof v === 'string';
@@ -57,11 +64,34 @@ export function collectIdsFromEvents(events: IValidatedEvent[]): {
   };
 }
 
+/**
+ * Returns the relevant rule IDs for a given log event, based on the resolved search IDs and the policy ID.
+ * If search is not active (i.e., no matchingSearchIds), all rule IDs are relevant.
+ * If the policy ID is in the resolved search IDs, all rule IDs are relevant.
+ * If there are specific rule IDs in the resolved search IDs, only those are relevant.
+ * Otherwise, no rule IDs are relevant.
+ * @param policyId the ID of the policy for the current log event
+ * @param allRuleIds all rule IDs referenced by the current log event
+ * @param matchingSearchIds search IDs resolved from the search query, or undefined if no search is active
+ * @returns an array of relevant rule IDs for the current log event
+ */
+export function getRelevantRuleIdsFromLogEvent(policyId: string, allRuleIds: string[], matchingSearchIds?: ResolvedSearchIds): string[] {  
+  if (!matchingSearchIds || matchingSearchIds.policyIds.includes(policyId)) {
+    return allRuleIds;
+  }
+
+  return allRuleIds.filter((ruleId) => matchingSearchIds.ruleIds.includes(ruleId));
+}
+
+
 export function denormalizeEvent(
   event: IValidatedEvent,
-  { policyNames, ruleNames, workflowNames }: NameMaps
+  { policyNames, ruleNames, workflowNames }: NameMaps,
+  matchingSearchIds?: ResolvedSearchIds,
 ): PolicyExecutionHistoryItem[] {
-  if (!event) return [];
+  if (!event || (matchingSearchIds && !matchingSearchIds.hasMatches)) {
+    return [];
+  }
 
   const timestamp = event['@timestamp'];
   const action = event.event?.action;
@@ -77,12 +107,13 @@ export function denormalizeEvent(
     .filter((so) => so.type === RULE_SAVED_OBJECT_TYPE)
     .map((so) => so.id);
   const allRuleIds = [...referencedRuleIds, ...(dispatcher.rule_ids ?? [])].filter(isString);
+  const relevantRuleIds = getRelevantRuleIdsFromLogEvent(policyId, allRuleIds, matchingSearchIds);
 
   const workflows = (dispatcher.workflow_ids ?? [])
     .filter(isString)
     .map((id) => ({ id, name: workflowNames.get(id) ?? null }));
 
-  return allRuleIds.map((ruleId) => ({
+  return relevantRuleIds.map((ruleId) => ({
     '@timestamp': timestamp,
     policy: { id: policyId, name: policyNames.get(policyId) ?? null },
     rule: { id: ruleId, name: ruleNames.get(ruleId) ?? null },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/denormalize_event.ts
@@ -6,7 +6,11 @@
  */
 
 import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
-import type { PolicyExecutionHistoryItem, PolicyExecutionOutcome, SearchMatchCounts } from '@kbn/alerting-v2-schemas';
+import type {
+  PolicyExecutionHistoryItem,
+  PolicyExecutionOutcome,
+  SearchMatchCounts,
+} from '@kbn/alerting-v2-schemas';
 import { ACTION_POLICY_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
 import { ACTION_POLICY_EVENT_ACTIONS } from '../dispatcher/steps/constants';
 
@@ -75,7 +79,11 @@ export function collectIdsFromEvents(events: IValidatedEvent[]): {
  * @param matchingSearchIds search IDs resolved from the search query, or undefined if no search is active
  * @returns an array of relevant rule IDs for the current log event
  */
-export function getRelevantRuleIdsFromLogEvent(policyId: string, allRuleIds: string[], matchingSearchIds?: ResolvedSearchIds): string[] {  
+export function getRelevantRuleIdsFromLogEvent(
+  policyId: string,
+  allRuleIds: string[],
+  matchingSearchIds?: ResolvedSearchIds
+): string[] {
   if (!matchingSearchIds || matchingSearchIds.policyIds.includes(policyId)) {
     return allRuleIds;
   }
@@ -83,11 +91,10 @@ export function getRelevantRuleIdsFromLogEvent(policyId: string, allRuleIds: str
   return allRuleIds.filter((ruleId) => matchingSearchIds.ruleIds.includes(ruleId));
 }
 
-
 export function denormalizeEvent(
   event: IValidatedEvent,
   { policyNames, ruleNames, workflowNames }: NameMaps,
-  matchingSearchIds?: ResolvedSearchIds,
+  matchingSearchIds?: ResolvedSearchIds
 ): PolicyExecutionHistoryItem[] {
   if (!event || (matchingSearchIds && !matchingSearchIds.hasMatches)) {
     return [];


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/273727.

When searching the action policy execution history by rule name, the response included rows for unrelated rules that happened to share the same event log document.

The dispatcher batches all rules processed in a single tick into one event log document per policy. The KQL filter correctly returned only events that referenced the searched rule, but `denormalizeEvent` then fanned out **all** rule IDs in the event into separate rows — including rules the user did not search for.

### Fix

`denormalizeEvent` now receives the resolved search IDs and emits rows accordingly:

- **No active search** → emit all rules (unchanged behavior).
- **Policy matched the search** → emit all rules referenced by the event (the user asked for that policy's activity).
- **Only rule IDs matched** → emit only rows for those specific rule IDs.

https://github.com/user-attachments/assets/1cb434eb-99f6-4aed-ad1d-cc726c5d2fde


## Manual test plan

1. Create two rules (`cpu-alert-rule`, `memory-alert-rule`) and two **global** action policies (`cpu-policy`, `memory-policy`).
2. Wait ~15–30s for execution history events to accumulate.
3. Call the API:
   ```
   GET /api/alerting/v2/action_policies/execution_history?search=memory-alert-rule
   ```
4. **Expected:** `items` only contain rows where `rule.name === "memory-alert-rule"`.
5. **Also verify:**
   - `GET .../execution_history` (no `search`) still returns all rows for both rules.
   - `GET .../execution_history?search=memory-policy` returns rows for **all** rules dispatched under `memory-policy`.

## Checklist

- [x] Unit tests added for the new filtering logic (`denormalize_event.test.ts`).
- [x] Regression test covering the original issue scenario (`action_policy_execution_history_client.test.ts`).
- [ ] Manually verified against a local Kibana with the reproduction steps above.
