### PR TITLE
[Alerting] Fix TaskRunner test call sites

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -645,16 +645,12 @@ describe('Task Runner', () => {
         return { state: {} };
       }
     );
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
+    const taskRunner = createTaskRunner({
       context: {
         ...taskRunnerFactoryInitializerParams,
         apiKeyType: ApiKeyType.UIAM,
         shouldGrantUiam: true,
       },
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
     });
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
@@ -3426,13 +3422,7 @@ describe('Task Runner', () => {
       },
     };
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3499,13 +3489,7 @@ describe('Task Runner', () => {
       },
     };
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3549,13 +3533,7 @@ describe('Task Runner', () => {
     });
     alertsService.createAlertsClient.mockImplementation(() => alertsClient);
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3618,13 +3596,7 @@ describe('Task Runner', () => {
     });
     alertsService.createAlertsClient.mockImplementation(() => alertsClient);
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3661,13 +3633,7 @@ describe('Task Runner', () => {
     });
     alertsService.createAlertsClient.mockImplementation(() => alertsClient);
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3704,13 +3670,7 @@ describe('Task Runner', () => {
     });
     alertsService.createAlertsClient.mockImplementation(() => alertsClient);
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3754,13 +3714,7 @@ describe('Task Runner', () => {
     });
     alertsService.createAlertsClient.mockImplementation(() => alertsClient);
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3817,13 +3771,7 @@ describe('Task Runner', () => {
     });
     alertsService.createAlertsClient.mockImplementation(() => alertsClient);
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3892,13 +3840,7 @@ describe('Task Runner', () => {
       new Error('simulated ES update failure')
     );
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOWithSnooze);
@@ -3938,13 +3880,7 @@ describe('Task Runner', () => {
       },
     };
 
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
+    const taskRunner = createTaskRunner();
 
     mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
     encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(rawRuleSOAtRunStart);


### PR DESCRIPTION
PR #274434 made executionUuid required on TaskRunner constructor params and updated the call sites present in its PR build.

That PR passed CI against an older main. Before it was squash-merged, main gained additional direct TaskRunner constructor calls from #264090 and #272190. The on-merge build tested the combined result for the first time and failed typecheck because those newer call sites did not provide executionUuid.

Use the existing createTaskRunner helper for those missed call sites so tests get the shared default executionUuid while preserving the UIAM context override.