### PR TITLE
Bump @modelcontextprotocol/sdk to 1.29.0 and resolve fast-uri to 3.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1323,7 +1323,7 @@
     "@mapbox/mapbox-gl-rtl-text": "0.2.3",
     "@mapbox/mapbox-gl-supported": "2.0.1",
     "@mapbox/vector-tile": "1.3.1",
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@moonrepo/cli": "2.1.0",
     "@openfeature/core": "1.10.0",
     "@openfeature/launchdarkly-client-provider": "0.3.3",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -212,7 +212,7 @@ evp_bytestokey@1.0.3
 extend@3.0.2
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
-fast-uri@3.1.2
+fast-uri@3.1.3
 fastest-levenshtein@1.0.16
 file-selector@0.4.0
 find-root@1.1.0

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
@@ -68,7 +68,7 @@ events@3.3.0
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
 fast-shallow-equal@1.0.0
-fast-uri@3.1.2
+fast-uri@3.1.3
 fastest-stable-stringify@2.0.2
 find-cache-dir@4.0.0
 find-up@6.3.0

--- a/src/platform/packages/shared/kbn-monaco/version_dependencies.txt
+++ b/src/platform/packages/shared/kbn-monaco/version_dependencies.txt
@@ -51,7 +51,7 @@ estraverse@5.3.0
 events@3.3.0
 fast-deep-equal@3.1.3
 fast-json-stable-stringify@2.1.0
-fast-uri@3.1.2
+fast-uri@3.1.3
 find-cache-dir@4.0.0
 find-up@6.3.0
 glob-to-regexp@0.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -10530,10 +10530,10 @@
   resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
   integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
 
-"@modelcontextprotocol/sdk@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz#5b35d73062125f126cc70b0be83cbab53bcdde74"
-  integrity sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==
+"@modelcontextprotocol/sdk@1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
   dependencies:
     "@hono/node-server" "^1.19.9"
     ajv "^8.17.1"
@@ -22395,9 +22395,9 @@ fast-string-width@^3.0.2:
     fast-string-truncated-width "^3.0.2"
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
+  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Summary

Upgrades @modelcontextprotocol/sdk from 1.26.0 to 1.29.0 and adds a yarn.lock resolution to pin fast-uri to 3.1.3.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->