### PR TITLE
[One Workflow] Add typed ConnectorResponseSizeLimitError

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -38,6 +38,7 @@ export { isEarsExperimentalConnector } from './src/lib/ears_experimental_utils';
 
 export { ConnectorAuthorizationError, isConnectorAuthorizationError } from './src/errors';
 export type { ConnectorAuthorizationReason } from './src/errors';
+export { ConnectorResponseSizeLimitError, isConnectorResponseSizeLimitError } from './src/errors';
 export { AUTH_MODE_BY_AUTH_TYPE_ID } from './src/auth_mode_by_auth_type_id';
 export { getMeta, setMeta, addMeta } from './src/connector_spec_ui';
 export type { BaseMetadata } from './src/connector_spec_ui';

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
+} from './connector_response_size_limit_error';
+
+describe('ConnectorResponseSizeLimitError', () => {
+  it('exposes limitBytes, contentLengthBytes, and estimatedOutputBytes', () => {
+    const error = new ConnectorResponseSizeLimitError({
+      message: 'maxContentLength size of 1048576 exceeded',
+      limitBytes: 1048576,
+      contentLengthBytes: 2097152,
+      estimatedOutputBytes: 2800000,
+    });
+
+    expect(error.message).toBe('maxContentLength size of 1048576 exceeded');
+    expect(error.limitBytes).toBe(1048576);
+    expect(error.contentLengthBytes).toBe(2097152);
+    expect(error.estimatedOutputBytes).toBe(2800000);
+  });
+
+  it('allows undefined optional fields', () => {
+    const error = new ConnectorResponseSizeLimitError({
+      message: 'maxContentLength size of 1048576 exceeded',
+    });
+
+    expect(error.limitBytes).toBeUndefined();
+    expect(error.contentLengthBytes).toBeUndefined();
+    expect(error.estimatedOutputBytes).toBeUndefined();
+  });
+});
+
+describe('isConnectorResponseSizeLimitError', () => {
+  it('returns true for a ConnectorResponseSizeLimitError instance', () => {
+    const error = new ConnectorResponseSizeLimitError({
+      message: 'maxContentLength size of 1048576 exceeded',
+      limitBytes: 1048576,
+      contentLengthBytes: 2097152,
+    });
+
+    expect(isConnectorResponseSizeLimitError(error)).toBe(true);
+  });
+
+  it('returns true for an Error-like object with matching name (cross-realm)', () => {
+    // Simulates an error thrown from a different JS realm (vm context, worker,
+    // iframe, etc.) where `instanceof ConnectorResponseSizeLimitError` is false
+    // but the error's shape and name are preserved.
+    const crossRealmError = Object.assign(new Error('maxContentLength size of 1048576 exceeded'), {
+      name: 'ConnectorResponseSizeLimitError',
+      limitBytes: 1048576,
+    });
+
+    expect(crossRealmError).not.toBeInstanceOf(ConnectorResponseSizeLimitError);
+    expect(isConnectorResponseSizeLimitError(crossRealmError)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(
+      isConnectorResponseSizeLimitError(new Error('maxContentLength size of 1048576 exceeded'))
+    ).toBe(false);
+  });
+
+  it('returns false for a subclassed Error whose name does not match', () => {
+    class SomeOtherError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'SomeOtherError';
+      }
+    }
+
+    expect(isConnectorResponseSizeLimitError(new SomeOtherError('boom'))).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isError } from 'lodash';
+
+/**
+ * Structured error thrown when a connector response exceeds the Actions HTTP
+ * response-size limit (`xpack.actions.maxResponseContentLength`, or a per-request
+ * override). It carries the configured limit and any known size hints so the
+ * workflow layer can build an actionable error without string-matching the
+ * underlying Axios message.
+ */
+export class ConnectorResponseSizeLimitError extends Error {
+  public readonly limitBytes?: number;
+  public readonly contentLengthBytes?: number;
+  public readonly estimatedOutputBytes?: number;
+
+  constructor({
+    message,
+    limitBytes,
+    contentLengthBytes,
+    estimatedOutputBytes,
+  }: {
+    message: string;
+    limitBytes?: number;
+    contentLengthBytes?: number;
+    estimatedOutputBytes?: number;
+  }) {
+    super(message);
+    this.name = 'ConnectorResponseSizeLimitError';
+    this.limitBytes = limitBytes;
+    this.contentLengthBytes = contentLengthBytes;
+    this.estimatedOutputBytes = estimatedOutputBytes;
+  }
+}
+
+export const isConnectorResponseSizeLimitError = (
+  error: unknown
+): error is ConnectorResponseSizeLimitError => {
+  return (
+    error instanceof ConnectorResponseSizeLimitError ||
+    (isError(error) && error.name === 'ConnectorResponseSizeLimitError')
+  );
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/index.ts
@@ -12,3 +12,8 @@ export {
   isConnectorAuthorizationError,
 } from './connector_authorization_error';
 export type { ConnectorAuthorizationReason } from './connector_authorization_error';
+
+export {
+  ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
+} from './connector_response_size_limit_error';

--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/actions_plugin_mock/fake_connectors.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/actions_plugin_mock/fake_connectors.ts
@@ -52,6 +52,22 @@ export const FakeConnectors = {
     actionTypeId: 'inference',
     name: 'large_response_connector',
   },
+  /**
+   * Simulates the Actions HTTP transport limit (Layer 1): returns the typed
+   * `ConnectorResponseSizeLimitError` result shape that `action_executor.ts`
+   * produces when the Axios `maxContentLength` is exceeded.
+   */
+  transport_limit_http: {
+    id: 'a7b8c9d0-e1f2-3456-ab78-cd90ef123456',
+    actionTypeId: 'http',
+    name: 'transport_limit_http_connector',
+  },
+  /** Same as above but a spec connector type (Google Drive), to exercise the spec path. */
+  transport_limit_spec: {
+    id: 'b8c9d0e1-f2a3-4567-bc89-de01fa234567',
+    actionTypeId: 'google_drive',
+    name: 'transport_limit_spec_connector',
+  },
 };
 
 export async function getMockedConnectorResult(
@@ -114,6 +130,25 @@ export async function getMockedConnectorResult(
         status: 'ok' as const,
         actionId: id,
         data: { payload: largePayload },
+      };
+    }
+    case FakeConnectors.transport_limit_http.name:
+    case FakeConnectors.transport_limit_spec.name: {
+      const limitBytes = typeof params?.limitBytes === 'number' ? params.limitBytes : 1024 * 1024;
+      const contentLengthBytes =
+        typeof params?.contentLengthBytes === 'number'
+          ? params.contentLengthBytes
+          : 10 * 1024 * 1024;
+      return {
+        status: 'error' as const,
+        actionId: id,
+        message: 'an error occurred while running the action',
+        serviceMessage: `maxContentLength size of ${limitBytes} exceeded`,
+        errorName: 'ConnectorResponseSizeLimitError',
+        errorMeta: {
+          limitBytes,
+          contentLengthBytes,
+        },
       };
     }
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/response_size_limits.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/response_size_limits.test.ts
@@ -281,6 +281,64 @@ steps:
       });
     });
 
