### PR TITLE
[Agent Builder] HITL clarifying questions: keyboard controls

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.test.tsx
@@ -10,7 +10,6 @@ import { EuiProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { isMac } from '@kbn/shared-ux-utility';
 import type {
   AskUserQuestionPromptResponse,
   AskUserQuestionItem,
@@ -427,12 +426,11 @@ describe('AskUserQuestionPrompt', () => {
       });
     });
 
-    it('renders the navigation key hints on the action buttons', () => {
+    it('renders the ↵ key hint on the Continue/Submit button', () => {
       renderWithProviders(
         <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
       );
-      expect(screen.getByText('→')).toBeInTheDocument();
-      expect(screen.getByText(isMac ? '⌘↵' : 'Ctrl↵')).toBeInTheDocument();
+      expect(screen.getByText('↵')).toBeInTheDocument();
     });
 
     it('Back button is disabled on question 1 and enabled after advancing', async () => {
@@ -602,48 +600,6 @@ describe('AskUserQuestionPrompt', () => {
       await userEvent.keyboard('{ArrowLeft}');
       // Still on Q2 — the arrow key didn't trigger Back
       expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
-    });
-
-    it('Cmd/Ctrl+Enter submits a multi-select prompt', async () => {
-      const onSubmit = jest.fn();
-      renderWithProviders(
-        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={onSubmit} />
-      );
-      await userEvent.keyboard('1'); // toggle Cat
-      await userEvent.keyboard('2'); // toggle Dog
-      const modifier = isMac ? '{Meta>}{Enter}{/Meta}' : '{Control>}{Enter}{/Control}';
-      await userEvent.keyboard(modifier);
-      expect(onSubmit).toHaveBeenCalledWith({
-        answers: [{ choice: [0, 1] }],
-      } satisfies AskUserQuestionPromptResponse);
-    });
-
-    it('does not carry focus to the next question after Cmd/Ctrl+Enter from the custom input', async () => {
-      renderWithProviders(
-        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
-      );
-      // Q1 has 2 regular options → digit 3 selects the custom row and focuses its input.
-      await userEvent.keyboard('3');
-      expect(screen.getByRole('textbox')).toHaveFocus();
-      await userEvent.keyboard('hello');
-      const modifier = isMac ? '{Meta>}{Enter}{/Meta}' : '{Control>}{Enter}{/Control}';
-      await userEvent.keyboard(modifier);
-      // On Q2 the custom input must NOT be auto-focused.
-      expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
-      expect(screen.getByRole('textbox')).not.toHaveFocus();
-    });
-
-    it('Cmd/Ctrl+Enter fires even while the custom text input is focused', async () => {
-      const onSubmit = jest.fn();
-      renderWithProviders(
-        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={onSubmit} />
-      );
-      await userEvent.type(screen.getByRole('textbox'), 'Fish');
-      const modifier = isMac ? '{Meta>}{Enter}{/Meta}' : '{Control>}{Enter}{/Control}';
-      await userEvent.keyboard(modifier);
-      expect(onSubmit).toHaveBeenCalledWith({
-        answers: [{ custom: 'Fish' }],
-      } satisfies AskUserQuestionPromptResponse);
     });
 
     it('Enter confirms a multi-select prompt when an option is tracked', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.test.tsx
@@ -10,6 +10,7 @@ import { EuiProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { isMac } from '@kbn/shared-ux-utility';
 import type {
   AskUserQuestionPromptResponse,
   AskUserQuestionItem,
@@ -104,16 +105,25 @@ describe('AskUserQuestionPrompt', () => {
   });
 
   describe('single-select submission', () => {
-    it('Confirm on the only question fires onSubmit with { choice: [N] }', async () => {
+    it('Picking a single-select option on the only question auto-submits with { choice: [N] }', async () => {
       const onSubmit = jest.fn();
       renderWithProviders(
         <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={onSubmit} />
       );
       await userEvent.click(screen.getByLabelText('Blue'));
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
       expect(onSubmit).toHaveBeenCalledWith({
         answers: [{ choice: [1] }],
       } satisfies AskUserQuestionPromptResponse);
+    });
+
+    it('Picking a single-select option on a non-final question auto-advances without onSubmit', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={onSubmit} />
+      );
+      await userEvent.click(screen.getByLabelText('A'));
+      expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 
@@ -273,7 +283,7 @@ describe('AskUserQuestionPrompt', () => {
       renderWithProviders(
         <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={onSubmit} />
       );
-      await userEvent.click(screen.getByRole('button', { name: 'Skip' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Skip question' }));
       // advanced — Q2 visible
       expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
       expect(onSubmit).not.toHaveBeenCalled();
@@ -284,7 +294,7 @@ describe('AskUserQuestionPrompt', () => {
       renderWithProviders(
         <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={onSubmit} />
       );
-      await userEvent.click(screen.getByRole('button', { name: 'Skip' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Skip question' }));
       expect(onSubmit).toHaveBeenCalledWith({
         answers: [{ skipped: true }],
       } satisfies AskUserQuestionPromptResponse);
@@ -329,7 +339,7 @@ describe('AskUserQuestionPrompt', () => {
       await userEvent.click(screen.getByLabelText('A'));
       await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
       // Q2: skip
-      await userEvent.click(screen.getByRole('button', { name: 'Skip' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Skip question' }));
       // Q3: custom text
       await userEvent.type(screen.getByRole('textbox'), 'free text');
       await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
@@ -374,18 +384,18 @@ describe('AskUserQuestionPrompt', () => {
       renderWithProviders(
         <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={jest.fn()} />
       );
-      await userEvent.click(screen.getByRole('button', { name: 'Skip' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Skip question' }));
       expect(mockReportEvent).toHaveBeenCalledWith(
         AGENT_BUILDER_EVENT_TYPES.HitlQuestionAnswered,
         expect.objectContaining({ outcome: 'skipped', selected_option_count: 0 })
       );
     });
 
-    it('fires HitlQuestionAnswered with outcome=skipped_all on Skip all', async () => {
+    it('fires HitlQuestionAnswered with outcome=skipped_all on Escape', async () => {
       renderWithProviders(
         <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
       );
-      await userEvent.click(screen.getByRole('button', { name: 'Skip all' }));
+      await userEvent.keyboard('{Escape}');
       expect(mockReportEvent).toHaveBeenCalledWith(
         AGENT_BUILDER_EVENT_TYPES.HitlQuestionAnswered,
         expect.objectContaining({ outcome: 'skipped_all' })
@@ -402,6 +412,250 @@ describe('AskUserQuestionPrompt', () => {
         AGENT_BUILDER_EVENT_TYPES.HitlQuestionAnswered,
         expect.objectContaining({ outcome: 'answered', used_custom_text: true })
       );
+    });
+  });
+
+  describe('Key hints', () => {
+    it('renders a notification badge for every option and for the custom row', () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={jest.fn()} />
+      );
+      // multiQuestion has 3 options → custom row is #4
+      ['1', '2', '3', '4'].forEach((n) => {
+        const el = screen.getByText(n);
+        expect(el.closest('[aria-hidden="true"]')).not.toBeNull();
+      });
+    });
+
+    it('renders the navigation key hints on the action buttons', () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      expect(screen.getByText('→')).toBeInTheDocument();
+      expect(screen.getByText(isMac ? '⌘↵' : 'Ctrl↵')).toBeInTheDocument();
+    });
+
+    it('Back button is disabled on question 1 and enabled after advancing', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled();
+      await userEvent.click(screen.getByLabelText('A'));
+      expect(screen.getByRole('button', { name: 'Back' })).toBeEnabled();
+    });
+  });
+
+  describe('Keyboard shortcuts', () => {
+    it('digit key picks a single-select option and auto-advances', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      await userEvent.keyboard('1');
+      expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
+    });
+
+    it('handles shortcuts when a disabled text field outside the prompt holds focus', async () => {
+      // Mirrors Kibana's chat input, which is disabled while a HITL prompt is open
+      // but may still be the document.activeElement after page load.
+      const disabledChatInput = document.createElement('textarea');
+      disabledChatInput.disabled = true;
+      document.body.appendChild(disabledChatInput);
+      try {
+        // jsdom won't programmatically focus a disabled element, so simulate
+        // the post-load state by inserting a non-disabled element, focusing it,
+        // then flipping the disabled flag — Kibana's flow lands on the same
+        // activeElement-on-a-disabled-textarea state.
+        disabledChatInput.disabled = false;
+        disabledChatInput.focus();
+        disabledChatInput.disabled = true;
+        expect(document.activeElement).toBe(disabledChatInput);
+
+        renderWithProviders(
+          <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+        );
+        await userEvent.keyboard('1');
+        expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
+      } finally {
+        document.body.removeChild(disabledChatInput);
+      }
+    });
+
+    it('passes keys through to a live text field outside the prompt', async () => {
+      const liveInput = document.createElement('input');
+      liveInput.type = 'text';
+      document.body.appendChild(liveInput);
+      liveInput.focus();
+      try {
+        renderWithProviders(
+          <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+        );
+        await userEvent.keyboard('1');
+        // Still on Q1 — the digit went to the external input, not our handler.
+        expect(screen.getByRole('heading', { name: 'Q1: pick one' })).toBeInTheDocument();
+        expect(liveInput).toHaveValue('1');
+      } finally {
+        document.body.removeChild(liveInput);
+      }
+    });
+
+    it('digit key auto-submits on the only single-select question', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={onSubmit} />
+      );
+      await userEvent.keyboard('2');
+      expect(onSubmit).toHaveBeenCalledWith({
+        answers: [{ choice: [1] }],
+      } satisfies AskUserQuestionPromptResponse);
+    });
+
+    it('digit key toggles an option in multi-select', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={jest.fn()} />
+      );
+      await userEvent.keyboard('1');
+      expect(screen.getByLabelText('Cat')).toBeChecked();
+      await userEvent.keyboard('1');
+      expect(screen.getByLabelText('Cat')).not.toBeChecked();
+    });
+
+    it('out-of-range digit key is ignored', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={jest.fn()} />
+      );
+      // singleQuestion has 2 regular options + 1 custom row → indices 1, 2, 3 are valid
+      await userEvent.keyboard('9');
+      expect(screen.getByLabelText('Red')).not.toBeChecked();
+      expect(screen.getByLabelText('Blue')).not.toBeChecked();
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+
+    it('digit key for the "Be more specific…" row focuses the text input', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={jest.fn()} />
+      );
+      // singleQuestion has 2 options → custom row digit is 3
+      await userEvent.keyboard('3');
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('digit keys are suppressed while the custom text input is focused', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={singleQuestion} onSubmit={jest.fn()} />
+      );
+      const textbox = screen.getByRole('textbox');
+      await userEvent.click(textbox);
+      expect(textbox).toHaveFocus();
+      await userEvent.keyboard('1');
+      // '1' typed into the textbox instead of selecting option 1
+      expect(textbox).toHaveValue('1');
+      expect(screen.getByLabelText('Red')).not.toBeChecked();
+    });
+
+    it('Escape skips all remaining questions', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={onSubmit} />
+      );
+      await userEvent.keyboard('{Escape}');
+      expect(onSubmit).toHaveBeenCalledWith({
+        answers: [{ skipped: true }, { skipped: true }, { skipped: true }],
+      } satisfies AskUserQuestionPromptResponse);
+    });
+
+    it('Escape works even while the custom text input is focused', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={onSubmit} />
+      );
+      await userEvent.type(screen.getByRole('textbox'), 'something');
+      await userEvent.keyboard('{Escape}');
+      expect(onSubmit).toHaveBeenCalledWith({
+        answers: [{ skipped: true }, { skipped: true }, { skipped: true }],
+      } satisfies AskUserQuestionPromptResponse);
+    });
+
+    it('ArrowRight skips the current question and advances', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      await userEvent.keyboard('{ArrowRight}');
+      expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
+    });
+
+    it('ArrowLeft goes back to the previous question', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      await userEvent.keyboard('1'); // Q1 → Q2 (auto-advance)
+      await userEvent.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('heading', { name: 'Q1: pick one' })).toBeInTheDocument();
+    });
+
+    it('ArrowLeft is suppressed while the custom text input is focused', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      await userEvent.keyboard('1'); // Q1 → Q2
+      const textbox = screen.getByRole('textbox');
+      await userEvent.click(textbox);
+      await userEvent.keyboard('{ArrowLeft}');
+      // Still on Q2 — the arrow key didn't trigger Back
+      expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
+    });
+
+    it('Cmd/Ctrl+Enter submits a multi-select prompt', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={onSubmit} />
+      );
+      await userEvent.keyboard('1'); // toggle Cat
+      await userEvent.keyboard('2'); // toggle Dog
+      const modifier = isMac ? '{Meta>}{Enter}{/Meta}' : '{Control>}{Enter}{/Control}';
+      await userEvent.keyboard(modifier);
+      expect(onSubmit).toHaveBeenCalledWith({
+        answers: [{ choice: [0, 1] }],
+      } satisfies AskUserQuestionPromptResponse);
+    });
+
+    it('does not carry focus to the next question after Cmd/Ctrl+Enter from the custom input', async () => {
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={threeQuestions} onSubmit={jest.fn()} />
+      );
+      // Q1 has 2 regular options → digit 3 selects the custom row and focuses its input.
+      await userEvent.keyboard('3');
+      expect(screen.getByRole('textbox')).toHaveFocus();
+      await userEvent.keyboard('hello');
+      const modifier = isMac ? '{Meta>}{Enter}{/Meta}' : '{Control>}{Enter}{/Control}';
+      await userEvent.keyboard(modifier);
+      // On Q2 the custom input must NOT be auto-focused.
+      expect(screen.getByRole('heading', { name: 'Q2: pick many' })).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+
+    it('Cmd/Ctrl+Enter fires even while the custom text input is focused', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={onSubmit} />
+      );
+      await userEvent.type(screen.getByRole('textbox'), 'Fish');
+      const modifier = isMac ? '{Meta>}{Enter}{/Meta}' : '{Control>}{Enter}{/Control}';
+      await userEvent.keyboard(modifier);
+      expect(onSubmit).toHaveBeenCalledWith({
+        answers: [{ custom: 'Fish' }],
+      } satisfies AskUserQuestionPromptResponse);
+    });
+
+    it('Enter confirms a multi-select prompt when an option is tracked', async () => {
+      const onSubmit = jest.fn();
+      renderWithProviders(
+        <AskUserQuestionPrompt promptId="p1" questions={multiQuestion} onSubmit={onSubmit} />
+      );
+      await userEvent.keyboard('2'); // toggle Dog
+      await userEvent.keyboard('{Enter}');
+      expect(onSubmit).toHaveBeenCalledWith({
+        answers: [{ choice: [1] }],
+      } satisfies AskUserQuestionPromptResponse);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
@@ -5,16 +5,17 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   EuiButton,
-  EuiButtonEmpty,
+  EuiButtonIcon,
   EuiCheckableCard,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormErrorText,
   EuiIcon,
+  EuiNotificationBadge,
   EuiText,
   EuiTitle,
   useEuiTheme,
@@ -22,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { isMac } from '@kbn/shared-ux-utility';
 import {
   labels,
   containerStyles,
@@ -36,6 +38,35 @@ import type { AnswerDraft, AskUserQuestionPromptProps } from './ask_user_questio
 
 export type { AskUserQuestionPromptProps } from './ask_user_question_prompt_utils';
 
+const CONFIRM_KEY_HINT = isMac ? '⌘↵' : 'Ctrl↵';
+const HANDLED_DIGIT_KEY = /^[1-9]$/;
+
+/** True when the focused element can accept keyboard input — we don't steal those keys. */
+const isLiveTextEntry = (el: Element | null): boolean => {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return !el.disabled && !el.readOnly;
+  }
+  return el instanceof HTMLElement && el.isContentEditable;
+};
+
+const KeyHint = ({ children }: { children: React.ReactNode }) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <span
+      aria-hidden="true"
+      css={css`
+        margin-left: ${euiTheme.size.xs};
+        color: inherit;
+        opacity: 0.7;
+        font-size: 11px;
+        font-family: ${euiTheme.font.familyCode};
+      `}
+    >
+      {children}
+    </span>
+  );
+};
+
 export const AskUserQuestionPrompt = ({
   promptId,
   questions,
@@ -49,6 +80,7 @@ export const AskUserQuestionPrompt = ({
   const [drafts, setDrafts] = useState<AnswerDraft[]>(() => questions.map(() => ({})));
   const [showCustomError, setShowCustomError] = useState(false);
   const baseId = useGeneratedHtmlId({ prefix: 'askUserQuestionPrompt' });
+  const customInputRef = useRef<HTMLInputElement>(null);
 
   const { reportPromptShown, reportQuestionAnswered } = useAskUserQuestionTelemetry({
     promptId,
@@ -59,11 +91,21 @@ export const AskUserQuestionPrompt = ({
     reportPromptShown();
   }, [reportPromptShown]);
 
+  // When the question changes, drop focus from the custom input so it never
+  // carries over to the next question (e.g. user typed in custom on Q1 then
+  // hit Cmd+Enter — focus would otherwise stick to the new question's input).
+  useEffect(() => {
+    if (customInputRef.current && document.activeElement === customInputRef.current) {
+      customInputRef.current.blur();
+    }
+  }, [currentIndex]);
+
   const currentQuestion = questions[currentIndex];
   const currentDraft = drafts[currentIndex];
   const isFinalQuestion = currentIndex === totalQuestions - 1;
   const canConfirm = !currentDraft.skipped && isDraftAnswerable(currentDraft);
   const questionGroupName = `${baseId}-q${currentIndex}`;
+  const isInteractionDisabled = isDisabled || isLoading;
 
   const updateDraft = useCallback(
     (next: AnswerDraft) => {
@@ -144,14 +186,34 @@ export const AskUserQuestionPrompt = ({
         });
         return;
       }
-      updateDraft({
+
+      // Single-select: build the next draft inline and auto-advance / submit in the
+      // same call stack — avoids a stale-state read between setState and the
+      // advance decision.
+      const nextDraft: AnswerDraft = {
         skipped: false,
         choice: [optionIndex],
         custom: currentDraft.custom,
         customSelected: false,
-      });
+      };
+      updateDraft(nextDraft);
+      reportQuestionAnswered(currentIndex, nextDraft, 'answered');
+      if (isFinalQuestion) {
+        handleSubmit(nextDraft);
+        return;
+      }
+      setShowCustomError(false);
+      setCurrentIndex((idx) => idx + 1);
     },
-    [currentQuestion.multi_select, currentDraft, updateDraft]
+    [
+      currentQuestion.multi_select,
+      currentDraft,
+      updateDraft,
+      reportQuestionAnswered,
+      currentIndex,
+      isFinalQuestion,
+      handleSubmit,
+    ]
   );
 
   const handleCustomChange = useCallback(
@@ -184,7 +246,107 @@ export const AskUserQuestionPrompt = ({
 
   const isCustomActive = !!currentDraft.customSelected;
 
-  const isInteractionDisabled = isDisabled || isLoading;
+  // Keep the latest handler closures in a ref so the document-level keydown
+  // listener (below) can stay registered once for the lifetime of the prompt.
+  const keyboardHandlersRef = useRef({
+    isInteractionDisabled,
+    currentChoice: currentDraft.choice,
+    optionsCount: currentQuestion.options.length,
+    handleConfirm,
+    handleSkipAll,
+    handleSkip,
+    handleBack,
+    handleOptionPick,
+    handleCustomToggle,
+  });
+  keyboardHandlersRef.current = {
+    isInteractionDisabled,
+    currentChoice: currentDraft.choice,
+    optionsCount: currentQuestion.options.length,
+    handleConfirm,
+    handleSkipAll,
+    handleSkip,
+    handleBack,
+    handleOptionPick,
+    handleCustomToggle,
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const h = keyboardHandlersRef.current;
+      if (h.isInteractionDisabled) return;
+
+      const active = document.activeElement;
+      const isCustomInputFocused = !!customInputRef.current && customInputRef.current === active;
+
+      // Pass keys through to any text field the user is actively typing in.
+      // Disabled fields (e.g., the chat input while a HITL prompt is open)
+      // can't receive input, so they don't block shortcuts.
+      if (!isCustomInputFocused && isLiveTextEntry(active)) return;
+
+      // Cmd/Ctrl+Enter and Escape fire even while typing in the custom input.
+      if (event.key === 'Enter' && (isMac ? event.metaKey : event.ctrlKey)) {
+        event.preventDefault();
+        h.handleConfirm();
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        h.handleSkipAll();
+        return;
+      }
+
+      if (isCustomInputFocused) return;
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        h.handleConfirm();
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        h.handleBack();
+        return;
+      }
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        h.handleSkip();
+        return;
+      }
+
+      if (HANDLED_DIGIT_KEY.test(event.key) && !event.altKey && !event.ctrlKey && !event.metaKey) {
+        const optionIndex = Number(event.key) - 1;
+        if (optionIndex < h.optionsCount) {
+          event.preventDefault();
+          const alreadyChecked = (h.currentChoice ?? []).includes(optionIndex);
+          h.handleOptionPick(optionIndex, !alreadyChecked);
+          return;
+        }
+        if (optionIndex === h.optionsCount) {
+          event.preventDefault();
+          h.handleCustomToggle(true);
+          customInputRef.current?.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const optionRowWrapperStyles = css`
+    position: relative;
+  `;
+  const optionBadgeAnchorStyles = css`
+    position: absolute;
+    right: ${euiTheme.size.base};
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+  `;
 
   return (
     <EuiFlexGroup
@@ -243,27 +405,36 @@ export const AskUserQuestionPrompt = ({
           const checked = (currentDraft.choice ?? []).includes(optionIndex);
           return (
             <EuiFlexItem key={`${currentIndex}-${optionIndex}`} grow={false}>
-              <EuiCheckableCard
-                id={inputId}
-                label={option.label}
-                checkableType={currentQuestion.multi_select ? 'checkbox' : 'radio'}
-                name={questionGroupName}
-                checked={checked}
-                disabled={isInteractionDisabled}
-                css={optionCardStyles}
-                onChange={(e) =>
-                  handleOptionPick(
-                    optionIndex,
-                    currentQuestion.multi_select ? e.target.checked : true
-                  )
-                }
-              >
-                {option.description && (
-                  <EuiText size="xs" color="subdued">
-                    {option.description}
-                  </EuiText>
-                )}
-              </EuiCheckableCard>
+              <div css={optionRowWrapperStyles}>
+                <EuiCheckableCard
+                  id={inputId}
+                  label={option.label}
+                  checkableType={currentQuestion.multi_select ? 'checkbox' : 'radio'}
+                  name={questionGroupName}
+                  checked={checked}
+                  disabled={isInteractionDisabled}
+                  css={optionCardStyles}
+                  onChange={(e) =>
+                    handleOptionPick(
+                      optionIndex,
+                      currentQuestion.multi_select ? e.target.checked : true
+                    )
+                  }
+                >
+                  {option.description && (
+                    <EuiText size="xs" color="subdued">
+                      {option.description}
+                    </EuiText>
+                  )}
+                </EuiCheckableCard>
+                {/* Badge positioned over the card so it doesn't pollute the
+                      label's text content (would break getByLabelText). */}
+                <div aria-hidden="true" css={optionBadgeAnchorStyles}>
+                  <EuiNotificationBadge size="s" color="subdued">
+                    {optionIndex + 1}
+                  </EuiNotificationBadge>
+                </div>
+              </div>
             </EuiFlexItem>
           );
         })}
@@ -289,6 +460,7 @@ export const AskUserQuestionPrompt = ({
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFieldText
+                  inputRef={customInputRef}
                   value={currentDraft.custom ?? ''}
                   placeholder={labels.customPlaceholder}
                   onChange={(e) => handleCustomChange(e.target.value)}
@@ -307,6 +479,20 @@ export const AskUserQuestionPrompt = ({
                   `}
                   fullWidth
                 />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                {/* The custom row has zero right padding (see customRowStyles); compensate
+                      so the badge number aligns with the regular option numbers above. */}
+                <EuiNotificationBadge
+                  size="s"
+                  color="subdued"
+                  aria-hidden="true"
+                  css={css`
+                    margin-right: ${euiTheme.size.base};
+                  `}
+                >
+                  {currentQuestion.options.length + 1}
+                </EuiNotificationBadge>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiCheckableCard>
@@ -331,38 +517,21 @@ export const AskUserQuestionPrompt = ({
         `}
       >
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            {totalQuestions > 1 && currentIndex === 0 && (
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  onClick={handleSkipAll}
-                  disabled={isInteractionDisabled}
-                  size="s"
-                  color="text"
-                >
-                  {labels.skipAllButton}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            )}
-            {currentIndex > 0 && (
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  onClick={handleBack}
-                  disabled={isInteractionDisabled}
-                  size="s"
-                  color="text"
-                  iconType="sortLeft"
-                >
-                  {labels.backButton}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
+          <EuiButtonIcon
+            onClick={handleBack}
+            disabled={currentIndex === 0 || isInteractionDisabled}
+            iconType="arrowLeft"
+            size="s"
+            color="text"
+            display="empty"
+            aria-label={labels.backButton}
+          />
         </EuiFlexItem>
         <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiButton onClick={handleSkip} disabled={isInteractionDisabled} size="s" color="text">
-              {labels.skipButton}
+              {labels.skipQuestionButton}
+              <KeyHint>→</KeyHint>
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -375,6 +544,7 @@ export const AskUserQuestionPrompt = ({
               color="primary"
             >
               {isFinalQuestion ? labels.confirmButton : labels.continueButton}
+              <KeyHint>{CONFIRM_KEY_HINT}</KeyHint>
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt.tsx
@@ -23,7 +23,6 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { isMac } from '@kbn/shared-ux-utility';
 import {
   labels,
   containerStyles,
@@ -38,7 +37,6 @@ import type { AnswerDraft, AskUserQuestionPromptProps } from './ask_user_questio
 
 export type { AskUserQuestionPromptProps } from './ask_user_question_prompt_utils';
 
-const CONFIRM_KEY_HINT = isMac ? '⌘↵' : 'Ctrl↵';
 const HANDLED_DIGIT_KEY = /^[1-9]$/;
 
 /** True when the focused element can accept keyboard input — we don't steal those keys. */
@@ -55,10 +53,14 @@ const KeyHint = ({ children }: { children: React.ReactNode }) => {
     <span
       aria-hidden="true"
       css={css`
+        display: inline-flex;
+        align-items: center;
+        height: 1em;
+        vertical-align: middle;
         margin-left: ${euiTheme.size.xs};
         color: inherit;
         opacity: 0.7;
-        font-size: 11px;
+        font-size: ${euiTheme.font.scale.m * euiTheme.base}px;
         font-family: ${euiTheme.font.familyCode};
       `}
     >
@@ -284,13 +286,8 @@ export const AskUserQuestionPrompt = ({
       // can't receive input, so they don't block shortcuts.
       if (!isCustomInputFocused && isLiveTextEntry(active)) return;
 
-      // Cmd/Ctrl+Enter and Escape fire even while typing in the custom input.
-      if (event.key === 'Enter' && (isMac ? event.metaKey : event.ctrlKey)) {
-        event.preventDefault();
-        h.handleConfirm();
-        return;
-      }
-
+      // Escape fires even while typing in the custom input.
+      // Might be revisited when when decide to enable the STOP button in the chat input during HITL
       if (event.key === 'Escape') {
         event.preventDefault();
         h.handleSkipAll();
@@ -430,7 +427,13 @@ export const AskUserQuestionPrompt = ({
                 {/* Badge positioned over the card so it doesn't pollute the
                       label's text content (would break getByLabelText). */}
                 <div aria-hidden="true" css={optionBadgeAnchorStyles}>
-                  <EuiNotificationBadge size="s" color="subdued">
+                  <EuiNotificationBadge
+                    size="s"
+                    color="subdued"
+                    css={css`
+                      padding-inline: ${euiTheme.size.xs};
+                    `}
+                  >
                     {optionIndex + 1}
                   </EuiNotificationBadge>
                 </div>
@@ -489,6 +492,7 @@ export const AskUserQuestionPrompt = ({
                   aria-hidden="true"
                   css={css`
                     margin-right: ${euiTheme.size.base};
+                    padding-inline: ${euiTheme.size.xs};
                   `}
                 >
                   {currentQuestion.options.length + 1}
@@ -520,8 +524,8 @@ export const AskUserQuestionPrompt = ({
           <EuiButtonIcon
             onClick={handleBack}
             disabled={currentIndex === 0 || isInteractionDisabled}
-            iconType="arrowLeft"
-            size="s"
+            iconType="sortLeft"
+            size="m"
             color="text"
             display="empty"
             aria-label={labels.backButton}
@@ -529,9 +533,15 @@ export const AskUserQuestionPrompt = ({
         </EuiFlexItem>
         <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={handleSkip} disabled={isInteractionDisabled} size="s" color="text">
+            <EuiButton
+              onClick={handleSkip}
+              disabled={isInteractionDisabled}
+              size="s"
+              color="text"
+              iconType="sortRight"
+              iconSide="right"
+            >
               {labels.skipQuestionButton}
-              <KeyHint>→</KeyHint>
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -544,7 +554,7 @@ export const AskUserQuestionPrompt = ({
               color="primary"
             >
               {isFinalQuestion ? labels.confirmButton : labels.continueButton}
-              <KeyHint>{CONFIRM_KEY_HINT}</KeyHint>
+              <KeyHint>↵</KeyHint>
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_prompt/ask_user_question_prompt_utils.ts
@@ -45,12 +45,12 @@ export const labels = {
   backButton: i18n.translate('xpack.agentBuilder.askUserQuestionPrompt.backButton', {
     defaultMessage: 'Back',
   }),
-  skipButton: i18n.translate('xpack.agentBuilder.askUserQuestionPrompt.skipButton', {
-    defaultMessage: 'Skip',
-  }),
-  skipAllButton: i18n.translate('xpack.agentBuilder.askUserQuestionPrompt.skipAllButton', {
-    defaultMessage: 'Skip all',
-  }),
+  skipQuestionButton: i18n.translate(
+    'xpack.agentBuilder.askUserQuestionPrompt.skipQuestionButton',
+    {
+      defaultMessage: 'Skip question',
+    }
+  ),
   confirmButton: i18n.translate('xpack.agentBuilder.askUserQuestionPrompt.confirmButton', {
     defaultMessage: 'Submit',
   }),
@@ -67,14 +67,29 @@ export const labels = {
 
 export const optionCardStyles = ({ euiTheme }: UseEuiTheme) => css`
   border-radius: ${euiTheme.border.radius.medium};
+  /* The checkbox panel (subdued/primary) must stretch to the full card height,
+     so its background covers the description row as well. align-self: stretch
+     beats height: 100% here — the outer SplitPanel has no fixed height, so
+     percent heights collapse to auto and leave the panel content-sized. */
   .euiSplitPanel__inner.euiPanel--subdued,
   .euiSplitPanel__inner.euiPanel--primary {
     display: flex;
     align-items: center;
-    height: 100%;
+    align-self: stretch;
   }
   .euiCheckableCard__children {
     margin-block-start: 2px;
+  }
+  /* No focus ring on answer cards — the kbd number hint is the only nav indicator. */
+  &:focus,
+  &:focus-within {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+  input:focus,
+  input:focus-visible {
+    outline: none !important;
+    box-shadow: none !important;
   }
 `;
 


### PR DESCRIPTION
## Summary

- Replace custom `<kbd>` number hints with `EuiNotificationBadge` (`color="subdued"`, `size="s"`) per the updated design spec
- Remove the **Skip All** button (ESC keyboard shortcut still triggers skip-all); replace with a persistent `EuiButtonIcon` Back arrow — always visible, disabled only on question 1
- Rename **Skip** → **Skip question** to clarify the action
- Apply `euiTheme.font.familyCode` (mono) to inline key hints (`→`, `⌘↵`) in action buttons

## Screenshots

> ⚠️ The feature branch server wasn't running during PR creation. Before/after screenshots to be added manually after local verification.

| Before | After |
|--------|-------|
| _paste before screenshot_ | _paste after screenshot_ |

## References

Closes elastic/search-team#15047

🤖 Generated with [Claude Code](https://claude.com/claude-code)