### PR TITLE
[Chrome Next] Add app menu isDestructive variant

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
@@ -494,3 +494,48 @@ export const PrimaryActionWithPopover: Story = {
     },
   },
 };
+
+const destructiveItemConfig: AppMenuConfig = {
+  items: [
+    {
+      id: 'runRule',
+      order: 1,
+      label: 'Run rule',
+      run: action('run-rule-clicked'),
+      iconType: 'play',
+      testId: 'runRuleButton',
+    },
+    {
+      id: 'delete',
+      order: 3,
+      label: 'Delete',
+      run: action('delete-clicked'),
+      iconType: 'trash',
+      testId: 'deleteButton',
+      isDestructive: true,
+      overflow: true,
+    },
+    {
+      id: 'updateApiKey',
+      order: 4,
+      label: 'Update API key',
+      run: action('update-api-key-clicked'),
+      iconType: 'key',
+      testId: 'updateApiKeyButton',
+      overflow: true,
+    },
+  ],
+  primaryActionItem: {
+    run: action('edit-clicked'),
+    id: 'edit',
+    label: 'Edit rule',
+    testId: 'editButton',
+    iconType: 'pencil',
+  },
+};
+export const DestructiveItems: Story = {
+  name: 'Destructive items',
+  args: {
+    config: destructiveItemConfig,
+  },
+};

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -97,12 +97,7 @@ interface AppMenuItemBase {
    */
   iconType: IconType;
   /**
-   * Sets the `data-test-subj` attribute for the item, used for testing purposes.
-   *
-   * When provided, it fully replaces the element's default subject. When omitted, the element falls
-   * back to a structural subject derived from `id` (`app-menu-item-<id>` for menu items,
-   * `app-menu-action-button-<id>` for primary action buttons). Either way, derived sub-elements use
-   * the resolved value as a prefix (e.g. the label badge is `<resolved>-badge`).
+   * A unique identifier for the item, used for testing purposes. Maps to `data-test-subj` attribute.
    */
   testId?: string;
   /**
@@ -215,24 +210,40 @@ type AppMenuItemWithPopover = AppMenuItemBase & {
 
 export type AppMenuItemCommon = AppMenuButtonItem | AppMenuItemWithPopover | AppMenuLinkItem;
 
-/**
- * Full item type for use in `config.items` arrays.
- */
-export type AppMenuItemType = AppMenuItemCommon & {
+type AppMenuItemTypeBase = AppMenuItemCommon & {
   /**
    * Order of the item in the menu. Lower numbers appear first.
    */
   order: number;
-  /**
-   * If `true`, the item will be moved to the "More" menu. Only used in top-level items, not in popover items.
-   */
-  overflow?: boolean;
   /**
    * Adds a separator line above or below the item when rendered inside a popover menu.
    * Ignored for top-level, non-popover items.
    */
   separator?: 'above' | 'below';
 };
+
+type AppMenuItemTopLevel = AppMenuItemTypeBase & {
+  overflow?: boolean;
+  isDestructive?: never;
+};
+
+type AppMenuItemOverflow = AppMenuItemTypeBase & {
+  /**
+   * The item will be moved to the "More" menu. Only used in top-level items, not in popover items.
+   */
+  overflow: true;
+  /**
+   * Marks the item as destructive (e.g. delete) by rendering in danger/red color.
+   */
+  isDestructive?: boolean;
+};
+
+/**
+ * Full item type for use in `config.items` arrays.
+ * Can be a top-level item or an overflow item.
+ *
+ */
+export type AppMenuItemType = AppMenuItemTopLevel | AppMenuItemOverflow;
 
 export type AppMenuStaticItem = AppMenuItemType & {
   /**

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -440,6 +440,16 @@ describe('utils', () => {
       expect(result.toolTipContent).toBe('Content');
       expect(result.toolTipProps?.title).toBe('Title');
     });
+
+    it('should set danger color when isDestructive is true', () => {
+      const result = mapAppMenuItemToPanelItem({ ...baseItem, isDestructive: true });
+      expect(result.color).toBe('danger');
+    });
+
+    it('should not set color when isDestructive is falsy', () => {
+      const result = mapAppMenuItemToPanelItem(baseItem);
+      expect(result.color).toBeUndefined();
+    });
   });
 
   describe('getPopoverActionItems', () => {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -86,7 +86,11 @@ export const getAppMenuItems = ({
 }: {
   config?: AppMenuConfig;
   hasStaticItems?: boolean;
-}) => {
+}): {
+  displayedItems: AppMenuItemType[];
+  overflowItems: AppMenuItemType[];
+  shouldOverflow: boolean;
+} => {
   if (!config || !config.items) {
     return {
       displayedItems: [],
@@ -230,6 +234,7 @@ export const mapAppMenuItemToPanelItem = (
       title,
     },
     ...(childPanelId !== undefined && { panel: childPanelId }),
+    ...(item?.isDestructive && { color: 'danger' }),
   };
 };
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/chrome_app_header/chrome_app_header.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chrome_app_header/chrome_app_header.tsx
@@ -10,7 +10,7 @@
 import type { ReactNode } from 'react';
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
-import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
+import type { AppMenuConfig, AppMenuItemType } from '@kbn/core-chrome-app-menu-components';
 import { AppHeader } from '@kbn/app-header';
 import { AppMenuActionId } from '@kbn/discover-utils';
 import { getChromeHeaderBack, getChromeHeaderTitle } from './utils';
@@ -52,12 +52,15 @@ export const ChromeAppHeader = ({
     return {
       ...menu,
       isCollapsed,
-      items: menu?.items?.map((item) => ({
-        ...item,
-        // We need more space for the tabs as the title is now in the same row. Move all items to the overflow menu.
-        // (Except switch language)
-        overflow: item.id !== AppMenuActionId.switchLanguageMode,
-      })),
+      items: menu?.items?.map(
+        (item) =>
+          ({
+            ...item,
+            // We need more space for the tabs as the title is now in the same row. Move all items to the overflow menu.
+            // (Except switch language)
+            overflow: item.id !== AppMenuActionId.switchLanguageMode,
+          } as AppMenuItemType)
+      ),
     };
   }, [isCollapsed, menu]);
 


### PR DESCRIPTION
## Summary

This PR adds `isDestructive` property to app menu overflow items. 

<img width="337" height="166" alt="Screenshot 2026-07-01 at 12 56 31" src="https://github.com/user-attachments/assets/85d1bb84-d3aa-4568-bd21-5f48eace023a" />

This brings back https://github.com/elastic/kibana/pull/274362 but without the type errors.



