### PR TITLE
[9.4] [SO migrations] Disable cumulative logger by default (except Serverless) (#273473)

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -118,6 +118,12 @@ migrations.batchSize: 250
 migrations.zdt:
   metaPickupSyncDelaySec: 5
 
+# Buffer migration progress logs and only emit them on failure to keep startup logs quiet.
+# Serverless can apply temporary overrides if a migration needs detailed logs, and its frequent
+# releases would otherwise pile up these logs. ECH/on-premise keep the default (continuous logging)
+# for better visibility into stuck or failing migrations.
+migrations.useCumulativeLogger: true
+
 # Management team plugins
 xpack.upgrade_assistant.enabled: false
 xpack.rollup.enabled: false

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -279,7 +279,7 @@ $$$tilemap-url$$$ `map.tilemap.url` ![logo cloud](https://doc-icons.s3.us-east-2
 :   The number of times migrations retry temporary failures, such as a network timeout, 503 status code, or `snapshot_in_progress_exception`. When upgrade migrations frequently fail after exhausting all retry attempts with a message such as `Unable to complete the [...] step after 15 attempts, terminating.`, increase the setting value. **Default: `15`**
 
 `migrations.useCumulativeLogger` {applies_to}`stack: ga 9.2`
-:   Skip logging migration progress unless there are any errors. Set to `false` when troubleshooting migration issues and not automatically shown. **Default: `true`**
+:   When enabled, migration progress is only logged if the migration fails, reducing log volume during successful startups. When disabled (the default), migration steps are logged continuously, which keeps failing or stuck migrations visible. Set to `true` to reduce startup log volume. **Default: `false`**
 
 `newsfeed.enabled`
 :   Controls whether to enable the newsfeed system for the {{kib}} UI notification center. Set to `false` to disable the newsfeed system. **Default: `true`**

--- a/src/core/packages/saved-objects/base-server-internal/src/saved_objects_config.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/saved_objects_config.ts
@@ -60,9 +60,13 @@ const migrationSchema = schema.object({
     runOnRoles: schema.arrayOf(schema.string(), { defaultValue: ['migrator'] }),
   }),
   /**
-   * Skip logging migration progress unless there are any errors.
+   * When enabled, migration progress logs are buffered and only emitted if the migration fails,
+   * which reduces log volume during successful startups at the cost of losing visibility while a
+   * migration is stuck or fails via FATAL / timeout (the buffer is only dumped on uncaught
+   * exceptions). Defaults to `false` so migration steps are logged continuously; Serverless
+   * re-enables it via config to keep startup logs quiet across its frequent releases.
    */
-  useCumulativeLogger: schema.boolean({ defaultValue: true }),
+  useCumulativeLogger: schema.boolean({ defaultValue: false }),
 });
 
 export type SavedObjectsMigrationConfigType = TypeOf<typeof migrationSchema>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
- [[SO migrations] Disable cumulative logger by default (except Serverless) (#273473)](https://github.com/elastic/kibana/pull/273473)

<!--- Backport version: manual -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

---

## Summary

Manual backport of #273473 (auto-backport failed due to conflicts).

Changes the `migrations.useCumulativeLogger` default to `false` (continuous migration logging) for ECH / on-premise, while Serverless re-enables it via `config/serverless.yml`.

### Conflict resolution notes
- `src/core/packages/saved-objects/base-server-internal/src/saved_objects_config.ts`: kept only the default flip. The `allowWipTypes` field that appeared in the conflict does not exist on `9.4` (added later on `main`), so it was intentionally omitted.
- Docs: on `9.4` the configuration reference is in `general-settings.md` (the `.yml` format was introduced on `main` after `9.4` was cut). The `.yml` change was dropped and the equivalent update applied to `general-settings.md` instead.
- `config/serverless.yml`: applied cleanly.

Ref: https://github.com/elastic/incident-management/issues/1964

Made with [Cursor](https://cursor.com)