### PR TITLE
[Index Management] Fix tests by filter by data stream name before clicking

### DIFF
--- a/x-pack/platform/test/functional/page_objects/index_management_page.ts
+++ b/x-pack/platform/test/functional/page_objects/index_management_page.ts
@@ -69,6 +69,17 @@ export function IndexManagementPageProvider({ getService, getPageObjects }: FtrP
       await find.clickByLinkText(name);
     },
 
+    async searchAndClickDataStreamNameLink(name: string): Promise<void> {
+      await retry.try(async () => {
+        await testSubjects.setValue('dataStreamSearch', name);
+        if (!(await find.existsByLinkText(name))) {
+          await testSubjects.click('reloadButton');
+          throw new Error(`Data stream "${name}" is not visible yet`);
+        }
+      });
+      await find.clickByLinkText(name);
+    },
+
     async clickDeleteEnrichPolicyAt(indexOfRow: number): Promise<void> {
       const deleteButons = await testSubjects.findAll('deletePolicyButton');
       await deleteButons[indexOfRow].click();

--- a/x-pack/platform/test/serverless/functional/test_suites/management/index_management/data_streams.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/management/index_management/data_streams.ts
@@ -91,7 +91,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     it('shows the details flyout when clicking on a data stream', async () => {
       // Open details flyout
-      await pageObjects.indexManagement.clickDataStreamNameLink(TEST_DS_NAME);
+      await pageObjects.indexManagement.searchAndClickDataStreamNameLink(TEST_DS_NAME);
       // Verify url is stateful
       const url = await browser.getCurrentUrl();
       expect(url).to.contain(`/data_streams/${TEST_DS_NAME}`);
@@ -106,7 +106,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       this.tags(['failsOnMKI']);
       it('allows to update data retention', async () => {
         // Open details flyout
-        await pageObjects.indexManagement.clickDataStreamNameLink(TEST_DS_NAME);
+        await pageObjects.indexManagement.searchAndClickDataStreamNameLink(TEST_DS_NAME);
         // Open the edit retention dialog
         await testSubjects.click('manageDataStreamButton');
         await testSubjects.click('editDataRetentionButton');
@@ -145,7 +145,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       it('disabling data retention in serverless is not allowed', async () => {
         // Open details flyout
-        await pageObjects.indexManagement.clickDataStreamNameLink(TEST_DS_NAME);
+        await pageObjects.indexManagement.searchAndClickDataStreamNameLink(TEST_DS_NAME);
         // Open the edit retention dialog
         await testSubjects.click('manageDataStreamButton');
         await testSubjects.click('editDataRetentionButton');
@@ -173,7 +173,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       const verifyIndexModeIsOrigin = async (indexModeName: string) => {
         // Open details flyout of data stream
-        await pageObjects.indexManagement.clickDataStreamNameLink(TEST_DS_NAME_INDEX_MODE);
+        await pageObjects.indexManagement.searchAndClickDataStreamNameLink(TEST_DS_NAME_INDEX_MODE);
         // Check that index mode detail exists and its label is origin
         expect(await testSubjects.exists('indexModeDetail')).to.be(true);
         expect(await testSubjects.getVisibleText('indexModeDetail')).to.be(indexModeName);
@@ -220,7 +220,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.header.waitUntilLoadingHasFinished();
 
         // Open data stream
-        await pageObjects.indexManagement.clickDataStreamNameLink(TEST_DS_NAME_INDEX_MODE);
+        await pageObjects.indexManagement.searchAndClickDataStreamNameLink(TEST_DS_NAME_INDEX_MODE);
         // Check that index mode detail exists and its label is destination index mode
         expect(await testSubjects.exists('indexModeDetail')).to.be(true);
         expect(await testSubjects.getVisibleText('indexModeDetail')).to.be(indexModeName);


### PR DESCRIPTION
## Summary

The data streams table paginates at 20 rows so on data-heavy environments the test data streams fell off the first page and `clickByLinkText` couldn't find the link.
Fix: `clickDataStreamNameLink` now types the name into the `dataStreamSearch` box first to filter the row onto the first page before clicking and clicks refresh in case the data stream is not available yet.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12927/