### PR TITLE
[DOCS] Update Security Solution Kibana settings

### DIFF
--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -1677,35 +1677,6 @@ groups:
           - "self: ga"
         deprecation_details: "Rollups are deprecated and will be removed in a future version. Use [downsampling](docs-content://manage-data/data-store/data-streams/downsampling-time-series-data-stream.md) instead."
 
-      - setting: xpack.securitySolution.maxUploadResponseActionFileBytes
-        description: |
-          Allow to configure the max file upload size for use with the Upload File Response action available with the Defend Integration. To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
-        datatype: string
-        applies_to:
-          stack: ga 8.9
-          ech: ga
-          self: ga
-
-      - setting: xpack.securitySolution.disableEndpointRuleAutoInstall
-        description: |
-          Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4.
-        datatype: bool
-        default: false
-        applies_to:
-          - "stack: ga 9.2.4+"
-          - "ech: ga"
-          - "self: ga"
-
-      - setting: xpack.securitySolution.maxEndpointScriptFileSize
-        description: |
-          The maximum file size in bytes for scripts uploaded to the Elastic Defend script library. Default is `26214400` (25MB).
-        datatype: bool
-        default: 26214400
-        applies_to:
-          - "stack: ga 9.4+"
-          - "ech: ga"
-          - "self: ga"
-
       - setting: xpack.snapshot_restore.ui.enabled
         description: |
           Set this value to false to disable the Snapshot and Restore UI.

--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -47,3 +47,55 @@ groups:
           stack: ga
           ech: ga
           self: ga
+
+  - group: Elastic Defend settings
+    id: elastic-defend-settings
+    settings:
+
+      - setting: xpack.securitySolution.maxUploadResponseActionFileBytes
+        description: |
+          Allow to configure the max file upload size for use with the Upload File Response action available with the Defend Integration. To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
+        datatype: string
+        applies_to:
+          stack: ga 8.9
+          ech: ga
+          self: ga
+
+      - setting: xpack.securitySolution.disableEndpointRuleAutoInstall
+        description: |
+          Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4.
+        datatype: bool
+        default: false
+        applies_to:
+          - "stack: ga 9.2.4+"
+          - "ech: ga"
+          - "self: ga"
+
+      - setting: xpack.securitySolution.maxEndpointScriptFileSize
+        description: |
+          The maximum file size in bytes for scripts uploaded to the Elastic Defend script library. Default is `26214400` (25MB).
+        datatype: int
+        default: 26214400
+        applies_to:
+          - "stack: ga 9.4+"
+          - "ech: ga"
+          - "self: ga"
+
+  - group: Experimental features
+    id: experimental-features
+    settings:
+
+      - setting: xpack.securitySolution.enableExperimental
+        description: |
+          Set experimental feature flags to enable functionality that is not yet released. Valid values must be defined in the `allowedExperimentalValues` object in the Security Solution plugin.
+        datatype: string
+        applies_to:
+          stack: ga
+          ech: ga
+          self: ga
+        note: "Experimental features should not be enabled in production environments. The features in this section are experimental and may be changed or removed completely in future releases. Elastic will make a best effort to fix any issues, but experimental features are not supported to the same level as generally available (GA) features."
+        example: |
+          ```yaml
+          xpack.securitySolution.enableExperimental:
+            - sentinelRulesMigration
+          ```

--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -55,7 +55,7 @@ groups:
       - setting: xpack.securitySolution.maxUploadResponseActionFileBytes
         description: |
           Allow to configure the max file upload size for use with the Upload File Response action available with the Defend Integration. To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
-        datatype: string
+        datatype: int
         applies_to:
           stack: ga 8.9
           ech: ga

--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -87,7 +87,7 @@ groups:
 
       - setting: xpack.securitySolution.enableExperimental
         description: |
-          Set experimental feature flags to enable functionality that is not yet released. Valid values must be defined in the `allowedExperimentalValues` object in the Security Solution plugin.
+          A list of experimental feature flags to enable.
         datatype: string
         applies_to:
           stack: ga

--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -63,11 +63,11 @@ groups:
 
       - setting: xpack.securitySolution.disableEndpointRuleAutoInstall
         description: |
-          Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4.
+          Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created.
         datatype: bool
         default: false
         applies_to:
-          - "stack: ga 9.2.4+"
+          - "stack: ga 9.2.4!+"
           - "ech: ga"
           - "self: ga"
 
@@ -93,7 +93,7 @@ groups:
           stack: ga
           ech: ga
           self: ga
-        note: "Experimental features should not be enabled in production environments. The features in this section are experimental and may be changed or removed completely in future releases. Elastic will make a best effort to fix any issues, but experimental features are not supported to the same level as generally available (GA) features."
+        note: "Experimental features should not be enabled in production environments. Experimental features may be changed or removed completely in future releases. Elastic will make a best effort to fix any issues, but experimental features are not supported to the same level as generally available (GA) features."
         example: |
           ```yaml
           xpack.securitySolution.enableExperimental:

--- a/docs/reference/configuration-reference/security-solution-settings.yml
+++ b/docs/reference/configuration-reference/security-solution-settings.yml
@@ -88,7 +88,7 @@ groups:
       - setting: xpack.securitySolution.enableExperimental
         description: |
           A list of experimental feature flags to enable.
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: ga


### PR DESCRIPTION
## Summary

* Adds `xpack.securitySolution.enableExperimental` to https://github.com/elastic/kibana/blob/main/docs/reference/configuration-reference/security-solution-settings.yml (related to https://github.com/elastic/docs-content/pull/7139#discussion_r3492115587)
* Moves the three `securitySolution` settings from  https://github.com/elastic/kibana/blob/main/docs/reference/configuration-reference/general-settings.yml to  https://github.com/elastic/kibana/blob/main/docs/reference/configuration-reference/security-solution-settings.yml
* Updates the datatype of `xpack.securitySolution.maxEndpointScriptFileSize` from `bool` to `int` based on the description and the default value.
* Updates the datatype of  `xpack.securitySolution.maxUploadResponseActionFileBytes` from `string` to `int`.
