### PR TITLE
[CI] YAML uploads should checkout sparse

### DIFF
--- a/.buildkite/pipeline-resource-definitions/cloud-security-posture/cspm-agentless-scout.yml
+++ b/.buildkite/pipeline-resource-definitions/cloud-security-posture/cspm-agentless-scout.yml
@@ -27,6 +27,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/cloud_security_posture/cspm_agentless_scout.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/cloud_security_posture/cspm_agentless_scout.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: true
         build_pull_requests: true
@@ -36,8 +41,7 @@ spec:
         trigger_mode: none
         filter_enabled: true
         filter_condition: >
-          build.pull_request.id != null &&
-          (
+          build.pull_request.id != null && (
             build.pull_request.labels includes "ci:cloud-security-posture-scout" ||
             build.pull_request.base_branch == "main"
           )
@@ -56,4 +60,3 @@ spec:
         - kibana
         - cloud-security
         - scout
-

--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/evals/on_demand_evals.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/evals/on_demand_evals.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
@@ -28,6 +28,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/evals/llm_evals.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/evals/llm_evals.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-agent-builder-smoke-tests-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-agent-builder-smoke-tests-daily.yml
@@ -27,6 +27,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/agent_builder/smoke_tests.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/agent_builder/smoke_tests.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/scalability/api_capacity_testing_daily.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/scalability/api_capacity_testing_daily.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
@@ -24,6 +24,11 @@ spec:
       branch_configuration: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts_container_image.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/artifacts_container_image.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         build_branches: false

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -25,6 +25,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/artifacts.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -25,6 +25,11 @@ spec:
       allow_rebuilds: true
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/artifacts.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts_trigger.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/artifacts_trigger.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
@@ -28,6 +28,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/chrome_forward_testing.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/chrome_forward_testing.yml
+            cleanup_sparse_state: true
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true

--- a/.buildkite/pipeline-resource-definitions/kibana-chromium-linux-build.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-chromium-linux-build.yml
@@ -25,6 +25,11 @@ spec:
       branch_configuration: main
       default_branch: main
       pipeline_file: ".buildkite/pipelines/chromium_linux_build/build_chromium.yml"
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/chromium_linux_build/build_chromium.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/.buildkite/pipeline-resource-definitions/kibana-codeql.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-codeql.yml
@@ -25,6 +25,11 @@ spec:
       branch_configuration: main
       default_branch: main
       pipeline_file: ".buildkite/pipelines/codeql/codeql.yml"
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/codeql/codeql.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/.buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/console_definitions_sync.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/console_definitions_sync.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-console-packaging-publish.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-console-packaging-publish.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/console_packaging_publish.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/console_packaging_publish.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
@@ -29,6 +29,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/code_coverage/daily.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/code_coverage/daily.yml
+            cleanup_sparse_state: true
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true

--- a/.buildkite/pipeline-resource-definitions/kibana-deploy-cloud.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-deploy-cloud.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/build_pr_and_deploy_cloud.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/build_pr_and_deploy_cloud.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_pull_requests: true
         prefix_pull_request_fork_branch_names: false

--- a/.buildkite/pipeline-resource-definitions/kibana-deploy-project.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-deploy-project.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_pull_requests: true
         prefix_pull_request_fork_branch_names: false

--- a/.buildkite/pipeline-resource-definitions/kibana-entity-store-performance-from-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-entity-store-performance-from-pr.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/build_pr_and_test_entity_store_performance.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/build_pr_and_test_entity_store_performance.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_pull_requests: true
         prefix_pull_request_fork_branch_names: false
@@ -45,4 +50,3 @@ spec:
           access_level: BUILD_AND_READ
       tags:
         - kibana
-

--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
@@ -28,6 +28,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_forward_9_dot_3.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/es_forward_9_dot_3.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -29,6 +29,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/build.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/es_snapshots/build.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false
@@ -91,6 +96,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/promote.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/es_snapshots/promote.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false
@@ -142,6 +152,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/verify.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/es_snapshots/verify.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/esql_grammar_sync.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/esql_grammar_sync.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-fleet-packages-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fleet-packages-daily.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/fleet/packages_daily.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/fleet/packages_daily.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
         publish_commit_status: false

--- a/.buildkite/pipeline-resource-definitions/kibana-gen-ai-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-gen-ai-daily.yml
@@ -27,6 +27,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/gen_ai_testing.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/gen_ai_testing.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-gen-ai-product-docs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-gen-ai-product-docs.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/gen_ai_product_docs.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/gen_ai_product_docs.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-kbn-ui-publish.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-kbn-ui-publish.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/kbn_ui_publish.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/kbn_ui_publish.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
@@ -18,6 +18,11 @@ spec:
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'false'
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/upload_pipeline.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/upload_pipeline.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-node-glibc-217.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-node-glibc-217.yml
@@ -25,6 +25,11 @@ spec:
       branch_configuration: main
       default_branch: main
       pipeline_file: ".buildkite/pipelines/node_glibc_217.yml"
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/node_glibc_217.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       schedules:

--- a/.buildkite/pipeline-resource-definitions/kibana-node-pointer-compression.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-node-pointer-compression.yml
@@ -25,6 +25,11 @@ spec:
       branch_configuration: main
       default_branch: main
       pipeline_file: ".buildkite/pipelines/node_pointer_compression.yml"
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/node_pointer_compression.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       schedules:

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -31,6 +31,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/on_merge.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/on_merge.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml
@@ -27,6 +27,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/otel_semconv_sync.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/otel_semconv_sync.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false
@@ -48,7 +53,7 @@ spec:
           access_level: BUILD_AND_READ
       schedules:
         Weekly build:
-          cronline: 0 2 * * 1 America/New_York  # Monday 2 AM EST (matches GitHub Actions)
+          cronline: 0 2 * * 1 America/New_York # Monday 2 AM EST (matches GitHub Actions)
           message: Weekly OpenTelemetry semantic conventions sync
           branch: main
       tags:

--- a/.buildkite/pipeline-resource-definitions/kibana-package-registry.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-package-registry.yml
@@ -29,6 +29,11 @@ spec:
       branch_configuration: main
       default_branch: main
       pipeline_file: '.buildkite/pipelines/fleet/package_registry.yml'
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/fleet/package_registry.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       schedules:

--- a/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/performance/daily.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/performance/daily.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-performance-data-set-extraction-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-performance-data-set-extraction-daily.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/performance/data_set_extraction_daily.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/performance/data_set_extraction_daily.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none

--- a/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/purge_cloud_deployments.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/purge_cloud_deployments.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-renovate-helper.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-renovate-helper.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/renovate_helper.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/renovate_helper.yml
+            cleanup_sparse_state: true
       cancel_intermediate_builds: true
       provider_settings:
         build_pull_requests: true

--- a/.buildkite/pipeline-resource-definitions/kibana-rspack-e2e-test.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-rspack-e2e-test.yml
@@ -33,6 +33,11 @@ spec:
       # Trimmed on-merge variant: build the distribution and run the full test fanout
       # (Jest, Scout, FTR, Cypress, serverless) without lint/typecheck/storybooks/api-docs/etc.
       pipeline_file: .buildkite/pipelines/rspack_e2e_test.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/rspack_e2e_test.yml
+            cleanup_sparse_state: true
       skip_intermediate_builds: false
       provider_settings:
         # Don't auto-build on commits; only run via schedule / manual trigger.

--- a/.buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml
@@ -28,6 +28,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/scout_update_metadata.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/scout_update_metadata.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
@@ -22,6 +22,11 @@ spec:
       provider_settings:
         trigger_mode: none
       pipeline_file: .buildkite/pipelines/emergency_release.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/emergency_release.yml
+            cleanup_sparse_state: true
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
@@ -20,6 +20,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: ./.buildkite/pipelines/quality-gates/emergency/pipeline.emergency.kibana-tests.yaml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - ./.buildkite/pipelines/quality-gates/emergency/pipeline.emergency.kibana-tests.yaml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
@@ -20,6 +20,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: ./.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - ./.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: true
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -25,6 +25,11 @@ spec:
       allow_rebuilds: false
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
@@ -19,6 +19,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/storybooks_from_pr.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/storybooks_from_pr.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_pull_requests: true
         prefix_pull_request_fork_branch_names: false

--- a/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml
@@ -25,6 +25,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/performance/streams_weekly.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/performance/streams_weekly.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
         build_branches: false

--- a/.buildkite/pipeline-resource-definitions/kibana-uiam-cosmos-db-emulator-verify-and-promote.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-uiam-cosmos-db-emulator-verify-and-promote.yml
@@ -29,6 +29,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-uiam-verify-and-promote.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-uiam-verify-and-promote.yml
@@ -29,6 +29,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/uiam/verify_and_promote.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/uiam/verify_and_promote.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-version-bump.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-version-bump.yml
@@ -25,11 +25,7 @@ spec:
       initial_step_plugins:
         - sparse-checkout#v1.6.0:
             paths:
-              - .buildkite
-              - .node-version
-              - package.json
-              - tsconfig.base.json
-              - versions.json
+              - .buildkite/pipelines/version_bump.yml
             cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none

--- a/.buildkite/pipeline-resource-definitions/kibana-vm-build-orchestrator.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-build-orchestrator.yml
@@ -27,11 +27,7 @@ spec:
       initial_step_plugins:
         - sparse-checkout#v1.6.0:
             paths:
-              - .buildkite
-              - .node-version
-              - package.json
-              - tsconfig.base.json
-              - versions.json
+              - .buildkite/pipelines/orchestrate_vm_builds.yml
             cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none

--- a/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
@@ -24,6 +24,11 @@ spec:
       default_branch: main
       repository: elastic/ci-agent-images
       pipeline_file: vm-images/.buildkite/pipeline.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - vm-images/.buildkite/pipeline.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       schedules:

--- a/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
@@ -26,6 +26,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/scalability/daily.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/scalability/daily.yml
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/scripts/ensure-sparse-checkout.ts
+++ b/.buildkite/pipeline-resource-definitions/scripts/ensure-sparse-checkout.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env ts-node-script
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Ensures the sparse-checkout plugin on a pipeline resource definition (RRE).
+ *
+ * When a pipeline's `spec.implementation.spec.pipeline_file` points at a single
+ * yml/yaml file, the build only needs that one file to upload its steps. This
+ * script adds/normalizes the sparse-checkout plugin so the initial step checks
+ * out that very file and nothing else.
+ *
+ * Usage:
+ *   ts-node .buildkite/pipeline-resource-definitions/scripts/ensure-sparse-checkout.ts <file.yml> [more.yml ...]
+ */
+
+import fs from 'fs';
+import { parseDocument, isMap, isSeq, Pair, YAMLSeq, type Document, type YAMLMap } from 'yaml';
+
+const SPARSE_PLUGIN_KEY = 'sparse-checkout#v1.6.0';
+const SPARSE_PLUGIN_PREFIX = 'sparse-checkout';
+
+type Outcome = 'updated' | 'unchanged' | 'skipped';
+
+async function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('Usage: ensure-sparse-checkout.ts <path_to_pipeline_file.yml> [more.yml ...]');
+    process.exit(1);
+  }
+
+  let updated = 0;
+  for (const file of files) {
+    const outcome = ensureSparseCheckoutForFile(file);
+    if (outcome === 'updated') updated++;
+    console.log(`${symbol(outcome)} ${outcome.padEnd(9)} ${file}`);
+  }
+
+  console.log(`\nDone. ${updated} file(s) updated.`);
+}
+
+function ensureSparseCheckoutForFile(file: string): Outcome {
+  const original = fs.readFileSync(file, 'utf8');
+  const doc = parseDocument(original);
+
+  const specNode = doc.getIn(['spec', 'implementation', 'spec'], true);
+  if (!isMap(specNode)) {
+    return 'skipped';
+  }
+
+  const pipelineFile = specNode.get('pipeline_file');
+  if (typeof pipelineFile !== 'string' || !isYamlFile(pipelineFile)) {
+    return 'skipped';
+  }
+
+  ensureSparsePlugin(doc, specNode, pipelineFile);
+
+  const next = doc.toString({ lineWidth: 0 });
+  if (next === original) {
+    return 'unchanged';
+  }
+
+  fs.writeFileSync(file, next);
+  return 'updated';
+}
+
+function ensureSparsePlugin(doc: Document, specNode: YAMLMap, pipelineFile: string) {
+  const sparseItem = doc.createNode({
+    [SPARSE_PLUGIN_KEY]: {
+      paths: [pipelineFile],
+      cleanup_sparse_state: true,
+    },
+  });
+
+  const existing = specNode.get('initial_step_plugins', true);
+  const plugins: YAMLSeq = isSeq(existing) ? existing : new YAMLSeq();
+  if (!isSeq(existing)) {
+    insertAfter(specNode, 'pipeline_file', 'initial_step_plugins', plugins);
+  }
+
+  // Drop any pre-existing sparse-checkout entry (possibly a different version)
+  // so we always land on the canonical single-file config.
+  plugins.items = plugins.items.filter((item: unknown) => !isSparseCheckoutItem(item));
+  plugins.items.push(sparseItem);
+}
+
+function isSparseCheckoutItem(item: unknown): boolean {
+  return (
+    isMap(item) && item.items.some((pair) => String(pair.key).startsWith(SPARSE_PLUGIN_PREFIX))
+  );
+}
+
+function insertAfter(mapNode: YAMLMap, afterKey: string, key: string, value: YAMLSeq) {
+  const pair = new Pair(key, value);
+  const idx = mapNode.items.findIndex((item) => String(item.key) === afterKey);
+  if (idx === -1) {
+    mapNode.items.push(pair);
+  } else {
+    mapNode.items.splice(idx + 1, 0, pair);
+  }
+}
+
+function isYamlFile(file: string): boolean {
+  return /\.ya?ml$/i.test(file);
+}
+
+function symbol(outcome: Outcome): string {
+  if (outcome === 'updated') return '✏️';
+  if (outcome === 'skipped') return '⏭️';
+  return '✅';
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.buildkite/pipeline-resource-definitions/scripts/ensure-sparse-checkout.ts
+++ b/.buildkite/pipeline-resource-definitions/scripts/ensure-sparse-checkout.ts
@@ -21,7 +21,7 @@
  */
 
 import fs from 'fs';
-import { parseDocument, isMap, isSeq, Pair, YAMLSeq, type Document, type YAMLMap } from 'yaml';
+import { parseAllDocuments, isMap, isSeq, Pair, YAMLSeq, type Document, type YAMLMap } from 'yaml';
 
 const SPARSE_PLUGIN_KEY = 'sparse-checkout#v1.6.0';
 const SPARSE_PLUGIN_PREFIX = 'sparse-checkout';
@@ -47,27 +47,40 @@ async function main() {
 
 function ensureSparseCheckoutForFile(file: string): Outcome {
   const original = fs.readFileSync(file, 'utf8');
-  const doc = parseDocument(original);
 
+  // RRE files may contain multiple resources separated by `---`.
+  const docs = parseAllDocuments(original);
+  if (docs.some((doc) => doc.errors.length > 0)) {
+    return 'skipped';
+  }
+
+  let changed = false;
+  for (const doc of docs) {
+    changed = ensureSparsePluginForDoc(doc) || changed;
+  }
+
+  if (!changed) {
+    return 'unchanged';
+  }
+
+  fs.writeFileSync(file, docs.map((doc) => doc.toString({ lineWidth: 0 })).join(''));
+  return 'updated';
+}
+
+function ensureSparsePluginForDoc(doc: Document): boolean {
   const specNode = doc.getIn(['spec', 'implementation', 'spec'], true);
   if (!isMap(specNode)) {
-    return 'skipped';
+    return false;
   }
 
   const pipelineFile = specNode.get('pipeline_file');
   if (typeof pipelineFile !== 'string' || !isYamlFile(pipelineFile)) {
-    return 'skipped';
+    return false;
   }
 
+  const before = doc.toString({ lineWidth: 0 });
   ensureSparsePlugin(doc, specNode, pipelineFile);
-
-  const next = doc.toString({ lineWidth: 0 });
-  if (next === original) {
-    return 'unchanged';
-  }
-
-  fs.writeFileSync(file, next);
-  return 'updated';
+  return doc.toString({ lineWidth: 0 }) !== before;
 }
 
 function ensureSparsePlugin(doc: Document, specNode: YAMLMap, pipelineFile: string) {

--- a/.buildkite/pipeline-resource-definitions/security-solution-ess/gen-ai-evals.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-ess/gen-ai-evals.yml
@@ -24,6 +24,11 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution/gen_ai_evals.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution/gen_ai_evals.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-ess/security-solution-ess.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-ess/security-solution-ess.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution/ess_cypress.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution/ess_cypress.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-ai4dsoc.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-ai4dsoc.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
@@ -17,6 +17,11 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
+            cleanup_sparse_state: true
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -18,7 +18,7 @@ import { extname } from 'path';
 
 import { getFilesForCommit, runFileCasingCheck } from './precommit_hook';
 import { checkSemverRanges } from './no_pkg_semver_ranges';
-import { parse as yamlParse } from 'yaml';
+import { parseAllDocuments as yamlParseAllDocuments } from 'yaml';
 import { readFile } from 'fs/promises';
 
 class CheckResult {
@@ -125,7 +125,7 @@ class YamlLintCheck extends PrecommitCheck {
     for (const file of yamlFiles) {
       try {
         const content = await readFile(file.getAbsolutePath(), 'utf8');
-        yamlParse(content);
+        yamlParseAllDocuments(content);
       } catch (error) {
         errors.push(`Error in ${file.getRelativePath()}:\n${error.message}`);
       }

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -125,7 +125,11 @@ class YamlLintCheck extends PrecommitCheck {
     for (const file of yamlFiles) {
       try {
         const content = await readFile(file.getAbsolutePath(), 'utf8');
-        yamlParseAllDocuments(content);
+        const docs = yamlParseAllDocuments(content);
+        const parseErrors = docs.flatMap((doc) => doc.errors);
+        if (parseErrors.length > 0) {
+          throw new Error(parseErrors.map((e) => e.message).join('\n'));
+        }
       } catch (error) {
         errors.push(`Error in ${file.getRelativePath()}:\n${error.message}`);
       }


### PR DESCRIPTION
## Summary
When we're only uploading a yaml file in the initial step, there's no reason to clone any other parts of the repo. Sometimes the initial step gets super slow, this is generally going to save a lot of network traffic and step runtime.

Compare the upload timeouts:
 - https://buildkite.com/elastic/kibana-chrome-forward-testing/builds/646
 - https://buildkite.com/elastic/kibana-chrome-forward-testing/builds/647 (set the plugin manually)
 
