### PR TITLE
[SLO / Obs] fix cases nav in external apps

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/hooks/use_case_view_navigation.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/hooks/use_case_view_navigation.ts
@@ -6,8 +6,8 @@
  */
 
 import { generatePath } from 'react-router-dom';
-import useObservable from 'react-use/lib/useObservable';
 import { useCallback } from 'react';
+import { observabilityAppId } from '../../common';
 import { useKibana } from '../utils/kibana_react';
 
 export type NavigateToCaseView = (pathParams: { caseId: string }) => void;
@@ -20,18 +20,16 @@ const generateCaseViewPath = (caseId: string): string => {
 
 export const useCaseViewNavigation = () => {
   const {
-    application: { navigateToApp, currentAppId$ },
+    application: { navigateToApp },
   } = useKibana().services;
-
-  const currentAppId = useObservable(currentAppId$) ?? '';
 
   const navigateToCaseView = useCallback<NavigateToCaseView>(
     (pathParams) =>
-      navigateToApp(currentAppId, {
+      navigateToApp(observabilityAppId, {
         deepLinkId: CASE_DEEP_LINK_ID,
         path: generateCaseViewPath(pathParams.caseId),
       }),
-    [navigateToApp, currentAppId]
+    [navigateToApp]
   );
 
   return { navigateToCaseView };


### PR DESCRIPTION
## Release notes

Fixes a bug where alert details case link would route users to an internal route instead of externally to cases (particularly SLO)

<img width="599" height="152" alt="image" src="https://github.com/user-attachments/assets/3e268465-282e-47ec-b74a-732810f0ddcd" />


### After
https://github.com/user-attachments/assets/24536c44-0e69-4557-8d52-3a6b829d3529



<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->