### PR TITLE
[Security Solution][Cypress] Fix flaky event_rendered_view test (#236608)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts
@@ -26,6 +26,7 @@ import {
   waitForAlerts,
 } from '../../../tasks/alerts';
 import { createRule } from '../../../tasks/api_calls/rules';
+import { deleteAlertsAndRules } from '../../../tasks/api_calls/common';
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
 import { ALERTS_URL } from '../../../urls/navigation';
@@ -37,15 +38,18 @@ import {
 
 describe(`Event Rendered View`, { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
+    deleteAlertsAndRules();
     login();
     createRule(getNewRule());
-    visit(ALERTS_URL);
-    waitForAlerts();
-    // Set up intercept before switching views to avoid a race condition where the
-    // search request starts after waitForNetworkIdle's 500ms idle window has passed.
+    // Set up intercept before visiting the page so it captures all search
+    // requests, including those triggered by switchAlertTableToEventRenderedView.
+    // This avoids a race condition where the request completes before the alias
+    // is registered, causing cy.wait('@alertsSearch') to time out.
     cy.intercept('POST', '/internal/search/privateRuleRegistryAlertsSearchStrategy').as(
       'alertsSearch'
     );
+    visit(ALERTS_URL);
+    waitForAlerts();
     switchAlertTableToEventRenderedView();
     cy.wait('@alertsSearch');
     waitForAlerts();


### PR DESCRIPTION
Fixes #236608

## Summary

### 🛑 Problem

The `event_rendered_view` Cypress test was flaky due to two independent race conditions in `beforeEach`:

1. No `deleteAlertsAndRules()` call meant stale alerts and rules from prior test runs could bleed into the next run, causing the state seen by the test to be unpredictable.
2. `cy.intercept(...)` was registered *after* `visit(ALERTS_URL)` and `waitForAlerts()`, so the alias `@alertsSearch` could miss the search request entirely — it would have already resolved before the intercept was set up, causing `cy.wait('@alertsSearch')` to time out.

### 💡 Solution

Added `deleteAlertsAndRules()` at the top of `beforeEach` to ensure a clean slate before each run. Moved the `cy.intercept(...)` registration to before `visit(ALERTS_URL)` so the alias is guaranteed to capture the POST request triggered by `switchAlertTableToEventRenderedView`.

### 🧠 Notes

Both fixes are independently necessary — the stale-data issue causes wrong state, while the intercept ordering issue causes flaky waits. Neither fix alone would be sufficient if the other race condition remained.

### ✅ How to verify

Run the Cypress test locally or in CI and confirm it passes consistently across multiple runs:

```
node scripts/functional_tests_server --config x-pack/solutions/security/test/security_solution_cypress/config.ts
npx cypress run --spec "x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts"
```