### PR TITLE
[9.4] [ftr] remove global after hook before servers stopped (#274314)

### DIFF
--- a/src/platform/test/functional/apps/dashboard/esql_controls/index.ts
+++ b/src/platform/test/functional/apps/dashboard/esql_controls/index.ts
@@ -23,15 +23,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     );
   }
 
-  async function unloadCurrentData() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-  }
-
   describe('dashboard app - esql controls', function () {
     before(loadCurrentData);
-    after(unloadCurrentData);
 
     loadTestFile(require.resolve('./field_control'));
     loadTestFile(require.resolve('./interval_control'));

--- a/src/platform/test/functional/apps/dashboard/group1/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group1/index.ts
@@ -23,15 +23,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     );
   }
 
-  async function unloadCurrentData() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-  }
-
   describe('dashboard app - group 1', function () {
     before(loadCurrentData);
-    after(unloadCurrentData);
 
     // This has to be first since the other tests create some embeddables as side affects and our counting assumes
     // a fresh index.

--- a/src/platform/test/functional/apps/dashboard/group2/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group2/index.ts
@@ -23,15 +23,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     );
   }
 
-  async function unloadCurrentData() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-  }
-
   describe('dashboard app - group 2', function () {
     before(loadCurrentData);
-    after(unloadCurrentData);
 
     loadTestFile(require.resolve('./full_screen_mode'));
     loadTestFile(require.resolve('./dashboard_filter_bar'));

--- a/src/platform/test/functional/apps/dashboard/group4/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/index.ts
@@ -12,7 +12,6 @@ import type { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const browser = getService('browser');
   const esArchiver = getService('esArchiver');
-  const kibanaServer = getService('kibanaServer');
 
   async function loadLogstash() {
     await browser.setWindowSize(1200, 900);
@@ -21,16 +20,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     );
   }
 
-  async function unloadLogstash() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-    );
-    await kibanaServer.savedObjects.cleanStandardList();
-  }
-
   describe('dashboard app - group 4', function () {
     before(loadLogstash);
-    after(unloadLogstash);
 
     loadTestFile(require.resolve('./dashboard_empty'));
     loadTestFile(require.resolve('./dashboard_save'));

--- a/src/platform/test/functional/apps/dashboard/group5/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group5/index.ts
@@ -23,15 +23,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     );
   }
 
-  async function unloadCurrentData() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-  }
-
   describe('dashboard app - group 5', function () {
     before(loadCurrentData);
-    after(unloadCurrentData);
 
     // This has to be first since the other tests create some embeddables as side affects and our counting assumes
     // a fresh index.

--- a/src/platform/test/functional/apps/dashboard/group6/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group6/index.ts
@@ -23,15 +23,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     );
   }
 
-  async function unloadCurrentData() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-  }
-
   describe('dashboard app - group 6', function () {
     before(loadCurrentData);
-    after(unloadCurrentData);
 
     loadTestFile(require.resolve('./dashboard_grid'));
     loadTestFile(require.resolve('./view_edit'));

--- a/src/platform/test/functional/apps/dashboard_elements/controls/common/index.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/controls/common/index.ts
@@ -33,17 +33,8 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     await dashboard.preserveCrossAppState();
   }
 
-  async function teardown() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-    await security.testUser.restoreDefaults();
-    await kibanaServer.savedObjects.cleanStandardList();
-  }
-
   describe('Controls', function () {
     before(setup);
-    after(teardown);
     loadTestFile(require.resolve('./range_slider'));
     loadTestFile(require.resolve('./time_slider'));
     loadTestFile(require.resolve('./control_chaining'));

--- a/src/platform/test/functional/apps/dashboard_elements/controls/options_list/index.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/controls/options_list/index.ts
@@ -35,17 +35,8 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     await elasticChart.setNewChartUiDebugFlag();
   };
 
-  const teardown = async () => {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-    await security.testUser.restoreDefaults();
-    await kibanaServer.savedObjects.cleanStandardList();
-  };
-
   describe('Options list control', () => {
     before(setup);
-    after(teardown);
 
     loadTestFile(require.resolve('./options_list_creation_and_editing'));
     loadTestFile(require.resolve('./options_list_dashboard_interaction'));

--- a/src/platform/test/functional/apps/dashboard_elements/input_control_vis/index.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/input_control_vis/index.ts
@@ -27,16 +27,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       );
     });
 
