### PR TITLE
[Processing] Fix json_extract with dotted fields

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/test_bed_fixture.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/test_bed_fixture.ts
@@ -6,8 +6,23 @@
  */
 
 import type { Client } from '@elastic/elasticsearch';
-import type { ErrorCause, IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  ErrorCause,
+  IngestFieldAccessPattern,
+  IngestProcessorContainer,
+} from '@elastic/elasticsearch/lib/api/types';
 import { apiTest } from '@kbn/scout';
+
+/**
+ * Optional pipeline settings applied when a pipeline is created for an ingest call.
+ */
+export interface TestBedPipelineOptions {
+  field_access_pattern?: IngestFieldAccessPattern;
+}
+
+export interface TestBedIngestOptions {
+  pipeline?: TestBedPipelineOptions;
+}
 
 export interface TestBedFixture {
   testBed: {
@@ -17,12 +32,14 @@ export interface TestBedFixture {
      * @param indexName The name of the index.
      * @param documents An array of documents to ingest.
      * @param processors An optional array of ingest processors to create a pipeline.
+     * @param options Optional ingest options, e.g. pipeline settings like `field_access_pattern`.
      * @returns An object containing the number of ingested documents and an array of errors.
      */
     ingest: (
       indexName: string,
       documents: Array<Record<string, unknown>>,
-      processors?: IngestProcessorContainer[]
+      processors?: IngestProcessorContainer[],
+      options?: TestBedIngestOptions
     ) => Promise<{ errors: ErrorCause[]; docs: number }>;
     /**
      * Gets all documents from an index in their natural, non-deterministic order.
@@ -61,11 +78,15 @@ export const testBedFixture = apiTest.extend<TestBedFixture>({
       const createdPipelines = new Set<string>();
       const createdIndexes = new Set<string>();
 
-      const createPipeline = async (processors: IngestProcessorContainer[]) => {
+      const createPipeline = async (
+        processors: IngestProcessorContainer[],
+        pipelineOptions?: TestBedPipelineOptions
+      ) => {
         const pipelineId = `test-bed-pipeline-${Date.now()}`;
         await esClient.ingest.putPipeline({
           id: pipelineId,
           processors,
+          ...pipelineOptions,
         });
         createdPipelines.add(pipelineId);
         return pipelineId;
@@ -74,11 +95,12 @@ export const testBedFixture = apiTest.extend<TestBedFixture>({
       const ingest = async (
         indexName: string,
         documents: Array<Record<string, unknown>>,
-        processors?: IngestProcessorContainer[]
+        processors?: IngestProcessorContainer[],
+        options?: TestBedIngestOptions
       ) => {
         let pipelineId: string | undefined;
         if (processors && processors.length > 0) {
-          pipelineId = await createPipeline(processors);
+          pipelineId = await createPipeline(processors, options?.pipeline);
         }
 
         await ensureIndexCreated(indexName, esClient);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
@@ -7,7 +7,7 @@
 
 import { expect } from '@kbn/scout/api';
 import { tags } from '@kbn/scout';
-import type { JsonExtractProcessor, StreamlangDSL } from '@kbn/streamlang';
+import type { JsonExtractProcessor, MathProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
 
@@ -79,13 +79,13 @@ apiTest.describe(
 
     apiTest(
       'should write extracted value into a pre-existing parent object so it is readable downstream',
-      async ({ esClient }) => {
+      async ({ testBed }) => {
         const indexName = 'streams-e2e-test-json-extract-nested-target';
-        const pipelineId = 'streams-e2e-test-json-extract-nested-target-pipeline';
 
         // json_extract into a nested target, then a downstream step that reads it back
-        // via the flexible accessor (mirrors the customer's json_extract -> math repro).
-        const streamlangDSL = {
+        // via the flexible accessor (mirrors the customer's json_extract -> math repro
+        // that previously threw a NullPointerException).
+        const streamlangDSL: StreamlangDSL = {
           steps: [
             {
               action: 'json_extract',
@@ -97,64 +97,42 @@ apiTest.describe(
                   type: 'long',
                 },
               ],
-            },
+            } as JsonExtractProcessor,
             {
               action: 'math',
-              expression: 'attributes.app.action.duration_nano / 1000000000',
-              to: 'attributes.app.action.duration',
-            },
+              expression: 'attributes.app.action.duration_nano + 0',
+              to: 'duration_readback',
+            } as MathProcessor,
           ],
-        } as unknown as StreamlangDSL;
+        };
 
         const { processors } = await transpile(streamlangDSL);
 
-        try {
-          await esClient.indices.create({
-            index: indexName,
-            mappings: { dynamic: 'true' },
-          });
+        // The child-stream pipeline uses the flexible field access pattern; the bug
+        // only surfaces when reads/writes go through it. `attributes` already exists
+        // as a real object on the incoming document.
+        const docs = [
+          {
+            '@timestamp': '2026-06-29T15:30:00Z',
+            attributes: { payload: '{"duration": 68319744}' },
+          },
+        ];
+        const { errors } = await testBed.ingest(indexName, docs, processors, {
+          pipeline: { field_access_pattern: 'flexible' },
+        });
 
-          // The child-stream pipeline uses the flexible field access pattern; the bug
-          // only surfaces when reads/writes go through it.
-          await esClient.ingest.putPipeline({
-            id: pipelineId,
-            field_access_pattern: 'flexible',
-            processors,
-          });
+        // No script_exception / NullPointerException from the downstream read.
+        expect(errors).toHaveLength(0);
 
-          // `attributes` already exists as a real object on the incoming document.
-          const response = await esClient.bulk({
-            refresh: true,
-            pipeline: pipelineId,
-            body: [
-              { index: { _index: indexName } },
-              {
-                '@timestamp': '2026-06-29T15:30:00Z',
-                attributes: { repro: 'yes', payload: '{"duration": 68319744}' },
-              },
-            ],
-          });
+        const ingestedDocs = await testBed.getDocs(indexName);
+        expect(ingestedDocs).toHaveLength(1);
+        const source = ingestedDocs[0] as Record<string, unknown>;
 
-          // No script_exception / NullPointerException from the downstream read.
-          expect(response.errors).toBe(false);
-
-          const searchResponse = await esClient.search({
-            index: indexName,
-            query: { match_all: {} },
-            size: 1,
-          });
-          const source = searchResponse.hits.hits[0]._source as {
-            attributes?: Record<string, unknown>;
-          } & Record<string, unknown>;
-
-          // The value lands inside the existing `attributes` object...
-          expect(source.attributes?.['app.action.duration_nano']).toBe(68319744);
-          // ...and not as a literal top-level dotted key.
-          expect(source['attributes.app.action.duration_nano']).toBeUndefined();
-        } finally {
-          await esClient.indices.delete({ index: indexName, ignore_unavailable: true });
-          await esClient.ingest.deletePipeline({ id: pipelineId }, { ignore: [404] });
-        }
+        // The downstream `$()` read resolved the extracted value (instead of null),
+        // proving it was written somewhere reachable inside `attributes`.
+        expect(source.duration_readback).toBe(68319744);
+        // ...and it was not stranded as a literal top-level dotted key.
+        expect(source['attributes.app.action.duration_nano']).toBeUndefined();
       }
     );
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
@@ -76,5 +76,86 @@ apiTest.describe(
         expect(source.user_id).toBeUndefined();
       }
     );
+
+    apiTest(
+      'should write extracted value into a pre-existing parent object so it is readable downstream',
+      async ({ esClient }) => {
+        const indexName = 'streams-e2e-test-json-extract-nested-target';
+        const pipelineId = 'streams-e2e-test-json-extract-nested-target-pipeline';
+
+        // json_extract into a nested target, then a downstream step that reads it back
+        // via the flexible accessor (mirrors the customer's json_extract -> math repro).
+        const streamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'attributes.payload',
+              extractions: [
+                {
+                  selector: 'duration',
+                  target_field: 'attributes.app.action.duration_nano',
+                  type: 'long',
+                },
+              ],
+            },
+            {
+              action: 'math',
+              expression: 'attributes.app.action.duration_nano / 1000000000',
+              to: 'attributes.app.action.duration',
+            },
+          ],
+        } as unknown as StreamlangDSL;
+
+        const { processors } = await transpile(streamlangDSL);
+
+        try {
+          await esClient.indices.create({
+            index: indexName,
+            mappings: { dynamic: 'true' },
+          });
+
+          // The child-stream pipeline uses the flexible field access pattern; the bug
+          // only surfaces when reads/writes go through it.
+          await esClient.ingest.putPipeline({
+            id: pipelineId,
+            field_access_pattern: 'flexible',
+            processors,
+          });
+
+          // `attributes` already exists as a real object on the incoming document.
+          const response = await esClient.bulk({
+            refresh: true,
+            pipeline: pipelineId,
+            body: [
+              { index: { _index: indexName } },
+              {
+                '@timestamp': '2026-06-29T15:30:00Z',
+                attributes: { repro: 'yes', payload: '{"duration": 68319744}' },
+              },
+            ],
+          });
+
+          // No script_exception / NullPointerException from the downstream read.
+          expect(response.errors).toBe(false);
+
+          const searchResponse = await esClient.search({
+            index: indexName,
+            query: { match_all: {} },
+            size: 1,
+          });
+          const source = searchResponse.hits.hits[0]._source as {
+            attributes?: Record<string, unknown>;
+          } & Record<string, unknown>;
+
+          // The value lands inside the existing `attributes` object...
+          expect(source.attributes?.['app.action.duration_nano']).toBe(68319744);
+          // ...and not as a literal top-level dotted key.
+          expect(source['attributes.app.action.duration_nano']).toBeUndefined();
+        } finally {
+          await esClient.indices.delete({ index: indexName, ignore_unavailable: true });
+          await esClient.ingest.deletePipeline({ id: pipelineId }, { ignore: [404] });
+        }
+      }
+    );
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.test.ts
@@ -122,7 +122,7 @@ describe('processJsonExtractProcessor', () => {
       const { source } = result.script;
       // Complex types are passed through before type casting is applied
       expect(source).toContain('if (extracted_0 instanceof Map || extracted_0 instanceof List)');
-      expect(source).toContain("ctx['out'] = extracted_0;");
+      expect(source).toContain("field('out').set(extracted_0);");
     });
 
     it('should use intValue for integer type', () => {
@@ -188,8 +188,8 @@ describe('processJsonExtractProcessor', () => {
       const { source } = result.script;
       expect(source).toContain('def extracted_0');
       expect(source).toContain('def extracted_1');
-      expect(source).toContain("ctx['out_a']");
-      expect(source).toContain("ctx['out_b']");
+      expect(source).toContain("field('out_a').set(");
+      expect(source).toContain("field('out_b').set(");
     });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
@@ -11,7 +11,7 @@ import type {
   JsonExtraction,
   JsonExtractType,
 } from '../../../../types/processors';
-import { painlessFieldAccessor, painlessFieldAssignment } from '../../../../types/utils';
+import { painlessFieldAccessor, painlessFieldSetter } from '../../../../types/utils';
 import { parseJsonPath, segmentsToStrings } from '../../shared/json_path_parser';
 
 /**
@@ -104,17 +104,16 @@ function generateJsonExtractScript(
     const extraction = extractions[i];
     const parts = segmentsToStrings(parseJsonPath(extraction.selector).segments);
     const traversalExpr = generateTraversalExpression('parsed', parts);
-    const targetAssignment = painlessFieldAssignment(extraction.target_field);
     const varName = `extracted_${i}`;
     const targetType = extraction.type ?? 'keyword';
 
     lines.push(`def ${varName} = ${traversalExpr};`);
     lines.push(`if (${varName} != null) {`);
     lines.push(`  if (${varName} instanceof Map || ${varName} instanceof List) {`);
-    lines.push(`    ${targetAssignment} = ${varName};`);
+    lines.push(`    ${painlessFieldSetter(extraction.target_field, varName)};`);
     lines.push(`  } else {`);
     const typeCastExpr = generateTypeCast(varName, targetType);
-    lines.push(`    ${targetAssignment} = ${typeCastExpr};`);
+    lines.push(`    ${painlessFieldSetter(extraction.target_field, typeCastExpr)};`);
     lines.push(`  }`);
     lines.push(`}`);
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/utils/painless_field_access.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/utils/painless_field_access.ts
@@ -29,3 +29,20 @@ export function painlessFieldAccessor(field: string, defaultValue: string = 'nul
 export function painlessFieldAssignment(field: string): string {
   return `ctx['${field}']`;
 }
+
+/**
+ * Setter for writing field values via the Painless Field API.
+ *
+ * Unlike `painlessFieldAssignment` (which mutates `ctx` with a literal dotted
+ * key), `field('a.b.c').set(value)` resolves the path with the same
+ * nested-then-flat algorithm as the `$()` reader. This keeps reads and writes
+ * symmetric under `field_access_pattern: 'flexible'`, so a value written to a
+ * nested target (e.g. `attributes.app.action.duration_nano`) lands inside the
+ * existing `attributes` object where downstream `$()` reads look for it.
+ *
+ * @example
+ * painlessFieldSetter('order.total', 'extracted_0') -> "field('order.total').set(extracted_0)"
+ */
+export function painlessFieldSetter(field: string, valueExpr: string): string {
+  return `field('${field}').set(${valueExpr})`;
+}


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/275564

## Summary

When a Streamlang `json_extract` action writes into a nested target such as `attributes.app.action.duration_nano`, it stores the value as a literal, flattened top-level key instead of placing it inside the `attributes` object. Any later step that reads the field through the standard accessor ($(...)) looks inside the existing `attributes` object, doesn't find the value, and resolves to null — which is what triggers the NullPointerException in the math step. As observed, native processors like set/rename/grok don't have this problem because they honor the pipeline's flexible field-access pattern, whereas json_extract (and the other script-based actions: math, concat, join) currently write directly to a flat key.




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->