### PR TITLE
Enable EARS with TLS cert for testing

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/kibana_yml.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/kibana_yml.template.ts
@@ -24,6 +24,10 @@ function generator({ imageFlavor }: TemplateContext) {
   server.shutdownTimeout: "5s"
   elasticsearch.hosts: [ "http://elasticsearch:9200" ]
   monitoring.ui.container.elasticsearch.enabled: true
+  xpack.actions.auth.ears.enabled: true
+  xpack.actions.auth.ears.enableExperimental: true
+  xpack.actions.auth.ears.ssl.certificate: "config/certs/ecp-client.crt"
+  xpack.actions.auth.ears.ssl.key: "config/certs/ecp-client.key"
   `);
 }
 


### PR DESCRIPTION
Deploy to CFT region to test https://github.com/elastic/cloud/pull/156814 would still pass the proxy as expected