### PR TITLE
[SML] Add SORT _score DESC inside FORK branches to fix RRF relevance

### DIFF
--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -341,11 +341,13 @@ describe('SmlService', () => {
       expect(esql).toContain('| WHERE MV_CONTAINS(spaces, ?)');
       // Two FORK branches: BM25 (OR across text fields) + semantic (OR across semantic multi-fields).
       // Per-branch candidate depth is size(10) × MAX_SCAN_MULTIPLIER(10) for RRF recall.
+      // SORT _score DESC inside each branch is required so LIMIT selects the top-scoring
+      // candidates; without it LIMIT takes scan-order docs and FUSE assigns wrong RRF ranks.
       expect(esql).toContain(
-        '(WHERE MATCH(title, ?) OR MATCH(description, ?) OR MATCH(content, ?) | LIMIT 100)'
+        '(WHERE MATCH(title, ?) OR MATCH(description, ?) OR MATCH(content, ?) | SORT _score DESC | LIMIT 100)'
       );
       expect(esql).toContain(
-        '(WHERE MATCH(title.semantic, ?) OR MATCH(description.semantic, ?) OR MATCH(content.semantic, ?) | LIMIT 100)'
+        '(WHERE MATCH(title.semantic, ?) OR MATCH(description.semantic, ?) OR MATCH(content.semantic, ?) | SORT _score DESC | LIMIT 100)'
       );
       // Outer limit after FUSE is exactly `size` — authorization is enforced
       // in-query, so there is no overfetch to absorb a post-filter.

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -793,21 +793,21 @@ const buildSmlEsqlQuery = ({
   if (trimmed === '' || trimmed === '*') {
     lines.push('| SORT id ASC');
   } else {
-    // LIMIT inside each FORK branch caps the per-leg candidate set before FUSE
-    // computes RRF scores; without it FUSE would merge all matches. The outer
-    // LIMIT after FUSE+SORT bounds the final set to `size` (authorization is
-    // already enforced by the pre-FORK WHERE clauses above).
+    // SORT _score DESC inside each branch is required so LIMIT selects the
+    // top-scoring candidates before FUSE computes RRF ranks. Without it,
+    // LIMIT takes the first N docs in scan order and FUSE assigns arbitrary
+    // ranks, producing wrong results regardless of relevance scores.
     lines.push('| FORK');
     const bm25Conditions = SML_BM25_FIELDS.map((field) => {
       params.push(trimmed);
       return `MATCH(${field}, ?)`;
     }).join(' OR ');
-    lines.push(`  (WHERE ${bm25Conditions} | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
+    lines.push(`  (WHERE ${bm25Conditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
     const semanticConditions = SML_SEMANTIC_FIELDS.map((field) => {
       params.push(trimmed);
       return `MATCH(${field}, ?)`;
     }).join(' OR ');
-    lines.push(`  (WHERE ${semanticConditions} | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
+    lines.push(`  (WHERE ${semanticConditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
     lines.push('| FUSE');
     lines.push('| SORT _score DESC, id ASC');
   }

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -802,12 +802,16 @@ const buildSmlEsqlQuery = ({
       params.push(trimmed);
       return `MATCH(${field}, ?)`;
     }).join(' OR ');
-    lines.push(`  (WHERE ${bm25Conditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
+    lines.push(
+      `  (WHERE ${bm25Conditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`
+    );
     const semanticConditions = SML_SEMANTIC_FIELDS.map((field) => {
       params.push(trimmed);
       return `MATCH(${field}, ?)`;
     }).join(' OR ');
-    lines.push(`  (WHERE ${semanticConditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
+    lines.push(
+      `  (WHERE ${semanticConditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`
+    );
     lines.push('| FUSE');
     lines.push('| SORT _score DESC, id ASC');
   }


### PR DESCRIPTION
## Summary

The `buildSmlEsqlQuery` function in the SML service builds an ES|QL query using `FORK` + `FUSE` for hybrid BM25/semantic retrieval with RRF scoring. Each `FORK` branch ended with a bare `| LIMIT N` — without a preceding `| SORT _score DESC`.

**The bug:** `FORK` branches in ES|QL do not auto-sort by `_score`. Without an explicit sort, `LIMIT N` returns the first N documents in Lucene scan order, not the top-N by relevance. `FUSE` then computes RRF ranks from those arbitrary candidates, so the final ranked results bear no relation to actual BM25 or semantic scores.

**The fix:** Add `| SORT _score DESC` before `| LIMIT` in both FORK branches (BM25 leg and semantic leg).

```diff
- lines.push(`  (WHERE ${bm25Conditions} | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
+ lines.push(`  (WHERE ${bm25Conditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
- lines.push(`  (WHERE ${semanticConditions} | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
+ lines.push(`  (WHERE ${semanticConditions} | SORT _score DESC | LIMIT ${size * MAX_SCAN_MULTIPLIER})`);
```

## How to test

Query the SML via the Context Engine with a known-relevant document in the corpus. Before this fix, highly relevant documents appear at arbitrary ranks. After this fix, they rank at the top as expected.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)