### PR TITLE
[Developer Toolbar] Add theme toggle

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -44,7 +44,7 @@ pageLoadAssetSize:
   dataViewManagement: 6250
   dataViews: 66000
   dataVisualizer: 32727
-  developerToolbar: 5758
+  developerToolbar: 6503
   devTools: 8107
   discover: 30501
   discoverEnhanced: 5353

--- a/src/platform/packages/shared/kbn-developer-toolbar/index.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/index.ts
@@ -12,3 +12,8 @@ export {
   type DeveloperToolbarItemProps,
 } from './src/components/developer_toolbar_item';
 export { DeveloperToolbar, type DeveloperToolbarProps } from './src/components/developer_toolbar';
+export { ColorThemeToggle } from './src/toolbar_items/color_theme/color_theme_toggle';
+export {
+  installLocalColorThemeOverride,
+  type LocalColorThemeController,
+} from './src/toolbar_items/color_theme/local_color_theme';

--- a/src/platform/packages/shared/kbn-developer-toolbar/index.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/index.ts
@@ -12,8 +12,5 @@ export {
   type DeveloperToolbarItemProps,
 } from './src/components/developer_toolbar_item';
 export { DeveloperToolbar, type DeveloperToolbarProps } from './src/components/developer_toolbar';
-export { ColorThemeToggle } from './src/toolbar_items/color_theme/color_theme_toggle';
-export {
-  installLocalColorThemeOverride,
-  type LocalColorThemeController,
-} from './src/toolbar_items/color_theme/local_color_theme';
+export { LiveColorThemeToggle } from './src/toolbar_items/color_theme/color_theme_toggle';
+export { installLocalColorThemeOverride } from './src/toolbar_items/color_theme/local_color_theme';

--- a/src/platform/packages/shared/kbn-developer-toolbar/moon.yml
+++ b/src/platform/packages/shared/kbn-developer-toolbar/moon.yml
@@ -19,6 +19,7 @@ project:
 dependsOn:
   - '@kbn/config'
   - '@kbn/shared-ux-utility'
+  - '@kbn/core-theme-browser'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-developer-toolbar/moon.yml
+++ b/src/platform/packages/shared/kbn-developer-toolbar/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/config'
   - '@kbn/shared-ux-utility'
   - '@kbn/core-theme-browser'
+  - '@kbn/ui-theme'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/color_theme_toggle.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/color_theme_toggle.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
+
+interface Props {
+  isDarkMode: boolean;
+  onToggle: () => void;
+}
+
+export const ColorThemeToggle = ({ isDarkMode, onToggle }: Props) => (
+  <EuiToolTip content="Click to toggle color theme.">
+    <EuiBadge
+      color={isDarkMode ? '#1E293B' : '#FEF3C7'}
+      iconType={isDarkMode ? 'moon' : 'sun'}
+      iconSide="left"
+      onClick={onToggle}
+      onClickAriaLabel="Toggle color theme"
+    >
+      {isDarkMode ? 'Dark' : 'Light'}
+    </EuiBadge>
+  </EuiToolTip>
+);

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/color_theme_toggle.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/color_theme_toggle.tsx
@@ -9,13 +9,15 @@
 
 import React from 'react';
 import { EuiBadge, EuiToolTip } from '@elastic/eui';
+import useObservable from 'react-use/lib/useObservable';
+import type { LocalColorThemeController } from './local_color_theme';
 
 interface Props {
   isDarkMode: boolean;
   onToggle: () => void;
 }
 
