### PR TITLE
[9.4] fix(a11y): add accessible labels for no-unnamed-interactive-element violations in @elastic/kibana-management (#274610)

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/feature_states_form_field/feature_states_form_field.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/feature_states_form_field/feature_states_form_field.tsx
@@ -53,7 +53,11 @@ export const FeatureStatesFormField: FunctionComponent<Props> = ({
   };
 
   return (
-    <EuiFormRow>
+    <EuiFormRow
+      label={i18n.translate('xpack.snapshotRestore.featureStatesFormField.featureStatesLabel', {
+        defaultMessage: 'Feature states',
+      })}
+    >
       <EuiComboBox
         data-test-subj="featureStatesDropdown"
         placeholder={i18n.translate(

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
@@ -281,6 +281,10 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
           fullWidth
           data-test-subj="repositorySelect"
           disabled={policy?.isManagedPolicy && isEditing}
+          aria-label={i18n.translate(
+            'xpack.snapshotRestore.policyForm.stepLogistics.repositorySelectAriaLabel',
+            { defaultMessage: 'Repository' }
+          )}
         />
       </DisableToolTip>
     );

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_edit.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_edit.tsx
@@ -338,6 +338,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                 noSuggestions={!indexOptions.length}
                 options={indexOptions}
                 data-test-subj="indicesComboBox"
+                aria-label={i18n.translate(
+                  'xpack.watcher.sections.watchEdit.titlePanel.indicesToQueryAriaLabel',
+                  { defaultMessage: 'Indices to query' }
+                )}
                 selectedOptions={(watch.index || []).map((anIndex: string) => {
                   return {
                     label: anIndex,
@@ -409,6 +413,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                     setWatchProperty('timeField', '');
                   }
                 }}
+                aria-label={i18n.translate(
+                  'xpack.watcher.sections.watchEdit.titlePanel.timeFieldAriaLabel',
+                  { defaultMessage: 'Time field' }
+                )}
               />
             </ErrableFormRow>
           </EuiFlexItem>
@@ -580,6 +588,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                             <EuiComboBox
                               singleSelection={{ asPlainText: true }}
                               placeholder={firstFieldOption.text}
+                              aria-label={i18n.translate(
+                                'xpack.watcher.sections.watchEdit.threshold.aggFieldAriaLabel',
+                                { defaultMessage: 'Aggregation field' }
+                              )}
                               options={esFields.reduce((esFieldOptions: any[], field: any) => {
                                 if (
                                   aggTypes[watch.aggType].validNormalizedTypes.includes(
@@ -714,6 +726,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                             >
                               <EuiSelect
                                 value={watch.termField || ''}
+                                aria-label={i18n.translate(
+                                  'xpack.watcher.sections.watchEdit.threshold.termFieldAriaLabel',
+                                  { defaultMessage: 'Group by field' }
+                                )}
                                 onChange={(e) => {
                                   setWatchProperty('termField', e.target.value);
                                 }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(a11y): add accessible labels for no-unnamed-interactive-element violations in @elastic/kibana-management (#274610)](https://github.com/elastic/kibana/pull/274610)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-06-24T07:37:15Z","message":"fix(a11y): add accessible labels for no-unnamed-interactive-element violations in @elastic/kibana-management (#274610)\n\n## Summary\n\nFixes 7 ESLint violations of\n`@elastic/eui/no-unnamed-interactive-element` across 4 files for team\n`@elastic/kibana-management`.\n\n## Changes\n\n- **console/output_filter_row.tsx** — Added `aria-label` to `EuiSelect`\n(filter mode picker, outside any form row) and `aria-label` to\n`EuiFormRow` (expression input has no visible label)\n- **snapshot_restore/feature_states_form_field.tsx** — Added `label`\nprop to `EuiFormRow`; this also fixes the `EuiComboBox` violation since\nit is a direct child of the now-labeled row\n- **snapshot_restore/step_logistics.tsx** — Added `aria-label` to\n`EuiSelect` inside `DisableToolTip`; the intermediate wrapper component\nbreaks the automatic label association from the parent `EuiFormRow`\n- **watcher/threshold_watch_edit.tsx** — Added `aria-label` to\n`EuiComboBox` (indices, aggField) and `EuiSelect` (timeField, termField)\ninside `ErrableFormRow`; the custom wrapper is not recognised by the\nlint rule as a labelled form row\n\n## Accessibility playbook\n\n- Read and applied\n[`.agents/skills/accessibility/SKILL.md`](../../.agents/skills/accessibility/SKILL.md)\n✅\n- For controls inside `EuiFormRow` (direct child): the row supplies the\nname — no redundant `aria-*` added ✅\n- For controls behind intermediate wrappers (`DisableToolTip`,\n`ErrableFormRow`): added `aria-label` with text matching the visible\nlabel, since the lint rule (and browser label association) cannot see\nthrough custom wrapper components ✅\n- All translations use `i18n.translate` with unique keys and\n`defaultMessage` ✅\n\n## PR checklist\n\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](../../.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCloses #274598\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"747f02e40b4fcc68694d78989ed81797253ef9fd","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","backport:version","a11y:agent-pr","v9.5.0","v9.4.4"],"title":"fix(a11y): add accessible labels for no-unnamed-interactive-element violations in @elastic/kibana-management","number":274610,"url":"https://github.com/elastic/kibana/pull/274610","mergeCommit":{"message":"fix(a11y): add accessible labels for no-unnamed-interactive-element violations in @elastic/kibana-management (#274610)\n\n## Summary\n\nFixes 7 ESLint violations of\n`@elastic/eui/no-unnamed-interactive-element` across 4 files for team\n`@elastic/kibana-management`.\n\n## Changes\n\n- **console/output_filter_row.tsx** — Added `aria-label` to `EuiSelect`\n(filter mode picker, outside any form row) and `aria-label` to\n`EuiFormRow` (expression input has no visible label)\n- **snapshot_restore/feature_states_form_field.tsx** — Added `label`\nprop to `EuiFormRow`; this also fixes the `EuiComboBox` violation since\nit is a direct child of the now-labeled row\n- **snapshot_restore/step_logistics.tsx** — Added `aria-label` to\n`EuiSelect` inside `DisableToolTip`; the intermediate wrapper component\nbreaks the automatic label association from the parent `EuiFormRow`\n- **watcher/threshold_watch_edit.tsx** — Added `aria-label` to\n`EuiComboBox` (indices, aggField) and `EuiSelect` (timeField, termField)\ninside `ErrableFormRow`; the custom wrapper is not recognised by the\nlint rule as a labelled form row\n\n## Accessibility playbook\n\n- Read and applied\n[`.agents/skills/accessibility/SKILL.md`](../../.agents/skills/accessibility/SKILL.md)\n✅\n- For controls inside `EuiFormRow` (direct child): the row supplies the\nname — no redundant `aria-*` added ✅\n- For controls behind intermediate wrappers (`DisableToolTip`,\n`ErrableFormRow`): added `aria-label` with text matching the visible\nlabel, since the lint rule (and browser label association) cannot see\nthrough custom wrapper components ✅\n- All translations use `i18n.translate` with unique keys and\n`defaultMessage` ✅\n\n## PR checklist\n\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](../../.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCloses #274598\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"747f02e40b4fcc68694d78989ed81797253ef9fd"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274610","number":274610,"mergeCommit":{"message":"fix(a11y): add accessible labels for no-unnamed-interactive-element violations in @elastic/kibana-management (#274610)\n\n## Summary\n\nFixes 7 ESLint violations of\n`@elastic/eui/no-unnamed-interactive-element` across 4 files for team\n`@elastic/kibana-management`.\n\n## Changes\n\n- **console/output_filter_row.tsx** — Added `aria-label` to `EuiSelect`\n(filter mode picker, outside any form row) and `aria-label` to\n`EuiFormRow` (expression input has no visible label)\n- **snapshot_restore/feature_states_form_field.tsx** — Added `label`\nprop to `EuiFormRow`; this also fixes the `EuiComboBox` violation since\nit is a direct child of the now-labeled row\n- **snapshot_restore/step_logistics.tsx** — Added `aria-label` to\n`EuiSelect` inside `DisableToolTip`; the intermediate wrapper component\nbreaks the automatic label association from the parent `EuiFormRow`\n- **watcher/threshold_watch_edit.tsx** — Added `aria-label` to\n`EuiComboBox` (indices, aggField) and `EuiSelect` (timeField, termField)\ninside `ErrableFormRow`; the custom wrapper is not recognised by the\nlint rule as a labelled form row\n\n## Accessibility playbook\n\n- Read and applied\n[`.agents/skills/accessibility/SKILL.md`](../../.agents/skills/accessibility/SKILL.md)\n✅\n- For controls inside `EuiFormRow` (direct child): the row supplies the\nname — no redundant `aria-*` added ✅\n- For controls behind intermediate wrappers (`DisableToolTip`,\n`ErrableFormRow`): added `aria-label` with text matching the visible\nlabel, since the lint rule (and browser label association) cannot see\nthrough custom wrapper components ✅\n- All translations use `i18n.translate` with unique keys and\n`defaultMessage` ✅\n\n## PR checklist\n\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](../../.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\nCloses #274598\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"747f02e40b4fcc68694d78989ed81797253ef9fd"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->