### PR TITLE
[9.4] [Lens] Fix rendering colors for Legacy Metric (#275203)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -63,7 +63,7 @@ pageLoadAssetSize:
   exploratoryView: 45042
   expressionGauge: 15748
   expressionHeatmap: 17563
-  expressionLegacyMetricVis: 11834
+  expressionLegacyMetricVis: 13800
   expressionMetricVis: 18100
   expressionPartitionVis: 29826
   expressions: 105076

--- a/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/components/metric_component.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/components/metric_component.tsx
@@ -20,7 +20,7 @@ import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common'
 import { getFormatService, getPaletteService } from '../services';
 import type { VisParams, MetricOptions } from '../../common/types';
 import { MetricVisValue } from './metric_value';
-import { formatValue, shouldApplyColor } from '../utils';
+import { formatValue, shouldApplyColor, getLegacyMetricDataBounds } from '../utils';
 import { needsLightText } from '../utils/palette';
 import { withAutoScale } from './with_auto_scale';
 
@@ -35,11 +35,12 @@ export interface MetricVisComponentProps {
 const AutoScaleMetricVisValue = withAutoScale(MetricVisValue);
 
 class MetricVisComponent extends Component<MetricVisComponentProps> {
-  private getColor(value: number, paletteParams: CustomPaletteState) {
-    return getPaletteService().get('custom')?.getColorForValue?.(value, paletteParams, {
-      min: paletteParams.rangeMin,
-      max: paletteParams.rangeMax,
-    });
+  private getColor(
+    value: number,
+    paletteParams: CustomPaletteState,
+    bounds: { min: number; max: number }
+  ) {
+    return getPaletteService().get('custom')?.getColorForValue?.(value, paletteParams, bounds);
   }
 
   private processTableGroups(table: Datatable) {
@@ -67,10 +68,13 @@ class MetricVisComponent extends Component<MetricVisComponentProps> {
         const formatter = getFormatService().deserialize(
           getFormatByAccessor(metric, table.columns)
         );
+        // Color against the live data range (like the metric/datatable charts) rather than the
+        // edit-time `rangeMin`/`rangeMax` snapshot frozen on the palette.
+        const dataBounds = getLegacyMetricDataBounds(column?.id, table);
         const metrics = table.rows.map((row, rowIndex) => {
           let title = column!.name;
           let value: number = row[column!.id];
-          const color = palette ? this.getColor(value, palette) : undefined;
+          const color = palette ? this.getColor(value, palette, dataBounds) : undefined;
 
           if (isPercentageMode && stops.length) {
             value = (value - min) / (max - min);

--- a/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/index.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/index.ts
@@ -9,6 +9,8 @@
 
 import { ExpressionLegacyMetricPlugin } from './plugin';
 
+export { getLegacyMetricDataBounds } from './utils';
+
 export function plugin() {
   return new ExpressionLegacyMetricPlugin();
 }

--- a/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/utils/index.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/utils/index.ts
@@ -7,5 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { parseRgbString, shouldApplyColor, needsLightText } from './palette';
+export {
+  parseRgbString,
+  shouldApplyColor,
+  needsLightText,
+  getLegacyMetricDataBounds,
+} from './palette';
 export { formatValue } from './format';

--- a/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/utils/palette.test.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/utils/palette.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import { getLegacyMetricDataBounds } from './palette';
+
+const buildDatatable = (rows: Array<Record<string, unknown>>): Datatable => ({
+  type: 'datatable',
+  columns: [
+    {
+      id: 'edb34be1-c705-4ec4-8937-8743c064acd3',
+      name: 'Count of records',
+      meta: { type: 'number' },
+    },
+  ],
+  rows,
+});
+
+describe('getLegacyMetricDataBounds', () => {
+  describe('open bounds fallbacks', () => {
+    it('returns open bounds when no data is provided', () => {
+      expect(getLegacyMetricDataBounds('metric')).toEqual({ min: -Infinity, max: Infinity });
+    });
+
+    it('returns open bounds when no metric id is provided', () => {
+      expect(
+        getLegacyMetricDataBounds(
+          undefined,
+          buildDatatable([{ 'edb34be1-c705-4ec4-8937-8743c064acd3': 5 }])
+        )
+      ).toEqual({
+        min: -Infinity,
+        max: Infinity,
+      });
+    });
+
+    it('returns open bounds when there are no rows', () => {
+      expect(getLegacyMetricDataBounds('metric', buildDatatable([]))).toEqual({
+        min: -Infinity,
+        max: Infinity,
+      });
+    });
+  });
+
+  describe('single value', () => {
+    it('centers a positive value at zero (`[0, 2 * value]`)', () => {
+      expect(
+        getLegacyMetricDataBounds(
+          'edb34be1-c705-4ec4-8937-8743c064acd3',
+          buildDatatable([{ 'edb34be1-c705-4ec4-8937-8743c064acd3': 5 }])
+        )
+      ).toEqual({
+        min: 0,
+        max: 10,
+      });
+    });
+
+    it('centers a negative value at zero (`[2 * value, 0]`)', () => {
+      expect(
+        getLegacyMetricDataBounds(
+          'edb34be1-c705-4ec4-8937-8743c064acd3',
+          buildDatatable([{ 'edb34be1-c705-4ec4-8937-8743c064acd3': -1 }])
+        )
+      ).toEqual({
+        min: -2,
+        max: 0,
+      });
+    });
+
+    it('falls back to a fixed `[-50, 100]` domain for a single zero value', () => {
+      expect(
+        getLegacyMetricDataBounds(
+          'edb34be1-c705-4ec4-8937-8743c064acd3',
+          buildDatatable([{ 'edb34be1-c705-4ec4-8937-8743c064acd3': 0 }])
+        )
+      ).toEqual({
+        min: -50,
+        max: 100,
+      });
+    });
+  });
+
+  describe('multiple values', () => {
+    it('spans the actual min/max across rows', () => {
+      expect(
+        getLegacyMetricDataBounds(
+          'edb34be1-c705-4ec4-8937-8743c064acd3',
+          buildDatatable([
+            { 'edb34be1-c705-4ec4-8937-8743c064acd3': 3 },
+            { 'edb34be1-c705-4ec4-8937-8743c064acd3': -7 },
+            { 'edb34be1-c705-4ec4-8937-8743c064acd3': 12 },
+            { 'edb34be1-c705-4ec4-8937-8743c064acd3': 0 },
+          ])
+        )
+      ).toEqual({ min: -7, max: 12 });
+    });
+
+    it('does not center around zero when more than one row is present', () => {
+      expect(
+        getLegacyMetricDataBounds(
+          'edb34be1-c705-4ec4-8937-8743c064acd3',
+          buildDatatable([
+            { 'edb34be1-c705-4ec4-8937-8743c064acd3': 4 },
+            { 'edb34be1-c705-4ec4-8937-8743c064acd3': 8 },
+          ])
+        )
+      ).toEqual({ min: 4, max: 8 });
+    });
+  });
+});

--- a/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/utils/palette.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_legacy_metric/public/utils/palette.ts
@@ -8,6 +8,45 @@
  */
 
 import { isColorDark } from '@elastic/eui';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+
+/**
+ * Coloring domain for the legacy metric. This is the single source of truth shared by the editor
+ *  and the render-time coloring so the two can never diverge:
+ *  - a single value is centered at 0: `[0, 2 * value]` (or `[2 * value, 0]` for negatives), matching
+ *    the metric chart's single-value behavior.
+ *  - a single `0` has no meaningful range, so we fall back to a fixed `[-50, 100]` domain that keeps
+ *    the palette visible instead of collapsing to `[0, 0]`.
+ *  - multiple rows span the actual min/max of the values, so every tile is colored relative to the others
+ */
+export const getLegacyMetricDataBounds = (
+  metricId?: string,
+  data?: Datatable
+): { min: number; max: number } => {
+  if (!data || !metricId || data.rows.length === 0) {
+    return { min: -Infinity, max: Infinity };
+  }
+
+  const metricValues = data.rows.map((row) => row[metricId]);
+
+  if (metricValues.length === 1) {
+    const [value] = metricValues;
+    if (value === 0) {
+      return { min: -50, max: 100 };
+    }
+    return value < 0 ? { min: value * 2, max: 0 } : { min: 0, max: value * 2 };
+  }
+
+  const minMaxBounds = metricValues.reduce(
+    (bounds, value) => ({
+      min: Math.min(bounds.min, value),
+      max: Math.max(bounds.max, value),
+    }),
+    { min: Infinity, max: -Infinity }
+  );
+
+  return minMaxBounds;
+};
 
 export const parseRgbString = (rgb: string) => {
   const groups = rgb.match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*?(,\s*(\d+)\s*)?\)/) ?? [];

--- a/x-pack/platform/plugins/shared/lens/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/lens/kibana.jsonc
@@ -34,10 +34,10 @@
       "eventAnnotation",
       "unifiedSearch",
       "kql",
-      "contentManagement"
+      "contentManagement",
+      "expressionLegacyMetricVis",
     ],
     "optionalPlugins": [
-      "expressionLegacyMetricVis",
       "expressionPartitionVis",
       "usageCollection",
       "taskManager",

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/dimension_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/dimension_editor.test.tsx
@@ -183,7 +183,7 @@ describe('metric dimension editor', () => {
     expect(instance.find(CustomizablePalette).prop('dataBounds')).toEqual({ min: -2, max: 0 });
   });
 
-  it('should apply an initial range with shifted stops (first stop === rangeMin)', () => {
+  it('should apply the default named palette with open bounds', () => {
     frame.activeData!.first.columns[0].meta.type = 'number';
     frame.activeData!.first.rows[0].foo = 5;
     state.colorMode = ColorMode.None;
@@ -199,6 +199,10 @@ describe('metric dimension editor', () => {
 
     expect(setState).toHaveBeenCalledWith(
       paletteParamsContaining({
+        name: 'status',
+        continuity: 'all',
+        rangeMin: -Infinity,
+        rangeMax: Infinity,
         stops: expect.arrayContaining([]),
       })
     );

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/dimension_editor.tsx
@@ -6,12 +6,13 @@
  */
 import { EuiButtonGroup, EuiFormRow, htmlIdGenerator } from '@elastic/eui';
 import type { CustomPaletteParams, PaletteOutput, PaletteRegistry } from '@kbn/coloring';
-import { CustomizablePalette, CUSTOM_PALETTE, applyPaletteParams } from '@kbn/coloring';
+import { CustomizablePalette, applyPaletteParams } from '@kbn/coloring';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ColorMode } from '@kbn/charts-plugin/common';
 import { css } from '@emotion/react';
 import type { LegacyMetricState, VisualizationDimensionEditorProps } from '@kbn/lens-common';
+import { getLegacyMetricDataBounds } from '@kbn/expression-legacy-metric-vis-plugin/public';
 import { isNumericFieldForDatatable } from '../../../common/expressions/impl/datatable/utils';
 import { PalettePanelContainer } from '../../shared_components';
 import { defaultPaletteParams } from './palette_config';
@@ -34,11 +35,7 @@ export function MetricDimensionEditor(
   const currentColorMode = state?.colorMode || ColorMode.None;
   const hasDynamicColoring = currentColorMode !== ColorMode.None;
 
-  const currentMinMax = {
-    min: Math.min(firstRow[accessor] * 2, firstRow[accessor] === 0 ? -50 : 0),
-    // if value is 0, then fallback to 100 as last resort
-    max: Math.max(firstRow[accessor] * 2, firstRow[accessor] === 0 ? 100 : 0),
-  };
+  const currentMinMax = getLegacyMetricDataBounds(accessor, currentData);
 
   const activePalette =
     state?.palette ||
@@ -49,8 +46,6 @@ export function MetricDimensionEditor(
         ...defaultPaletteParams,
         stops: undefined,
         colorStops: undefined,
-        rangeMin: currentMinMax.min,
-        rangeMax: (currentMinMax.max * 3) / 4,
       },
     } satisfies PaletteOutput<CustomPaletteParams>);
 
@@ -106,12 +101,7 @@ export function MetricDimensionEditor(
                 ...activePalette,
                 params: {
                   ...activePalette.params,
-                  // align this initial computation with same format for default palettes in the panel. This to avoid custom computation issue with metric fake data range
-                  stops: stops.map((v, i, array) => ({
-                    ...v,
-                    // Note: these stops are the lower bound of the color stop for bwc. This is normally incorrect.
-                    stop: currentMinMax.min + (i === 0 ? 0 : array[i - 1].stop),
-                  })),
+                  stops,
                 },
               };
             }
@@ -150,14 +140,6 @@ export function MetricDimensionEditor(
               activePalette={activePalette}
               dataBounds={currentMinMax}
               setPalette={(newPalette) => {
-                // if the new palette is not custom, replace the rangeMin with the artificial one
-                if (
-                  newPalette.name !== CUSTOM_PALETTE &&
-                  newPalette.params &&
-                  newPalette.params.rangeMin !== currentMinMax.min
-                ) {
-                  newPalette.params.rangeMin = currentMinMax.min;
-                }
                 setState({
                   ...state,
                   palette: newPalette,

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/palette_config.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/palette_config.tsx
@@ -17,5 +17,9 @@ export const defaultPaletteParams: RequiredPaletteParamTypes = {
   name: DEFAULT_PALETTE_NAME,
   continuity: 'all',
   rangeType: 'number',
+  // Named palettes carry no user-defined range. Bounds are re-derived from live data at render time.
+  // Keep them consistent with `continuity: 'all'`.
+  rangeMin: -Infinity,
+  rangeMax: Infinity,
   steps: DEFAULT_COLOR_STEPS,
 };

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.test.ts
@@ -13,6 +13,7 @@ import { generateId } from '../../id_generator';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import { ColorMode } from '@kbn/charts-plugin/common';
 import { CUSTOM_PALETTE } from '@kbn/coloring';
+import type { CustomPaletteParams, PaletteOutput } from '@kbn/coloring';
 
 jest.mock('../../id_generator');
 
@@ -386,6 +387,76 @@ describe('metric_visualization', () => {
           "type": "expression",
         }
       `);
+    });
+
+    describe('palette stops', () => {
+      const numericDatasource = (): DatasourcePublicAPI => ({
+        ...createMockDatasource('l1').publicAPIMock,
+        getOperationForColumnId() {
+          return {
+            dataType: 'number',
+            isBucketed: false,
+            label: 'test_metric',
+            isStaticValue: false,
+            hasTimeShift: false,
+            hasReducedTimeRange: false,
+          };
+        },
+      });
+
+      const getCustomPaletteToExpression = (palette: PaletteOutput<CustomPaletteParams>) => {
+        const paletteService = chartPluginMock.createPaletteRegistry();
+        const customPaletteToExpression = paletteService.get(CUSTOM_PALETTE)
+          .toExpression as jest.Mock;
+        const visualization = getLegacyMetricVisualization({ paletteService });
+
+        visualization.toExpression(
+          {
+            ...exampleState(),
+            colorMode: ColorMode.Background,
+            palette,
+          },
+          { l1: numericDatasource() }
+        );
+
+        return customPaletteToExpression;
+      };
+
+      it('sends explicit stops for a custom palette', () => {
+        const customPaletteToExpression = getCustomPaletteToExpression({
+          type: 'palette',
+          name: CUSTOM_PALETTE,
+          params: {
+            name: CUSTOM_PALETTE,
+            stops: [
+              { color: 'blue', stop: 10 },
+              { color: 'red', stop: 20 },
+            ],
+          },
+        });
+
+        expect(customPaletteToExpression).toHaveBeenCalledWith(
+          expect.objectContaining({ stops: [10, 20] })
+        );
+      });
+
+      it('sends empty stops for a named palette so the renderer distributes across live data', () => {
+        const customPaletteToExpression = getCustomPaletteToExpression({
+          type: 'palette',
+          name: 'status',
+          params: {
+            rangeType: 'number',
+            stops: [
+              { color: 'blue', stop: 10 },
+              { color: 'red', stop: 20 },
+            ],
+          },
+        });
+
+        expect(customPaletteToExpression).toHaveBeenCalledWith(
+          expect.objectContaining({ stops: [] })
+        );
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
 import type { Ast } from '@kbn/interpreter';
 import type { PaletteOutput, PaletteRegistry } from '@kbn/coloring';
-import { CUSTOM_PALETTE, shiftPalette, getOverridePaletteStops } from '@kbn/coloring';
+import { CUSTOM_PALETTE, getOverridePaletteStops } from '@kbn/coloring';
 import type { CustomPaletteState } from '@kbn/charts-plugin/common';
 import { ColorMode } from '@kbn/charts-plugin/common';
 import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
@@ -82,13 +82,10 @@ const toExpression = (
   const paletteParams = {
     ...state.palette?.params,
     colors: stops.map(({ color }) => color),
-    stops:
-      isCustomPalette || state.palette?.params?.rangeMax == null
-        ? stops.map(({ stop }) => stop)
-        : shiftPalette(
-            stops,
-            Math.max(state.palette?.params?.rangeMax, ...stops.map(({ stop }) => stop))
-          ).map(({ stop }) => stop),
+    // Only custom palettes ship explicit thresholds. Named (predefined) palettes carry no
+    // user-defined range, so we send empty stops and let the renderer distribute the palette
+    // uniformly across the live data range (matching the metric/datatable charts).
+    stops: isCustomPalette ? stops.map(({ stop }) => stop) : [],
     reverse: false,
   };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens] Fix rendering colors for Legacy Metric (#275203)](https://github.com/elastic/kibana/pull/275203)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-07-01T12:34:06Z","message":"[Lens] Fix rendering colors for Legacy Metric (#275203)\n\nFix #202828\n\nThis is a pre-work needed for\nhttps://github.com/elastic/kibana/issues/267577\n\n## Summary\n\nFixes incorrect color rendering in the legacy metric visualization,\nwhere colors were applied against a stale, edit-time range instead of\nthe live data.\n\n## Before\n- Colors were computed from the `rangeMin/rangeMax` snapshot frozen on\nthe palette at edit time.\n- To get any colors out of the shared palette service, named\n(predefined) palettes were treated like custom ones —> running through\n`shiftPalette` to fabricate explicit stops.\n- Those thresholds and that range were frozen against stale data, so\nthey didn't track the rendered value and didn't match a named palette's\nuniform distribution, producing wrong colors.\n\n## After\nColor bounds are now re-derived from the live data range at render time\nvia a single shared `getLegacyMetricDataBounds` helper (used by both the\ndimension editor and the renderer, so they can't diverge):\n\n- single value → centered domain [0, 2 * value] (or [2 * value, 0] for\nnegatives)\n- single 0 → fixed [-50, 100] fallback\n- multiple rows → actual min/max across values\n\nNamed palettes now ship _**empty stops**_ and let the renderer\ndistribute colors uniformly across the live data range, while custom\npalettes keep their explicit user-defined thresholds.\n\n## Alignment with other charts\nThis brings legacy metric coloring in line with the metric and datatable\ncharts, which already color against the live data range, so the same\ndata produces consistent colors across all of them.\n\n## Videos\n- Left side -> Before\n- Right side -> After\n\n\nhttps://github.com/user-attachments/assets/deb228ad-1f27-4b3a-b1b5-79cff102488a\n\n## Dashboard to use for tests\n\n\n[legacy_metric_coloring.ndjson.txt](https://github.com/user-attachments/files/29463337/legacy_metric_coloring.ndjson.txt)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2669143acd56e99ef9116ba71af21947dfd304cc","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.5.0","v9.4.4"],"title":"[Lens] Fix rendering colors for Legacy Metric","number":275203,"url":"https://github.com/elastic/kibana/pull/275203","mergeCommit":{"message":"[Lens] Fix rendering colors for Legacy Metric (#275203)\n\nFix #202828\n\nThis is a pre-work needed for\nhttps://github.com/elastic/kibana/issues/267577\n\n## Summary\n\nFixes incorrect color rendering in the legacy metric visualization,\nwhere colors were applied against a stale, edit-time range instead of\nthe live data.\n\n## Before\n- Colors were computed from the `rangeMin/rangeMax` snapshot frozen on\nthe palette at edit time.\n- To get any colors out of the shared palette service, named\n(predefined) palettes were treated like custom ones —> running through\n`shiftPalette` to fabricate explicit stops.\n- Those thresholds and that range were frozen against stale data, so\nthey didn't track the rendered value and didn't match a named palette's\nuniform distribution, producing wrong colors.\n\n## After\nColor bounds are now re-derived from the live data range at render time\nvia a single shared `getLegacyMetricDataBounds` helper (used by both the\ndimension editor and the renderer, so they can't diverge):\n\n- single value → centered domain [0, 2 * value] (or [2 * value, 0] for\nnegatives)\n- single 0 → fixed [-50, 100] fallback\n- multiple rows → actual min/max across values\n\nNamed palettes now ship _**empty stops**_ and let the renderer\ndistribute colors uniformly across the live data range, while custom\npalettes keep their explicit user-defined thresholds.\n\n## Alignment with other charts\nThis brings legacy metric coloring in line with the metric and datatable\ncharts, which already color against the live data range, so the same\ndata produces consistent colors across all of them.\n\n## Videos\n- Left side -> Before\n- Right side -> After\n\n\nhttps://github.com/user-attachments/assets/deb228ad-1f27-4b3a-b1b5-79cff102488a\n\n## Dashboard to use for tests\n\n\n[legacy_metric_coloring.ndjson.txt](https://github.com/user-attachments/files/29463337/legacy_metric_coloring.ndjson.txt)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2669143acd56e99ef9116ba71af21947dfd304cc"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275203","number":275203,"mergeCommit":{"message":"[Lens] Fix rendering colors for Legacy Metric (#275203)\n\nFix #202828\n\nThis is a pre-work needed for\nhttps://github.com/elastic/kibana/issues/267577\n\n## Summary\n\nFixes incorrect color rendering in the legacy metric visualization,\nwhere colors were applied against a stale, edit-time range instead of\nthe live data.\n\n## Before\n- Colors were computed from the `rangeMin/rangeMax` snapshot frozen on\nthe palette at edit time.\n- To get any colors out of the shared palette service, named\n(predefined) palettes were treated like custom ones —> running through\n`shiftPalette` to fabricate explicit stops.\n- Those thresholds and that range were frozen against stale data, so\nthey didn't track the rendered value and didn't match a named palette's\nuniform distribution, producing wrong colors.\n\n## After\nColor bounds are now re-derived from the live data range at render time\nvia a single shared `getLegacyMetricDataBounds` helper (used by both the\ndimension editor and the renderer, so they can't diverge):\n\n- single value → centered domain [0, 2 * value] (or [2 * value, 0] for\nnegatives)\n- single 0 → fixed [-50, 100] fallback\n- multiple rows → actual min/max across values\n\nNamed palettes now ship _**empty stops**_ and let the renderer\ndistribute colors uniformly across the live data range, while custom\npalettes keep their explicit user-defined thresholds.\n\n## Alignment with other charts\nThis brings legacy metric coloring in line with the metric and datatable\ncharts, which already color against the live data range, so the same\ndata produces consistent colors across all of them.\n\n## Videos\n- Left side -> Before\n- Right side -> After\n\n\nhttps://github.com/user-attachments/assets/deb228ad-1f27-4b3a-b1b5-79cff102488a\n\n## Dashboard to use for tests\n\n\n[legacy_metric_coloring.ndjson.txt](https://github.com/user-attachments/files/29463337/legacy_metric_coloring.ndjson.txt)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"2669143acd56e99ef9116ba71af21947dfd304cc"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->