### PR TITLE
Fix ES|QL hover option selection in FTR

### DIFF
--- a/src/platform/test/functional/services/esql.ts
+++ b/src/platform/test/functional/services/esql.ts
@@ -12,6 +12,19 @@ import type { WebElementWrapper } from '@kbn/ftr-common-functional-ui-services';
 import { Key } from 'selenium-webdriver';
 import { FtrService } from '../ftr_provider_context';
 
+function xpathTextLiteral(text: string) {
+  if (!text.includes("'")) {
+    return `'${text}'`;
+  }
+  if (!text.includes('"')) {
+    return `"${text}"`;
+  }
+  return `concat(${text
+    .split("'")
+    .map((part) => `'${part}'`)
+    .join(', "\'", ')})`;
+}
+
 export class ESQLService extends FtrService {
   private readonly retry = this.ctx.getService('retry');
   private readonly testSubjects = this.ctx.getService('testSubjects');
@@ -271,18 +284,11 @@ export class ESQLService extends FtrService {
       await badge.moveMouseTo();
 
       await this.findService.byCssSelector(`.monaco-hover`);
-      const options = await this.findService.allByCssSelector(`.monaco-hover .hover-row`);
-      let optionToSelect;
-      for (const option of options) {
-        if ((await option.getVisibleText()).includes(optionText)) {
-          optionToSelect = option;
-          break;
-        }
-      }
-
-      if (!optionToSelect) {
-        throw new Error(`Option with text "${optionText}" not found in badge hover.`);
-      }
+      const optionToSelect = await this.findService.byXPath(
+        `//*[contains(concat(' ', normalize-space(@class), ' '), ' monaco-hover ')]//a[normalize-space(.)=${xpathTextLiteral(
+          optionText
+        )}]`
+      );
 
       await optionToSelect.click();
       return true;


### PR DESCRIPTION
## Summary

Fixes the ES|QL FTR hover helper to click the rendered Monaco hover link directly instead of reading and clicking the whole hover row.

In rspack failures, the `Edit lookup index` link was visible in the screenshot and present in the page source, but the helper did not find it via row visible text.

## Verification

- `node scripts/eslint src/platform/test/functional/services/esql.ts`
- `node scripts/type_check --project src/platform/test/tsconfig.json` was attempted but hit an existing-looking `piscina` interop error in `src/platform/packages/private/kbn-babel-transform/fast_async_transformer.js` and timed out.