### PR TITLE
Add custom secondary menu title to side navigation

### DIFF
--- a/src/platform/kbn-ui/side-navigation/README.mdx
+++ b/src/platform/kbn-ui/side-navigation/README.mdx
@@ -99,6 +99,8 @@ function App() {
 
 The navigation is configured by passing the structure to `items` prop. The structure is an array of `MenuItem` objects, where each `MenuItem` can have an optional `sections` array of `Section` objects.
 
+A `MenuItem` with sections can set `secondaryMenuTitle` to show a custom header in its secondary menu (both the expanded side panel and the hover popover) instead of the item's `label`. Use it to surface dynamic context, e.g. the name of the resource currently in view. When omitted, the title falls back to `label`.
+
 ```js
 export const navigationItems = {
   primaryItems: [
@@ -116,6 +118,7 @@ export const navigationItems = {
       label: 'Analytics',
       iconType: 'graphApp',
       href: '/analytics/reports',
+      secondaryMenuTitle: 'Acme project', // optional, overrides the secondary menu/panel header title (defaults to `label`)
       sections: [
         {
           id: 'reports-section',

--- a/src/platform/kbn-ui/side-navigation/packaging/react/types.ts
+++ b/src/platform/kbn-ui/side-navigation/packaging/react/types.ts
@@ -68,6 +68,8 @@ export interface MenuItem {
   id: string;
   /** Display text for the menu item. */
   label: string;
+  /** Optional override for the secondary menu/panel header title. Defaults to `label` when omitted. */
+  secondaryMenuTitle?: string;
   /** Optional test selector for automated testing. */
   'data-test-subj'?: string;
   /** Optional badge to display next to the label. */

--- a/src/platform/kbn-ui/side-navigation/src/__stories__/navigation.stories.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/__stories__/navigation.stories.tsx
@@ -152,6 +152,66 @@ export const WithManyItems: StoryObj<PropsAndArgs> = {
   render: (args) => <ControlledNavigation {...args} />,
 };
 
+const customTitleItem = PRIMARY_MENU_ITEMS.find((item) => item.sections)!;
+
+export const WithCustomSecondaryMenuTitle: StoryObj<PropsAndArgs> = {
+  name: 'Navigation with Custom Secondary Menu Title',
+  decorators: [
+    (Story) => {
+      return (
+        <>
+          <Global styles={styles} />
+          <Story />
+        </>
+      );
+    },
+  ],
+  args: {
+    activeItemId: customTitleItem.id,
+    items: {
+      primaryItems: PRIMARY_MENU_ITEMS.map((item) =>
+        item.id === customTitleItem.id
+          ? { ...item, secondaryMenuTitle: 'my-production-cluster' }
+          : item
+      ),
+      footerItems: PRIMARY_MENU_FOOTER_ITEMS,
+      overflowItems: [],
+    },
+  },
+  render: (args) => <ControlledNavigation {...args} />,
+};
+
+export const WithLongSecondaryMenuTitle: StoryObj<PropsAndArgs> = {
+  name: 'Navigation with Long Secondary Menu Title',
+  decorators: [
+    (Story) => {
+      return (
+        <>
+          <Global styles={styles} />
+          <Story />
+        </>
+      );
+    },
+  ],
+  args: {
+    activeItemId: customTitleItem.id,
+    items: {
+      primaryItems: PRIMARY_MENU_ITEMS.map((item) =>
+        item.id === customTitleItem.id
+          ? {
+              ...item,
+              secondaryMenuTitle:
+                'my-extremely-long-production-cluster-name-that-should-wrap-or-truncate-gracefully',
+            }
+          : item
+      ),
+      footerItems: PRIMARY_MENU_FOOTER_ITEMS,
+      overflowItems: [],
+    },
+  },
+  render: (args) => <ControlledNavigation {...args} />,
+};
+
 export const WithinLayout: StoryObj<PropsAndArgs> = {
   name: 'Navigation within Layout',
   render: (args) => <Layout {...args} />,

--- a/src/platform/kbn-ui/side-navigation/src/__tests__/both_modes.test.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/__tests__/both_modes.test.tsx
@@ -1165,6 +1165,165 @@ describe('Both modes', () => {
         expect(tracesLink).toHaveAttribute('target', '_blank');
       });
     });
+
+    describe('Custom secondary menu title', () => {
+      const longTitle =
+        'A very long custom secondary menu title that should still render fully in the header';
+
+      const customTitleNav = {
+        primaryItems: [
+          {
+            id: 'resource',
+            label: 'Resources',
+            iconType: 'apps',
+            href: '/resource/overview',
+            secondaryMenuTitle: longTitle,
+            sections: [
+              {
+                id: 'resource-section',
+                items: [
+                  { id: 'resource-overview', label: 'Overview', href: '/resource/overview' },
+                  { id: 'resource-settings', label: 'Settings', href: '/resource/settings' },
+                ],
+              },
+            ],
+          },
+        ],
+        overflowItems: [],
+        footerItems: [],
+      };
+
+      /**
+       * GIVEN a primary menu item defines a custom `secondaryMenuTitle`
+       * WHEN its side panel is open
+       * THEN the panel header shows the custom title instead of the item label
+       */
+      it('should render the custom title in the side panel header', () => {
+        render(
+          <TestComponent
+            items={customTitleNav}
+            logo={basicMock.logo}
+            initialActiveItemId="resource-overview"
+          />
+        );
+
+        const sidePanel = screen.getByTestId(sidePanelId);
+
+        expect(within(sidePanel).getByRole('heading', { name: longTitle })).toBeInTheDocument();
+        expect(
+          within(sidePanel).queryByRole('heading', { name: 'Resources' })
+        ).not.toBeInTheDocument();
+      });
+
+      /**
+       * GIVEN a primary menu item defines a custom `secondaryMenuTitle`
+       * WHEN I hover the item to open its popover
+       * THEN the popover header shows the custom title instead of the item label
+       */
+      it('should render the custom title in the hover popover header', async () => {
+        render(<TestComponent items={customTitleNav} logo={basicMock.logo} />);
+
+        const resourceLink = screen.getByTestId(primaryItemId('resource'));
+
+        await user.hover(resourceLink);
+        flushPopoverTimers();
+
+        const popover = await screen.findByTestId(popoverId('Resources'));
+
+        expect(within(popover).getByRole('heading', { name: longTitle })).toBeInTheDocument();
+      });
+
+      /**
+       * GIVEN a primary menu item does NOT define a custom `secondaryMenuTitle`
+       * WHEN its side panel is open
+       * THEN the panel header falls back to the item label
+       */
+      it('should fall back to the item label when no custom title is provided', () => {
+        render(
+          <TestComponent
+            items={basicMock.navItems}
+            logo={basicMock.logo}
+            initialActiveItemId={tlsCertificatesItemId}
+          />
+        );
+
+        const sidePanel = screen.getByTestId(sidePanelId);
+
+        expect(within(sidePanel).getByRole('heading', { name: 'Apps' })).toBeInTheDocument();
+      });
+
+      /**
+       * GIVEN an overflow item (in the "More" menu) defines a custom `secondaryMenuTitle`
+       * WHEN I open its nested panel
+       * THEN the nested panel header shows the custom title instead of the item label
+       */
+      it('should render the custom title in the "More" nested panel header', async () => {
+        const overflowNav = {
+          primaryItems: [
+            {
+              id: 'dashboards',
+              label: 'Dashboards',
+              iconType: 'dashboardApp',
+              href: '/dashboards',
+            },
+          ],
+          footerItems: [],
+          overflowItems: [
+            {
+              id: 'resource',
+              label: 'Resources',
+              iconType: 'apps',
+              href: '/resource/overview',
+              secondaryMenuTitle: longTitle,
+              sections: [
+                {
+                  id: 'resource-section',
+                  items: [
+                    { id: 'resource-overview', label: 'Overview', href: '/resource/overview' },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        render(<TestComponent items={overflowNav} logo={basicMock.logo} />);
+
+        const moreButton = await screen.findByTestId(moreMenuId);
+
+        await user.click(moreButton);
+        flushPopoverTimers();
+
+        const popover = await screen.findByTestId(popoverId('More'));
+        const resourceTrigger = within(popover).getByTestId(secondaryItemId('resource'));
+
+        await user.click(resourceTrigger);
+        flushPopoverTimers();
+
+        expect(
+          await within(popover).findByRole('heading', { name: longTitle })
+        ).toBeInTheDocument();
+      });
+
+      /**
+       * GIVEN a primary menu item defines a custom `secondaryMenuTitle`
+       * WHEN I open its popover
+       * THEN the popover's accessible (screen-reader) label uses the custom title, not the item label
+       */
+      it('should use the custom title in the popover accessible label', async () => {
+        render(<TestComponent items={customTitleNav} logo={basicMock.logo} />);
+
+        const resourceLink = screen.getByTestId(primaryItemId('resource'));
+
+        await user.hover(resourceLink);
+        flushPopoverTimers();
+
+        const popover = await screen.findByTestId(popoverId('Resources'));
+        const instructions = within(popover).getByText(/secondary menu dialog/i);
+
+        expect(instructions).toHaveTextContent(longTitle);
+      });
+    });
   });
 
   describe('Keyboard navigation', () => {

--- a/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
@@ -171,7 +171,7 @@ export const Navigation = ({
           {({ mainNavigationInstructionsId }) => (
             <>
               {visibleMenuItems.map((item, index) => {
-                const { sections, ...itemProps } = item;
+                const { sections, secondaryMenuTitle, ...itemProps } = item;
                 const isFirstItem = index === 0;
                 const ariaDescribedBy = isFirstItem ? mainNavigationInstructionsId : undefined;
 
@@ -182,6 +182,7 @@ export const Navigation = ({
                     isSidePanelOpen={!isCollapsed && item.id === openerNode?.id}
                     isAnyPopoverLocked={isAnyPopoverLocked}
                     label={item.label}
+                    secondaryMenuTitle={secondaryMenuTitle}
                     trigger={
                       <SideNav.PrimaryMenu.Item
                         aria-describedby={ariaDescribedBy}
@@ -201,7 +202,7 @@ export const Navigation = ({
                   >
                     {(closePopover, ids) => (
                       <SideNav.SecondaryMenu
-                        title={item.label}
+                        title={secondaryMenuTitle ?? item.label}
                         badgeType={item.badgeType}
                         isNew={getIsNewSecondary(item.id)}
                       >
@@ -294,7 +295,7 @@ export const Navigation = ({
                             <SideNav.NestedSecondaryMenu.Section>
                               {allOverflowItems.map((item, index) => {
                                 const hasSubmenu = getHasSubmenu(item);
-                                const { sections, ...itemProps } = item;
+                                const { sections, secondaryMenuTitle, ...itemProps } = item;
                                 const isFirstItem = index === 0;
                                 const ariaDescribedBy =
                                   [
@@ -352,7 +353,7 @@ export const Navigation = ({
                           {({ panelNavigationInstructionsId }) => (
                             <>
                               <SideNav.NestedSecondaryMenu.Header
-                                title={item.label}
+                                title={item.secondaryMenuTitle ?? item.label}
                                 aria-describedby={panelNavigationInstructionsId}
                               />
                               {item.sections?.map((section) => (
@@ -394,7 +395,7 @@ export const Navigation = ({
           {({ footerNavigationInstructionsId }) => (
             <>
               {items.footerItems.slice(0, MAX_FOOTER_ITEMS).map((item, index) => {
-                const { sections, ...itemProps } = item;
+                const { sections, secondaryMenuTitle, ...itemProps } = item;
                 const isFirstItem = index === 0;
                 const ariaDescribedBy = isFirstItem ? footerNavigationInstructionsId : undefined;
 
@@ -405,6 +406,7 @@ export const Navigation = ({
                     isSidePanelOpen={!isCollapsed && item.id === openerNode?.id}
                     isAnyPopoverLocked={isAnyPopoverLocked}
                     label={item.label}
+                    secondaryMenuTitle={secondaryMenuTitle}
                     persistent={false}
                     trigger={
                       <SideNav.Footer.Item
@@ -420,7 +422,7 @@ export const Navigation = ({
                   >
                     {(closePopover, ids) => (
                       <SideNav.SecondaryMenu
-                        title={item.label}
+                        title={secondaryMenuTitle ?? item.label}
                         badgeType={item.badgeType}
                         isNew={getIsNewSecondary(item.id)}
                       >
@@ -481,7 +483,7 @@ export const Navigation = ({
               <SideNav.SecondaryMenu
                 badgeType={openerNode.badgeType}
                 isPanel
-                title={openerNode.label}
+                title={openerNode.secondaryMenuTitle ?? openerNode.label}
                 isNew={getIsNewSecondary(openerNode.id)}
               >
                 {openerNode.sections?.map((section, sectionIndex) => (

--- a/src/platform/kbn-ui/side-navigation/src/components/side_nav/popover.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/side_nav/popover.tsx
@@ -54,6 +54,12 @@ export interface PopoverProps {
   isAnyPopoverLocked?: boolean;
   setIsLocked?: (isLocked: boolean) => void;
   label: string;
+  /**
+   * Accessible title for the popover dialog (aria-label and screen-reader instructions).
+   * Defaults to `label`. Set when the visible secondary header differs from `label`
+   * (e.g. a custom `secondaryMenuTitle`) so the announced title matches what is shown.
+   */
+  secondaryMenuTitle?: string;
   persistent?: boolean;
   trigger: ReactElement<{
     ref?: Ref<HTMLElement>;
@@ -82,9 +88,11 @@ export const Popover = ({
   isAnyPopoverLocked = false,
   setIsLocked = () => {},
   label,
+  secondaryMenuTitle,
   persistent = false,
   trigger,
 }: PopoverProps): JSX.Element => {
+  const dialogLabel = secondaryMenuTitle ?? label;
   const { euiTheme } = useEuiTheme();
   const { setHoverTimeout, clearHoverTimeout } = useHoverTimeout();
   const popoverEnterAndExitInstructionsId = useGeneratedHtmlId({
@@ -292,7 +300,7 @@ export const Popover = ({
         </EuiScreenReaderOnly>
       )}
       <EuiPopover
-        aria-label={label}
+        aria-label={dialogLabel}
         anchorPosition="rightUp"
         buffer={[TOP_BAR_HEIGHT + TOP_BAR_POPOVER_GAP, 0, BOTTOM_POPOVER_GAP, POPOVER_OFFSET]}
         button={enhancedTrigger}
@@ -333,7 +341,7 @@ export const Popover = ({
                 defaultMessage:
                   'You are in the {label} secondary menu dialog. Use Up and Down arrow keys to navigate the menu. Press Escape to exit to the menu trigger.',
                 values: {
-                  label,
+                  label: dialogLabel,
                 },
               })}
             </p>

--- a/src/platform/kbn-ui/side-navigation/src/components/side_nav/side_panel.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/side_nav/side_panel.tsx
@@ -104,7 +104,7 @@ export const SidePanel = ({ children, footer, openerNode }: SidePanelProps): JSX
             defaultMessage:
               'You are in the {label} secondary menu side panel. Use Up and Down arrow keys to navigate the menu.',
             values: {
-              label: openerNode.label,
+              label: openerNode.secondaryMenuTitle ?? openerNode.label,
             },
           })}
         </p>
@@ -113,7 +113,7 @@ export const SidePanel = ({ children, footer, openerNode }: SidePanelProps): JSX
         aria-label={i18n.translate('kbnUI.sideNavigation.sidePanelAriaLabel', {
           defaultMessage: `Side panel for {label}`,
           values: {
-            label: openerNode.label,
+            label: openerNode.secondaryMenuTitle ?? openerNode.label,
           },
         })}
         aria-describedby={secondaryNavigationInstructionsId}

--- a/src/platform/kbn-ui/side-navigation/types.ts
+++ b/src/platform/kbn-ui/side-navigation/types.ts
@@ -83,6 +83,10 @@ export interface MenuItem {
    */
   label: string;
   /**
+   * (optional) Override for the secondary menu/panel header title. Defaults to `label` when omitted.
+   */
+  secondaryMenuTitle?: string;
+  /**
    * (optional) `data-test-subj` attribute for testing and tracking purposes.
    */
   'data-test-subj'?: string;


### PR DESCRIPTION
Part of elastic/kibana#256267

## Summary

Adds an optional `secondaryMenuTitle` to the side navigation `MenuItem` (`@kbn/ui-side-navigation`). When set, the secondary menu header shows it instead of the primary item `label` — letting consumers surface dynamic context such as the name of the resource currently in view. It falls back to `label` when omitted.

The override is applied consistently across every secondary surface — the expanded side panel, hover popovers (primary and footer), and the "More" nested panel — and their accessible labels (aria-label / screen-reader instructions) match the visible header.

This is the component-level change; **new API is not intended for use in Kibana yet,** but is needed for @elastic/cloud-ui team 

<img width="435" height="671" alt="Screenshot 2026-06-30 at 12 29 31" src="https://github.com/user-attachments/assets/9d65984c-fecc-4d00-9f4f-a53a356a09ce" />

<img width="345" height="664" alt="Screenshot 2026-06-30 at 12 29 42" src="https://github.com/user-attachments/assets/d28b93df-7323-407d-8cdb-08d83ef6eb7a" />


