### PR TITLE
[Entity Analytics][Graph] filter unrelated relationships when showing relationships of entity node

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_entity_relationships_graph.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph/fetch_entity_relationships_graph.ts
@@ -32,6 +32,7 @@ import type { EntityEnrichmentFields } from './fetch_entity_enrichment';
 interface BuildRelationshipsEsqlQueryParams {
   indexName: string;
   relationshipFields: readonly string[];
+  entityIds: EntityId[];
 }
 
 const RESOLUTION_RELATIONSHIP_FIELD = 'resolution.resolved_to' as const;
@@ -55,10 +56,16 @@ const buildRelationshipTargetsEval = (field: string): string => {
  * Uses FORK to expand each relationship field and aggregates results.
  * The filter is applied via the DSL filter parameter.
  * Target enrichment is applied later in TypeScript via fetchEntityEnrichment.
+ *
+ * After FORK expansion each row is filtered to only include relationships where the actor
+ * or the target is one of the originally requested entity IDs. This prevents entities
+ * fetched because they point TO a requested entity (via the DSL should clauses) from
+ * leaking their unrelated outbound relationships into the result set.
  */
 const buildRelationshipsEsqlQuery = ({
   indexName,
   relationshipFields,
+  entityIds,
 }: BuildRelationshipsEsqlQueryParams): string => {
   const targetsEval = relationshipFields
     .map((field) => buildRelationshipTargetsEval(field))
@@ -72,6 +79,12 @@ const buildRelationshipsEsqlQuery = ({
     })
     .join('\n');
 
+  // Restrict rows to only those where the actor or target is one of the requested entity IDs.
+  // Without this, entities fetched because they point TO a requested entity would expose all
+  // of their own outbound relationships, not just the ones touching the requested entity.
+  const idParams = entityIds.map((_, idx) => `?entityId${idx}`).join(', ');
+  const relevantEntityFilter = `TO_STRING(entity.id) IN (${idParams}) OR _target_id IN (${idParams})`;
+
   return `SET unmapped_fields="nullify";
 FROM ${indexName}
 | EVAL _source_source_fields = ${buildSourceFieldsJson(GRAPH_ACTOR_EUID_SOURCE_FIELDS)}
@@ -80,6 +93,7 @@ FROM ${indexName}
 | FORK
 ${forkBranches}
 | WHERE _target_id != ""
+| WHERE ${relevantEntityFilter}
 // Build actors doc data with entity metadata (from the entity store source entity)
 | EVAL actorDocData = CONCAT(${JSON_OBJECT_START},
     ${concatJsonObjectPropertyEsqlExprSafe('id', 'entity.id')},
@@ -203,8 +217,10 @@ export const fetchEntityRelationships = async ({
   const query = buildRelationshipsEsqlQuery({
     indexName,
     relationshipFields: ENTITY_RELATIONSHIP_FIELDS,
+    entityIds,
   });
   const filter = buildRelationshipDslFilter(entityIds);
+  const params = entityIds.map((entity, idx) => ({ [`entityId${idx}`]: entity.id }));
 
   logger.trace(`Relationships ES|QL query: ${query}`);
   logger.trace(`Relationships filter: ${JSON.stringify(filter)}`);
@@ -214,6 +230,7 @@ export const fetchEntityRelationships = async ({
       columnar: false,
       filter,
       query,
+      params,
     })
     .toRecords<RelationshipEsqlRow>();
 

--- a/x-pack/solutions/security/test/cloud_security_posture_api/es_archives/entity_store_v2/data.json
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/es_archives/entity_store_v2/data.json
@@ -1833,3 +1833,121 @@
     }
   }
 }
+
+{
+  "type": "doc",
+  "value": {
+    "id": "unrelated-rel-my-server-1",
+    "index": ".entities.v2.latest.security_entities-space-00001",
+    "source": {
+      "@timestamp": "2024-09-01T12:00:00.000Z",
+      "entity": {
+        "EngineMetadata": { "Type": "host" },
+        "id": "host:my-server-1",
+        "name": "my-server-1",
+        "source": "manual",
+        "sub_type": "Linux Host",
+        "type": "Host",
+        "relationships": {
+          "resolution": {
+            "resolved_to": ["host:my-server-2"]
+          }
+        }
+      },
+      "host": { "name": "my-server-1", "id": "some-hw-uuid", "ip": ["10.0.1.42"] },
+      "event": { "ingested": "2024-09-01T12:00:00.000Z" }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "unrelated-rel-my-server-2",
+    "index": ".entities.v2.latest.security_entities-space-00001",
+    "source": {
+      "@timestamp": "2024-09-01T12:00:00.000Z",
+      "entity": {
+        "EngineMetadata": { "Type": "host" },
+        "id": "host:my-server-2",
+        "name": "my-server-2",
+        "source": "manual",
+        "sub_type": "Linux Host",
+        "type": "Host"
+      },
+      "host": { "name": "my-server-2", "id": "some-hw-uuid", "ip": ["10.0.1.42"] },
+      "event": { "ingested": "2024-09-01T12:00:00.000Z" }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "unrelated-rel-my-server-3",
+    "index": ".entities.v2.latest.security_entities-space-00001",
+    "source": {
+      "@timestamp": "2024-09-01T12:00:00.000Z",
+      "entity": {
+        "EngineMetadata": { "Type": "host" },
+        "id": "host:my-server-3",
+        "name": "my-server-3",
+        "source": "manual",
+        "sub_type": "Linux Host",
+        "type": "Host",
+        "relationships": {
+          "communicates_with": {
+            "ids": ["host:my-server-2", "host:my-server-5"]
+          },
+          "resolution": {
+            "resolved_to": ["host:my-server-4"]
+          }
+        }
+      },
+      "host": { "name": "my-server-3", "id": "some-hw-uuid", "ip": ["10.0.1.42"] },
+      "event": { "ingested": "2024-09-01T12:00:00.000Z" }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "unrelated-rel-my-server-4",
+    "index": ".entities.v2.latest.security_entities-space-00001",
+    "source": {
+      "@timestamp": "2024-09-01T12:00:00.000Z",
+      "entity": {
+        "EngineMetadata": { "Type": "host" },
+        "id": "host:my-server-4",
+        "name": "my-server-4",
+        "source": "manual",
+        "sub_type": "Linux Host",
+        "type": "Host"
+      },
+      "host": { "name": "my-server-4", "id": "some-hw-uuid", "ip": ["10.0.1.42"] },
+      "event": { "ingested": "2024-09-01T12:00:00.000Z" }
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "unrelated-rel-my-server-5",
+    "index": ".entities.v2.latest.security_entities-space-00001",
+    "source": {
+      "@timestamp": "2024-09-01T12:00:00.000Z",
+      "entity": {
+        "EngineMetadata": { "Type": "host" },
+        "id": "host:my-server-5",
+        "name": "my-server-5",
+        "source": "manual",
+        "sub_type": "Linux Host",
+        "type": "Host"
+      },
+      "host": { "name": "my-server-5", "id": "some-hw-uuid", "ip": ["10.0.1.42"] },
+      "event": { "ingested": "2024-09-01T12:00:00.000Z" }
+    }
+  }
+}

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts
@@ -3218,7 +3218,6 @@ export default function (providerContext: FtrProviderContext) {
               expect(communicatesWithNode).not.to.be(undefined);
               expect(communicatesWithNode.label).to.equal('Communicates with');
 
-
               expect(allNodes.length).to.equal(5);
               expect(allEdges.length).to.equal(4);
 

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph.ts
@@ -2673,7 +2673,7 @@ export default function (providerContext: FtrProviderContext) {
               logger,
               retry,
               entitiesIndex: getEntitiesLatestIndexName(entitiesSpaceId),
-              expectedCount: 48,
+              expectedCount: 53,
             });
           });
 
@@ -3159,6 +3159,78 @@ export default function (providerContext: FtrProviderContext) {
                   }),
                 })
               );
+            });
+
+            it('should not include unrelated relationships from intermediary nodes (issue #272043)', async () => {
+              // Scenario:
+              //   my-server-1  --resolution.resolved_to-->  my-server-2
+              //   my-server-3  --communicates_with-->        my-server-2   (✓ relevant)
+              //   my-server-3  --communicates_with-->        my-server-5   (✗ unrelated)
+              //   my-server-3  --resolution.resolved_to-->   my-server-4   (✗ unrelated)
+              //
+              // When expanding relationships for my-server-2, only the two edges that
+              // touch my-server-2 should appear. my-server-3's outbound edges to my-server-5
+              // and my-server-4 must be filtered out.
+              const response = await postGraph(
+                supertest,
+                {
+                  query: {
+                    originEventIds: [],
+                    entityIds: [{ id: 'host:my-server-2', isOrigin: false }],
+                    start: 'now-30d',
+                    end: 'now',
+                  },
+                },
+                undefined,
+                entitiesSpaceId
+              ).expect(result(200, logger));
+
+              const allNodes: NodeDataModel[] = response.body.nodes;
+              const allEdges: EdgeDataModel[] = response.body.edges;
+
+              // --- Entity nodes ---
+              const entityNodes = allNodes.filter(
+                (n: NodeDataModel) =>
+                  n.shape === 'hexagon' || n.shape === 'ellipse' || n.shape === 'rectangle'
+              ) as EntityNodeDataModel[];
+
+              const entityIds = entityNodes.map((n) => n.id).sort();
+              expectExpect(entityIds).toEqual(
+                ['host:my-server-1', 'host:my-server-2', 'host:my-server-3'].sort()
+              );
+
+              // --- Relationship nodes ---
+              const relationshipNodes = allNodes.filter(
+                (n: NodeDataModel) => n.shape === 'relationship'
+              ) as RelationshipNodeDataModel[];
+
+              expect(relationshipNodes.length).to.equal(2);
+
+              const resolvedToNode = relationshipNodes.find(
+                (n) => n.id === 'rel(host:my-server-1-resolution.resolved_to)'
+              ) as RelationshipNodeDataModel;
+              expect(resolvedToNode).not.to.be(undefined);
+              expect(resolvedToNode.label).to.equal('Resolved to');
+
+              const communicatesWithNode = relationshipNodes.find(
+                (n) => n.id === 'rel(host:my-server-3-communicates_with)'
+              ) as RelationshipNodeDataModel;
+              expect(communicatesWithNode).not.to.be(undefined);
+              expect(communicatesWithNode.label).to.equal('Communicates with');
+
+
+              expect(allNodes.length).to.equal(5);
+              expect(allEdges.length).to.equal(4);
+
+              const expectedEdgeIds = [
+                'a(host:my-server-1)-b(rel(host:my-server-1-resolution.resolved_to))',
+                'a(rel(host:my-server-1-resolution.resolved_to))-b(host:my-server-2)',
+                'a(host:my-server-3)-b(rel(host:my-server-3-communicates_with))',
+                'a(rel(host:my-server-3-communicates_with))-b(host:my-server-2)',
+              ].sort();
+
+              const actualEdgeIds = allEdges.map((e: EdgeDataModel) => e.id).sort();
+              expectExpect(actualEdgeIds).toEqual(expectedEdgeIds);
             });
 
             it('should return hierarchical relationships with grouped targets and events', async () => {

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph_entities.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/graph_entities.ts
@@ -188,7 +188,7 @@ export default function (providerContext: FtrProviderContext) {
           logger,
           retry,
           entitiesIndex: defaultSpaceIndex,
-          expectedCount: 48,
+          expectedCount: 53,
         });
       });
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/272043

## Summary

When clicking "Show entity relationships" for entity X, the DSL filter fetched intermediary entities that point **to** X via their relationship fields. The ES|QL FORK then expanded **all** of those entities' outbound relationships, leaking edges unrelated to X into the graph.

## How to test

1. Enable entity store at `http://localhost:5601/kbn/app/security/entity_analytics_management`
2. Open Kibana Dev Tools and index the following test entities:

```
POST .entities.v2.latest.security_default-00001/_doc/my-server-1
{"entity":{"id":"host:my-server-1","name":"my-server-1","type":"Host","sub_type":"Linux Host","source":"manual","EngineMetadata":{"Type":"host"},"relationships":{"resolution":{"resolved_to":["host:my-server-2"]}}},"host":{"name":"my-server-1","id":"some-hw-uuid","ip":["10.0.1.42"]},"@timestamp":"2024-09-01T12:00:00.000Z"}

POST .entities.v2.latest.security_default-00001/_doc/my-server-2
{"entity":{"id":"host:my-server-2","name":"my-server-2","type":"Host","sub_type":"Linux Host","source":"manual","EngineMetadata":{"Type":"host"}},"host":{"name":"my-server-2","id":"some-hw-uuid","ip":["10.0.1.42"]},"@timestamp":"2024-09-01T12:00:00.000Z"}

POST .entities.v2.latest.security_default-00001/_doc/my-server-3
{"entity":{"id":"host:my-server-3","name":"my-server-3","type":"Host","sub_type":"Linux Host","source":"manual","EngineMetadata":{"Type":"host"},"relationships":{"communicates_with":{"ids":["host:my-server-2","host:my-server-5"]},"resolution":{"resolved_to":["host:my-server-4"]}}},"host":{"name":"my-server-3","id":"some-hw-uuid","ip":["10.0.1.42"]},"@timestamp":"2024-09-01T12:00:00.000Z"}

POST .entities.v2.latest.security_default-00001/_doc/my-server-4
{"entity":{"id":"host:my-server-4","name":"my-server-4","type":"Host","sub_type":"Linux Host","source":"manual","EngineMetadata":{"Type":"host"}},"host":{"name":"my-server-4","id":"some-hw-uuid","ip":["10.0.1.42"]},"@timestamp":"2024-09-01T12:00:00.000Z"}

POST .entities.v2.latest.security_default-00001/_doc/my-server-5
{"entity":{"id":"host:my-server-5","name":"my-server-5","type":"Host","sub_type":"Linux Host","source":"manual","EngineMetadata":{"Type":"host"}},"host":{"name":"my-server-5","id":"some-hw-uuid","ip":["10.0.1.42"]},"@timestamp":"2024-09-01T12:00:00.000Z"}
```

3. Navigate to `http://localhost:5601/kbn/app/security/entity_analytics_home_page` and expand entity `host:my-server-1`
4. Open the **Visualization** tab, open the graph, and click **Show entity relationships** on `my-server-2`
5. **Expected (after fix):** only two relationship edges appear:
   - `my-server-1` → **Resolved to** → `my-server-2`
   - `my-server-3` → **Communicates with** → `my-server-2`
6. **Before fix:** two additional unrelated edges also appeared:
   - `my-server-3` → Communicates with → `my-server-5` ✗
   - `my-server-3` → Resolved to → `my-server-4` ✗

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

**Video Recording**

https://github.com/user-attachments/assets/3a42a2ba-09c1-4416-89e6-2af778744bb3


### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...