### PR TITLE
[docs] Fix Node.js flag name in server.ssl.supportedProtocols (--tls-min-1.1 → --tls-min-v1.1)

### DIFF
--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -1449,7 +1449,7 @@ groups:
       - setting: server.ssl.supportedProtocols
         id: server-ssl-supportedprotocols
         description: |
-          An array of supported protocols with versions. Valid protocols: `TLSv1`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`. Enabling `TLSv1.1` would require both setting the `--tls-min-1.1` option in the `node.options` configuration and adding `TLSv1.1` to `server.ssl.supportedProtocols`. `HTTP/2` requires the use of minimum `TLSv1.2` for secure connections.
+          An array of supported protocols with versions. Valid protocols: `TLSv1`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`. Enabling `TLSv1.1` would require both setting the `--tls-min-v1.1` option in the `node.options` configuration and adding `TLSv1.1` to `server.ssl.supportedProtocols`. `HTTP/2` requires the use of minimum `TLSv1.2` for secure connections.
         datatype: string
         default: "TLSv1.2, TLSv1.3"
         applies_to:


### PR DESCRIPTION
## Summary

The [`server.ssl.supportedProtocols`](https://www.elastic.co/docs/reference/kibana/configuration-reference/general-settings) reference documents the wrong Node.js runtime flag for enabling TLSv1.1.

The docs currently say:

> Enabling `TLSv1.1` would require both setting the `--tls-min-1.1` option in the `node.options` configuration and adding `TLSv1.1` to `server.ssl.supportedProtocols`.

But `--tls-min-1.1` is **not a valid Node.js flag**. Node rejects it at startup:

```
node: bad option: --tls-min-1.1
# via NODE_OPTIONS / node.options:
--tls-min-1.1 is not allowed in NODE_OPTIONS
```

so a user following the docs verbatim ends up with a Kibana that refuses to start.

Node's actual flag is `--tls-min-v1.1` (note the `v`); the family is `--tls-min-v1.0` / `--tls-min-v1.1` / `--tls-min-v1.2` / `--tls-min-v1.3` (see `node --help`). This PR corrects the single occurrence in `docs/reference/configuration-reference/general-settings.yml`.

### Verification

```
$ node --tls-min-1.1 -e 0
node: bad option: --tls-min-1.1
$ node --tls-min-v1.1 -e 'console.log("started ok")'
started ok
$ node --help | grep tls-min
  --tls-min-v1.0              set default TLS minimum to TLSv1.0
  --tls-min-v1.1              set default TLS minimum to TLSv1.1
  --tls-min-v1.2              set default TLS minimum to TLSv1.2
  --tls-min-v1.3              set default TLS minimum to TLSv1.3
```

Surfaced via a support case where a customer followed this doc and hit `--tls-min-1.1 is not allowed in NODE_OPTIONS`.

### Release note

Docs-only change.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->