### PR TITLE
[9.4] [ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050) (#275060)

### DIFF
--- a/x-pack/examples/alerting_example/public/alert_types/pattern.tsx
+++ b/x-pack/examples/alerting_example/public/alert_types/pattern.tsx
@@ -13,6 +13,7 @@ import {
   EuiFormRow,
   EuiButton,
   EuiButtonIcon,
+  EuiToolTip,
   EuiSpacer,
   EuiBasicTable,
   EuiCallOut,
@@ -203,12 +204,14 @@ const PatternExpression: React.FunctionComponent<RuleTypeParamsExpressionProps<P
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiFormRow hasEmptyLabelSpace display="rowCompressed">
-                <EuiButtonIcon
-                  iconType="trash"
-                  color="danger"
-                  aria-label={`Remove ${instanceName}`}
-                  onClick={() => removeInstance(instanceName)}
-                />
+                <EuiToolTip content={`Remove ${instanceName}`} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="trash"
+                    color="danger"
+                    aria-label={`Remove ${instanceName}`}
+                    onClick={() => removeInstance(instanceName)}
+                  />
+                </EuiToolTip>
               </EuiFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx
+++ b/x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx
@@ -8,7 +8,7 @@
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFormRow, EuiButtonIcon, EuiTitle } from '@elastic/eui';
+import { EuiFormRow, EuiButtonIcon, EuiToolTip, EuiTitle } from '@elastic/eui';
 import type { RuleConditionsProps, ActionGroupWithCondition } from './rule_conditions';
 
 export type RuleConditionsGroupProps<ConditionProps> = {
@@ -21,6 +21,11 @@ export const RuleConditionsGroup = <ConditionProps extends unknown>({
   children,
   ...otherProps
 }: PropsWithChildren<RuleConditionsGroupProps<ConditionProps>>) => {
+  const removeConditionLabel = i18n.translate(
+    'xpack.triggersActionsUI.sections.ruleForm.conditions.removeConditionLabel',
+    { defaultMessage: 'Remove' }
+  );
+
   if (!actionGroup) {
     return null;
   }
@@ -36,17 +41,14 @@ export const RuleConditionsGroup = <ConditionProps extends unknown>({
       labelAppend={
         onResetConditionsFor &&
         !actionGroup.isRequired && (
-          <EuiButtonIcon
-            iconType="minusCircle"
-            color="danger"
-            aria-label={i18n.translate(
-              'xpack.triggersActionsUI.sections.ruleForm.conditions.removeConditionLabel',
-              {
-                defaultMessage: 'Remove',
-              }
-            )}
-            onClick={() => onResetConditionsFor(actionGroup)}
-          />
+          <EuiToolTip content={removeConditionLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="minusCircle"
+              color="danger"
+              aria-label={removeConditionLabel}
+              onClick={() => onResetConditionsFor(actionGroup)}
+            />
+          </EuiToolTip>
         )
       }
     >

--- a/x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx
@@ -14,6 +14,7 @@ import {
   EuiHorizontalRule,
   EuiPanel,
   EuiText,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -309,14 +310,16 @@ const Operator = ({ operator, onDelete }: OperatorProps) => {
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          iconType="trash"
-          aria-label={DELETE_OPERAND_LABEL}
-          onClick={onDelete}
-          iconSize="s"
-          color="text"
-          data-test-subj={DELETE_OPERAND_BUTTON_SUBJ}
-        />
+        <EuiToolTip content={DELETE_OPERAND_LABEL} disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="trash"
+            aria-label={DELETE_OPERAND_LABEL}
+            onClick={onDelete}
+            iconSize="s"
+            color="text"
+            data-test-subj={DELETE_OPERAND_BUTTON_SUBJ}
+          />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx
@@ -14,7 +14,7 @@ import { AlertsDataGrid } from './alerts_data_grid';
 import type { AlertsDataGridProps, BulkActionsState } from '../types';
 import type { AdditionalContext, RenderContext } from '../types';
 import type { EuiDataGridColumnCellAction } from '@elastic/eui';
-import { EuiButton, EuiButtonIcon, EuiFlexItem } from '@elastic/eui';
+import { EuiButton, EuiButtonIcon, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { testQueryClientConfig } from '@kbn/alerts-ui-shared/src/common/test_utils/test_query_client_config';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
@@ -241,24 +241,28 @@ describe('AlertsDataGrid', () => {
               renderActionsCell: () => (
                 <>
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="analyzeEvent"
-                      color="primary"
-                      onClick={() => {}}
-                      size="s"
-                      data-test-subj="testAction"
-                      aria-label="testActionLabel"
-                    />
+                    <EuiToolTip content="testActionLabel" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        iconType="analyzeEvent"
+                        color="primary"
+                        onClick={() => {}}
+                        size="s"
+                        data-test-subj="testAction"
+                        aria-label="testActionLabel"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="analyzeEvent"
-                      color="primary"
-                      onClick={() => {}}
-                      size="s"
-                      data-test-subj="testAction2"
-                      aria-label="testActionLabel2"
-                    />
+                    <EuiToolTip content="testActionLabel2" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        iconType="analyzeEvent"
+                        color="primary"
+                        onClick={() => {}}
+                        size="s"
+                        data-test-subj="testAction2"
+                        aria-label="testActionLabel2"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 </>
               ),

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import React, { useState, memo, useCallback } from 'react';
 
 import type { EsQuerySnapshot } from '@kbn/alerting-types';
@@ -53,15 +53,16 @@ const AlertsQueryInspectorComponent: React.FC<InspectButtonProps> = ({
 
   return (
     <>
-      <EuiButtonIcon
-        className={BUTTON_CLASS}
-        aria-label={i18n.INSPECT}
-        data-test-subj="inspect-icon-button"
-        iconSize="m"
-        iconType="inspect"
-        title={i18n.INSPECT}
-        onClick={onOpenModal}
-      />
+      <EuiToolTip content={i18n.INSPECT} disableScreenReaderOutput>
+        <EuiButtonIcon
+          className={BUTTON_CLASS}
+          aria-label={i18n.INSPECT}
+          data-test-subj="inspect-icon-button"
+          iconSize="m"
+          iconType="inspect"
+          onClick={onOpenModal}
+        />
+      </EuiToolTip>
       {isShowingModal && (
         <AlertsQueryInspectorModal
           closeModal={onCloseModal}

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx
@@ -11,7 +11,7 @@ import { AlertsField } from '../types';
 import type { AdditionalContext, RenderContext } from '../types';
 import { createCasesServiceMock, getCasesMapMock } from './cases.mock';
 import { getMaintenanceWindowsMock } from './maintenance_windows.mock';
-import { EuiButtonIcon, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import React from 'react';
 import { identity } from 'lodash';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
@@ -214,14 +214,16 @@ export const mockRenderContext = createPartialObjectMock<RenderContext<Additiona
   }),
   renderActionsCell: () => (
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="analyzeEvent"
-        color="primary"
-        onClick={() => {}}
-        size="s"
-        data-test-subj="testAction"
-        aria-label="Test action"
-      />
+      <EuiToolTip content="Test action" disableScreenReaderOutput>
+        <EuiButtonIcon
+          iconType="analyzeEvent"
+          color="primary"
+          onClick={() => {}}
+          size="s"
+          data-test-subj="testAction"
+          aria-label="Test action"
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   ),
   services: {

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx
@@ -676,21 +676,29 @@ export const RuleActionsItem = (props: RuleActionsItemProps) => {
         `,
       }}
       extraAction={
-        <EuiButtonIcon
-          data-test-subj="ruleActionsItemDeleteButton"
-          style={{
-            marginRight: euiTheme.size.l,
-          }}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
-            {
-              defaultMessage: 'delete action',
-            }
+            { defaultMessage: 'delete action' }
           )}
-          iconType="trash"
-          color="danger"
-          onClick={() => onDelete(action.uuid!)}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="ruleActionsItemDeleteButton"
+            style={{
+              marginRight: euiTheme.size.l,
+            }}
+            aria-label={i18n.translate(
+              'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
+              {
+                defaultMessage: 'delete action',
+              }
+            )}
+            iconType="trash"
+            color="danger"
+            onClick={() => onDelete(action.uuid!)}
+          />
+        </EuiToolTip>
       }
       buttonContentClassName="eui-fullWidth"
       buttonContent={

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx
@@ -252,21 +252,29 @@ export const RuleActionsSystemActionsItem = (props: RuleActionsSystemActionsItem
         `,
       }}
       extraAction={
-        <EuiButtonIcon
-          data-test-subj="ruleActionsSystemActionsItemDeleteActionButton"
-          style={{
-            marginRight: euiTheme.size.l,
-          }}
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
-            {
-              defaultMessage: 'delete action',
-            }
+            { defaultMessage: 'delete action' }
           )}
-          iconType="trash"
-          color="danger"
-          onClick={() => onDelete(action.uuid!)}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            data-test-subj="ruleActionsSystemActionsItemDeleteActionButton"
+            style={{
+              marginRight: euiTheme.size.l,
+            }}
+            aria-label={i18n.translate(
+              'responseOpsRuleForm.ruleActionsSystemActionsItem.deleteActionAriaLabel',
+              {
+                defaultMessage: 'delete action',
+              }
+            )}
+            iconType="trash"
+            color="danger"
+            onClick={() => onDelete(action.uuid!)}
+          />
+        </EuiToolTip>
       }
       buttonContentClassName="eui-fullWidth"
       buttonContent={

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx
@@ -14,6 +14,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 import React from 'react';
 import {
@@ -32,12 +33,14 @@ export const RuleFlyoutSelectConnector = ({ onClose }: RuleFlyoutSelectConnector
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="chevronSingleLeft"
-              onClick={onClose}
-              aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
-              color="text"
-            />
+            <EuiToolTip content={RULE_FLYOUT_HEADER_BACK_TEXT} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="chevronSingleLeft"
+                onClick={onClose}
+                aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
+                color="text"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="xs" data-test-subj="ruleFlyoutSelectConnectorTitle">

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import {
@@ -41,12 +42,14 @@ export const RuleFlyoutShowRequest = ({ onClose }: RuleFlyoutShowRequestProps) =
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="chevronSingleLeft"
-              onClick={onClose}
-              aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
-              color="text"
-            />
+            <EuiToolTip content={RULE_FLYOUT_HEADER_BACK_TEXT} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="chevronSingleLeft"
+                onClick={onClose}
+                aria-label={RULE_FLYOUT_HEADER_BACK_TEXT}
+                color="text"
+              />
+            </EuiToolTip>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="xs" data-test-subj="ruleFlyoutShowRequestTitle">

--- a/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx
+++ b/x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx
@@ -15,6 +15,7 @@ import {
   EuiFlexItem,
   useEuiTheme,
   EuiFormRow,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   RULE_NAME_ARIA_LABEL_TEXT,
@@ -112,13 +113,15 @@ export const RulePageNameInput = () => {
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            color="primary"
-            iconType="check"
-            size="m"
-            onClick={onCancelEdit}
-            aria-label={RULE_NAME_INPUT_BUTTON_ARIA_LABEL}
-          />
+          <EuiToolTip content={RULE_NAME_INPUT_BUTTON_ARIA_LABEL} disableScreenReaderOutput>
+            <EuiButtonIcon
+              color="primary"
+              iconType="check"
+              size="m"
+              onClick={onCancelEdit}
+              aria-label={RULE_NAME_INPUT_BUTTON_ARIA_LABEL}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
     );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050) (#275060)](https://github.com/elastic/kibana/pull/275060)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-06-26T09:09:38Z","message":"[ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050) (#275060)\n\n## Summary\n\nFixes all 21 `@elastic/eui/tooltip-button-icon-wrap` ESLint violations\nacross 14 `@elastic/response-ops` files by wrapping every\n`EuiButtonIcon` with `EuiToolTip`.\n\nCloses #275050\n\n## Changes\n\nEach `EuiButtonIcon` is wrapped with `<EuiToolTip content={ariaLabel}\ndisableScreenReaderOutput>` where the tooltip `content` matches the\nbutton's `aria-label`. `disableScreenReaderOutput` prevents duplicate\nscreen reader announcements. The native `title` prop was removed from\n`alerts_query_inspector.tsx` where it was present.\n\n## PR checklist\n\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\n## Files fixed\n\n- `x-pack/examples/alerting_example/public/alert_types/pattern.tsx`\n-\n`x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/snooze_duration_picker.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/time_condition_panel.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"95ed3ed7594e0132062fc5718ef758e7787cd78c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","backport:version","a11y:agent-pr","v9.5.0","v9.4.4"],"title":"[ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050)","number":275060,"url":"https://github.com/elastic/kibana/pull/275060","mergeCommit":{"message":"[ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050) (#275060)\n\n## Summary\n\nFixes all 21 `@elastic/eui/tooltip-button-icon-wrap` ESLint violations\nacross 14 `@elastic/response-ops` files by wrapping every\n`EuiButtonIcon` with `EuiToolTip`.\n\nCloses #275050\n\n## Changes\n\nEach `EuiButtonIcon` is wrapped with `<EuiToolTip content={ariaLabel}\ndisableScreenReaderOutput>` where the tooltip `content` matches the\nbutton's `aria-label`. `disableScreenReaderOutput` prevents duplicate\nscreen reader announcements. The native `title` prop was removed from\n`alerts_query_inspector.tsx` where it was present.\n\n## PR checklist\n\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\n## Files fixed\n\n- `x-pack/examples/alerting_example/public/alert_types/pattern.tsx`\n-\n`x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/snooze_duration_picker.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/time_condition_panel.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"95ed3ed7594e0132062fc5718ef758e7787cd78c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275060","number":275060,"mergeCommit":{"message":"[ResponseOps] Fix tooltip-button-icon-wrap a11y violations (#275050) (#275060)\n\n## Summary\n\nFixes all 21 `@elastic/eui/tooltip-button-icon-wrap` ESLint violations\nacross 14 `@elastic/response-ops` files by wrapping every\n`EuiButtonIcon` with `EuiToolTip`.\n\nCloses #275050\n\n## Changes\n\nEach `EuiButtonIcon` is wrapped with `<EuiToolTip content={ariaLabel}\ndisableScreenReaderOutput>` where the tooltip `content` matches the\nbutton's `aria-label`. `disableScreenReaderOutput` prevents duplicate\nscreen reader announcements. The native `title` prop was removed from\n`alerts_query_inspector.tsx` where it was present.\n\n## PR checklist\n\n- [x] Read and applied\n[`.agents/skills/accessibility/SKILL.md`](./.agents/skills/accessibility/SKILL.md)\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files (or documented skips in the PR body)\n\n## Files fixed\n\n- `x-pack/examples/alerting_example/public/alert_types/pattern.tsx`\n-\n`x-pack/examples/alerting_example/public/components/rule_conditions_group.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/data_condition_panel.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/snooze_duration_picker.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alert-snooze/components/time_condition_panel.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-filters-form/components/alerts_filters_form.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_data_grid.test.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_query_inspector.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_item.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_actions/rule_actions_system_actions_item.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_select_connector.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_show_request.tsx`\n-\n`x-pack/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_name_input.tsx`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"95ed3ed7594e0132062fc5718ef758e7787cd78c"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->