### PR TITLE
[Discover] Update Scout tests tagged with `tags.stateful.classic`

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/dataview_without_timefield.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/dataview_without_timefield.spec.ts
@@ -11,10 +11,10 @@
  * Tests for timepicker and data view switching behavior.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
-spaceTest.describe('Data view without timefield', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Data view without timefield', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     // Load Kibana saved objects (3 data views: with and without time fields)
     await scoutSpace.savedObjects.load(

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/surrounding_docs/context_accessibility.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/surrounding_docs/context_accessibility.spec.ts
@@ -8,7 +8,6 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '@kbn/scout';
 import {
   spaceTest,
   testData,
@@ -16,7 +15,7 @@ import {
   navigateToFirstDocContext,
 } from '../../../fixtures/surrounding_docs';
 
-spaceTest.describe('Discover context - accessibility', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Discover context - accessibility', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     await scoutSpace.savedObjects.load(testData.KBN_ARCHIVE_VISUALIZE);
     await scoutSpace.uiSettings.setDefaultIndex(testData.LOGSTASH_DATA_VIEW);

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/surrounding_docs/context_date_nanos.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/surrounding_docs/context_date_nanos.spec.ts
@@ -8,13 +8,12 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '@kbn/scout';
 import { spaceTest, testData, resolveDataViewId } from '../../../fixtures/surrounding_docs';
 
 const TEST_DEFAULT_CONTEXT_SIZE = 1;
 const TEST_STEP_SIZE = 3;
 
-spaceTest.describe('Discover context - date_nanos', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Discover context - date_nanos', { tag: '@local-stateful-classic' }, () => {
   let dataViewId: string;
 
   spaceTest.beforeAll(async ({ scoutSpace }) => {

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/surrounding_docs/context_date_nanos_custom.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/surrounding_docs/context_date_nanos_custom.spec.ts
@@ -8,7 +8,6 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '@kbn/scout';
 import { spaceTest, testData, resolveDataViewId } from '../../../fixtures/surrounding_docs';
 
 const TEST_DEFAULT_CONTEXT_SIZE = 1;
@@ -16,7 +15,7 @@ const TEST_STEP_SIZE = 3;
 
 spaceTest.describe(
   'Discover context - date_nanos custom timestamp',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     let dataViewId: string;
 

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/unmapped_fields.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/core/unmapped_fields.spec.ts
@@ -11,7 +11,7 @@
  * Tests for unmapped fields visibility in the Discover sidebar.
  */
 
-import { spaceTest, tags } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 
 const DATA_VIEW_NAME = 'test-index-unmapped-fields';
@@ -20,7 +20,7 @@ const TIME_RANGE = {
   to: '2021-01-25T00:00:00.000Z',
 };
 
-spaceTest.describe('Data view with unmapped fields', { tag: tags.stateful.classic }, () => {
+spaceTest.describe('Data view with unmapped fields', { tag: '@local-stateful-classic' }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     // Load Kibana saved objects (data view + saved search)
     await scoutSpace.savedObjects.load(

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/discover/discovery.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/discover/discovery.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { test, tags } from '@kbn/scout';
+import { test } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import fs from 'fs';
 import os from 'os';
@@ -31,7 +31,7 @@ const queryName2 = 'Query # 2';
 const queryName3 = 'CSV Export Test';
 let downloadedFilePath: string | null = null;
 
-test.describe('Discover app', { tag: tags.stateful.classic }, () => {
+test.describe('Discover app', { tag: '@local-stateful-classic' }, () => {
   test.beforeAll(async ({ kbnClient }) => {
     await kbnClient.uiSettings.update(defaultSettings);
   });

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/discover/esql.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/discover/esql.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { test, tags } from '@kbn/scout';
+import { test } from '@kbn/scout';
 import { SavedObjectsTracker } from '../../helpers';
 
 // Sample data for `kibana_sample_data_logs` is generated relative to the install
@@ -41,7 +41,7 @@ const CONTROLS_GROUP_WRAPPER = 'controls-group-wrapper';
 
 const tracker = new SavedObjectsTracker();
 
-test.describe('Discover ES|QL', { tag: tags.stateful.classic }, () => {
+test.describe('Discover ES|QL', { tag: '@local-stateful-classic' }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects, uiSettings }) => {
     await browserAuth.loginAsAdmin();
     await uiSettings.set({


### PR DESCRIPTION
## Summary

This PR updates the Discover Scout tests currently tagged with `tags.stateful.classic` to instead use `'@local-stateful-classic'` since we agreed we're going to hold off on validating in ECH until the migration is complete.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.