### PR TITLE
[Scout] Add `--ui` flag to `scout run-tests` for Playwright UI mode

### DIFF
--- a/docs/extend/testing/debugging.md
+++ b/docs/extend/testing/debugging.md
@@ -27,6 +27,24 @@ node scripts/playwright show-report <plugin-path>/test/scout/ui/output/reports
 
 [UI Mode](https://playwright.dev/docs/test-ui-mode) lets you run and debug tests interactively.
 
+#### Using Scout `run-tests` [playwright-ui-mode-run-tests]
+
+The simplest way is to pass `--ui` to `run-tests`. Scout starts the test servers for you, resolves the correct `--project` and `--grep` tag from `--arch`/`--domain`, opens the Playwright UI, and keeps the servers running until you close the UI (then it tears them down automatically).
+
+```bash
+node scripts/scout run-tests \
+  --arch stateful \
+  --domain classic \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts \
+  --ui
+```
+
+`--ui` cannot be combined with `--headed` (UI mode manages its own browser) or `--repeatEach` (UI mode is interactive, not a batch run).
+
+#### Using Playwright directly [playwright-ui-mode-playwright]
+
+If servers are already running (for example, started once with `node scripts/scout start-server`), you can launch UI mode against them directly. This is handy when you want to keep servers up across many iterations.
+
 ```bash
 node scripts/playwright test \
   --config <plugin-path>/test/scout/ui/playwright.config.ts \

--- a/docs/extend/testing/debugging.md
+++ b/docs/extend/testing/debugging.md
@@ -41,6 +41,18 @@ node scripts/scout run-tests \
 
 `--ui` cannot be combined with `--headed` (UI mode manages its own browser) or `--repeatEach` (UI mode is interactive, not a batch run).
 
+To make the UI reachable from another machine (for example, when servers run on a remote host), pass `--uiHost` and `--uiPort`:
+
+```bash
+node scripts/scout run-tests \
+  --arch stateful \
+  --domain classic \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts \
+  --ui \
+  --uiHost 0.0.0.0 \
+  --uiPort 8888
+```
+
 #### Using Playwright directly [playwright-ui-mode-playwright]
 
 If servers are already running (for example, started once with `node scripts/scout start-server`), you can launch UI mode against them directly. This is handy when you want to keep servers up across many iterations.

--- a/docs/extend/testing/run-scout-tests.md
+++ b/docs/extend/testing/run-scout-tests.md
@@ -55,6 +55,16 @@ node scripts/scout.js run-tests \
 
 When Scout starts Kibana and Elasticsearch locally, it saves the server configuration to `.scout/servers/local.json` and later reads it when running tests.
 
+Add `--ui` to open Playwright's [**UI mode**](./debugging.md#playwright-ui-mode) after the servers are started; the servers stay up until you close the UI:
+
+```bash
+node scripts/scout.js run-tests \
+  --arch <stateful|serverless> \
+  --domain <domain> \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts \
+  --ui
+```
+
 ### Run a subset with `--testFiles` [scout-run-tests-testFiles]
 
 Directory:

--- a/src/platform/packages/shared/kbn-scout/src/cli/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/run_tests.ts
@@ -53,6 +53,9 @@ export const runTestsCmd: Command<void> = {
 
     Local flakiness validation (run each test N times):
     node scripts/scout run-tests --arch stateful --domain classic --config <playwright_config_path> --repeatEach 5
+
+    Interactive Playwright UI mode (starts servers, then opens the UI; servers stop when the UI is closed):
+    node scripts/scout run-tests --arch stateful --domain classic --config <playwright_config_path> --ui
   `,
   flags: TEST_FLAG_OPTIONS,
   run: async ({ flagsReader, log }) => {

--- a/src/platform/packages/shared/kbn-scout/src/cli/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/run_tests.ts
@@ -56,6 +56,9 @@ export const runTestsCmd: Command<void> = {
 
     Interactive Playwright UI mode (starts servers, then opens the UI; servers stop when the UI is closed):
     node scripts/scout run-tests --arch stateful --domain classic --config <playwright_config_path> --ui
+
+    Interactive Playwright UI mode reachable from another machine:
+    node scripts/scout run-tests --arch stateful --domain classic --config <playwright_config_path> --ui --uiHost 0.0.0.0 --uiPort 8888
   `,
   flags: TEST_FLAG_OPTIONS,
   run: async ({ flagsReader, log }) => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
@@ -39,6 +39,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       headed: false,
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       serverConfigSet: 'default',
     });
@@ -56,6 +57,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: 'classic',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -72,6 +74,7 @@ describe('parseTestFlags', () => {
       arch: true,
       domain: 'classic',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -86,6 +89,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: true,
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -100,6 +104,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: 'classic',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -116,6 +121,7 @@ describe('parseTestFlags', () => {
       arch: 'bad_arch',
       domain: 'classic',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -132,6 +138,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: 'rainbow-barfing-unicorns',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -149,6 +156,7 @@ describe('parseTestFlags', () => {
       domain: 'observability_complete',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -160,6 +168,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: undefined,
       headed: false,
+      ui: false,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -176,6 +185,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: true,
       esFrom: 'snapshot',
@@ -188,6 +198,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: 'snapshot',
       headed: true,
+      ui: false,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -204,6 +215,7 @@ describe('parseTestFlags', () => {
       domain: 'security_ease',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
@@ -215,6 +227,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: undefined,
       headed: false,
+      ui: false,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -231,6 +244,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: true,
       esFrom: 'snapshot',
@@ -243,6 +257,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: 'snapshot',
       headed: true,
+      ui: false,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -259,6 +274,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       repeatEach: '5',
@@ -271,6 +287,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: undefined,
       headed: false,
+      ui: false,
       repeatEach: 5,
       installDir: undefined,
       logsDir: undefined,
@@ -280,6 +297,72 @@ describe('parseTestFlags', () => {
     });
   });
 
+  it(`should parse with --ui flag`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      preserveEsData: false,
+      headed: false,
+      ui: true,
+      serverConfigSet: 'default',
+    });
+    validatePlaywrightConfigMock.mockResolvedValueOnce();
+    const result = await parseTestFlags(flags);
+
+    expect(result).toEqual({
+      configPath: '/path/to/config',
+      esFrom: undefined,
+      headed: false,
+      ui: true,
+      repeatEach: undefined,
+      installDir: undefined,
+      logsDir: undefined,
+      preserveEsData: false,
+      serverConfigSet: 'default',
+      testTarget: new ScoutTestTarget('local', 'stateful', 'classic'),
+    });
+  });
+
+  it(`should throw an error when '--ui' is combined with '--headed'`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      preserveEsData: false,
+      headed: true,
+      ui: true,
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `'--headed' cannot be combined with '--ui': UI mode manages its own browser`
+    );
+  });
+
+  it(`should throw an error when '--ui' is combined with '--repeatEach'`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      preserveEsData: false,
+      headed: false,
+      ui: true,
+      repeatEach: '5',
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `'--repeatEach' cannot be combined with '--ui': UI mode is interactive, not a batch run`
+    );
+  });
+
   it(`should throw an error when '--repeatEach' is not a number`, async () => {
     const flags = new FlagsReader({
       location: 'local',
@@ -287,6 +370,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       repeatEach: 'abc',
@@ -305,6 +389,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       repeatEach: '0',
@@ -323,6 +408,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      ui: false,
       preserveEsData: false,
       headed: false,
       repeatEach: '2.5',
@@ -357,6 +443,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        ui: false,
         preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
@@ -369,6 +456,7 @@ describe('parseTestFlags', () => {
         configPath: derivedConfig,
         esFrom: undefined,
         headed: false,
+        ui: false,
         repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
@@ -399,6 +487,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFilesString,
         logToFile: false,
+        ui: false,
         preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
@@ -411,6 +500,7 @@ describe('parseTestFlags', () => {
         configPath: derivedConfig,
         esFrom: undefined,
         headed: false,
+        ui: false,
         repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
@@ -438,6 +528,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        ui: false,
         preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
@@ -466,6 +557,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        ui: false,
         preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
@@ -491,6 +583,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        ui: false,
         preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
@@ -506,6 +599,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         config: '/path/to/config',
         logToFile: false,
+        ui: false,
         preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
@@ -169,6 +169,8 @@ describe('parseTestFlags', () => {
       esFrom: undefined,
       headed: false,
       ui: false,
+      uiHost: undefined,
+      uiPort: undefined,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -199,6 +201,8 @@ describe('parseTestFlags', () => {
       esFrom: 'snapshot',
       headed: true,
       ui: false,
+      uiHost: undefined,
+      uiPort: undefined,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -228,6 +232,8 @@ describe('parseTestFlags', () => {
       esFrom: undefined,
       headed: false,
       ui: false,
+      uiHost: undefined,
+      uiPort: undefined,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -258,6 +264,8 @@ describe('parseTestFlags', () => {
       esFrom: 'snapshot',
       headed: true,
       ui: false,
+      uiHost: undefined,
+      uiPort: undefined,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -288,6 +296,8 @@ describe('parseTestFlags', () => {
       esFrom: undefined,
       headed: false,
       ui: false,
+      uiHost: undefined,
+      uiPort: undefined,
       repeatEach: 5,
       installDir: undefined,
       logsDir: undefined,
@@ -317,6 +327,8 @@ describe('parseTestFlags', () => {
       esFrom: undefined,
       headed: false,
       ui: true,
+      uiHost: undefined,
+      uiPort: undefined,
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
@@ -360,6 +372,77 @@ describe('parseTestFlags', () => {
 
     await expect(parseTestFlags(flags)).rejects.toThrow(
       `'--repeatEach' cannot be combined with '--ui': UI mode is interactive, not a batch run`
+    );
+  });
+
+  it(`should parse with --ui, --uiHost and --uiPort flags`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      preserveEsData: false,
+      headed: false,
+      ui: true,
+      uiHost: '0.0.0.0',
+      uiPort: '8888',
+      serverConfigSet: 'default',
+    });
+    validatePlaywrightConfigMock.mockResolvedValueOnce();
+    const result = await parseTestFlags(flags);
+
+    expect(result).toEqual({
+      configPath: '/path/to/config',
+      esFrom: undefined,
+      headed: false,
+      ui: true,
+      uiHost: '0.0.0.0',
+      uiPort: 8888,
+      repeatEach: undefined,
+      installDir: undefined,
+      logsDir: undefined,
+      preserveEsData: false,
+      serverConfigSet: 'default',
+      testTarget: new ScoutTestTarget('local', 'stateful', 'classic'),
+    });
+  });
+
+  it(`should throw an error when '--uiHost' is used without '--ui'`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      preserveEsData: false,
+      headed: false,
+      ui: false,
+      uiHost: '0.0.0.0',
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `'--uiHost' and '--uiPort' can only be used together with '--ui'`
+    );
+  });
+
+  it(`should throw an error when '--uiPort' is out of range`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      preserveEsData: false,
+      headed: false,
+      ui: true,
+      uiPort: '70000',
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `'--uiPort' must be an integer between 0 and 65535, got '70000'`
     );
   });
 
@@ -457,6 +540,8 @@ describe('parseTestFlags', () => {
         esFrom: undefined,
         headed: false,
         ui: false,
+        uiHost: undefined,
+        uiPort: undefined,
         repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
@@ -501,6 +586,8 @@ describe('parseTestFlags', () => {
         esFrom: undefined,
         headed: false,
         ui: false,
+        uiHost: undefined,
+        uiPort: undefined,
         repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.ts
@@ -21,6 +21,8 @@ export interface RunTestsOptions {
   configPath: string;
   headed: boolean;
   ui: boolean;
+  uiHost: string | undefined;
+  uiPort: number | undefined;
   repeatEach: number | undefined;
   testFiles?: string[];
   esFrom: 'serverless' | 'source' | 'snapshot' | undefined;
@@ -31,7 +33,14 @@ export interface RunTestsOptions {
 export const TEST_FLAG_OPTIONS: FlagOptions = {
   ...SERVER_FLAG_OPTIONS,
   boolean: [...(SERVER_FLAG_OPTIONS.boolean || []), 'headed', 'ui'],
-  string: [...(SERVER_FLAG_OPTIONS.string || []), 'config', 'testFiles', 'repeatEach'],
+  string: [
+    ...(SERVER_FLAG_OPTIONS.string || []),
+    'config',
+    'testFiles',
+    'repeatEach',
+    'uiHost',
+    'uiPort',
+  ],
   default: { ...SERVER_FLAG_OPTIONS.default, headed: false, ui: false },
   help: `
     ${SERVER_FLAG_OPTIONS.help}
@@ -39,6 +48,8 @@ export const TEST_FLAG_OPTIONS: FlagOptions = {
     --testFiles         Comma-separated list of test file paths or test directory path (required if --config not provided)
     --headed            Run Playwright with browser head
     --ui                Run Playwright in interactive UI mode. Servers are started first and kept running until the UI is closed
+    --uiHost            Host to serve the Playwright UI on (requires --ui, e.g. --uiHost 0.0.0.0 for remote access)
+    --uiPort            Port to serve the Playwright UI on (requires --ui)
     --repeatEach        Run each test N times for local flakiness validation (e.g. --repeatEach 5)
   `,
 };
@@ -60,6 +71,8 @@ export async function parseTestFlags(flags: FlagsReader) {
 
   const headed = flags.boolean('headed');
   const ui = flags.boolean('ui');
+  const uiHost = flags.string('uiHost');
+  const uiPort = flags.number('uiPort');
   const repeatEach = flags.number('repeatEach');
 
   if (repeatEach !== undefined && (repeatEach < 1 || !Number.isInteger(repeatEach))) {
@@ -76,6 +89,14 @@ export async function parseTestFlags(flags: FlagsReader) {
     throw createFlagError(
       `'--repeatEach' cannot be combined with '--ui': UI mode is interactive, not a batch run`
     );
+  }
+
+  if (!ui && (uiHost !== undefined || uiPort !== undefined)) {
+    throw createFlagError(`'--uiHost' and '--uiPort' can only be used together with '--ui'`);
+  }
+
+  if (uiPort !== undefined && (!Number.isInteger(uiPort) || uiPort < 0 || uiPort > 65535)) {
+    throw createFlagError(`'--uiPort' must be an integer between 0 and 65535, got '${uiPort}'`);
   }
 
   let scoutConfigPath: string;
@@ -101,6 +122,8 @@ export async function parseTestFlags(flags: FlagsReader) {
     configPath: scoutConfigPath,
     headed,
     ui,
+    uiHost,
+    uiPort,
     repeatEach,
     ...(testFiles.length > 0 && { testFiles }),
   };

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.ts
@@ -20,6 +20,7 @@ export interface RunTestsOptions {
   testTarget: ScoutTestTarget;
   configPath: string;
   headed: boolean;
+  ui: boolean;
   repeatEach: number | undefined;
   testFiles?: string[];
   esFrom: 'serverless' | 'source' | 'snapshot' | undefined;
@@ -29,14 +30,15 @@ export interface RunTestsOptions {
 
 export const TEST_FLAG_OPTIONS: FlagOptions = {
   ...SERVER_FLAG_OPTIONS,
-  boolean: [...(SERVER_FLAG_OPTIONS.boolean || []), 'headed'],
+  boolean: [...(SERVER_FLAG_OPTIONS.boolean || []), 'headed', 'ui'],
   string: [...(SERVER_FLAG_OPTIONS.string || []), 'config', 'testFiles', 'repeatEach'],
-  default: { ...SERVER_FLAG_OPTIONS.default, headed: false },
+  default: { ...SERVER_FLAG_OPTIONS.default, headed: false, ui: false },
   help: `
     ${SERVER_FLAG_OPTIONS.help}
     --config            Playwright config file path (required if --testFiles not provided)
     --testFiles         Comma-separated list of test file paths or test directory path (required if --config not provided)
     --headed            Run Playwright with browser head
+    --ui                Run Playwright in interactive UI mode. Servers are started first and kept running until the UI is closed
     --repeatEach        Run each test N times for local flakiness validation (e.g. --repeatEach 5)
   `,
 };
@@ -57,10 +59,23 @@ export async function parseTestFlags(flags: FlagsReader) {
   }
 
   const headed = flags.boolean('headed');
+  const ui = flags.boolean('ui');
   const repeatEach = flags.number('repeatEach');
 
   if (repeatEach !== undefined && (repeatEach < 1 || !Number.isInteger(repeatEach))) {
     throw createFlagError(`'--repeatEach' must be a positive integer, got '${repeatEach}'`);
+  }
+
+  if (ui && headed) {
+    throw createFlagError(
+      `'--headed' cannot be combined with '--ui': UI mode manages its own browser`
+    );
+  }
+
+  if (ui && repeatEach !== undefined) {
+    throw createFlagError(
+      `'--repeatEach' cannot be combined with '--ui': UI mode is interactive, not a batch run`
+    );
   }
 
   let scoutConfigPath: string;
@@ -85,6 +100,7 @@ export async function parseTestFlags(flags: FlagsReader) {
     ...serverOptions,
     configPath: scoutConfigPath,
     headed,
+    ui,
     repeatEach,
     ...(testFiles.length > 0 && { testFiles }),
   };

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -196,6 +196,12 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     );
   }
 
+  if (options.ui) {
+    log.info(
+      `scout: Launching Playwright UI mode. Test servers will be started first and kept running until the UI is closed.`
+    );
+  }
+
   const pwBinPath = resolve(REPO_ROOT, './node_modules/.bin/playwright');
   const pwCmdArgs = [
     'test',
@@ -205,10 +211,15 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     `--project=${pwProject}`,
     ...(options.headed ? ['--headed'] : []),
     ...(options.repeatEach ? [`--repeat-each=${options.repeatEach}`] : []),
+    ...(options.ui ? ['--ui'] : []),
   ];
 
   await withProcRunner(log, async (procs) => {
-    const exitCode = await hasTestsInPlaywrightConfig(log, pwBinPath, pwCmdArgs, pwConfigPath);
+    // UI mode is interactive and long-running; the `--list` pre-check is incompatible
+    // with `--ui`, so we skip it and let the Playwright UI surface any config errors.
+    const exitCode = options.ui
+      ? 0
+      : await hasTestsInPlaywrightConfig(log, pwBinPath, pwCmdArgs, pwConfigPath);
     const pwEnv = {
       SCOUT_LOG_LEVEL: logsLevel,
       SCOUT_TARGET_LOCATION: options.testTarget.location,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -212,6 +212,8 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     ...(options.headed ? ['--headed'] : []),
     ...(options.repeatEach ? [`--repeat-each=${options.repeatEach}`] : []),
     ...(options.ui ? ['--ui'] : []),
+    ...(options.ui && options.uiHost ? [`--ui-host=${options.uiHost}`] : []),
+    ...(options.ui && options.uiPort !== undefined ? [`--ui-port=${options.uiPort}`] : []),
   ];
 
   await withProcRunner(log, async (procs) => {
@@ -238,10 +240,14 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
       await runPlaywrightTest(procs, pwBinPath, pwCmdArgs, pwEnv);
     }
 
-    reportTime(runStartTime, 'ready', {
-      success: true,
-      ...options,
-    });
+    // UI mode is an interactive local session, not a batch run, so its wall-clock
+    // time is not a meaningful CI-stats signal.
+    if (!options.ui) {
+      reportTime(runStartTime, 'ready', {
+        success: true,
+        ...options,
+      });
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

Adds a `--ui` flag to `node scripts/scout run-tests` that starts the test servers, launches [Playwright UI mode](https://playwright.dev/docs/test-ui-mode) against them, and keeps the servers running until the UI is closed (then tears them down through the existing lifecycle).

Previously, using Playwright UI mode with Scout required the two-terminal workflow:

```bash
# Terminal 1
node scripts/scout start-server --arch stateful --domain classic
# Terminal 2
node scripts/playwright test --config <plugin>/test/scout/ui/playwright.config.ts --project local --grep @local-stateful-classic --ui
```

That workflow still works and is great when you want to keep servers up across many iterations. This PR adds a single-command alternative for the common case:

```bash
node scripts/scout run-tests \
  --arch stateful \
  --domain classic \
  --config <plugin>/test/scout/ui/playwright.config.ts \
  --ui
```

Scout resolves the correct `--project` and `--grep` tag from `--arch`/`--domain` (same as a normal `run-tests` invocation), so you don't have to remember the deployment tag.

## What changed

- Wire `ui` into `TEST_FLAG_OPTIONS` and `parseTestFlags` (boolean, default `false`).
- Forward `--ui` to the Playwright CLI args in the runner.
- Add `--uiHost`/`--uiPort` flags that forward to Playwright's `--ui-host`/`--ui-port` so the UI can be served for remote access (e.g. `--ui --uiHost 0.0.0.0 --uiPort 8888`).
- Skip the `--list` "has tests" pre-check when `--ui` is set (it is incompatible with UI mode) and log the server-lifecycle behavior so it's clear servers stay up until the UI is closed.
- Skip the `reportTime` CI-stats call in UI mode, since an interactive session's wall-clock time is not a meaningful build-timing signal.
- Guard against invalid combinations with friendly errors:
  - `--ui` + `--headed` → UI mode manages its own browser.
  - `--ui` + `--repeatEach` → UI mode is interactive, not a batch run.
  - `--uiHost`/`--uiPort` without `--ui` → not allowed.
  - `--uiPort` outside `0-65535` → rejected.
- Docs: update `run-scout-tests.md` and `debugging.md` to document the `run-tests --ui` path (including remote `--uiHost`/`--uiPort`) alongside the direct `playwright test --ui` path.
- Unit tests for parsing `--ui`/`--uiHost`/`--uiPort` and all guard errors.

For `local` targets this reuses the existing `runLocalServersAndTests` flow: servers start, Playwright (in `--ui` mode) runs to completion — i.e. until the user closes the UI — and the `finally` block tears servers down. For cloud targets (`ech`/`mki`) it runs Playwright UI mode directly against the pre-provisioned cloud config, matching existing `run-tests` behavior.

## How to test

```bash
node scripts/scout run-tests \
  --arch stateful \
  --domain classic \
  --config src/platform/plugins/shared/dashboard/test/scout/ui/playwright.config.ts \
  --ui
```

- The Playwright UI opens; servers stay up until you close it, then shut down.
- `--ui --uiHost 0.0.0.0 --uiPort 8888` serves the UI on all interfaces / the chosen port.
- `--ui --headed`, `--ui --repeatEach 5`, `--uiHost 0.0.0.0` (without `--ui`), and `--ui --uiPort 70000` should each fail fast with a descriptive error.

## Checklist

- [x] Unit tests updated (`flags.test.ts`), 35/35 passing
- [x] Scoped type check clean (`@kbn/scout`)
- [x] ESLint clean
- [ ] Docs reviewed by owning team

cc @elastic/appex-qa