### PR TITLE
[DO NOT COMMIT][EDR Workflows] Bulk response actions at policy level

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/common/base.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/common/base.ts
@@ -7,6 +7,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
+import { validateNonEmptyString } from '../../schema_utils';
 import { SUPPORTED_HOST_OS_TYPE } from '../../../../endpoint/constants';
 import { RESPONSE_ACTION_AGENT_TYPE } from '../../../../endpoint/service/response_actions/constants';
 
@@ -31,15 +32,16 @@ export const HostOsTypeSchemaLiteral = SUPPORTED_HOST_OS_TYPE.map((osType) =>
 
 export const BaseActionRequestSchema = {
   /** A list of endpoint IDs whose hosts will be isolated (Fleet Agent IDs will be retrieved for these) */
-  endpoint_ids: schema.arrayOf(schema.string({ minLength: 1 }), {
-    minSize: 1,
+  endpoint_ids: schema.arrayOf(schema.string({ minLength: 1, validate: validateNonEmptyString }), {
+    minSize: 0,
     maxSize: 250,
-    validate: (endpointIds) => {
-      if (endpointIds.map((v) => v.trim()).some((v) => !v.length)) {
-        return 'endpoint_ids cannot contain empty strings';
-      }
-    },
   }),
+  integration_policy_ids: schema.maybe(
+    schema.arrayOf(
+      schema.string({ minLength: 1, maxLength: 100, validate: validateNonEmptyString }),
+      { minSize: 1, maxSize: 1 }
+    )
+  ),
   /** If defined, any case associated with the given IDs will be updated */
   alert_ids: schema.maybe(
     schema.arrayOf(schema.string({ minLength: 1 }), {

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -66,7 +66,7 @@ export const allowedExperimentalValues = Object.freeze({
    * `cancel` response action for Elastic Defend Endpoint
    * Release: 9.5
    */
-  responseActionsEndpointCancel: false,
+  responseActionsEndpointCancel: true, // FIXME:PT done only for POC. DO NOT COMMIT
 
   /**
    * Enables the Assistant Model Evaluation advanced setting and API endpoint, introduced in `8.11.0`.

--- a/x-pack/solutions/security/plugins/security_solution/public/management/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/common/constants.ts
@@ -59,3 +59,6 @@ export const MANAGEMENT_DEFAULT_SORT_FIELD = 'created_at';
 // --[ DEFAULTS ]---------------------------------------------------------------------------
 /** The default polling interval for API calls that require a refresh interval */
 export const DEFAULT_POLL_INTERVAL = 10000;
+
+// LocalStorage key used to store Response Console entered command history
+export const RESPONSE_CONSOLE_STORAGE_KEY = 'xpack.securitySolution.Responder';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/cancel_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/cancel_action.tsx
@@ -28,7 +28,7 @@ export const CancelActionResult = memo<
     return endpointId
       ? {
           agent_type: agentType,
-          endpoint_ids: [endpointId],
+          endpoint_ids: endpointId,
           comment: comment?.[0],
           parameters: {
             id: action[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/cancel_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/cancel_action.tsx
@@ -21,14 +21,12 @@ export const CancelActionResult = memo<
   const actionCreator = useSendCancelRequest();
 
   const actionRequestBody = useMemo<undefined | CancelActionRequestBody>(() => {
-    const endpointId = command.commandDefinition?.meta?.endpointId;
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { action, comment, force } = command.args.args;
-    const agentType = command.commandDefinition?.meta?.agentType;
 
-    return endpointId
+    return endpointId && apiReqBodyBase
       ? {
-          agent_type: agentType,
-          endpoint_ids: endpointId,
+          ...apiReqBodyBase,
           comment: comment?.[0],
           parameters: {
             id: action[0],
@@ -36,11 +34,11 @@ export const CancelActionResult = memo<
           },
         }
       : undefined;
-  }, [
-    command.args.args,
-    command.commandDefinition?.meta?.agentType,
-    command.commandDefinition?.meta?.endpointId,
-  ]);
+  }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   return useConsoleActionSubmitter<CancelActionRequestBody>({
     ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/execute_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/execute_action.tsx
@@ -32,9 +32,9 @@ export const ExecuteActionResult = memo<
 >(({ command, setStore, store, status, setStatus, ResultComponent }) => {
   const actionCreator = useSendExecuteEndpoint();
   const actionRequestBody = useMemo<undefined | ExecuteActionRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
 
-    if (!endpointId || !apiReqBodyBase) {
+    if (!apiReqBodyBase) {
       return;
     }
     return {
@@ -88,7 +88,6 @@ export const ExecuteActionResult = memo<
       <ExecuteActionHostResponse
         action={completedActionDetails}
         canAccessFileDownloadLink={true}
-        agentId={command.commandDefinition?.meta?.endpointId}
         textSize="s"
         data-test-subj="console"
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/execute_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/execute_action.tsx
@@ -32,14 +32,13 @@ export const ExecuteActionResult = memo<
 >(({ command, setStore, store, status, setStatus, ResultComponent }) => {
   const actionCreator = useSendExecuteEndpoint();
   const actionRequestBody = useMemo<undefined | ExecuteActionRequestBody>(() => {
-    const { endpointId, agentType } = command.commandDefinition?.meta ?? {};
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
 
-    if (!endpointId) {
+    if (!endpointId || !apiReqBodyBase) {
       return;
     }
     return {
-      agent_type: agentType,
-      endpoint_ids: endpointId,
+      ...apiReqBodyBase,
       parameters: {
         command: command.args.args.command[0],
         timeout: parsedExecuteTimeout(command.args.args.timeout?.[0]),
@@ -52,6 +51,10 @@ export const ExecuteActionResult = memo<
     command.args.args.timeout,
     command.args.args?.comment,
   ]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   const { result, actionDetails: completedActionDetails } = useConsoleActionSubmitter<
     ExecuteActionRequestBody,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/execute_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/execute_action.tsx
@@ -39,7 +39,7 @@ export const ExecuteActionResult = memo<
     }
     return {
       agent_type: agentType,
-      endpoint_ids: [endpointId],
+      endpoint_ids: endpointId,
       parameters: {
         command: command.args.args.command[0],
         timeout: parsedExecuteTimeout(command.args.args.timeout?.[0]),

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_file_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_file_action.tsx
@@ -29,7 +29,7 @@ export const GetFileActionResult = memo<
     return endpointId
       ? {
           agent_type: agentType,
-          endpoint_ids: [endpointId],
+          endpoint_ids: endpointId,
           comment: comment?.[0],
           parameters: {
             path: path[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_file_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_file_action.tsx
@@ -23,13 +23,12 @@ export const GetFileActionResult = memo<
   const actionCreator = useSendGetFileRequest();
 
   const actionRequestBody = useMemo<undefined | ResponseActionGetFileRequestBody>(() => {
-    const { agentType, endpointId } = command.commandDefinition?.meta ?? {};
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { path, comment } = command.args.args;
 
-    return endpointId
+    return endpointId && apiReqBodyBase
       ? {
-          agent_type: agentType,
-          endpoint_ids: endpointId,
+          ...apiReqBodyBase,
           comment: comment?.[0],
           parameters: {
             path: path[0],
@@ -37,6 +36,10 @@ export const GetFileActionResult = memo<
         }
       : undefined;
   }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   const { result, actionDetails } = useConsoleActionSubmitter<ResponseActionGetFileRequestBody>({
     ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_file_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_file_action.tsx
@@ -23,10 +23,10 @@ export const GetFileActionResult = memo<
   const actionCreator = useSendGetFileRequest();
 
   const actionRequestBody = useMemo<undefined | ResponseActionGetFileRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { path, comment } = command.args.args;
 
-    return endpointId && apiReqBodyBase
+    return apiReqBodyBase
       ? {
           ...apiReqBodyBase,
           comment: comment?.[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
@@ -22,7 +22,7 @@ export const GetProcessesActionResult = memo<ActionRequestComponentProps>(
     const actionRequestBody = useMemo(() => {
       return endpointId
         ? {
-            endpoint_ids: [endpointId],
+            endpoint_ids: endpointId,
             comment,
             agent_type: agentType,
           }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
@@ -18,10 +18,10 @@ export const GetProcessesActionResult = memo<ActionRequestComponentProps>(
     const actionCreator = useSendGetEndpointProcessesRequest();
 
     const actionRequestBody = useMemo(() => {
-      const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+      const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
       const comment = command.args.args?.comment?.[0];
 
-      return endpointId && apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
+      return apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
     }, [command.args.args?.comment, command.commandDefinition?.meta]);
 
     if (!actionRequestBody) {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
@@ -15,19 +15,18 @@ import type { ActionRequestComponentProps } from '../types';
 
 export const GetProcessesActionResult = memo<ActionRequestComponentProps>(
   ({ command, setStore, store, status, setStatus, ResultComponent }) => {
-    const { endpointId, agentType } = command.commandDefinition?.meta ?? {};
-    const comment = command.args.args?.comment?.[0];
     const actionCreator = useSendGetEndpointProcessesRequest();
 
     const actionRequestBody = useMemo(() => {
-      return endpointId
-        ? {
-            endpoint_ids: endpointId,
-            comment,
-            agent_type: agentType,
-          }
-        : undefined;
-    }, [endpointId, comment, agentType]);
+      const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+      const comment = command.args.args?.comment?.[0];
+
+      return endpointId && apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
+    }, [command.args.args?.comment, command.commandDefinition?.meta]);
+
+    if (!actionRequestBody) {
+      throw new Error('Command definition missing `apiReqBodyBase`!!');
+    }
 
     const { result, actionDetails: completedActionDetails } = useConsoleActionSubmitter<
       GetProcessesRequestBody,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
@@ -16,10 +16,10 @@ export const IsolateActionResult = memo<ActionRequestComponentProps>(
     const isolateHostApi = useSendIsolateEndpointRequest();
 
     const actionRequestBody: IsolationRouteRequestBody | undefined = useMemo(() => {
-      const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+      const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
       const comment = command.args.args?.comment?.[0];
 
-      return endpointId && apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
+      return apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
     }, [command.args.args?.comment, command.commandDefinition?.meta]);
 
     if (!actionRequestBody) {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
@@ -6,6 +6,7 @@
  */
 
 import { memo, useMemo } from 'react';
+import type { IsolationRouteRequestBody } from '../../../../../common/api/endpoint';
 import { useConsoleActionSubmitter } from '../hooks/use_console_action_submitter';
 import type { ActionRequestComponentProps } from '../types';
 import { useSendIsolateEndpointRequest } from '../../../hooks/response_actions/use_send_isolate_endpoint_request';
@@ -14,18 +15,16 @@ export const IsolateActionResult = memo<ActionRequestComponentProps>(
   ({ command, setStore, store, status, setStatus, ResultComponent }) => {
     const isolateHostApi = useSendIsolateEndpointRequest();
 
-    const actionRequestBody = useMemo(() => {
-      const { agentType, endpointId } = command.commandDefinition?.meta ?? {};
+    const actionRequestBody: IsolationRouteRequestBody | undefined = useMemo(() => {
+      const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
       const comment = command.args.args?.comment?.[0];
 
-      return endpointId
-        ? {
-            agent_type: agentType,
-            endpoint_ids: endpointId,
-            comment,
-          }
-        : undefined;
+      return endpointId && apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
     }, [command.args.args?.comment, command.commandDefinition?.meta]);
+
+    if (!actionRequestBody) {
+      throw new Error('Command defintion missing `apiReqBodyBase`!!');
+    }
 
     return useConsoleActionSubmitter({
       ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
@@ -21,7 +21,7 @@ export const IsolateActionResult = memo<ActionRequestComponentProps>(
       return endpointId
         ? {
             agent_type: agentType,
-            endpoint_ids: [endpointId],
+            endpoint_ids: endpointId,
             comment,
           }
         : undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/isolate_action.tsx
@@ -23,7 +23,7 @@ export const IsolateActionResult = memo<ActionRequestComponentProps>(
     }, [command.args.args?.comment, command.commandDefinition?.meta]);
 
     if (!actionRequestBody) {
-      throw new Error('Command defintion missing `apiReqBodyBase`!!');
+      throw new Error('Command definition missing `apiReqBodyBase`!!');
     }
 
     return useConsoleActionSubmitter({

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/kill_process_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/kill_process_action.tsx
@@ -18,18 +18,21 @@ export const KillProcessActionResult = memo<
   const actionCreator = useSendKillProcessRequest();
 
   const actionRequestBody = useMemo<undefined | KillProcessRequestBody>(() => {
-    const { endpointId, agentType } = command.commandDefinition?.meta ?? {};
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const parameters = parsedKillOrSuspendParameter(command.args.args);
 
-    return endpointId
+    return endpointId && apiReqBodyBase
       ? {
-          agent_type: agentType,
-          endpoint_ids: endpointId,
+          ...apiReqBodyBase,
           comment: command.args.args?.comment?.[0],
           parameters,
         }
       : undefined;
   }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   return useConsoleActionSubmitter<KillProcessRequestBody>({
     ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/kill_process_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/kill_process_action.tsx
@@ -24,7 +24,7 @@ export const KillProcessActionResult = memo<
     return endpointId
       ? {
           agent_type: agentType,
-          endpoint_ids: [endpointId],
+          endpoint_ids: endpointId,
           comment: command.args.args?.comment?.[0],
           parameters,
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/kill_process_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/kill_process_action.tsx
@@ -18,10 +18,10 @@ export const KillProcessActionResult = memo<
   const actionCreator = useSendKillProcessRequest();
 
   const actionRequestBody = useMemo<undefined | KillProcessRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const parameters = parsedKillOrSuspendParameter(command.args.args);
 
-    return endpointId && apiReqBodyBase
+    return apiReqBodyBase
       ? {
           ...apiReqBodyBase,
           comment: command.args.args?.comment?.[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/memory_dump_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/memory_dump_action.tsx
@@ -32,18 +32,17 @@ export const MemoryDumpActionResult = memo<
   >
 >(({ command, setStore, store, status, setStatus, ResultComponent }) => {
   const actionCreator = useSendMemoryDumpRequest();
-  const { agentType, endpointId } = command.commandDefinition?.meta ?? {};
 
   const actionRequestBody = useMemo<undefined | MemoryDumpActionRequestBody>(() => {
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { comment, kernel, pid, entityId } = command.args.args;
 
-    if (!endpointId) {
+    if (!endpointId || !apiReqBodyBase) {
       return;
     }
 
     const reqBody: MemoryDumpActionRequestBody = {
-      agent_type: agentType,
-      endpoint_ids: endpointId,
+      ...apiReqBodyBase,
       ...(comment?.[0] ? { comment: comment?.[0] } : {}),
       parameters: {
         type: kernel?.[0] ? 'kernel' : 'process',
@@ -53,7 +52,11 @@ export const MemoryDumpActionResult = memo<
     };
 
     return reqBody;
-  }, [agentType, command.args.args, endpointId]);
+  }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   const { result, actionDetails } = useConsoleActionSubmitter<
     MemoryDumpActionRequestBody,
@@ -75,7 +78,7 @@ export const MemoryDumpActionResult = memo<
       <ResultComponent>
         <MemoryDumpResponseActionOutputResult
           action={actionDetails}
-          agentId={endpointId}
+          agentId={command.commandDefinition?.meta?.endpointId}
           data-test-subj="memoryDumpResult"
         />
       </ResultComponent>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/memory_dump_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/memory_dump_action.tsx
@@ -43,7 +43,7 @@ export const MemoryDumpActionResult = memo<
 
     const reqBody: MemoryDumpActionRequestBody = {
       agent_type: agentType,
-      endpoint_ids: [endpointId],
+      endpoint_ids: endpointId,
       ...(comment?.[0] ? { comment: comment?.[0] } : {}),
       parameters: {
         type: kernel?.[0] ? 'kernel' : 'process',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/memory_dump_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/memory_dump_action.tsx
@@ -34,10 +34,10 @@ export const MemoryDumpActionResult = memo<
   const actionCreator = useSendMemoryDumpRequest();
 
   const actionRequestBody = useMemo<undefined | MemoryDumpActionRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { comment, kernel, pid, entityId } = command.args.args;
 
-    if (!endpointId || !apiReqBodyBase) {
+    if (!apiReqBodyBase) {
       return;
     }
 
@@ -78,7 +78,6 @@ export const MemoryDumpActionResult = memo<
       <ResultComponent>
         <MemoryDumpResponseActionOutputResult
           action={actionDetails}
-          agentId={command.commandDefinition?.meta?.endpointId}
           data-test-subj="memoryDumpResult"
         />
       </ResultComponent>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/release_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/release_action.tsx
@@ -15,17 +15,15 @@ export const ReleaseActionResult = memo<ActionRequestComponentProps>(
     const releaseHostApi = useSendReleaseEndpointRequest();
 
     const actionRequestBody = useMemo(() => {
-      const { endpointId, agentType } = command.commandDefinition?.meta ?? {};
+      const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
       const comment = command.args.args?.comment?.[0];
 
-      return endpointId
-        ? {
-            agent_type: agentType,
-            endpoint_ids: endpointId,
-            comment,
-          }
-        : undefined;
+      return endpointId && apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
     }, [command.args.args?.comment, command.commandDefinition?.meta]);
+
+    if (!actionRequestBody) {
+      throw new Error('Command definition missing `apiReqBodyBase`!!');
+    }
 
     return useConsoleActionSubmitter({
       ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/release_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/release_action.tsx
@@ -21,7 +21,7 @@ export const ReleaseActionResult = memo<ActionRequestComponentProps>(
       return endpointId
         ? {
             agent_type: agentType,
-            endpoint_ids: [endpointId],
+            endpoint_ids: endpointId,
             comment,
           }
         : undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/release_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/release_action.tsx
@@ -15,10 +15,10 @@ export const ReleaseActionResult = memo<ActionRequestComponentProps>(
     const releaseHostApi = useSendReleaseEndpointRequest();
 
     const actionRequestBody = useMemo(() => {
-      const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+      const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
       const comment = command.args.args?.comment?.[0];
 
-      return endpointId && apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
+      return apiReqBodyBase ? { ...apiReqBodyBase, comment } : undefined;
     }, [command.args.args?.comment, command.commandDefinition?.meta]);
 
     if (!actionRequestBody) {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/run_script_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/run_script_action.tsx
@@ -61,9 +61,9 @@ export const RunScriptActionResult = memo<
 >(({ command, setStore, store, status, setStatus, ResultComponent }) => {
   const actionCreator = useSendRunScriptEndpoint();
   const actionRequestBody = useMemo<undefined | RunScriptActionRequestBody>(() => {
-    const { endpointId, agentType } = command.commandDefinition?.meta ?? {};
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
 
-    if (!endpointId) {
+    if (!endpointId || !apiReqBodyBase) {
       return {} as unknown as RunScriptActionRequestBody;
     }
 
@@ -124,8 +124,7 @@ export const RunScriptActionResult = memo<
     };
 
     return {
-      agent_type: agentType,
-      endpoint_ids: endpointId,
+      ...apiReqBodyBase,
       parameters: getParams(),
       comment: command.args.args?.comment?.[0],
     } as unknown as RunScriptActionRequestBody;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/run_script_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/run_script_action.tsx
@@ -125,7 +125,7 @@ export const RunScriptActionResult = memo<
 
     return {
       agent_type: agentType,
-      endpoint_ids: [endpointId],
+      endpoint_ids: endpointId,
       parameters: getParams(),
       comment: command.args.args?.comment?.[0],
     } as unknown as RunScriptActionRequestBody;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/run_script_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/run_script_action.tsx
@@ -61,9 +61,9 @@ export const RunScriptActionResult = memo<
 >(({ command, setStore, store, status, setStatus, ResultComponent }) => {
   const actionCreator = useSendRunScriptEndpoint();
   const actionRequestBody = useMemo<undefined | RunScriptActionRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase, agentType } = command.commandDefinition?.meta ?? {};
 
-    if (!endpointId || !apiReqBodyBase) {
+    if (!apiReqBodyBase) {
       return {} as unknown as RunScriptActionRequestBody;
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/scan_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/scan_action.tsx
@@ -20,10 +20,10 @@ export const ScanActionResult = memo<
   const actionCreator = useSendScanRequest();
 
   const actionRequestBody = useMemo<undefined | ScanActionRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { path, comment } = command.args.args;
 
-    return endpointId && apiReqBodyBase
+    return apiReqBodyBase
       ? {
           ...apiReqBodyBase,
           comment: comment?.[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/scan_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/scan_action.tsx
@@ -20,25 +20,23 @@ export const ScanActionResult = memo<
   const actionCreator = useSendScanRequest();
 
   const actionRequestBody = useMemo<undefined | ScanActionRequestBody>(() => {
-    const endpointId = command.commandDefinition?.meta?.endpointId;
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { path, comment } = command.args.args;
-    const agentType = command.commandDefinition?.meta?.agentType;
 
-    return endpointId
+    return endpointId && apiReqBodyBase
       ? {
-          agent_type: agentType,
-          endpoint_ids: endpointId,
+          ...apiReqBodyBase,
           comment: comment?.[0],
           parameters: {
             path: path[0],
           },
         }
       : undefined;
-  }, [
-    command.args.args,
-    command.commandDefinition?.meta?.agentType,
-    command.commandDefinition?.meta?.endpointId,
-  ]);
+  }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   return useConsoleActionSubmitter<ScanActionRequestBody>({
     ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/scan_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/scan_action.tsx
@@ -27,7 +27,7 @@ export const ScanActionResult = memo<
     return endpointId
       ? {
           agent_type: agentType,
-          endpoint_ids: [endpointId],
+          endpoint_ids: endpointId,
           comment: comment?.[0],
           parameters: {
             path: path[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/status_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/status_action.tsx
@@ -34,7 +34,7 @@ export const EndpointStatusActionResult = memo<
     EndpointCommandDefinitionMeta
   >
 >(({ command, status, setStatus, store, setStore, ResultComponent }) => {
-  const endpointId = command.commandDefinition?.meta?.endpointId as string;
+  const endpointId = command.commandDefinition?.meta?.endpointId.at(0) as string;
   const { endpointPendingActions, endpointDetails, detailsFetchError, apiCalled } = store;
   const isPending = status === 'pending';
   const queryKey = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/suspend_process_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/suspend_process_action.tsx
@@ -23,12 +23,12 @@ export const SuspendProcessActionResult = memo<
   const actionCreator = useSendSuspendProcessRequest();
 
   const actionRequestBody = useMemo<undefined | SuspendProcessRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const parameters = parsedKillOrSuspendParameter(command.args.args) as
       | ResponseActionParametersWithPid
       | ResponseActionParametersWithEntityId;
 
-    return endpointId && apiReqBodyBase
+    return apiReqBodyBase
       ? {
           ...apiReqBodyBase,
           comment: command.args.args?.comment?.[0],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/suspend_process_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/suspend_process_action.tsx
@@ -23,20 +23,23 @@ export const SuspendProcessActionResult = memo<
   const actionCreator = useSendSuspendProcessRequest();
 
   const actionRequestBody = useMemo<undefined | SuspendProcessRequestBody>(() => {
-    const { agentType, endpointId } = command.commandDefinition?.meta ?? {};
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const parameters = parsedKillOrSuspendParameter(command.args.args) as
       | ResponseActionParametersWithPid
       | ResponseActionParametersWithEntityId;
 
-    return endpointId
+    return endpointId && apiReqBodyBase
       ? {
-          agent_type: agentType,
-          endpoint_ids: endpointId,
+          ...apiReqBodyBase,
           comment: command.args.args?.comment?.[0],
           parameters,
         }
       : undefined;
   }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   return useConsoleActionSubmitter<SuspendProcessRequestBody, SuspendProcessActionOutputContent>({
     ResultComponent,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/suspend_process_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/suspend_process_action.tsx
@@ -31,7 +31,7 @@ export const SuspendProcessActionResult = memo<
     return endpointId
       ? {
           agent_type: agentType,
-          endpoint_ids: [endpointId],
+          endpoint_ids: endpointId,
           comment: command.args.args?.comment?.[0],
           parameters,
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -29,16 +29,15 @@ export const UploadActionResult = memo<
   const actionCreator = useSendUploadEndpointRequest();
 
   const actionRequestBody = useMemo<undefined | UploadActionUIRequestBody>(() => {
-    const { agentType, endpointId } = command.commandDefinition?.meta ?? {};
+    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { comment, overwrite, file } = command.args.args;
 
-    if (!endpointId) {
+    if (!endpointId || !apiReqBodyBase) {
       return;
     }
 
     const reqBody: UploadActionUIRequestBody = {
-      agent_type: agentType,
-      endpoint_ids: endpointId,
+      ...apiReqBodyBase,
       ...(comment?.[0] ? { comment: comment?.[0] } : {}),
       parameters:
         overwrite !== undefined
@@ -51,6 +50,10 @@ export const UploadActionResult = memo<
 
     return reqBody;
   }, [command.args.args, command.commandDefinition?.meta]);
+
+  if (!actionRequestBody) {
+    throw new Error('Command definition missing `apiReqBodyBase`!!');
+  }
 
   const { result, actionDetails } = useConsoleActionSubmitter<
     UploadActionUIRequestBody,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -29,10 +29,10 @@ export const UploadActionResult = memo<
   const actionCreator = useSendUploadEndpointRequest();
 
   const actionRequestBody = useMemo<undefined | UploadActionUIRequestBody>(() => {
-    const { endpointId, apiReqBodyBase } = command.commandDefinition?.meta ?? {};
+    const { apiReqBodyBase } = command.commandDefinition?.meta ?? {};
     const { comment, overwrite, file } = command.args.args;
 
-    if (!endpointId || !apiReqBodyBase) {
+    if (!apiReqBodyBase) {
       return;
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -38,7 +38,7 @@ export const UploadActionResult = memo<
 
     const reqBody: UploadActionUIRequestBody = {
       agent_type: agentType,
-      endpoint_ids: [endpointId],
+      endpoint_ids: endpointId,
       ...(comment?.[0] ? { comment: comment?.[0] } : {}),
       parameters:
         overwrite !== undefined

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -115,6 +115,7 @@ const capabilitiesAndPrivilegesValidator = (
 ): ((command: Command) => string | true) => {
   return (command: Command) => {
     const privileges = command.commandDefinition.meta.privileges;
+    const isBulkResponseMode = command.commandDefinition.meta.isBulkResponseMode;
     const agentCapabilities: EndpointCapabilities[] = command.commandDefinition.meta.capabilities;
     const commandName = command.commandDefinition.name as ConsoleResponseActionCommands;
     const responderCapabilities =
@@ -122,7 +123,7 @@ const capabilitiesAndPrivilegesValidator = (
     let errorMessage = '';
 
     // We only validate Agent capabilities for the command for Endpoint agents
-    if (agentType === 'endpoint') {
+    if (agentType === 'endpoint' && !isBulkResponseMode) {
       if (!responderCapabilities.length) {
         errorMessage = errorMessage.concat(UPGRADE_AGENT_FOR_RESPONDER(agentType, commandName));
       } else if (
@@ -179,7 +180,10 @@ const commandCommentArgument = (): { comment: CommandArgDefinition } => {
 };
 
 export interface GetEndpointConsoleCommandsOptions {
-  endpointAgentId: string;
+  /** Endpoint agent ID. When an array with length > 1 is used, the console commands will be setup for "bulk" response */
+  endpointAgentId: string | string[];
+  /** The integration policy id. When defined, the console commands will be setup for "bulk" response */
+  integrationPolicyId?: string;
   agentType: ResponseActionAgentType;
   /** Applicable only for Endpoint Agents */
   endpointCapabilities: ImmutableArray<string>;
@@ -189,12 +193,17 @@ export interface GetEndpointConsoleCommandsOptions {
 }
 
 export const getEndpointConsoleCommands = ({
-  endpointAgentId,
+  endpointAgentId: _endpointAgentId,
+  integrationPolicyId,
   agentType,
   endpointCapabilities,
   endpointPrivileges,
   platform,
 }: GetEndpointConsoleCommandsOptions): CommandDefinition[] => {
+  const endpointAgentId: string[] = Array.isArray(_endpointAgentId)
+    ? _endpointAgentId
+    : [_endpointAgentId];
+  const isBulkResponseMode = endpointAgentId.length > 1 || !!integrationPolicyId;
   const featureFlags = ExperimentalFeaturesService.get();
   const {
     crowdstrikeRunScriptEnabled,
@@ -207,14 +216,16 @@ export const getEndpointConsoleCommands = ({
   const commandMeta: EndpointCommandDefinitionMeta = {
     agentType,
     platform,
+    isBulkResponseMode,
     endpointId: endpointAgentId,
     capabilities: endpointCapabilities,
     privileges: endpointPrivileges,
   };
 
   const doesEndpointSupportCommand = (commandName: ConsoleResponseActionCommands) => {
-    // Agent capabilities are only validated for Endpoint agent types
-    if (agentType !== 'endpoint') {
+    // Agent capabilities are only validated for Endpoint agent types. Also, if in "bulk" mode,
+    // we don't do capability validation checks
+    if (agentType !== 'endpoint' || isBulkResponseMode) {
       return true;
     }
 
@@ -251,7 +262,7 @@ export const getEndpointConsoleCommands = ({
       helpGroupLabel: HELP_GROUPS.responseActions.label,
       helpGroupPosition: HELP_GROUPS.responseActions.position,
       helpCommandPosition: 0,
-      helpDisabled: doesEndpointSupportCommand('isolate') === false,
+      helpDisabled: !doesEndpointSupportCommand('isolate'),
       helpHidden: !getRbacControl({ commandName: 'isolate', privileges: endpointPrivileges }),
     },
     {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -202,7 +202,9 @@ export const getEndpointConsoleCommands = ({
 }: GetEndpointConsoleCommandsOptions): CommandDefinition[] => {
   const endpointAgentId: string[] = Array.isArray(_endpointAgentId)
     ? _endpointAgentId
-    : [_endpointAgentId];
+    : _endpointAgentId
+    ? [_endpointAgentId]
+    : [];
   const isBulkResponseMode = endpointAgentId.length > 1 || !!integrationPolicyId;
   const featureFlags = ExperimentalFeaturesService.get();
   const {
@@ -220,6 +222,11 @@ export const getEndpointConsoleCommands = ({
     endpointId: endpointAgentId,
     capabilities: endpointCapabilities,
     privileges: endpointPrivileges,
+    apiReqBodyBase: {
+      endpoint_ids: endpointAgentId,
+      integration_policy_ids: integrationPolicyId ? [integrationPolicyId] : undefined,
+      agent_type: agentType,
+    },
   };
 
   const doesEndpointSupportCommand = (commandName: ConsoleResponseActionCommands) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -732,12 +732,14 @@ export const getEndpointConsoleCommands = ({
   }
 
   if (responseActionsEndpointMemoryDump) {
-    const endpointSupportsKernelDump = (endpointCapabilities as EndpointCapabilities[]).includes(
-      'memdump_kernel'
-    );
-    const endpointSupportsProcessDump = (endpointCapabilities as EndpointCapabilities[]).includes(
-      'memdump_process'
-    );
+    // In bulk mode, we just set the memory dump support variables below true and the
+    // API will figure out if the command should be sent to the host based on capabilities
+    const endpointSupportsKernelDump =
+      isBulkResponseMode ||
+      (endpointCapabilities as EndpointCapabilities[]).includes('memdump_kernel');
+    const endpointSupportsProcessDump =
+      isBulkResponseMode ||
+      (endpointCapabilities as EndpointCapabilities[]).includes('memdump_process');
     const getMemoryDumpTypeNotSupportedMessage = (type: 'process' | 'kernel') =>
       i18n.translate(
         'xpack.securitySolution.consoleCommandsDefinition.memoryDump.kernelTypeNotSupported',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/types.ts
@@ -23,11 +23,12 @@ import type { CommandExecutionComponentProps } from '../console/types';
  * the data that is defined for all commands (see `lib/console_commands_definition.ts`).
  */
 export interface EndpointCommandDefinitionMeta {
-  endpointId: string;
+  endpointId: string[];
   agentType: ResponseActionAgentType;
   capabilities: MaybeImmutable<string[]>;
   privileges: EndpointPrivileges;
   platform: SupportedHostOsType;
+  isBulkResponseMode: boolean;
 }
 
 export type EndpointResponderExtensionComponentProps =

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_responder/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { BaseActionRequestBody } from '../../../../common/api/endpoint';
 import type { SupportedHostOsType } from '../../../../common/endpoint/constants';
 import type { BasicConsoleProps } from '../../hooks/use_with_show_responder';
 import type { ResponseActionAgentType } from '../../../../common/endpoint/service/response_actions/constants';
@@ -29,6 +30,11 @@ export interface EndpointCommandDefinitionMeta {
   privileges: EndpointPrivileges;
   platform: SupportedHostOsType;
   isBulkResponseMode: boolean;
+  /** Response Action API base properties that should be used by all requests */
+  apiReqBodyBase: Pick<
+    BaseActionRequestBody,
+    'endpoint_ids' | 'integration_policy_ids' | 'agent_type'
+  >;
 }
 
 export type EndpointResponderExtensionComponentProps =

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/use_with_show_responder.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/use_with_show_responder.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
+import { RESPONSE_CONSOLE_STORAGE_KEY } from '../common/constants';
 import { type SupportedHostOsType } from '../../../common/endpoint/constants';
 import { useLicense } from '../../common/hooks/use_license';
 import type { MaybeImmutable } from '../../../common/endpoint/types';
@@ -77,7 +78,7 @@ export const useWithShowResponder = (): ShowResponseActionsConsole => {
             platform: platform as SupportedHostOsType,
           }),
           'data-test-subj': `${agentType}ResponseActionsConsole`,
-          storagePrefix: 'xpack.securitySolution.Responder',
+          storagePrefix: RESPONSE_CONSOLE_STORAGE_KEY,
           TitleComponent: () => {
             return (
               <AgentInfo

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
+import { EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle } from '@elastic/eui';
+import type { EuiModalProps } from '@elastic/eui/src/components/modal/modal';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { RESPONSE_CONSOLE_STORAGE_KEY } from '../../../../../common/constants';
+import { Console } from '../../../../../components/console';
+import { getEndpointConsoleCommands } from '../../../../../components/endpoint_responder';
+import { useUserPrivileges } from '../../../../../../common/components/user_privileges';
 import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
 
 export interface BulkResponseConsoleProps {
@@ -17,8 +24,59 @@ export interface BulkResponseConsoleProps {
 export const BulkResponseConsole = memo<BulkResponseConsoleProps>(
   ({ 'data-test-subj': dataTestSubj }) => {
     const getTestId = useTestIdGenerator(dataTestSubj);
+    const authz = useUserPrivileges().endpointPrivileges;
 
-    return <div data-test-subj={getTestId()}>{'a console here'}</div>;
+    const consoleCommands = useMemo(() => {
+      return getEndpointConsoleCommands({
+        agentType: 'endpoint',
+        endpointPrivileges: authz,
+        platform: 'windows',
+        endpointAgentId: '',
+        endpointCapabilities: [],
+      });
+    }, [authz]);
+
+    return (
+      <Console
+        commands={consoleCommands}
+        storagePrefix={RESPONSE_CONSOLE_STORAGE_KEY}
+        data-test-subj={getTestId()}
+        TitleComponent={() => <>{'Policy: blah (300 agents)'}</>}
+      />
+    );
   }
 );
 BulkResponseConsole.displayName = 'BulkResponseConsole';
+
+interface BulkResponseConsoleModalProps extends BulkResponseConsoleProps {
+  onClose: EuiModalProps['onClose'];
+}
+
+export const BulkResponseConsoleModal = memo<BulkResponseConsoleModalProps>(
+  ({ onClose, ...props }) => {
+    const getTestId = useTestIdGenerator(props['data-test-subj']);
+
+    return (
+      <EuiModal
+        maxWidth={false}
+        style={{ height: '70vw', width: '70vw' }}
+        onClose={onClose}
+        aria-label="user take action modal"
+        data-test-subj={getTestId('modal')}
+      >
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>
+            <FormattedMessage
+              id="xpack.securitySolution.endpointPolicyTakeAction.consoleModalTitle"
+              defaultMessage="Bulk Respond"
+            />
+          </EuiModalHeaderTitle>
+        </EuiModalHeader>
+        <EuiModalBody>
+          <BulkResponseConsole {...props} />
+        </EuiModalBody>
+      </EuiModal>
+    );
+  }
+);
+BulkResponseConsoleModal.displayName = 'BulkResponseConsoleModal';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
@@ -6,9 +6,22 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle } from '@elastic/eui';
+import {
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSkeletonText,
+  EuiStat,
+} from '@elastic/eui';
 import type { EuiModalProps } from '@elastic/eui/src/components/modal/modal';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { useFetchAgentByAgentPolicySummary } from '../../../../../hooks/policy/use_fetch_endpoint_policy_agent_summary';
+import { useFetchEndpointPolicy } from '../../../../../hooks/policy/use_fetch_endpoint_policy';
 import { RESPONSE_CONSOLE_STORAGE_KEY } from '../../../../../common/constants';
 import { Console } from '../../../../../components/console';
 import { getEndpointConsoleCommands } from '../../../../../components/endpoint_responder';
@@ -16,15 +29,20 @@ import { useUserPrivileges } from '../../../../../../common/components/user_priv
 import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
 
 export interface BulkResponseConsoleProps {
-  // TODO:PT define props
-
+  /** The Endpoint (or 3rd party EDR) Integration policy ID */
+  integrationPolicyId: string;
   'data-test-subj'?: string;
 }
 
 export const BulkResponseConsole = memo<BulkResponseConsoleProps>(
-  ({ 'data-test-subj': dataTestSubj }) => {
+  ({ integrationPolicyId, 'data-test-subj': dataTestSubj }) => {
     const getTestId = useTestIdGenerator(dataTestSubj);
     const authz = useUserPrivileges().endpointPrivileges;
+    const { data: policyDetailsResponse, isLoading } = useFetchEndpointPolicy(integrationPolicyId);
+    const { data: policyAgentCounts, isLoading: isAgentCountsLoading } =
+      useFetchAgentByAgentPolicySummary(policyDetailsResponse?.item.policy_ids ?? [], {
+        enabled: Boolean(policyDetailsResponse?.item),
+      });
 
     const consoleCommands = useMemo(() => {
       return getEndpointConsoleCommands({
@@ -36,12 +54,57 @@ export const BulkResponseConsole = memo<BulkResponseConsoleProps>(
       });
     }, [authz]);
 
+    const ConsoleTitleComponent: React.ComponentType = useMemo(() => {
+      if (!policyDetailsResponse?.item) {
+        return () => null;
+      }
+
+      const TitleComponent = () => {
+        return (
+          <EuiFlexGroup responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiStat
+                description={i18n.translate(
+                  'xpack.securitySolution.bulkResponseConsole.policyAgentTotal',
+                  { defaultMessage: 'Agent count' }
+                )}
+                title={policyAgentCounts?.active ?? 0}
+                isLoading={isAgentCountsLoading}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiDescriptionList
+                listItems={[
+                  {
+                    title: i18n.translate('xpack.securitySolution.bulkResponseConsole.policyName', {
+                      defaultMessage: 'Policy',
+                    }),
+                    description: policyDetailsResponse?.item.name ?? '',
+                  },
+                ]}
+                textStyle="reverse"
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      };
+      TitleComponent.displayName = 'TitleComponent';
+
+      return TitleComponent;
+    }, [isAgentCountsLoading, policyAgentCounts?.active, policyDetailsResponse?.item]);
+
+    if (isLoading) {
+      return <EuiSkeletonText lines={10} isLoading />;
+    }
+
+    // FIMXE:PT show message if policy has no agents
+
     return (
       <Console
         commands={consoleCommands}
         storagePrefix={RESPONSE_CONSOLE_STORAGE_KEY}
         data-test-subj={getTestId()}
-        TitleComponent={() => <>{'Policy: blah (300 agents)'}</>}
+        TitleComponent={ConsoleTitleComponent}
       />
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
+
+export interface BulkResponseConsoleProps {
+  // TODO:PT define props
+
+  'data-test-subj'?: string;
+}
+
+export const BulkResponseConsole = memo<BulkResponseConsoleProps>(
+  ({ 'data-test-subj': dataTestSubj }) => {
+    const getTestId = useTestIdGenerator(dataTestSubj);
+
+    return <div data-test-subj={getTestId()}>{'a console here'}</div>;
+  }
+);
+BulkResponseConsole.displayName = 'BulkResponseConsole';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
@@ -10,6 +10,7 @@ import {
   EuiDescriptionList,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiModal,
   EuiModalBody,
   EuiModalHeader,
@@ -32,6 +33,8 @@ export interface BulkResponseConsoleProps {
   /** The Endpoint (or 3rd party EDR) Integration policy ID */
   integrationPolicyId: string;
   'data-test-subj'?: string;
+
+  // TODO: also add support for multiple agent IDs
 }
 
 export const BulkResponseConsole = memo<BulkResponseConsoleProps>(
@@ -129,10 +132,17 @@ export const BulkResponseConsoleModal = memo<BulkResponseConsoleModalProps>(
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="xpack.securitySolution.endpointPolicyTakeAction.consoleModalTitle"
-              defaultMessage="Bulk Respond"
-            />
+            <EuiFlexGroup responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiIcon type="console" size="l" aria-hidden={true} />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <FormattedMessage
+                  id="xpack.securitySolution.endpointPolicyTakeAction.consoleModalTitle"
+                  defaultMessage="Bulk Respond"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/bulk_response_console.tsx
@@ -49,13 +49,14 @@ export const BulkResponseConsole = memo<BulkResponseConsoleProps>(
 
     const consoleCommands = useMemo(() => {
       return getEndpointConsoleCommands({
-        agentType: 'endpoint',
+        agentType: 'endpoint', // FIXME:PT support for other agent types
+        integrationPolicyId,
         endpointPrivileges: authz,
         platform: 'windows',
         endpointAgentId: '',
         endpointCapabilities: [],
       });
-    }, [authz]);
+    }, [authz, integrationPolicyId]);
 
     const ConsoleTitleComponent: React.ComponentType = useMemo(() => {
       if (!policyDetailsResponse?.item) {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './policy_take_action_button';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/policy_take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/policy_take_action_button.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { EuiButton, EuiModal } from '@elastic/eui';
+import { BulkResponseConsole } from './bulk_response_console';
+import {
+  type ContextMenuItemNavByRouterProps,
+  ContextMenuWithRouterSupport,
+} from '../../../../../components/context_menu_with_router_support';
+import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
+
+type TakeActionType = 'respond';
+
+export interface PolicyTakeActionButtonProps {
+  'data-test-subj'?: string;
+}
+
+export const PolicyTakeActionButton = memo<PolicyTakeActionButtonProps>(
+  ({ 'data-test-subj': dataTestSubj }) => {
+    const getTestId = useTestIdGenerator(dataTestSubj);
+    const [showActionType, setShowActionType] = useState<TakeActionType | undefined>();
+
+    const menuItems: ContextMenuItemNavByRouterProps[] = useMemo(() => {
+      return [
+        {
+          onClick: () => {
+            setShowActionType('respond');
+          },
+          children: 'Respond',
+          icon: 'console',
+        },
+      ];
+    }, []);
+
+    const userActionUi = useMemo(() => {
+      switch (showActionType) {
+        case 'respond':
+          return <BulkResponseConsole />;
+        default:
+          return null;
+      }
+    }, [showActionType]);
+
+    const closeDialogHandler = useCallback(() => {
+      setShowActionType(undefined);
+    }, []);
+
+    return (
+      <>
+        <ContextMenuWithRouterSupport
+          maxHeight="235px"
+          fixedWidth={true}
+          panelPaddingSize="none"
+          items={menuItems}
+          data-test-subj={getTestId('popover')}
+          button={
+            <EuiButton data-test-subj={getTestId()}>
+              {/* FIXME:PT i18n this */}
+              {'Take action'}
+            </EuiButton>
+          }
+          // FIXME:PT cleanup
+          // title={POLICY_EFFECT_SCOPE_TITLE(policies.length)}
+          // isNavigationDisabled={!canReadPolicies}
+        />
+
+        {showActionType && <EuiModal onClose={closeDialogHandler}>{userActionUi}</EuiModal>}
+      </>
+    );
+  }
+);
+PolicyTakeActionButton.displayName = 'PolicyTakeActionButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/policy_take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/policy_take_action_button.tsx
@@ -6,8 +6,8 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { EuiButton, EuiModal } from '@elastic/eui';
-import { BulkResponseConsole } from './bulk_response_console';
+import { EuiButton } from '@elastic/eui';
+import { BulkResponseConsoleModal } from './bulk_response_console';
 import {
   type ContextMenuItemNavByRouterProps,
   ContextMenuWithRouterSupport,
@@ -37,18 +37,18 @@ export const PolicyTakeActionButton = memo<PolicyTakeActionButtonProps>(
       ];
     }, []);
 
+    const handleUserActionUiOnCloseHandler = useCallback(() => {
+      setShowActionType(undefined);
+    }, []);
+
     const userActionUi = useMemo(() => {
       switch (showActionType) {
         case 'respond':
-          return <BulkResponseConsole />;
+          return <BulkResponseConsoleModal onClose={handleUserActionUiOnCloseHandler} />;
         default:
           return null;
       }
-    }, [showActionType]);
-
-    const closeDialogHandler = useCallback(() => {
-      setShowActionType(undefined);
-    }, []);
+    }, [handleUserActionUiOnCloseHandler, showActionType]);
 
     return (
       <>
@@ -69,7 +69,7 @@ export const PolicyTakeActionButton = memo<PolicyTakeActionButtonProps>(
           // isNavigationDisabled={!canReadPolicies}
         />
 
-        {showActionType && <EuiModal onClose={closeDialogHandler}>{userActionUi}</EuiModal>}
+        {userActionUi}
       </>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/policy_take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/components/policy_take_action_button/policy_take_action_button.tsx
@@ -7,6 +7,8 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { MaybeImmutable, PolicyData } from '../../../../../../../common/endpoint/types';
 import { BulkResponseConsoleModal } from './bulk_response_console';
 import {
   type ContextMenuItemNavByRouterProps,
@@ -17,11 +19,12 @@ import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
 type TakeActionType = 'respond';
 
 export interface PolicyTakeActionButtonProps {
+  integrationPolicy: MaybeImmutable<PolicyData>;
   'data-test-subj'?: string;
 }
 
 export const PolicyTakeActionButton = memo<PolicyTakeActionButtonProps>(
-  ({ 'data-test-subj': dataTestSubj }) => {
+  ({ integrationPolicy, 'data-test-subj': dataTestSubj }) => {
     const getTestId = useTestIdGenerator(dataTestSubj);
     const [showActionType, setShowActionType] = useState<TakeActionType | undefined>();
 
@@ -31,7 +34,9 @@ export const PolicyTakeActionButton = memo<PolicyTakeActionButtonProps>(
           onClick: () => {
             setShowActionType('respond');
           },
-          children: 'Respond',
+          children: i18n.translate('xpack.securitySolution.endpointPolicyTakeAction.bulkRespond', {
+            defaultMessage: 'Bulk respond',
+          }),
           icon: 'console',
         },
       ];
@@ -44,11 +49,16 @@ export const PolicyTakeActionButton = memo<PolicyTakeActionButtonProps>(
     const userActionUi = useMemo(() => {
       switch (showActionType) {
         case 'respond':
-          return <BulkResponseConsoleModal onClose={handleUserActionUiOnCloseHandler} />;
+          return (
+            <BulkResponseConsoleModal
+              integrationPolicyId={integrationPolicy.id}
+              onClose={handleUserActionUiOnCloseHandler}
+            />
+          );
         default:
           return null;
       }
-    }, [handleUserActionUiOnCloseHandler, showActionType]);
+    }, [handleUserActionUiOnCloseHandler, integrationPolicy.id, showActionType]);
 
     return (
       <>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_details.tsx
@@ -68,10 +68,17 @@ export const PolicyDetails = React.memo(() => {
           offline={policyAgentStatusSummary?.offline ?? 0}
           error={policyAgentStatusSummary?.error ?? 0}
         />
-        <EuiSpacer />
-        <div className="eui-textRight">
-          <PolicyTakeActionButton />
-        </div>
+        {policyItem && (
+          <>
+            <EuiSpacer />
+            <div className="eui-textRight">
+              <PolicyTakeActionButton
+                data-test-subj="policyDetailsTakeAction"
+                integrationPolicy={policyItem}
+              />
+            </div>
+          </>
+        )}
       </>
     );
   }, [
@@ -79,6 +86,7 @@ export const PolicyDetails = React.memo(() => {
     policyAgentStatusSummary?.error,
     policyAgentStatusSummary?.offline,
     policyAgentStatusSummary?.online,
+    policyItem,
   ]);
 
   const backToEndpointList = (

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_details.tsx
@@ -8,7 +8,8 @@
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useLocation } from 'react-router-dom';
-import { EuiCallOut, EuiLoadingSpinner, EuiPageTemplate } from '@elastic/eui';
+import { EuiCallOut, EuiLoadingSpinner, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
+import { PolicyTakeActionButton } from './components/policy_take_action_button';
 import { usePolicyDetailsSelector } from './policy_hooks';
 import { policyDetails, agentStatusSummary, apiError } from '../store/policy_details/selectors';
 import { AgentsSummary } from './components/agents_summary';
@@ -58,14 +59,27 @@ export const PolicyDetails = React.memo(() => {
     };
   }, [getAppUrl, routeState?.backLink]);
 
-  const headerRightContent = (
-    <AgentsSummary
-      total={policyAgentStatusSummary?.active ?? 0}
-      online={policyAgentStatusSummary?.online ?? 0}
-      offline={policyAgentStatusSummary?.offline ?? 0}
-      error={policyAgentStatusSummary?.error ?? 0}
-    />
-  );
+  const headerRightContent = useMemo(() => {
+    return (
+      <>
+        <AgentsSummary
+          total={policyAgentStatusSummary?.active ?? 0}
+          online={policyAgentStatusSummary?.online ?? 0}
+          offline={policyAgentStatusSummary?.offline ?? 0}
+          error={policyAgentStatusSummary?.error ?? 0}
+        />
+        <EuiSpacer />
+        <div className="eui-textRight">
+          <PolicyTakeActionButton />
+        </div>
+      </>
+    );
+  }, [
+    policyAgentStatusSummary?.active,
+    policyAgentStatusSummary?.error,
+    policyAgentStatusSummary?.offline,
+    policyAgentStatusSummary?.online,
+  ]);
 
   const backToEndpointList = (
     <BackToExternalAppButton {...backLinkOptions} data-test-subj="policyDetailsBackLink" />

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
@@ -392,6 +392,15 @@ function responseActionRequestHandler<T extends EndpointActionDataParameterTypes
     try {
       const experimentalFeatures = endpointContext.experimentalFeatures;
 
+      // TODO:PT Move this validation to the schema (needs some refactoring lift)
+      // Validate that at least 1 endpoint ID or 1 Policy ID is present in the request and error is not
+      if (!req.body.endpoint_ids?.length && !req.body.integration_policy_ids?.length) {
+        throw new CustomHttpRequestError(
+          `[request body.endpoint_ids]: must contain at least 1 ID, OR, [request.body.integration_policy_ids]: must contain at least 1 ID`,
+          400
+        );
+      }
+
       // Note:  because our API schemas are defined as module static variables (as opposed to a
       //        `getter` function), we need to include this additional validation here, since
       //        `agent_type` is included in the schema independent of the feature flag

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/endpoint/endpoint_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/endpoint/endpoint_actions_client.ts
@@ -106,13 +106,39 @@ export class EndpointActionsClient extends ResponseActionsClientImpl {
     return agentPolicyInfo;
   }
 
-  private async checkAgentIds(ids: string[]): Promise<{
+  private async checkAgentIds(
+    ids: string[],
+    integrationPolicyIds?: string[]
+  ): Promise<{
     valid: string[];
     invalid: string[];
     allValid: boolean;
     hosts: HostMetadata[];
   }> {
+    const fleetServices = this.options.endpointService.getInternalFleetServices(
+      this.options.spaceId
+    );
     const uniqueIds = [...new Set(ids)];
+
+    if (integrationPolicyIds?.length) {
+      const integrationPolicyAgentIds = await fleetServices.getAgentIdsForIntegrations(
+        integrationPolicyIds
+      );
+
+      for (const agentId of integrationPolicyAgentIds.agentIds) {
+        if (!uniqueIds.includes(agentId)) {
+          uniqueIds.push(agentId);
+        }
+      }
+
+      this.log.debug(
+        () =>
+          `List of agents IDs after adding agents associated with integration policies [${integrationPolicyIds.join(
+            ', '
+          )}]: ${stringify(uniqueIds)}`
+      );
+    }
+
     const foundEndpointHosts = await this.options.endpointService
       .getEndpointMetadataService(this.options.spaceId)
       .getMetadataForEndpoints(uniqueIds);
@@ -256,8 +282,11 @@ export class EndpointActionsClient extends ResponseActionsClientImpl {
     actionReq: TOptions,
     options?: TMethodOptions
   ): Promise<TResponse> {
-    const validatedAgents = await this.checkAgentIds(actionReq.endpoint_ids);
     const actionId = uuidv4();
+    const validatedAgents = await this.checkAgentIds(
+      actionReq.endpoint_ids,
+      actionReq.integration_policy_ids
+    );
     const { error: validationError } = await this.validateRequest({
       ...actionReq,
       command,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.ts
@@ -559,6 +559,10 @@ const fetchAgentIdsForIntegrations = async ({
     integrationPolicy.policy_ids.forEach((policyId) => agentPolicyIds.add(policyId));
   }
 
+  if (agentPolicyIds.size === 0) {
+    return response;
+  }
+
   // FIXME:PT listAgents below needs to use PIT and do pagination in order to be more efficient (maybe use aysnc iterator)
 
   const listAgentsOptions: Parameters<AgentClient['listAgents']>[0] = {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/fleet/endpoint_fleet_services_factory.ts
@@ -74,6 +74,12 @@ export interface EndpointFleetServicesInterface {
    */
   getIntegrationNamespaces(integrationNames: string[]): Promise<Record<string, string[]>>;
 
+  /**
+   * Retrieves a list of all agent IDs for a given integration policy ID
+   * @param integrationPolicyIds
+   */
+  getAgentIdsForIntegrations(integrationPolicyIds: string[]): Promise<{ agentIds: string[] }>;
+
   /** Checks to see if the Endpoint (Elastic Defend) package is installed */
   isEndpointPackageInstalled: () => Promise<boolean>;
 }
@@ -189,6 +195,17 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
         });
       };
 
+    const getAgentIdsForIntegrations: EndpointFleetServicesInterface['getAgentIdsForIntegrations'] =
+      async (integrationPolicyIds) => {
+        return fetchAgentIdsForIntegrations({
+          soClient: getSoClient(),
+          logger: this.logger,
+          packagePolicyService: packagePolicy,
+          agentService: agent,
+          integrationPolicyIds,
+        });
+      };
+
     const isEndpointPackageInstalled = async (): Promise<boolean> => {
       const installedEndpointPackages = await packageService.asInternalUser.getInstalledPackages({
         nameQuery: 'endpoint',
@@ -215,6 +232,7 @@ export class EndpointFleetServicesFactory implements EndpointFleetServicesFactor
       ensureInCurrentSpace,
       getPolicyNamespace,
       getIntegrationNamespaces,
+      getAgentIdsForIntegrations,
       getSoClient,
       isEndpointPackageInstalled,
     };
@@ -503,6 +521,69 @@ const fetchIntegrationNamespaces = async ({
   );
 
   logger.debug(() => `Integration namespaces in use:\n${stringify(response)}`);
+
+  return response;
+};
+
+interface FetchAgentIdsForIntegrationOptions {
+  integrationPolicyIds: string[];
+  logger: Logger;
+  soClient: SavedObjectsClientContract;
+  packagePolicyService: PackagePolicyClient;
+  agentService: AgentClient;
+}
+
+const fetchAgentIdsForIntegrations = async ({
+  integrationPolicyIds,
+  logger: _logger,
+  soClient,
+  packagePolicyService,
+  agentService,
+}: FetchAgentIdsForIntegrationOptions): Promise<{ agentIds: string[] }> => {
+  const logger = _logger.get('fetchAgentIdsForIntegration');
+
+  logger.debug(
+    () =>
+      `Retrieving list of fleet agents running with integration policies: ${stringify(
+        integrationPolicyIds
+      )}`
+  );
+
+  const response: { agentIds: string[] } = { agentIds: [] };
+  const integrationPolicies = await packagePolicyService
+    .getByIDs(soClient, integrationPolicyIds)
+    .catch(catchAndWrapError);
+  const agentPolicyIds = new Set<string>();
+
+  for (const integrationPolicy of integrationPolicies) {
+    integrationPolicy.policy_ids.forEach((policyId) => agentPolicyIds.add(policyId));
+  }
+
+  // FIXME:PT listAgents below needs to use PIT and do pagination in order to be more efficient (maybe use aysnc iterator)
+
+  const listAgentsOptions: Parameters<AgentClient['listAgents']>[0] = {
+    kuery: `policy_id:(${Array.from(agentPolicyIds)
+      .map((id) => `"${id}"`)
+      .join(' OR ')})`,
+    showInactive: false,
+    page: 1,
+    perPage: 10_000,
+  };
+
+  logger.debug(() => `searching for agents using: ${stringify(listAgentsOptions)}`);
+
+  const agentList = await agentService.listAgents(listAgentsOptions).catch(catchAndWrapError);
+
+  for (const agent of agentList.agents) {
+    response.agentIds.push(agent.id);
+  }
+
+  logger.debug(
+    () =>
+      `Found ${response.agentIds.length} agents running with integration policies: ${stringify(
+        integrationPolicyIds
+      )}`
+  );
 
   return response;
 };


### PR DESCRIPTION
## Summary


POC showing how Response Console can be used in a "bulk" mode. This initial implementation adds a `Take action` button to the Endpoint Policy Details (in Security Solution) that enables a user to send response actions against all hosts running with that policy.

> [!IMPORTANT]
> This is a POC and some visual things in the Kibana UI will not look or display correctly. All of it would be address, however, if/when we decide to productize this functionality



<br><br>

__________

<img width="2069" height="1302" alt="image" src="https://github.com/user-attachments/assets/2581e269-71c0-4c67-b6b1-0c44b471de77" />




