### PR TITLE
[Console] Fix memoize ES|QL autocomplete sources

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts
@@ -12,3 +12,4 @@ export { useSetInitialValue } from './use_set_initial_value';
 export { useSetupAutocompletePolling } from './use_setup_autocomplete_polling';
 export { useSetupAutosave } from './use_setup_autosave';
 export { useKeyboardCommandsUtils } from './use_register_keyboard_commands';
+export { useConsoleEsqlCallbacks } from './use_console_esql_callbacks';

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { ESQLSourceResult } from '@kbn/esql-types';
+import { getESQLSources, getEsqlColumns } from '@kbn/esql-utils';
+import { serviceContextMock } from '../../../contexts/services_context.mock';
+import {
+  CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY,
+  useConsoleEsqlCallbacks,
+} from './use_console_esql_callbacks';
+
+jest.mock('@kbn/esql-utils', () => ({
+  getESQLSources: jest.fn(),
+  getEsqlColumns: jest.fn(),
+}));
+
+const mockGetESQLSources = getESQLSources as jest.MockedFunction<typeof getESQLSources>;
+const mockGetEsqlColumns = getEsqlColumns as jest.MockedFunction<typeof getEsqlColumns>;
+
+const createParams = () => {
+  const {
+    services: { application, http, licensing, data },
+  } = serviceContextMock.create();
+
+  return { application, http, licensing, data };
+};
+
+describe('useConsoleEsqlCallbacks', () => {
+  const sources = [{ name: 'logs', hidden: false, type: 'index' } as ESQLSourceResult];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+    mockGetESQLSources.mockResolvedValue(sources);
+    mockGetEsqlColumns.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reuses the same sources request while the cache is fresh', async () => {
+    const params = createParams();
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(params));
+
+    const firstRequest = result.current.getSources!();
+    const secondRequest = result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+    expect(mockGetESQLSources).toHaveBeenCalledWith(
+      { application: params.application, http: params.http },
+      params.licensing.getLicense
+    );
+    await expect(firstRequest).resolves.toBe(sources);
+    await expect(secondRequest).resolves.toBe(sources);
+
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches sources again after the cache expires', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    await result.current.getSources!();
+    nowSpy.mockReturnValue(1000 + CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY + 1);
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache rejected sources requests', async () => {
+    const error = new Error('failed to fetch sources');
+    mockGetESQLSources.mockRejectedValueOnce(error).mockResolvedValueOnce(sources);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    await expect(result.current.getSources!()).rejects.toThrow(error);
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects concurrent callers sharing an in-flight request that fails and refetches afterwards', async () => {
+    const error = new Error('failed to fetch sources');
+    let rejectInFlight: (reason: Error) => void;
+    mockGetESQLSources
+      .mockImplementationOnce(
+        () =>
+          new Promise<ESQLSourceResult[]>((_resolve, reject) => {
+            rejectInFlight = reject;
+          })
+      )
+      .mockResolvedValueOnce(sources);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    const firstRequest = result.current.getSources!();
+    const secondRequest = result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+
+    rejectInFlight!(error);
+
+    await expect(firstRequest).rejects.toThrow(error);
+    await expect(secondRequest).rejects.toThrow(error);
+
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a fresh cache when a stale request rejects after the cache was refreshed', async () => {
+    const staleError = new Error('stale sources request');
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    let rejectStale: (reason: Error) => void;
+    mockGetESQLSources
+      .mockImplementationOnce(
+        () =>
+          new Promise<ESQLSourceResult[]>((_resolve, reject) => {
+            rejectStale = reject;
+          })
+      )
+      .mockResolvedValueOnce(sources);
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(createParams()));
+
+    const staleRequest = Promise.resolve(result.current.getSources!());
+    staleRequest.catch(() => {});
+
+    nowSpy.mockReturnValue(1000 + CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY + 1);
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+
+    rejectStale!(staleError);
+    await expect(staleRequest).rejects.toThrow(staleError);
+
+    await expect(result.current.getSources!()).resolves.toBe(sources);
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts a fresh sources cache when dependencies change', async () => {
+    const { result, rerender } = renderHook((props) => useConsoleEsqlCallbacks(props), {
+      initialProps: createParams(),
+    });
+
+    await result.current.getSources!();
+    rerender(createParams());
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the cached sources and callback identity across rerenders when dependencies are unchanged', async () => {
+    const params = createParams();
+    const { result, rerender } = renderHook((props) => useConsoleEsqlCallbacks(props), {
+      initialProps: params,
+    });
+
+    const initialCallbacks = result.current;
+    await result.current.getSources!();
+    rerender(params);
+
+    expect(result.current).toBe(initialCallbacks);
+
+    await result.current.getSources!();
+
+    expect(mockGetESQLSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates column requests without caching them', async () => {
+    const params = createParams();
+    const { result } = renderHook(() => useConsoleEsqlCallbacks(params));
+
+    await result.current.getColumnsFor!({ query: 'FROM logs' });
+    await result.current.getColumnsFor!({ query: 'FROM logs' });
+
+    expect(mockGetEsqlColumns).toHaveBeenCalledWith({
+      esqlQuery: 'FROM logs',
+      search: params.data.search.search,
+    });
+    expect(mockGetEsqlColumns).toHaveBeenCalledTimes(2);
+
+    await result.current.getColumnsFor!();
+
+    expect(mockGetEsqlColumns).toHaveBeenLastCalledWith({
+      esqlQuery: undefined,
+      search: params.data.search.search,
+    });
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { ESQLCallbacks } from '@kbn/esql-types';
+import { getESQLSources, getEsqlColumns } from '@kbn/esql-utils';
+import type { ContextValue } from '../../../contexts';
+
+export const CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
+
+interface CachedSources {
+  timestamp: number;
+  result: ReturnType<typeof getESQLSources>;
+}
+
+interface UseConsoleEsqlCallbacksParams {
+  application: ContextValue['services']['application'];
+  http: ContextValue['services']['http'];
+  licensing: ContextValue['services']['licensing'];
+  data: ContextValue['services']['data'];
+}
+
+export const useConsoleEsqlCallbacks = ({
+  application,
+  http,
+  licensing,
+  data,
+}: UseConsoleEsqlCallbacksParams): ESQLCallbacks => {
+  const getSources = useMemo<Required<ESQLCallbacks>['getSources']>(() => {
+    let cachedSources: CachedSources | undefined;
+
+    return async () => {
+      // Re-fetch only when there is no cached result yet or the cached one has
+      // gone stale, so autocomplete does not hit the sources API on every keystroke.
+      // The staleness window mirrors the ES|QL editor's cache TTL for consistent behavior.
+      if (
+        !cachedSources ||
+        Date.now() - cachedSources.timestamp > CONSOLE_ESQL_SOURCES_CACHE_INVALIDATE_DELAY
+      ) {
+        const result = getESQLSources({ application, http }, licensing?.getLicense);
+        // Evict the cached entry if this fetch rejects, but only if it is still the
+        // current one, so a later successful fetch is never overwritten by a stale failure.
+        void result.catch(() => {
+          if (cachedSources?.result === result) {
+            cachedSources = undefined;
+          }
+        });
+
+        cachedSources = {
+          timestamp: Date.now(),
+          result,
+        };
+      }
+
+      return cachedSources.result;
+    };
+  }, [application, http, licensing?.getLicense]);
+
+  const getColumnsFor = useCallback(
+    async ({ query }: { query?: string } | undefined = {}) => {
+      const columns = await getEsqlColumns({
+        esqlQuery: query,
+        search: data?.search?.search,
+      });
+      return columns;
+    },
+    [data?.search?.search]
+  );
+
+  return useMemo<ESQLCallbacks>(
+    () => ({
+      getSources,
+      getColumnsFor,
+    }),
+    [getSources, getColumnsFor]
+  );
+};

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
@@ -11,13 +11,11 @@ import type { CSSProperties } from 'react';
 import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import type { ESQLCallbacks } from '@kbn/esql-types';
 import { CodeEditor } from '@kbn/code-editor/code_editor';
 import type { monaco } from '@kbn/monaco';
 import { CONSOLE_LANG_ID, CONSOLE_THEME_ID, ConsoleLang } from '@kbn/monaco';
 
 import { i18n } from '@kbn/i18n';
-import { getESQLSources, getEsqlColumns } from '@kbn/esql-utils';
 import { MonacoEditorActionsProvider } from './monaco_editor_actions_provider';
 import type { EditorRequest } from './types';
 import {
@@ -26,6 +24,7 @@ import {
   useSetupAutosave,
   useResizeCheckerUtils,
   useKeyboardCommandsUtils,
+  useConsoleEsqlCallbacks,
 } from './hooks';
 import {
   useServicesContext,
@@ -179,22 +178,7 @@ export const MonacoEditor = ({
     unregisterKeyboardCommands();
   }, [destroyResizeChecker, unregisterKeyboardCommands]);
 
-  const esqlCallbacks: ESQLCallbacks = useMemo(() => {
-    const callbacks: ESQLCallbacks = {
-      getSources: async () => {
-        const getLicense = licensing?.getLicense;
-        return await getESQLSources({ application, http }, getLicense);
-      },
-      getColumnsFor: async ({ query }: { query?: string } | undefined = {}) => {
-        const columns = await getEsqlColumns({
-          esqlQuery: query,
-          search: data?.search?.search,
-        });
-        return columns;
-      },
-    };
-    return callbacks;
-  }, [licensing, application, http, data?.search?.search]);
+  const esqlCallbacks = useConsoleEsqlCallbacks({ application, http, licensing, data });
 
   const suggestionProvider = useMemo(
     () => ConsoleLang.getSuggestionProvider?.(esqlCallbacks, actionsProvider),


### PR DESCRIPTION
Closes #271878

## Summary

- Memoizes Console's ES|QL source autocomplete callback so repeated source completions reuse a fresh request instead of refetching the same source list on every keystroke.
- Keeps ES|QL column lookup uncached and refreshes the source cache when service dependencies change, after the cache expires, or after a failed source request.

## Root Cause

- Console wired ES|QL source autocomplete directly to `getESQLSources`, so every source-position completion invoked the sources lookup again.

## Fix

- Moves Console ES|QL callbacks into `useConsoleEsqlCallbacks`, caches the in-flight/resolved sources request for 10 minutes, and clears the cache on rejection.
- Adds hook coverage for fresh-cache reuse, cache expiry, rejected-request retry, dependency changes, rerender identity stability, and uncached column lookup.

https://github.com/user-attachments/assets/5217ef88-9ee2-4163-937f-16320bbc30cb

## Test Plan

- In local Kibana, open Dev Tools > Console and enter:
  ```
  POST _query
  {
    "query": """FROM """
  }
  ```
  Place the cursor after `FROM `, open browser DevTools > Network, and type a few characters of an index name, such as `logs`. Expected result: after the initial ES|QL sources and Fleet package requests, typing more characters does not issue a new sources request or `GET /api/fleet/epm/packages/installed` on every keystroke while the source cache is fresh.
- `node scripts/jest src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts` — 8 tests passed
- `node scripts/eslint src/platform/plugins/shared/console/public/application/containers/editor/hooks/index.ts src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.test.ts src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_console_esql_callbacks.ts src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx` — no errors
- `node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json` — exited with 0

## Release Note

- Console ES|QL source autocomplete now reuses a fresh source list instead of refetching it on every keystroke.

Assisted with Copilot using GPT-5.5



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->