### PR TITLE
[Dashboards] Set longer timeout for dashboardViewport on scout tests

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -552,7 +552,7 @@ export class DashboardApp {
    * Uses the data-render-complete attribute to determine panel rendering completion.
    */
   async waitForRenderComplete() {
-    await this.dashboardViewport.waitFor({ state: 'visible', timeout: 60_000 });
+    await this.dashboardViewport.waitFor({ state: 'visible', timeout: 30_000 });
 
     await this.waitForControlsReady();
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -552,7 +552,7 @@ export class DashboardApp {
    * Uses the data-render-complete attribute to determine panel rendering completion.
    */
   async waitForRenderComplete() {
-    await expect(this.dashboardViewport).toBeVisible();
+    await this.dashboardViewport.waitFor({ state: 'visible', timeout: 60_000 });
 
     await this.waitForControlsReady();
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -552,6 +552,8 @@ export class DashboardApp {
    * Uses the data-render-complete attribute to determine panel rendering completion.
    */
   async waitForRenderComplete() {
+    // Dashboard viewport can be slow to appear on cold CI runs (see https://github.com/elastic/kibana/pull/275767);
+    // the default 10s flakes on slower agents. Revisit once the root cause is fixed.
     await this.dashboardViewport.waitFor({ state: 'visible', timeout: 30_000 });
 
     await this.waitForControlsReady();


### PR DESCRIPTION
## Summary

Try to fix flakiness for slower network requests by extending the timeout for `dashboardViewport` to 30s.

[Flaky test runner x 50](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12915/canvas)

Sometimes we see tests fail showing a screenshot with a loading indicator while expecting the Dashboard Viewport. The current `expect` has a 10s timeout which appears to be too short for some CI runs. This PR increases the timeout to 30s as a stopgap measure. In the future it might be worth exploring whether we can rewrite some of these tests to be less flaky.