### PR TITLE
[9.4] [scout] move non-shared page objects to its only consumer (#273466)

### DIFF
--- a/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.js
@@ -149,9 +149,8 @@ module.exports = {
       }
 
       // File is in /test/scout but not in the correct subdirectory structure
-      // Only report if it looks like a test file (has test/spec in name or is .ts)
-      const basename = path.basename(filename, '.ts');
-      if (basename.includes('spec') || hasSpecExtension(filename)) {
+      // Only report if it looks like a test file (has .spec.ts extension)
+      if (hasSpecExtension(filename)) {
         return {
           Program(node) {
             context.report({

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.test.js
@@ -80,6 +80,12 @@ ruleTester.run('@kbn/eslint/scout_test_file_naming', rule, {
       filename:
         'x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/test_bed_fixture.ts',
     },
+    // Valid: Scout page object whose name contains 'spec' as a substring (not a test file)
+    {
+      code: '',
+      filename:
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/inspector.ts',
+    },
     // Valid: Scout config file
     {
       code: '',

--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -240,7 +240,13 @@ The `global_hooks` directory contains setup and teardown logic that applies glob
 
 The `page_objects` directory contains all the Page Objects that represent Platform core functionality such as Discover, Dashboard, Index Management, etc.
 
-If a Page Object is likely to be used in more than one plugin, it should be added here. This allows other teams to reuse it, improving collaboration across teams, reducing code duplication, and simplifying support and adoption.
+##### Where should a Page Object live?
+
+`@kbn/scout` is a critical package for Scout: any change to it triggers a full Scout test run. To keep CI fast, only add Page Objects here when they are shared across plugins. Use the following guidance to decide where a Page Object belongs:
+
+- If it is used by a single plugin, keep it in that plugin under `test/scout/ui/fixtures/page_objects/` and register it locally (see ["Registering a plugin-local Page Object"](#registering-a-plugin-local-page-object)). Changes are then scoped to that plugin's tests instead of the whole suite.
+- If it is used by a few plugins that already depend on the owning plugin, keep it in the owning plugin and import it from the others as a test helper (see ["Reusing a Page Object from another plugin"](#reusing-a-page-object-from-another-plugin)).
+- If it represents a core Platform surface with no natural owner (Discover, Dashboard, etc.), add it here so other teams can reuse it.
 
 Page Objects must be registered with the `createLazyPageObject` function, which guarantees its instance is lazy-initialized. This way, we can have all the page objects available in the test context, but only the ones that are called will be actually initialized:
 
@@ -259,6 +265,72 @@ All registered Page Objects are available via the `pageObjects` fixture:
 ```ts
 test.beforeEach(async ({ pageObjects }) => {
   await pageObjects.discover.goto();
+});
+```
+
+###### Registering a plugin-local Page Object
+
+For a Page Object used by a single plugin, keep it next to the tests in `test/scout/ui/fixtures/page_objects/` and extend the base `test` (or `spaceTest`) to add it to the `pageObjects` fixture:
+
+```ts
+import type { PageObjects, ScoutParallelTestFixtures, ScoutParallelWorkerFixtures } from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+import { MyPluginPage } from './page_objects';
+
+export interface MyPluginTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & { myPluginPage: MyPluginPage };
+}
+
+export const spaceTest = spaceBaseTest.extend<MyPluginTestFixtures, ScoutParallelWorkerFixtures>({
+  pageObjects: async ({ pageObjects, page }, use) => {
+    await use({
+      ...pageObjects,
+      myPluginPage: createLazyPageObject(MyPluginPage, page),
+    });
+  },
+});
+```
+
+Tests then import `spaceTest` (or `test`) from the plugin's own fixtures instead of `@kbn/scout`.
+
+###### Reusing a Page Object from another plugin
+
+When a Page Object is owned by one plugin but needed by another that already depends on it, keep it in the owning plugin and import it as a test helper, rather than moving it to `@kbn/scout`. Two prerequisites:
+
+1. The owning plugin exports the Page Object from its `page_objects` barrel, e.g. `unified_search/test/scout/ui/fixtures/page_objects/index.ts`:
+
+```ts
+export { SavedQueryManagementMenu } from './saved_query_management_menu';
+export type { SaveQueryOptions } from './saved_query_management_menu';
+```
+
+2. The consuming plugin already lists the owner in its `tsconfig.json` `kbn_references` (true whenever there is a real plugin dependency, e.g. `discover` → `@kbn/unified-search-plugin`).
+
+The consumer then imports the Page Object via the owner's `@kbn/<plugin>` subpath and registers it on its own `pageObjects` fixture:
+
+```ts
+import type {
+  PageObjects,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+} from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+// Page Object owned by the unified_search plugin, reused here as a test helper:
+import { SavedQueryManagementMenu } from '@kbn/unified-search-plugin/test/scout/ui/fixtures/page_objects';
+
+export interface DiscoverTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & {
+    savedQueryManagementMenu: SavedQueryManagementMenu;
+  };
+}
+
+export const spaceTest = spaceBaseTest.extend<DiscoverTestFixtures, ScoutParallelWorkerFixtures>({
+  pageObjects: async ({ pageObjects, page }, use) => {
+    await use({
+      ...pageObjects,
+      savedQueryManagementMenu: createLazyPageObject(SavedQueryManagementMenu, page),
+    });
+  },
 });
 ```
 
@@ -718,7 +790,7 @@ export const scoutTestFixtures = mergeTests(coreFixtures, newTestFixture);
 
 #### Best Practices
 
-- **Reusable Code:** When creating Page Objects, API services or Fixtures that apply to more than one plugin, ensure they are added to the `kbn-scout` package.
+- **Reusable Code:** When creating Page Objects, API services or Fixtures that apply to more than one plugin, ensure they are added to the `kbn-scout` package. Single-consumer Page Objects should instead live in the consuming plugin (see ["Where should a Page Object live?"](#where-should-a-page-object-live)), since any change to `kbn-scout` re-runs the whole Scout suite.
 - **Adhere to Existing Structure:** Maintain consistency with the project's architecture.
 - **Keep the Scope of Components Clear** When designing test components, keep in mind naming conventions, scope, maintainability and performance.
   - `Page Objects` should focus exclusively on UI interactions (clicking buttons, filling forms, navigating page). They should not make API calls directly.

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -43,12 +43,6 @@ export * from './src/playwright/eui_components';
 // Kibana-wide components
 export * from './src/playwright/ui_components';
 
-// Page-object wrappers and helpers for shared Kibana surfaces.
-export {
-  CopySavedObjectsToSpaceFlyout,
-  SavedObjectsManagementPage,
-} from './src/playwright/page_objects';
-
 // Scout core types
 export type {
   ScoutPlaywrightOptions,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -13,6 +13,19 @@ import type { ScoutPage } from '..';
 import { expect } from '..';
 import { KibanaCodeEditorWrapper } from '../ui_components';
 
+export type DiscoverQueryMode = 'esql' | 'classic';
+
+export interface DiscoverGotoOptions {
+  queryMode: DiscoverQueryMode;
+}
+
+export interface DataViewOptions {
+  /** Data view title; `*` is appended automatically by the editor. */
+  name: string;
+  /** Create a temporary ("ad hoc") data view via "Explore" instead of saving. */
+  adHoc?: boolean;
+}
+
 export class DiscoverApp {
   public readonly codeEditor: KibanaCodeEditorWrapper;
 
@@ -76,6 +89,58 @@ export class DiscoverApp {
     return this.page.testSubj
       .locator('discover-dataView-switch-link')
       .or(this.page.testSubj.locator('dataView-switch-link'));
+  }
+
+  /**
+   * Returns the trimmed display name of the currently selected data view.
+   */
+  async getSelectedDataViewName(): Promise<string> {
+    return (await this.getSelectedDataView().innerText()).trim();
+  }
+
+  private async fillAndSubmitDataViewEditor({ name, adHoc = false }: DataViewOptions) {
+    // Minimal inline interaction with the data view editor flyout. The full
+    // `DataViewEditorPage` object lives in the `data_view_editor` plugin, but
+    // `kbn-scout` is a base package and must not depend on a plugin, so the few
+    // steps Discover needs are driven directly here.
+    const flyout = this.page.testSubj.locator('indexPatternEditorFlyout');
+    const form = this.page.testSubj.locator('indexPatternEditorForm');
+    const titleInput = this.page.testSubj.locator('createIndexPatternTitleInput');
+    const timestampField = this.page.testSubj.locator('timestampField');
+
+    await flyout.waitFor({ state: 'visible' });
+
+    // FTR passes the base name and relies on the editor auto-appending `*` as the
+    // user types. Scout sets the title verbatim (`fill`), so append the wildcard
+    // here to preserve that contract (`name`, `* will be added automatically`).
+    await titleInput.fill(name.endsWith('*') ? name : `${name}*`);
+    // wait for async title validation to settle before continuing.
+    await form.and(this.page.locator('[data-validation-error="0"]')).waitFor({ state: 'visible' });
+
+    // wait for timestamp options; default @timestamp applies.
+    await timestampField
+      .and(this.page.locator('[data-is-loading="0"]'))
+      .waitFor({ state: 'visible', timeout: 30_000 });
+
+    if (adHoc) {
+      await this.page.testSubj.click('exploreIndexPatternButton');
+    } else {
+      await this.page.testSubj.click('saveIndexPatternButton');
+    }
+    await flyout.waitFor({ state: 'hidden' });
+
+    await this.waitUntilTabIsLoaded();
+  }
+
+  /**
+   * Creates a new data view from the Discover search bar data-view switcher
+   * (classic mode only). The editor appends `*` to the title automatically.
+   */
+  async createDataViewFromSearchBar(options: DataViewOptions) {
+    const dataViewSwitch = await this.getVisibleDataViewSwitch();
+    await dataViewSwitch.click();
+    await this.page.testSubj.click('dataview-create-new');
+    await this.fillAndSubmitDataViewEditor(options);
   }
 
   private async clickAppMenuItem(
@@ -209,6 +274,12 @@ export class DiscoverApp {
     const canvas = this.page.locator('[data-test-subj="unifiedHistogramChart"] canvas');
     // Click at the center of the canvas
     await canvas.click();
+  }
+
+  // Waits for a Discover tab to finish loading.
+  async waitUntilTabIsLoaded() {
+    await this.waitForDiscoverPage();
+    await this.waitUntilSearchingHasFinished();
   }
 
   async waitUntilSearchingHasFinished() {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
@@ -11,11 +11,8 @@ import type { ScoutPage } from '..';
 import type { ScoutLogger } from '../../common';
 import type { ScoutTestConfig } from '../../types';
 import { CollapsibleNav } from './collapsible_nav';
-import { CopySavedObjectsToSpaceFlyout } from './copy_saved_objects_to_space_flyout';
 import { DashboardApp } from './dashboard_app';
 import { DataViewsManagementPage } from './data_views_management_page';
-import { DashboardLinks } from './dashboard_links';
-import { DataViewEditorPage } from './data_view_editor_page';
 import { DatePicker } from './date_picker';
 import { DiscoverApp } from './discover_app';
 import { HomePage } from './home_page';
@@ -23,18 +20,13 @@ import { FilterBar } from './filter_bar';
 import { MapsPage } from './maps_page';
 import { QueryBar } from './query_bar';
 import { RenderablePage } from './renderable_page';
-import { SavedObjectsManagementPage } from './saved_objects_management_page';
-import { SavedQueryManagementMenu } from './saved_query_management_menu';
 import { Toasts } from './toasts';
 import { createLazyPageObject } from './utils';
-import { Inspector } from './inspector';
 import { LensApp } from './lens_app';
 import { LoginPage } from './login_page';
 import { OverlaysPage } from './overlays';
 import { VisualizeApp } from './visualize_app';
 import type { KibanaUrl } from '../../common/services/kibana_url';
-
-export { CopySavedObjectsToSpaceFlyout, SavedObjectsManagementPage };
 
 export interface PageObjectsFixtures {
   page: ScoutPage;
@@ -48,19 +40,13 @@ export interface PageObjects {
   dataViewsManagement: DataViewsManagementPage;
   discover: DiscoverApp;
   dashboard: DashboardApp;
-  dashboardLinks: DashboardLinks;
-  dataViewEditor: DataViewEditorPage;
   filterBar: FilterBar;
   home: HomePage;
   maps: MapsPage;
   queryBar: QueryBar;
   renderable: RenderablePage;
-  savedObjectsManagement: SavedObjectsManagementPage;
-  copySavedObjectsToSpaceFlyout: CopySavedObjectsToSpaceFlyout;
-  savedQueryManagementMenu: SavedQueryManagementMenu;
   collapsibleNav: CollapsibleNav;
   toasts: Toasts;
-  inspector: Inspector;
   lens: LensApp;
   login: LoginPage;
   overlays: OverlaysPage;
@@ -76,29 +62,16 @@ export interface PageObjects {
 export function createCorePageObjects(fixtures: PageObjectsFixtures): PageObjects {
   return {
     datePicker: createLazyPageObject(DatePicker, fixtures.page),
-    dataViewEditor: createLazyPageObject(DataViewEditorPage, fixtures.page),
     dataViewsManagement: createLazyPageObject(DataViewsManagementPage, fixtures.page),
     dashboard: createLazyPageObject(DashboardApp, fixtures.page),
-    dashboardLinks: createLazyPageObject(DashboardLinks, fixtures.page),
     discover: createLazyPageObject(DiscoverApp, fixtures.page),
     filterBar: createLazyPageObject(FilterBar, fixtures.page),
     home: createLazyPageObject(HomePage, fixtures.page),
     maps: createLazyPageObject(MapsPage, fixtures.page),
     queryBar: createLazyPageObject(QueryBar, fixtures.page),
     renderable: createLazyPageObject(RenderablePage, fixtures.page),
-    savedObjectsManagement: createLazyPageObject(
-      SavedObjectsManagementPage,
-      fixtures.page,
-      fixtures.kbnUrl
-    ),
-    copySavedObjectsToSpaceFlyout: createLazyPageObject(
-      CopySavedObjectsToSpaceFlyout,
-      fixtures.page
-    ),
-    savedQueryManagementMenu: createLazyPageObject(SavedQueryManagementMenu, fixtures.page),
     collapsibleNav: createLazyPageObject(CollapsibleNav, fixtures.page, fixtures.config),
     toasts: createLazyPageObject(Toasts, fixtures.page),
-    inspector: createLazyPageObject(Inspector, fixtures.page),
     lens: createLazyPageObject(LensApp, fixtures.page),
     login: createLazyPageObject(LoginPage, fixtures.page, fixtures.kbnUrl),
     overlays: createLazyPageObject(OverlaysPage, fixtures.page),

--- a/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/index.ts
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/index.ts
@@ -7,5 +7,32 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { test } from '@kbn/scout';
+import type { PageObjects, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import { test as baseTest, createLazyPageObject } from '@kbn/scout';
+import { DataViewEditorPage } from './page_objects';
+
+export interface DataViewEditorTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    dataViewEditor: DataViewEditorPage;
+  };
+}
+
+export const test = baseTest.extend<DataViewEditorTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: DataViewEditorTestFixtures['pageObjects'];
+      page: DataViewEditorTestFixtures['page'];
+    },
+    use: (pageObjects: DataViewEditorTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      dataViewEditor: createLazyPageObject(DataViewEditorPage, page),
+    });
+  },
+});
+
 export { CUSTOM_ROLES } from './custom_roles';

--- a/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/data_view_editor_page.ts
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/data_view_editor_page.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ScoutPage } from '..';
+import type { ScoutPage } from '@kbn/scout';
 
 // Detail page URL after a data view is saved: /app/management/kibana/dataViews/dataView/<id>
 export const DATA_VIEW_DETAIL_URL_PATTERN = /\/management\/kibana\/dataViews\/.+/;

--- a/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { DataViewEditorPage } from './data_view_editor_page';

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
@@ -13,12 +13,14 @@ import type {
   ScoutParallelWorkerFixtures,
 } from '@kbn/scout';
 import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+import { Inspector } from '@kbn/inspector-plugin/test/scout/ui/fixtures/page_objects';
 import { MetricsExperiencePage } from './page_objects';
 import { METRICS_EXPERIENCE_VIEWER_ROLE, METRICS_EXPERIENCE_PRIVILEGED_ROLE } from './constants';
 
 export interface MetricsExperienceTestFixtures extends ScoutParallelTestFixtures {
   pageObjects: PageObjects & {
     metricsExperience: MetricsExperiencePage;
+    inspector: Inspector;
   };
 }
 
@@ -69,6 +71,7 @@ export const spaceTest = spaceBaseTest.extend<
         },
       }),
       metricsExperience: createLazyPageObject(MetricsExperiencePage, page),
+      inspector: createLazyPageObject(Inspector, page),
     };
 
     await use(extendedPageObjects);

--- a/src/platform/plugins/shared/inspector/moon.yml
+++ b/src/platform/plugins/shared/inspector/moon.yml
@@ -30,6 +30,7 @@ dependsOn:
   - '@kbn/code-editor'
   - '@kbn/core-lifecycle-browser'
   - '@kbn/presentation-util'
+  - '@kbn/scout'
 tags:
   - plugin
   - prod
@@ -40,6 +41,7 @@ fileGroups:
   src:
     - common/**/*
     - public/**/*
+    - test/**/*
     - index.ts
     - '!target/**/*'
   jest-config:

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { Inspector } from './inspector';
+export type { InspectorView } from './inspector';

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator } from '@playwright/test';
-import type { ScoutPage } from '..';
+import type { Locator } from '@kbn/scout';
+import type { ScoutPage } from '@kbn/scout';
 
 export type InspectorView = 'Requests' | 'Data';
 

--- a/src/platform/plugins/shared/inspector/tsconfig.json
+++ b/src/platform/plugins/shared/inspector/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
-    "outDir": "target/types",
+    "outDir": "target/types"
   },
-  "include": ["common/**/*", "public/**/*", "index.ts"],
+  "include": ["common/**/*", "public/**/*", "test/**/*", "index.ts"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/kibana-react-plugin",
@@ -17,9 +17,8 @@
     "@kbn/std",
     "@kbn/code-editor",
     "@kbn/core-lifecycle-browser",
-    "@kbn/presentation-util"
+    "@kbn/presentation-util",
+    "@kbn/scout"
   ],
-  "exclude": [
-    "target/**/*",
-  ]
+  "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/index.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/index.ts
@@ -7,6 +7,37 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { test } from '@kbn/scout';
+import type { PageObjects, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import { test as baseTest, createLazyPageObject } from '@kbn/scout';
+import { SavedObjectsManagementPage, CopySavedObjectsToSpaceFlyout } from './page_objects';
+
+export interface SavedObjectsManagementTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    savedObjectsManagement: SavedObjectsManagementPage;
+    copySavedObjectsToSpaceFlyout: CopySavedObjectsToSpaceFlyout;
+  };
+}
+
+export const test = baseTest.extend<SavedObjectsManagementTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+      kbnUrl,
+    }: {
+      pageObjects: SavedObjectsManagementTestFixtures['pageObjects'];
+      page: SavedObjectsManagementTestFixtures['page'];
+      kbnUrl: ScoutWorkerFixtures['kbnUrl'];
+    },
+    use: (pageObjects: SavedObjectsManagementTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      savedObjectsManagement: createLazyPageObject(SavedObjectsManagementPage, page, kbnUrl),
+      copySavedObjectsToSpaceFlyout: createLazyPageObject(CopySavedObjectsToSpaceFlyout, page),
+    });
+  },
+});
+
 export { CUSTOM_ROLES } from '../../api/fixtures/custom_roles';
 export { testData } from '../../api/fixtures';

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/copy_saved_objects_to_space_flyout.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/copy_saved_objects_to_space_flyout.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator } from 'playwright/test';
-import type { ScoutPage } from '..';
+import type { Locator } from '@kbn/scout';
+import type { ScoutPage } from '@kbn/scout';
 
 export interface CopyToSpaceSetupOptions {
   destinationSpaceId: string;

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { SavedObjectsManagementPage } from './saved_objects_management_page';
+export { CopySavedObjectsToSpaceFlyout } from './copy_saved_objects_to_space_flyout';
+export type {
+  CopyToSpaceSetupOptions,
+  CopyToSpaceSummary,
+} from './copy_saved_objects_to_space_flyout';

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/saved_objects_management_page.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/saved_objects_management_page.ts
@@ -7,10 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator } from 'playwright/test';
-import { expect, type ScoutPage } from '..';
-import type { KibanaUrl } from '../../common/services/kibana_url';
-import { KibanaCodeEditorWrapper } from '../ui_components';
+import type { Locator, ScoutPage, KibanaUrl } from '@kbn/scout';
+import { KibanaCodeEditorWrapper } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 const spacePrefix = (spaceId?: string) => (spaceId && spaceId !== 'default' ? `/s/${spaceId}` : '');
 

--- a/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/index.ts
+++ b/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/index.ts
@@ -7,7 +7,39 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest } from '@kbn/scout';
+import type {
+  PageObjects,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+} from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+import { SavedQueryManagementMenu } from './page_objects';
 
-export { spaceTest };
+export interface UnifiedSearchTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & {
+    savedQueryManagementMenu: SavedQueryManagementMenu;
+  };
+}
+
+export const spaceTest = spaceBaseTest.extend<
+  UnifiedSearchTestFixtures,
+  ScoutParallelWorkerFixtures
+>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: UnifiedSearchTestFixtures['pageObjects'];
+      page: UnifiedSearchTestFixtures['page'];
+    },
+    use: (pageObjects: UnifiedSearchTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      savedQueryManagementMenu: createLazyPageObject(SavedQueryManagementMenu, page),
+    });
+  },
+});
+
 export * as testData from './constants';

