### PR TITLE
[9.4] [Cases] Fix markdown Lens "Save and return" not updating comment (#275117)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/moon.yml
+++ b/x-pack/platform/plugins/shared/cases/moon.yml
@@ -19,6 +19,7 @@ project:
 dependsOn:
   - '@kbn/core'
   - '@kbn/lens-plugin'
+  - '@kbn/lens-common'
   - '@kbn/security-plugin'
   - '@kbn/spaces-plugin'
   - '@kbn/actions-plugin'

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
@@ -27,11 +27,11 @@ import { useLocation } from 'react-router-dom';
 import { css } from '@emotion/react';
 
 import type { TypedLensByValueInput, LensSavedObjectAttributes } from '@kbn/lens-plugin/public';
+import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
 import type { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
 import type { TimeRange } from '@kbn/data-plugin/common';
-import { isLensAPIFormat, LensConfigBuilder } from '@kbn/lens-embeddable-utils';
 import { useKibana } from '../../../../common/lib/kibana';
 import { DRAFT_COMMENT_STORAGE_ID, ID } from './constants';
 import { CommentEditorContext } from '../../context';
@@ -39,6 +39,7 @@ import { useLensDraftComment } from './use_lens_draft_comment';
 import { VISUALIZATION } from './translations';
 import { useIsMainApplication } from '../../../../common/hooks';
 import { convertToAbsoluteTimeRange } from '../../../attachments/lens/actions/convert_to_absolute_time_range';
+import { toLensAttributes } from './to_lens_attributes';
 
 const DEFAULT_TIMERANGE: TimeRange = {
   from: 'now-7d',
@@ -89,11 +90,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
 
   const handleAdd = useCallback(
     (_attributes: Record<string, unknown>, timeRange?: TimeRange) => {
-      // For now, Lens attributes can come in either the API format or the internal format
-      // depending on the value of the lens.apiFormat feature flag
-      const attributes = isLensAPIFormat(_attributes)
-        ? new LensConfigBuilder().fromAPIFormat(_attributes)
-        : _attributes;
+      const attributes = toLensAttributes(_attributes);
 
       onSave(
         `!{${ID}${JSON.stringify({
@@ -116,11 +113,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
       timeRange: TimeRange | undefined,
       position: EuiMarkdownAstNodePosition
     ) => {
-      // For now, Lens attributes can come in either the API format or the internal format
-      // depending on the value of the lens.apiFormat feature flag
-      const attributes = isLensAPIFormat(_attributes)
-        ? new LensConfigBuilder().fromAPIFormat(_attributes)
-        : _attributes;
+      const attributes = toLensAttributes(_attributes);
 
       markdownContext.replaceNode(
         position,
@@ -254,44 +247,52 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
   }, [currentAppId$]);
 
   useEffect(() => {
-    let incomingEmbeddablePackage;
-
-    if (currentAppId) {
-      incomingEmbeddablePackage = embeddable
-        ?.getStateTransfer()
-        .getIncomingEmbeddablePackage(currentAppId, true);
+    if (!currentAppId) {
+      return;
     }
+    // `draftComment` hydrates asynchronously; wait for it so we don't drain the
+    // package before the draft is ready and drop the edit.
+    if (!draftComment) {
+      return;
+    }
+
+    // Peek first so we only drain when we are committing an add/update.
+    const incomingEmbeddablePackage = embeddable
+      ?.getStateTransfer()
+      .getIncomingEmbeddablePackage(currentAppId, false);
 
     const lensEmbeddablePackage = incomingEmbeddablePackage?.find(
-      (pkg) => pkg.type === 'lens'
+      (pkg) => pkg.type === LENS_EMBEDDABLE_TYPE
     ) as LensIncomingEmbeddablePackage;
 
-    if (lensEmbeddablePackage && lensEmbeddablePackage?.serializedState?.attributes) {
-      const lensTime = timefilter.getTime();
-      const newTimeRange =
-        lensTime?.from && lensTime?.to
-          ? {
-              from: lensTime.from,
-              to: lensTime.to,
-              mode: [lensTime.from, lensTime.to].join('').includes('now')
-                ? ('relative' as const)
-                : ('absolute' as const),
-            }
-          : undefined;
-
-      if (draftComment?.position) {
-        handleUpdate(
-          lensEmbeddablePackage.serializedState.attributes,
-          newTimeRange,
-          draftComment.position
-        );
-        return;
-      }
-
-      if (draftComment) {
-        handleAdd(lensEmbeddablePackage.serializedState.attributes, newTimeRange);
-      }
+    if (!lensEmbeddablePackage?.serializedState?.attributes) {
+      return;
     }
+
+    embeddable?.getStateTransfer().getIncomingEmbeddablePackage(currentAppId, true);
+
+    const lensTime = timefilter.getTime();
+    const newTimeRange =
+      lensTime?.from && lensTime?.to
+        ? {
+            from: lensTime.from,
+            to: lensTime.to,
+            mode: [lensTime.from, lensTime.to].join('').includes('now')
+              ? ('relative' as const)
+              : ('absolute' as const),
+          }
+        : undefined;
+
+    if (draftComment.position) {
+      handleUpdate(
+        lensEmbeddablePackage.serializedState.attributes,
+        newTimeRange,
+        draftComment.position
+      );
+      return;
+    }
+
+    handleAdd(lensEmbeddablePackage.serializedState.attributes, newTimeRange);
   }, [embeddable, storage, timefilter, currentAppId, handleAdd, handleUpdate, draftComment]);
 
   const createLensButton = (

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/to_lens_attributes.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/to_lens_attributes.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { toLensAttributes } from './to_lens_attributes';
+
+const mockIsSupported = jest.fn();
+const mockFromAPIFormat = jest.fn();
+
+jest.mock('@kbn/lens-embeddable-utils', () => ({
+  LensConfigBuilder: jest.fn().mockImplementation(() => ({
+    isSupported: (type?: string) => mockIsSupported(type),
+    fromAPIFormat: (config: unknown) => mockFromAPIFormat(config),
+  })),
+}));
+
+describe('toLensAttributes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes internal Lens state through untouched when the type is unsupported', () => {
+    // Internal Lens state is keyed by the saved-object type 'lens', which has no
+    // API converter. It must NOT be routed through `fromAPIFormat` (that throws
+    // `No attributes converter found for chart type: lens`).
+    mockIsSupported.mockReturnValue(false);
+    const internalState = { type: 'lens', state: { foo: 'bar' } };
+
+    const result = toLensAttributes(internalState);
+
+    expect(mockIsSupported).toHaveBeenCalledWith('lens');
+    expect(mockFromAPIFormat).not.toHaveBeenCalled();
+    expect(result).toBe(internalState);
+  });
+
+  it('routes API-format input through fromAPIFormat when the chart type is supported', () => {
+    mockIsSupported.mockReturnValue(true);
+    const converted = { state: { converted: true } };
+    mockFromAPIFormat.mockReturnValue(converted);
+    const apiConfig = { type: 'xy', layers: [] };
+
+    const result = toLensAttributes(apiConfig);
+
+    expect(mockIsSupported).toHaveBeenCalledWith('xy');
+    expect(mockFromAPIFormat).toHaveBeenCalledWith(apiConfig);
+    expect(result).toBe(converted);
+  });
+
+  it('passes through when there is no type field', () => {
+    mockIsSupported.mockReturnValue(false);
+    const attributes = { state: { foo: 'bar' } };
+
+    const result = toLensAttributes(attributes);
+
+    expect(mockIsSupported).toHaveBeenCalledWith(undefined);
+    expect(mockFromAPIFormat).not.toHaveBeenCalled();
+    expect(result).toBe(attributes);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/to_lens_attributes.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/to_lens_attributes.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LensConfigBuilder } from '@kbn/lens-embeddable-utils';
+
+// Lens may return attributes in either the API spec (when the `lens.apiFormat`
+// builder is enabled) or the internal Lens state (the default). Only the API
+// spec carries a chart type the builder can convert; internal state is keyed by
+// the saved-object type ('lens'), which has no converter. Guard on
+// `isSupported` so internal state passes through untouched instead of throwing
+// `No attributes converter found for chart type: lens`.
+export const toLensAttributes = (attributes: Record<string, unknown>): Record<string, unknown> => {
+  const builder = new LensConfigBuilder();
+  return builder.isSupported(attributes.type as string | undefined)
+    ? builder.fromAPIFormat(attributes as Parameters<LensConfigBuilder['fromAPIFormat']>[0])
+    : attributes;
+};

--- a/x-pack/platform/plugins/shared/cases/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cases/tsconfig.json
@@ -14,6 +14,7 @@
     "@kbn/core",
     // optionalPlugins from ./kibana.json
     "@kbn/lens-plugin",
+    "@kbn/lens-common",
     "@kbn/security-plugin",
     "@kbn/spaces-plugin",
     // Required from './kibana.json'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Cases] Fix markdown Lens "Save and return" not updating comment (#275117)](https://github.com/elastic/kibana/pull/275117)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-30T20:42:48Z","message":"[Cases] Fix markdown Lens \"Save and return\" not updating comment (#275117)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/267829 Adding a Lens\nvisualization from the Cases markdown editor was broken: clicking Save\nand return from Lens silently did nothing.\n\n### Root cause\n2 independent regressions stacked on the same code path in the Cases\nmarkdown Lens plugin:\n\n1. The consumer claims the embeddable package Lens hands back on\nsave-and-return by matching `pkg.type === 'lens'`.\nhttps://github.com/elastic/kibana/pull/260040 renamed the Lens\nembeddable type to `vis` (LENS_EMBEDDABLE_TYPE) but never updated Cases,\nso the package was never matched and the edit was dropped.\n\n2. https://github.com/elastic/kibana/pull/255889 added a defensive\nisLensAPIFormat(attrs) ? fromAPIFormat(attrs) : attrs conversion.\n`isLensAPIFormat` only checks that a type key exists, so internal Lens\nstate (which carries type: 'lens') is misclassified as API format and\nrouted into fromAPIFormat, which has no 'lens' converter and throws.\n\n### Changes in this PR:\n\n- Match the returned package on LENS_EMBEDDABLE_TYPE (`vis`) instead of\nthe hardcoded `lens`.\n- Peek the incoming package first and only drain it once `draftComment`\nhas hydrated.\n- Replace the loose `isLensAPIFormat` guard with a `toLensAttributes`\nhelper that converts via `fromAPIFormat` only when the chart type is\n`builder.isSupported`\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"05f476ed0db4c9f73635368da6b23c834a18e93f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Team:Cases","v9.5.0","v9.4.4","v9.3.7"],"title":"[Cases] Fix markdown Lens \"Save and return\" not updating comment","number":275117,"url":"https://github.com/elastic/kibana/pull/275117","mergeCommit":{"message":"[Cases] Fix markdown Lens \"Save and return\" not updating comment (#275117)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/267829 Adding a Lens\nvisualization from the Cases markdown editor was broken: clicking Save\nand return from Lens silently did nothing.\n\n### Root cause\n2 independent regressions stacked on the same code path in the Cases\nmarkdown Lens plugin:\n\n1. The consumer claims the embeddable package Lens hands back on\nsave-and-return by matching `pkg.type === 'lens'`.\nhttps://github.com/elastic/kibana/pull/260040 renamed the Lens\nembeddable type to `vis` (LENS_EMBEDDABLE_TYPE) but never updated Cases,\nso the package was never matched and the edit was dropped.\n\n2. https://github.com/elastic/kibana/pull/255889 added a defensive\nisLensAPIFormat(attrs) ? fromAPIFormat(attrs) : attrs conversion.\n`isLensAPIFormat` only checks that a type key exists, so internal Lens\nstate (which carries type: 'lens') is misclassified as API format and\nrouted into fromAPIFormat, which has no 'lens' converter and throws.\n\n### Changes in this PR:\n\n- Match the returned package on LENS_EMBEDDABLE_TYPE (`vis`) instead of\nthe hardcoded `lens`.\n- Peek the incoming package first and only drain it once `draftComment`\nhas hydrated.\n- Replace the loose `isLensAPIFormat` guard with a `toLensAttributes`\nhelper that converts via `fromAPIFormat` only when the chart type is\n`builder.isSupported`\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"05f476ed0db4c9f73635368da6b23c834a18e93f"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/275117","number":275117,"mergeCommit":{"message":"[Cases] Fix markdown Lens \"Save and return\" not updating comment (#275117)\n\n## Summary\n\nRef: https://github.com/elastic/kibana/issues/267829 Adding a Lens\nvisualization from the Cases markdown editor was broken: clicking Save\nand return from Lens silently did nothing.\n\n### Root cause\n2 independent regressions stacked on the same code path in the Cases\nmarkdown Lens plugin:\n\n1. The consumer claims the embeddable package Lens hands back on\nsave-and-return by matching `pkg.type === 'lens'`.\nhttps://github.com/elastic/kibana/pull/260040 renamed the Lens\nembeddable type to `vis` (LENS_EMBEDDABLE_TYPE) but never updated Cases,\nso the package was never matched and the edit was dropped.\n\n2. https://github.com/elastic/kibana/pull/255889 added a defensive\nisLensAPIFormat(attrs) ? fromAPIFormat(attrs) : attrs conversion.\n`isLensAPIFormat` only checks that a type key exists, so internal Lens\nstate (which carries type: 'lens') is misclassified as API format and\nrouted into fromAPIFormat, which has no 'lens' converter and throws.\n\n### Changes in this PR:\n\n- Match the returned package on LENS_EMBEDDABLE_TYPE (`vis`) instead of\nthe hardcoded `lens`.\n- Peek the incoming package first and only drain it once `draftComment`\nhas hydrated.\n- Replace the loose `isLensAPIFormat` guard with a `toLensAttributes`\nhelper that converts via `fromAPIFormat` only when the chart type is\n`builder.isSupported`\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"05f476ed0db4c9f73635368da6b23c834a18e93f"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->