### PR TITLE
[ES|QL] Includes _meta from ES to the Datatable columns meta

### DIFF
--- a/src/platform/packages/shared/kbn-es-types/src/search.ts
+++ b/src/platform/packages/shared/kbn-es-types/src/search.ts
@@ -658,6 +658,7 @@ export interface ESQLColumn {
   name: string;
   type: string;
   original_types?: string[];
+  _meta?: estypes.Metadata;
 }
 
 export type ESQLRow = unknown[];

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.test.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.test.ts
@@ -40,7 +40,7 @@ const createExecutionContext = (): ExecutionContext =>
   } as unknown as ExecutionContext);
 
 const getMockSearchService = (
-  columns: Array<{ name: string; type: string }>,
+  columns: Array<{ name: string; type: string; _meta?: Record<string, unknown> }>,
   values: unknown[][] = [['v1']]
 ): MockTypedSearchService => {
   const mockTyped = {
@@ -158,6 +158,33 @@ describe('getEsqlFn', () => {
 
     expect(result?.columns?.[0]?.meta?.sourceParams?.sourceField).toBe('a');
     expect(result?.columns?.[0]?.name).toBe('c');
+  });
+
+  it('passes ES column _meta through to meta.esMeta', async () => {
+    const columnMeta = { approximation: { type: 'count_distinct', column: '@timestamp' } };
+    const mockSearchService = getMockSearchService([
+      { name: 'count', type: 'long', _meta: columnMeta },
+    ]);
+
+    const result = await createEsqlFn(mockSearchService).fn(
+      null,
+      { query: 'FROM index | STATS COUNT(DISTINCT @timestamp)' },
+      createExecutionContext()
+    );
+
+    expect(result?.columns?.[0]?.meta?.esMeta).toEqual(columnMeta);
+  });
+
+  it('omits meta.esMeta when ES column has no _meta', async () => {
+    const mockSearchService = getMockSearchService([{ name: 'host', type: 'keyword' }]);
+
+    const result = await createEsqlFn(mockSearchService).fn(
+      null,
+      { query: 'FROM index' },
+      createExecutionContext()
+    );
+
+    expect(result?.columns?.[0]?.meta?.esMeta).toBeUndefined();
   });
 
   it('resolves meta.sourceParams.sourceField for STATS BY alias = column', async () => {

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -120,7 +120,7 @@ function mapResponseToDatatable(
     : null;
 
   const allColumns =
-    (body.all_columns ?? body.columns)?.map(({ name, type, original_types }) => {
+    (body.all_columns ?? body.columns)?.map(({ name, type, original_types, _meta }) => {
       const originalTypes = original_types ?? [];
       const hasConflict = type === 'unsupported' && originalTypes.length > 1;
       const kibanaFieldType = hasConflict
@@ -150,6 +150,7 @@ function mapResponseToDatatable(
           params: {
             id: kibanaFieldType,
           },
+          ...(_meta !== undefined && { esMeta: _meta }),
         },
         isNull: hasEmptyColumns ? !lookup.has(name) : false,
         isComputedColumn: isComputedColumn(name, querySummary),

--- a/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
@@ -103,6 +103,10 @@ export interface DatatableColumnMeta {
    * any extra parameters for the source that produced this column
    */
   sourceParams?: SerializableRecord;
+  /**
+   * raw metadata from the data source (e.g. ES column _meta)
+   */
+  esMeta?: Record<string, unknown>;
 }
 
 interface SourceParamsESQL extends Record<string, unknown> {


### PR DESCRIPTION
## Summary

ES will send us some _meta per column, important for various occasions. (I want them for example for the approximation). This PR is passing them (if they exist) to the DatablecolumnMeta as esMeta

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


