### PR TITLE
[a11y] Fix tooltip-focusable-anchor violations across ml-ui files

### DIFF
--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/file_clash.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/file_clash.tsx
@@ -130,7 +130,7 @@ export const FileClashIcon: FC<Props> = ({ fileClash }) => {
     case CLASH_ERROR_TYPE.ERROR:
       return (
         <EuiToolTip content={getClashText(fileClash)}>
-          <EuiBadge color={euiTheme.colors.backgroundBaseDanger}>
+          <EuiBadge color={euiTheme.colors.backgroundBaseDanger} tabIndex={0}>
             <EuiIcon aria-hidden={true} type="warning" color="danger" size="s" />
           </EuiBadge>
         </EuiToolTip>
@@ -138,7 +138,7 @@ export const FileClashIcon: FC<Props> = ({ fileClash }) => {
     case CLASH_ERROR_TYPE.WARNING:
       return (
         <EuiToolTip content={getClashText(fileClash)}>
-          <EuiBadge color={euiTheme.colors.backgroundBaseWarning}>
+          <EuiBadge color={euiTheme.colors.backgroundBaseWarning} tabIndex={0}>
             <EuiIcon aria-hidden={true} type="warning" color="warning" size="s" />
           </EuiBadge>
         </EuiToolTip>

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
@@ -302,7 +302,7 @@ export const useColumns = (
         }),
         render: (_, { fieldValue, type }) => (
           <EuiToolTip content={String(fieldValue)} disableScreenReaderOutput>
-            <span>
+            <span tabIndex={0}>
               {type === 'keyword' ? (
                 String(fieldValue)
               ) : (

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
@@ -257,7 +257,7 @@ export const useColumns = (
       render: (id: string) => {
         return (
           <EuiToolTip content={id}>
-            <span>{id}</span>
+            <span tabIndex={0}>{id}</span>
           </EuiToolTip>
         );
       },
@@ -273,7 +273,7 @@ export const useColumns = (
       render: (description: string) => {
         return (
           <EuiToolTip content={description}>
-            <span>{description}</span>
+            <span tabIndex={0}>{description}</span>
           </EuiToolTip>
         );
       },


### PR DESCRIPTION
## Summary

Fixes the 5 `@elastic/eui/tooltip-focusable-anchor` ESLint violations for team `@elastic/ml-ui` across 3 files, per [`.agents/skills/accessibility/SKILL.md`](.agents/skills/accessibility/SKILL.md) (`components/focus_and_keyboard.md`).

The rule requires the direct child of `EuiToolTip` to be keyboard-focusable. Where the anchor was already an interactive EUI control (`EuiButtonIcon`, `EuiLink`), no change was needed. Where the anchor was non-interactive (`EuiBadge` without `onClick`, plain `span`), added `tabIndex={0}` so keyboard users can reveal the tooltip content.

## Files fixed

- [x] `x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/file_clash.tsx` — added `tabIndex={0}` to both `EuiBadge` anchors (error/warning clash icons).
- [x] `x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx` — added `tabIndex={0}` to the `span` anchor for the field value tooltip.
- [x] `x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx` — added `tabIndex={0}` to the `span` anchors for the ID and Description column tooltips (the failure-reason badge, progress bar, job-id link, and expand/collapse button tooltips already had focusable anchors).

## Verification

- `node scripts/eslint.js` — no errors on the 3 changed files.
- `node scripts/type_check.js --project x-pack/platform/packages/shared/file-upload/tsconfig.json` — passes.
- `node scripts/type_check.js --project x-pack/platform/plugins/shared/aiops/tsconfig.json` — passes.
- `node scripts/type_check.js --project x-pack/platform/plugins/shared/ml/tsconfig.json` — passes.

## PR checklist

- [x] Read and applied [`.agents/skills/accessibility/SKILL.md`](.agents/skills/accessibility/SKILL.md)
- [x] Added label `a11y:agent-pr`
- [x] Fixed all files (no skips)

Closes #275758

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->