### PR TITLE
[Chrome Next] Add tooltip to app menu switch

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
@@ -403,6 +403,9 @@ const InteractiveSwitchWrapper = (props: AppMenuWrapperProps) => {
         setChecked(value);
         action('switch-toggled')(value);
       },
+      tooltipContent: checked
+        ? 'Disable to stop running the workflow'
+        : 'Enable to start running the workflow',
       'data-test-subj': 'switch',
     },
   };

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.test.tsx
@@ -194,5 +194,31 @@ describe('AppMenu', () => {
       expect(screen.getByTestId(APP_MENU_TEST_SUBJECTS.overflowButton)).toBeInTheDocument();
       expect(screen.queryByTestId('test-switch')).not.toBeInTheDocument();
     });
+
+    it('should not wrap the switch in a tooltip when no tooltip is provided', () => {
+      render(<AppMenuComponent config={{ switch: switchConfig }} />);
+
+      expect(
+        screen.getByTestId('test-switch').closest('.euiToolTipAnchor')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should wrap the switch in a tooltip when tooltipContent is provided', () => {
+      render(
+        <AppMenuComponent
+          config={{ switch: { ...switchConfig, tooltipContent: 'Save changes to enable' } }}
+        />
+      );
+
+      expect(screen.getByTestId('test-switch').closest('.euiToolTipAnchor')).toBeInTheDocument();
+    });
+
+    it('should wrap the switch in a tooltip when tooltipTitle is provided', () => {
+      render(
+        <AppMenuComponent config={{ switch: { ...switchConfig, tooltipTitle: 'Disabled' } }} />
+      );
+
+      expect(screen.getByTestId('test-switch').closest('.euiToolTipAnchor')).toBeInTheDocument();
+    });
   });
 });

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.tsx
@@ -9,9 +9,10 @@
 
 import React from 'react';
 import type { EuiSwitchEvent } from '@elastic/eui';
-import { EuiSwitch, useEuiTheme } from '@elastic/eui';
+import { EuiSwitch, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AppMenuSwitch } from '../types';
+import { getTooltip } from '../utils';
 import { APP_MENU_TEST_SUBJECTS } from '../test_subjects';
 
 interface AppMenuSwitchComponentProps {
@@ -27,6 +28,8 @@ export const AppMenuSwitchComponent = ({ switchConfig }: AppMenuSwitchComponentP
     checked,
     onChange,
     disabled,
+    tooltipContent,
+    tooltipTitle,
     'data-test-subj': dataTestSubj,
   } = switchConfig;
 
@@ -38,7 +41,10 @@ export const AppMenuSwitchComponent = ({ switchConfig }: AppMenuSwitchComponentP
     onChange(e.target.checked);
   };
 
-  return (
+  const { title, content } = getTooltip({ tooltipContent, tooltipTitle });
+  const showTooltip = Boolean(content || title);
+
+  const switchElement = (
     <EuiSwitch
       id={id}
       label={label}
@@ -50,5 +56,13 @@ export const AppMenuSwitchComponent = ({ switchConfig }: AppMenuSwitchComponentP
       css={switchCss}
       data-test-subj={dataTestSubj ?? APP_MENU_TEST_SUBJECTS.switch}
     />
+  );
+
+  return showTooltip ? (
+    <EuiToolTip content={content} title={title}>
+      {switchElement}
+    </EuiToolTip>
+  ) : (
+    switchElement
   );
 };

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -278,6 +278,8 @@ export interface AppMenuSwitch {
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;
+  tooltipContent?: string | (() => string | undefined);
+  tooltipTitle?: string | (() => string | undefined);
   'data-test-subj'?: string;
 }
 

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -10,6 +10,8 @@
 import { isValidElement } from 'react';
 import { render } from '@testing-library/react';
 import type { EuiThemeComputed } from '@elastic/eui';
+import type { ReactElement } from 'react';
+import { EuiSwitch, EuiToolTip, type EuiThemeComputed } from '@elastic/eui';
 import {
   createReturnFocus,
   getDisplayedItemsAllowedAmount,
@@ -551,6 +553,22 @@ describe('utils', () => {
       const result = getPopoverSwitchItems({ switchConfig: defaultSwitch });
 
       expect(result[1].renderItem).toBeDefined();
+    });
+
+    it('should not wrap the switch in a tooltip when no tooltip is provided', () => {
+      const result = getPopoverSwitchItems({ switchConfig: defaultSwitch });
+      const element = result[1].renderItem?.() as ReactElement;
+
+      expect(element.type).toBe(EuiSwitch);
+    });
+
+    it('should wrap the switch in a tooltip when tooltipContent is provided', () => {
+      const result = getPopoverSwitchItems({
+        switchConfig: { ...defaultSwitch, tooltipContent: 'Save changes to enable' },
+      });
+      const element = result[1].renderItem?.() as ReactElement;
+
+      expect(element.type).toBe(EuiToolTip);
     });
   });
 

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -9,7 +9,6 @@
 
 import { isValidElement } from 'react';
 import { render } from '@testing-library/react';
-import type { EuiThemeComputed } from '@elastic/eui';
 import type { ReactElement } from 'react';
 import { EuiSwitch, EuiToolTip, type EuiThemeComputed } from '@elastic/eui';
 import {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -18,6 +18,7 @@ import {
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiSwitch,
+  EuiToolTip,
 } from '@elastic/eui';
 import { getRouterLinkProps } from '@kbn/router-utils';
 import { AppMenuBadge } from './components/app_menu_badge';
@@ -305,22 +306,38 @@ export const getPopoverSwitchItems = ({
   switchConfig: AppMenuSwitch;
 }): EuiContextMenuPanelItemDescriptor[] => {
   const separator = createSeparatorItem('switch-separator');
+  const { title, content } = getTooltip({
+    tooltipContent: switchConfig.tooltipContent,
+    tooltipTitle: switchConfig.tooltipTitle,
+  });
+  const showTooltip = Boolean(content || title);
 
   return [
     separator,
     {
       key: `switch-${switchConfig.id}`,
-      renderItem: () => (
-        <EuiSwitch
-          id={switchConfig.id}
-          label={switchConfig.label}
-          labelProps={switchConfig.labelProps}
-          checked={switchConfig.checked}
-          onChange={(e) => switchConfig.onChange(e.target.checked)}
-          compressed
-          data-test-subj={switchConfig['data-test-subj'] ?? APP_MENU_TEST_SUBJECTS.switch}
-        />
-      ),
+      renderItem: () => {
+        const switchElement = (
+          <EuiSwitch
+            id={switchConfig.id}
+            label={switchConfig.label}
+            labelProps={switchConfig.labelProps}
+            checked={switchConfig.checked}
+            onChange={(e) => switchConfig.onChange(e.target.checked)}
+            disabled={switchConfig.disabled}
+            compressed
+            data-test-subj={switchConfig['data-test-subj'] ?? APP_MENU_TEST_SUBJECTS.switch}
+          />
+        );
+
+        return showTooltip ? (
+          <EuiToolTip content={content} title={title}>
+            {switchElement}
+          </EuiToolTip>
+        ) : (
+          switchElement
+        );
+      },
     },
   ];
 };


### PR DESCRIPTION
## Summary

This PR adds the ability for app menu switch to have a tooltip.

<img width="524" height="112" alt="Screenshot 2026-07-01 at 15 39 41" src="https://github.com/user-attachments/assets/2721bd20-7ba8-4bc9-9c10-b716948b90ce" />