--- a/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { SavedQueryManagementMenu } from './saved_query_management_menu';
+export type { SaveQueryOptions } from './saved_query_management_menu';

--- a/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/saved_query_management_menu.ts
+++ b/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/saved_query_management_menu.ts
@@ -7,9 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator } from 'playwright/test';
-import type { ScoutPage } from '..';
-import { expect } from '..';
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 export interface SaveQueryOptions {
   includeFilters?: boolean;

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/index.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PageObjects, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import { test as baseTest, createLazyPageObject } from '@kbn/scout';
+import { DashboardLinks } from './page_objects';
+
+export interface ReleaseTestingTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    dashboardLinks: DashboardLinks;
+  };
+}
+
+export const test = baseTest.extend<ReleaseTestingTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ReleaseTestingTestFixtures['pageObjects'];
+      page: ReleaseTestingTestFixtures['page'];
+    },
+    use: (pageObjects: ReleaseTestingTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      dashboardLinks: createLazyPageObject(DashboardLinks, page),
+    });
+  },
+});

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/dashboard_links.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/dashboard_links.ts
@@ -1,16 +1,14 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
-import type { Locator } from '@playwright/test';
-import type { ScoutPage } from '..';
-import { expect } from '..';
-import { EuiComboBoxWrapper } from '../eui_components';
+import type { Locator } from '@kbn/scout';
+import type { ScoutPage } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { EuiComboBoxWrapper } from '@kbn/scout';
 
 type LinksLayoutType = 'horizontal' | 'vertical';
 

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { DashboardLinks } from './dashboard_links';

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
@@ -8,6 +8,7 @@
 import { expect } from '@kbn/scout/ui';
 import fs from 'fs';
 import os from 'os';