-    after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/long_window_logstash'
-      );
-    });
-
     loadTestFile(require.resolve('./input_control_options'));
     loadTestFile(require.resolve('./dynamic_options'));
     loadTestFile(require.resolve('./chained_controls'));

--- a/src/platform/test/functional/apps/dashboard_elements/links/index.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/links/index.ts
@@ -33,17 +33,8 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     await dashboard.preserveCrossAppState();
   }
 
-  async function teardown() {
-    await esArchiver.unload(
-      'src/platform/test/functional/fixtures/es_archiver/dashboard/current/data'
-    );
-    await security.testUser.restoreDefaults();
-    await kibanaServer.savedObjects.cleanStandardList();
-  }
-
   describe('links panel', function () {
     before(setup);
-    after(teardown);
     loadTestFile(require.resolve('./links_create_edit'));
     loadTestFile(require.resolve('./links_navigation'));
   });

--- a/src/platform/test/functional/apps/discover/cascade_layout/index.ts
+++ b/src/platform/test/functional/apps/discover/cascade_layout/index.ts
@@ -47,20 +47,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_grouping_selection'));
     loadTestFile(require.resolve('./_data_fetching'));
     loadTestFile(require.resolve('./_state_restoration'));

--- a/src/platform/test/functional/apps/discover/context_awareness/index.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/index.ts
@@ -9,10 +9,9 @@
 
 import type { FtrProviderContext } from '../ftr_provider_context';
 
-export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
+export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const { timePicker } = getPageObjects(['timePicker']);
 
   const from = '2024-06-10T14:00:00.000Z';
   const to = '2024-06-10T16:30:00.000Z';
@@ -31,16 +30,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await kibanaServer.uiSettings.update({
         'timepicker:timeDefaults': `{ "from": "${from}", "to": "${to}"}`,
       });
-    });
-
-    after(async () => {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/discover/context_awareness'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover/context_awareness'
-      );
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
     });
 
     loadTestFile(require.resolve('./_framework'));

--- a/src/platform/test/functional/apps/discover/esql_2/index.ts
+++ b/src/platform/test/functional/apps/discover/esql_2/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/esql_2', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_esql_view'));

--- a/src/platform/test/functional/apps/discover/esql_3/index.ts
+++ b/src/platform/test/functional/apps/discover/esql_3/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/esql_3', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_index_editor'));

--- a/src/platform/test/functional/apps/discover/esql_4/index.ts
+++ b/src/platform/test/functional/apps/discover/esql_4/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/esql_4', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_esql_controls'));

--- a/src/platform/test/functional/apps/discover/group10/index.ts
+++ b/src/platform/test/functional/apps/discover/group10/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/group10', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_lens_vis')); // 16 min

--- a/src/platform/test/functional/apps/discover/group13/index.ts
+++ b/src/platform/test/functional/apps/discover/group13/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/group13', function () {
     before(async function () {
       await browser.setWindowSize(1600, 1200);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     loadTestFile(require.resolve('./_field_stats_table'));

--- a/src/platform/test/functional/apps/discover/group5/index.ts
+++ b/src/platform/test/functional/apps/discover/group5/index.ts
@@ -10,18 +10,11 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
   describe('discover/group5', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
-    });
-
-    after(async function unloadMakelogs() {
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
     });
 
     // `_no_data` is intentionally first: it expects a clean ES/Kibana state.

--- a/src/platform/test/functional/apps/management/group1/index.ts
+++ b/src/platform/test/functional/apps/management/group1/index.ts
@@ -20,10 +20,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await esArchiver.loadIfNeeded('src/platform/test/functional/fixtures/es_archiver/makelogs');
     });
 
