### PR TITLE
[9.4] [Security Solution] Fixes deprecated rules showing up as installable once they are deleted via callouts (#274447)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/methods/fetch_latest_assets.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/methods/fetch_latest_assets.ts
@@ -15,6 +15,7 @@ import type { PrebuiltRuleAsset } from '../../../../model/rule_assets/prebuilt_r
 import { PREBUILT_RULE_ASSETS_SO_TYPE } from '../../prebuilt_rule_assets_type';
 import { validatePrebuiltRuleAssets } from '../../prebuilt_rule_assets_validation';
 import { invariant } from '../../../../../../../../common/utils/invariant';
+import { fetchDeprecatedRules } from './fetch_deprecated_rules';
 
 export interface FetchLatestAssetsOptions {
   size: number;
@@ -22,6 +23,15 @@ export interface FetchLatestAssetsOptions {
 
 /**
  * Fetches the latest version of each prebuilt rule asset.
+ *
+ * Rule_ids that have any deprecated asset are excluded from the search
+ * via a `NOT (rule_id: ...)` KQL filter that is built from the result of
+ * `fetchDeprecatedRules`. Deprecation is monotonic per rule_id, so the
+ * presence of a deprecated stub means the whole rule_id is deprecated
+ * and must not flow into `validatePrebuiltRuleAssets` (the deprecated
+ * stub schema is a strict subset of `PrebuiltRuleAsset` and would fail
+ * validation). The deprecated rule_id lookup runs first so its result
+ * can scope the main aggregation.
  *
  * @param savedObjectsClient - The saved objects client used to query the saved objects store
  * @returns A promise that resolves to an array of prebuilt rule assets.
@@ -32,6 +42,9 @@ export async function fetchLatestAssets(
     size: MAX_PREBUILT_RULES_COUNT,
   }
 ): Promise<PrebuiltRuleAsset[]> {
+  const deprecatedRuleAssets = await fetchDeprecatedRules(savedObjectsClient);
+  const deprecatedRuleIds = deprecatedRuleAssets.map((asset) => asset.rule_id);
+
   const findResult = await savedObjectsClient.find<
     PrebuiltRuleAsset,
     {
@@ -41,9 +54,11 @@ export async function fetchLatestAssets(
     }
   >({
     type: PREBUILT_RULE_ASSETS_SO_TYPE,
-    // Exclude deprecated rule assets so they are not returned as installable/upgradeable
-    filter: `NOT ${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes.deprecated: true`,
-    // Aggregation groups prebuilt rule assets by rule_id and gets a rule with the highest version for each group.
+    ...(deprecatedRuleIds.length > 0 && {
+      filter: `NOT (${deprecatedRuleIds
+        .map((id) => `${PREBUILT_RULE_ASSETS_SO_TYPE}.attributes.rule_id: "${id}"`)
+        .join(' OR ')})`,
+    }),
     aggs: {
       rules: {
         terms: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/methods/fetch_latest_versions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/methods/fetch_latest_versions.ts
@@ -23,6 +23,7 @@ import {
   getPrebuiltRuleAssetSoId,
   getPrebuiltRuleAssetsSearchNamespace,
 } from '../utils';
+import { fetchDeprecatedRules } from './fetch_deprecated_rules';
 
 /**
  * Fetches the BasicRuleInfo for prebuilt rule assets: rule_id, version and type.
@@ -71,6 +72,16 @@ async function fetchLatestVersionSpecifiers(
   ruleIds?: string[],
   filter?: PrebuiltRuleAssetsFilter
 ) {
+  /**
+   * Fetches deprecated rule assets in order to filter out all versions of the deprecated rules
+   * in the latest version query. Since we fetch the most recent version of the asset, if we filter
+   * out assets using the `type` field, the query would still return the deprecated asset, just one
+   * version older. This filter ensures all rule assets fetched will not contain any rule ids that
+   * have been labeled as deprecated.
+   */
+  const deprecatedRuleAssets = await fetchDeprecatedRules(savedObjectsClient, ruleIds);
+  const deprecatedRuleIds = deprecatedRuleAssets.map((asset) => asset.rule_id);
+
   const latestVersionSpecifiersResult = await savedObjectsClient.search<
     SavedObjectsRawDocSource,
     {
@@ -88,9 +99,7 @@ async function fetchLatestVersionSpecifiers(
     _source: false,
     size: 0,
     query: {
-      bool: {
-        filter: prepareQueryDslFilter(ruleIds, filter),
-      },
+      bool: prepareQueryDslFilter({ ruleIds, excludeRuleIds: deprecatedRuleIds, filter }),
     },
     aggs: {
       rules: {
@@ -132,6 +141,7 @@ async function fetchLatestVersionSpecifiers(
     invariant(hitSource, 'fetchLatestVersionSpecifiers: expected hit source to be defined');
 
     const soAttributes = hitSource[PREBUILT_RULE_ASSETS_SO_TYPE];
+
     return {
       rule_id: soAttributes.rule_id,
       version: soAttributes.version,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/utils.ts
@@ -12,25 +12,28 @@ import type { PrebuiltRuleAssetsFilter } from '../../../../../../../common/api/d
 import type { PrebuiltRuleAssetsSort } from '../../../../../../../common/api/detection_engine/prebuilt_rules/common/prebuilt_rule_assets_sort';
 import { PREBUILT_RULE_ASSETS_SO_TYPE } from '../prebuilt_rule_assets_type';
 
-export function prepareQueryDslFilter(
-  ruleIds?: string[],
-  filter?: PrebuiltRuleAssetsFilter
-): ESFilter[] {
-  const queryFilter: ESFilter[] = [];
-
-  // Exclude deprecated rules by default from all queries that use this filter.
-  // For existing SOs without a `deprecated` field, the term query matches nothing,
-  // so must_not correctly includes them.
-  queryFilter.push({
-    bool: {
-      must_not: {
-        term: { [`${PREBUILT_RULE_ASSETS_SO_TYPE}.deprecated`]: true },
-      },
-    },
-  });
+/**
+ * Builds the filter clauses for prebuilt rule asset searches.
+ *
+ * @ruleIds restrict the search to those rule_ids
+ * @filter the caller's structured filter
+ * @excludeRuleIds rule_ids that must be excluded entirely. Used to
+ * suppress fully-deprecated rule_ids from the latest-version aggregation;
+ * the caller is responsible for sourcing the list (typically from `fetchDeprecatedRules`)
+ */
+export function prepareQueryDslFilter({
+  ruleIds,
+  excludeRuleIds,
+  filter,
+}: {
+  ruleIds?: string[];
+  excludeRuleIds?: string[];
+  filter?: PrebuiltRuleAssetsFilter;
+}): { filter: ESFilter[]; must_not?: ESFilter } {
+  const filterClauses: ESFilter[] = [];
 
   if (ruleIds) {
-    queryFilter.push({
+    filterClauses.push({
       terms: {
         [`${PREBUILT_RULE_ASSETS_SO_TYPE}.rule_id`]: ruleIds,
       },
@@ -39,7 +42,7 @@ export function prepareQueryDslFilter(
 
   if (filter?.fields?.name?.include?.values) {
     filter.fields.name.include.values.forEach((name) => {
-      queryFilter.push({
+      filterClauses.push({
         wildcard: {
           [`${PREBUILT_RULE_ASSETS_SO_TYPE}.name.keyword`]: `*${name}*`,
         },
@@ -49,14 +52,26 @@ export function prepareQueryDslFilter(
 
   if (filter?.fields.tags?.include?.values) {
     filter.fields.tags.include.values.forEach((tag) => {
-      queryFilter.push({
+      filterClauses.push({
         term: {
           [`${PREBUILT_RULE_ASSETS_SO_TYPE}.tags`]: tag,
         },
       });
     });
   }
-  return queryFilter;
+
+  if (excludeRuleIds && excludeRuleIds.length > 0) {
+    return {
+      filter: filterClauses,
+      must_not: {
+        terms: {
+          [`${PREBUILT_RULE_ASSETS_SO_TYPE}.rule_id`]: excludeRuleIds,
+        },
+      },
+    };
+  }
+
+  return { filter: filterClauses };
 }
 
 export function prepareQueryDslSort(sort?: PrebuiltRuleAssetsSort): Sort | undefined {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/install_prebuilt_rules/review_installation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/install_prebuilt_rules/review_installation.ts
@@ -1023,6 +1023,73 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(response.rules).toHaveLength(0);
         expect(response.stats.num_rules_to_install).toBe(0);
       });
+
+      it('excludes a rule_id when its latest version is a deprecated stub but an older non-deprecated SO still exists', async () => {
+        // Stale non-deprecated SOs left over from earlier package versions.
+        await createPrebuiltRuleAssetSavedObjects(es, [
+          createRuleAssetSavedObject({
+            rule_id: 'rule-going-away',
+            version: 1,
+            name: 'Deprecated - Going Away',
+          }),
+          createRuleAssetSavedObject({
+            rule_id: 'rule-going-away',
+            version: 2,
+            name: 'Deprecated - Going Away',
+          }),
+          createRuleAssetSavedObject({
+            rule_id: 'active-rule',
+            version: 1,
+            name: 'Active rule',
+          }),
+        ]);
+        await createDeprecatedPrebuiltRuleAssetSavedObjects(es, [
+          { rule_id: 'rule-going-away', version: 3, name: 'Deprecated - Going Away' },
+        ]);
+
+        const response = await reviewPrebuiltRulesToInstall(supertest);
+
+        const ruleIds = response.rules.map((r: { rule_id: string }) => r.rule_id);
+        expect(ruleIds).toContain('active-rule');
+        expect(ruleIds).not.toContain('rule-going-away');
+        expect(response.stats.num_rules_to_install).toBe(1);
+      });
+
+      it('excludes a rule_id whose latest version is a deprecated stub even when a user KQL filter is applied that the stub does not match', async () => {
+        // Deprecated stubs carry only a minimal schema (no `tags`,
+        // `severity`, etc.), so a naive single-query approach that
+        // excludes deprecated SOs via the search filter would leak the
+        // older non-deprecated SO whenever a user filter targets fields
+        // the stub doesn't carry. The deprecated rule_id lookup runs as a
+        // separate query that ignores the user filter, which keeps this
+        // case correct.
+        await createPrebuiltRuleAssetSavedObjects(es, [
+          createRuleAssetSavedObject({
+            rule_id: 'rule-going-away',
+            version: 1,
+            name: 'Deprecated - Going Away',
+            tags: ['Tactic: Collection'],
+          }),
+          createRuleAssetSavedObject({
+            rule_id: 'active-rule',
+            version: 1,
+            name: 'Active rule',
+            tags: ['Tactic: Collection'],
+          }),
+        ]);
+        await createDeprecatedPrebuiltRuleAssetSavedObjects(es, [
+          { rule_id: 'rule-going-away', version: 3, name: 'Deprecated - Going Away' },
+        ]);
+
+        const response = await reviewPrebuiltRulesToInstall(supertest, {
+          filter: { term: 'security-rule.tags: "Tactic: Collection"', mode: 'KQL' },
+        });
+
+        const ruleIds = response.rules.map((r: { rule_id: string }) => r.rule_id);
+        expect(ruleIds).toContain('active-rule');
+        expect(ruleIds).not.toContain('rule-going-away');
+        expect(response.stats.num_rules_to_install).toBe(1);
+      });
     });
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/install_prebuilt_rules/review_installation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/install_prebuilt_rules/review_installation.ts
@@ -1082,7 +1082,7 @@ export default ({ getService }: FtrProviderContext): void => {
         ]);
 
         const response = await reviewPrebuiltRulesToInstall(supertest, {
-          filter: { term: 'security-rule.tags: "Tactic: Collection"', mode: 'KQL' },
+          filter: { fields: { tags: { include: { values: ['Tactic: Collection'] } } } },
         });
 
         const ruleIds = response.rules.map((r: { rule_id: string }) => r.rule_id);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/review_prebuilt_rules_upgrade.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/customization_enabled/upgrade_prebuilt_rules/review_prebuilt_rules_upgrade.ts
@@ -319,6 +319,33 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(ruleIds).toContain('rule-a');
         expect(ruleIds).not.toContain('rule-b');
       });
+
+      it('excludes a rule_id from upgrade review when the latest asset is deprecated but an older non-deprecated SO still exists', async () => {
+        // Install rule-a and rule-b at version 1.
+        await createPrebuiltRuleAssetSavedObjects(es, [
+          createRuleAssetSavedObject({ rule_id: 'rule-a', version: 1 }),
+          createRuleAssetSavedObject({ rule_id: 'rule-b', version: 1 }),
+        ]);
+        await installPrebuiltRules(es, supertest);
+
+        await createPrebuiltRuleAssetSavedObjects(es, [
+          createRuleAssetSavedObject({ rule_id: 'rule-a', version: 2 }),
+          createRuleAssetSavedObject({
+            rule_id: 'rule-b',
+            version: 2,
+            name: 'Deprecated - Rule B',
+          }),
+        ]);
+        await createDeprecatedPrebuiltRuleAssetSavedObjects(es, [
+          { rule_id: 'rule-b', version: 3, name: 'Deprecated - Rule B' },
+        ]);
+
+        const response = await reviewPrebuiltRulesToUpgrade(supertest);
+
+        const ruleIds = response.rules.map((r: { rule_id: string }) => r.rule_id);
+        expect(ruleIds).toContain('rule-a');
+        expect(ruleIds).not.toContain('rule-b');
+      });
     });
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] Fixes deprecated rules showing up as installable once they are deleted via callouts (#274447)](https://github.com/elastic/kibana/pull/274447)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis Plumlee","email":"56367316+dplumlee@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-07-01T19:06:56Z","message":"[Security Solution] Fixes deprecated rules showing up as installable once they are deleted via callouts (#274447)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/273111\n\nThis PR adds filters around our methods for fetching the \"latest\nversions\" of prebuilt rules to ensure we aren't returning any assets\nthat have been deemed deprecated by the TRADE team.\n\nPreviously we were performing a query filter on our rule SO search, but\nwhen we were doing a post query aggregate, the latest version call would\npick up the previous version of the rule object (not a deprecated asset)\nand still return it as a valid object. This led to the behavior\ndescribed in the ticket where a user who had rules that had iterated\nthrough multiple package upgrades would see the older versions of\ndeprecated rules reappear on the installable rules page, causing a cycle\nwhere rules could be installed and deleted and installed and deleted,\netc. which is confusing at the very least.\n\nThis PR solves this issue by filtering post query aggregation so the\ndeprecated rule asset can act as a definition for all versions of the\nrule asset. Performance-wise this should not affect these endpoints too\nmuch as this logic happens while fetching the version stubs, no sizeable\ndifference is made in return time/memory.\n\nThis PR also adds integration tests for these edge cases in the upgrade\nand installation endpoint API paths.\n\n**NOTE**\nThis PR does _not_ get rid of rules labeled as `Deprecated -\n{rule_name}` on the install page, that is a separate process handled by\nthe TRADE team and many of those rules are in process of being\ndeprecated, not fully deprecated yet. I'm putting this here as we've had\nSDH's about this behavior and want to be clear that will be addressed\nseparately. This PR fixes rules that are defined as fully deprecated and\nshow up in the rule deprecation warning modals should a user install\nthem.\n\n### Testing\n\nThere are repro steps in the ticket linked but reviewers can also\nutilize this script to quickly install test data in order to validate\nthe behavior both before and after a fix is made.\n\n\n[repro_deprecated_rule_install_bug.sh](https://github.com/user-attachments/files/29223852/repro_deprecated_rule_install_bug.sh)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"2c502d944eec878728abe923a7281ec6972ce6b2","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team: SecuritySolution","Feature:Prebuilt Detection Rules","backport:version","v9.5.0","Team:Detection Engineering","v9.4.4"],"title":"[Security Solution] Fixes deprecated rules showing up as installable once they are deleted via callouts","number":274447,"url":"https://github.com/elastic/kibana/pull/274447","mergeCommit":{"message":"[Security Solution] Fixes deprecated rules showing up as installable once they are deleted via callouts (#274447)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/273111\n\nThis PR adds filters around our methods for fetching the \"latest\nversions\" of prebuilt rules to ensure we aren't returning any assets\nthat have been deemed deprecated by the TRADE team.\n\nPreviously we were performing a query filter on our rule SO search, but\nwhen we were doing a post query aggregate, the latest version call would\npick up the previous version of the rule object (not a deprecated asset)\nand still return it as a valid object. This led to the behavior\ndescribed in the ticket where a user who had rules that had iterated\nthrough multiple package upgrades would see the older versions of\ndeprecated rules reappear on the installable rules page, causing a cycle\nwhere rules could be installed and deleted and installed and deleted,\netc. which is confusing at the very least.\n\nThis PR solves this issue by filtering post query aggregation so the\ndeprecated rule asset can act as a definition for all versions of the\nrule asset. Performance-wise this should not affect these endpoints too\nmuch as this logic happens while fetching the version stubs, no sizeable\ndifference is made in return time/memory.\n\nThis PR also adds integration tests for these edge cases in the upgrade\nand installation endpoint API paths.\n\n**NOTE**\nThis PR does _not_ get rid of rules labeled as `Deprecated -\n{rule_name}` on the install page, that is a separate process handled by\nthe TRADE team and many of those rules are in process of being\ndeprecated, not fully deprecated yet. I'm putting this here as we've had\nSDH's about this behavior and want to be clear that will be addressed\nseparately. This PR fixes rules that are defined as fully deprecated and\nshow up in the rule deprecation warning modals should a user install\nthem.\n\n### Testing\n\nThere are repro steps in the ticket linked but reviewers can also\nutilize this script to quickly install test data in order to validate\nthe behavior both before and after a fix is made.\n\n\n[repro_deprecated_rule_install_bug.sh](https://github.com/user-attachments/files/29223852/repro_deprecated_rule_install_bug.sh)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"2c502d944eec878728abe923a7281ec6972ce6b2"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274447","number":274447,"mergeCommit":{"message":"[Security Solution] Fixes deprecated rules showing up as installable once they are deleted via callouts (#274447)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/273111\n\nThis PR adds filters around our methods for fetching the \"latest\nversions\" of prebuilt rules to ensure we aren't returning any assets\nthat have been deemed deprecated by the TRADE team.\n\nPreviously we were performing a query filter on our rule SO search, but\nwhen we were doing a post query aggregate, the latest version call would\npick up the previous version of the rule object (not a deprecated asset)\nand still return it as a valid object. This led to the behavior\ndescribed in the ticket where a user who had rules that had iterated\nthrough multiple package upgrades would see the older versions of\ndeprecated rules reappear on the installable rules page, causing a cycle\nwhere rules could be installed and deleted and installed and deleted,\netc. which is confusing at the very least.\n\nThis PR solves this issue by filtering post query aggregation so the\ndeprecated rule asset can act as a definition for all versions of the\nrule asset. Performance-wise this should not affect these endpoints too\nmuch as this logic happens while fetching the version stubs, no sizeable\ndifference is made in return time/memory.\n\nThis PR also adds integration tests for these edge cases in the upgrade\nand installation endpoint API paths.\n\n**NOTE**\nThis PR does _not_ get rid of rules labeled as `Deprecated -\n{rule_name}` on the install page, that is a separate process handled by\nthe TRADE team and many of those rules are in process of being\ndeprecated, not fully deprecated yet. I'm putting this here as we've had\nSDH's about this behavior and want to be clear that will be addressed\nseparately. This PR fixes rules that are defined as fully deprecated and\nshow up in the rule deprecation warning modals should a user install\nthem.\n\n### Testing\n\nThere are repro steps in the ticket linked but reviewers can also\nutilize this script to quickly install test data in order to validate\nthe behavior both before and after a fix is made.\n\n\n[repro_deprecated_rule_install_bug.sh](https://github.com/user-attachments/files/29223852/repro_deprecated_rule_install_bug.sh)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"2c502d944eec878728abe923a7281ec6972ce6b2"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->