### PR TITLE
[Fleet] Install package transforms by stack environment (_meta.environments)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -681,6 +681,69 @@ interface InstallTransformsParams {
    */
   request?: KibanaRequest;
 }
+type TransformStackEnvironment = 'stateful' | 'serverless';
+
+/**
+ * Drops transform definitions that declare, via `_meta.environments`, that they do
+ * not apply to the current stack flavor (stateful vs serverless). A transform with no
+ * `_meta.environments` installs everywhere — so every existing package is unaffected.
+ *
+ * This lets a package ship environment-specific variants of the same transform — e.g. a
+ * cross-cluster (`*:`) source for stateful and a local-only source for serverless (where
+ * CCS is unsupported and ES rejects remote sources) — and have Fleet install only the
+ * matching one, verbatim, without mutating any asset body at install time.
+ */
+const filterTransformPathsByEnvironment = async (
+  packageInstallContext: PackageInstallContext,
+  transformPaths: string[],
+  logger: Logger
+): Promise<string[]> => {
+  if (transformPaths.length === 0) {
+    return transformPaths;
+  }
+
+  const currentEnvironment: TransformStackEnvironment = appContextService.getCloud()
+    ?.isServerlessEnabled
+    ? 'serverless'
+    : 'stateful';
+
+  const transformAssetsMap: AssetsMap = new Map();
+  await packageInstallContext.archiveIterator.traverseEntries(
+    async (entry) => {
+      if (entry.buffer) {
+        transformAssetsMap.set(entry.path, entry.buffer);
+      }
+    },
+    (path) => transformPaths.includes(path)
+  );
+
+  return transformPaths.filter((path) => {
+    const buffer = transformAssetsMap.get(path);
+    if (!buffer) {
+      return true;
+    }
+    let environments: unknown;
+    try {
+      environments = parse(buffer.toString('utf-8'))?._meta?.environments;
+    } catch (e) {
+      // Non-parseable here (e.g. a fields file) — leave it for the installer to handle.
+      return true;
+    }
+    if (!Array.isArray(environments) || environments.length === 0) {
+      return true;
+    }
+    const appliesToCurrentEnvironment = environments.includes(currentEnvironment);
+    if (!appliesToCurrentEnvironment) {
+      logger.debug(
+        `Skipping transform [${path}] on ${currentEnvironment}: _meta.environments=[${environments.join(
+          ', '
+        )}]`
+      );
+    }
+    return appliesToCurrentEnvironment;
+  });
+};
+
 export const installTransforms = async ({
   packageInstallContext,
   esClient,
@@ -691,7 +754,11 @@ export const installTransforms = async ({
   request,
 }: InstallTransformsParams) => {
   const { paths, packageInfo } = packageInstallContext;
-  const transformPaths = paths.filter((path) => isTransform(path));
+  const transformPaths = await filterTransformPathsByEnvironment(
+    packageInstallContext,
+    paths.filter((path) => isTransform(path)),
+    logger
+  );
 
   const installation = await getInstallation({
     savedObjectsClient,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/transforms.test.ts
@@ -1358,3 +1358,105 @@ _meta:
     expect(esClient.transform.startTransform.mock.calls).toEqual([]);
   });
 });
+
+describe('installTransforms - _meta.environments gating', () => {
+  let esClient: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>;
+  let savedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
+
+  const VERSION = '9.5.0';
+  const DEST_INDEX = '.metrics-endpoint.metadata_united_default';
+  const PIVOT = { group_by: { 'agent.id': { terms: { field: 'agent.id' } } }, aggs: {} };
+  const STATEFUL_SOURCE = [
+    'metrics-endpoint.metadata_current_default*',
+    '*:metrics-endpoint.metadata_current_default*',
+    '.fleet-agents*',
+  ];
+  const SERVERLESS_SOURCE = ['metrics-endpoint.metadata_current_default*', '.fleet-agents*'];
+
+  const statefulPath = `endpoint-${VERSION}/elasticsearch/transform/metadata_united/default.json`;
+  const serverlessPath = `endpoint-${VERSION}/elasticsearch/transform/metadata_united/serverless.json`;
+  const ungatedPath = `endpoint-${VERSION}/elasticsearch/transform/metadata_current/default.json`;
+
+  const buildTransformJson = (index: string[], environments?: string[]) =>
+    JSON.stringify({
+      source: { index },
+      dest: { index: DEST_INDEX },
+      pivot: PIVOT,
+      _meta: { managed: true, ...(environments ? { environments } : {}) },
+    });
+
+  const installPackage = (assets: Array<[string, string]>) =>
+    installTransforms({
+      packageInstallContext: {
+        packageInfo: { name: 'endpoint', version: VERSION },
+        paths: assets.map(([path]) => path),
+        archiveIterator: createArchiveIteratorFromMap(
+          new Map(assets.map(([path, content]) => [path, Buffer.from(content)]))
+        ),
+      } as unknown as PackageInstallContext,
+      esClient,
+      savedObjectsClient,
+      logger: loggerMock.create(),
+      esReferences: [],
+    });
+
+  const installedTransformIds = () =>
+    esClient.transform.putTransform.mock.calls.map(
+      (call) => (call[0] as { transform_id: string }).transform_id
+    );
+
+  beforeEach(() => {
+    esClient = elasticsearchClientMock.createClusterClient().asInternalUser;
+    savedObjectsClient = savedObjectsClientMock.create();
+    savedObjectsClient.update.mockImplementation(async (type, id, attributes) => ({
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      id: 'endpoint',
+      attributes,
+      references: [],
+    }));
+    (getInstallation as jest.MockedFunction<typeof getInstallation>).mockReset();
+    (getInstallation as jest.MockedFunction<typeof getInstallation>).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('installs only the serverless variant on serverless', async () => {
+    appContextService.start(createAppContextStartContractMock({}, true));
+
+    await installPackage([
+      [statefulPath, buildTransformJson(STATEFUL_SOURCE, ['stateful'])],
+      [serverlessPath, buildTransformJson(SERVERLESS_SOURCE, ['serverless'])],
+    ]);
+
+    expect(installedTransformIds()).toEqual([`endpoint.metadata_united-serverless-${VERSION}`]);
+    expect(esClient.transform.putTransform).toHaveBeenCalledWith(
+      expect.objectContaining({ source: expect.objectContaining({ index: SERVERLESS_SOURCE }) }),
+      expect.anything()
+    );
+  });
+
+  it('installs only the stateful variant on stateful', async () => {
+    appContextService.start(createAppContextStartContractMock());
+
+    await installPackage([
+      [statefulPath, buildTransformJson(STATEFUL_SOURCE, ['stateful'])],
+      [serverlessPath, buildTransformJson(SERVERLESS_SOURCE, ['serverless'])],
+    ]);
+
+    expect(installedTransformIds()).toEqual([`endpoint.metadata_united-default-${VERSION}`]);
+    expect(esClient.transform.putTransform).toHaveBeenCalledWith(
+      expect.objectContaining({ source: expect.objectContaining({ index: STATEFUL_SOURCE }) }),
+      expect.anything()
+    );
+  });
+
+  it('installs a transform with no _meta.environments everywhere (back-compat)', async () => {
+    appContextService.start(createAppContextStartContractMock({}, true));
+
+    await installPackage([[ungatedPath, buildTransformJson(SERVERLESS_SOURCE)]]);
+
+    expect(installedTransformIds()).toEqual([`endpoint.metadata_current-default-${VERSION}`]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/constants.ts
@@ -42,8 +42,10 @@ export const METADATA_CURRENT_TRANSFORM_V2 = `${PACKAGE_V2_PREFIX}${metadataTran
 export const METADATA_TRANSFORMS_PATTERN = 'endpoint.metadata_*';
 export const METADATA_TRANSFORMS_PATTERN_V2 = `${PACKAGE_V2_PREFIX}${METADATA_TRANSFORMS_PATTERN}`;
 
-// united metadata transform id
-export const METADATA_UNITED_TRANSFORM = 'endpoint.metadata_united-default';
+// united metadata transform id prefix — variant-agnostic so it matches the deployment
+// variants of the transform (e.g. `-default` on stateful, `-serverless` on serverless).
+// All consumers use it as a prefix (`startsWith` / `${...}*`), never as an exact id.
+export const METADATA_UNITED_TRANSFORM = 'endpoint.metadata_united-';
 export const METADATA_UNITED_TRANSFORM_V2 = `${PACKAGE_V2_PREFIX}${METADATA_UNITED_TRANSFORM}`;
 
 // united metadata transform destination index


### PR DESCRIPTION
## Summary

Lets a package declare, per transform, which stack flavor it applies to via a new `_meta.environments` field, and has Fleet install only the matching variant — **verbatim, with no install-time mutation**.

In `installTransforms`, transform assets whose `_meta.environments` excludes the current flavor (`stateful` / `serverless`, from `isServerlessEnabled`) are filtered out before install. A transform with **no** `_meta.environments` installs everywhere, so every existing package is unaffected (back-compat).

## Why

The endpoint `metadata_united` transform gained a cross-cluster (`*:`) source for remote-output support (elastic/endpoint-package#747). CCS is stateful-only, so on serverless ES rejects any transform with a remote source (`action_request_validation_exception: Cross-project calls are not supported, but remote indices were requested`), which aborts the whole package install — it had to be reverted (elastic/endpoint-package#749).

This is the declarative fix: the package ships a stateful variant (with `*:`) and a serverless variant (local-only), each tagged with `_meta.environments`, and Fleet installs the right one. Nothing is mutated at install, so the runtime transform matches the package definition.

Pairs with **elastic/endpoint-package#750** (the two variants).

> Alternative to #275649 (which instead strips `*:` on serverless at install time). Whichever approach the teams prefer, the other will be closed.

## Changes

- `transform/install.ts` — `installTransforms` filters transform paths by `_meta.environments` vs the current stack flavor before delegating to the (untouched) install functions. Skips are logged.
- `security_solution/common/endpoint/constants.ts` — `METADATA_UNITED_TRANSFORM` widened to the variant-agnostic prefix `endpoint.metadata_united-`, so the endpoint data-loader/cypress/evals helpers match either the `-default` (stateful) or `-serverless` id. Every consumer uses it as a prefix (`startsWith` / `${...}*`), never as an exact id.

## Testing

- **Unit** (`transforms.test.ts`): serverless installs only the serverless variant; stateful only the stateful variant; a field-less transform installs everywhere (back-compat).
- **Manual E2E** on local stateful + serverless (cross-project enabled): the matching variant installs verbatim (HTTP 200), the other is skipped, transform `started`; the field-less published package (`9.5.0-prerelease.2`) installs unchanged.

### Follow-up
`x-pack/platform/test/fleet_api_integration/apis/epm/install_endpoint.ts` hardcodes the `-default` transform id (it tests the published package, green today). It will need a deployment-aware assertion once the endpoint-package variants ship to the registry and that FTR runs on serverless.
