### PR TITLE
[9.4] Fix `@elastic/eui/require-aria-label-for-modals` lint violations across `@elastic/actionable-obs-team` files (#273783)

### DIFF
--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/series_color_picker.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/series_color_picker.tsx
@@ -48,7 +48,14 @@ export function SeriesColorPicker({ seriesId, series }: { seriesId: number; seri
   );
 
   return (
-    <EuiPopover button={button} isOpen={isOpen} closePopover={() => setIsOpen(false)}>
+    <EuiPopover
+      aria-label={i18n.translate('xpack.exploratoryView.seriesColorPicker.popoverAriaLabel', {
+        defaultMessage: 'Pick a color',
+      })}
+      button={button}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+    >
       <EuiFormRow label={PICK_A_COLOR_LABEL}>
         <EuiColorPicker onChange={onChange} color={color} />
       </EuiFormRow>

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/url_search/selectable_url_list.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/url_search/selectable_url_list.tsx
@@ -20,6 +20,7 @@ import {
   EuiSelectable,
   EuiSelectableMessage,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import useEvent from 'react-use/lib/useEvent';
@@ -73,6 +74,7 @@ export function SelectableUrlList({
 }: SelectableUrlListProps) {
   const [searchRef, setSearchRef] = useState<HTMLInputElement | null>(null);
 
+  const selectableUrlListPopoverTitleId = useGeneratedHtmlId();
   const titleRef = useRef<HTMLDivElement>(null);
 
   const formattedOptions = formatOptions(data.items ?? []);
@@ -124,7 +126,7 @@ export function SelectableUrlList({
 
   function PopOverTitle() {
     return (
-      <EuiPopoverTitle paddingSize="s">
+      <EuiPopoverTitle id={selectableUrlListPopoverTitleId} paddingSize="s">
         <EuiFlexGroup ref={titleRef} gutterSize="xs">
           <EuiFlexItem style={{ justifyContent: 'center' }}>
             {loading ? <EuiLoadingSpinner /> : titleText}
@@ -181,6 +183,7 @@ export function SelectableUrlList({
     >
       {(list, search) => (
         <EuiPopover
+          aria-labelledby={selectableUrlListPopoverTitleId}
           panelPaddingSize="none"
           isOpen={popoverIsOpen}
           display={'block'}

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/header/embed_action.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/header/embed_action.tsx
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiPopover, EuiCodeBlock, EuiPopoverTitle } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiPopover,
+  EuiCodeBlock,
+  EuiPopoverTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
@@ -17,6 +23,7 @@ export function EmbedAction({
   lensAttributes: TypedLensByValueInput['attributes'] | null;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const embedActionPopoverTitleId = useGeneratedHtmlId();
 
   const { reportType, allSeries } = useSeriesStorage();
 
@@ -34,8 +41,13 @@ export function EmbedAction({
   );
 
   return (
-    <EuiPopover button={button} isOpen={isOpen} closePopover={() => setIsOpen(false)}>
-      <EuiPopoverTitle>{EMBED_TITLE_LABEL}</EuiPopoverTitle>
+    <EuiPopover
+      aria-labelledby={embedActionPopoverTitleId}
+      button={button}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+    >
+      <EuiPopoverTitle id={embedActionPopoverTitleId}>{EMBED_TITLE_LABEL}</EuiPopoverTitle>
       <EuiCodeBlock
         language="jsx"
         fontSize="m"

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/chart_type_select.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/chart_type_select.tsx
@@ -36,6 +36,9 @@ export function SeriesChartTypes({ seriesId, series, seriesConfig }: Props) {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.exploratoryView.seriesChartTypes.popoverAriaLabel', {
+        defaultMessage: 'Edit chart type for series',
+      })}
       isOpen={isPopoverOpen}
       closePopover={() => setIsPopoverOpen(false)}
       button={

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/data_type_select.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/data_type_select.tsx
@@ -63,6 +63,9 @@ export function DataTypesSelect({ seriesId, series }: Props) {
     <>
       {!series.dataType && (
         <EuiPopover
+          aria-label={i18n.translate('xpack.exploratoryView.dataTypesSelect.popoverAriaLabel', {
+            defaultMessage: 'Select data type',
+          })}
           button={
             <EuiButton
               data-test-subj="o11yDataTypesSelectButton"

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/filter_expanded.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/filter_expanded.tsx
@@ -8,6 +8,7 @@
 import React, { useState } from 'react';
 
 import { EuiFilterButton, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { SeriesConfig, SeriesUrl } from '../../types';
 import { useFilterValues } from '../use_filter_values';
 import { FilterValuesList } from '../components/filter_values_list';
@@ -36,6 +37,9 @@ export function FilterExpanded(props: FilterProps) {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.exploratoryView.filterExpanded.popoverAriaLabel', {
+        defaultMessage: 'Filter options',
+      })}
       button={
         <EuiFilterButton
           onClick={() => setIsOpen((prevState) => !prevState)}

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/series_actions.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/series_actions.tsx
@@ -99,6 +99,9 @@ export function SeriesActions({ seriesId, series, seriesConfig, onEditClick }: P
 
       <EuiFlexItem grow={false}>
         <EuiPopover
+          aria-label={i18n.translate('xpack.exploratoryView.seriesActions.popoverAriaLabel', {
+            defaultMessage: 'Series actions',
+          })}
           button={popoverButton}
           isOpen={isPopoverOpen}
           closePopover={closePopover}

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/components/labels_filter.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/components/labels_filter.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopover,
   EuiIcon,
   EuiButtonEmpty,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { EuiSelectable } from '@elastic/eui';
@@ -25,6 +26,7 @@ import { useFilterValues } from '../use_filter_values';
 
 export function LabelsFieldFilter(props: FilterProps) {
   const { series } = props;
+  const labelsFilterPopoverTitleId = useGeneratedHtmlId();
 
   const [query, setQuery] = useState('');
 
@@ -73,10 +75,22 @@ export function LabelsFieldFilter(props: FilterProps) {
   };
 
   return (
-    <EuiPopover button={button} closePopover={closePopover} isOpen={isPopoverOpen}>
+    <EuiPopover
+      aria-label={
+        selectedLabel
+          ? undefined
+          : i18n.translate('xpack.exploratoryView.labelsFieldFilter.popoverAriaLabel', {
+              defaultMessage: 'Select label field',
+            })
+      }
+      aria-labelledby={selectedLabel ? labelsFilterPopoverTitleId : undefined}
+      button={button}
+      closePopover={closePopover}
+      isOpen={isPopoverOpen}
+    >
       {selectedLabel ? (
         <>
-          <EuiPopoverTitle>
+          <EuiPopoverTitle id={labelsFilterPopoverTitleId}>
             <EuiButtonEmpty
               data-test-subj="o11yLabelsFieldFilterButton"
               iconType="chevronSingleLeft"

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/report_metric_options.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/report_metric_options.tsx
@@ -105,6 +105,9 @@ export function ReportMetricOptions({ seriesId, series, seriesConfig }: Props) {
     <>
       {!series.selectedMetricField && (
         <EuiPopover
+          aria-label={i18n.translate('xpack.exploratoryView.reportMetricOptions.popoverAriaLabel', {
+            defaultMessage: 'Select report metric',
+          })}
           button={
             <EuiButton
               data-test-subj="o11yReportMetricOptionsButton"

--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/closable_popover_title.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/closable_popover_title.tsx
@@ -17,12 +17,13 @@ import {
 
 interface ClosablePopoverTitleProps {
   children: JSX.Element;
+  id?: string;
   onClose: () => void;
 }
 
-export function ClosablePopoverTitle({ children, onClose }: ClosablePopoverTitleProps) {
+export function ClosablePopoverTitle({ children, id, onClose }: ClosablePopoverTitleProps) {
   return (
-    <EuiPopoverTitle>
+    <EuiPopoverTitle id={id}>
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem>{children}</EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/custom_equation/custom_equation_editor.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/custom_equation/custom_equation_editor.tsx
@@ -15,6 +15,7 @@ import {
   EuiSpacer,
   EuiExpression,
   EuiPopover,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { range, first, xor, debounce } from 'lodash';
@@ -65,6 +66,7 @@ export function CustomEquationEditor({
     expression?.metrics ?? [NEW_METRIC]
   );
   const [customEqPopoverOpen, setCustomEqPopoverOpen] = useState(false);
+  const customEquationPopoverTitleId = useGeneratedHtmlId();
   const [equation, setEquation] = useState<string | undefined>(expression?.equation);
   const debouncedOnChange = useMemo(() => debounce(onChange, 500), [onChange]);
 
@@ -215,9 +217,13 @@ export function CustomEquationEditor({
           ownFocus
           anchorPosition={'downLeft'}
           repositionOnScroll
+          aria-labelledby={customEquationPopoverTitleId}
         >
           <div>
-            <ClosablePopoverTitle onClose={() => setCustomEqPopoverOpen(false)}>
+            <ClosablePopoverTitle
+              id={customEquationPopoverTitleId}
+              onClose={() => setCustomEqPopoverOpen(false)}
+            >
               <span>
                 <FormattedMessage
                   id="xpack.observability.customThreshold.rule.alertFlyout.customEquationLabel"

--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
@@ -14,6 +14,7 @@ import {
   EuiFormRow,
   EuiPopover,
   EuiSelect,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { DataViewBase } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
@@ -62,6 +63,7 @@ export function MetricRowWithAgg({
   }, [name, onDelete]);
 
   const [aggTypePopoverOpen, setAggTypePopoverOpen] = useState(false);
+  const aggTypePopoverTitleId = useGeneratedHtmlId();
 
   const fieldOptions = useMemo(
     () =>
@@ -184,9 +186,13 @@ export function MetricRowWithAgg({
           ownFocus
           anchorPosition={'downLeft'}
           repositionOnScroll
+          aria-labelledby={aggTypePopoverTitleId}
         >
           <div>
-            <ClosablePopoverTitle onClose={() => setAggTypePopoverOpen(false)}>
+            <ClosablePopoverTitle
+              id={aggTypePopoverTitleId}
+              onClose={() => setAggTypePopoverOpen(false)}
+            >
               <FormattedMessage
                 id="xpack.observability.customThreshold.rule.alertFlyout.customEquationEditor.aggregationLabel"
                 defaultMessage="Aggregation {name}"

--- a/x-pack/solutions/observability/plugins/slo/public/components/burn_rate_rule_editor/dependency_editor.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/burn_rate_rule_editor/dependency_editor.tsx
@@ -136,7 +136,14 @@ export function DependencyEditor({
   );
 
   return (
-    <EuiPopover button={button} isOpen={isOpen} closePopover={handleSubmit}>
+    <EuiPopover
+      aria-label={i18n.translate('xpack.slo.dependencyEditor.popoverAriaLabel', {
+        defaultMessage: 'Dependency editor',
+      })}
+      button={button}
+      isOpen={isOpen}
+      closePopover={handleSubmit}
+    >
       <div style={{ width: 400 }}>
         <EuiForm component="form">
           <EuiFormRow

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/header_control.tsx
@@ -211,6 +211,9 @@ export function HeaderControl({ slo }: Props) {
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate('xpack.slo.sloDetailsHeaderControl.popoverAriaLabel', {
+          defaultMessage: 'SLO details actions',
+        })}
         data-test-subj="sloDetailsHeaderControlPopover"
         button={
           <EuiButton

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/header_control/header_control.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/header_control/header_control.tsx
@@ -36,6 +36,9 @@ export function HeaderControl() {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.slo.sloManagementHeaderControl.popoverAriaLabel', {
+        defaultMessage: 'SLO management actions',
+      })}
       data-test-subj="headerControlPopover"
       button={
         <EuiButton

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_definitions/slo_management_bulk_actions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_definitions/slo_management_bulk_actions.tsx
@@ -87,6 +87,9 @@ export function SloManagementBulkActions({ items, setSelectedItems }: Props) {
   return (
     <EuiPopover
       id={popoverId}
+      aria-label={i18n.translate('xpack.slo.sloManagementBulkActions.popoverAriaLabel', {
+        defaultMessage: 'Bulk actions for selected SLOs',
+      })}
       panelPaddingSize="none"
       button={
         <EuiButtonEmpty

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/card_view/slo_card_item_instance_badge.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/card_view/slo_card_item_instance_badge.tsx
@@ -27,6 +27,9 @@ export function SLOCardItemInstanceBadge({ slo }: Props) {
   return (
     <EuiFlexItem grow={false}>
       <EuiPopover
+        aria-label={i18n.translate('xpack.slo.sloCardItemInstanceBadge.popoverAriaLabel', {
+          defaultMessage: 'All instance IDs',
+        })}
         isOpen={isPopoverOpen}
         button={
           <EuiBadge

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/create_slo_btn.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/create_slo_btn.tsx
@@ -59,6 +59,9 @@ export function CreateSloBtn() {
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate('xpack.slo.createSloBtn.popoverAriaLabel', {
+          defaultMessage: 'Create SLO options',
+        })}
         button={
           <EuiButton
             color="primary"

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.tsx
@@ -180,6 +180,9 @@ export function SloItemActions({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.slo.sloItemActions.popoverAriaLabel', {
+        defaultMessage: 'SLO item actions',
+      })}
       anchorPosition="downLeft"
       button={btnProps ? <IconPanel>{btn}</IconPanel> : btn}
       panelPaddingSize="m"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/field_popover_expression.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/field_popover_expression.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import type { EuiExpressionProps } from '@elastic/eui';
 import { EuiExpression, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { ALL_VALUE } from '@kbn/slo-schema';
 import { isEmpty } from 'lodash';
 import { allOptionText } from './fields';
@@ -68,6 +69,9 @@ export function FieldPopoverExpression({
           />
         }
         repositionOnScroll
+        aria-label={i18n.translate('xpack.synthetics.fieldPopoverExpression.popoverAriaLabel', {
+          defaultMessage: 'Field selection options',
+        })}
       >
         <div style={{ width: 300 }}>{children}</div>
       </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/for_the_last_expression.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/for_the_last_expression.tsx
@@ -4,7 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiExpression, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
+import {
+  EuiExpression,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { StatusRuleCondition } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
@@ -90,6 +96,7 @@ export const ForTheLastExpression = ({ ruleParams, setRuleParams }: Props) => {
   const { useTimeWindow } = getConditionType(condition);
 
   const [isOpen, setIsOpen] = useState(false);
+  const forTheLastPopoverTitleId = useGeneratedHtmlId();
 
   const [options, setOptions] = useState<Option[]>(OPTIONS);
 
@@ -130,6 +137,7 @@ export const ForTheLastExpression = ({ ruleParams, setRuleParams }: Props) => {
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}
       anchorPosition="downLeft"
+      aria-labelledby={forTheLastPopoverTitleId}
     >
       <EuiSelectable<Option>
         singleSelection="always"
@@ -156,7 +164,7 @@ export const ForTheLastExpression = ({ ruleParams, setRuleParams }: Props) => {
       >
         {(list) => (
           <div style={{ width: 240 }}>
-            <EuiPopoverTitle>
+            <EuiPopoverTitle id={forTheLastPopoverTitleId}>
               {i18n.translate('xpack.synthetics.forTheLastExpression.whenPopoverTitleLabel', {
                 defaultMessage: 'When',
               })}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/popover_expression.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/popover_expression.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { EuiExpressionProps } from '@elastic/eui';
 import { EuiExpression, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 interface Props {
   title?: ReactNode;
@@ -36,6 +37,9 @@ export function PopoverExpression(props: Props) {
         />
       }
       repositionOnScroll
+      aria-label={i18n.translate('xpack.synthetics.popoverExpression.popoverAriaLabel', {
+        defaultMessage: 'Popover expression options',
+      })}
     >
       {children}
     </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/rule_viz.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/rule_viz.tsx
@@ -16,6 +16,7 @@ import {
   EuiPopoverTitle,
   EuiSpacer,
   EuiToolTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useSelector, useDispatch } from 'react-redux';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -36,6 +37,7 @@ export const RuleViz = ({ dispatchedAction }: { dispatchedAction: PayloadAction<
   } = useKibana<ClientPluginsStart>();
 
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+  const ruleVizPopoverTitleId = useGeneratedHtmlId();
 
   const { inspectorAdapters, addInspectorRequest } = useInspectorContext();
 
@@ -96,8 +98,9 @@ export const RuleViz = ({ dispatchedAction }: { dispatchedAction: PayloadAction<
                 </EuiButtonEmpty>
               )
             }
+            aria-labelledby={ruleVizPopoverTitleId}
           >
-            <EuiPopoverTitle>
+            <EuiPopoverTitle id={ruleVizPopoverTitleId}>
               {i18n.translate('xpack.synthetics.statusRuleViz.monitorsPopoverTitleLabel', {
                 defaultMessage: 'Monitors',
               })}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/toggle_alert_flyout_button.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/toggle_alert_flyout_button.tsx
@@ -148,6 +148,9 @@ export const ToggleAlertFlyoutButton = () => {
         isOpen={isOpen}
         ownFocus
         panelPaddingSize="none"
+        aria-label={i18n.translate('xpack.synthetics.toggleAlertFlyoutButton.popoverAriaLabel', {
+          defaultMessage: 'Alerts and rules menu',
+        })}
       >
         <EuiContextMenu initialPanelId={0} panels={panels} />
       </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
@@ -163,6 +163,9 @@ export const AddToDashboard = ({
           }
           isOpen={isPopoverOpen}
           closePopover={closePopover}
+          aria-label={i18n.translate('xpack.synthetics.addToDashboard.popoverAriaLabel', {
+            defaultMessage: 'Add to dashboard menu',
+          })}
         >
           <EuiContextMenuPanel
             size="s"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_location_select.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_location_select.tsx
@@ -114,6 +114,9 @@ export const MonitorLocationSelect = ({
           isOpen={isLocationListOpen}
           closePopover={closeLocationList}
           panelPaddingSize="none"
+          aria-label={i18n.translate('xpack.synthetics.monitorLocationSelect.popoverAriaLabel', {
+            defaultMessage: 'Location selection menu',
+          })}
         >
           <EuiContextMenuPanel
             items={menuItems}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/journey_screenshot_preview.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/journey_screenshot_preview.tsx
@@ -117,6 +117,9 @@ export const JourneyScreenshotPreview: React.FC<StepImagePopoverProps> = ({
         anchorPosition="leftDown"
         button={renderScreenshotImage(size)}
         isOpen={isImagePopoverOpen}
+        aria-label={i18n.translate('xpack.synthetics.journeyScreenshotPreview.popoverAriaLabel', {
+          defaultMessage: 'Screenshot preview',
+        })}
       >
         {renderScreenshotImage(POPOVER_SCREENSHOT_SIZE)}
       </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/actions.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/actions.tsx
@@ -34,6 +34,9 @@ export function Actions() {
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}
+      aria-label={i18n.translate('xpack.synthetics.monitorDetails.actions.popoverAriaLabel', {
+        defaultMessage: 'Monitor actions menu',
+      })}
     >
       <EuiContextMenuPanel
         size="m"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_selector/monitor_selector.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_selector/monitor_selector.tsx
@@ -6,12 +6,19 @@
  */
 
 import React, { Fragment, useState } from 'react';
-import { EuiButtonIcon, EuiPopover, EuiPopoverTitle, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { MonitorSearchableList } from './monitor_searchable_list';
 
 export const MonitorSelector = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const monitorSelectorPopoverTitleId = useGeneratedHtmlId();
 
   const onButtonClick = () => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -41,8 +48,11 @@ export const MonitorSelector = () => {
         button={button}
         isOpen={isPopoverOpen}
         closePopover={closePopover}
+        aria-labelledby={monitorSelectorPopoverTitleId}
       >
-        <EuiPopoverTitle paddingSize="s">{GO_TO_MONITOR}</EuiPopoverTitle>
+        <EuiPopoverTitle id={monitorSelectorPopoverTitleId} paddingSize="s">
+          {GO_TO_MONITOR}
+        </EuiPopoverTitle>
         <MonitorSearchableList closePopover={closePopover} />
       </EuiPopover>
     </Fragment>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/alert_actions.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/alert_actions.tsx
@@ -95,6 +95,9 @@ export const AlertActions = ({ from, to }: { from: string; to: string }) => {
       closePopover={() => setPopover(false)}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate('xpack.synthetics.alertActions.popoverAriaLabel', {
+        defaultMessage: 'Alert actions menu',
+      })}
     >
       <EuiContextMenuPanel size="s" items={items} />
     </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/show_all_spaces.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/show_all_spaces.tsx
@@ -109,6 +109,9 @@ const SelectablePopover = ({ space }: { space: Space }) => {
       closePopover={() => setIsPopoverOpen(false)}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate('xpack.synthetics.showAllSpaces.popoverAriaLabel', {
+        defaultMessage: 'Spaces menu',
+      })}
     >
       <EuiContextMenu
         initialPanelId={0}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -352,6 +352,9 @@ export function ActionsPopover({
           closePopover={() => setIsPopoverOpen(false)}
           anchorPosition="rightUp"
           panelPaddingSize="none"
+          aria-label={i18n.translate('xpack.synthetics.actionsPopover.popoverAriaLabel', {
+            defaultMessage: 'Actions menu',
+          })}
         >
           <EuiContextMenu
             initialPanelId={0}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/grid_by_group/group_menu.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/grid_by_group/group_menu.tsx
@@ -16,6 +16,7 @@ import {
   EuiText,
   EuiHorizontalRule,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { GROUP_TITLE } from './group_fields';
 import { ORDER_BY_TITLE } from '../sort_menu';
 
@@ -92,6 +93,9 @@ export const GroupMenu = ({ groupOptions, orderByOptions, groupField }: Props) =
       closePopover={closePopover}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate('xpack.synthetics.groupMenu.popoverAriaLabel', {
+        defaultMessage: 'Group options',
+      })}
     >
       <EuiContextMenuPanel size="s" items={items} style={{ minWidth: 160 }} />
     </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_icon.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_icon.tsx
@@ -21,6 +21,7 @@ import {
   EuiSpacer,
   EuiSkeletonText,
   EuiIconTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from '@emotion/styled';
@@ -75,6 +76,7 @@ export const MetricItemIcon = ({
 
   const formatter = useDateFormat();
   const testTime = formatter(timestamp);
+  const metricItemPopoverTitleId = useGeneratedHtmlId();
 
   if (inProgress) {
     return (
@@ -121,8 +123,9 @@ export const MetricItemIcon = ({
           panelStyle={{
             outline: 'none',
           }}
+          aria-labelledby={metricItemPopoverTitleId}
         >
-          <EuiPopoverTitle>
+          <EuiPopoverTitle id={metricItemPopoverTitleId}>
             <EuiFlexGroup>
               <EuiFlexItem grow>{testTime}</EuiFlexItem>
               <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/sort_menu.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/sort_menu.tsx
@@ -89,6 +89,9 @@ export const SortMenu = ({ sortOptions, orderOptions, sortField }: Props) => {
       closePopover={closePopover}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate('xpack.synthetics.sortMenu.popoverAriaLabel', {
+        defaultMessage: 'Sort options',
+      })}
     >
       <EuiContextMenuPanel size="s" items={items} style={{ minWidth: 160 }} />
     </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/unhealthy_count_badge.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/unhealthy_count_badge.tsx
@@ -52,6 +52,9 @@ export const UnhealthyCountBadge = ({ item }: { item: { id: string; label: strin
         button={badge}
         isOpen={isPopoverOpen}
         closePopover={() => setIsPopoverOpen(false)}
+        aria-label={i18n.translate('xpack.synthetics.unhealthyCountBadge.popoverAriaLabel', {
+          defaultMessage: 'Unhealthy monitors details',
+        })}
       >
         <EuiText size="s">
           <FormattedMessage

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
@@ -50,7 +50,14 @@ export const ViewLocationMonitors = ({
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      aria-label={i18n.translate('xpack.synthetics.viewLocationMonitors.popoverAriaLabel', {
+        defaultMessage: 'Location monitors details',
+      })}
+    >
       {count > 0 ? (
         <GreaterThanZeroMessage count={count} name={formattedLocationName} />
       ) : (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_metrics/definitions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_metrics/definitions_popover.tsx
@@ -6,7 +6,13 @@
  */
 
 import React, { useState } from 'react';
-import { EuiPopover, EuiPopoverTitle, EuiButtonEmpty, EuiDescriptionList } from '@elastic/eui';
+import {
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiButtonEmpty,
+  EuiDescriptionList,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
   CLS_HELP_LABEL,
@@ -43,6 +49,7 @@ export const DefinitionsPopover = () => {
 
   const onButtonClick = () => setIsPopoverOpen((prevPopoverOpen) => !prevPopoverOpen);
   const closePopover = () => setIsPopoverOpen(false);
+  const definitionsPopoverTitleId = useGeneratedHtmlId();
 
   return (
     <EuiPopover
@@ -59,8 +66,9 @@ export const DefinitionsPopover = () => {
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       anchorPosition="rightCenter"
+      aria-labelledby={definitionsPopoverTitleId}
     >
-      <EuiPopoverTitle>{DEFINITIONS_LABEL}</EuiPopoverTitle>
+      <EuiPopoverTitle id={definitionsPopoverTitleId}>{DEFINITIONS_LABEL}</EuiPopoverTitle>
       <div style={{ width: '350px' }}>
         <EuiDescriptionList listItems={definitionList} />
       </div>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_number_nav.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_number_nav.tsx
@@ -79,6 +79,9 @@ export const StepNav = ({ stepIndex, totalSteps, handleStepHref }: Props) => {
       closePopover={closePopover}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate('xpack.synthetics.stepNav.popoverAriaLabel', {
+        defaultMessage: 'Step navigation menu',
+      })}
     >
       <EuiContextMenuPanel size="s" items={items} />
     </EuiPopover>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_page_nav.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_page_nav.tsx
@@ -98,6 +98,9 @@ export const StepPageNavigation = ({ testRunPage }: { testRunPage?: boolean }) =
           {startedAtWrapped}
         </EuiButtonEmpty>
       }
+      aria-label={i18n.translate('xpack.synthetics.stepPageNavigation.popoverAriaLabel', {
+        defaultMessage: 'Check navigation menu',
+      })}
     >
       <EuiFlexGroup alignItems="center" justifyContent="flexEnd" responsive={false}>
         <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_marker/waterfall_marker_icon.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_marker/waterfall_marker_icon.tsx
@@ -34,6 +34,9 @@ export function WaterfallMarkerIcon({ field, label }: { field: string; label: st
       panelStyle={{ paddingBottom: 0, paddingLeft: 4 }}
       zIndex={100}
       css={{ top: 4 }}
+      aria-label={i18n.translate('xpack.synthetics.waterfallMarkerIcon.popoverAriaLabel', {
+        defaultMessage: 'Waterfall marker details',
+      })}
       button={
         <EuiToolTip
           content={i18n.translate(

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/ml/manage_ml_job.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/ml/manage_ml_job.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useContext, useState } from 'react';
 
 import { EuiButton, EuiContextMenu, EuiIcon, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useSelector, useDispatch } from 'react-redux';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { CLIENT_ALERT_TYPES } from '../../../../../common/constants/uptime_alerts';
@@ -168,6 +169,9 @@ export const ManageMLJobComponent = ({ hasMLJob, onEnableJob, onJobDelete }: Pro
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate('xpack.uptime.manageMlJob.popoverAriaLabel', {
+          defaultMessage: 'Manage anomaly detection actions',
+        })}
         button={button}
         isOpen={isPopOverOpen}
         closePopover={() => setIsPopOverOpen(false)}

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/ping_list/columns/ping_timestamp/step_image_popover.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/ping_list/columns/ping_timestamp/step_image_popover.tsx
@@ -7,6 +7,7 @@
 
 import { EuiImage, EuiPopover } from '@elastic/eui';
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { LoadingImageState } from './no_image_available';
 import type { ScreenshotRefImageData } from '../../../../../../../common/runtime_types';
@@ -131,6 +132,9 @@ export const StepImagePopover: React.FC<StepImagePopoverProps> = ({
   );
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.stepImagePopover.popoverAriaLabel', {
+        defaultMessage: 'Step image preview',
+      })}
       anchorPosition="leftDown"
       button={
         <StepImageComponent

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/status_details/status_bar/monitor_redirects.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/status_details/status_bar/monitor_redirects.tsx
@@ -48,6 +48,9 @@ export const MonitorRedirects: React.FC<Props> = ({ monitorStatus }) => {
     <>
       <EuiDescriptionListTitle>Redirects</EuiDescriptionListTitle>
       <EuiPopover
+        aria-label={i18n.translate('xpack.uptime.monitorRedirects.popoverAriaLabel', {
+          defaultMessage: 'Monitor redirects details',
+        })}
         button={button}
         isOpen={isPopoverOpen}
         anchorPosition="downLeft"

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/synthetics/step_detail/waterfall/waterfall_filter.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/synthetics/step_detail/waterfall/waterfall_filter.tsx
@@ -7,6 +7,7 @@
 
 import type { Dispatch, SetStateAction } from 'react';
 import React, { useEffect, useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import {
   EuiButtonIcon,
   EuiCheckbox,
@@ -143,6 +144,9 @@ export const WaterfallFilter = ({
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiPopover
+          aria-label={i18n.translate('xpack.uptime.waterfallFilter.popoverAriaLabel', {
+            defaultMessage: 'Request filters',
+          })}
           button={
             <EuiToolTip content={FILTER_POPOVER_OPEN_LABEL} disableScreenReaderOutput>
               <EuiButtonIcon

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/synthetics/waterfall/components/waterfall_marker_icon.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/synthetics/waterfall/components/waterfall_marker_icon.tsx
@@ -27,6 +27,9 @@ export function WaterfallMarkerIcon({ field, label }: { field: string; label: st
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.waterfallMarkerIcon.popoverAriaLabel', {
+        defaultMessage: 'Waterfall marker metrics',
+      })}
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}
       anchorPosition="downLeft"

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/alert_expression_popover.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/alert_expression_popover.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiExpression, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 interface AlertExpressionPopoverProps {
   'aria-label': string;
@@ -42,6 +43,9 @@ export const AlertExpressionPopover: React.FC<AlertExpressionPopoverProps> = ({
   const [isOpen, setIsOpen] = useState<boolean>(false);
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.alertExpressionPopover.popoverAriaLabel', {
+        defaultMessage: 'Alert expression details',
+      })}
       id={id}
       anchorPosition="downLeft"
       button={

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/monitor_status_alert/add_filter_btn.test.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/monitor_status_alert/add_filter_btn.test.tsx
@@ -18,6 +18,7 @@ describe('AddFilterButton component', () => {
     expect(component).toMatchInlineSnapshot(`
       <EuiPopover
         anchorPosition="downLeft"
+        aria-label="Add alert filter options"
         button={
           <EuiButtonEmpty
             data-test-subj="uptimeCreateAlertAddFilter"
@@ -84,6 +85,7 @@ describe('AddFilterButton component', () => {
     expect(component).toMatchInlineSnapshot(`
       <EuiPopover
         anchorPosition="downLeft"
+        aria-label="Add alert filter options"
         button={
           <EuiButtonEmpty
             data-test-subj="uptimeCreateAlertAddFilter"
@@ -137,6 +139,7 @@ describe('AddFilterButton component', () => {
     expect(component).toMatchInlineSnapshot(`
       <EuiPopover
         anchorPosition="downLeft"
+        aria-label="Add alert filter options"
         button={
           <EuiButtonEmpty
             data-test-subj="uptimeCreateAlertAddFilter"

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/monitor_status_alert/add_filter_btn.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/monitor_status_alert/add_filter_btn.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiButtonEmpty, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import * as labels from '../translations';
 import { useUptimeDataView } from '../../../../contexts/uptime_data_view_context';
 
@@ -73,6 +74,9 @@ export const AddFilterButton: React.FC<Props> = ({ newFilters, onNewFilter, aler
   return (
     <EuiPopover
       id="singlePanel"
+      aria-label={i18n.translate('xpack.uptime.monitorStatusAlertAddFilter.popoverAriaLabel', {
+        defaultMessage: 'Add alert filter options',
+      })}
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/toggle_alert_flyout_button.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/alerts/toggle_alert_flyout_button.tsx
@@ -136,6 +136,9 @@ export const ToggleAlertFlyoutButtonComponent: React.FC<Props> = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.toggleAlertFlyoutButton.popoverAriaLabel', {
+        defaultMessage: 'Alerts actions',
+      })}
       button={
         <EuiHeaderLink
           color="primary"

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/columns/define_connectors.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/columns/define_connectors.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiSwitch, EuiPopover, EuiText, EuiFormRow } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ReactRouterEuiLink } from '../../../common/react_router_helpers';
 import { SETTINGS_ROUTE } from '../../../../../../common/constants';
@@ -20,6 +21,9 @@ export const DefineAlertConnectors = () => {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.monitorList.defineConnectors.popoverAriaLabel', {
+        defaultMessage: 'Default connector information',
+      })}
       button={
         <>
           <EuiFormRow>

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/monitor_list_drawer/actions_popover/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/monitor_list_drawer/actions_popover/actions_popover.tsx
@@ -31,6 +31,9 @@ export const ActionsPopoverComponent = ({
     !!popoverState && popoverState.open && popoverState.id === popoverId;
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.monitorList.actionsPopover.popoverAriaLabel', {
+        defaultMessage: 'Monitor actions',
+      })}
       button={
         <EuiButton
           aria-label={i18n.translate(

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/monitor_list_page_size_select.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/monitor_list_page_size_select.tsx
@@ -7,6 +7,7 @@
 
 import { EuiButtonEmpty, EuiContextMenuPanel, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
 import React, { useState, useEffect } from 'react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { UpdateUrlParams } from '../../../hooks';
 import { useUrlParams } from '../../../hooks';
@@ -103,6 +104,9 @@ export const MonitorListPageSizeSelectComponent: React.FC<ComponentProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.monitorList.pageSizeSelect.popoverAriaLabel', {
+        defaultMessage: 'Rows per page options',
+      })}
       button={<PopoverButton setIsOpen={(value) => setIsOpen(value)} size={size} />}
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/troubleshoot_popover.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/troubleshoot_popover.tsx
@@ -14,6 +14,7 @@ import {
   EuiPopoverTitle,
   EuiPopover,
   EuiPopoverFooter,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -30,6 +31,7 @@ export const TroubleshootPopover = () => {
   const { pingHistogram } = useSelector(selectPingHistogram);
 
   const updatedUrlParams = useUrlParams()[1];
+  const troubleshootPopoverTitleId = useGeneratedHtmlId();
 
   const histogram = pingHistogram?.histogram ?? [];
 
@@ -38,6 +40,7 @@ export const TroubleshootPopover = () => {
 
   return (
     <EuiPopover
+      aria-labelledby={troubleshootPopoverTitleId}
       button={
         <EuiButtonEmpty
           data-test-subj="syntheticsTroubleshootPopoverButton"
@@ -50,7 +53,7 @@ export const TroubleshootPopover = () => {
       closePopover={closePopover}
       anchorPosition="upCenter"
     >
-      <EuiPopoverTitle>{SYSTEM_CLOCK_OUT_OF_SYNC}</EuiPopoverTitle>
+      <EuiPopoverTitle id={troubleshootPopoverTitleId}>{SYSTEM_CLOCK_OUT_OF_SYNC}</EuiPopoverTitle>
       <div style={{ width: '300px' }}>
         <EuiText size="s">
           <p>

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/synthetics/check_steps/step_duration.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/synthetics/check_steps/step_duration.tsx
@@ -72,6 +72,9 @@ export const StepDuration = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.uptime.stepDuration.popoverAriaLabel', {
+        defaultMessage: 'Step duration trend',
+      })}
       onClick={(evt: MouseEvent<HTMLDivElement>) => evt.stopPropagation()}
       isOpen={durationPopoverOpenIndex === step.synthetics.step?.index}
       button={button}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix `@elastic/eui/require-aria-label-for-modals` lint violations across `@elastic/actionable-obs-team` files (#273783)](https://github.com/elastic/kibana/pull/273783)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-22T12:53:03Z","message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across `@elastic/actionable-obs-team` files (#273783)\n\nAdds missing accessible names to 57 `EuiPopover` instances across SLO,\nSynthetics, Uptime, Exploratory View, and Observability plugins.\n\n### Pattern applied\n\n- **Popovers with a visible `EuiPopoverTitle`**: wired `aria-labelledby`\n+ `useGeneratedHtmlId()` + `id` on the title element\n- **Popovers without a visible title**: added i18n-backed `aria-label`\n\n```tsx\n// With visible title (preferred)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId}>\n  <EuiPopoverTitle id={popoverTitleId}>Title</EuiPopoverTitle>\n</EuiPopover>\n\n// Without visible title\n<EuiPopover\n  aria-label={i18n.translate('xpack.slo.dependencyEditor.popoverAriaLabel', {\n    defaultMessage: 'Dependency editor',\n  })}\n>\n```\n\n### Scope\n\n| Plugin | Files |\n|--------|-------|\n| SLO | 8 |\n| Synthetics | 23 |\n| Uptime | 14 |\n| Exploratory View | 9 |\n| Observability (custom_threshold) | 3 |\n\nOne structural change: `ClosablePopoverTitle` now accepts an optional\n`id` prop and passes it through to `EuiPopoverTitle`, enabling\n`aria-labelledby` wiring from parent popovers.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"48d0c7c22e1787a0282dc2d22cc734eb2af3feea","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","a11y:agent-pr","v9.5.0","v9.4.3"],"title":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across `@elastic/actionable-obs-team` files","number":273783,"url":"https://github.com/elastic/kibana/pull/273783","mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across `@elastic/actionable-obs-team` files (#273783)\n\nAdds missing accessible names to 57 `EuiPopover` instances across SLO,\nSynthetics, Uptime, Exploratory View, and Observability plugins.\n\n### Pattern applied\n\n- **Popovers with a visible `EuiPopoverTitle`**: wired `aria-labelledby`\n+ `useGeneratedHtmlId()` + `id` on the title element\n- **Popovers without a visible title**: added i18n-backed `aria-label`\n\n```tsx\n// With visible title (preferred)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId}>\n  <EuiPopoverTitle id={popoverTitleId}>Title</EuiPopoverTitle>\n</EuiPopover>\n\n// Without visible title\n<EuiPopover\n  aria-label={i18n.translate('xpack.slo.dependencyEditor.popoverAriaLabel', {\n    defaultMessage: 'Dependency editor',\n  })}\n>\n```\n\n### Scope\n\n| Plugin | Files |\n|--------|-------|\n| SLO | 8 |\n| Synthetics | 23 |\n| Uptime | 14 |\n| Exploratory View | 9 |\n| Observability (custom_threshold) | 3 |\n\nOne structural change: `ClosablePopoverTitle` now accepts an optional\n`id` prop and passes it through to `EuiPopoverTitle`, enabling\n`aria-labelledby` wiring from parent popovers.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"48d0c7c22e1787a0282dc2d22cc734eb2af3feea"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273783","number":273783,"mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across `@elastic/actionable-obs-team` files (#273783)\n\nAdds missing accessible names to 57 `EuiPopover` instances across SLO,\nSynthetics, Uptime, Exploratory View, and Observability plugins.\n\n### Pattern applied\n\n- **Popovers with a visible `EuiPopoverTitle`**: wired `aria-labelledby`\n+ `useGeneratedHtmlId()` + `id` on the title element\n- **Popovers without a visible title**: added i18n-backed `aria-label`\n\n```tsx\n// With visible title (preferred)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId}>\n  <EuiPopoverTitle id={popoverTitleId}>Title</EuiPopoverTitle>\n</EuiPopover>\n\n// Without visible title\n<EuiPopover\n  aria-label={i18n.translate('xpack.slo.dependencyEditor.popoverAriaLabel', {\n    defaultMessage: 'Dependency editor',\n  })}\n>\n```\n\n### Scope\n\n| Plugin | Files |\n|--------|-------|\n| SLO | 8 |\n| Synthetics | 23 |\n| Uptime | 14 |\n| Exploratory View | 9 |\n| Observability (custom_threshold) | 3 |\n\nOne structural change: `ClosablePopoverTitle` now accepts an optional\n`id` prop and passes it through to `EuiPopoverTitle`, enabling\n`aria-labelledby` wiring from parent popovers.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"48d0c7c22e1787a0282dc2d22cc734eb2af3feea"}},{"branch":"9.4","label":"v9.4.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->