### PR TITLE
[kbn-evals] Skip suite-owner Slack notification on non-main weekly runs

### DIFF
--- a/.buildkite/scripts/steps/evals/run_suite.sh
+++ b/.buildkite/scripts/steps/evals/run_suite.sh
@@ -204,7 +204,11 @@ EOF
 EOF
       done <<<"$CONNECTOR_IDS"
 
-      if [[ "${KBN_EVALS_WEEKLY:-}" =~ ^(1|true)$ ]] && [[ -n "${EVAL_SUITE_SLACK_CHANNEL:-}" ]]; then
+      # Only ping suite owners on the pipeline's default branch (main). Manual rebuilds
+      # from feature branches still run the evals but skip the Slack notification, so we
+      # don't spam suite owners with results from in-progress/experimental branches.
+      EVAL_NOTIFY_BRANCH="${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-main}"
+      if [[ "${KBN_EVALS_WEEKLY:-}" =~ ^(1|true)$ ]] && [[ -n "${EVAL_SUITE_SLACK_CHANNEL:-}" ]] && [[ "${BUILDKITE_BRANCH:-}" == "${EVAL_NOTIFY_BRANCH}" ]]; then
         cat >>"$FANOUT_PIPELINE_FILE" <<EOF
       - label: "LLM Evals: ${EVAL_SUITE_ID} (suite owner notify)"
         key: "kbn-evals-${group_key_safe}-suite-owner-notify"


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/672

## Summary

The weekly LLM evals pipeline (`kibana-evals-weekly-llm-evals`) is scheduled on `main` but allows manual rebuilds (`allow_rebuilds: true`). In `run_suite.sh`, the per-suite "suite owner notify" Buildkite step was generated whenever `KBN_EVALS_WEEKLY=1` and the suite defined a `slackChannel`, regardless of branch. As a result, rebuilding the pipeline from a feature branch to test changes would still ping suite owners' Slack channels (e.g. `#significant-events-alerts`) on a hard failure, creating noise from in-progress work.

This gates generation of that step on the build running the pipeline's default branch (`BUILDKITE_BRANCH == BUILDKITE_PIPELINE_DEFAULT_BRANCH`, falling back to `main`). Feature-branch rebuilds still run the evals; they just skip the Slack notification. Behavior on `main` is unchanged.

## Test plan

- [ ] `bash -n .buildkite/scripts/steps/evals/run_suite.sh` passes.
- [ ] Manually rebuild `kibana-evals-weekly-llm-evals` from this branch and confirm the `LLM Evals: <suite> (suite owner notify)` step is absent from the uploaded fanout, and no Slack message is posted even when a suite hard-fails.
- [ ] Confirm the scheduled `main` run still generates the notify step and posts to the suite's Slack channel on hard failure (the added condition is always true on the default branch, so existing behavior is preserved).

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
