### PR TITLE
[Agent Builder] Allow updating saved skill attachments

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.test.tsx
@@ -17,10 +17,17 @@ jest.mock('@kbn/agent-builder-plugin/public', () => ({
 }));
 
 const CREATE_BUTTON_LABEL = 'Create skill';
+const UPDATE_BUTTON_LABEL = 'Update skill';
+const EDIT_IN_MANAGEMENT_BUTTON_LABEL = 'Edit in Management';
 const NEW_SKILL_ID = 'track-purchases';
 
-const buildAttachment = (): SkillAttachment =>
-  ({
+type SkillAttachmentOverrides = Partial<Omit<SkillAttachment, 'data'>> & {
+  data?: Partial<SkillAttachment['data']>;
+};
+
+const buildAttachment = (overrides: SkillAttachmentOverrides = {}): SkillAttachment => {
+  const { data, ...attachmentOverrides } = overrides;
+  return {
     id: 'attachment-1',
     type: SKILL_ATTACHMENT_TYPE,
     data: {
@@ -30,49 +37,67 @@ const buildAttachment = (): SkillAttachment =>
       content: 'instructions',
       tool_ids: [],
       referenced_content: [],
+      ...data,
     },
     // version === versionCount marks the draft as the latest, which is the
     // condition under which the "Create skill" button is rendered.
     version: 1,
     versionCount: 1,
-  } as unknown as SkillAttachment);
+    ...attachmentOverrides,
+  } as SkillAttachment;
+};
 
 const setup = () => {
   const post = jest.fn().mockResolvedValue({ id: NEW_SKILL_ID });
+  const put = jest.fn().mockResolvedValue({ id: NEW_SKILL_ID });
   const addSuccess = jest.fn();
   const addError = jest.fn();
   const addSkillToAgent = jest.fn().mockResolvedValue({});
   const updateOrigin = jest.fn().mockResolvedValue(undefined);
 
-  const http = { post } as unknown as HttpStart;
+  const http = { post, put } as unknown as HttpStart;
   const notifications = {
     toasts: { addSuccess, addError },
   } as unknown as CoreStart['notifications'];
   const application = {
     capabilities: { agentBuilder: { manageSkills: true } },
-    getUrlForApp: jest.fn(),
+    getUrlForApp: jest.fn().mockReturnValue('/app/agent_builder/manage/skills/track-purchases'),
   } as unknown as CoreStart['application'];
   const agents = { list: jest.fn(), addSkillToAgent } as unknown as AgentsServiceStartContract;
 
   const definition = createSkillAttachmentDefinition({ http, notifications, application, agents });
 
-  const getCreateHandler = (agentId?: string) => {
-    const buttons: ActionButton[] =
-      definition.getActionButtons?.({
-        attachment: buildAttachment(),
-        agentId,
-        isSidebar: false,
-        isCanvas: false,
-        updateOrigin,
-      }) ?? [];
-    const createButton = buttons.find((button) => button.label === CREATE_BUTTON_LABEL);
-    if (!createButton) {
-      throw new Error('Create skill button not found');
+  const getButtons = (attachment = buildAttachment(), agentId?: string): ActionButton[] =>
+    definition.getActionButtons?.({
+      attachment,
+      agentId,
+      isSidebar: false,
+      isCanvas: false,
+      updateOrigin,
+    }) ?? [];
+
+  const getHandler = (label: string, attachment = buildAttachment(), agentId?: string) => {
+    const button = getButtons(attachment, agentId).find((action) => action.label === label);
+    if (!button) {
+      throw new Error(`${label} button not found`);
     }
-    return createButton.handler;
+    return button.handler;
   };
 
-  return { post, addSuccess, addError, addSkillToAgent, updateOrigin, getCreateHandler };
+  const getCreateHandler = (agentId?: string) =>
+    getHandler(CREATE_BUTTON_LABEL, buildAttachment(), agentId);
+
+  return {
+    post,
+    put,
+    addSuccess,
+    addError,
+    addSkillToAgent,
+    updateOrigin,
+    getButtons,
+    getHandler,
+    getCreateHandler,
+  };
 };
 
 describe('createSkillAttachmentDefinition - Create skill', () => {
@@ -117,6 +142,75 @@ describe('createSkillAttachmentDefinition - Create skill', () => {
     await getCreateHandler('agent-1')();
 
     expect(addSkillToAgent).not.toHaveBeenCalled();
+    expect(addSuccess).not.toHaveBeenCalled();
+    expect(addError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createSkillAttachmentDefinition - Update skill', () => {
+  const buildSavedAttachment = () =>
+    buildAttachment({
+      origin: NEW_SKILL_ID,
+      version: 2,
+      versionCount: 2,
+      data: {
+        id: NEW_SKILL_ID,
+        name: 'Track purchases',
+        description: 'Tracks updated purchases',
+        content: 'updated instructions',
+        tool_ids: ['platform.core.execute_esql'],
+        referenced_content: [
+          {
+            name: 'examples',
+            relativePath: './examples',
+            content: '# Examples',
+          },
+        ],
+      },
+    });
+
+  it('updates a saved skill', async () => {
+    const { put, addSuccess, addError, updateOrigin, getHandler } = setup();
+
+    await getHandler(UPDATE_BUTTON_LABEL, buildSavedAttachment())();
+
+    expect(put).toHaveBeenCalledWith('/api/agent_builder/skills/track-purchases', {
+      body: expect.any(String),
+    });
+    const [, request] = put.mock.calls[0];
+    expect(JSON.parse(request.body)).toEqual({
+      name: 'Track purchases',
+      description: 'Tracks updated purchases',
+      content: 'updated instructions',
+      referenced_content: [
+        {
+          name: 'examples',
+          relativePath: './examples',
+          content: '# Examples',
+        },
+      ],
+      tool_ids: ['platform.core.execute_esql'],
+    });
+    expect(updateOrigin).toHaveBeenCalledWith(NEW_SKILL_ID);
+    expect(addSuccess).toHaveBeenCalledTimes(1);
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('shows update and edit in management for a saved skill', () => {
+    const { getButtons } = setup();
+    const labels = getButtons(buildSavedAttachment()).map((button) => button.label);
+
+    expect(labels).toContain(EDIT_IN_MANAGEMENT_BUTTON_LABEL);
+    expect(labels).toContain(UPDATE_BUTTON_LABEL);
+  });
+
+  it('reports an error when saved skill update fails', async () => {
+    const { put, addSuccess, addError, updateOrigin, getHandler } = setup();
+    put.mockRejectedValueOnce(new Error('boom'));
+
+    await getHandler(UPDATE_BUTTON_LABEL, buildSavedAttachment())();
+
+    expect(updateOrigin).not.toHaveBeenCalled();
     expect(addSuccess).not.toHaveBeenCalled();
     expect(addError).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.tsx
@@ -60,6 +60,12 @@ const createSkillLabel = i18n.translate(
     defaultMessage: 'Create skill',
   }
 );
+const updateSkillLabel = i18n.translate(
+  'xpack.agentBuilderPlatform.attachments.skill.updateButtonLabel',
+  {
+    defaultMessage: 'Update skill',
+  }
+);
 const lackManageSkillsPermissionDescription = i18n.translate(
   'xpack.agentBuilderPlatform.attachments.skill.createDisabledReason',
   {
@@ -238,6 +244,9 @@ const SkillCanvasContent: React.FC<AttachmentRenderProps<SkillAttachment>> = (pr
   <SkillCard {...props} isCanvas />
 );
 
+const getSkillByIdApiPath = (skillId: string): string =>
+  `${SKILLS_API_PATH}/${encodeURIComponent(skillId)}`;
+
 interface CreateSkillDeps {
   http: HttpStart;
   notifications: CoreStart['notifications'];
@@ -248,16 +257,16 @@ interface CreateSkillDeps {
 /**
  * Factory for the `skill` UI definition.
  *
- * The Create button:
+ * The create/update buttons:
  * 1. Disables when the user lacks the `manageSkills` capability.
- * 2. POSTs the captured payload to `/api/agent_builder/skills`.
- * 3. On success, calls the framework-provided `updateOrigin(skillId)` so the
- *    same attachment now references the persisted skill (the card flips to
- *    a "Created" badge and the button disables).
- * 4. Adds the new skill to the current conversation's agent (`agentId`) so it
- *    is immediately usable; a failure here is reported separately and does not
+ * 2. POSTs new drafts to `/api/agent_builder/skills`.
+ * 3. PUTs saved attachments back to their origin skill.
+ * 4. On success, calls the framework-provided `updateOrigin(skillId)` so the
+ *    attachment origin snapshot reflects the latest persisted version.
+ * 5. Adds newly-created skills to the current conversation's agent (`agentId`) so they
+ *    are immediately usable; a failure here is reported separately and does not
  *    undo the skill creation.
- * 5. On failure, surfaces the agent_builder error message via core toasts.
+ * 6. On failure, surfaces the agent_builder error message via core toasts.
  */
 export const createSkillAttachmentDefinition = ({
   http,
@@ -265,7 +274,7 @@ export const createSkillAttachmentDefinition = ({
   application,
   agents,
 }: CreateSkillDeps): AttachmentUIDefinition<SkillAttachment> => {
-  const canCreate = application.capabilities.agentBuilder?.manageSkills === true;
+  const canManageSkills = application.capabilities.agentBuilder?.manageSkills === true;
   const isLatest = ({
     version,
     versionCount,
@@ -394,15 +403,68 @@ export const createSkillAttachmentDefinition = ({
               // Do nothing. navigation handled by href
             },
           };
-          actionButtons.push(editInManagementButton);
+
+          const updateSkill = async () => {
+            const {
+              name,
+              description,
+              content,
+              referenced_content: referencedContent,
+              tool_ids: toolIds,
+            } = attachment.data;
+            try {
+              const response = await http.put<CreateSkillResponse>(getSkillByIdApiPath(skillId), {
+                body: JSON.stringify({
+                  name,
+                  description,
+                  content,
+                  referenced_content: referencedContent,
+                  tool_ids: toolIds,
+                }),
+              });
+              await updateOrigin(response.id);
+
+              notifications.toasts.addSuccess({
+                title: i18n.translate(
+                  'xpack.agentBuilderPlatform.attachments.skill.updateSuccessToast',
+                  {
+                    defaultMessage: 'Skill "{skillId}" updated.',
+                    values: { skillId: response.id },
+                  }
+                ),
+              });
+            } catch (error) {
+              notifications.toasts.addError(error as Error, {
+                title: i18n.translate(
+                  'xpack.agentBuilderPlatform.attachments.skill.updateErrorToast',
+                  {
+                    defaultMessage: 'Could not update skill from draft',
+                  }
+                ),
+              });
+            }
+          };
+
+          actionButtons.push({
+            label: updateSkillLabel,
+            icon: 'save',
+            type: ActionButtonType.PRIMARY,
+            disabled: !canManageSkills,
+            disabledReason: !canManageSkills ? lackManageSkillsPermissionDescription : undefined,
+            handler: updateSkill,
+          });
+          actionButtons.push({
+            ...editInManagementButton,
+            type: ActionButtonType.SECONDARY,
+          });
         } else {
           // Only show create button for the latest draft
           const createButton: ActionButton = {
             label: createSkillLabel,
             icon: 'plus',
             type: ActionButtonType.PRIMARY,
-            disabled: !canCreate,
-            disabledReason: !canCreate ? lackManageSkillsPermissionDescription : undefined,
+            disabled: !canManageSkills,
+            disabledReason: !canManageSkills ? lackManageSkillsPermissionDescription : undefined,
             handler: createSkill,
           };
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/skill.ts
@@ -65,6 +65,6 @@ export const createSkillAttachmentType = (): AttachmentTypeDefinition<
     };
   },
   getAgentDescription: () => {
-    return `A \`skill\` attachment is a versioned, by-value snapshot of a candidate Agent Builder skill. The user reviews it as an inline card with a "Create" button. Render it inline by emitting <render_attachment id="ATTACHMENT_ID" />. After patching, re-render the same attachment id so the card refreshes in place. Do not invent attachment ids — only render ids returned by propose_skill or patch_skill.`;
+    return `A \`skill\` attachment is a versioned, by-value snapshot of an Agent Builder skill. New drafts show a "Create skill" button; saved skills patched in chat show an "Update skill" button. Render it inline by emitting <render_attachment id="ATTACHMENT_ID" />. After patching, re-render the same attachment id so the card refreshes in place. Do not invent attachment ids — only render ids returned by propose_skill or patch_skill.`;
   },
 });

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/skill_authoring/skill_authoring_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/skill_authoring/skill_authoring_skill.ts
@@ -34,7 +34,7 @@ Use this skill when:
 
 Do **not** use this skill when:
 - The user only wants a one-off answer (just answer it).
-- The user wants to edit an already-persisted skill — direct them to the skill editor at /manage/skills.
+- The user wants to edit a persisted skill that is not already represented by a skill attachment in the current conversation — direct them to the skill editor at /manage/skills.
 - The user wants to author a tool, plugin, or agent (different entity types, not yet supported in chat).
 
 ## Available Tools
@@ -102,8 +102,11 @@ This skill exposes the following tools:
 8. **Iterate on feedback via \`patch_skill\`.**
    - Prefer search-replace patches over full rewrites; it's cheaper and easier for the user to follow.
    - After each patch, re-render the attachment so the card refreshes in place.
+   - If the attachment was already created, patching updates the conversation copy first. After re-rendering, tell the user to click **Update skill** on the card to persist the edited version.
 
-9. **When the user approves the draft, direct them to the create button on the card.**
+9. **When the user approves the draft or saved edit, direct them to the card action.**
+   - For a new draft, tell them to click **Create skill**.
+   - For a patched saved skill, tell them to click **Update skill**.
    - The card handles submission — you do not need to call any API endpoint yourself.
 
 ## Examples


### PR DESCRIPTION
## Summary
- Allows saved skill attachments to persist chat edits via an Update skill action.
- Keeps Create skill for unsaved drafts and Edit in Management as a secondary action for saved skills.
- Updates skill-authoring guidance so agents patch current saved skill attachments and prompt users to save them.

## Test plan
- node scripts/jest x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/skill_attachment/skill_attachment.test.tsx x-pack/platform/plugins/shared/agent_builder_platform/server/skills/skill_authoring/skill_authoring.test.ts
- Manually create and edit skill in UI

## Screenshots
<details>
<summary>Before</summary>
<img width="1056" height="2248" alt="image" src="https://github.com/user-attachments/assets/a9a8fa7e-1738-4a91-a964-e798772baff0" />
</details>


<details>
<summary>After</summary>
<img width="894" height="2052" alt="image" src="https://github.com/user-attachments/assets/6d1d8c94-8f07-454e-add4-051edccd99d1" />
</details>



[Agent Session](https://cursor.com/dashboard/shared-chats?shareId=skill-editing-issue-7qLcfBumgOut)

Made with [Cursor](https://cursor.com)