+    describe('Layer 1: transport limit (typed ConnectorResponseSizeLimitError)', () => {
+      describe('http connector routes to StepSizeLimitExceeded', () => {
+        let workflowRunFixture: WorkflowRunFixture;
+
+        beforeAll(async () => {
+          workflowRunFixture = new WorkflowRunFixture();
+
+          const workflowYaml = `
+steps:
+  - name: http_transport_limit
+    type: ${FakeConnectors.transport_limit_http.actionTypeId}
+    connector-id: ${FakeConnectors.transport_limit_http.name}
+    with:
+      limitBytes: 1048576
+      contentLengthBytes: 10485760
+`;
+          await workflowRunFixture.runWorkflow({ workflowYaml });
+        });
+
+        it('fails with StepSizeLimitExceeded (workflow transport limit applies)', () => {
+          const stepExecutions = Array.from(
+            workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
+          );
+          const step = stepExecutions.find((s) => s.stepId === 'http_transport_limit');
+          expect(step?.status).toBe(ExecutionStatus.FAILED);
+          expect(step?.error?.type).toBe('StepSizeLimitExceeded');
+        });
+      });
+
+      describe('spec connector without max-step-size routes to ActionsResponseContentLengthExceeded', () => {
+        let workflowRunFixture: WorkflowRunFixture;
+
+        beforeAll(async () => {
+          workflowRunFixture = new WorkflowRunFixture();
+
+          const workflowYaml = `
+steps:
+  - name: spec_transport_limit
+    type: ${FakeConnectors.transport_limit_spec.actionTypeId}
+    connector-id: ${FakeConnectors.transport_limit_spec.name}
+    with:
+      limitBytes: 1048576
+      contentLengthBytes: 10485760
+`;
+          await workflowRunFixture.runWorkflow({ workflowYaml });
+        });
+
+        it('fails with ActionsResponseContentLengthExceeded (actions HTTP limit fired first)', () => {
+          const stepExecutions = Array.from(
+            workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
+          );
+          const step = stepExecutions.find((s) => s.stepId === 'spec_transport_limit');
+          expect(step?.status).toBe(ExecutionStatus.FAILED);
+          expect(step?.error?.type).toBe('ActionsResponseContentLengthExceeded');
+        });
+      });
+    });
+
     describe('input size check rejects oversized inputs before _run()', () => {
       let workflowRunFixture: WorkflowRunFixture;
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
@@ -230,7 +230,7 @@ describe('ConnectorStepImpl', () => {
     expect(result.error.message).toBe('connector failed');
   });
 
-  it('returns ResponseSizeLimitError when maxContentLength exceeded', async () => {
+  it('returns ResponseSizeLimitError when ConnectorResponseSizeLimitError is reported', async () => {
     const { stepExecutionRuntime, connectorExecutor, workflowRuntime, workflowLogger } =
       createMocks();
 
@@ -238,6 +238,8 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 10485760 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: { limitBytes: 10485760 },
     });
 
     const step = {
@@ -267,7 +269,9 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
       errorMeta: {
+        limitBytes: 1024 * 1024,
         contentLengthBytes: 10 * 1024 * 1024,
         estimatedOutputBytes: 14 * 1024 * 1024,
       },
@@ -314,6 +318,8 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: { limitBytes: 1024 * 1024 },
     });
 
     const step = {
@@ -352,7 +358,9 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
       errorMeta: {
+        limitBytes: 1024 * 1024,
         contentLengthBytes: 10 * 1024 * 1024,
         estimatedOutputBytes: 14 * 1024 * 1024,
       },
@@ -394,7 +402,8 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
-      errorMeta: { contentLengthBytes: 10 * 1024 * 1024 },
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: { limitBytes: 1048576, contentLengthBytes: 10 * 1024 * 1024 },
     });
 
     const step = {
@@ -422,6 +431,37 @@ describe('ConnectorStepImpl', () => {
       contentLengthBytes: 10 * 1024 * 1024,
       suggestedLimitBytes: 10 * 1024 * 1024,
     });
+  });
+
+  it('returns ConnectorExecutionError for connector errors without the size-limit errorName', async () => {
+    const { stepExecutionRuntime, connectorExecutor, workflowRuntime, workflowLogger } =
+      createMocks();
+
+    // Even if the message happens to contain "maxContentLength", detection is now
+    // driven by errorName, not string-matching.
+    connectorExecutor.execute.mockResolvedValue({
+      status: 'error',
+      message: null,
+      serviceMessage: 'maxContentLength size of 1048576 exceeded',
+    });
+
+    const step = {
+      name: 'http-step',
+      stepId: 'http-step',
+      type: 'http',
+      'connector-id': 'conn-123',
+    };
+
+    const impl = new ConnectorStepImpl(
+      step,
+      stepExecutionRuntime as any,
+      connectorExecutor as any,
+      workflowRuntime as any,
+      workflowLogger as any
+    );
+
+    const result = await (impl as any)._run({});
+    expect(result.error.type).toBe('ConnectorExecutionError');
   });
 
   it('throws when connectorExecutor is undefined', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
@@ -29,16 +29,13 @@ import type { IWorkflowEventLogger } from '../workflow_event_logger';
  */
 const CONNECTOR_TYPES_WITH_LAYER_1 = new Set<string>(['http']);
 
-// Axios internal error message format — no typed error code is exposed for this case,
-// so regex matching is the only reliable detection method.
-const ACTIONS_MAX_CONTENT_LENGTH_ERROR_PATTERN = /maxContentLength size of (\d+) exceeded/;
+// errorName set by the Actions executor when it catches a typed
+// ConnectorResponseSizeLimitError (see action_executor.ts).
+const CONNECTOR_RESPONSE_SIZE_LIMIT_ERROR_NAME = 'ConnectorResponseSizeLimitError';
 
-const getActionsMaxContentLengthLimit = (errorMessage: string): number | undefined => {
-  const match = errorMessage.match(ACTIONS_MAX_CONTENT_LENGTH_ERROR_PATTERN);
-  if (!match) {
-    return undefined;
-  }
-  return Number(match[1]);
+const getLimitBytes = (errorMeta: Record<string, unknown> | undefined): number | undefined => {
+  const limitBytes = errorMeta?.limitBytes;
+  return typeof limitBytes === 'number' ? limitBytes : undefined;
 };
 
 const getContentLengthBytes = (
@@ -190,7 +187,7 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
         }
       }
 
-      const { data, status, message, serviceMessage, errorMeta } = output;
+      const { data, status, message, serviceMessage, errorName, errorMeta } = output;
 
       if (status === 'ok') {
         return {
@@ -201,14 +198,13 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
       } else {
         const errorMsg = serviceMessage ?? message ?? 'Unknown error';
 
-        if (errorMsg.includes('maxContentLength')) {
+        if (errorName === CONNECTOR_RESPONSE_SIZE_LIMIT_ERROR_NAME) {
           if (!usesWorkflowTransportLimit) {
-            const limitBytes = getActionsMaxContentLengthLimit(errorMsg);
             return {
               input: withInputs,
               output: undefined,
               error: new ActionsResponseContentLengthLimitError(step.name, {
-                limitBytes,
+                limitBytes: getLimitBytes(errorMeta),
                 contentLengthBytes: getContentLengthBytes(errorMeta),
                 estimatedOutputBytes: getEstimatedOutputBytes(errorMeta),
                 canOverrideWithMaxStepSize: isSpecConnector,

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -31,7 +31,7 @@ import { finished } from 'stream/promises';
 import { PassThrough } from 'stream';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { createTaskRunError, getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
-import { ConnectorAuthorizationError } from '@kbn/connector-specs';
+import { ConnectorAuthorizationError, ConnectorResponseSizeLimitError } from '@kbn/connector-specs';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import type { ConnectorRateLimiter } from './connector_rate_limiter';
 import { createMockInMemoryConnector } from '../application/connector/mocks';
@@ -1557,6 +1557,46 @@ describe('Action Executor', () => {
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
         tags: ['test', '1', 'action-run-failed', 'user-error'],
+      });
+    });
+
+    test(`${label} returns structured error result when executor throws ConnectorResponseSizeLimitError`, async () => {
+      const err = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+        contentLengthBytes: 10 * 1024 * 1024,
+        estimatedOutputBytes: 14 * 1024 * 1024,
+      });
+      err.stack = 'foo error\n  stack 1\n  stack 2\n  stack 3';
+      (
+        connectorType.executor as jest.MockedFunction<NonNullable<ConnectorType['executor']>>
+      ).mockRejectedValueOnce(err);
+      encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValueOnce(
+        connectorSavedObject
+      );
+      connectorTypeRegistry.get.mockReturnValueOnce(connectorType);
+
+      let executorResult;
+      if (executeUnsecure) {
+        executorResult = await actionExecutor.executeUnsecured(executeUnsecuredParams);
+      } else {
+        executorResult = await actionExecutor.execute(executeParams);
+      }
+
+      expect(executorResult).toEqual({
+        actionId: CONNECTOR_ID,
+        status: 'error',
+        message: 'an error occurred while running the action',
+        serviceMessage: 'maxContentLength size of 1048576 exceeded',
+        errorName: 'ConnectorResponseSizeLimitError',
+        errorMeta: {
+          connectorName: '1',
+          limitBytes: 1048576,
+          contentLengthBytes: 10 * 1024 * 1024,
+          estimatedOutputBytes: 14 * 1024 * 1024,
+        },
+        retry: false,
+        errorSource: TaskErrorSource.USER,
       });
     });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -21,7 +21,10 @@ import type { IEventLogger } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getErrorSource as getTaskManagerErrorSource } from '@kbn/task-manager-plugin/server/task_running';
-import { isConnectorAuthorizationError } from '@kbn/connector-specs';
+import {
+  isConnectorAuthorizationError,
+  isConnectorResponseSizeLimitError,
+} from '@kbn/connector-specs';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import { ConnectorUsageCollector } from '../usage/connector_usage_collector';
 import {
@@ -602,6 +605,27 @@ export class ActionExecutor {
                 connectorName: name,
                 authMethod: err.authMethod,
                 reason: err.reason,
+              },
+              error: err,
+              retry: false,
+              errorSource: TaskErrorSource.USER,
+            };
+          } else if (isConnectorResponseSizeLimitError(err)) {
+            rawResult = {
+              actionId,
+              status: 'error',
+              message: 'an error occurred while running the action',
+              serviceMessage: err.message,
+              errorName: 'ConnectorResponseSizeLimitError',
+              errorMeta: {
+                connectorName: name,
+                ...(err.limitBytes !== undefined ? { limitBytes: err.limitBytes } : {}),
+                ...(err.contentLengthBytes !== undefined
+                  ? { contentLengthBytes: err.contentLengthBytes }
+                  : {}),
+                ...(err.estimatedOutputBytes !== undefined
+                  ? { estimatedOutputBytes: err.estimatedOutputBytes }
+                  : {}),
               },
               error: err,
               retry: false,

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.test.ts
@@ -17,6 +17,7 @@ import { requestOAuthClientCredentialsToken } from './request_oauth_client_crede
 import { getOAuthAuthorizationCodeAccessToken } from './get_oauth_authorization_code_access_token';
 import { PFX } from '@kbn/connector-specs/src/auth_types/pfx';
 import type { NormalizedAuthType } from '@kbn/connector-specs';
+import { ConnectorResponseSizeLimitError } from '@kbn/connector-specs';
 
 jest.mock('./get_custom_agents', () => ({
   getCustomAgents: jest.fn().mockReturnValue({
@@ -120,11 +121,35 @@ describe('getAxiosInstance', () => {
 
     // @ts-expect-error accessing internal axios interceptor handlers
     const rejectionHandler = result!.interceptors.response.handlers[0].rejected as Function;
-    await expect(rejectionHandler(error)).rejects.toBe(error);
+    await expect(rejectionHandler(error)).rejects.toMatchObject({
+      name: 'ConnectorResponseSizeLimitError',
+      limitBytes: 20971520,
+      contentLengthBytes: 104857600,
+    });
+    await expect(rejectionHandler(error)).rejects.toBeInstanceOf(ConnectorResponseSizeLimitError);
 
     expect(logger.debug).toHaveBeenCalledWith(
       'Actions Axios request exceeded maxContentLength: maxContentLength size of 20971520 exceeded; metadata: {"connectorId":"1","configuredMaxContentLength":20971520,"errorCode":"ERR_BAD_RESPONSE","responseStatus":200,"responseHeaders":{"content-length":"104857600","content-type":"application/octet-stream"},"requestResponseHeaders":{"Content-Length":"104857600"}}'
     );
+  });
+
+  test('passes through non-size errors from the response interceptor unchanged', async () => {
+    const getAxios = getAxiosInstanceWithAuth({
+      authTypeRegistry,
+      configurationUtilities,
+      logger,
+    });
+    const result = await getAxios({
+      connectorId: '1',
+      secrets: {},
+      maxContentLength: 20 * 1024 * 1024,
+    });
+
+    const error = new Error('some other network error');
+
+    // @ts-expect-error accessing internal axios interceptor handlers
+    const rejectionHandler = result!.interceptors.response.handlers[0].rejected as Function;
+    await expect(rejectionHandler(error)).rejects.toBe(error);
   });
 
   test('throws error when auth type is not supported', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
@@ -14,6 +14,10 @@ import type {
 import axios from 'axios';
 import type { Logger } from '@kbn/core/server';
 import type { AuthMode, GetTokenOpts } from '@kbn/connector-specs';
+import {
+  ConnectorResponseSizeLimitError,
+  getResponseContentLengthBytes,
+} from '@kbn/connector-specs';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { ActionInfo } from './action_executor';
 import type { AuthTypeRegistry } from '../auth_types';
@@ -108,6 +112,31 @@ const logMaxContentLengthError = ({
       requestResponseHeaders: pickSafeHeaders(axiosError.request?.res?.headers),
     })}`
   );
+};
+
+/**
+ * Converts an Axios `maxContentLength` rejection into a typed
+ * `ConnectorResponseSizeLimitError` so downstream layers (action executor,
+ * workflow step) can detect the size-limit case via `errorName` instead of
+ * string-matching the Axios message. Non-size errors are returned unchanged.
+ */
+const toConnectorResponseSizeLimitError = ({
+  error,
+  maxContentLength,
+}: {
+  error: unknown;
+  maxContentLength: number;
+}): unknown => {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  if (!errorMessage.includes(MAX_CONTENT_LENGTH_ERROR_MESSAGE)) {
+    return error;
+  }
+
+  return new ConnectorResponseSizeLimitError({
+    message: errorMessage,
+    limitBytes: maxContentLength,
+    contentLengthBytes: getResponseContentLengthBytes(error),
+  });
 };
 
 export interface GetAxiosInstanceWithAuthFnOpts {
@@ -220,7 +249,12 @@ export const getAxiosInstanceWithAuth = ({
           logger,
           maxContentLength: configuredMaxContentLength,
         });
-        return Promise.reject(error);
+        return Promise.reject(
+          toConnectorResponseSizeLimitError({
+            error,
+            maxContentLength: configuredMaxContentLength,
+          })
+        );
       });
 
       return configuredAxiosInstance;

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -8,7 +8,11 @@
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
 import { generateExecutorFunction } from './generate_executor_function';
-import { setConnectorActionErrorMeta } from '@kbn/connector-specs';
+import {
+  ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
+  setConnectorActionErrorMeta,
+} from '@kbn/connector-specs';
 import type { ConnectorSpec } from '@kbn/connector-specs';
 import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
 
@@ -361,6 +365,70 @@ describe('generateExecutorFunction', () => {
       await expect(
         executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
       ).resolves.toMatchObject({ status: 'error' });
+    });
+  });
+
+  describe('ConnectorResponseSizeLimitError handling', () => {
+    it('re-throws the typed error enriched with content-length from the response header', async () => {
+      const error = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+      }) as ConnectorResponseSizeLimitError & {
+        response?: { headers?: Record<string, string> };
+      };
+      error.response = { headers: { 'content-length': '10485760' } };
+      mockHandler.mockRejectedValue(error);
+
+      const executor = generateExecutorFunction({
+        actions: makeActions(),
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+      });
+
+      await expect(
+        executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
+      ).rejects.toMatchObject({
+        name: 'ConnectorResponseSizeLimitError',
+        limitBytes: 1048576,
+        contentLengthBytes: 10 * 1024 * 1024,
+      });
+    });
+
+    it('enriches the typed error using the action responseSizeHeader and connector meta', async () => {
+      const error = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+      }) as ConnectorResponseSizeLimitError & {
+        request?: { res?: { headers?: Record<string, string> } };
+      };
+      error.request = { res: { headers: { 'x-decompressed-content-length': '2048' } } };
+      setConnectorActionErrorMeta(error, { estimatedOutputBytes: 4096 });
+      mockHandler.mockRejectedValue(error);
+
+      const executor = generateExecutorFunction({
+        actions: {
+          testAction: {
+            isTool: true,
+            input: {} as never,
+            responseSizeHeader: 'x-decompressed-content-length',
+            handler: mockHandler,
+          },
+        },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+      });
+
+      let thrown: unknown;
+      try {
+        await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(isConnectorResponseSizeLimitError(thrown)).toBe(true);
+      expect(thrown).toMatchObject({
+        limitBytes: 1048576,
+        contentLengthBytes: 2048,
+        estimatedOutputBytes: 4096,
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -7,9 +7,11 @@
 
 import type { ConnectorSpec } from '@kbn/connector-specs';
 import {
+  ConnectorResponseSizeLimitError,
   getConnectorActionErrorMeta,
   getFinitePositiveNumber,
   getHeaderValue,
+  isConnectorResponseSizeLimitError,
 } from '@kbn/connector-specs';
 import type { ExecutorParams } from '../../sub_action_framework/types';
 import type {
@@ -131,6 +133,19 @@ export const generateExecutorFunction = ({
       });
       const errorMeta = getErrorMeta({ error, contentLengthBytes });
       logger.error(`error on ${connectorId} event: ${errorMessage}`);
+
+      // Re-throw the typed size-limit error (enriched with the connector's
+      // declared responseSizeHeader value and any provider size hints) so the
+      // action executor can surface it as a structured `errorName` result.
+      if (isConnectorResponseSizeLimitError(error)) {
+        throw new ConnectorResponseSizeLimitError({
+          message: errorMessage,
+          limitBytes: error.limitBytes,
+          contentLengthBytes: getFinitePositiveNumber(errorMeta?.contentLengthBytes),
+          estimatedOutputBytes: getFinitePositiveNumber(errorMeta?.estimatedOutputBytes),
+        });
+      }
+
       return {
         status: 'error',
         message: errorMessage,


### PR DESCRIPTION
## Summary

Follow-up to #268591 (requested by @jcger in [this thread](https://github.com/elastic/kibana/pull/268591#discussion_r3254247175); based on his design / draft in jcger/kibana#4).

Replaces the brittle string-matching of the Axios `maxContentLength` error message with a typed `ConnectorResponseSizeLimitError`, following the same pattern as the existing `ConnectorAuthorizationError`. The cross-layer contract between the actions plugin and the workflow execution engine becomes explicit and typed instead of an untyped `errorMeta` bag detected by substring-matching an internal Axios message.

### What changed

- **New `ConnectorResponseSizeLimitError`** in `@kbn/connector-specs` — typed error carrying `limitBytes`, `contentLengthBytes`, and `estimatedOutputBytes`, plus an `isConnectorResponseSizeLimitError` guard (mirrors `ConnectorAuthorizationError`).
- **`get_axios_instance.ts`** — the response interceptor now converts the Axios `maxContentLength` rejection into the typed error at the source (carrying the configured limit and the response `content-length`). Non-size errors pass through unchanged.
- **`generate_executor_function.ts`** — re-throws the typed error enriched with the connector's declared `responseSizeHeader` value (e.g. Jina's `x-decompressed-content-length`) and any provider size hints attached via the `setConnectorActionErrorMeta` WeakMap.
- **`action_executor.ts`** — handles `ConnectorResponseSizeLimitError` in its catch block (parallel to `isConnectorAuthorizationError`), serializing it into `errorName: 'ConnectorResponseSizeLimitError'` + structured `errorMeta`.
- **`connector_step.ts`** — detection now uses `errorName === 'ConnectorResponseSizeLimitError'` instead of `errorMsg.includes('maxContentLength')`. The string-match is removed entirely. Routing is unchanged: `ResponseSizeLimitError` (`StepSizeLimitExceeded`) when the workflow transport limit applies, or `ActionsResponseContentLengthLimitError` (`ActionsResponseContentLengthExceeded`) when the actions HTTP limit fired first.

### Two size-limit paths (unchanged behavior)

- **Layer 1 (transport)**: Axios aborts the stream at `xpack.actions.maxResponseContentLength` / the per-step `max_content_length` override. This is the path now made typed.
- **Layer 2 (output)**: the workflow base class rejects step output bigger than `max-step-size`. Untouched; existing integration coverage stays green.

## Test plan

- [x] Unit: new `connector_response_size_limit_error.test.ts`
- [x] Unit: `get_axios_instance.test.ts` (interceptor now produces the typed error; non-size errors pass through)
- [x] Unit: `generate_executor_function.test.ts` (typed error re-thrown enriched with `responseSizeHeader` + WeakMap meta)
- [x] Unit: `action_executor.test.ts` (typed error -> `errorName`/`errorMeta` result)
- [x] Unit: `connector_step.test.ts` (errorName-driven detection across http / spec-with-max-step-size / spec-without / non-layer-1; non-typed error still -> `ConnectorExecutionError`)
- [x] Integration: `response_size_limits.test.ts` new Layer 1 block (http -> `StepSizeLimitExceeded`, spec-without-max-step-size -> `ActionsResponseContentLengthExceeded`); Layer 2 cases unchanged
- [x] `node scripts/type_check` for `kbn-connector-specs`, `actions`, `workflows_execution_engine`
- [x] `node scripts/eslint`
- [ ] Manual: Jina large page (`x-decompressed-content-length`), Google Drive large file, plain HTTP over actions limit, HTTP with `max-step-size`, small-response regression

## Release note

Workflow connector response size-limit errors are now detected via a typed error rather than internal message matching, producing more reliable and actionable error messages.

Made with [Cursor](https://cursor.com)