### PR TITLE
[Workflows][NFR] Add structured logging for workflow API and task failures (alert RCA)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/log_workflow_task_failure.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/log_workflow_task_failure.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { logWorkflowTaskFailure } from './log_workflow_task_failure';
+
+describe('logWorkflowTaskFailure', () => {
+  it('logs task failures with structured context', () => {
+    const logger = loggingSystemMock.createLogger();
+    const error = new Error('task execution failed');
+
+    logWorkflowTaskFailure(logger, error, {
+      taskType: 'workflow:run',
+      workflowRunId: 'run-1',
+      spaceId: 'default',
+      taskId: 'task-1',
+      attempt: 2,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Workflow task failed', {
+      taskType: 'workflow:run',
+      workflowId: undefined,
+      workflowRunId: 'run-1',
+      spaceId: 'default',
+      taskId: 'task-1',
+      attempt: 2,
+      errorMessage: 'task execution failed',
+      errorName: 'Error',
+      error,
+    });
+  });
+
+  it('tags version conflict failures for Task Manager spike triage', () => {
+    const logger = loggingSystemMock.createLogger();
+    const error = new Error(
+      '[version_conflict_engine_exception]: version conflict, required seqNo [1], primary term [1]'
+    );
+
+    logWorkflowTaskFailure(logger, error, {
+      taskType: 'workflow:scheduled',
+      workflowId: 'wf-1',
+      spaceId: 'default',
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Workflow task failed',
+      expect.objectContaining({
+        failureKind: 'task_manager_version_conflict',
+        taskType: 'workflow:scheduled',
+        workflowId: 'wf-1',
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/log_workflow_task_failure.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/log_workflow_task_failure.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+export interface WorkflowTaskFailureLogContext {
+  taskType: 'workflow:run' | 'workflow:resume' | 'workflow:scheduled';
+  workflowId?: string;
+  workflowRunId?: string;
+  spaceId?: string;
+  taskId?: string;
+  attempt?: number;
+}
+
+const LOG_MESSAGE = 'Workflow task failed';
+const VERSION_CONFLICT_MARKER = 'version_conflict_engine_exception';
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export function logWorkflowTaskFailure(
+  logger: Logger,
+  error: unknown,
+  context: WorkflowTaskFailureLogContext
+): void {
+  const normalizedError = toError(error);
+  const meta: Record<string, unknown> = {
+    taskType: context.taskType,
+    workflowId: context.workflowId,
+    workflowRunId: context.workflowRunId,
+    spaceId: context.spaceId,
+    taskId: context.taskId,
+    attempt: context.attempt,
+    errorMessage: normalizedError.message,
+    errorName: normalizedError.name,
+    error: normalizedError,
+  };
+
+  if (normalizedError.message.includes(VERSION_CONFLICT_MARKER)) {
+    meta.failureKind = 'task_manager_version_conflict';
+  }
+
+  logger.error(LOG_MESSAGE, meta);
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -28,6 +28,7 @@ import type {
   WorkflowSettings,
 } from '@kbn/workflows';
 import {
+  WorkflowDisabledError,
   WorkflowExecutionInvalidStatusError,
   WorkflowExecutionNotFoundError,
 } from '@kbn/workflows/common/errors';
@@ -44,6 +45,7 @@ import { buildWorkflowExecutionDocument } from './lib/build_workflow_execution_d
 import { checkLicense } from './lib/check_license';
 import { ensureWorkflowsDataStreamsRolledOver } from './lib/data_streams/ensure_data_streams_rolled_over';
 import { getAuthenticatedUser } from './lib/get_user';
+import { logWorkflowTaskFailure } from './lib/log_workflow_task_failure';
 import {
   resolveExhaustedWorkflowRunTask,
   resolveInterruptedWorkflowResumeTask,
@@ -266,6 +268,13 @@ export class WorkflowsExecutionEnginePlugin
                   internalResumeWorkflowExecution: this.internalResumeWorkflowExecutionHandler,
                 });
               } catch (error) {
+                logWorkflowTaskFailure(logger, error, {
+                  taskType: WORKFLOW_RUN_TASK_TYPE,
+                  workflowRunId,
+                  spaceId,
+                  taskId: taskInstance.id,
+                  attempt: taskInstance.attempts,
+                });
                 await resolveExhaustedWorkflowRunTask({
                   workflowExecutionRepository,
                   stepExecutionRepository,
@@ -377,6 +386,13 @@ export class WorkflowsExecutionEnginePlugin
                   internalResumeWorkflowExecution: this.internalResumeWorkflowExecutionHandler,
                 });
               } catch (error) {
+                logWorkflowTaskFailure(logger, error, {
+                  taskType: WORKFLOW_RESUME_TASK_TYPE,
+                  workflowRunId,
+                  spaceId,
+                  taskId: taskInstance.id,
+                  attempt: taskInstance.attempts,
+                });
                 await resolveExhaustedWorkflowRunTask({
                   workflowExecutionRepository,
                   stepExecutionRepository,
@@ -419,187 +435,199 @@ export class WorkflowsExecutionEnginePlugin
                 triggerType: string;
               };
 
-              // Add queue delay metrics to APM trace for observability
-              // This shows how long the task waited in the queue before execution
-              const now = Date.now();
-              const scheduledAt = taskInstance.scheduledAt
-                ? new Date(taskInstance.scheduledAt).getTime()
-                : null;
-              const runAt = taskInstance.runAt ? new Date(taskInstance.runAt).getTime() : null;
+              try {
+                // Add queue delay metrics to APM trace for observability
+                // This shows how long the task waited in the queue before execution
+                const now = Date.now();
+                const scheduledAt = taskInstance.scheduledAt
+                  ? new Date(taskInstance.scheduledAt).getTime()
+                  : null;
+                const runAt = taskInstance.runAt ? new Date(taskInstance.runAt).getTime() : null;
 
-              const queueDelayMs = scheduledAt ? now - scheduledAt : null;
-              const scheduleDelayMs = runAt ? now - runAt : null;
+                const queueDelayMs = scheduledAt ? now - scheduledAt : null;
+                const scheduleDelayMs = runAt ? now - runAt : null;
 
-              // Add labels to current APM transaction for queue visibility
-              const { default: apm } = await import('elastic-apm-node');
-              const currentTransaction = apm.currentTransaction;
-              if (currentTransaction) {
-                if (queueDelayMs !== null) {
-                  currentTransaction.setLabel('queue_delay_ms', queueDelayMs);
-                  currentTransaction.setLabel(
-                    'queue_delay_seconds',
-                    Math.round(queueDelayMs / 1000)
-                  );
+                // Add labels to current APM transaction for queue visibility
+                const { default: apm } = await import('elastic-apm-node');
+                const currentTransaction = apm.currentTransaction;
+                if (currentTransaction) {
+                  if (queueDelayMs !== null) {
+                    currentTransaction.setLabel('queue_delay_ms', queueDelayMs);
+                    currentTransaction.setLabel(
+                      'queue_delay_seconds',
+                      Math.round(queueDelayMs / 1000)
+                    );
+                  }
+                  if (scheduleDelayMs !== null) {
+                    currentTransaction.setLabel('schedule_delay_ms', scheduleDelayMs);
+                  }
+                  currentTransaction.setLabel('workflow_id', workflowId);
+                  currentTransaction.setLabel('space_id', spaceId);
                 }
-                if (scheduleDelayMs !== null) {
-                  currentTransaction.setLabel('schedule_delay_ms', scheduleDelayMs);
-                }
-                currentTransaction.setLabel('workflow_id', workflowId);
-                currentTransaction.setLabel('space_id', spaceId);
-              }
 
-              logger.debug(
-                `Workflow ${workflowId} queue metrics: queueDelayMs=${queueDelayMs}, scheduleDelayMs=${scheduleDelayMs}`
-              );
-
-              const [coreStart, pluginsStart] = await core.getStartServices();
-              await checkLicense(pluginsStart.licensing);
-
-              await this.initialize(coreStart);
-              const dependencies: ContextDependencies = {
-                ...setupDependencies,
-                coreStart,
-                actions: pluginsStart.actions,
-                taskManager: pluginsStart.taskManager,
-                workflowsExtensions: pluginsStart.workflowsExtensions,
-                config,
-              };
-              const esClient = coreStart.elasticsearch.client.asInternalUser;
-
-              const workflowRepository = new WorkflowRepository({ esClient, logger });
-              const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
-              const stepExecutionRepository = new StepExecutionRepository(esClient);
-
-              const workflow = await workflowRepository.getWorkflow(workflowId, spaceId, {
-                includeGlobal: true,
-              });
-              if (!workflow) {
-                // Keep this as error for a while to ensure that such message appears only once per workflow
-                logger.error(
-                  `Workflow ${workflowId} not found in space ${spaceId}; removing orphaned scheduled task`
+                logger.debug(
+                  `Workflow ${workflowId} queue metrics: queueDelayMs=${queueDelayMs}, scheduleDelayMs=${scheduleDelayMs}`
                 );
-                return {
-                  state: taskInstance.state,
-                  shouldDeleteTask: true,
+
+                const [coreStart, pluginsStart] = await core.getStartServices();
+                await checkLicense(pluginsStart.licensing);
+
+                await this.initialize(coreStart);
+                const dependencies: ContextDependencies = {
+                  ...setupDependencies,
+                  coreStart,
+                  actions: pluginsStart.actions,
+                  taskManager: pluginsStart.taskManager,
+                  workflowsExtensions: pluginsStart.workflowsExtensions,
+                  config,
                 };
-              }
-              logger.debug(`Running scheduled workflow task for workflow ${workflow.id}`);
+                const esClient = coreStart.elasticsearch.client.asInternalUser;
 
-              // Guard check: Check&Skip only when workflow has no concurrency strategy. When strategy is
-              // set, the concurrency check (later) governs the limit and strategy.
-              if (!workflow.definition?.settings?.concurrency?.strategy) {
-                const wasSkipped = await checkAndSkipIfExistingScheduledExecution(
-                  workflow,
-                  spaceId,
-                  workflowExecutionRepository,
-                  stepExecutionRepository,
-                  taskInstance,
-                  logger
+                const workflowRepository = new WorkflowRepository({ esClient, logger });
+                const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
+                const stepExecutionRepository = new StepExecutionRepository(esClient);
+
+                const workflow = await workflowRepository.getWorkflow(workflowId, spaceId, {
+                  includeGlobal: true,
+                });
+                if (!workflow) {
+                  // Keep this as error for a while to ensure that such message appears only once per workflow
+                  logger.error(
+                    `Workflow ${workflowId} not found in space ${spaceId}; removing orphaned scheduled task`
+                  );
+                  return {
+                    state: taskInstance.state,
+                    shouldDeleteTask: true,
+                  };
+                }
+                logger.debug(`Running scheduled workflow task for workflow ${workflow.id}`);
+
+                // Guard check: Check&Skip only when workflow has no concurrency strategy. When strategy is
+                // set, the concurrency check (later) governs the limit and strategy.
+                if (!workflow.definition?.settings?.concurrency?.strategy) {
+                  const wasSkipped = await checkAndSkipIfExistingScheduledExecution(
+                    workflow,
+                    spaceId,
+                    workflowExecutionRepository,
+                    stepExecutionRepository,
+                    taskInstance,
+                    logger
+                  );
+                  if (wasSkipped) {
+                    return;
+                  }
+                }
+
+                // Check for RRule triggers and log details
+                const scheduledTriggers =
+                  workflow.definition?.triggers?.filter(
+                    (trigger) => trigger.type === 'scheduled'
+                  ) || [];
+                const rruleTriggers = scheduledTriggers.filter(
+                  (trigger) => trigger.type === 'scheduled' && 'rrule' in (trigger.with || {})
                 );
-                if (wasSkipped) {
+
+                // Create workflow execution record
+                const workflowCreatedAt = new Date();
+                const executionContext = {
+                  workflowRunId: `scheduled-${Date.now()}`,
+                  spaceId,
+                  inputs: {},
+                  event: {
+                    type: 'scheduled',
+                    timestamp: new Date().toISOString(),
+                    source: 'task-manager',
+                  },
+                  triggeredBy: 'scheduled',
+                };
+
+                // Extract user from fake request (contains API key of user who scheduled the workflow)
+                const span = apm.startSpan(
+                  'workflow get authenticated user',
+                  'workflow',
+                  'execution'
+                );
+                const executedBy = await getAuthenticatedUser(
+                  fakeRequest,
+                  coreStart.security,
+                  coreStart.elasticsearch.client
+                );
+                span?.end();
+
+                const workflowExecution = buildWorkflowExecutionDocument({
+                  workflow: toWorkflowExecutionEngineModel(workflow),
+                  context: executionContext,
+                  defaultTriggeredBy: 'scheduled',
+                  authenticatedUser: executedBy,
+                  now: workflowCreatedAt,
+                  workflowVersioningEnabled: await readWorkflowVersioningEnabled(coreStart, logger),
+                  maxEventChainDepth: this.config.eventDriven.maxChainDepth,
+                  getConcurrencyGroupKey: (execution) =>
+                    this.getConcurrencyGroupKey(
+                      execution,
+                      workflow.definition?.settings,
+                      coreStart,
+                      dependencies
+                    ),
+                });
+
+                workflowExecution.taskRunAt = taskInstance.runAt?.toISOString() ?? null;
+                if (this.config.collectQueueMetrics) {
+                  workflowExecution.queueMetrics = {
+                    scheduledAt: taskInstance.scheduledAt?.toString(),
+                    runAt: taskInstance.runAt?.toString(),
+                    startedAt: new Date(now).toISOString(),
+                    queueDelayMs,
+                    scheduleDelayMs,
+                  };
+                }
+
+                // Use refresh: 'wait_for' to ensure the execution is immediately searchable
+                // for deduplication checks by subsequent scheduled tasks
+                await workflowExecutionRepository.createWorkflowExecution(workflowExecution, {
+                  refresh: 'wait_for',
+                });
+
+                // Check concurrency limits and apply collision strategy if needed
+                const canProceed = await this.checkConcurrencyIfNeeded(workflowExecution);
+                if (!canProceed) {
+                  // Execution was dropped due to concurrency limit, skip running
                   return;
                 }
+
+                if (!workflowExecution.id || !workflowExecution.spaceId) {
+                  throw new Error('Workflow execution must have id and spaceId');
+                }
+
+                const [, , workflowsExecutionEngine] = await core.getStartServices();
+
+                await runWorkflow({
+                  workflowRunId: workflowExecution.id,
+                  spaceId: workflowExecution.spaceId,
+                  taskAbortController,
+                  logger,
+                  config,
+                  fakeRequest,
+                  dependencies,
+                  workflowsExecutionEngine,
+                  meteringService: this.meteringService,
+                  internalResumeWorkflowExecution: this.internalResumeWorkflowExecutionHandler,
+                });
+
+                const scheduleType = rruleTriggers.length > 0 ? 'RRule' : 'interval/cron';
+                logger.debug(
+                  `Successfully executed ${scheduleType}-scheduled workflow ${workflow.id}`
+                );
+              } catch (error) {
+                logWorkflowTaskFailure(logger, error, {
+                  taskType: WORKFLOW_SCHEDULED_TASK_TYPE,
+                  workflowId,
+                  spaceId,
+                  taskId: taskInstance.id,
+                  attempt: taskInstance.attempts,
+                });
+                throw error;
               }
-
-              // Check for RRule triggers and log details
-              const scheduledTriggers =
-                workflow.definition?.triggers?.filter((trigger) => trigger.type === 'scheduled') ||
-                [];
-              const rruleTriggers = scheduledTriggers.filter(
-                (trigger) => trigger.type === 'scheduled' && 'rrule' in (trigger.with || {})
-              );
-
-              // Create workflow execution record
-              const workflowCreatedAt = new Date();
-              const executionContext = {
-                workflowRunId: `scheduled-${Date.now()}`,
-                spaceId,
-                inputs: {},
-                event: {
-                  type: 'scheduled',
-                  timestamp: new Date().toISOString(),
-                  source: 'task-manager',
-                },
-                triggeredBy: 'scheduled',
-              };
-
-              // Extract user from fake request (contains API key of user who scheduled the workflow)
-              const span = apm.startSpan(
-                'workflow get authenticated user',
-                'workflow',
-                'execution'
-              );
-              const executedBy = await getAuthenticatedUser(
-                fakeRequest,
-                coreStart.security,
-                coreStart.elasticsearch.client
-              );
-              span?.end();
-
-              const workflowExecution = buildWorkflowExecutionDocument({
-                workflow: toWorkflowExecutionEngineModel(workflow),
-                context: executionContext,
-                defaultTriggeredBy: 'scheduled',
-                authenticatedUser: executedBy,
-                now: workflowCreatedAt,
-                workflowVersioningEnabled: await readWorkflowVersioningEnabled(coreStart, logger),
-                maxEventChainDepth: this.config.eventDriven.maxChainDepth,
-                getConcurrencyGroupKey: (execution) =>
-                  this.getConcurrencyGroupKey(
-                    execution,
-                    workflow.definition?.settings,
-                    coreStart,
-                    dependencies
-                  ),
-              });
-
-              workflowExecution.taskRunAt = taskInstance.runAt?.toISOString() ?? null;
-              if (this.config.collectQueueMetrics) {
-                workflowExecution.queueMetrics = {
-                  scheduledAt: taskInstance.scheduledAt?.toString(),
-                  runAt: taskInstance.runAt?.toString(),
-                  startedAt: new Date(now).toISOString(),
-                  queueDelayMs,
-                  scheduleDelayMs,
-                };
-              }
-
-              // Use refresh: 'wait_for' to ensure the execution is immediately searchable
-              // for deduplication checks by subsequent scheduled tasks
-              await workflowExecutionRepository.createWorkflowExecution(workflowExecution, {
-                refresh: 'wait_for',
-              });
-
-              // Check concurrency limits and apply collision strategy if needed
-              const canProceed = await this.checkConcurrencyIfNeeded(workflowExecution);
-              if (!canProceed) {
-                // Execution was dropped due to concurrency limit, skip running
-                return;
-              }
-
-              if (!workflowExecution.id || !workflowExecution.spaceId) {
-                throw new Error('Workflow execution must have id and spaceId');
-              }
-
-              const [, , workflowsExecutionEngine] = await core.getStartServices();
-
-              await runWorkflow({
-                workflowRunId: workflowExecution.id,
-                spaceId: workflowExecution.spaceId,
-                taskAbortController,
-                logger,
-                config,
-                fakeRequest,
-                dependencies,
-                workflowsExecutionEngine,
-                meteringService: this.meteringService,
-                internalResumeWorkflowExecution: this.internalResumeWorkflowExecutionHandler,
-              });
-
-              const scheduleType = rruleTriggers.length > 0 ? 'RRule' : 'interval/cron';
-              logger.debug(
-                `Successfully executed ${scheduleType}-scheduled workflow ${workflow.id}`
-              );
             },
             async cancel() {
               taskAbortController.abort();
@@ -655,7 +683,7 @@ export class WorkflowsExecutionEnginePlugin
         includeGlobal: true,
       });
       if (!stillEnabled) {
-        throw new Error(`Workflow is disabled: ${workflow.id}. Enable the workflow to run it.`);
+        throw new WorkflowDisabledError(workflow.id);
       }
     };
 

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts
@@ -23,6 +23,7 @@ describe('Execution Routes', () => {
   let routeHandlers: Record<string, { handler: (...args: any[]) => Promise<any> }>;
   let mockApi: Record<string, jest.Mock>;
   let mockSpaces: { getSpaceId: jest.Mock };
+  let mockLogger: ReturnType<typeof loggingSystemMock.createLogger>;
 
   const mockContext = {
     workflows: Promise.resolve({
@@ -81,6 +82,7 @@ describe('Execution Routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     routeHandlers = {};
+    mockLogger = loggingSystemMock.createLogger();
     mockSpaces = { getSpaceId: jest.fn().mockReturnValue('default') };
     mockApi = {
       getWorkflow: jest.fn(),
@@ -141,7 +143,7 @@ describe('Execution Routes', () => {
     registerExecutionRoutes({
       router: mockRouter,
       api: mockApi as any,
-      logger: loggingSystemMock.createLogger(),
+      logger: mockLogger,
       spaces: mockSpaces as any,
       audit: createWorkflowManagementAuditLogMock(),
     } as unknown as RouteDependencies);
@@ -242,6 +244,15 @@ describe('Execution Routes', () => {
 
       const result = await h(mockContext, request as any, mockResponse as any);
 
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Workflows API request failed',
+        expect.objectContaining({
+          route: 'POST /api/workflows/workflow/{id}/run',
+          workflowId: 'wf-1',
+          spaceId: 'default',
+          errorMessage: 'engine failed',
+        })
+      );
       expect(mockResponse.customError).toHaveBeenCalled();
       expect(result).toMatchObject({ type: 'customError', body: expect.objectContaining({}) });
     });

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
@@ -109,7 +109,14 @@ export function registerRunWorkflowRoute(deps: RouteDependencies) {
             workflowId: request.params.id,
             error,
           });
-          return handleRouteError(response, error);
+          return handleRouteError(response, error, {
+            logger,
+            logContext: {
+              route: 'POST /api/workflows/workflow/{id}/run',
+              workflowId: request.params.id,
+              spaceId: spaces.getSpaceId(request),
+            },
+          });
         }
       })
     );

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
@@ -97,7 +97,14 @@ export function registerTestWorkflowRoute(deps: RouteDependencies) {
             workflowId: request.body.workflowId,
             error,
           });
-          return handleRouteError(response, error);
+          return handleRouteError(response, error, {
+            logger,
+            logContext: {
+              route: 'POST /api/workflows/test',
+              workflowId: request.body.workflowId,
+              spaceId: spaces.getSpaceId(request),
+            },
+          });
         }
       })
     );

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/log_workflows_route_error.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/log_workflows_route_error.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { logWorkflowsRouteError } from './log_workflows_route_error';
+
+describe('logWorkflowsRouteError', () => {
+  it('logs framework errors at error level with context', () => {
+    const logger = loggingSystemMock.createLogger();
+    const error = new Error('engine failed');
+
+    logWorkflowsRouteError(logger, error, {
+      route: 'POST /api/workflows/workflow/{id}/run',
+      workflowId: 'wf-1',
+      spaceId: 'default',
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Workflows API request failed', {
+      route: 'POST /api/workflows/workflow/{id}/run',
+      workflowId: 'wf-1',
+      spaceId: 'default',
+      workflowExecutionId: undefined,
+      errorMessage: 'engine failed',
+      errorName: 'Error',
+      isUserError: false,
+      error,
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs user errors at warn level', () => {
+    const logger = loggingSystemMock.createLogger();
+    const error = Object.assign(new Error('invalid input'), { isUserError: true as const });
+
+    logWorkflowsRouteError(logger, error, {
+      route: 'POST /api/workflows/test',
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Workflows API request failed',
+      expect.objectContaining({
+        isUserError: true,
+        errorMessage: 'invalid input',
+      })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/log_workflows_route_error.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/log_workflows_route_error.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+export interface WorkflowsRouteErrorLogContext {
+  route: string;
+  workflowId?: string;
+  spaceId?: string;
+  workflowExecutionId?: string;
+}
+
+const LOG_MESSAGE = 'Workflows API request failed';
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function isUserError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isUserError' in error &&
+    (error as { isUserError?: boolean }).isUserError === true
+  );
+}
+
+export function logWorkflowsRouteError(
+  logger: Logger,
+  error: unknown,
+  context: WorkflowsRouteErrorLogContext
+): void {
+  const normalizedError = toError(error);
+  const meta = {
+    route: context.route,
+    workflowId: context.workflowId,
+    spaceId: context.spaceId,
+    workflowExecutionId: context.workflowExecutionId,
+    errorMessage: normalizedError.message,
+    errorName: normalizedError.name,
+    isUserError: isUserError(error),
+    error: normalizedError,
+  };
+
+  if (meta.isUserError) {
+    logger.warn(LOG_MESSAGE, meta);
+    return;
+  }
+
+  logger.error(LOG_MESSAGE, meta);
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_error_handlers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_error_handlers.test.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { httpServerMock } from '@kbn/core/server/mocks';
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { WorkflowDisabledError } from '@kbn/workflows/common/errors';
 import { handleRouteError } from './route_error_handlers';
 import { WorkflowChangeHistoryDisabledError } from '../../../lib/workflow_change_history_disabled_error';
 import { ManagedWorkflowDeleteForbiddenError } from '../../managed_workflow_delete_error';
@@ -49,6 +50,55 @@ describe('handleRouteError', () => {
         attributes: {
           code: 'HISTORY_DISABLED',
         },
+      },
+    });
+  });
+
+  it('returns bad request for disabled workflow errors without logging', () => {
+    const response = httpServerMock.createResponseFactory();
+    const logger = loggingSystemMock.createLogger();
+
+    handleRouteError(response, new WorkflowDisabledError('wf-1'), {
+      logger,
+      logContext: { route: 'POST /api/workflows/workflow/{id}/run', workflowId: 'wf-1' },
+    });
+
+    expect(response.badRequest).toHaveBeenCalledWith({
+      body: {
+        message: 'Workflow is disabled: wf-1. Enable the workflow to run it.',
+      },
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs and returns 500 for unexpected errors when logger is provided', () => {
+    const response = httpServerMock.createResponseFactory();
+    const logger = loggingSystemMock.createLogger();
+    const error = new Error('unexpected failure');
+
+    handleRouteError(response, error, {
+      logger,
+      logContext: {
+        route: 'POST /api/workflows/workflow/{id}/run',
+        workflowId: 'wf-1',
+        spaceId: 'default',
+      },
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Workflows API request failed',
+      expect.objectContaining({
+        route: 'POST /api/workflows/workflow/{id}/run',
+        workflowId: 'wf-1',
+        spaceId: 'default',
+        errorMessage: 'unexpected failure',
+      })
+    );
+    expect(response.customError).toHaveBeenCalledWith({
+      statusCode: 500,
+      body: {
+        message: 'Internal server error: Error: unexpected failure',
       },
     });
   });

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_error_handlers.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_error_handlers.ts
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { KibanaResponseFactory } from '@kbn/core/server';
+import type { KibanaResponseFactory, Logger } from '@kbn/core/server';
 import {
+  WorkflowDisabledError,
   WorkflowExecutionInvalidStatusError,
   WorkflowExecutionNotFoundError,
   WorkflowNotFoundError,
@@ -19,6 +20,8 @@ import {
   isWorkflowConflictError,
   isWorkflowValidationError,
 } from '@kbn/workflows-yaml';
+import type { WorkflowsRouteErrorLogContext } from './log_workflows_route_error';
+import { logWorkflowsRouteError } from './log_workflows_route_error';
 import { WorkflowChangeHistoryDisabledError } from '../../../lib/workflow_change_history_disabled_error';
 import { WorkflowHistoryEventNotFoundError } from '../../../lib/workflow_history_event_not_found_error';
 import { WorkflowForbiddenError } from '../../workflow_forbidden_error';
@@ -30,10 +33,16 @@ import { WorkflowForbiddenError } from '../../workflow_forbidden_error';
  * @param options - Optional configuration for error handling
  * @returns Appropriate error response
  */
+export interface HandleRouteErrorOptions {
+  checkNotFound?: boolean;
+  logger?: Logger;
+  logContext?: WorkflowsRouteErrorLogContext;
+}
+
 export function handleRouteError(
   response: KibanaResponseFactory,
   error: Error,
-  options?: { checkNotFound?: boolean }
+  options?: HandleRouteErrorOptions
 ) {
   if (options?.checkNotFound && error instanceof WorkflowExecutionNotFoundError) {
     return response.notFound();
@@ -101,6 +110,18 @@ export function handleRouteError(
         },
       },
     });
+  }
+
+  if (error instanceof WorkflowDisabledError) {
+    return response.badRequest({
+      body: {
+        message: error.message,
+      },
+    });
+  }
+
+  if (options?.logger && options.logContext) {
+    logWorkflowsRouteError(options.logger, error, options.logContext);
   }
 
   return response.customError({


### PR DESCRIPTION
## Summary

- Log workflow `/run` and `/test` API failures with `workflowId`, `spaceId`, and route name before returning unexpected 500 responses.
- Log `workflow:run`, `workflow:resume`, and `workflow:scheduled` Task Manager failures with task/workflow identifiers for framework-error spike triage (including `failureKind: task_manager_version_conflict` for version conflicts).
- Map `WorkflowDisabledError` to HTTP 400 to reduce false-positive API 500 alerts when a workflow is disabled between route check and engine persist.

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/server/api/routes/utils/log_workflows_route_error.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_error_handlers.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/lib/log_workflow_task_failure.test.ts`
- [ ] After deploy: pivot Overview alert windows on `Workflows API request failed` / `Workflow task failed` in kibana logs


Fixes https://github.com/elastic/security-team/issues/19106


Made with Cursor