### PR TITLE
[Dashboard] Disable broken deferBelowFold experimental setting

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx
@@ -11,16 +11,12 @@ import type { UseEuiTheme } from '@elastic/eui';
 import { EuiLoadingChart, transparentize, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import {
-  useBatchedPublishingSubjects,
-  useStateFromPublishingSubject,
-} from '@kbn/presentation-publishing';
+import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import classNames from 'classnames';
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useLayoutEffect, useMemo } from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { useDashboardApi } from '../../dashboard_api/use_dashboard_api';
 import { useDashboardInternalApi } from '../../dashboard_api/use_dashboard_internal_api';
-import { presentationUtilService } from '../../services/kibana_services';
 import { printViewportVisStyles } from '../print_styles';
 import { DASHBOARD_MARGIN_SIZE } from './constants';
 import { getHighlightStyles } from './highlight_styles';
@@ -187,49 +183,12 @@ export const Item = React.forwardRef<HTMLDivElement, Props>(
   }
 );
 
-export const ObservedItem = React.forwardRef<HTMLDivElement, Props>((props, panelRef) => {
-  const [intersection, updateIntersection] = useState<IntersectionObserverEntry>();
-  const [isRenderable, setIsRenderable] = useState(false);
-
-  const observerRef = useRef(
-    new window.IntersectionObserver(([value]) => updateIntersection(value), {
-      root: (panelRef as React.RefObject<HTMLDivElement>).current,
-    })
-  );
-
-  useEffect(() => {
-    const { current: currentObserver } = observerRef;
-    currentObserver.disconnect();
-    const { current } = panelRef as React.RefObject<HTMLDivElement>;
-
-    if (current) {
-      currentObserver.observe(current);
-    }
-
-    return () => currentObserver.disconnect();
-  }, [panelRef]);
-
-  useEffect(() => {
-    if (intersection?.isIntersecting && !isRenderable) {
-      setIsRenderable(true);
-    }
-  }, [intersection, isRenderable]);
-
-  return <Item ref={panelRef} isRenderable={isRenderable} {...props} />;
-});
-
 export const DashboardGridItem = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-  const dashboardApi = useDashboardApi();
-  const viewMode = useStateFromPublishingSubject(dashboardApi.viewMode$);
-
-  const deferBelowFoldEnabled = useMemo(
-    () => presentationUtilService.labsService.isProjectEnabled('labs:dashboard:deferBelowFold'),
-    []
-  );
-
-  const isEnabled = viewMode !== 'print' && deferBelowFoldEnabled;
-
-  return isEnabled ? <ObservedItem ref={ref} {...props} /> : <Item ref={ref} {...props} />;
+  // The `labs:dashboard:deferBelowFold` setting is intentionally not honored: its deferred
+  // (below-the-fold) loading behavior is currently broken, so panels are always rendered
+  // eagerly. The advanced setting remains available but has no effect until it is fixed
+  // (https://github.com/elastic/kibana/issues/150459)
+  return <Item ref={ref} {...props} />;
 });
 
 const dashboardGridItemStyles = {


### PR DESCRIPTION
## Summary

The experimental `labs:dashboard:deferBelowFold` advanced setting enables deferred (below-the-fold) loading of dashboard panels via an `IntersectionObserver`. That behavior is currently broken, and the proper fix is a larger change that can't land right now.

As a stop-gap, this PR **removes the runtime effect of the setting** while keeping the toggle/advanced setting fully in place:

- `DashboardGridItem` no longer reads `labs:dashboard:deferBelowFold` and always renders panels eagerly.
- The broken `ObservedItem` / `IntersectionObserver` implementation is removed.
- The setting registration, telemetry schema, `config/serverless.yml`, and docs are intentionally left untouched, so the toggle still appears in Advanced Settings — it just has no effect until the feature is fixed (https://github.com/elastic/kibana/pull/271580).

Since this is an experimental (labs) feature, toggling it being a no-op is acceptable until the real fix lands.

## Test plan

- [ ] Existing `dashboard_grid_item` Jest tests pass.
- [ ] With `labs:dashboard:deferBelowFold` toggled on, dashboard panels still render correctly (eagerly) and the toggle remains visible in Advanced Settings.

## Release note

Disabled the broken experimental "Defer loading panels below the fold" (`labs:dashboard:deferBelowFold`) dashboard setting; the toggle remains but currently has no effect.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->