### PR TITLE
Ignore Codex workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ __tmp__
 .bug-fixer-session/
 .playwright-mcp/
 .exploratory-session/
+.codex/
 config_sets/bug_fixer/
 
 # Ignore example plugin builds


### PR DESCRIPTION
## Summary

Adds `.codex/` to `.gitignore` so local Codex workspace files do not show up as untracked repository changes.

No issue reference; this is a small repository hygiene change.

## Test plan

- [x] `git status --short --ignored .codex` shows local `.codex` files as ignored
- [x] `git diff --check`

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->