### PR TITLE
[APM] Fix incorrect handling of environment in service logs

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_logs/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_logs/index.test.ts
@@ -4,7 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import {
+  ENVIRONMENT_ALL,
+  ENVIRONMENT_NOT_DEFINED,
+} from '../../../../common/environment_filter_values';
 import { getInfrastructureFilter } from '.';
 
 describe('service logs', () => {
@@ -12,7 +15,7 @@ describe('service logs', () => {
   const environment = 'production';
 
   describe('getInfrastructureFilter', () => {
-    it('filter by service name and environment', () => {
+    it('filter by service name and a specific environment only', () => {
       expect(
         getInfrastructureFilter({
           containerIds: [],
@@ -31,6 +34,22 @@ describe('service logs', () => {
                 ],
               },
             },
+          ],
+        },
+      });
+    });
+
+    it('filter by service name and missing environment when environment is not defined', () => {
+      expect(
+        getInfrastructureFilter({
+          containerIds: [],
+          serviceName,
+          environment: ENVIRONMENT_NOT_DEFINED.value,
+        })
+      ).toEqual({
+        bool: {
+          minimum_should_match: 1,
+          should: [
             {
               bool: {
                 filter: [{ term: { 'service.name': 'opbeans-node' } }],
@@ -75,12 +94,6 @@ describe('service logs', () => {
             },
             {
               bool: {
-                filter: [{ term: { 'service.name': 'opbeans-node' } }],
-                must_not: [{ exists: { field: 'service.environment' } }],
-              },
-            },
-            {
-              bool: {
                 filter: [{ terms: { 'container.id': ['foo', 'bar'] } }],
                 must_not: [{ term: { 'service.name': '*' } }],
               },
@@ -107,12 +120,6 @@ describe('service logs', () => {
                   { term: { 'service.name': 'opbeans-node' } },
                   { term: { 'service.environment': 'production' } },
                 ],
-              },
-            },
-            {
-              bool: {
-                filter: [{ term: { 'service.name': 'opbeans-node' } }],
-                must_not: [{ exists: { field: 'service.environment' } }],
               },
             },
           ],

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_logs/index.tsx
@@ -8,7 +8,10 @@
 import React, { useMemo } from 'react';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
-import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import {
+  ENVIRONMENT_ALL,
+  ENVIRONMENT_NOT_DEFINED,
+} from '../../../../common/environment_filter_values';
 import { CONTAINER_ID, SERVICE_ENVIRONMENT, SERVICE_NAME } from '../../../../common/es_fields/apm';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { useKibana } from '../../../context/kibana_context/use_kibana';
@@ -71,6 +74,11 @@ export function ServiceLogs() {
     }
   }, [kuery]);
 
+  const logsOverviewKey = useMemo(
+    () => JSON.stringify([documentLogFilters, internalLogFilters]),
+    [documentLogFilters, internalLogFilters]
+  );
+
   if (
     status === FETCH_STATUS.SUCCESS ||
     (status === FETCH_STATUS.LOADING &&
@@ -78,6 +86,7 @@ export function ServiceLogs() {
   ) {
     return (
       <logsShared.LogsOverview
+        key={logsOverviewKey}
         documentFilters={documentLogFilters}
         nonHighlightingFilters={internalLogFilters}
         timeRange={timeRange}
@@ -128,6 +137,21 @@ export function getServiceShouldClauses({
 
   if (environment === ENVIRONMENT_ALL.value) {
     return [serviceNameFilter];
+  } else if (environment === ENVIRONMENT_NOT_DEFINED.value) {
+    return [
+      {
+        bool: {
+          filter: [serviceNameFilter],
+          must_not: [
+            {
+              exists: {
+                field: SERVICE_ENVIRONMENT,
+              },
+            },
+          ],
+        },
+      },
+    ];
   } else {
     return [
       {
@@ -137,18 +161,6 @@ export function getServiceShouldClauses({
             {
               term: {
                 [SERVICE_ENVIRONMENT]: environment,
-              },
-            },
-          ],
-        },
-      },
-      {
-        bool: {
-          filter: [serviceNameFilter],
-          must_not: [
-            {
-              exists: {
-                field: SERVICE_ENVIRONMENT,
               },
             },
           ],


### PR DESCRIPTION
## Summary

Fixes incorrect handling of the service environment in the APM service logs tab.

- Corrects the log query so it properly filters by `service.environment`, handling the `ENVIRONMENT_ALL` and `ENVIRONMENT_NOT_DEFINED` cases explicitly. Previously, a `must_not` clause was always appended even when filtering for a specific environment, which caused over-broad log matches.
- Fixes the bug where switching the environment filter did not refresh the logs. The `LogsOverview` is remounted via a `key` derived from the resolved filters to force a fresh fetch whenever the environment or kuery changes.

Closes #274661

## Demo

https://github.com/user-attachments/assets/16cd4c4b-ea22-43ab-8fa6-a9cbf17c917a

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->