### PR TITLE
[Alerting v2] Use Experimental badge instead of Technical Preview for global advanced setting

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/settings/advanced_settings.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/settings/advanced_settings.ts
@@ -40,6 +40,6 @@ export const alertingAdvancedSettings = {
     }),
     schema: schema.boolean(),
     requiresPageReload: true,
-    technicalPreview: true,
+    experimental: true,
   },
 } satisfies AlertingV2AdvancedSettingsRegistration;


### PR DESCRIPTION
## Summary

Changes the badge shown next to the "Alerting V2" global advanced setting from **Technical Preview** to **Experimental**, which more accurately reflects the maturity of this setting.

Single-line change: `technicalPreview: true` → `experimental: true` in `x-pack/platform/plugins/shared/alerting_v2/server/settings/advanced_settings.ts`.

## Test plan

- [ ] Confirm the "Alerting V2" setting in Stack Management → Advanced Settings shows an "Experimental" badge instead of "Technical Preview"