### PR TITLE
[Security Solution] Fix phantom history entries when duplicating rules

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -25,14 +25,18 @@ import {
   getPerformBulkActionDuplicateSchemaMock,
 } from '../../../../../../../common/api/detection_engine/rule_management/mocks';
 import { BulkActionsDryRunErrCodeEnum } from '../../../../../../../common/api/detection_engine';
+import { SecurityRuleChangeTrackingAction } from '../../../../../../../common/detection_engine/rule_management/rule_change_tracking';
 import { createMockEndpointAppContextService } from '../../../../../../endpoint/mocks';
 import { validateRuleResponseActions as _validateRuleResponseActions } from '../../../../../../endpoint/services';
+import { duplicateExceptions as _duplicateExceptions } from '../../../logic/actions/duplicate_exceptions';
 
 jest.mock('../../../../../machine_learning/authz');
+jest.mock('../../../logic/actions/duplicate_exceptions');
 
 let bulkGetRulesMock: jest.Mock;
 
 const validateRuleResponseActionsMock = _validateRuleResponseActions as jest.Mock;
+const duplicateExceptionsMock = _duplicateExceptions as jest.Mock;
 
 jest.mock('../../../../../../endpoint/services', () => {
   const actualModule = jest.requireActual('../../../../../../endpoint/services');
@@ -65,6 +69,8 @@ describe('Perform bulk action route', () => {
       errors: [],
       total: 1,
     });
+    clients.rulesClient.create.mockResolvedValue(mockRule);
+    duplicateExceptionsMock.mockResolvedValue([]);
     performBulkActionRoute(server.router, ml);
   });
 
@@ -816,6 +822,73 @@ describe('Perform bulk action route', () => {
         rulePayload: {},
         existingRule: mockRule,
       });
+    });
+  });
+
+  describe('rule duplication', () => {
+    beforeEach(() => {
+      bulkGetRulesMock.mockResolvedValue({ rules: [mockRule], errors: [] });
+    });
+
+    it('creates the duplicate once with cloned exceptions and never calls update', async () => {
+      const clonedExceptions = [
+        {
+          id: 'cloned-list-id',
+          list_id: 'cloned-list',
+          namespace_type: 'single' as const,
+          type: 'rule_default' as const,
+        },
+      ];
+      duplicateExceptionsMock.mockResolvedValue(clonedExceptions);
+
+      const request = requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_RULES_BULK_ACTION,
+        body: {
+          ...getPerformBulkActionDuplicateSchemaMock(),
+          duplicate: { include_exceptions: true, include_expired_exceptions: true },
+        },
+      });
+
+      await server.inject(request, requestContextMock.convertContext(context));
+
+      expect(duplicateExceptionsMock).toHaveBeenCalledTimes(1);
+      expect(clients.rulesClient.create).toHaveBeenCalledTimes(1);
+      expect(clients.rulesClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            params: expect.objectContaining({ exceptionsList: clonedExceptions }),
+          }),
+          changeTracking: expect.objectContaining({
+            action: SecurityRuleChangeTrackingAction.ruleDuplicate,
+          }),
+        })
+      );
+      expect(clients.rulesClient.update).not.toHaveBeenCalled();
+    });
+
+    it('skips exception duplication when include_exceptions is false but still creates once', async () => {
+      const request = requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_RULES_BULK_ACTION,
+        body: {
+          ...getPerformBulkActionDuplicateSchemaMock(),
+          duplicate: { include_exceptions: false, include_expired_exceptions: false },
+        },
+      });
+
+      await server.inject(request, requestContextMock.convertContext(context));
+
+      expect(duplicateExceptionsMock).not.toHaveBeenCalled();
+      expect(clients.rulesClient.create).toHaveBeenCalledTimes(1);
+      expect(clients.rulesClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            params: expect.objectContaining({ exceptionsList: [] }),
+          }),
+        })
+      );
+      expect(clients.rulesClient.update).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -830,7 +830,7 @@ describe('Perform bulk action route', () => {
       bulkGetRulesMock.mockResolvedValue({ rules: [mockRule], errors: [] });
     });
 
