### PR TITLE
Ignore package level harness directories during build

### DIFF
--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -76,6 +76,9 @@ function excludeDirsByRel(rel: string) {
  */
 function excludeDirsByName(name: string) {
   return (
+    name === '.agents' ||
+    name === '.claude' ||
+    name === '.opencode' ||
     name === '__fixtures__' ||
     name === '__jest__' ||
     name === '__mocks__' ||


### PR DESCRIPTION
## Summary

When building package level dists, ignore the ai harness directories and don't copy them. 



