### PR TITLE
[CI] Skip CI for .gitignore and .editorconfig only changes

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -30,7 +30,9 @@
         "^src/dev/prs/kibana_qa_pr_list\\.json$",
         "^\\.buildkite/pull_requests\\.json$",
         "^\\.devcontainer/",
-        "^\\.ona/"
+        "^\\.ona/",
+        "(^|/)\\.gitignore$",
+        "(^|/)\\.editorconfig$"
       ],
       "always_require_ci_on_changed": [
         "^docs/developer/plugin-list.asciidoc$",


### PR DESCRIPTION
## Summary

PRs that only touch `.gitignore` or `.editorconfig` currently trigger the full Kibana PR pipeline (see e.g. #275509, a one-line `.gitignore` change). These files cannot affect any build or test outcome, so running full CI on them wastes a lot of compute and reviewer wait time.

This adds them to `skip_ci_on_only_changed` in `.buildkite/pull_requests.json`, following the existing pattern used for `.devcontainer/`, `.ona/`, docs, `*.md`, etc. When **every** changed file in a PR matches a skip pattern (and none match `always_require_ci_on_changed`), `areChangesSkippable()` short-circuits the pipeline to `steps: []` and the `kibana-ci` status goes green immediately.

The patterns are anchored with `(^|/)` so they match the root and any nested `.gitignore` / `.editorconfig` but not unrelated names like `foo.gitignore`.

### Notes
- **CODEOWNERS is intentionally not included.** `.github/CODEOWNERS` is in `always_require_ci_on_changed` (#144728) because `verify_codeowners.sh` regenerates and validates it, so those changes must still run CI.

## Test plan
- [ ] A PR that only changes `.gitignore` and/or `.editorconfig` generates an empty pipeline (no jobs) and reports `kibana-ci` success.
- [ ] A PR that changes `.gitignore` **plus** any non-skippable file still runs the full pipeline.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->