### PR TITLE
[9.3] [scout] move non-shared page objects to its only consumer (#273466)

### DIFF
--- a/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.js
@@ -149,9 +149,8 @@ module.exports = {
       }
 
       // File is in /test/scout but not in the correct subdirectory structure
-      // Only report if it looks like a test file (has test/spec in name or is .ts)
-      const basename = path.basename(filename, '.ts');
-      if (basename.includes('spec') || hasSpecExtension(filename)) {
+      // Only report if it looks like a test file (has .spec.ts extension)
+      if (hasSpecExtension(filename)) {
         return {
           Program(node) {
             context.report({

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.test.js
@@ -80,6 +80,12 @@ ruleTester.run('@kbn/eslint/scout_test_file_naming', rule, {
       filename:
         'x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/test_bed_fixture.ts',
     },
+    // Valid: Scout page object whose name contains 'spec' as a substring (not a test file)
+    {
+      code: '',
+      filename:
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/inspector.ts',
+    },
     // Valid: Scout config file
     {
       code: '',

--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -239,7 +239,13 @@ The `global_hooks` directory contains setup and teardown logic that applies glob
 
 The `page_objects` directory contains all the Page Objects that represent Platform core functionality such as Discover, Dashboard, Index Management, etc.
 
-If a Page Object is likely to be used in more than one plugin, it should be added here. This allows other teams to reuse it, improving collaboration across teams, reducing code duplication, and simplifying support and adoption.
+##### Where should a Page Object live?
+
+`@kbn/scout` is a critical package for Scout: any change to it triggers a full Scout test run. To keep CI fast, only add Page Objects here when they are shared across plugins. Use the following guidance to decide where a Page Object belongs:
+
+- If it is used by a single plugin, keep it in that plugin under `test/scout/ui/fixtures/page_objects/` and register it locally (see ["Registering a plugin-local Page Object"](#registering-a-plugin-local-page-object)). Changes are then scoped to that plugin's tests instead of the whole suite.
+- If it is used by a few plugins that already depend on the owning plugin, keep it in the owning plugin and import it from the others as a test helper (see ["Reusing a Page Object from another plugin"](#reusing-a-page-object-from-another-plugin)).
+- If it represents a core Platform surface with no natural owner (Discover, Dashboard, etc.), add it here so other teams can reuse it.
 
 Page Objects must be registered with the `createLazyPageObject` function, which guarantees its instance is lazy-initialized. This way, we can have all the page objects available in the test context, but only the ones that are called will be actually initialized:
 
@@ -258,6 +264,72 @@ All registered Page Objects are available via the `pageObjects` fixture:
 ```ts
 test.beforeEach(async ({ pageObjects }) => {
   await pageObjects.discover.goto();
+});
+```
+
+###### Registering a plugin-local Page Object
+
+For a Page Object used by a single plugin, keep it next to the tests in `test/scout/ui/fixtures/page_objects/` and extend the base `test` (or `spaceTest`) to add it to the `pageObjects` fixture:
+
+```ts
+import type { PageObjects, ScoutParallelTestFixtures, ScoutParallelWorkerFixtures } from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+import { MyPluginPage } from './page_objects';
+
+export interface MyPluginTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & { myPluginPage: MyPluginPage };
+}
+
+export const spaceTest = spaceBaseTest.extend<MyPluginTestFixtures, ScoutParallelWorkerFixtures>({
+  pageObjects: async ({ pageObjects, page }, use) => {
+    await use({
+      ...pageObjects,
+      myPluginPage: createLazyPageObject(MyPluginPage, page),
+    });
+  },
+});
+```
+
+Tests then import `spaceTest` (or `test`) from the plugin's own fixtures instead of `@kbn/scout`.
+
+###### Reusing a Page Object from another plugin
+
+When a Page Object is owned by one plugin but needed by another that already depends on it, keep it in the owning plugin and import it as a test helper, rather than moving it to `@kbn/scout`. Two prerequisites:
+
+1. The owning plugin exports the Page Object from its `page_objects` barrel, e.g. `unified_search/test/scout/ui/fixtures/page_objects/index.ts`:
+
+```ts
+export { SavedQueryManagementMenu } from './saved_query_management_menu';
+export type { SaveQueryOptions } from './saved_query_management_menu';
+```
+
+2. The consuming plugin already lists the owner in its `tsconfig.json` `kbn_references` (true whenever there is a real plugin dependency, e.g. `discover` → `@kbn/unified-search-plugin`).
+
+The consumer then imports the Page Object via the owner's `@kbn/<plugin>` subpath and registers it on its own `pageObjects` fixture:
+
+```ts
+import type {
+  PageObjects,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+} from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+// Page Object owned by the unified_search plugin, reused here as a test helper:
+import { SavedQueryManagementMenu } from '@kbn/unified-search-plugin/test/scout/ui/fixtures/page_objects';
+
+export interface DiscoverTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & {
+    savedQueryManagementMenu: SavedQueryManagementMenu;
+  };
+}
+
+export const spaceTest = spaceBaseTest.extend<DiscoverTestFixtures, ScoutParallelWorkerFixtures>({
+  pageObjects: async ({ pageObjects, page }, use) => {
+    await use({
+      ...pageObjects,
+      savedQueryManagementMenu: createLazyPageObject(SavedQueryManagementMenu, page),
+    });
+  },
 });
 ```
 
@@ -672,7 +744,7 @@ export const scoutTestFixtures = mergeTests(coreFixtures, newTestFixture);
 
 #### Best Practices
 
-- **Reusable Code:** When creating Page Objects, API services or Fixtures that apply to more than one plugin, ensure they are added to the `kbn-scout` package.
+- **Reusable Code:** When creating Page Objects, API services or Fixtures that apply to more than one plugin, ensure they are added to the `kbn-scout` package. Single-consumer Page Objects should instead live in the consuming plugin (see ["Where should a Page Object live?"](#where-should-a-page-object-live)), since any change to `kbn-scout` re-runs the whole Scout suite.
 - **Adhere to Existing Structure:** Maintain consistency with the project's architecture.
 - **Keep the Scope of Components Clear** When designing test components, keep in mind naming conventions, scope, maintainability and performance.
   - `Page Objects` should focus exclusively on UI interactions (clicking buttons, filling forms, navigating page). They should not make API calls directly.

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -43,12 +43,6 @@ export * from './src/playwright/eui_components';
 // Kibana-wide components
 export * from './src/playwright/ui_components';
 
-// Page-object wrappers and helpers for shared Kibana surfaces.
-export {
-  CopySavedObjectsToSpaceFlyout,
-  SavedObjectsManagementPage,
-} from './src/playwright/page_objects';
-
 // Scout core types
 export type {
   ScoutPlaywrightOptions,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
@@ -12,24 +12,18 @@ import type { ScoutLogger } from '../../common';
 import type { KibanaUrl } from '../../common/services/kibana_url';
 import type { ScoutTestConfig } from '../../types';
 import { CollapsibleNav } from './collapsible_nav';
-import { CopySavedObjectsToSpaceFlyout } from './copy_saved_objects_to_space_flyout';
 import { DashboardApp } from './dashboard_app';
 import { DataViewsManagementPage } from './data_views_management_page';
-import { DashboardLinks } from './dashboard_links';
 import { DatePicker } from './date_picker';
 import { DiscoverApp } from './discover_app';
 import { FilterBar } from './filter_bar';
 import { HomePage } from './home_page';
 import { MapsPage } from './maps_page';
 import { RenderablePage } from './renderable_page';
-import { SavedObjectsManagementPage } from './saved_objects_management_page';
 import { Toasts } from './toasts';
 import { createLazyPageObject } from './utils';
-import { Inspector } from './inspector';
 import { LensApp } from './lens_app';
 import { VisualizeApp } from './visualize_app';
-
-export { CopySavedObjectsToSpaceFlyout, SavedObjectsManagementPage };
 
 export interface PageObjectsFixtures {
   page: ScoutPage;
@@ -43,16 +37,12 @@ export interface PageObjects {
   dataViewsManagement: DataViewsManagementPage;
   discover: DiscoverApp;
   dashboard: DashboardApp;
-  dashboardLinks: DashboardLinks;
   filterBar: FilterBar;
   home: HomePage;
   maps: MapsPage;
   renderable: RenderablePage;
-  savedObjectsManagement: SavedObjectsManagementPage;
-  copySavedObjectsToSpaceFlyout: CopySavedObjectsToSpaceFlyout;
   collapsibleNav: CollapsibleNav;
   toasts: Toasts;
-  inspector: Inspector;
   lens: LensApp;
   visualize: VisualizeApp;
 }
@@ -68,24 +58,13 @@ export function createCorePageObjects(fixtures: PageObjectsFixtures): PageObject
     datePicker: createLazyPageObject(DatePicker, fixtures.page),
     dataViewsManagement: createLazyPageObject(DataViewsManagementPage, fixtures.page),
     dashboard: createLazyPageObject(DashboardApp, fixtures.page),
-    dashboardLinks: createLazyPageObject(DashboardLinks, fixtures.page),
     discover: createLazyPageObject(DiscoverApp, fixtures.page),
     filterBar: createLazyPageObject(FilterBar, fixtures.page),
     home: createLazyPageObject(HomePage, fixtures.page),
     maps: createLazyPageObject(MapsPage, fixtures.page),
     renderable: createLazyPageObject(RenderablePage, fixtures.page),
-    savedObjectsManagement: createLazyPageObject(
-      SavedObjectsManagementPage,
-      fixtures.page,
-      fixtures.kbnUrl
-    ),
-    copySavedObjectsToSpaceFlyout: createLazyPageObject(
-      CopySavedObjectsToSpaceFlyout,
-      fixtures.page
-    ),
     collapsibleNav: createLazyPageObject(CollapsibleNav, fixtures.page, fixtures.config),
     toasts: createLazyPageObject(Toasts, fixtures.page),
-    inspector: createLazyPageObject(Inspector, fixtures.page),
     lens: createLazyPageObject(LensApp, fixtures.page),
     visualize: createLazyPageObject(VisualizeApp, fixtures.page),
   };

--- a/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/data_view_editor_page.ts
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/data_view_editor_page.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+
+// Detail page URL after a data view is saved: /app/management/kibana/dataViews/dataView/<id>
+export const DATA_VIEW_DETAIL_URL_PATTERN = /\/management\/kibana\/dataViews\/.+/;
+
+/**
+ * Page object for the data view editor flyout.
+ * Use `DataViewsManagementPage.openCreateWizard()` to open the flyout first,
+ * then interact with it through this page object.
+ */
+export class DataViewEditorPage {
+  private readonly flyout;
+  private readonly form;
+  readonly titleInput;
+  readonly timestampField;
+  readonly saveButton;
+  readonly detailPageTitle;
+  readonly detailUrlPattern = DATA_VIEW_DETAIL_URL_PATTERN;
+
+  constructor(private readonly page: ScoutPage) {
+    this.flyout = page.testSubj.locator('indexPatternEditorFlyout');
+    this.form = page.testSubj.locator('indexPatternEditorForm');
+    this.titleInput = page.testSubj.locator('createIndexPatternTitleInput');
+    this.timestampField = page.testSubj.locator('timestampField');
+    this.saveButton = page.testSubj.locator('saveIndexPatternButton');
+    this.detailPageTitle = page.testSubj.locator('indexPatternTitle');
+  }
+
+  // Fills the title field and waits for async validation to settle.
+  async setTitle(title: string): Promise<void> {
+    await this.titleInput.fill(title);
+    await this.form
+      .and(this.page.locator('[data-validation-error="0"]'))
+      .waitFor({ state: 'visible' });
+  }
+
+  // Returns the timestamp field combo box value after the field finishes loading.
+  async getTimestampFieldValue(): Promise<string> {
+    // data-is-loading is on the EuiComboBox element itself; use .and() to narrow to it.
+    await this.timestampField
+      .and(this.page.locator('[data-is-loading="0"]'))
+      .waitFor({ state: 'visible' });
+    return this.timestampField.locator('input[data-test-subj="comboBoxSearchInput"]').inputValue();
+  }
+
+  async save(): Promise<void> {
+    await this.saveButton.click();
+    await this.flyout.waitFor({ state: 'hidden' });
+  }
+}

--- a/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { DataViewEditorPage } from './data_view_editor_page';

--- a/src/platform/plugins/shared/data_view_editor/tsconfig.json
+++ b/src/platform/plugins/shared/data_view_editor/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "target/types",
   },
   "include": [
-    "public/**/*",
+    "public/**/*", "test/**/*"
   ],
   "kbn_references": [
     "@kbn/core",
@@ -22,6 +22,7 @@
     "@kbn/code-editor",
     "@kbn/rollup",
     "@kbn/css-utils",
+    "@kbn/scout",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/inspector/moon.yml
+++ b/src/platform/plugins/shared/inspector/moon.yml
@@ -30,6 +30,7 @@ dependsOn:
   - '@kbn/code-editor'
   - '@kbn/core-lifecycle-browser'
   - '@kbn/presentation-util'
+  - '@kbn/scout'
 tags:
   - plugin
   - prod
@@ -40,6 +41,7 @@ fileGroups:
   src:
     - common/**/*
     - public/**/*
+    - test/**/*
     - index.ts
     - '!target/**/*'
   jest-config:

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { Inspector } from './inspector';
+export type { InspectorView } from './inspector';

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/index.ts
@@ -8,4 +8,3 @@
  */
 
 export { Inspector } from './inspector';
-export type { InspectorView } from './inspector';

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
@@ -9,7 +9,7 @@
 
 import type { ScoutPage } from '@kbn/scout';
 
-export class InspectorView {
+export class Inspector {
   constructor(private readonly page: ScoutPage) {}
 
   async open() {

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ScoutPage } from '..';
+import type { ScoutPage } from '@kbn/scout';
 
 export class Inspector {
   constructor(private readonly page: ScoutPage) {}

--- a/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
+++ b/src/platform/plugins/shared/inspector/test/scout/ui/fixtures/page_objects/inspector.ts
@@ -9,7 +9,7 @@
 
 import type { ScoutPage } from '@kbn/scout';
 
-export class Inspector {
+export class InspectorView {
   constructor(private readonly page: ScoutPage) {}
 
   async open() {

--- a/src/platform/plugins/shared/inspector/tsconfig.json
+++ b/src/platform/plugins/shared/inspector/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
-    "outDir": "target/types",
+    "outDir": "target/types"
   },
-  "include": ["common/**/*", "public/**/*", "index.ts"],
+  "include": ["common/**/*", "public/**/*", "test/**/*", "index.ts"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/kibana-react-plugin",
@@ -17,9 +17,8 @@
     "@kbn/std",
     "@kbn/code-editor",
     "@kbn/core-lifecycle-browser",
-    "@kbn/presentation-util"
+    "@kbn/presentation-util",
+    "@kbn/scout"
   ],
-  "exclude": [
-    "target/**/*",
-  ]
+  "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/index.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/index.ts
@@ -7,6 +7,37 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { test } from '@kbn/scout';
+import type { PageObjects, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import { test as baseTest, createLazyPageObject } from '@kbn/scout';
+import { SavedObjectsManagementPage, CopySavedObjectsToSpaceFlyout } from './page_objects';
+
+export interface SavedObjectsManagementTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    savedObjectsManagement: SavedObjectsManagementPage;
+    copySavedObjectsToSpaceFlyout: CopySavedObjectsToSpaceFlyout;
+  };
+}
+
+export const test = baseTest.extend<SavedObjectsManagementTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+      kbnUrl,
+    }: {
+      pageObjects: SavedObjectsManagementTestFixtures['pageObjects'];
+      page: SavedObjectsManagementTestFixtures['page'];
+      kbnUrl: ScoutWorkerFixtures['kbnUrl'];
+    },
+    use: (pageObjects: SavedObjectsManagementTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      savedObjectsManagement: createLazyPageObject(SavedObjectsManagementPage, page, kbnUrl),
+      copySavedObjectsToSpaceFlyout: createLazyPageObject(CopySavedObjectsToSpaceFlyout, page),
+    });
+  },
+});
+
 export { CUSTOM_ROLES } from '../../api/fixtures/custom_roles';
 export { testData } from '../../api/fixtures';

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/copy_saved_objects_to_space_flyout.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/copy_saved_objects_to_space_flyout.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator } from 'playwright/test';
-import type { ScoutPage } from '..';
+import type { Locator } from '@kbn/scout';
+import type { ScoutPage } from '@kbn/scout';
 
 export interface CopyToSpaceSetupOptions {
   destinationSpaceId: string;

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { SavedObjectsManagementPage } from './saved_objects_management_page';
+export { CopySavedObjectsToSpaceFlyout } from './copy_saved_objects_to_space_flyout';
+export type {
+  CopyToSpaceSetupOptions,
+  CopyToSpaceSummary,
+} from './copy_saved_objects_to_space_flyout';

--- a/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/saved_objects_management_page.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/ui/fixtures/page_objects/saved_objects_management_page.ts
@@ -7,10 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator } from 'playwright/test';
-import { expect, type ScoutPage } from '..';
-import type { KibanaUrl } from '../../common/services/kibana_url';
-import { KibanaCodeEditorWrapper } from '../ui_components';
+import type { Locator, ScoutPage, KibanaUrl } from '@kbn/scout';
+import { KibanaCodeEditorWrapper } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 const spacePrefix = (spaceId?: string) => (spaceId && spaceId !== 'default' ? `/s/${spaceId}` : '');
 

--- a/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { SavedQueryManagementMenu } from './saved_query_management_menu';
+export type { SaveQueryOptions } from './saved_query_management_menu';

--- a/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/saved_query_management_menu.ts
+++ b/src/platform/plugins/shared/unified_search/test/scout/ui/fixtures/page_objects/saved_query_management_menu.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+export interface SaveQueryOptions {
+  includeFilters?: boolean;
+  includeTimeFilter?: boolean;
+}
+
+/**
+ * Page object for the saved query menu attached to the global query bar
+ * (`<SavedQueryManagementComponent>` in `unified_search`). Exposes the
+ * popover's save / load / update / delete affordances.
+ *
+ * Methods return state booleans; specs own the assertions so the same page
+ * object works for "should be visible" and "should be hidden" scenarios.
+ */
+export class SavedQueryManagementMenu {
+  public readonly menuButton: Locator;
+  public readonly saveButton: Locator;
+  public readonly loadButton: Locator;
+
+  private readonly panel: Locator;
+  private readonly saveChangesButton: Locator;
+  private readonly applyChangesButton: Locator;
+  private readonly clearAllFiltersButton: Locator;
+  private readonly backToMainPanel: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.menuButton = this.page.testSubj.locator('showQueryBarMenu');
+    this.saveButton = this.page.testSubj.locator('saved-query-management-save-button');
+    this.loadButton = this.page.testSubj.locator('saved-query-management-load-button');
+    this.panel = this.page.testSubj.locator('queryBarMenuPanel');
+    this.saveChangesButton = this.page.testSubj.locator(
+      'saved-query-management-save-changes-button'
+    );
+    this.applyChangesButton = this.page.testSubj.locator(
+      'saved-query-management-apply-changes-button'
+    );
+    this.clearAllFiltersButton = this.page.testSubj.locator('filter-sets-removeAllFilters');
+    // EuiContextMenuPanel renders this back-arrow on every non-root panel.
+    this.backToMainPanel = this.page.testSubj.locator('contextMenuPanelTitleButton');
+  }
+
+  /**
+   * Reads the popover open/closed state from `aria-expanded` on the trigger
+   * button rather than checking the panel itself. The button is always in the
+   * DOM, while the panel detaches on close — which races with `close()` after
+   * a menu item (e.g. "Clear all", "Apply changes") auto-dismisses the popover.
+   */
+  private async isOpen(): Promise<boolean> {
+    return (await this.menuButton.getAttribute('aria-expanded')) === 'true';
+  }
+
+  /**
+   * Lower-level open: clicks the trigger and waits for `aria-expanded`, without
+   * assuming any specific panel content is rendered. Use this when inspecting
+   * capability-gated affordances that may be absent (e.g. the saved-query
+   * section when `savedQueryManagement.showQueries` is false). For any
+   * interaction that targets the root panel, call `open()` instead.
+   */
+  private async openPopover(): Promise<void> {
+    if (await this.isOpen()) return;
+    await this.menuButton.click();
+    await expect(this.menuButton).toHaveAttribute('aria-expanded', 'true');
+    // EUI popover animation has no deterministic settled event; inner-panel clicks
+    // race the panel slide. Two-part mitigation: this fixed wait, plus
+    // `dispatchEvent('click')` (instead of `.click()`) on inner-panel buttons in the
+    // action methods below — it bypasses Playwright actionability checks that flicker
+    // while the panel transform is in flight.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await this.page.waitForTimeout(1000);
+  }
+
+  /**
+   * Opens the popover and guarantees we land on the root context-menu panel.
+   *
+   * EuiPopover un-mounts the panel DOM on close, but EuiContextMenu's panel-id
+   * state persists across hide/show. Without `ensureOnMainPanel()`, calls that
+   * follow a Load-submenu interaction would re-open into the submenu where
+   * `loadButton` / `clearAllFiltersButton` don't exist and the click times out.
+   */
+  async open(): Promise<void> {
+    await this.openPopover();
+    await this.ensureOnMainPanel();
+  }
+
+  async close(): Promise<void> {
+    if (!(await this.isOpen())) return;
+    await this.menuButton.click();
+    await expect(this.menuButton).toHaveAttribute('aria-expanded', 'false');
+  }
+
+  /**
+   * Walks the popover back to the root panel. Prefers the EUI back-arrow over
+   * a full remount; waiting for the arrow to hide is a deterministic
+   * "panel-slide finished" signal that avoids racing the CSS transform.
+   */
+  private async ensureOnMainPanel(): Promise<void> {
+    if (await this.loadButton.isVisible()) return;
+
+    if (await this.backToMainPanel.isVisible()) {
+      await this.backToMainPanel.click();
+      await this.backToMainPanel.waitFor({ state: 'hidden' });
+      await expect(this.loadButton).toBeVisible();
+      return;
+    }
+
+    // Last resort (e.g. inside the save form): hard-remount resets EuiContextMenu to root.
+    await this.close();
+    await this.menuButton.click();
+    await expect(this.menuButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(this.loadButton).toBeVisible();
+  }
+
+  async saveNewQuery(name: string, options: SaveQueryOptions = {}): Promise<void> {
+    await this.open();
+    // dispatchEvent instead of click — see openPopover for the EUI panel-slide rationale.
+    await this.saveButton.dispatchEvent('click');
+    await this.page.testSubj.locator('saveQueryForm').waitFor({ state: 'visible' });
+    await this.submitSaveQueryForm(name, options);
+  }
+
+  /**
+   * Saves the currently loaded query as a new copy. Requires the live query to
+   * differ from the loaded one — the popover's "Save query" item is otherwise
+   * disabled and the click will time out.
+   */
+  async saveLoadedQueryAsNew(name: string, options: SaveQueryOptions = {}): Promise<void> {
+    await this.saveNewQuery(name, options);
+  }
+
+  async updateLoadedQuery(options: SaveQueryOptions = {}): Promise<void> {
+    await this.open();
+    await this.saveChangesButton.dispatchEvent('click');
+    await this.page.testSubj.locator('saveQueryForm').waitFor({ state: 'visible' });
+    await this.submitSaveQueryForm(null, options);
+  }
+
+  async loadSavedQuery(title: string): Promise<void> {
+    await this.openLoadSubmenu();
+    await this.page.testSubj.locator(`~load-saved-query-${title}-button`).dispatchEvent('click');
+    await this.applyChangesButton.click();
+    await this.panel.waitFor({ state: 'hidden' });
+  }
+
+  async deleteSavedQuery(title: string): Promise<void> {
+    await this.openLoadSubmenu();
+    await this.page.testSubj.locator(`~load-saved-query-${title}-button`).dispatchEvent('click');
+    await this.page.testSubj.locator('delete-saved-query-button').dispatchEvent('click');
+    await this.page.testSubj.locator('confirmModalTitleText').waitFor({ state: 'visible' });
+    await this.page.testSubj.locator('confirmModalConfirmButton').click();
+  }
+
+  async clearLoadedQuery(): Promise<void> {
+    await this.open();
+    await this.clearAllFiltersButton.dispatchEvent('click');
+    await this.close();
+  }
+
+  /**
+   * Opens the popover and navigates to the Load submenu.
+   *
+   * Always force-closes first so EuiPopover remounts on open: an already-open
+   * popover serves a stale saved-query list after a save/update/delete.
+   */
+  private async openLoadSubmenu(): Promise<void> {
+    await this.close();
+    await this.open();
+    await this.loadButton.dispatchEvent('click');
+    await this.applyChangesButton.waitFor({ state: 'visible' });
+  }
+
+  // ---- state ----
+
+  async hasSavedQuery(title: string): Promise<boolean> {
+    await this.openLoadSubmenu();
+    const exists = await this.waitForVisible(
+      this.page.testSubj.locator(`~load-saved-query-${title}-button`),
+      2000
+    );
+    await this.close();
+    return exists;
+  }
+
+  async isLoadButtonVisible(): Promise<boolean> {
+    await this.open();
+    const visible = await this.loadButton.isVisible();
+    await this.close();
+    return visible;
+  }
+
+  async isSaveButtonEnabled(): Promise<boolean> {
+    await this.open();
+    const enabled = await this.saveButton.isEnabled();
+    await this.close();
+    return enabled;
+  }
+
+  async isSaveChangesButtonVisible(): Promise<boolean> {
+    await this.open();
+    const visible = await this.saveChangesButton.isVisible();
+    await this.close();
+    return visible;
+  }
+
+  /**
+   * Returns the rendered state of the saved-query affordances without
+   * assuming they exist. Designed for capability-matrix specs that need to
+   * verify the section is hidden for users without
+   * `savedQueryManagement.showQueries`. Unlike `isLoadButtonVisible` /
+   * `isSaveButtonEnabled`, this skips `ensureOnMainPanel()` so the call does
+   * not time out when the main panel has no saved-query items at all.
+   */
+  async inspectSavedQueryAffordances(): Promise<{
+    loadVisible: boolean;
+    saveVisible: boolean;
+    saveEnabled: boolean;
+  }> {
+    await this.openPopover();
+    const loadVisible = await this.loadButton.isVisible();
+    const saveVisible = await this.saveButton.isVisible();
+    const saveEnabled = saveVisible && (await this.saveButton.isEnabled());
+    await this.close();
+    return { loadVisible, saveVisible, saveEnabled };
+  }
+
+  /**
+   * Returns whether the per-row "delete" button is rendered for the given
+   * saved query while the load list is open. Used to validate that read-only
+   * users cannot delete other users' queries.
+   */
+  async isDeleteVisibleForQuery(title: string): Promise<boolean> {
+    await this.openLoadSubmenu();
+    await this.page.testSubj.locator(`~load-saved-query-${title}-button`).dispatchEvent('click');
+    const visible = await this.waitForVisible(
+      this.page.testSubj.locator('delete-saved-query-button'),
+      2000
+    );
+    await this.close();
+    return visible;
+  }
+
+  /** Waits up to `timeoutMs` for the element to appear; returns `false` on timeout. */
+  private waitForVisible(locator: Locator, timeoutMs: number): Promise<boolean> {
+    return locator
+      .waitFor({ state: 'visible', timeout: timeoutMs })
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  private async submitSaveQueryForm(
+    title: string | null,
+    { includeFilters = true, includeTimeFilter = false }: SaveQueryOptions
+  ): Promise<void> {
+    if (title) {
+      await this.page.testSubj.locator('saveQueryFormTitle').fill(title);
+    }
+    await this.toggleSwitchTo('saveQueryFormIncludeFiltersOption', includeFilters);
+    await this.toggleSwitchTo('saveQueryFormIncludeTimeFilterOption', includeTimeFilter);
+    await this.page.testSubj.locator('savedQueryFormSaveButton').click();
+    await this.page.testSubj.locator('saveQueryForm').waitFor({ state: 'hidden' });
+  }
+
+  private async toggleSwitchTo(testSubj: string, desired: boolean): Promise<void> {
+    const el = this.page.testSubj.locator(testSubj);
+    if ((await el.isChecked()) !== desired) {
+      await el.click();
+    }
+  }
+}

--- a/src/platform/plugins/shared/unified_search/tsconfig.json
+++ b/src/platform/plugins/shared/unified_search/tsconfig.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": ["public/**/*", "public/**/*.json", "server/**/*", "../../../../../typings/**/*"],
+  "include": [
+    "public/**/*",
+    "public/**/*.json",
+    "server/**/*",
+    "../../../../../typings/**/*",
+    "test/**/*"
+  ],
   "kbn_references": [
     "@kbn/core",
     "@kbn/data-plugin",
@@ -51,6 +57,7 @@
     "@kbn/split-button",
     "@kbn/cps",
     "@kbn/css-utils",
+    "@kbn/scout",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/index.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PageObjects, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import { test as baseTest, createLazyPageObject } from '@kbn/scout';
+import { DashboardLinks } from './page_objects';
+
+export interface ReleaseTestingTestFixtures extends ScoutTestFixtures {
+  pageObjects: PageObjects & {
+    dashboardLinks: DashboardLinks;
+  };
+}
+
+export const test = baseTest.extend<ReleaseTestingTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ReleaseTestingTestFixtures['pageObjects'];
+      page: ReleaseTestingTestFixtures['page'];
+    },
+    use: (pageObjects: ReleaseTestingTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      dashboardLinks: createLazyPageObject(DashboardLinks, page),
+    });
+  },
+});

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/dashboard_links.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/dashboard_links.ts
@@ -1,16 +1,14 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
-import type { Locator } from '@playwright/test';
-import type { ScoutPage } from '..';
-import { expect } from '..';
-import { EuiComboBoxWrapper } from '../eui_components';
+import type { Locator } from '@kbn/scout';
+import type { ScoutPage } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { EuiComboBoxWrapper } from '@kbn/scout';
 
 type LinksLayoutType = 'horizontal' | 'vertical';
 

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { DashboardLinks } from './dashboard_links';

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/tests/dashboard/dashboard.spec.ts
@@ -6,9 +6,10 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { test, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
 import fs from 'fs';
 import os from 'os';
+import { test } from '../../fixtures';
 import {
   SavedObjectsTracker,
   cleanupDownloadedFile,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[scout] move non-shared page objects to its only consumer (#273466)](https://github.com/elastic/kibana/pull/273466)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-07-01T13:33:51Z","message":"[scout] move non-shared page objects to its only consumer (#273466)\n\n## Summary\n\nMoving Page Objects with single consumer directly to the plugin that\nuses it to avoid triggering extra tests on page object update:\n\n`kbn/scout` is part of critical changes and based on selective testing\nstrategy every change in module triggers **all the existing scout tests\nto be run**.\n\nThe idea is to keep in `kbn/scout` only page objects and services that\nare re-used in multiple plugins/packages.\nWhenever Page Object is required by a new plugin for its own scout\ntests, it should be imported into that plugin like a test helper (plugin\ndependency should be already in place)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ac54b7f9cf45e244f3d0547654b58be1018593f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0","reviewer:scout"],"title":"[scout] move non-shared page objects to its only consumer","number":273466,"url":"https://github.com/elastic/kibana/pull/273466","mergeCommit":{"message":"[scout] move non-shared page objects to its only consumer (#273466)\n\n## Summary\n\nMoving Page Objects with single consumer directly to the plugin that\nuses it to avoid triggering extra tests on page object update:\n\n`kbn/scout` is part of critical changes and based on selective testing\nstrategy every change in module triggers **all the existing scout tests\nto be run**.\n\nThe idea is to keep in `kbn/scout` only page objects and services that\nare re-used in multiple plugins/packages.\nWhenever Page Object is required by a new plugin for its own scout\ntests, it should be imported into that plugin like a test helper (plugin\ndependency should be already in place)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ac54b7f9cf45e244f3d0547654b58be1018593f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/273466","number":273466,"mergeCommit":{"message":"[scout] move non-shared page objects to its only consumer (#273466)\n\n## Summary\n\nMoving Page Objects with single consumer directly to the plugin that\nuses it to avoid triggering extra tests on page object update:\n\n`kbn/scout` is part of critical changes and based on selective testing\nstrategy every change in module triggers **all the existing scout tests\nto be run**.\n\nThe idea is to keep in `kbn/scout` only page objects and services that\nare re-used in multiple plugins/packages.\nWhenever Page Object is required by a new plugin for its own scout\ntests, it should be imported into that plugin like a test helper (plugin\ndependency should be already in place)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ac54b7f9cf45e244f3d0547654b58be1018593f"}},{"url":"https://github.com/elastic/kibana/pull/275786","number":275786,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->