+import { tags } from '@kbn/scout';
 import { test } from '../../fixtures';
 import {
   SavedObjectsTracker,
@@ -15,7 +16,6 @@ import {
   installLogsSampleData,
   removeLogsSampleData,
 } from '../../helpers';
-import { tags } from '`@kbn/scout`';
 
 const defaultSettings = {
   defaultIndex: 'kibana_sample_data_logs',

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '@kbn/scout';
+import { tags } from '`@kbn/scout`';
+import { test } from '../../fixtures';
 import fs from 'fs';
 import os from 'os';
 import {

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { test, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
 import fs from 'fs';
 import os from 'os';
 import {

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
@@ -6,16 +6,16 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '`@kbn/scout`';
-import { test } from '../../fixtures';
 import fs from 'fs';
 import os from 'os';
+import { test } from '../../fixtures';
 import {
   SavedObjectsTracker,
   cleanupDownloadedFile,
   installLogsSampleData,
   removeLogsSampleData,
 } from '../../helpers';
+import { tags } from '`@kbn/scout`';
 
 const defaultSettings = {
   defaultIndex: 'kibana_sample_data_logs',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[scout] move non-shared page objects to its only consumer (#273466)](https://github.com/elastic/kibana/pull/273466)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-01T13:33:51Z","message":"[scout] move non-shared page objects to its only consumer (#273466)\n\n## Summary\n\nMoving Page Objects with single consumer directly to the plugin that\nuses it to avoid triggering extra tests on page object update:\n\n`kbn/scout` is part of critical changes and based on selective testing\nstrategy every change in module triggers **all the existing scout tests\nto be run**.\n\nThe idea is to keep in `kbn/scout` only page objects and services that\nare re-used in multiple plugins/packages.\nWhenever Page Object is required by a new plugin for its own scout\ntests, it should be imported into that plugin like a test helper (plugin\ndependency should be already in place)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ac54b7f9cf45e244f3d0547654b58be1018593f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0","reviewer:scout"],"title":"[scout] move non-shared page objects to its only consumer","number":273466,"url":"https://github.com/elastic/kibana/pull/273466","mergeCommit":{"message":"[scout] move non-shared page objects to its only consumer (#273466)\n\n## Summary\n\nMoving Page Objects with single consumer directly to the plugin that\nuses it to avoid triggering extra tests on page object update:\n\n`kbn/scout` is part of critical changes and based on selective testing\nstrategy every change in module triggers **all the existing scout tests\nto be run**.\n\nThe idea is to keep in `kbn/scout` only page objects and services that\nare re-used in multiple plugins/packages.\nWhenever Page Object is required by a new plugin for its own scout\ntests, it should be imported into that plugin like a test helper (plugin\ndependency should be already in place)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ac54b7f9cf45e244f3d0547654b58be1018593f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273466","number":273466,"mergeCommit":{"message":"[scout] move non-shared page objects to its only consumer (#273466)\n\n## Summary\n\nMoving Page Objects with single consumer directly to the plugin that\nuses it to avoid triggering extra tests on page object update:\n\n`kbn/scout` is part of critical changes and based on selective testing\nstrategy every change in module triggers **all the existing scout tests\nto be run**.\n\nThe idea is to keep in `kbn/scout` only page objects and services that\nare re-used in multiple plugins/packages.\nWhenever Page Object is required by a new plugin for its own scout\ntests, it should be imported into that plugin like a test helper (plugin\ndependency should be already in place)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ac54b7f9cf45e244f3d0547654b58be1018593f"}}]}] BACKPORT-->