### PR TITLE
[Security Solution][Cypress] Fix flaky alert details response tab test (#256909)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
@@ -8,6 +8,7 @@
 import {
   DOCUMENT_DETAILS_FLYOUT_RESPONSE_DETAILS,
   DOCUMENT_DETAILS_FLYOUT_RESPONSE_EMPTY,
+  DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB,
 } from '../../../../screens/expandable_flyout/alert_details_left_panel_response_tab';
 import { openResponseTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_response_tab';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
@@ -19,7 +20,6 @@ import { createRule } from '../../../../tasks/api_calls/rules';
 import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
-import { DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB } from '../../../../screens/expandable_flyout/alert_details_left_panel';
 
 describe(
   'Alert details expandable flyout left panel investigation',


### PR DESCRIPTION
Fixes #256909

## Summary

### 🛑 Problem

`alert_details_left_panel_response_tab.cy.ts` was importing `DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB` from the wrong screen file (`alert_details_left_panel` instead of `alert_details_left_panel_response_tab`). This caused the test to be flaky because it was referencing a selector from a different panel's screen file rather than the one specific to the response tab.

### 💡 Solution

Moved the `DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB` import to the correct screen file (`alert_details_left_panel_response_tab`), where it is already exported alongside the other response-tab selectors used by this test.

### 🧠 Notes

The upstream `waitForAlerts()` spinner bug (the likely trigger for flakiness being noticed) has already been fixed in main via commits `2ad5bfb41fdd` and `efc08efdccda`. This PR is a targeted test-level cleanup: consolidating the import to the right screen file removes a source of brittleness regardless of the spinner fix.

### ✅ How to verify

Run the Cypress test in isolation and confirm it passes consistently:

```
node scripts/functional_tests \
  --config x-pack/solutions/security/test/security_solution_cypress/cypress.config.ts \
  --grep "Alert details expandable flyout left panel investigation"
```