-    after(async () => {
-      await esArchiver.unload('src/platform/test/functional/fixtures/es_archiver/makelogs');
-    });
-
     loadTestFile(require.resolve('./_create_index_pattern_wizard'));
     loadTestFile(require.resolve('./_data_view_create_delete'));
     loadTestFile(require.resolve('./_index_pattern_results_sort'));

--- a/src/platform/test/functional/apps/management/group2/index.ts
+++ b/src/platform/test/functional/apps/management/group2/index.ts
@@ -20,10 +20,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await esArchiver.loadIfNeeded('src/platform/test/functional/fixtures/es_archiver/makelogs');
     });
 
-    after(async () => {
-      await esArchiver.unload('src/platform/test/functional/fixtures/es_archiver/makelogs');
-    });
-
     loadTestFile(require.resolve('./_scripted_fields'));
     loadTestFile(require.resolve('./_scripted_fields_preview'));
     loadTestFile(require.resolve('./_scripted_fields_filter'));

--- a/src/platform/test/functional/apps/management/group3/index.ts
+++ b/src/platform/test/functional/apps/management/group3/index.ts
@@ -20,10 +20,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await esArchiver.loadIfNeeded('src/platform/test/functional/fixtures/es_archiver/makelogs');
     });
 
-    after(async () => {
-      await esArchiver.unload('src/platform/test/functional/fixtures/es_archiver/makelogs');
-    });
-
     loadTestFile(require.resolve('./_mgmt_import_saved_objects'));
     loadTestFile(require.resolve('./_import_objects'));
     loadTestFile(require.resolve('./_test_huge_fields'));

--- a/src/platform/test/functional/apps/management/group4/index.ts
+++ b/src/platform/test/functional/apps/management/group4/index.ts
@@ -20,10 +20,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await esArchiver.loadIfNeeded('src/platform/test/functional/fixtures/es_archiver/makelogs');
     });
 
-    after(async () => {
-      await esArchiver.unload('src/platform/test/functional/fixtures/es_archiver/makelogs');
-    });
-
     loadTestFile(require.resolve('./_kibana_settings'));
     loadTestFile(require.resolve('./_data_view_relationships'));
     loadTestFile(require.resolve('./_edit_field'));

--- a/x-pack/platform/test/functional/apps/lens/group1/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group1/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     if (config.get('esTestCluster.ccs')) {
       loadTestFile(require.resolve('./smokescreen'));
     } else {

--- a/x-pack/platform/test/functional/apps/lens/group10/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group10/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./logsdb_downgrade'));
   });
 };

--- a/x-pack/platform/test/functional/apps/lens/group11/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group11/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./tsdb_downgrade'));
   });
 };

--- a/x-pack/platform/test/functional/apps/lens/group12/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group12/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./terms')); // 1m 35s
     loadTestFile(require.resolve('./epoch_millis')); // 30s
   });

--- a/x-pack/platform/test/functional/apps/lens/group13/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group13/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./dashboard_inline_editing'));
   });
 };

--- a/x-pack/platform/test/functional/apps/lens/group14/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group14/index.ts
@@ -67,14 +67,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./inspector')); // 1m 19s
     loadTestFile(require.resolve('./error_handling')); // 1m 8s
     loadTestFile(require.resolve('./lens_tagging')); // 1m 9s

--- a/x-pack/platform/test/functional/apps/lens/group15/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group15/index.ts
@@ -66,14 +66,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./legend_statistics'));
     loadTestFile(require.resolve('./lens_reporting'));
     loadTestFile(require.resolve('./rollup'));

--- a/x-pack/platform/test/functional/apps/lens/group2/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group2/index.ts
@@ -45,14 +45,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-    });
-
     // total run time ~ 16m 20s
     loadTestFile(require.resolve('./partition')); // 1m 40s
     loadTestFile(require.resolve('./persistent_context')); // 1m

