### PR TITLE
[Entity Analytics] [Bug] Fix recent anomalies query when anomalies index does not exist

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.test.ts
@@ -74,8 +74,11 @@ const baseParams = {
 let resolvedEntityIds: string[] | undefined;
 let resolveLoading: boolean;
 let topRowsRecords: Array<Record<string, string>>;
+let mlIndexExists: boolean | undefined;
+let mlIndexLoading: boolean;
 
 const RESOLUTION_KEY = 'recent-anomalies-filtered-entity-ids';
+const ML_INDEX_EXISTS_KEY = 'recent-anomalies-ml-index-exists';
 const callFor = (predicate: (key: unknown) => boolean) =>
   mockUseQuery.mock.calls.find(([key]) => predicate(key));
 const resolutionCall = () => callFor((key) => Array.isArray(key) && key[0] === RESOLUTION_KEY);
@@ -89,8 +92,14 @@ describe('useRecentAnomaliesQuery', () => {
     resolvedEntityIds = undefined;
     resolveLoading = false;
     topRowsRecords = [];
+    mlIndexExists = true;
+    mlIndexLoading = false;
 
-    mockUseKibana.mockReturnValue({ services: { data: { search: { search: jest.fn() } } } });
+    mockUseKibana.mockReturnValue({
+      services: {
+        data: { search: { search: jest.fn() }, dataViews: { getExistingIndices: jest.fn() } },
+      },
+    });
     mockUseGlobalTime.mockReturnValue({ from: 'global-from', to: 'global-to' });
     mockUseEsqlTimeRangeFilter.mockReturnValue(TIME_FILTER);
     mockUseGlobalFilterQuery.mockReturnValue({ filterQuery: EMPTY_BOOL });
@@ -103,6 +112,9 @@ describe('useRecentAnomaliesQuery', () => {
       const key = queryKey as unknown[];
       if (key[0] === RESOLUTION_KEY) {
         return { data: resolvedEntityIds, isLoading: resolveLoading };
+      }
+      if (key[0] === ML_INDEX_EXISTS_KEY) {
+        return { data: mlIndexExists, isLoading: mlIndexLoading };
       }
       if (key[1] === TOP_ROWS_SQL) {
         return {
@@ -201,6 +213,41 @@ describe('useRecentAnomaliesQuery', () => {
 
       expect(result).toEqual({ anomalyRecords: [], rowLabels: [] });
       expect(mockGetESQLResults).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the ML anomalies index does not exist', () => {
+    it('short-circuits the top rows query to an empty result without querying ES|QL', async () => {
+      mlIndexExists = false;
+      renderHook(() => useRecentAnomaliesQuery(baseParams));
+
+      mockGetESQLResults.mockClear();
+      const result = await topRowsCall()![1]({ signal: undefined });
+
+      expect(result).toEqual({ records: [], rawResponse: undefined });
+      expect(mockGetESQLResults).not.toHaveBeenCalled();
+    });
+
+    it('runs the ES|QL query as normal when the index does exist', async () => {
+      mlIndexExists = true;
+      renderHook(() => useRecentAnomaliesQuery(baseParams));
+
+      mockGetESQLResults.mockClear();
+      await topRowsCall()![1]({ signal: undefined });
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ esqlQuery: TOP_ROWS_SQL })
+      );
+    });
+  });
+
+  describe('while checking whether the ML anomalies index exists', () => {
+    it('disables the top rows query and keeps the result loading', () => {
+      mlIndexLoading = true;
+      const { result } = renderHook(() => useRecentAnomaliesQuery(baseParams));
+
+      expect(topRowsCall()![2].enabled).toBe(false);
+      expect(result.current.isLoading).toBe(true);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -119,6 +119,29 @@ const useFilteredEntityIds = (spaceId?: string): FilteredEntityIds => {
   };
 };
 
+interface MlAnomaliesIndexExists {
+  indexExists: boolean | undefined;
+  isLoading: boolean;
+}
+
+/**
+ * Checks whether the ML anomalies index actually exists. When no ML job has
+ * ever run, `ML_ANOMALIES_INDEX` resolves to zero concrete indices, which
+ * makes the downstream `LOOKUP JOIN` against the entity store report a
+ * misleading "resolves to multiple indices" error instead of an empty
+ * result. Short-circuiting here avoids issuing that query at all.
+ */
+const useMlAnomaliesIndexExists = (): MlAnomaliesIndexExists => {
+  const { dataViews } = useKibana().services.data;
+
+  const { data, isLoading } = useQuery(['recent-anomalies-ml-index-exists'], async () => {
+    const existingIndices = await dataViews.getExistingIndices([ML_ANOMALIES_INDEX]);
+    return existingIndices.length > 0;
+  });
+
+  return { indexExists: data, isLoading };
+};
+
 const useRecentAnomaliesTopRowsQuery = (params: {
   anomalyBands: AnomalyBand[];
   viewBy: ViewByMode;
@@ -133,6 +156,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
   const search = useKibana().services.data.search.search;
   const timeFilter = useRecentAnomaliesTimeFilter(params.timeRange);
   const { entityIds, isLoading: isEntityIdsLoading } = useFilteredEntityIds(params.spaceId);
+  const { indexExists: mlIndexExists, isLoading: isMlIndexLoading } = useMlAnomaliesIndexExists();
   const noFilterMatches = entityIds !== undefined && entityIds.length === 0;
   const rowField = params.viewBy === 'jobId' ? 'job_id' : 'entity_id';
 
@@ -143,9 +167,11 @@ const useRecentAnomaliesTopRowsQuery = (params: {
   });
 
   const { isLoading, data, isError } = useQuery(
-    [timeFilter, topRowsEsqlSource, entityIds],
+    [timeFilter, topRowsEsqlSource, entityIds, mlIndexExists],
     async ({ signal }) => {
-      if (!topRowsEsqlSource || noFilterMatches) return { records: [], rawResponse: undefined };
+      if (!topRowsEsqlSource || noFilterMatches || !mlIndexExists) {
+        return { records: [], rawResponse: undefined };
+      }
       const esqlResult = await getESQLResults({
         esqlQuery: topRowsEsqlSource,
         search,
@@ -157,7 +183,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
         rawResponse: esqlResult?.response,
       };
     },
-    { enabled: !!topRowsEsqlSource && !isEntityIdsLoading }
+    { enabled: !!topRowsEsqlSource && !isEntityIdsLoading && !isMlIndexLoading }
   );
 
   const records = data?.records;
@@ -175,7 +201,7 @@ const useRecentAnomaliesTopRowsQuery = (params: {
   );
 
   return {
-    isLoading: isLoading || isEntityIdsLoading,
+    isLoading: isLoading || isEntityIdsLoading || isMlIndexLoading,
     rowLabels: records?.map((each) => each[rowField]),
     entityMetadata,
     isError,
@@ -257,7 +283,6 @@ export const useRecentAnomaliesQuery = (params: {
       keepPreviousData: true,
     }
   );
-
   const inspect = useMemo(() => {
     // when there are no anomalies, rowLabels comes back empty from the top-rows query,
     // so the main query never actually runs. In that case, we use the top-rows query's esql source and raw response.

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout/resolution_section.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout/resolution_section.cy.ts
@@ -63,8 +63,7 @@ const waitForTableToLoad = () => {
 // scoping to RESOLUTION_GROUP_TAB_CONTENT disambiguates.
 const groupTable = () => cy.get(RESOLUTION_GROUP_TAB_CONTENT).find(RESOLUTION_GROUP_TABLE);
 
-// Times out: https://github.com/elastic/kibana/issues/275782
-describe.skip(
+describe(
   'Entity flyout — Manual Entity Resolution',
   {
     tags: ['@ess', '@serverless'],


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/275782

## Summary

The `Recent Anomalies` panel on the EA homepage was started showing an error loading when the ML anomalies index does not exist (instead of returning empty results) because the ES|QL query with LOOKUP JOIN was throwing an error. There have been no recent changes to this part of the code so possibly caused by updates in ESQL query code. This was causing some cypress tests to time out. This adds an index exists check before trying to perform the ESQL query.

Note: the cypress tests just started timing out so this is a very recent issue, no need to backport to 9.4