-export const ColorThemeToggle = ({ isDarkMode, onToggle }: Props) => (
+const ColorThemeToggle = ({ isDarkMode, onToggle }: Props) => (
   <EuiToolTip content="Click to toggle color theme.">
     <EuiBadge
       color={isDarkMode ? '#1E293B' : '#FEF3C7'}
@@ -28,3 +30,14 @@ export const ColorThemeToggle = ({ isDarkMode, onToggle }: Props) => (
     </EuiBadge>
   </EuiToolTip>
 );
+
+/**
+ * Toolbar item that reflects and toggles the color theme override. It subscribes
+ * to the controller so the badge updates live when the theme flips. The
+ * controller (which installs the global override) is created eagerly by the
+ * plugin; only this presentational component is lazy-loaded.
+ */
+export const LiveColorThemeToggle = ({ controller }: { controller: LocalColorThemeController }) => {
+  const isDarkMode = useObservable(controller.isDark$, controller.isDark$.getValue());
+  return <ColorThemeToggle isDarkMode={isDarkMode} onToggle={controller.toggle} />;
+};

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
@@ -28,6 +28,22 @@ export interface LocalColorThemeController {
  * resolved theme. While active, the theme is applied live by hijacking the
  * shared core theme contract (`core.theme`) so every `KibanaEuiProvider`
  * re-themes without a page reload.
+ *
+ * Known limitation — this is a *partial* live preview:
+ *
+ * The override works by swapping `core.theme.theme$` for a live subject, so it
+ * only reaches consumers that read `theme$` (directly or via `KibanaEuiProvider`
+ * / `useKibanaIsDarkMode`) *at or after* the toggle is installed. Subsystems
+ * that snapshot the original `theme$` earlier — most notably elastic-charts,
+ * whose charts plugin theme service captures and subscribes to `theme$` once
+ * during its own `setup()` (see `charts/public/services/theme/theme.ts`) — hold
+ * the original static observable and never see our updates, so charts keep
+ * rendering the real theme. Anything reading dark mode from a different source
+ * entirely is likewise unaffected.
+ *
+ * Fully covering these would require guaranteed plugin setup ordering
+ * or core-level dynamic theme-switching support.
+ * A hard refresh always reflects the real, server-resolved theme everywhere.
  */
 export const installLocalColorThemeOverride = (
   theme: ThemeServiceStart

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
@@ -10,81 +10,30 @@
 import { BehaviorSubject } from 'rxjs';
 import type { CoreTheme, ThemeServiceStart } from '@kbn/core-theme-browser';
 
-const STORAGE_KEY = 'kbn_developer_toolbar_color_theme_override';
-
-interface StoredOverride {
-  /** The forced color mode. */
-  mode: 'dark' | 'light';
-  /** The server-resolved dark mode at the time the override was set. */
-  base: boolean;
-}
-
-const readOverride = (): StoredOverride | null => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (
-      (parsed?.mode === 'dark' || parsed?.mode === 'light') &&
-      typeof parsed?.base === 'boolean'
-    ) {
-      return parsed;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-};
-
-const writeOverride = (value: StoredOverride | null): void => {
-  try {
-    if (value === null) {
-      localStorage.removeItem(STORAGE_KEY);
-    } else {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
-    }
-  } catch {
-    // Silently ignore storage errors.
-  }
-};
-
 export interface LocalColorThemeController {
   /** Emits the currently applied dark-mode state. */
   isDark$: BehaviorSubject<boolean>;
-  /** Flip between dark and light, applying and persisting the choice locally. */
+  /** Flip between dark and light, applying the choice live. */
   toggle: () => void;
 }
 
 /**
  * A fully client-side color theme override for the developer toolbar.
  *
- * This intentionally does NOT touch the server: nothing is written to the user
- * profile or uiSettings. The preference lives only in `localStorage` for this
- * browser, and the theme is applied live by hijacking the shared core theme
- * contract (`core.theme`) so every `KibanaEuiProvider` re-themes without a page
- * reload.
- *
- * The override always yields to the real setting: we remember the server-resolved
- * theme at the time the override was set, and if it later changes (i.e. the user
- * updated their actual color theme setting), the local override is discarded.
+ * This intentionally does NOT touch the server (nothing is written to the user
+ * profile or uiSettings) and does NOT persist across reloads: the override is
+ * session-only, so refreshing the page always falls back to the real, server
+ * resolved theme. While active, the theme is applied live by hijacking the
+ * shared core theme contract (`core.theme`) so every `KibanaEuiProvider`
+ * re-themes without a page reload.
  */
 export const installLocalColorThemeOverride = (
   theme: ThemeServiceStart
 ): LocalColorThemeController => {
   const baseTheme = theme.getTheme();
-  const stored = readOverride();
 
-  // If the real (server-resolved) theme changed since the override was set, the
-  // user must have updated their actual setting — drop the stale override.
-  const overrideIsValid = stored !== null && stored.base === baseTheme.darkMode;
-  if (stored !== null && !overrideIsValid) {
-    writeOverride(null);
-  }
-
-  const initialDark = overrideIsValid ? stored!.mode === 'dark' : baseTheme.darkMode;
-
-  const isDark$ = new BehaviorSubject<boolean>(initialDark);
-  const theme$ = new BehaviorSubject<CoreTheme>({ ...baseTheme, darkMode: initialDark });
+  const isDark$ = new BehaviorSubject<boolean>(baseTheme.darkMode);
+  const theme$ = new BehaviorSubject<CoreTheme>(baseTheme);
 
   const apply = (darkMode: boolean): void => {
     (globalThis as { __kbnThemeTag__?: string }).__kbnThemeTag__ = `${baseTheme.name}${
@@ -99,20 +48,9 @@ export const installLocalColorThemeOverride = (
   mutableTheme.theme$ = theme$;
   mutableTheme.getTheme = () => theme$.getValue();
 
-  // Apply a stored override immediately on boot (server rendered the base theme).
-  if (overrideIsValid && initialDark !== baseTheme.darkMode) {
-    apply(initialDark);
-  }
-
   const toggle = (): void => {
     const next = !isDark$.getValue();
     isDark$.next(next);
-    if (next === baseTheme.darkMode) {
-      // Back to the real theme — no need to keep an override around.
-      writeOverride(null);
-    } else {
-      writeOverride({ mode: next ? 'dark' : 'light', base: baseTheme.darkMode });
-    }
     apply(next);
   };
 

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
@@ -9,6 +9,8 @@
 
 import { BehaviorSubject } from 'rxjs';
 import type { CoreTheme, ThemeServiceStart } from '@kbn/core-theme-browser';
+// eslint-disable-next-line @elastic/eui/no-restricted-eui-imports
+import { _setDarkMode } from '@kbn/ui-theme';
 
 export interface LocalColorThemeController {
   /** Emits the currently applied dark-mode state. */
@@ -36,6 +38,9 @@ export const installLocalColorThemeOverride = (
   const theme$ = new BehaviorSubject<CoreTheme>(baseTheme);
 
   const apply = (darkMode: boolean): void => {
+    // Flip the `euiThemeVars`/`euiDarkVars` proxy (read at access time) so
+    // components that read those static vars directly also reflect the preview.
+    _setDarkMode(darkMode);
     (globalThis as { __kbnThemeTag__?: string }).__kbnThemeTag__ = `${baseTheme.name}${
       darkMode ? 'dark' : 'light'
     }`;

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/color_theme/local_color_theme.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import type { CoreTheme, ThemeServiceStart } from '@kbn/core-theme-browser';
+
+const STORAGE_KEY = 'kbn_developer_toolbar_color_theme_override';
+
+interface StoredOverride {
+  /** The forced color mode. */
+  mode: 'dark' | 'light';
+  /** The server-resolved dark mode at the time the override was set. */
+  base: boolean;
+}
+
+const readOverride = (): StoredOverride | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (
+      (parsed?.mode === 'dark' || parsed?.mode === 'light') &&
+      typeof parsed?.base === 'boolean'
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const writeOverride = (value: StoredOverride | null): void => {
+  try {
+    if (value === null) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    }
+  } catch {
+    // Silently ignore storage errors.
+  }
+};
+
+export interface LocalColorThemeController {
+  /** Emits the currently applied dark-mode state. */
+  isDark$: BehaviorSubject<boolean>;
+  /** Flip between dark and light, applying and persisting the choice locally. */
+  toggle: () => void;
+}
+
+/**
+ * A fully client-side color theme override for the developer toolbar.
+ *
+ * This intentionally does NOT touch the server: nothing is written to the user
+ * profile or uiSettings. The preference lives only in `localStorage` for this
+ * browser, and the theme is applied live by hijacking the shared core theme
+ * contract (`core.theme`) so every `KibanaEuiProvider` re-themes without a page
+ * reload.
+ *
+ * The override always yields to the real setting: we remember the server-resolved
+ * theme at the time the override was set, and if it later changes (i.e. the user
+ * updated their actual color theme setting), the local override is discarded.
+ */
+export const installLocalColorThemeOverride = (
+  theme: ThemeServiceStart
+): LocalColorThemeController => {
+  const baseTheme = theme.getTheme();
+  const stored = readOverride();
+
+  // If the real (server-resolved) theme changed since the override was set, the
+  // user must have updated their actual setting — drop the stale override.
+  const overrideIsValid = stored !== null && stored.base === baseTheme.darkMode;
+  if (stored !== null && !overrideIsValid) {
+    writeOverride(null);
+  }
+
+  const initialDark = overrideIsValid ? stored!.mode === 'dark' : baseTheme.darkMode;
+
+  const isDark$ = new BehaviorSubject<boolean>(initialDark);
+  const theme$ = new BehaviorSubject<CoreTheme>({ ...baseTheme, darkMode: initialDark });
+
+  const apply = (darkMode: boolean): void => {
+    (globalThis as { __kbnThemeTag__?: string }).__kbnThemeTag__ = `${baseTheme.name}${
+      darkMode ? 'dark' : 'light'
+    }`;
+    theme$.next({ ...baseTheme, darkMode });
+  };
+
+  // Replace the shared theme contract so that every React root subscribing to
+  // `core.theme.theme$` (each `KibanaEuiProvider`) reacts to our live updates.
+  const mutableTheme = theme as { theme$: unknown; getTheme: () => CoreTheme };
+  mutableTheme.theme$ = theme$;
+  mutableTheme.getTheme = () => theme$.getValue();
+
+  // Apply a stored override immediately on boot (server rendered the base theme).
+  if (overrideIsValid && initialDark !== baseTheme.darkMode) {
+    apply(initialDark);
+  }
+
+  const toggle = (): void => {
+    const next = !isDark$.getValue();
+    isDark$.next(next);
+    if (next === baseTheme.darkMode) {
+      // Back to the real theme — no need to keep an override around.
+      writeOverride(null);
+    } else {
+      writeOverride({ mode: next ? 'dark' : 'light', base: baseTheme.darkMode });
+    }
+    apply(next);
+  };
+
+  return { isDark$, toggle };
+};

--- a/src/platform/packages/shared/kbn-developer-toolbar/tsconfig.json
+++ b/src/platform/packages/shared/kbn-developer-toolbar/tsconfig.json
@@ -9,6 +9,7 @@
   "kbn_references": [
     "@kbn/config",
     "@kbn/shared-ux-utility",
-    "@kbn/core-theme-browser"
+    "@kbn/core-theme-browser",
+    "@kbn/ui-theme"
   ]
 }

--- a/src/platform/packages/shared/kbn-developer-toolbar/tsconfig.json
+++ b/src/platform/packages/shared/kbn-developer-toolbar/tsconfig.json
@@ -6,5 +6,9 @@
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],
-  "kbn_references": ["@kbn/config", "@kbn/shared-ux-utility"]
+  "kbn_references": [
+    "@kbn/config",
+    "@kbn/shared-ux-utility",
+    "@kbn/core-theme-browser"
+  ]
 }

--- a/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
+++ b/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
@@ -8,17 +8,14 @@
  */
 
 import React, { Suspense, lazy } from 'react';
-import useObservable from 'react-use/lib/useObservable';
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-types';
 
 import { BehaviorSubject } from 'rxjs';
 import {
-  ColorThemeToggle,
   installLocalColorThemeOverride,
   type DeveloperToolbarItemProps,
-  type LocalColorThemeController,
 } from '@kbn/developer-toolbar';
 
 import { NEXT_CHROME_FEATURE_FLAG_KEY } from '@kbn/core-chrome-feature-flags';
@@ -31,10 +28,11 @@ export interface DeveloperToolbarItemRegistry {
 export type DeveloperToolbarSetup = DeveloperToolbarItemRegistry;
 export type DeveloperToolbarStart = DeveloperToolbarItemRegistry;
 
-const LiveColorThemeToggle = ({ controller }: { controller: LocalColorThemeController }) => {
-  const isDarkMode = useObservable(controller.isDark$, controller.isDark$.getValue());
-  return <ColorThemeToggle isDarkMode={isDarkMode} onToggle={controller.toggle} />;
-};
+const LazyColorThemeToggle = lazy(() =>
+  import('@kbn/developer-toolbar').then(({ LiveColorThemeToggle }) => ({
+    default: LiveColorThemeToggle,
+  }))
+);
 
 const LazyMeasureButton = lazy(() =>
   import('@kbn/design-tools').then(({ MeasureButton }) => ({
@@ -69,11 +67,19 @@ export class DeveloperToolbarPlugin
       </Suspense>
     );
 
+    /**
+     * Install the override eagerly so it takes effect globally (before the app
+     * root subscribes to `core.theme.theme$`).
+     */
     const colorThemeController = installLocalColorThemeOverride(core.theme);
 
     this.registerItem({
       id: 'Color Theme',
-      children: <LiveColorThemeToggle controller={colorThemeController} />,
+      children: (
+        <Suspense fallback={null}>
+          <LazyColorThemeToggle controller={colorThemeController} />
+        </Suspense>
+      ),
     });
 
     this.registerItem({

--- a/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
+++ b/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
@@ -8,12 +8,19 @@
  */
 
 import React, { Suspense, lazy } from 'react';
+import useObservable from 'react-use/lib/useObservable';
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-types';
 
 import { BehaviorSubject } from 'rxjs';
-import type { DeveloperToolbarItemProps } from '@kbn/developer-toolbar';
+import {
+  ColorThemeToggle,
+  installLocalColorThemeOverride,
+  type DeveloperToolbarItemProps,
+  type LocalColorThemeController,
+} from '@kbn/developer-toolbar';
+
 import { NEXT_CHROME_FEATURE_FLAG_KEY } from '@kbn/core-chrome-feature-flags';
 
 export type UnregisterItemFn = () => void;
@@ -23,6 +30,11 @@ export interface DeveloperToolbarItemRegistry {
 
 export type DeveloperToolbarSetup = DeveloperToolbarItemRegistry;
 export type DeveloperToolbarStart = DeveloperToolbarItemRegistry;
+
+const LiveColorThemeToggle = ({ controller }: { controller: LocalColorThemeController }) => {
+  const isDarkMode = useObservable(controller.isDark$, controller.isDark$.getValue());
+  return <ColorThemeToggle isDarkMode={isDarkMode} onToggle={controller.toggle} />;
+};
 
 const LazyMeasureButton = lazy(() =>
   import('@kbn/design-tools').then(({ MeasureButton }) => ({
@@ -56,6 +68,13 @@ export class DeveloperToolbarPlugin
         <LazyToolbar items$={this.items$} envInfo={this.context.env} />
       </Suspense>
     );
+
+    const colorThemeController = installLocalColorThemeOverride(core.theme);
+
+    this.registerItem({
+      id: 'Color Theme',
+      children: <LiveColorThemeToggle controller={colorThemeController} />,
+    });
 
     this.registerItem({
       id: 'Measure Component',


### PR DESCRIPTION
## Summary

This PR adds a color theme toggle to the developer toolbar. The toggle is a fully local solution that doesn't require reloading the page. The theme change is ephemeral and changing it back via user profile or refreshing the page prioritizes the actual theme.

The toggle doesn't work for components like charts which capture the theme at setup.

https://github.com/user-attachments/assets/8319a19a-0d98-4ed7-a9ea-ca55d341bbfe