--- a/x-pack/platform/test/functional/apps/lens/group3/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group3/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./add_to_dashboard')); // 12m 50s
     loadTestFile(require.resolve('./runtime_fields')); // 1m
   });

--- a/x-pack/platform/test/functional/apps/lens/group4/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group4/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     // total run time ~16m 30s
     loadTestFile(require.resolve('./colors')); // 1m 2s
     loadTestFile(require.resolve('./color_mapping'));

--- a/x-pack/platform/test/functional/apps/lens/group5/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group5/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     // total run time ~ 16m
     loadTestFile(require.resolve('./drag_and_drop')); // 7m 40s
     loadTestFile(require.resolve('./geo_field')); // 26s

--- a/x-pack/platform/test/functional/apps/lens/group6/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group6/index.ts
@@ -67,14 +67,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./metric')); // 4m 7s
     loadTestFile(require.resolve('./legacy_metric')); // 29s
     loadTestFile(require.resolve('./disable_auto_apply')); // 1m 6s

--- a/x-pack/platform/test/functional/apps/lens/group7/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group7/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./esql'));
   });
 };

--- a/x-pack/platform/test/functional/apps/lens/group8/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group8/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./logsdb'));
   });
 };

--- a/x-pack/platform/test/functional/apps/lens/group9/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group9/index.ts
@@ -63,14 +63,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./tsdb'));
   });
 };

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_1/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_1/index.ts
@@ -62,13 +62,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./pie'));
     loadTestFile(require.resolve('./metric'));
   });

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_2/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_2/index.ts
@@ -62,13 +62,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./xy'));
     loadTestFile(require.resolve('./gauge'));
   });

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_3/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_3/index.ts
@@ -62,13 +62,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./goal'));
     loadTestFile(require.resolve('./table'));
   });

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_4/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based_4/index.ts
@@ -62,13 +62,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./heatmap'));
     loadTestFile(require.resolve('./navigation'));
   });

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/index.ts
@@ -63,13 +63,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./dashboard'));
   });
 }

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_1/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_1/index.ts
@@ -63,13 +63,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./dashboard'));
     loadTestFile(require.resolve('./metric'));
   });

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_2/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_2/index.ts
@@ -61,13 +61,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./gauge'));
     loadTestFile(require.resolve('./timeseries'));
   });

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_3/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_3/index.ts
@@ -63,13 +63,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./top_n'));
   });
 }

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_4/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb_4/index.ts
@@ -63,13 +63,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esNode.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./table'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ftr] remove global after hook before servers stopped (#274314)](https://github.com/elastic/kibana/pull/274314)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-01T08:22:41Z","message":"[ftr] remove global after hook before servers stopped (#274314)\n\n## Summary\n\nPart of https://github.com/elastic/appex-qa-team/issues/917\n\nDropping unloading esArchives/resetting Kibana settings right before\nservers are shutdown. It should save CI time + help with migration as\nagent still tries to unload data even though we explicitly set not to do\nso.","sha":"c9f7aab600323c026a6a51186c78f29763290aec","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.4","v9.3.7"],"title":"[ftr] remove global after hook before servers stopped","number":274314,"url":"https://github.com/elastic/kibana/pull/274314","mergeCommit":{"message":"[ftr] remove global after hook before servers stopped (#274314)\n\n## Summary\n\nPart of https://github.com/elastic/appex-qa-team/issues/917\n\nDropping unloading esArchives/resetting Kibana settings right before\nservers are shutdown. It should save CI time + help with migration as\nagent still tries to unload data even though we explicitly set not to do\nso.","sha":"c9f7aab600323c026a6a51186c78f29763290aec"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274314","number":274314,"mergeCommit":{"message":"[ftr] remove global after hook before servers stopped (#274314)\n\n## Summary\n\nPart of https://github.com/elastic/appex-qa-team/issues/917\n\nDropping unloading esArchives/resetting Kibana settings right before\nservers are shutdown. It should save CI time + help with migration as\nagent still tries to unload data even though we explicitly set not to do\nso.","sha":"c9f7aab600323c026a6a51186c78f29763290aec"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->