-    it('creates the duplicate once with cloned exceptions and never calls update', async () => {
+    it('creates the duplicate rule with cloned exceptions when include_exceptions is true', async () => {
       const clonedExceptions = [
         {
           id: 'cloned-list-id',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -886,6 +886,9 @@ describe('Perform bulk action route', () => {
           data: expect.objectContaining({
             params: expect.objectContaining({ exceptionsList: [] }),
           }),
+          changeTracking: expect.objectContaining({
+            action: SecurityRuleChangeTrackingAction.ruleDuplicate,
+          }),
         })
       );
       expect(clients.rulesClient.update).not.toHaveBeenCalled();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -867,7 +867,7 @@ describe('Perform bulk action route', () => {
       expect(clients.rulesClient.update).not.toHaveBeenCalled();
     });
 
-    it('skips exception duplication when include_exceptions is false but still creates once', async () => {
+    it('creates the duplicate rule with empty exceptions when include_exceptions is false', async () => {
       const request = requestMock.create({
         method: 'post',
         path: DETECTION_ENGINE_RULES_BULK_ACTION,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -890,6 +890,67 @@ describe('Perform bulk action route', () => {
       );
       expect(clients.rulesClient.update).not.toHaveBeenCalled();
     });
+
+    it('deletes cloned rule_default exception lists when rule creation fails', async () => {
+      const clonedExceptions = [
+        {
+          id: 'shared-list-id',
+          list_id: 'shared-list',
+          namespace_type: 'single' as const,
+          type: 'detection' as const,
+        },
+        {
+          id: 'cloned-list-id',
+          list_id: 'cloned-list',
+          namespace_type: 'single' as const,
+          type: 'rule_default' as const,
+        },
+      ];
+      duplicateExceptionsMock.mockResolvedValue(clonedExceptions);
+      clients.rulesClient.create.mockRejectedValue(new Error('create failed'));
+
+      const request = requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_RULES_BULK_ACTION,
+        body: {
+          ...getPerformBulkActionDuplicateSchemaMock(),
+          duplicate: { include_exceptions: true, include_expired_exceptions: true },
+        },
+      });
+
+      await server.inject(request, requestContextMock.convertContext(context));
+
+      expect(clients.lists.exceptionListClient.deleteExceptionList).toHaveBeenCalledTimes(1);
+      expect(clients.lists.exceptionListClient.deleteExceptionList).toHaveBeenCalledWith({
+        id: 'cloned-list-id',
+        listId: undefined,
+        namespaceType: 'single',
+      });
+    });
+
+    it('does not delete exception lists when rule creation succeeds', async () => {
+      duplicateExceptionsMock.mockResolvedValue([
+        {
+          id: 'cloned-list-id',
+          list_id: 'cloned-list',
+          namespace_type: 'single' as const,
+          type: 'rule_default' as const,
+        },
+      ]);
+
+      const request = requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_RULES_BULK_ACTION,
+        body: {
+          ...getPerformBulkActionDuplicateSchemaMock(),
+          duplicate: { include_exceptions: true, include_expired_exceptions: true },
+        },
+      });
+
+      await server.inject(request, requestContextMock.convertContext(context));
+
+      expect(clients.lists.exceptionListClient.deleteExceptionList).not.toHaveBeenCalled();
+    });
   });
 
   describe('gap range functionality', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -328,26 +328,8 @@ export const performBulkActionRoute = (
                     shouldDuplicateExpiredExceptions = body.duplicate.include_expired_exceptions;
                   }
 
-                  const duplicateRuleToCreate = await duplicateRule({
-                    rule,
-                  });
-
-                  const createdRule = await rulesClient.create({
-                    data: duplicateRuleToCreate,
-                    changeTracking: {
-                      action: SecurityRuleChangeTrackingAction.ruleDuplicate,
-                      metadata: {
-                        bulkCount: rules.length,
-                        originalRuleSoId: rule.id,
-                      },
-                    },
-                  });
-
-                  if (!shouldDuplicateExceptions) {
-                    return createdRule;
-                  }
-
-                  // we try to create exceptions after rule created, and then update rule
+                  // Clone exceptions first so the rule can be created with them already
+                  // attached, avoiding a follow-up update. If this throws, no rule is created.
                   const exceptions = shouldDuplicateExceptions
                     ? await duplicateExceptions({
                         ruleId: rule.params.ruleId,
@@ -357,8 +339,11 @@ export const performBulkActionRoute = (
                       })
                     : [];
 
-                  const updatedRule = await rulesClient.update({
-                    id: createdRule.id,
+                  const duplicateRuleToCreate = await duplicateRule({
+                    rule,
+                  });
+
+                  const createdRule = await rulesClient.create({
                     data: {
                       ...duplicateRuleToCreate,
                       params: {
@@ -367,15 +352,15 @@ export const performBulkActionRoute = (
                       },
                     },
                     changeTracking: {
+                      action: SecurityRuleChangeTrackingAction.ruleDuplicate,
                       metadata: {
                         bulkCount: rules.length,
+                        originalRuleSoId: rule.id,
                       },
                     },
-                    shouldIncrementRevision: () => false,
                   });
 
-                  // TODO: figureout why types can't return just updatedRule
-                  return { ...createdRule, ...updatedRule };
+                  return createdRule;
                 },
                 abortSignal: abortController.signal,
               });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import type { IKibanaResponse } from '@kbn/core/server';
+import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import type { ExceptionListClient } from '@kbn/lists-plugin/server';
+import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import { AbortError } from '@kbn/kibana-utils-plugin/common';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
@@ -34,7 +36,7 @@ import { initPromisePool } from '../../../../../../utils/promise_pool';
 import { routeLimitedConcurrencyTag } from '../../../../../../utils/route_limited_concurrency_tag';
 import { buildMlAuthz } from '../../../../../machine_learning/authz';
 import { buildSiemResponse } from '../../../../routes/utils';
-import type { RuleAlertType } from '../../../../rule_schema';
+import type { RuleAlertType, RuleParams } from '../../../../rule_schema';
 import { duplicateExceptions } from '../../../logic/actions/duplicate_exceptions';
 import { duplicateRule } from '../../../logic/actions/duplicate_rule';
 import { bulkEditRules } from '../../../logic/bulk_actions/bulk_edit_rules';
@@ -140,6 +142,36 @@ const prepareGapParams = ({
   };
 };
 
+const deleteOrphanedExceptions = async ({
+  exceptions,
+  exceptionsClient,
+  logger,
+}: {
+  exceptions: RuleParams['exceptionsList'];
+  exceptionsClient: ExceptionListClient | undefined;
+  logger: Logger;
+}): Promise<void> => {
+  if (exceptionsClient == null) {
+    return;
+  }
+
+  const orphaned = exceptions.filter(({ type }) => type === ExceptionListTypeEnum.RULE_DEFAULT);
+
+  await Promise.all(
+    orphaned.map(async ({ id, namespace_type: namespaceType, list_id: listId }) => {
+      try {
+        await exceptionsClient.deleteExceptionList({ id, listId: undefined, namespaceType });
+      } catch (cleanupError) {
+        logger.warn(
+          `Failed to delete orphaned exception list "${listId}" after rule duplication error: ${
+            transformError(cleanupError).message
+          }`
+        );
+      }
+    })
+  );
+};
+
 export const performBulkActionRoute = (
   router: SecuritySolutionPluginRouter,
   ml: SetupPlugins['ml']
@@ -218,6 +250,7 @@ export const performBulkActionRoute = (
           const endpointAuthz = await ctx.securitySolution.getEndpointAuthz();
           const endpointService = ctx.securitySolution.getEndpointService();
           const spaceId = ctx.securitySolution.getSpaceId();
+          const logger = ctx.securitySolution.getLogger();
 
           const { getExporter, getClient } = ctx.core.savedObjects;
           const client = getClient({ includedHiddenTypes: ['action'] });
@@ -343,22 +376,27 @@ export const performBulkActionRoute = (
                     rule,
                   });
 
-                  const createdRule = await rulesClient.create({
-                    data: {
-                      ...duplicateRuleToCreate,
-                      params: {
-                        ...duplicateRuleToCreate.params,
-                        exceptionsList: exceptions,
+                  const createdRule = await rulesClient
+                    .create({
+                      data: {
+                        ...duplicateRuleToCreate,
+                        params: {
+                          ...duplicateRuleToCreate.params,
+                          exceptionsList: exceptions,
+                        },
                       },
-                    },
-                    changeTracking: {
-                      action: SecurityRuleChangeTrackingAction.ruleDuplicate,
-                      metadata: {
-                        bulkCount: rules.length,
-                        originalRuleSoId: rule.id,
+                      changeTracking: {
+                        action: SecurityRuleChangeTrackingAction.ruleDuplicate,
+                        metadata: {
+                          bulkCount: rules.length,
+                          originalRuleSoId: rule.id,
+                        },
                       },
-                    },
-                  });
+                    })
+                    .catch(async (createError) => {
+                      await deleteOrphanedExceptions({ exceptions, exceptionsClient, logger });
+                      throw createError;
+                    });
 
                   return createdRule;
                 },

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
@@ -384,7 +384,9 @@ export default ({ getService }: FtrProviderContext): void => {
             query: {},
             body: {
               action: BulkActionTypeEnum.duplicate,
-              duplicate: { include_exceptions: false, include_expired_exceptions: false },
+              // Exceptions enabled exercises the path that used to emit a phantom
+              // second history entry; toHaveLength(1) below guards that regression.
+              duplicate: { include_exceptions: true, include_expired_exceptions: true },
             },
           })
           .expect(200);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
@@ -8,7 +8,10 @@
 import expect from 'expect';
 import { ModeEnum } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import { BulkActionTypeEnum } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management';
-import { DETECTION_ENGINE_RULES_IMPORT_URL } from '@kbn/security-solution-plugin/common/constants';
+import {
+  DETECTION_ENGINE_RULES_IMPORT_URL,
+  DETECTION_ENGINE_RULES_URL,
+} from '@kbn/security-solution-plugin/common/constants';
 import { deleteAllRules } from '@kbn/detections-response-ftr-services';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 import {
@@ -374,9 +377,28 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(body.items[0].action).toBe('rule_upgrade');
       });
 
-      it('records rule_duplicate when duplicating a rule', async () => {
+      it('records a single rule_duplicate entry when duplicating a rule with exceptions', async () => {
         const { body: original } = await detectionsApi
           .createRule({ body: getCustomQueryRuleParams() })
+          .expect(200);
+
+        // A rule_default exception makes duplication actually clone and reattach a
+        // list — the path that previously emitted a phantom second history entry.
+        await supertest
+          .post(`${DETECTION_ENGINE_RULES_URL}/${original.id}/exceptions`)
+          .set('kbn-xsrf', 'true')
+          .send({
+            items: [
+              {
+                description: 'Sample exception item',
+                name: 'Sample exception item',
+                type: 'simple',
+                entries: [
+                  { field: 'some.field', operator: 'included', type: 'match', value: 'some value' },
+                ],
+              },
+            ],
+          })
           .expect(200);
 
         const { body: bulkResponse } = await detectionsApi
@@ -384,8 +406,6 @@ export default ({ getService }: FtrProviderContext): void => {
             query: {},
             body: {
               action: BulkActionTypeEnum.duplicate,
-              // Exceptions enabled exercises the path that used to emit a phantom
-              // second history entry; toHaveLength(1) below guards that regression.
               duplicate: { include_exceptions: true, include_expired_exceptions: true },
             },
           })
@@ -400,8 +420,58 @@ export default ({ getService }: FtrProviderContext): void => {
           .expect(200);
 
         expect(body.items).toHaveLength(1);
-        expect(body.items[0].action).toBe('rule_duplicate');
-        expect(body.items[0].metadata?.original_rule_so_id).toBe(original.id);
+
+        const [item] = body.items;
+        expect(item.action).toBe('rule_duplicate');
+        expect(item.old_values).toBeNull();
+        expect(item.metadata?.original_rule_so_id).toBe(original.id);
+        expect(item.rule).toMatchObject({
+          id: duplicatedRuleId,
+          revision: 0,
+          name: 'Custom query rule [Duplicate]',
+          enabled: false,
+        });
+        // The cloned rule_default list is a fresh container, so only its type is stable.
+        expect(item.rule.exceptions_list).toHaveLength(1);
+        expect(item.rule.exceptions_list[0]).toMatchObject({ type: 'rule_default' });
+      });
+
+      it('records a single rule_duplicate entry when duplicating a rule without exceptions', async () => {
+        const { body: original } = await detectionsApi
+          .createRule({ body: getCustomQueryRuleParams() })
+          .expect(200);
+
+        const { body: bulkResponse } = await detectionsApi
+          .performRulesBulkAction({
+            query: {},
+            body: {
+              action: BulkActionTypeEnum.duplicate,
+              duplicate: { include_exceptions: false, include_expired_exceptions: false },
+            },
+          })
+          .expect(200);
+
+        const duplicatedRuleId = bulkResponse.attributes.results.created[0].id;
+
+        await refreshHistory();
+
+        const { body } = await detectionsApi
+          .ruleChangesHistory({ params: { ruleId: duplicatedRuleId }, query: {} })
+          .expect(200);
+
+        expect(body.items).toHaveLength(1);
+
+        const [item] = body.items;
+        expect(item.action).toBe('rule_duplicate');
+        expect(item.old_values).toBeNull();
+        expect(item.metadata?.original_rule_so_id).toBe(original.id);
+        expect(item.rule).toMatchObject({
+          id: duplicatedRuleId,
+          revision: 0,
+          name: 'Custom query rule [Duplicate]',
+          enabled: false,
+        });
+        expect(item.rule.exceptions_list).toEqual([]);
       });
 
       it('records rule_revert when reverting a prebuilt rule', async () => {


### PR DESCRIPTION

**Closes: #272784**

## Summary

Fixes the confusing change-history entries produced when duplicating a detection rule.

## Problem

Rule duplication in the bulk-action route used to create the duplicated rule and then immediately run a **second** `rulesClient.update` to attach the cloned exceptions. That follow-up write produced two misleading history entries:

1. A `Current version • R1` entry showing `No visible field changes` — meaningless for a freshly duplicated rule.
2. A phantom `R0` entry with no action label, change count, or description (`R0` isn't a valid user-facing revision state; the header correctly shows `Revision: 1`).

## Solution

We flip the order so that exceptions are duplicated first and then we create the rule using `rulesClient.create()`.

`duplicateExceptions` never depended on the newly created rule, so we now clone the exceptions **first** and create the duplicated rule **once** with them already attached. This drops the second `update`, the `shouldIncrementRevision: () => false` workaround, and the `{ ...createdRule, ...updatedRule }` merge — leaving a single clean `Duplicated the rule` history entry.

<img width="1392" height="1105" alt="image" src="https://github.com/user-attachments/assets/8c1561ef-6e23-4c33-8a85-179ba0f48b25" />

<img width="1392" height="1105" alt="image" src="https://github.com/user-attachments/assets/fb027ac7-1128-4107-a46a-08c824c6431b" />


## Tradeoff

Partial-failure behavior flips: if exception cloning throws, no rule is created at all (all-or-nothing), instead of leaving an exception-less duplicate behind. ~~If `create` throws after a successful clone, the cloned exception lists are orphaned. This was deemed acceptable.~~

> **Update** ([6ad4367](https://github.com/elastic/kibana/pull/275559/changes/6ad436786f7e8c46f3b3d9d74a1db621ccd2f89b))**:** Following review, `create` failures after a successful clone now trigger a best-effort cleanup that deletes the freshly cloned `rule_default` exception list(s), so they aren't left orphaned. Shared lists are referenced (not cloned), so they're never touched. Cleanup errors are logged and swallowed to avoid masking the original `create` error.

## How to test this

- [ ] Duplicate a rule (with and without exceptions) and confirm the History panel shows exactly one `Current version` / `Duplicated the rule` entry with `Revision: 1`.
- [ ] Confirm duplicated rules still carry their cloned exceptions (shared + rule_default lists).
- [ ] Confirm `include_exceptions` / `include_expired_exceptions` options still behave correctly.


Made with [Cursor](https://cursor.com)
